### PR TITLE
StartWithdrawal returns a previously saved WithdrawalStatus in subsequent calls with identical parameters

### DIFF
--- a/votingpool/common_test.go
+++ b/votingpool/common_test.go
@@ -19,6 +19,7 @@ package votingpool
 import (
 	"fmt"
 	"os"
+	"reflect"
 	"runtime"
 	"testing"
 
@@ -61,6 +62,42 @@ func TstRunWithManagerUnlocked(t *testing.T, mgr *waddrmgr.Manager, callback fun
 	}
 	defer mgr.Lock()
 	callback()
+}
+
+// TstCheckWithdrawalStatusMatches compares s1 and s2 using reflect.DeepEqual
+// and calls t.Fatal() if they're not identical.
+func TstCheckWithdrawalStatusMatches(t *testing.T, s1, s2 WithdrawalStatus) {
+	if s1.Fees() != s2.Fees() {
+		t.Fatalf("Wrong amount of network fees; want %d, got %d", s1.Fees(), s2.Fees())
+	}
+
+	if !reflect.DeepEqual(s1.Sigs(), s2.Sigs()) {
+		t.Fatalf("Wrong tx signatures; got %x, want %x", s1.Sigs(), s2.Sigs())
+	}
+
+	if !reflect.DeepEqual(s1.NextInputAddr(), s2.NextInputAddr()) {
+		t.Fatalf("Wrong NextInputAddr; got %v, want %v", s1.NextInputAddr(), s2.NextInputAddr())
+	}
+
+	if !reflect.DeepEqual(s1.NextChangeAddr(), s2.NextChangeAddr()) {
+		t.Fatalf("Wrong NextChangeAddr; got %v, want %v", s1.NextChangeAddr(), s2.NextChangeAddr())
+	}
+
+	if !reflect.DeepEqual(s1.Outputs(), s2.Outputs()) {
+		t.Fatalf("Wrong WithdrawalOutputs; got %v, want %v", s1.Outputs(), s2.Outputs())
+	}
+
+	if !reflect.DeepEqual(s1.transactions, s2.transactions) {
+		t.Fatalf("Wrong transactions; got %v, want %v", s1.transactions, s2.transactions)
+	}
+
+	// The above checks could be replaced by this one, but when they fail the
+	// failure msg wouldn't give us much clue as to what is not equal, so we do
+	// the individual checks above and use this one as a catch-all check in case
+	// we forget to check any of the individual fields.
+	if !reflect.DeepEqual(s1, s2) {
+		t.Fatalf("Wrong WithdrawalStatus; got %v, want %v", s1, s2)
+	}
 }
 
 // replaceCalculateTxFee replaces the calculateTxFee func with the given one

--- a/votingpool/db.go
+++ b/votingpool/db.go
@@ -19,8 +19,12 @@ package votingpool
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/gob"
 	"fmt"
 
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcwallet/snacl"
 	"github.com/btcsuite/btcwallet/walletdb"
 )
@@ -43,8 +47,9 @@ const (
 )
 
 var (
-	usedAddrsBucketName = []byte("usedaddrs")
-	seriesBucketName    = []byte("series")
+	usedAddrsBucketName   = []byte("usedaddrs")
+	seriesBucketName      = []byte("series")
+	withdrawalsBucketName = []byte("withdrawals")
 	// string representing a non-existent private key
 	seriesNullPrivKey = [seriesKeyLength]byte{}
 )
