### PR TITLE
Make scrypt parameters overridable/optional when creating the Manager

### DIFF
--- a/waddrmgr/common_test.go
+++ b/waddrmgr/common_test.go
@@ -65,8 +65,3 @@ func hexToBytes(origHex string) []byte {
 	}
 	return buf
 }
-
-func init() {
-	// Tune the scrypt params down for tests so they execute quickly.
-	waddrmgr.TstSetScryptParams(16, 8, 1)
-}

--- a/waddrmgr/internal_test.go
+++ b/waddrmgr/internal_test.go
@@ -23,34 +23,24 @@ interface. The functions are only exported while the tests are being run.
 
 package waddrmgr
 
-import (
-	"github.com/conformal/btcwallet/snacl"
-)
+import "github.com/conformal/btcwallet/snacl"
 
 // TstMaxRecentHashes makes the unexported maxRecentHashes constant available
 // when tests are run.
 var TstMaxRecentHashes = maxRecentHashes
 
-// TstSetScryptParams allows the scrypt parameters to be set to much lower
-// values while the tests are running so they are faster.
-func TstSetScryptParams(n, r, p int) {
-	scryptN = n
-	scryptR = r
-	scryptP = p
-}
-
-// TstReplaceNewSecretKeyFunc replaces the new secret key generation function
-// with a version that intentionally fails.
-func TstReplaceNewSecretKeyFunc() {
+// Replace package newSecretKey function with the given one and calls
+// the callback function. Afterwards the original newSecretKey
+// function will be restored.
+func TstRunWithReplacedCryptoKeyScript(callback func()) {
+	orig := newSecretKey
+	defer func() {
+		newSecretKey = orig
+	}()
 	newSecretKey = func(passphrase *[]byte) (*snacl.SecretKey, error) {
 		return nil, snacl.ErrDecryptFailed
 	}
-}
-
-// TstResetNewSecretKeyFunc resets the new secret key generation function to the
-// original version.
-func TstResetNewSecretKeyFunc() {
-	newSecretKey = defaultNewSecretKey
+	callback()
 }
 
 // TstCheckPublicPassphrase return true if the provided public passphrase is

--- a/waddrmgr/manager_test.go
+++ b/waddrmgr/manager_test.go
@@ -1018,12 +1018,15 @@ func testChangePassphrase(tc *testContext) bool {
 	// generate a new secret key by replacing the generation function one
 	// that intentionally errors.
 	testName := "ChangePassphrase (public) with invalid new secret key"
-	waddrmgr.TstReplaceNewSecretKeyFunc()
-	err := tc.manager.ChangePassphrase(pubPassphrase, pubPassphrase2, false)
+
+	var err error
+
+	waddrmgr.TstRunWithReplacedCryptoKeyScript(func() {
+		err = tc.manager.ChangePassphrase(pubPassphrase, pubPassphrase2, false)
+	})
 	if !checkManagerError(tc.t, testName, err, waddrmgr.ErrCrypto) {
 		return false
 	}
-	waddrmgr.TstResetNewSecretKeyFunc()
 
 	// Attempt to change public passphrase with invalid old passphrase.
 	testName = "ChangePassphrase (public) with invalid old passphrase"
@@ -1438,7 +1441,7 @@ func TestManager(t *testing.T) {
 
 	// Create a new manager.
 	mgr, err := waddrmgr.Create(mgrName, seed, pubPassphrase, privPassphrase,
-		&btcnet.MainNetParams)
+		&btcnet.MainNetParams, waddrmgr.Scrypt(16, 8, 1))
 	if err != nil {
 		t.Errorf("Create: unexpected error: %v", err)
 		return


### PR DESCRIPTION
Here is a proposal for making the scrypt parameters overridable when the Manager is created in the waddrmgr.Create call.

Note that I do not store the scrypt parameters in the Manager structure, since they are only used to create the masterKeyPub and masterKeyPriv keys which persisted in the database. Hence the scrypt parameters are not needed later on.

I've modeled the optional parameter on Dave Cheneys 'Functional Options' pattern: http://dotgo.sourcegraph.com/post/99643162983/dave-cheney-functional-options, with the difference that the parameter function does not work directly on the Manager structure but on an auxiliary options structure.

Also note that the tests can currently not be run in parallel. This is not new, but due to the fact that we store the function to generate keys in the package variable newSecretKey, which is set in Create. For now I am considering that a different issue that should be solved separately.
