### PR TITLE
Fix waddrmgr version 4 upgrade path.

### DIFF
--- a/waddrmgr/db.go
+++ b/waddrmgr/db.go
@@ -1921,8 +1921,18 @@ func upgradeToVersion4(namespace walletdb.Namespace, pubPassPhrase []byte) error
 			}
 		}
 
-		// Ensure that the "default" name maps forwards and backwards to
-		// the default account index.
+		// The account number to name index may map to the wrong name,
+		// so rewrite the entry with the true name from the account row
+		// instead of leaving it set to an incorrect alias.
+		err = putAccountIDIndex(tx, DefaultAccountNum, acctInfo.name)
+		if err != nil {
+			const str = "account number to name index could not be " +
+				"rewritten with actual account name"
+			return managerError(ErrUpgrade, str, err)
+		}
+
+		// Ensure that the true name for the default account maps
+		// forwards and backwards to the default account number.
 		name, err := fetchAccountName(tx, DefaultAccountNum)
 		if err != nil {
 			return err


### PR DESCRIPTION
If the account number to name index mapped the default account name to
an alias, the upgrade would not succeed and the upgrade would be
aborted (and rolled back).

This became a problem for upgrading old (pre-v3) wallets since the v3
upgrade did not rename the previous "" account to "default", but
instead just created an alias.

Fix tested by @dajohi, who ran into this issue with a wallet upgrade
from an older keystore version.