### PR TITLE
waddrmgr: Make create/update logic more explicit.

### DIFF
--- a/waddrmgr/error.go
+++ b/waddrmgr/error.go
@@ -57,6 +57,11 @@ const (
 	// set to the underlying error returned from the database.
 	ErrDatabase ErrorCode = iota
 
+	// ErrUpgrade indicates the manager needs to be upgraded.  This should
+	// not happen in practice unless the version number has been increased
+	// and there is not yet any code written to upgrade.
+	ErrUpgrade
+
 	// ErrKeyChain indicates an error with the key chain typically either
 	// due to the inability to create an extended key or deriving a child
 	// extended key.  When this error code is set, the Err field of the
@@ -128,6 +133,7 @@ const (
 // Map of ErrorCode values back to their constant names for pretty printing.
 var errorCodeStrings = map[ErrorCode]string{
 	ErrDatabase:          "ErrDatabase",
+	ErrUpgrade:           "ErrUpgrade",
 	ErrKeyChain:          "ErrKeyChain",
 	ErrCrypto:            "ErrCrypto",
 	ErrInvalidKeyType:    "ErrInvalidKeyType",

--- a/waddrmgr/error_test.go
+++ b/waddrmgr/error_test.go
@@ -30,6 +30,7 @@ func TestErrorCodeStringer(t *testing.T) {
 		want string
 	}{
 		{waddrmgr.ErrDatabase, "ErrDatabase"},
+		{waddrmgr.ErrUpgrade, "ErrUpgrade"},
 		{waddrmgr.ErrKeyChain, "ErrKeyChain"},
 		{waddrmgr.ErrCrypto, "ErrCrypto"},
 		{waddrmgr.ErrInvalidKeyType, "ErrInvalidKeyType"},

--- a/waddrmgr/internal_test.go
+++ b/waddrmgr/internal_test.go
@@ -33,6 +33,10 @@ import (
 // when tests are run.
 var TstMaxRecentHashes = maxRecentHashes
 
+// TstLatestMgrVersion makes the unexported latestMgrVersion variable available
+// for change when the tests are run.
+var TstLatestMgrVersion = &latestMgrVersion
+
 // Replace the Manager.newSecretKey function with the given one and calls
 // the callback function. Afterwards the original newSecretKey
 // function will be restored.

--- a/waddrmgr/manager.go
+++ b/waddrmgr/manager.go
@@ -1841,8 +1841,7 @@ func Open(namespace walletdb.Namespace, pubPassphrase []byte, chainParams *chain
 		return nil, managerError(ErrNoExist, str, nil)
 	}
 
-	// Upgrade the manager to the latest version as needed.  This includes
-	// the initial creation.
+	// Upgrade the manager to the latest version as needed.
 	if err := upgradeManager(namespace); err != nil {
 		return nil, err
 	}
@@ -1882,9 +1881,8 @@ func Create(namespace walletdb.Namespace, seed, pubPassphrase, privPassphrase []
 		return nil, managerError(ErrAlreadyExists, errAlreadyExists, nil)
 	}
 
-	// Upgrade the manager to the latest version as needed.  This includes
-	// the initial creation.
-	if err := upgradeManager(namespace); err != nil {
+	// Perform the initial bucket creation and database namespace setup.
+	if err := createManagerNS(namespace); err != nil {
 		return nil, err
 	}
 

--- a/waddrmgr/manager_test.go
+++ b/waddrmgr/manager_test.go
@@ -1508,6 +1508,16 @@ func TestManager(t *testing.T) {
 	})
 	mgr.Close()
 
+	// Ensure the expected error is returned if the latest manager version
+	// constant is bumped without writing code to actually do the upgrade.
+	*waddrmgr.TstLatestMgrVersion++
+	_, err = waddrmgr.Open(mgrNamespace, pubPassphrase,
+		&chaincfg.MainNetParams, fastScrypt)
+	if !checkManagerError(t, "Upgrade needed", err, waddrmgr.ErrUpgrade) {
+		return
+	}
+	*waddrmgr.TstLatestMgrVersion--
+
 	// Open the manager and run all the tests again in open mode which
 	// avoids reinserting new addresses like the create mode tests do.
 	mgr, err = waddrmgr.Open(mgrNamespace, pubPassphrase,


### PR DESCRIPTION
This pull request makes the creation and updating of the address manager more explicit so it's easier to upgrade in the future.

In particular, rather than treating the initial creation as an upgrade by relying on creating the initial buckets on the fly on each load, the code now explicitly provides distinct create and upgrade paths that are invoked from the `Create` and `Open` functions, respectively.

It also adds some commented out sample code to illustrate how upgrades should be done and a check to ensure bumping the version number without writing upgrade code results in a new error, `ErrUpgrade`, being returned.

Finally, a test has been added for the new functionality.