### PR TITLE
panic when btcd connection fails and chainSvr is nil

### DIFF
--- a/btcwallet.go
+++ b/btcwallet.go
@@ -82,6 +82,10 @@ func walletMain() error {
 	// Shutdown the server if an interrupt signal is received.
 	addInterruptHandler(server.Stop)
 
+	// Create a channel to report unrecoverable errors during chain
+	// server connection
+	chainSvrErrors := make(chan error)
+
 	// Create channel so that the goroutine which opens the chain server
 	// connection can pass the conn to the goroutine which opens the wallet.
 	// Buffer the channel so sends are not blocked, since if the wallet is
@@ -89,11 +93,14 @@ func walletMain() error {
 	chainSvrChan := make(chan *chain.Client, 1)
 
 	go func() {
+		defer close(chainSvrErrors)
+
 		// Read CA certs and create the RPC client.
 		certs, err := ioutil.ReadFile(cfg.CAFile)
 		if err != nil {
 			log.Errorf("Cannot open CA file: %v", err)
 			close(chainSvrChan)
+			chainSvrErrors <- err
 			return
 		}
 		rpcc, err := chain.NewClient(activeNet.Params, cfg.RPCConnect,
@@ -101,6 +108,7 @@ func walletMain() error {
 		if err != nil {
 			log.Errorf("Cannot create chain server RPC client: %v", err)
 			close(chainSvrChan)
+			chainSvrErrors <- err
 			return
 		}
 		err = rpcc.Start()
@@ -146,16 +154,29 @@ func walletMain() error {
 
 		// Start wallet goroutines and handle RPC client notifications
 		// if the chain server connection was opened.
+		// If the chain server connection failed due to an unrecoverable error,
+		// doesn't matter that the wallet goroutines are not started since the
+		// entire program will exit on receiving chainSvrErrors
 		select {
-		case chainSvr := <-chainSvrChan:
-			w.Start(chainSvr)
+		case chainSvr, ok := <-chainSvrChan:
+			if ok {
+				// Start wallet goroutines only when the chain rpc client was created
+				w.Start(chainSvr)
+			}
 		case <-server.quit:
 		}
 	}()
 
+	// Check for unrecoverable errors during chain server connection, and return
+	// the error, if any.
+	err, ok := <-chainSvrErrors
+	if ok {
+		return err
+	}
+
 	// Check for unrecoverable errors during the wallet startup, and return
 	// the error, if any.
-	err, ok := <-walletOpenErrors
+	err, ok = <-walletOpenErrors
 	if ok {
 		return err
 	}


### PR DESCRIPTION
For example, when an invalid CA file is passed:

```
btcwallet --simnet --cafile=abc
```

and the file is not found, `chainSvr` is `nil`, resulting in a panic

```
16:27:51 2014-10-14 [ERR] BTCW: Cannot open CA file: open abc: no such file or directory
16:27:51 2014-10-14 [INF] BTCW: Opened wallet files
panic: runtime error: invalid memory address or nil pointer dereference
        panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x1 pc=0x806cb13]

goroutine 56 [running]:
runtime.panic(0x84ca040, 0x88d2d93)
        /usr/local/go/src/pkg/runtime/panic.c:279 +0xe9
main.func·017()
        /home/tuxcanfly/Work/conformal/src/github.com/conformal/btcwallet/wallet.go:449 +0x33
runtime.panic(0x84ca040, 0x88d2d93)
        /usr/local/go/src/pkg/runtime/panic.c:248 +0x176
main.(*Wallet).syncWithChain(0x193bad80, 0x0, 0x0)
        /home/tuxcanfly/Work/conformal/src/github.com/conformal/btcwallet/wallet.go:464 +0x172
main.func·016()
        /home/tuxcanfly/Work/conformal/src/github.com/conformal/btcwallet/wallet.go:373 +0x30
created by main.(*Wallet).Start
        /home/tuxcanfly/Work/conformal/src/github.com/conformal/btcwallet/wallet.go:377 +0x213
```
