### PR TITLE
Fixes btcwallet to work with btcec when btcec #4 gets merged.

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1902,7 +1902,7 @@ func SignRawTransaction(icmd btcjson.Cmd) (interface{}, *btcjson.Error) {
 				}
 			}
 			keys[addr.EncodeAddress()] = keyInfo{
-				key:        privk,
+				key:        privk.ToECDSA(),
 				compressed: compressed,
 			}
 		}
@@ -2041,7 +2041,7 @@ func SignRawTransaction(icmd btcjson.Cmd) (interface{}, *btcjson.Error) {
 		// SigHashSingle inputs can only be signed if there's a
 		// corresponding output. However this could be already signed,
 		// so we always verify the output.
-		if (hashType & btcscript.SigHashSingle) == 0 ||
+		if (hashType&btcscript.SigHashSingle) == 0 ||
 			i < len(msgTx.TxOut) {
 
 			script, err := btcscript.SignTxOutput(cfg.Net(),


### PR DESCRIPTION
Note: I see that, upon saving, gofmt has changed a line too.
