### PR TITLE
Rollback transactions past the last saved recent block.

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -104,6 +104,11 @@ func (w *Wallet) disconnectBlock(bs waddrmgr.BlockStamp) error {
 			// earliest blockstamp the addresses in the manager are
 			// known to have been created.
 			w.Manager.SetSyncedTo(nil)
+			// Rollback everything but the genesis block.
+			err := w.TxStore.Rollback(1)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	w.notifyDisconnectedBlock(bs)


### PR DESCRIPTION
If a long reorganize occurs farther back than the last saved recent
block hash (currently max 20 are saved) a full rescan is triggered
since there is no guarantee the previous blocks weren't also removed
in the reorg.  In this case, the address manager was set unsynced, but
transaction history was not rolled back as well.  This commit corrects
this by unconfirming all transactions but those in the genesis block.