### PR TITLE
Use 0 instead of -1 for zero-conf listtransactions results.

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -843,7 +843,7 @@ func ListTransactions(details *wtxmgr.TxDetails, syncHeight int32, net *chaincfg
 	var (
 		blockHashStr  string
 		blockTime     int64
-		confirmations int64 = -1
+		confirmations int64
 	)
 	if details.Block.Height != -1 {
 		blockHashStr = details.Block.Hash.String()


### PR DESCRIPTION
Fixes #278.