### PR TITLE
Issue #65: Give the correct error when wallet is locked

### DIFF
--- a/createtx.go
+++ b/createtx.go
@@ -140,6 +140,11 @@ func selectInputs(utxos []*tx.RecvTxOut, amt int64,
 // block hash) Utxo.  ErrInsufficientFunds is returned if there are not
 // enough eligible unspent outputs to create the transaction.
 func (a *Account) txToPairs(pairs map[string]int64, minconf int) (*CreatedTx, error) {
+	// Wallet must be unlocked to compose transaction.
+	if a.IsLocked() {
+		return nil, wallet.ErrWalletLocked
+	}
+
 	// Create a new transaction which will include all input scripts.
 	msgtx := btcwire.NewMsgTx()
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1770,7 +1770,9 @@ func WalletPassphrase(icmd btcjson.Cmd) (interface{}, *btcjson.Error) {
 
 	go func(timeout int64) {
 		time.Sleep(time.Second * time.Duration(timeout))
+		AcctMgr.Grab()
 		_ = AcctMgr.LockWallets()
+		AcctMgr.Release()
 	}(cmd.Timeout)
 
 	return nil, nil


### PR DESCRIPTION
When sending coins to an address with a wallet that's both
locked and has insufficient funds, the correct ErrWalletLocked
error will be thrown.
