### PR TITLE
Set chain synced on empty rescan

### DIFF
--- a/rescan.go
+++ b/rescan.go
@@ -253,11 +253,6 @@ func (w *Wallet) rescanRPCHandler() {
 // current best block in the main chain, and is considered an initial sync
 // rescan.
 func (w *Wallet) Rescan(addrs []btcutil.Address, unspent []txstore.Credit) error {
-	// Avoid rescan if there is no work to do.
-	if len(addrs) == 0 && len(unspent) == 0 {
-		return nil
-	}
-
 	outpoints := make([]*wire.OutPoint, len(unspent))
 	for i, output := range unspent {
 		outpoints[i] = output.OutPoint()


### PR DESCRIPTION
When an empty rescan is requested, the chain was not being marked as synced and this was preventing syncing afterwards because `w.ChainSynced()` would return `false`