### PR TITLE
waddrmgr: Avoid unnecessarily rederiving keys on unlock.

### DIFF
--- a/waddrmgr/manager.go
+++ b/waddrmgr/manager.go
@@ -1226,6 +1226,10 @@ func (m *Manager) Unlock(passphrase []byte) error {
 		}
 		info.managedAddr.privKeyEncrypted = privKeyEncrypted
 		info.managedAddr.privKeyCT = privKeyBytes
+
+		// Avoid re-deriving this key on subsequent unlocks.
+		m.deriveOnUnlock[0] = nil
+		m.deriveOnUnlock = m.deriveOnUnlock[1:]
 	}
 
 	m.locked = false


### PR DESCRIPTION
The slice of keys which must have their private extended keys derived
on unlock was never being removed from and all of these keys were
being rederived unnecessarily on every unlock.  Fix this by re-slicing
the deriveOnUnlock slice to remove the just derived key if the
derivation was successful.