### PR TITLE
Use txscript.StandardVerifyFlags

### DIFF
--- a/createtx.go
+++ b/createtx.go
@@ -415,14 +415,10 @@ func signMsgTx(msgtx *wire.MsgTx, prevOutputs []txstore.Credit, store *keystore.
 }
 
 func validateMsgTx(msgtx *wire.MsgTx, prevOutputs []txstore.Credit) error {
-	flags := txscript.ScriptVerifyDERSignatures | txscript.ScriptStrictMultiSig
-	bip16 := time.Now().After(txscript.Bip16Activation)
-	if bip16 {
-		flags |= txscript.ScriptBip16
-	}
 	for i, txin := range msgtx.TxIn {
 		engine, err := txscript.NewScript(
-			txin.SignatureScript, prevOutputs[i].TxOut().PkScript, i, msgtx, flags)
+			txin.SignatureScript, prevOutputs[i].TxOut().PkScript,
+			i, msgtx, txscript.StandardVerifyFlags)
 		if err != nil {
 			return fmt.Errorf("cannot create script engine: %s", err)
 		}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2841,10 +2841,8 @@ func SignRawTransaction(w *Wallet, chainSvr *chain.Client, icmd btcjson.Cmd) (in
 
 		// Either it was already signed or we just signed it.
 		// Find out if it is completely satisfied or still needs more.
-		flags := txscript.ScriptBip16 | txscript.ScriptVerifyDERSignatures |
-			txscript.ScriptStrictMultiSig
 		engine, err := txscript.NewScript(txIn.SignatureScript, input,
-			i, msgTx, flags)
+			i, msgTx, txscript.StandardVerifyFlags)
 		if err != nil || engine.Execute() != nil {
 			complete = false
 		}


### PR DESCRIPTION
By using txscript.StandardVerifyFlags when creating and validating
transactions, we can ensure the transactions successfully created
will be accepted by btcd.