### PR TITLE
votingpool: API to store withdrawal txs in the txstore

### DIFF
--- a/votingpool/error.go
+++ b/votingpool/error.go
@@ -147,6 +147,10 @@ const (
 	// invalid ID.
 	ErrSeriesIDInvalid
 
+	// ErrWithdrawalTxStorage indicates an error when storing withdrawal
+	// transactions.
+	ErrWithdrawalTxStorage
+
 	// lastErr is used for testing, making it possible to iterate over
 	// the error codes in order to check that they all have proper
 	// translations in errorCodeStrings.
@@ -187,6 +191,7 @@ var errorCodeStrings = map[ErrorCode]string{
 	ErrTxSigning:                 "ErrTxSigning",
 	ErrInvalidScriptHash:         "ErrInvalidScriptHash",
 	ErrWithdrawFromUnusedAddr:    "ErrWithdrawFromUnusedAddr",
+	ErrWithdrawalTxStorage:       "ErrWithdrawalTxStorage",
 }
 
 // String returns the ErrorCode as a human-readable name.

--- a/votingpool/error_test.go
+++ b/votingpool/error_test.go
@@ -64,6 +64,7 @@ func TestErrorCodeStringer(t *testing.T) {
 		{vp.ErrTxSigning, "ErrTxSigning"},
 		{vp.ErrInvalidScriptHash, "ErrInvalidScriptHash"},
 		{vp.ErrWithdrawFromUnusedAddr, "ErrWithdrawFromUnusedAddr"},
+		{vp.ErrWithdrawalTxStorage, "ErrWithdrawalTxStorage"},
 		{0xffff, "Unknown ErrorCode (65535)"},
 	}
 


### PR DESCRIPTION
This is not yet used but will be needed for the implementation of the updatewithdrawal API, which will be coming soon.

~~Depends on #234~~