### PR TITLE
Convert waddrmgr to new walletdb package.

### DIFF
--- a/waddrmgr/error.go
+++ b/waddrmgr/error.go
@@ -74,10 +74,10 @@ const (
 	// key type has been selected.
 	ErrInvalidKeyType
 
-	// ErrNoExist indicates the specified database does not exist.
+	// ErrNoExist indicates the manager does not exist.
 	ErrNoExist
 
-	// ErrAlreadyExists indicates the specified database already exists.
+	// ErrAlreadyExists indicates the specified manager already exists.
 	ErrAlreadyExists
 
 	// ErrCoinTypeTooHigh indicates the coin type specified in the provided

--- a/waddrmgr/sync.go
+++ b/waddrmgr/sync.go
@@ -19,6 +19,7 @@ package waddrmgr
 import (
 	"sync"
 
+	"github.com/conformal/btcwallet/walletdb"
 	"github.com/conformal/btcwire"
 )
 
@@ -210,13 +211,13 @@ func (m *Manager) SetSyncedTo(bs *BlockStamp) error {
 	}
 
 	// Update the database.
-	err := m.db.Update(func(tx *managerTx) error {
-		err := tx.PutSyncedTo(bs)
+	err := m.namespace.Update(func(tx walletdb.Tx) error {
+		err := putSyncedTo(tx, bs)
 		if err != nil {
 			return err
 		}
 
-		return tx.PutRecentBlocks(recentHeight, recentHashes)
+		return putRecentBlocks(tx, recentHeight, recentHashes)
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
This pull request converts the waddrmgr package to use the new walletdb package semantics.

Since waddrmgr no longer controls the database, it is unable to make a copy of the database and return it as the old ExportWatchingOnly function required.  As a result, it has been renamed to ConvertToWatchingOnly and it now modifies the namespace provided to it.  The idea is that the caller which does control the database can now make a copy of the database, get the waddrmgr namespace in the database copy and invoke the new function to modify it.  This also works well with other packages that might also need to make modifications for watching-only mode.

In addition, the following changes are made:
- All places that worked with database paths now work with the walletdb.Namespace interface
- The managerTx code is replaced to use the walletdb.Tx interface
- The code which checks if the manager already exists is updated to work with the walletdb.Namespace interface
- The LatestDbVersion constant is now LatestMgrVersion since it no longer controls the database
