### PR TITLE
Stop mocking global func() variables in votingpool tests

### DIFF
--- a/votingpool/common_test.go
+++ b/votingpool/common_test.go
@@ -108,14 +108,6 @@ func replaceCalculateTxFee(f func(*withdrawalTx) btcutil.Amount) func() {
 	return func() { calculateTxFee = orig }
 }
 
-// replaceIsTxTooBig replaces the isTxTooBig func with the given one
-// and returns a function that restores it to the original one.
-func replaceIsTxTooBig(f func(*withdrawalTx) bool) func() {
-	orig := isTxTooBig
-	isTxTooBig = f
-	return func() { isTxTooBig = orig }
-}
-
 // replaceCalculateTxSize replaces the calculateTxSize func with the given one
 // and returns a function that restores it to the original one.
 func replaceCalculateTxSize(f func(*withdrawalTx) int) func() {

--- a/votingpool/common_test.go
+++ b/votingpool/common_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btclog"
-	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 )
 
@@ -98,20 +97,4 @@ func TstCheckWithdrawalStatusMatches(t *testing.T, s1, s2 WithdrawalStatus) {
 	if !reflect.DeepEqual(s1, s2) {
 		t.Fatalf("Wrong WithdrawalStatus; got %v, want %v", s1, s2)
 	}
-}
-
-// replaceCalculateTxFee replaces the calculateTxFee func with the given one
-// and returns a function that restores it to the original one.
-func replaceCalculateTxFee(f func(*withdrawalTx) btcutil.Amount) func() {
-	orig := calculateTxFee
-	calculateTxFee = f
-	return func() { calculateTxFee = orig }
-}
-
-// replaceCalculateTxSize replaces the calculateTxSize func with the given one
-// and returns a function that restores it to the original one.
-func replaceCalculateTxSize(f func(*withdrawalTx) int) func() {
-	orig := calculateTxSize
-	calculateTxSize = f
-	return func() { calculateTxSize = orig }
 }

--- a/votingpool/factory_test.go
+++ b/votingpool/factory_test.go
@@ -54,7 +54,7 @@ func getUniqueID() uint32 {
 // createWithdrawalTx creates a withdrawalTx with the given input and output amounts.
 func createWithdrawalTx(t *testing.T, pool *Pool, inputAmounts []int64, outputAmounts []int64) *withdrawalTx {
 	net := pool.Manager().ChainParams()
-	tx := newWithdrawalTx()
+	tx := newWithdrawalTx(defaultTxOptions)
 	_, credits := TstCreateCreditsOnNewSeries(t, pool, inputAmounts)
 	for _, c := range credits {
 		tx.addInput(c)
@@ -418,8 +418,8 @@ func TstNewChangeAddress(t *testing.T, p *Pool, seriesID uint32, idx Index) (add
 	return addr
 }
 
-func TstConstantFee(fee btcutil.Amount) func(tx *withdrawalTx) btcutil.Amount {
-	return func(tx *withdrawalTx) btcutil.Amount { return fee }
+func TstConstantFee(fee btcutil.Amount) func() btcutil.Amount {
+	return func() btcutil.Amount { return fee }
 }
 
 func createAndFulfillWithdrawalRequests(t *testing.T, pool *Pool, roundID uint32) withdrawalInfo {


### PR DESCRIPTION
Doing that may cause erratic test failures when we run them in parallel, so
move the functions the tests need to mock as struct fields that are not
shared across tests.