### PR TITLE
Only use the empty string as the default account name.

### DIFF
--- a/waddrmgr/db.go
+++ b/waddrmgr/db.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	// LatestMgrVersion is the most recent manager version.
-	LatestMgrVersion = 3
+	LatestMgrVersion = 4
 )
 
 var (
@@ -1661,7 +1661,7 @@ func upgradeToVersion2(namespace walletdb.Namespace) error {
 
 // upgradeManager upgrades the data in the provided manager namespace to newer
 // versions as neeeded.
-func upgradeManager(namespace walletdb.Namespace, pubPassPhrase []byte, config *Options) error {
+func upgradeManager(namespace walletdb.Namespace, pubPassPhrase []byte, chainParams *chaincfg.Params, config *Options) error {
 	var version uint32
 	err := namespace.View(func(tx walletdb.Tx) error {
 		var err error
@@ -1728,12 +1728,21 @@ func upgradeManager(namespace walletdb.Namespace, pubPassPhrase []byte, config *
 			return err
 		}
 		// Upgrade from version 2 to 3.
-		if err := upgradeToVersion3(namespace, seed, privPassPhrase, pubPassPhrase); err != nil {
+		if err := upgradeToVersion3(namespace, seed, privPassPhrase, pubPassPhrase, chainParams); err != nil {
 			return err
 		}
 
 		// The manager is now at version 3.
 		version = 3
+	}
+
+	if version < 4 {
+		if err := upgradeToVersion4(namespace, pubPassPhrase); err != nil {
+			return err
+		}
+
+		// The manager is now at version 4.
+		version = 4
 	}
 
 	// Ensure the manager is upraded to the latest version.  This check is
@@ -1754,12 +1763,12 @@ func upgradeManager(namespace walletdb.Namespace, pubPassPhrase []byte, config *
 // * acctNameIdxBucketName
 // * acctIDIdxBucketName
 // * metaBucketName
-func upgradeToVersion3(namespace walletdb.Namespace, seed, privPassPhrase, pubPassPhrase []byte) error {
+func upgradeToVersion3(namespace walletdb.Namespace, seed, privPassPhrase, pubPassPhrase []byte, chainParams *chaincfg.Params) error {
 	err := namespace.Update(func(tx walletdb.Tx) error {
 		currentMgrVersion := uint32(3)
 		rootBucket := tx.RootBucket()
 
-		woMgr, err := loadManager(namespace, pubPassPhrase, &chaincfg.SimNetParams, nil)
+		woMgr, err := loadManager(namespace, pubPassPhrase, chainParams, nil)
 		if err != nil {
 			return err
 		}
@@ -1778,7 +1787,7 @@ func upgradeToVersion3(namespace walletdb.Namespace, seed, privPassPhrase, pubPa
 		}
 
 		// Derive the cointype key according to BIP0044.
-		coinTypeKeyPriv, err := deriveCoinTypeKey(root, chaincfg.SimNetParams.HDCoinType)
+		coinTypeKeyPriv, err := deriveCoinTypeKey(root, chainParams.HDCoinType)
 		if err != nil {
 			str := "failed to derive cointype extended key"
 			return managerError(ErrKeyChain, str, err)
@@ -1832,11 +1841,14 @@ func upgradeToVersion3(namespace walletdb.Namespace, seed, privPassPhrase, pubPa
 			return err
 		}
 
+		// Use the default account name prior to version 4.
+		const defaultAccountName = "default"
+
 		// Update default account indexes
-		if err := putAccountIDIndex(tx, DefaultAccountNum, DefaultAccountName); err != nil {
+		if err := putAccountIDIndex(tx, DefaultAccountNum, defaultAccountName); err != nil {
 			return err
 		}
-		if err := putAccountNameIndex(tx, DefaultAccountNum, DefaultAccountName); err != nil {
+		if err := putAccountNameIndex(tx, DefaultAccountNum, defaultAccountName); err != nil {
 			return err
 		}
 		// Update imported account indexes
@@ -1854,6 +1866,122 @@ func upgradeToVersion3(namespace walletdb.Namespace, seed, privPassPhrase, pubPa
 
 		// Save "" alias for default account name for backward compat
 		return putAccountNameIndex(tx, DefaultAccountNum, "")
+	})
+	if err != nil {
+		return maybeConvertDbError(err)
+	}
+	return nil
+}
+
+// upgradeToVersion4 upgrades the database from version 3 to version 4.
+// The default account is now only named by the empty string and the old
+// "default" name is no longer used.
+func upgradeToVersion4(namespace walletdb.Namespace, pubPassPhrase []byte) error {
+	err := namespace.Update(func(tx walletdb.Tx) error {
+		// Write new manager version.
+		err := putManagerVersion(tx, 4)
+		if err != nil {
+			return err
+		}
+
+		acctInfoIface, err := fetchAccountInfo(tx, DefaultAccountNum)
+		if err != nil {
+			return err
+		}
+		acctInfo, ok := acctInfoIface.(*dbBIP0044AccountRow)
+		if !ok {
+			str := fmt.Sprintf("unsupported account type %T", acctInfoIface)
+			return managerError(ErrDatabase, str, nil)
+		}
+
+		// Rewrite the default account with the new account name.
+		// Avoid using the global default account name constant here in
+		// case it is ever changed again in a later upgrade.
+		err = putAccountInfo(tx, DefaultAccountNum,
+			acctInfo.pubKeyEncrypted, acctInfo.privKeyEncrypted,
+			acctInfo.nextExternalIndex, acctInfo.nextInternalIndex,
+			"")
+		if err != nil {
+			return err
+		}
+
+		// Delete any non-zero length names for the default account.
+		// This includes the "default" name if it still exists, as well
+		// as any other names if the "default" account was erroneously
+		// renamed to something else by a user.
+		c := tx.RootBucket().Bucket(acctNameIdxBucketName).Cursor()
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			// Skip nested buckets.
+			if v == nil {
+				continue
+			}
+
+			// Skip account names which aren't for the default account.
+			account := binary.LittleEndian.Uint32(v)
+			if account != DefaultAccountNum {
+				continue
+			}
+
+			// Only delete default account names which are not the
+			// empty string.
+			nameLen := binary.LittleEndian.Uint32(k[0:4])
+			if nameLen != 0 {
+				err := c.Delete()
+				if err != nil {
+					const str = "error deleting default account alias"
+					return managerError(ErrUpgrade, str, err)
+				}
+			}
+		}
+
+		// Ensure that the empty string maps forwards and backwards to
+		// the default account index, and that the account row contains
+		// the new name.
+		name, err := fetchAccountName(tx, DefaultAccountNum)
+		if err != nil {
+			return err
+		}
+		if name != "" {
+			const str = "account name index does not map default account number to new name"
+			return managerError(ErrUpgrade, str, nil)
+		}
+		acct, err := fetchAccountByName(tx, "")
+		if err != nil {
+			return err
+		}
+		if acct != DefaultAccountNum {
+			const str = "default account not accessible under new name"
+			return managerError(ErrUpgrade, str, nil)
+		}
+		acctInfoIface, err = fetchAccountInfo(tx, DefaultAccountNum)
+		if err != nil {
+			return err
+		}
+		acctInfo, ok = acctInfoIface.(*dbBIP0044AccountRow)
+		if !ok {
+			str := fmt.Sprintf("unsupported account type %T", acctInfoIface)
+			return managerError(ErrDatabase, str, nil)
+		}
+		if acctInfo.name != "" {
+			const str = "default account row does not contain new account name"
+			return managerError(ErrUpgrade, str, nil)
+		}
+
+		// Ensure that looking up the default account by the "default"
+		// name cannot succeed.  "default" was previously a reserved
+		// name, so there should be no other accounts by this name.
+		_, err = fetchAccountByName(tx, "default")
+		if err == nil {
+			const str = "default account exists under old name"
+			return managerError(ErrUpgrade, str, nil)
+		} else {
+			merr, ok := err.(ManagerError)
+			if !ok || merr.ErrorCode != ErrAccountNotFound {
+				return err
+			}
+		}
+
+		return nil
 	})
 	if err != nil {
 		return maybeConvertDbError(err)

--- a/walletdb/bdb/db.go
+++ b/walletdb/bdb/db.go
@@ -167,6 +167,76 @@ func (b *bucket) Delete(key []byte) error {
 	return convertErr((*bolt.Bucket)(b).Delete(key))
 }
 
+// Cursor returns a new cursor, allowing for iteration over the bucket's
+// key/value pairs and nested buckets in forward or backward order.
+//
+// This function is part of the walletdb.Bucket interface implementation.
+func (b *bucket) Cursor() walletdb.Cursor {
+	return (*cursor)((*bolt.Bucket)(b).Cursor())
+}
+
+// cursor represents a cursor over key/value pairs and nested buckets of a
+// bucket.
+//
+// Note that open cursors are not tracked on bucket changes and any
+// modifications to the bucket, with the exception of cursor.Delete, invalidate
+// the cursor. After invalidation, the cursor must be repositioned, or the keys
+// and values returned may be unpredictable.
+type cursor bolt.Cursor
+
+// Bucket returns the bucket the cursor was created for.
+//
+// This function is part of the walletdb.Cursor interface implementation.
+func (c *cursor) Bucket() walletdb.Bucket {
+	return (*bucket)((*bolt.Cursor)(c).Bucket())
+}
+
+// Delete removes the current key/value pair the cursor is at without
+// invalidating the cursor. Returns ErrTxNotWritable if attempted on a read-only
+// transaction, or ErrIncompatibleValue if attempted when the cursor points to a
+// nested bucket.
+//
+// This function is part of the walletdb.Cursor interface implementation.
+func (c *cursor) Delete() error {
+	return convertErr((*bolt.Cursor)(c).Delete())
+}
+
+// First positions the cursor at the first key/value pair and returns the pair.
+//
+// This function is part of the walletdb.Cursor interface implementation.
+func (c *cursor) First() (key, value []byte) {
+	return (*bolt.Cursor)(c).First()
+}
+
+// Last positions the cursor at the last key/value pair and returns the pair.
+//
+// This function is part of the walletdb.Cursor interface implementation.
+func (c *cursor) Last() (key, value []byte) {
+	return (*bolt.Cursor)(c).Last()
+}
+
+// Next moves the cursor one key/value pair forward and returns the new pair.
+//
+// This function is part of the walletdb.Cursor interface implementation.
+func (c *cursor) Next() (key, value []byte) {
+	return (*bolt.Cursor)(c).Next()
+}
+
+// Prev moves the cursor one key/value pair backward and returns the new pair.
+//
+// This function is part of the walletdb.Cursor interface implementation.
+func (c *cursor) Prev() (key, value []byte) {
+	return (*bolt.Cursor)(c).Prev()
+}
+
+// Seek positions the cursor at the passed seek key. If the key does not exist,
+// the cursor is moved to the next key after seek. Returns the new pair.
+//
+// This function is part of the walletdb.Cursor interface implementation.
+func (c *cursor) Seek(seek []byte) (key, value []byte) {
+	return (*bolt.Cursor)(c).Seek(seek)
+}
+
 // transaction represents a database transaction.  It can either by read-only or
 // read-write and implements the walletdb.Bucket interface.  The transaction
 // provides a root bucket against which all read and writes occur.


### PR DESCRIPTION
Disallow renaming accounts with reserved names.

Fixes #245.