### PR TITLE
Make scrypt parameters overridable/optional when creating the Manager

### DIFF
--- a/waddrmgr/common_test.go
+++ b/waddrmgr/common_test.go
@@ -65,8 +65,3 @@ func hexToBytes(origHex string) []byte {
 	}
 	return buf
 }
-
-func init() {
-	// Tune the scrypt params down for tests so they execute quickly.
-	waddrmgr.TstSetScryptParams(16, 8, 1)
-}

--- a/waddrmgr/internal_test.go
+++ b/waddrmgr/internal_test.go
@@ -23,34 +23,24 @@ interface. The functions are only exported while the tests are being run.
 
 package waddrmgr
 
-import (
-	"github.com/conformal/btcwallet/snacl"
-)
+import "github.com/conformal/btcwallet/snacl"
 
 // TstMaxRecentHashes makes the unexported maxRecentHashes constant available
 // when tests are run.
 var TstMaxRecentHashes = maxRecentHashes
 
-// TstSetScryptParams allows the scrypt parameters to be set to much lower
-// values while the tests are running so they are faster.
-func TstSetScryptParams(n, r, p int) {
-	scryptN = n
-	scryptR = r
-	scryptP = p
-}
-
-// TstReplaceNewSecretKeyFunc replaces the new secret key generation function
-// with a version that intentionally fails.
-func TstReplaceNewSecretKeyFunc() {
-	newSecretKey = func(passphrase *[]byte) (*snacl.SecretKey, error) {
+// Replace the Manager.newSecretKey function with the given one and calls
+// the callback function. Afterwards the original newSecretKey
+// function will be restored.
+func TstRunWithReplacedNewSecretKey(callback func()) {
+	orig := newSecretKey
+	defer func() {
+		newSecretKey = orig
+	}()
+	newSecretKey = func(passphrase *[]byte, config *Options) (*snacl.SecretKey, error) {
 		return nil, snacl.ErrDecryptFailed
 	}
-}
-
-// TstResetNewSecretKeyFunc resets the new secret key generation function to the
-// original version.
-func TstResetNewSecretKeyFunc() {
-	newSecretKey = defaultNewSecretKey
+	callback()
 }
 
 // TstCheckPublicPassphrase return true if the provided public passphrase is


### PR DESCRIPTION
Here is a proposal for making the scrypt parameters overridable when the Manager is created in the waddrmgr.Create call.

This removes the package scope variables scryptN, scryptR, scryptP and newSecretKey.

Note that I do not store the scrypt parameters in the Manager structure, but persist them in the database so Load can retrieve them in order to recreate the newSecretKey function on the Manager structure which is needed by the ChangePassphrase function. The scrypt parameters are not needed elsewhere.

I've modeled the optional parameter on Dave Cheneys 'Functional Options' pattern: http://dotgo.sourcegraph.com/post/99643162983/dave-cheney-functional-options, with the difference that the parameter function does not work directly on the Manager structure but on an auxiliary options structure.
