### PR TITLE
CurrentAddress - mark first address used and return new address

### DIFF
--- a/waddrmgr/address.go
+++ b/waddrmgr/address.go
@@ -53,7 +53,7 @@ type ManagedAddress interface {
 	Compressed() bool
 
 	// Used returns true if the backing address has been used in a transaction.
-	Used() bool
+	Used() (bool, error)
 }
 
 // ManagedPubKeyAddress extends ManagedAddress and additionally provides the
@@ -191,8 +191,8 @@ func (a *managedAddress) Compressed() bool {
 // Used returns true if the address has been used in a transaction.
 //
 // This is part of the ManagedAddress interface implementation.
-func (a *managedAddress) Used() bool {
-	return a.used
+func (a *managedAddress) Used() (bool, error) {
+	return a.manager.fetchUsed(a.AddrHash())
 }
 
 // PubKey returns the public key associated with the address.
@@ -456,8 +456,8 @@ func (a *scriptAddress) Compressed() bool {
 // Used returns true if the address has been used in a transaction.
 //
 // This is part of the ManagedAddress interface implementation.
-func (a *scriptAddress) Used() bool {
-	return a.used
+func (a *scriptAddress) Used() (bool, error) {
+	return a.manager.fetchUsed(a.AddrHash())
 }
 
 // Script returns the script associated with the address.
@@ -484,7 +484,7 @@ func (a *scriptAddress) Script() ([]byte, error) {
 }
 
 // newScriptAddress initializes and returns a new pay-to-script-hash address.
-func newScriptAddress(m *Manager, account uint32, scriptHash, scriptEncrypted []byte, used bool) (*scriptAddress, error) {
+func newScriptAddress(m *Manager, account uint32, scriptHash, scriptEncrypted []byte) (*scriptAddress, error) {
 	address, err := btcutil.NewAddressScriptHashFromHash(scriptHash,
 		m.chainParams)
 	if err != nil {
@@ -496,6 +496,5 @@ func newScriptAddress(m *Manager, account uint32, scriptHash, scriptEncrypted []
 		account:         account,
 		address:         address,
 		scriptEncrypted: scriptEncrypted,
-		used:            used,
 	}, nil
 }

--- a/waddrmgr/manager_test.go
+++ b/waddrmgr/manager_test.go
@@ -1028,28 +1028,37 @@ func testMarkUsed(tc *testContext) bool {
 	addrHash := expectedAddr1.addressHash
 	addr, err := btcutil.NewAddressPubKeyHash(addrHash, chainParams)
 
-	if tc.create {
-		// Test that initially the address is not flagged as used
-		maddr, err := tc.manager.Address(addr)
-		if err != nil {
-			tc.t.Errorf("%s: unexpected error: %v", prefix, err)
-		}
-		if maddr.Used() != false {
-			tc.t.Errorf("%v: unexpected used flag -- got "+
-				"%v, want %v", prefix, maddr.Used(), expectedAddr1.used)
-		}
-	}
-	err = tc.manager.MarkUsed(addrHash)
-	if err != nil {
-		tc.t.Errorf("%s: unexpected error: %v", prefix, err)
-	}
 	maddr, err := tc.manager.Address(addr)
 	if err != nil {
 		tc.t.Errorf("%s: unexpected error: %v", prefix, err)
+		return false
 	}
-	if maddr.Used() != expectedAddr1.used {
+	if tc.create {
+		// Test that initially the address is not flagged as used
+		used, err := maddr.Used()
+		if err != nil {
+			tc.t.Errorf("%s: unexpected error: %v", prefix, err)
+			return false
+		}
+		if used != false {
+			tc.t.Errorf("%v: unexpected used flag -- got "+
+				"%v, want %v", prefix, used, expectedAddr1.used)
+			return false
+		}
+	}
+	err = tc.manager.MarkUsed(addr)
+	if err != nil {
+		tc.t.Errorf("%s: unexpected error: %v", prefix, err)
+		return false
+	}
+	used, err := maddr.Used()
+	if err != nil {
+		tc.t.Errorf("%s: unexpected error: %v", prefix, err)
+		return false
+	}
+	if used != expectedAddr1.used {
 		tc.t.Errorf("%v: unexpected used flag -- got "+
-			"%v, want %v", prefix, maddr.Used(), expectedAddr1.used)
+			"%v, want %v", prefix, used, expectedAddr1.used)
 	}
 	return true
 }


### PR DESCRIPTION
Fixed `Last(In/Ex)ternalAddress` to make sure `CurrentAddress` returns a new address when the first and subsequent addresses are flagged as used. 