@@ -55,6 +60,61 @@ type dbSeriesRow struct {
 	reqSigs           uint32
 	pubKeysEncrypted  [][]byte
 	privKeysEncrypted [][]byte
+}
+
+type dbWithdrawalRow struct {
+	Requests      []dbOutputRequest
+	StartAddress  dbWithdrawalAddress
+	ChangeStart   dbChangeAddress
+	LastSeriesID  uint32
+	DustThreshold btcutil.Amount
+	Status        dbWithdrawalStatus
+}
+
+type dbWithdrawalAddress struct {
+	SeriesID uint32
+	Branch   Branch
+	Index    Index
+}
+
+type dbChangeAddress struct {
+	SeriesID uint32
+	Index    Index
+}
+
+type dbOutputRequest struct {
+	Addr        string
+	Amount      btcutil.Amount
+	Server      string
+	Transaction uint32
+}
+
+type dbWithdrawalOutput struct {
+	// We store the OutBailmentID here as we need a way to look up the
+	// corresponding dbOutputRequest in dbWithdrawalRow when deserializing.
+	OutBailmentID OutBailmentID
+	Status        outputStatus
+	Outpoints     []dbOutBailmentOutpoint
+}
+
+type dbOutBailmentOutpoint struct {
+	Ntxid  Ntxid
+	Index  uint32
+	Amount btcutil.Amount
+}
+
+type dbChangeAwareTx struct {
+	SerializedMsgTx []byte
+	ChangeIdx       int32
+}
+
+type dbWithdrawalStatus struct {
+	NextInputAddr  dbWithdrawalAddress
+	NextChangeAddr dbChangeAddress
+	Fees           btcutil.Amount
+	Outputs        map[OutBailmentID]dbWithdrawalOutput
+	Sigs           map[Ntxid]TxSigs
+	Transactions   map[Ntxid]dbChangeAwareTx
 }
 
 // getUsedAddrBucketID returns the used addresses bucket ID for the given series
@@ -139,6 +199,11 @@ func putPool(tx walletdb.Tx, poolID []byte) error {
 	if err != nil {
 		return newError(ErrDatabase, fmt.Sprintf("cannot create used addrs bucket for pool %v",
 			poolID), err)
+	}
+	_, err = poolBucket.CreateBucket(withdrawalsBucketName)
+	if err != nil {
+		return newError(
+			ErrDatabase, fmt.Sprintf("cannot create withdrawals bucket for pool %v", poolID), err)
 	}
 	return nil
 }
@@ -337,6 +402,188 @@ func serializeSeriesRow(row *dbSeriesRow) ([]byte, error) {
 		}
 	}
 	return serialized, nil
