### PR TITLE
Expose functions needed from the voting pool package

### DIFF
--- a/waddrmgr/error.go
+++ b/waddrmgr/error.go
@@ -70,6 +70,10 @@ const (
 	// error.
 	ErrCrypto
 
+	// ErrInvalidKeyType indicates an error where an invalid crypto
+	// key type has been selected.
+	ErrInvalidKeyType
+
 	// ErrNoExist indicates the specified database does not exist.
 	ErrNoExist
 


### PR DESCRIPTION
We are working on moving the voting pool code into a separate package (see https://github.com/larshesel/btcwallet/tree/move-vp-into-own-package), and to that end we need access to a few resources from the waddrmgr package. Currently we have just added these functions to our own tree to make it work: https://github.com/larshesel/btcwallet/blob/move-vp-into-own-package/waddrmgr/votingpool_bridge.go#L9-L19 and https://github.com/larshesel/btcwallet/blob/move-vp-into-own-package/waddrmgr/votingpool_bridge.go#L28-L32.
- Make the cryptoKey\* accessible from outside the Manager to support the voting pool package split.
- Make the newScriptAddress accessible outside the Manager to support the voting pool package split.
