### PR TITLE
Add fix for reorganizations from ppcwallet

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -90,13 +90,13 @@ func (w *Wallet) disconnectBlock(bs waddrmgr.BlockStamp) error {
 	// removed block.
 	iter := w.Manager.NewIterateRecentBlocks()
 	if iter != nil && iter.BlockStamp().Hash == bs.Hash {
+		err := w.TxStore.Rollback(iter.BlockStamp().Height)
+		if err != nil {
+			return err
+		}
 		if iter.Prev() {
 			prev := iter.BlockStamp()
 			w.Manager.SetSyncedTo(&prev)
-			err := w.TxStore.Rollback(prev.Height + 1)
-			if err != nil {
-				return err
-			}
 		} else {
 			// The reorg is farther back than the recently-seen list
 			// of blocks has recorded, so set it to unsynced which


### PR DESCRIPTION
Wallet had an issue in which blocks failed to be removed from wtxmgr by
disconnectBlock for long (>20 block) reorganizations because Rollback
failed to be called. This fix was written by mably for ppcwallet,
commit ffb1eeea39138be8a500dab4778abae3ade004a3.