### PR TITLE
Change the stack semantics in withdrawal.eligibleInputs

### DIFF
--- a/votingpool/input_selection.go
+++ b/votingpool/input_selection.go
@@ -96,7 +96,8 @@ func (c byAddress) Less(i, j int) bool {
 }
 
 // getEligibleInputs returns eligible inputs with addresses between startAddress
-// and the last used address of lastSeriesID.
+// and the last used address of lastSeriesID. They're reverse ordered based on
+// their address.
 func (p *Pool) getEligibleInputs(store *wtxmgr.Store, startAddress WithdrawalAddress,
 	lastSeriesID uint32, dustThreshold btcutil.Amount, chainHeight int32,
 	minConf int) ([]credit, error) {
@@ -125,8 +126,6 @@ func (p *Pool) getEligibleInputs(store *wtxmgr.Store, startAddress WithdrawalAdd
 					eligibles = append(eligibles, candidate)
 				}
 			}
-			// Make sure the eligibles are correctly sorted.
-			sort.Sort(byAddress(eligibles))
 			inputs = append(inputs, eligibles...)
 		}
 		nAddr, err := nextAddr(p, address.seriesID, address.branch, address.index, lastSeriesID+1)
@@ -138,6 +137,7 @@ func (p *Pool) getEligibleInputs(store *wtxmgr.Store, startAddress WithdrawalAdd
 		}
 		address = *nAddr
 	}
+	sort.Sort(sort.Reverse(byAddress(inputs)))
 	return inputs, nil
 }
 

--- a/votingpool/input_selection_wb_test.go
+++ b/votingpool/input_selection_wb_test.go
@@ -74,8 +74,8 @@ func TestGetEligibleInputs(t *testing.T) {
 			len(eligibles), expNoEligibleInputs)
 	}
 
-	// Check that the returned eligibles are sorted by address.
-	if !sort.IsSorted(byAddress(eligibles)) {
+	// Check that the returned eligibles are reverse sorted by address.
+	if !sort.IsSorted(sort.Reverse(byAddress(eligibles))) {
 		t.Fatal("Eligible inputs are not sorted.")
 	}
 

--- a/votingpool/withdrawal.go
+++ b/votingpool/withdrawal.go
@@ -482,17 +482,14 @@ func (w *withdrawal) pushRequest(request OutputRequest) {
 // popInput removes and returns the first input from the stack of eligible
 // inputs.
 func (w *withdrawal) popInput() credit {
-	input := w.eligibleInputs[0]
-	w.eligibleInputs = w.eligibleInputs[1:]
+	input := w.eligibleInputs[len(w.eligibleInputs)-1]
+	w.eligibleInputs = w.eligibleInputs[:len(w.eligibleInputs)-1]
 	return input
 }
 
 // pushInput adds a new input to the top of the stack of eligible inputs.
-// TODO: Reverse the stack semantics here as the current one generates a lot of
-// extra garbage since it always creates a new single-element slice and append
-// the rest of the items to it.
 func (w *withdrawal) pushInput(input credit) {
-	w.eligibleInputs = append([]credit{input}, w.eligibleInputs...)
+	w.eligibleInputs = append(w.eligibleInputs, input)
 }
 
 // If this returns it means we have added an output and the necessary inputs to fulfil that


### PR DESCRIPTION
I decided not to change the byAddress sorting and instead simply reverse
sort the inputs in getEligibleInputs().