### PR TITLE
Reorder wtxmgr.CreditRecord fields.

### DIFF
--- a/wtxmgr/query.go
+++ b/wtxmgr/query.go
@@ -28,8 +28,8 @@ import (
 // transaction.  Further details may be looked up by indexing a wire.MsgTx.TxOut
 // with the Index field.
 type CreditRecord struct {
-	Index  uint32
 	Amount btcutil.Amount
+	Index  uint32
 	Spent  bool
 	Change bool
 }


### PR DESCRIPTION
This reverses the order of index and amount fields to match
DebitRecord and also saves 8 bytes per instance on amd64.