+}
+
+// serializeWithdrawal constructs a dbWithdrawalRow and serializes it (using
+// encoding/gob) so that it can be stored in the DB.
+func serializeWithdrawal(requests []OutputRequest, startAddress WithdrawalAddress,
+	lastSeriesID uint32, changeStart ChangeAddress, dustThreshold btcutil.Amount,
+	status WithdrawalStatus) ([]byte, error) {
+
+	dbStartAddr := dbWithdrawalAddress{
+		SeriesID: startAddress.SeriesID(),
+		Branch:   startAddress.Branch(),
+		Index:    startAddress.Index(),
+	}
+	dbChangeStart := dbChangeAddress{
+		SeriesID: startAddress.SeriesID(),
+		Index:    startAddress.Index(),
+	}
+	dbRequests := make([]dbOutputRequest, len(requests))
+	for i, request := range requests {
+		dbRequests[i] = dbOutputRequest{
+			Addr:        request.Address.EncodeAddress(),
+			Amount:      request.Amount,
+			Server:      request.Server,
+			Transaction: request.Transaction,
+		}
+	}
+	dbOutputs := make(map[OutBailmentID]dbWithdrawalOutput, len(status.outputs))
+	for oid, output := range status.outputs {
+		dbOutpoints := make([]dbOutBailmentOutpoint, len(output.outpoints))
+		for i, outpoint := range output.outpoints {
+			dbOutpoints[i] = dbOutBailmentOutpoint{
+				Ntxid:  outpoint.ntxid,
+				Index:  outpoint.index,
+				Amount: outpoint.amount,
+			}
+		}
+		dbOutputs[oid] = dbWithdrawalOutput{
+			OutBailmentID: output.request.outBailmentID(),
+			Status:        output.status,
+			Outpoints:     dbOutpoints,
+		}
+	}
+	dbTransactions := make(map[Ntxid]dbChangeAwareTx, len(status.transactions))
+	for ntxid, tx := range status.transactions {
+		var buf bytes.Buffer
+		buf.Grow(tx.SerializeSize())
+		if err := tx.Serialize(&buf); err != nil {
+			return nil, err
+		}
+		dbTransactions[ntxid] = dbChangeAwareTx{
+			SerializedMsgTx: buf.Bytes(),
+			ChangeIdx:       tx.changeIdx,
+		}
+	}
+	nextChange := status.nextChangeAddr
+	dbStatus := dbWithdrawalStatus{
+		NextChangeAddr: dbChangeAddress{
+			SeriesID: nextChange.seriesID,
+			Index:    nextChange.index,
+		},
+		Fees:         status.fees,
+		Outputs:      dbOutputs,
+		Sigs:         status.sigs,
+		Transactions: dbTransactions,
+	}
+	row := dbWithdrawalRow{
+		Requests:      dbRequests,
+		StartAddress:  dbStartAddr,
+		LastSeriesID:  lastSeriesID,
+		ChangeStart:   dbChangeStart,
+		DustThreshold: dustThreshold,
+		Status:        dbStatus,
+	}
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(row); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// deserializeWithdrawal deserializes the given byte slice into a dbWithdrawalRow,
+// converts it into an withdrawalInfo and returns it. This function must run
+// with the address manager unlocked.
+func deserializeWithdrawal(p *Pool, serialized []byte) (*withdrawalInfo, error) {
+	var row dbWithdrawalRow
+	if err := gob.NewDecoder(bytes.NewReader(serialized)).Decode(&row); err != nil {
+		return nil, newError(ErrWithdrawalStorage, "cannot deserialize withdrawal information",
+			err)
+	}
+	wInfo := &withdrawalInfo{
+		lastSeriesID:  row.LastSeriesID,
+		dustThreshold: row.DustThreshold,
+	}
+	chainParams := p.Manager().ChainParams()
+	wInfo.requests = make([]OutputRequest, len(row.Requests))
+	// A map of requests indexed by OutBailmentID; needed to populate
+	// WithdrawalStatus.Outputs later on.
+	requestsByOID := make(map[OutBailmentID]OutputRequest)
+	for i, req := range row.Requests {
+		addr, err := btcutil.DecodeAddress(req.Addr, chainParams)
+		if err != nil {
+			return nil, newError(ErrWithdrawalStorage,
+				"cannot deserialize addr for requested output", err)
+		}
+		pkScript, err := txscript.PayToAddrScript(addr)
+		if err != nil {
+			return nil, newError(ErrWithdrawalStorage, "invalid addr for requested output", err)
+		}
+		request := OutputRequest{
+			Address:     addr,
+			Amount:      req.Amount,
+			PkScript:    pkScript,
+			Server:      req.Server,
+			Transaction: req.Transaction,
+		}
+		wInfo.requests[i] = request
+		requestsByOID[request.outBailmentID()] = request
+	}
+	startAddr := row.StartAddress
+	wAddr, err := p.WithdrawalAddress(startAddr.SeriesID, startAddr.Branch, startAddr.Index)
+	if err != nil {
+		return nil, newError(ErrWithdrawalStorage, "cannot deserialize startAddress", err)
+	}
+	wInfo.startAddress = *wAddr
+
+	cAddr, err := p.ChangeAddress(row.ChangeStart.SeriesID, row.ChangeStart.Index)
+	if err != nil {
+		return nil, newError(ErrWithdrawalStorage, "cannot deserialize changeStart", err)
+	}
+	wInfo.changeStart = *cAddr
+
+	// TODO: Copy over row.Status.nextInputAddr. Not done because StartWithdrawal
+	// does not update that yet.
+	nextChangeAddr := row.Status.NextChangeAddr
+	cAddr, err = p.ChangeAddress(nextChangeAddr.SeriesID, nextChangeAddr.Index)
+	if err != nil {
+		return nil, newError(ErrWithdrawalStorage,
+			"cannot deserialize nextChangeAddress for withdrawal", err)
+	}
+	wInfo.status = WithdrawalStatus{
+		nextChangeAddr: *cAddr,
+		fees:           row.Status.Fees,
+		outputs:        make(map[OutBailmentID]*WithdrawalOutput, len(row.Status.Outputs)),
+		sigs:           row.Status.Sigs,
+		transactions:   make(map[Ntxid]changeAwareTx, len(row.Status.Transactions)),
+	}
+	for oid, output := range row.Status.Outputs {
+		outpoints := make([]OutBailmentOutpoint, len(output.Outpoints))
+		for i, outpoint := range output.Outpoints {
+			outpoints[i] = OutBailmentOutpoint{
+				ntxid:  outpoint.Ntxid,
+				index:  outpoint.Index,
+				amount: outpoint.Amount,
+			}
+		}
+		wInfo.status.outputs[oid] = &WithdrawalOutput{
+			request:   requestsByOID[output.OutBailmentID],
+			status:    output.Status,
+			outpoints: outpoints,
+		}
+	}
+	for ntxid, tx := range row.Status.Transactions {
+		msgtx := wire.NewMsgTx()
+		if err := msgtx.Deserialize(bytes.NewBuffer(tx.SerializedMsgTx)); err != nil {
+			return nil, newError(ErrWithdrawalStorage, "cannot deserialize transaction", err)
+		}
+		wInfo.status.transactions[ntxid] = changeAwareTx{
+			MsgTx:     msgtx,
+			changeIdx: tx.ChangeIdx,
+		}
+	}
+	return wInfo, nil
+}
+
+func putWithdrawal(tx walletdb.Tx, poolID []byte, roundID uint32, serialized []byte) error {
+	bucket := tx.RootBucket().Bucket(poolID)
+	return bucket.Put(uint32ToBytes(roundID), serialized)
+}
+
+func getWithdrawal(tx walletdb.Tx, poolID []byte, roundID uint32) []byte {
+	bucket := tx.RootBucket().Bucket(poolID)
+	return bucket.Get(uint32ToBytes(roundID))
 }
 
 // uint32ToBytes converts a 32 bit unsigned integer into a 4-byte slice in

--- a/votingpool/db_wb_test.go
+++ b/votingpool/db_wb_test.go
@@ -18,6 +18,7 @@ package votingpool
 
 import (
 	"bytes"
+	"reflect"
 	"testing"
 
 	"github.com/btcsuite/btcwallet/walletdb"
@@ -78,5 +79,79 @@ func TestGetMaxUsedIdx(t *testing.T) {
 		})
 	if maxIdx != Index(3001) {
 		t.Fatalf("Wrong max idx; got %d, want %d", maxIdx, Index(3001))
+	}
+}
+
+func TestWithdrawalSerialization(t *testing.T) {
+	tearDown, _, pool := TstCreatePool(t)
+	defer tearDown()
+
+	roundID := uint32(0)
+	wi := createAndFulfillWithdrawalRequests(t, pool, roundID)
+
+	serialized, err := serializeWithdrawal(wi.requests, wi.startAddress, wi.lastSeriesID,
+		wi.changeStart, wi.dustThreshold, wi.status)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var wInfo *withdrawalInfo
+	TstRunWithManagerUnlocked(t, pool.Manager(), func() {
+		wInfo, err = deserializeWithdrawal(pool, serialized)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if !reflect.DeepEqual(wInfo.startAddress, wi.startAddress) {
+		t.Fatalf("Wrong startAddr; got %v, want %v", wInfo.startAddress, wi.startAddress)
+	}
+
+	if !reflect.DeepEqual(wInfo.changeStart, wi.changeStart) {
+		t.Fatalf("Wrong changeStart; got %v, want %v", wInfo.changeStart, wi.changeStart)
+	}
+
+	if wInfo.lastSeriesID != wi.lastSeriesID {
+		t.Fatalf("Wrong LastSeriesID; got %d, want %d", wInfo.lastSeriesID, wi.lastSeriesID)
+	}
+
+	if wInfo.dustThreshold != wi.dustThreshold {
+		t.Fatalf("Wrong DustThreshold; got %d, want %d", wInfo.dustThreshold, wi.dustThreshold)
+	}
+
+	if !reflect.DeepEqual(wInfo.requests, wi.requests) {
+		t.Fatalf("Wrong output requests; got %v, want %v", wInfo.requests, wi.requests)
+	}
+
+	TstCheckWithdrawalStatusMatches(t, wInfo.status, wi.status)
+}
+
+func TestPutAndGetWithdrawal(t *testing.T) {
+	tearDown, _, pool := TstCreatePool(t)
+	defer tearDown()
+
+	serialized := bytes.Repeat([]byte{1}, 10)
+	poolID := []byte{0x00}
+	roundID := uint32(0)
+	err := pool.namespace.Update(
+		func(tx walletdb.Tx) error {
+			return putWithdrawal(tx, poolID, roundID, serialized)
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var retrieved []byte
+	err = pool.namespace.View(
+		func(tx walletdb.Tx) error {
+			retrieved = getWithdrawal(tx, poolID, roundID)
+			return nil
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(retrieved, serialized) {
+		t.Fatalf("Wrong value retrieved from DB; got %x, want %x", retrieved, serialized)
 	}
 }

--- a/votingpool/error.go
+++ b/votingpool/error.go
@@ -151,6 +151,10 @@ const (
 	// transactions.
 	ErrWithdrawalTxStorage
 
+	// ErrWithdrawalStorage indicates an error occurred when serializing or
+	// deserializing withdrawal information.
+	ErrWithdrawalStorage
+
 	// lastErr is used for testing, making it possible to iterate over
 	// the error codes in order to check that they all have proper
 	// translations in errorCodeStrings.
@@ -192,6 +196,7 @@ var errorCodeStrings = map[ErrorCode]string{
 	ErrInvalidScriptHash:         "ErrInvalidScriptHash",
 	ErrWithdrawFromUnusedAddr:    "ErrWithdrawFromUnusedAddr",
 	ErrWithdrawalTxStorage:       "ErrWithdrawalTxStorage",
+	ErrWithdrawalStorage:         "ErrWithdrawalStorage",
 }
 
 // String returns the ErrorCode as a human-readable name.

--- a/votingpool/error_test.go
+++ b/votingpool/error_test.go
@@ -65,6 +65,7 @@ func TestErrorCodeStringer(t *testing.T) {
 		{vp.ErrInvalidScriptHash, "ErrInvalidScriptHash"},
 		{vp.ErrWithdrawFromUnusedAddr, "ErrWithdrawFromUnusedAddr"},
 		{vp.ErrWithdrawalTxStorage, "ErrWithdrawalTxStorage"},
+		{vp.ErrWithdrawalStorage, "ErrWithdrawalStorage"},
 		{0xffff, "Unknown ErrorCode (65535)"},
 	}
 

--- a/votingpool/internal_test.go
+++ b/votingpool/internal_test.go
@@ -96,7 +96,8 @@ func (vp *Pool) TstDecryptExtendedKey(keyType waddrmgr.CryptoKeyType, encrypted 
 	return vp.decryptExtendedKey(keyType, encrypted)
 }
 
-// TstGetMsgTx returns the withdrawal transaction with the given ntxid.
+// TstGetMsgTx returns a copy of the withdrawal transaction with the given
+// ntxid.
 func (s *WithdrawalStatus) TstGetMsgTx(ntxid Ntxid) *wire.MsgTx {
-	return s.transactions[ntxid].MsgTx
+	return s.transactions[ntxid].MsgTx.Copy()
 }

--- a/votingpool/withdrawal_test.go
+++ b/votingpool/withdrawal_test.go
@@ -96,6 +96,18 @@ func TestStartWithdrawal(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
+
+	// Any subsequent StartWithdrawal() calls with the same parameters will
+	// return the previously stored WithdrawalStatus.
+	var status2 *vp.WithdrawalStatus
+	vp.TstRunWithManagerUnlocked(t, mgr, func() {
+		status2, err = pool.StartWithdrawal(0, requests, *startAddr, lastSeriesID, *changeStart,
+			store, currentBlock, dustThreshold)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	vp.TstCheckWithdrawalStatusMatches(t, *status, *status2)
 }
 
 func checkWithdrawalOutputs(


### PR DESCRIPTION
StartWithdrawal now persists the WithdrawalStatus before returning, and also returns a previously saved one in subsequent calls with the same parameters.

The data structures we need to persist are slightly complex so I decided to use encoding/gob to serialize them. The performance loss from using that over manual serialization should not be a problem as multiple output requests from users are batched into a single startwithdrawal