### PR TITLE
Implement Pool.UpdateWithdrawal

### DIFF
--- a/votingpool/common_test.go
+++ b/votingpool/common_test.go
@@ -63,38 +63,39 @@ func TstRunWithManagerUnlocked(t *testing.T, mgr *waddrmgr.Manager, callback fun
 	callback()
 }
 
-// TstCheckWithdrawalStatusMatches compares s1 and s2 using reflect.DeepEqual
-// and calls t.Fatal() if they're not identical.
-func TstCheckWithdrawalStatusMatches(t *testing.T, s1, s2 WithdrawalStatus) {
-	if s1.Fees() != s2.Fees() {
-		t.Fatalf("Wrong amount of network fees; want %d, got %d", s1.Fees(), s2.Fees())
+// TstCheckWithdrawalStatusMatches compares the individual fields of the two
+// WithdrawalStatus given (using reflect.DeepEqual) and calls t.Fatal() if
+// any of them don't match.
+func TstCheckWithdrawalStatusMatches(t *testing.T, got, want WithdrawalStatus) {
+	if got.Fees() != want.Fees() {
+		t.Fatalf("Wrong amount of network fees; got %d, want %d", got.Fees(), want.Fees())
 	}
 
-	if !reflect.DeepEqual(s1.Sigs(), s2.Sigs()) {
-		t.Fatalf("Wrong tx signatures; got %x, want %x", s1.Sigs(), s2.Sigs())
+	if !reflect.DeepEqual(got.Sigs(), want.Sigs()) {
+		t.Fatalf("Wrong tx signatures; got %x, want %x", got.Sigs(), want.Sigs())
 	}
 
-	if !reflect.DeepEqual(s1.NextInputAddr(), s2.NextInputAddr()) {
-		t.Fatalf("Wrong NextInputAddr; got %v, want %v", s1.NextInputAddr(), s2.NextInputAddr())
+	if !reflect.DeepEqual(got.NextInputAddr(), want.NextInputAddr()) {
+		t.Fatalf("Wrong NextInputAddr; got %v, want %v", got.NextInputAddr(), want.NextInputAddr())
 	}
 
-	if !reflect.DeepEqual(s1.NextChangeAddr(), s2.NextChangeAddr()) {
-		t.Fatalf("Wrong NextChangeAddr; got %v, want %v", s1.NextChangeAddr(), s2.NextChangeAddr())
+	if !reflect.DeepEqual(got.NextChangeAddr(), want.NextChangeAddr()) {
+		t.Fatalf("Wrong NextChangeAddr; got %v, want %v", got.NextChangeAddr(), want.NextChangeAddr())
 	}
 
-	if !reflect.DeepEqual(s1.Outputs(), s2.Outputs()) {
-		t.Fatalf("Wrong WithdrawalOutputs; got %v, want %v", s1.Outputs(), s2.Outputs())
+	if !reflect.DeepEqual(got.Outputs(), want.Outputs()) {
+		t.Fatalf("Wrong WithdrawalOutputs; got %v, want %v", got.Outputs(), want.Outputs())
 	}
 
-	if !reflect.DeepEqual(s1.transactions, s2.transactions) {
-		t.Fatalf("Wrong transactions; got %v, want %v", s1.transactions, s2.transactions)
+	if !reflect.DeepEqual(got.transactions, want.transactions) {
+		t.Fatalf("Wrong transactions; got %v, want %v", got.transactions, want.transactions)
 	}
 
 	// The above checks could be replaced by this one, but when they fail the
 	// failure msg wouldn't give us much clue as to what is not equal, so we do
 	// the individual checks above and use this one as a catch-all check in case
 	// we forget to check any of the individual fields.
-	if !reflect.DeepEqual(s1, s2) {
-		t.Fatalf("Wrong WithdrawalStatus; got %v, want %v", s1, s2)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Wrong WithdrawalStatus; got %v, want %v", got, want)
 	}
 }

--- a/votingpool/db.go
+++ b/votingpool/db.go
@@ -107,6 +107,7 @@ type dbChangeAwareTx struct {
 	SerializedMsgTx []byte
 	ChangeIdx       int32
 	Addrs           map[wire.OutPoint]dbWithdrawalAddress
+	Broadcast       bool
 }
 
 type dbWithdrawalStatus struct {
@@ -464,6 +465,7 @@ func serializeWithdrawal(requests []OutputRequest, startAddress WithdrawalAddres
 			SerializedMsgTx: buf.Bytes(),
 			ChangeIdx:       tx.changeIdx,
 			Addrs:           addrs,
+			Broadcast:       tx.broadcast,
 		}
 	}
 	nextChange := status.nextChangeAddr
@@ -590,6 +592,7 @@ func deserializeWithdrawal(p *Pool, serialized []byte) (*withdrawalInfo, error) 
 			MsgTx:     msgtx,
 			changeIdx: tx.ChangeIdx,
 			addrs:     addrs,
+			broadcast: tx.Broadcast,
 		}
 	}
 	return wInfo, nil

--- a/votingpool/db.go
+++ b/votingpool/db.go
@@ -106,6 +106,7 @@ type dbOutBailmentOutpoint struct {
 type dbChangeAwareTx struct {
 	SerializedMsgTx []byte
 	ChangeIdx       int32
+	Addrs           map[wire.OutPoint]dbWithdrawalAddress
 }
 
 type dbWithdrawalStatus struct {
@@ -451,9 +452,18 @@ func serializeWithdrawal(requests []OutputRequest, startAddress WithdrawalAddres
 		if err := tx.Serialize(&buf); err != nil {
 			return nil, err
 		}
+		addrs := make(map[wire.OutPoint]dbWithdrawalAddress)
+		for outpoint, addr := range tx.addrs {
+			addrs[outpoint] = dbWithdrawalAddress{
+				SeriesID: addr.SeriesID(),
+				Branch:   addr.Branch(),
+				Index:    addr.Index(),
+			}
+		}
 		dbTransactions[ntxid] = dbChangeAwareTx{
 			SerializedMsgTx: buf.Bytes(),
 			ChangeIdx:       tx.changeIdx,
+			Addrs:           addrs,
 		}
 	}
 	nextChange := status.nextChangeAddr
@@ -568,9 +578,18 @@ func deserializeWithdrawal(p *Pool, serialized []byte) (*withdrawalInfo, error) 
 		if err := msgtx.Deserialize(bytes.NewBuffer(tx.SerializedMsgTx)); err != nil {
 			return nil, newError(ErrWithdrawalStorage, "cannot deserialize transaction", err)
 		}
+		addrs := make(map[wire.OutPoint]WithdrawalAddress)
+		for outpoint, addr := range tx.Addrs {
+			wAddr, err := p.WithdrawalAddress(addr.SeriesID, addr.Branch, addr.Index)
+			if err != nil {
+				return nil, newError(ErrWithdrawalStorage, "cannot deserialize addr: ", err)
+			}
+			addrs[outpoint] = *wAddr
+		}
 		wInfo.status.transactions[ntxid] = changeAwareTx{
 			MsgTx:     msgtx,
 			changeIdx: tx.ChangeIdx,
+			addrs:     addrs,
 		}
 	}
 	return wInfo, nil

--- a/votingpool/db_wb_test.go
+++ b/votingpool/db_wb_test.go
@@ -83,11 +83,11 @@ func TestGetMaxUsedIdx(t *testing.T) {
 }
 
 func TestWithdrawalSerialization(t *testing.T) {
-	tearDown, _, pool := TstCreatePool(t)
+	tearDown, pool, store := TstCreatePoolAndTxStore(t)
 	defer tearDown()
 
 	roundID := uint32(0)
-	wi := createAndFulfillWithdrawalRequests(t, pool, roundID)
+	wi := createAndFulfillWithdrawalRequests(t, pool, roundID, store)
 
 	serialized, err := serializeWithdrawal(wi.requests, wi.startAddress, wi.lastSeriesID,
 		wi.changeStart, wi.dustThreshold, wi.status)

--- a/votingpool/doc.go
+++ b/votingpool/doc.go
@@ -95,5 +95,15 @@ the state of every requested output, the raw signatures for the constructed
 transactions, the network fees included in those transactions and the input
 range to use in the next withdrawal.
 
+Signing and broadcasting withdrawal transactions
+
+The raw signatures returned by StartWithdrawal are exchanged by the pool
+members and passed on to their wallets via the Pool.UpdateWithdrawal method,
+which takes the ID of the consensus round, a list of raw signatures and a
+wtxmgr.Store. The given list of signatures is merged with the existing one, and
+then any transactions that can be signed (i.e. those for which we have the
+minimum required raw signatures for each input) are broadcast. The merged list
+of signatures is then returned so that it can be passed on to other pool members.
+
 */
 package votingpool

--- a/votingpool/error.go
+++ b/votingpool/error.go
@@ -24,7 +24,9 @@ type ErrorCode int
 const (
 	// ErrInputSelection indicates an error in the input selection
 	// algorithm.
-	ErrInputSelection ErrorCode = iota
+	// Defined as iota+1 so that an uninitialized ErrorCode doesn't present
+	// itself as an ErrInputSelection.
+	ErrInputSelection ErrorCode = iota + 1
 
 	// ErrWithdrawalProcessing indicates an internal error when processing a
 	// withdrawal request.
@@ -155,6 +157,15 @@ const (
 	// deserializing withdrawal information.
 	ErrWithdrawalStorage
 
+	// ErrSigsListMismatch indicates a length mismatch when trying to merge two
+	// signature lists.
+	ErrSigsListMismatch
+
+	// ErrNotEnoughSigs indicates a given transaction can't be signed because
+	// we don't have the minimum required signatures for one of its multi-sig
+	// inputs.
+	ErrNotEnoughSigs
+
 	// lastErr is used for testing, making it possible to iterate over
 	// the error codes in order to check that they all have proper
 	// translations in errorCodeStrings.
@@ -197,6 +208,8 @@ var errorCodeStrings = map[ErrorCode]string{
 	ErrWithdrawFromUnusedAddr:    "ErrWithdrawFromUnusedAddr",
 	ErrWithdrawalTxStorage:       "ErrWithdrawalTxStorage",
 	ErrWithdrawalStorage:         "ErrWithdrawalStorage",
+	ErrSigsListMismatch:          "ErrSigsListMismatch",
+	ErrNotEnoughSigs:             "ErrNotEnoughSigs",
 }
 
 // String returns the ErrorCode as a human-readable name.

--- a/votingpool/error_test.go
+++ b/votingpool/error_test.go
@@ -66,10 +66,12 @@ func TestErrorCodeStringer(t *testing.T) {
 		{vp.ErrWithdrawFromUnusedAddr, "ErrWithdrawFromUnusedAddr"},
 		{vp.ErrWithdrawalTxStorage, "ErrWithdrawalTxStorage"},
 		{vp.ErrWithdrawalStorage, "ErrWithdrawalStorage"},
+		{vp.ErrSigsListMismatch, "ErrSigsListMismatch"},
+		{vp.ErrNotEnoughSigs, "ErrNotEnoughSigs"},
 		{0xffff, "Unknown ErrorCode (65535)"},
 	}
 
-	if int(vp.TstLastErr) != len(tests)-1 {
+	if int(vp.TstLastErr) != len(tests) {
 		t.Errorf("Wrong number of errorCodeStrings. Got: %d, want: %d",
 			int(vp.TstLastErr), len(tests))
 	}

--- a/votingpool/factory_test.go
+++ b/votingpool/factory_test.go
@@ -67,6 +67,64 @@ func createWithdrawalTx(t *testing.T, pool *Pool, inputAmounts []int64, outputAm
 	return tx
 }
 
+// createWithdrawalTxWithStoreCredits creates a new Credit in the given store
+// for each entry in inputAmounts, and uses them to construct a withdrawalTx
+// with one output for every entry in outputAmounts.
+func createWithdrawalTxWithStoreCredits(t *testing.T, store *wtxmgr.Store, pool *Pool,
+	inputAmounts []int64, outputAmounts []int64) *withdrawalTx {
+	masters := []*hdkeychain.ExtendedKey{
+		TstCreateMasterKey(t, bytes.Repeat(uint32ToBytes(getUniqueID()), 4)),
+		TstCreateMasterKey(t, bytes.Repeat(uint32ToBytes(getUniqueID()), 4)),
+		TstCreateMasterKey(t, bytes.Repeat(uint32ToBytes(getUniqueID()), 4)),
+	}
+	def := TstCreateSeriesDef(t, pool, 2, masters)
+	TstCreateSeries(t, pool, []TstSeriesDef{def})
+	net := pool.Manager().ChainParams()
+	tx := newWithdrawalTx(defaultTxOptions)
+	for _, c := range TstCreateSeriesCreditsOnStore(t, pool, def.SeriesID, inputAmounts, store) {
+		tx.addInput(c)
+	}
+	for i, amount := range outputAmounts {
+		request := TstNewOutputRequest(
+			t, uint32(i), "34eVkREKgvvGASZW7hkgE2uNc1yycntMK6", btcutil.Amount(amount), net)
+		tx.addOutput(request)
+	}
+	return tx
+}
+
+func createChangeAwareTx(t *testing.T, store *wtxmgr.Store, pool *Pool, inputAmounts []int64,
+	outputAmounts []int64) changeAwareTx {
+	wTx := createWithdrawalTxWithStoreCredits(t, store, pool, inputAmounts, outputAmounts)
+	return changeAwareTxFromWithdrawalTx(wTx)
+}
+
+func changeAwareTxFromWithdrawalTx(tx *withdrawalTx) changeAwareTx {
+	msgtx := tx.toMsgTx()
+	changeIdx := -1
+	if tx.hasChange() {
+		// When withdrawalTx has a change, we know it will be the last entry
+		// in the generated MsgTx.
+		changeIdx = len(msgtx.TxOut) - 1
+	}
+	cTx := changeAwareTx{
+		MsgTx:     msgtx,
+		changeIdx: int32(changeIdx),
+	}
+	cTx.addrs = make(map[wire.OutPoint]WithdrawalAddress)
+	for _, txIn := range msgtx.TxIn {
+		prevOutpoint := txIn.PreviousOutPoint
+		var c credit
+		for _, input := range tx.inputs {
+			if prevOutpoint == input.OutPoint {
+				c = input
+				break
+			}
+		}
+		cTx.addrs[prevOutpoint] = c.addr
+	}
+	return cTx
+}
+
 func createMsgTx(pkScript []byte, amts []int64) *wire.MsgTx {
 	msgtx := &wire.MsgTx{
 		Version: 1,
@@ -243,27 +301,29 @@ func TstCreateCreditsOnNewSeries(t *testing.T, pool *Pool, amounts []int64) (uin
 }
 
 // TstCreateSeriesCredits creates a new credit for every item in the amounts
-// slice, locked to the given series' address with branch==1 and index==0.
+// slice, locked to the given series' address with branch==1 and the index
+// varying according to the index of the amount on the amounts slice.
 func TstCreateSeriesCredits(t *testing.T, pool *Pool, seriesID uint32, amounts []int64) []credit {
-	addr := TstNewWithdrawalAddress(t, pool, seriesID, Branch(1), Index(0))
-	pkScript, err := txscript.PayToAddrScript(addr.addr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	msgTx := createMsgTx(pkScript, amounts)
-	txSha := msgTx.TxSha()
 	credits := make([]credit, len(amounts))
-	for i := range msgTx.TxOut {
+	for i, amount := range amounts {
+		addr := TstNewWithdrawalAddress(t, pool, seriesID, Branch(1), Index(i))
+		pkScript, err := txscript.PayToAddrScript(addr.addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		msgTx := createMsgTx(pkScript, []int64{amount})
+		txSha := msgTx.TxSha()
+		idx := 0
 		c := wtxmgr.Credit{
 			OutPoint: wire.OutPoint{
 				Hash:  txSha,
-				Index: uint32(i),
+				Index: uint32(idx),
 			},
 			BlockMeta: wtxmgr.BlockMeta{
 				Block: wtxmgr.Block{Height: TstInputsBlock},
 			},
-			Amount:   btcutil.Amount(msgTx.TxOut[i].Value),
-			PkScript: msgTx.TxOut[i].PkScript,
+			Amount:   btcutil.Amount(amount),
+			PkScript: msgTx.TxOut[idx].PkScript,
 		}
 		credits[i] = newCredit(c, *addr)
 	}

--- a/votingpool/factory_test.go
+++ b/votingpool/factory_test.go
@@ -482,20 +482,32 @@ func TstConstantFee(fee btcutil.Amount) func() btcutil.Amount {
 	return func() btcutil.Amount { return fee }
 }
 
-func createAndFulfillWithdrawalRequests(t *testing.T, pool *Pool, roundID uint32) withdrawalInfo {
-
+// createAndFulfillWithdrawalRequests creates two output requests with amounts
+// 3e6 and 2e6 and fulfills them using newly created inputs (locked to a 2-of-3
+// multi-sig address belonging to a series created with a unique ID) of amounts
+// 2e6 and 4e6. The returned withdrawalInfo will contain a single transaction
+// and all raw signatures needed to sign that transaction.
+func createAndFulfillWithdrawalRequests(t *testing.T, pool *Pool, roundID uint32, store *wtxmgr.Store) withdrawalInfo {
+	masters := []*hdkeychain.ExtendedKey{
+		TstCreateMasterKey(t, bytes.Repeat(uint32ToBytes(getUniqueID()), 4)),
+		TstCreateMasterKey(t, bytes.Repeat(uint32ToBytes(getUniqueID()), 4)),
+		TstCreateMasterKey(t, bytes.Repeat(uint32ToBytes(getUniqueID()), 4)),
+	}
+	def := TstCreateSeriesDef(t, pool, 2, masters)
+	TstCreateSeries(t, pool, []TstSeriesDef{def})
+	credits := TstCreateSeriesCreditsOnStore(t, pool, def.SeriesID, []int64{2e6, 4e6}, store)
 	params := pool.Manager().ChainParams()
-	seriesID, eligible := TstCreateCreditsOnNewSeries(t, pool, []int64{2e6, 4e6})
 	requests := []OutputRequest{
 		TstNewOutputRequest(t, 1, "34eVkREKgvvGASZW7hkgE2uNc1yycntMK6", 3e6, params),
 		TstNewOutputRequest(t, 2, "3PbExiaztsSYgh6zeMswC49hLUwhTQ86XG", 2e6, params),
 	}
-	changeStart := TstNewChangeAddress(t, pool, seriesID, 0)
+	changeStart := TstNewChangeAddress(t, pool, def.SeriesID, 0)
 	dustThreshold := btcutil.Amount(1e4)
-	startAddr := TstNewWithdrawalAddress(t, pool, seriesID, 1, 0)
-	lastSeriesID := seriesID
-	w := newWithdrawal(roundID, requests, eligible, *changeStart)
-	if err := w.fulfillRequests(); err != nil {
+	startAddr := TstNewWithdrawalAddress(t, pool, def.SeriesID, 1, 0)
+	lastSeriesID := def.SeriesID
+	status, err := pool.fulfillAndSaveWithdrawal(roundID, requests, *startAddr, lastSeriesID,
+		*changeStart, dustThreshold, credits)
+	if err != nil {
 		t.Fatal(err)
 	}
 	return withdrawalInfo{
@@ -504,6 +516,6 @@ func createAndFulfillWithdrawalRequests(t *testing.T, pool *Pool, roundID uint32
 		changeStart:   *changeStart,
 		lastSeriesID:  lastSeriesID,
 		dustThreshold: dustThreshold,
-		status:        *w.status,
+		status:        *status,
 	}
 }

--- a/votingpool/pool.go
+++ b/votingpool/pool.go
@@ -343,13 +343,13 @@ func (p *Pool) CreateSeries(version, seriesID, reqSigs uint32, rawPubKeys []stri
 		return newError(ErrSeriesIDInvalid, "series ID cannot be 0", nil)
 	}
 
-	if series := p.Series(seriesID); series != nil {
+	if p.Series(seriesID) != nil {
 		str := fmt.Sprintf("series #%d already exists", seriesID)
 		return newError(ErrSeriesAlreadyExists, str, nil)
 	}
 
 	if seriesID != 1 {
-		if _, ok := p.seriesLookup[seriesID-1]; !ok {
+		if p.Series(seriesID-1) == nil {
 			str := fmt.Sprintf("series #%d cannot be created because series #%d does not exist",
 				seriesID, seriesID-1)
 			return newError(ErrSeriesIDNotSequential, str, nil)

--- a/votingpool/withdrawal.go
+++ b/votingpool/withdrawal.go
@@ -124,11 +124,26 @@ type withdrawalInfo struct {
 	status        WithdrawalStatus
 }
 
-// TxSigs is list of raw signatures (one for every pubkey in the multi-sig
+// TxSigs is a slice containing one element for each input of a given
+// transaction.
+type TxSigs []TxInSigs
+
+// TxInSigs represents the raw signatures (one for every pubkey in the multi-sig
 // script) for a given transaction input. They should match the order of pubkeys
 // in the script and an empty RawSig should be used when the private key for a
 // pubkey is not known.
-type TxSigs [][]RawSig
+type TxInSigs struct {
+	Required uint32
+	Sigs     []RawSig
+}
+
+func newTxInSigs(reqSigs uint32, length int) TxInSigs {
+	sigs := make([]RawSig, length)
+	for i := range sigs {
+		sigs[i] = RawSig{}
+	}
+	return TxInSigs{Required: reqSigs, Sigs: sigs}
+}
 
 // RawSig represents one of the signatures included in the unlocking script of
 // inputs spending from P2SH UTXOs.
@@ -878,7 +893,7 @@ func getRawSigs(transactions []*withdrawalTx) (map[Ntxid]TxSigs, error) {
 			if err != nil {
 				return nil, err
 			}
-			txInSigs := make([]RawSig, len(pubKeys))
+			txInSigs := newTxInSigs(series.reqSigs, len(pubKeys))
 			for i, pubKey := range pubKeys {
 				var sig RawSig
 				privKey, err := series.getPrivKeyFor(pubKey)
@@ -906,7 +921,7 @@ func getRawSigs(transactions []*withdrawalTx) (map[Ntxid]TxSigs, error) {
 						"for %s is not available: %v", inputIdx, ntxid, pubKey.String(), err)
 					sig = []byte{}
 				}
-				txInSigs[i] = sig
+				txInSigs.Sigs[i] = sig
 			}
 			txSigs[inputIdx] = txInSigs
 		}
@@ -955,7 +970,7 @@ func getRedeemScript(mgr *waddrmgr.Manager, addr *btcutil.AddressScriptHash) ([]
 // The order of the signatures must match that of the public keys in the multi-sig
 // script as OP_CHECKMULTISIG expects that.
 // This function must be called with the manager unlocked.
-func signMultiSigUTXO(mgr *waddrmgr.Manager, tx *wire.MsgTx, idx int, pkScript []byte, sigs []RawSig) error {
+func signMultiSigUTXO(mgr *waddrmgr.Manager, tx *wire.MsgTx, idx int, pkScript []byte, sigs TxInSigs) error {
 	class, addresses, _, err := txscript.ExtractPkScriptAddrs(pkScript, mgr.ChainParams())
 	if err != nil {
 		return newError(ErrTxSigning, "unparseable pkScript", err)
@@ -975,16 +990,16 @@ func signMultiSigUTXO(mgr *waddrmgr.Manager, tx *wire.MsgTx, idx int, pkScript [
 	if class != txscript.MultiSigTy {
 		return newError(ErrTxSigning, fmt.Sprintf("redeem script is not multi-sig: %v", class), nil)
 	}
-	if len(sigs) < nRequired {
+	if len(sigs.Sigs) < nRequired {
 		errStr := fmt.Sprintf("not enough signatures; need %d but got only %d", nRequired,
-			len(sigs))
+			len(sigs.Sigs))
 		return newError(ErrTxSigning, errStr, nil)
 	}
 
 	// Construct the unlocking script.
 	// Start with an OP_0 because of the bug in bitcoind, then add nRequired signatures.
 	unlockingScript := txscript.NewScriptBuilder().AddOp(txscript.OP_FALSE)
-	for _, sig := range sigs[:nRequired] {
+	for _, sig := range sigs.Sigs[:nRequired] {
 		unlockingScript.AddData(sig)
 	}
 

--- a/votingpool/withdrawal.go
+++ b/votingpool/withdrawal.go
@@ -93,11 +93,15 @@ type OutBailmentOutpoint struct {
 	amount btcutil.Amount
 }
 
-// changeAwareTx is just a wrapper around wire.MsgTx that knows about its change
-// output, if any.
+// changeAwareTx is a wrapper around wire.MsgTx that has some auxiliary data
+// needed when processing voting pool withdrawals.
 type changeAwareTx struct {
 	*wire.MsgTx
-	changeIdx int32 // -1 if there's no change output.
+	// The index of the tx's change output. -1 if there's no change output.
+	changeIdx int32
+	// A map allowing us to link each TxIn from this tx to the
+	// WithdrawalAddress of the credit they spend.
+	addrs map[wire.OutPoint]WithdrawalAddress
 }
 
 // WithdrawalStatus contains the details of a processed withdrawal, including
@@ -528,7 +532,7 @@ func (p *Pool) StartWithdrawal(roundID uint32, requests []OutputRequest,
 	if err := w.fulfillRequests(); err != nil {
 		return nil, err
 	}
-	w.status.sigs, err = getRawSigs(w.transactions)
+	w.status.sigs, err = getRawSigs(w.status.transactions)
 	if err != nil {
 		return nil, err
 	}
@@ -751,9 +755,22 @@ func (w *withdrawal) fulfillRequests() error {
 			// in the generated MsgTx.
 			changeIdx = len(msgtx.TxOut) - 1
 		}
+		addrs := make(map[wire.OutPoint]WithdrawalAddress)
+		for _, txIn := range msgtx.TxIn {
+			prevOutpoint := txIn.PreviousOutPoint
+			var c credit
+			for _, input := range tx.inputs {
+				if prevOutpoint == input.OutPoint {
+					c = input
+					break
+				}
+			}
+			addrs[prevOutpoint] = c.addr
+		}
 		w.status.transactions[tx.ntxid()] = changeAwareTx{
 			MsgTx:     msgtx,
 			changeIdx: int32(changeIdx),
+			addrs:     addrs,
 		}
 	}
 	return nil
@@ -875,14 +892,12 @@ func getWithdrawalStatus(p *Pool, roundID uint32, requests []OutputRequest,
 // getRawSigs iterates over the inputs of each transaction given, constructing the
 // raw signatures for them using the private keys available to us.
 // It returns a map of ntxids to signature lists.
-func getRawSigs(transactions []*withdrawalTx) (map[Ntxid]TxSigs, error) {
+func getRawSigs(transactions map[Ntxid]changeAwareTx) (map[Ntxid]TxSigs, error) {
 	sigs := make(map[Ntxid]TxSigs)
-	for _, tx := range transactions {
-		txSigs := make(TxSigs, len(tx.inputs))
-		msgtx := tx.toMsgTx()
-		ntxid := tx.ntxid()
-		for inputIdx, input := range tx.inputs {
-			creditAddr := input.addr
+	for ntxid, tx := range transactions {
+		txSigs := make(TxSigs, len(tx.TxIn))
+		for inputIdx, input := range tx.TxIn {
+			creditAddr := tx.addrs[input.PreviousOutPoint]
 			redeemScript := creditAddr.redeemScript()
 			series := creditAddr.series()
 			// The order of the raw signatures in the signature script must match the
@@ -912,7 +927,7 @@ func getRawSigs(transactions []*withdrawalTx) (map[Ntxid]TxSigs, error) {
 					log.Debugf("Generating raw sig for input %d of tx %s with privkey of %s",
 						inputIdx, ntxid, pubKey.String())
 					sig, err = txscript.RawTxInSignature(
-						msgtx, inputIdx, redeemScript, txscript.SigHashAll, ecPrivKey)
+						tx.MsgTx, inputIdx, redeemScript, txscript.SigHashAll, ecPrivKey)
 					if err != nil {
 						return nil, newError(ErrRawSigning, "failed to generate raw signature", err)
 					}

--- a/votingpool/withdrawal.go
+++ b/votingpool/withdrawal.go
@@ -56,7 +56,7 @@ const (
 type OutBailmentID string
 
 // Ntxid is the normalized ID of a given bitcoin transaction, which is generated
-// by hashing the serialized tx with blank sig scripts on all inputs.
+// by hashing the serialized tx with nil sig scripts on all inputs.
 type Ntxid string
 
 // OutputRequest represents one of the outputs (address/amount) requested by a
@@ -102,6 +102,8 @@ type changeAwareTx struct {
 	// A map allowing us to link each TxIn from this tx to the
 	// WithdrawalAddress of the credit they spend.
 	addrs map[wire.OutPoint]WithdrawalAddress
+	// Has this transaction been broadcast yet?
+	broadcast bool
 }
 
 // WithdrawalStatus contains the details of a processed withdrawal, including
@@ -144,7 +146,7 @@ type TxInSigs struct {
 func newTxInSigs(reqSigs uint32, length int) TxInSigs {
 	sigs := make([]RawSig, length)
 	for i := range sigs {
-		sigs[i] = RawSig{}
+		sigs[i] = emptyRawSig
 	}
 	return TxInSigs{Required: reqSigs, Sigs: sigs}
 }
@@ -152,6 +154,8 @@ func newTxInSigs(reqSigs uint32, length int) TxInSigs {
 // RawSig represents one of the signatures included in the unlocking script of
 // inputs spending from P2SH UTXOs.
 type RawSig []byte
+
+var emptyRawSig = RawSig{}
 
 // byAmount defines the methods needed to satisify sort.Interface to
 // sort a slice of OutputRequests by their amount.
@@ -180,7 +184,7 @@ func (s outputStatus) String() string {
 	return strings[s]
 }
 
-func (tx *changeAwareTx) addSelfToStore(store *wtxmgr.Store) error {
+func (tx *changeAwareTx) addToStore(store *wtxmgr.Store) error {
 	rec, err := wtxmgr.NewTxRecordFromMsgTx(tx.MsgTx, time.Now())
 	if err != nil {
 		return newError(ErrWithdrawalTxStorage, "error constructing TxRecord for storing", err)
@@ -194,6 +198,7 @@ func (tx *changeAwareTx) addSelfToStore(store *wtxmgr.Store) error {
 			return newError(ErrWithdrawalTxStorage, "error adding tx credits to store", err)
 		}
 	}
+	tx.broadcast = true
 	return nil
 }
 
@@ -349,9 +354,8 @@ func newWithdrawalTx(setOptions func(tx *withdrawalTx)) *withdrawalTx {
 // ntxid returns the unique ID for this transaction.
 func (tx *withdrawalTx) ntxid() Ntxid {
 	msgtx := tx.toMsgTx()
-	var empty []byte
 	for _, txin := range msgtx.TxIn {
-		txin.SignatureScript = empty
+		txin.SignatureScript = nil
 	}
 	return Ntxid(msgtx.TxSha().String())
 }
@@ -513,7 +517,7 @@ func (p *Pool) StartWithdrawal(roundID uint32, requests []OutputRequest,
 	txStore *wtxmgr.Store, chainHeight int32, dustThreshold btcutil.Amount) (
 	*WithdrawalStatus, error) {
 
-	status, err := getWithdrawalStatus(p, roundID, requests, startAddress, lastSeriesID,
+	status, err := getWithdrawalStatusMatching(p, roundID, requests, startAddress, lastSeriesID,
 		changeStart, dustThreshold)
 	if err != nil {
 		return nil, err
@@ -528,29 +532,166 @@ func (p *Pool) StartWithdrawal(roundID uint32, requests []OutputRequest,
 		return nil, err
 	}
 
+	return p.fulfillAndSaveWithdrawal(roundID, requests, startAddress, lastSeriesID, changeStart,
+		dustThreshold, eligible)
+}
+
+func (p *Pool) fulfillAndSaveWithdrawal(roundID uint32, requests []OutputRequest,
+	startAddress WithdrawalAddress, lastSeriesID uint32, changeStart ChangeAddress,
+	dustThreshold btcutil.Amount, eligible []credit) (*WithdrawalStatus, error) {
+	var err error
 	w := newWithdrawal(roundID, requests, eligible, changeStart)
-	if err := w.fulfillRequests(); err != nil {
+	if err = w.fulfillRequests(); err != nil {
 		return nil, err
 	}
 	w.status.sigs, err = getRawSigs(w.status.transactions)
 	if err != nil {
 		return nil, err
 	}
-
-	serialized, err := serializeWithdrawal(requests, startAddress, lastSeriesID, changeStart,
+	err = p.saveWithdrawal(roundID, requests, startAddress, lastSeriesID, changeStart,
 		dustThreshold, *w.status)
 	if err != nil {
 		return nil, err
 	}
-	err = p.namespace.Update(
-		func(tx walletdb.Tx) error {
-			return putWithdrawal(tx, p.ID, roundID, serialized)
-		})
+	return w.status, nil
+}
+
+// UpdateWithdrawal looks up the information from the withdrawal with the given
+// roundID, merges the existing signature lists with the given ones, broadcasts
+// all transactions that can be signed (i.e. for which we have the minimum
+// number of signatures) and that haven't been broadcast yet, and finally saves
+// the updated withdrawal information in the database.
+// It must be called with the address manager unlocked.
+func (p *Pool) UpdateWithdrawal(roundID uint32, sigs map[Ntxid]TxSigs, store *wtxmgr.Store) (
+	map[Ntxid]TxSigs, error) {
+	wInfo, err := getWithdrawalInfo(p, roundID)
 	if err != nil {
 		return nil, err
 	}
+	status := wInfo.status
 
-	return w.status, nil
+	// Re-generate the raw signatures and merge them with the existing ones as
+	// one or more series may have been made hot since the StartWithdrawal call
+	// that initiated this withdrawal.
+	newSigs, err := getRawSigs(status.transactions)
+	if err != nil {
+		return nil, err
+	}
+	if err = status.mergeSigs(newSigs); err != nil {
+		return nil, err
+	}
+
+	// Now merge the raw signatures passed in.
+	if err = status.mergeSigs(sigs); err != nil {
+		return nil, err
+	}
+	if err = status.maybeBroadcastTxs(p.manager, store); err != nil {
+		return nil, err
+	}
+	err = p.saveWithdrawal(roundID, wInfo.requests, wInfo.startAddress, wInfo.lastSeriesID,
+		wInfo.changeStart, wInfo.dustThreshold, wInfo.status)
+	if err != nil {
+		return nil, err
+	}
+	return status.sigs, nil
+}
+
+// maybeBroadcastTxs will attempt to sign all transactions in this
+// WithdrawalStatus (using the raw signatures from WithdrawalStatus.sigs),
+// and broadcast the ones that can be signed (i.e. those for which we have
+// the minimum required signatures for each input). Any transactions broadcast
+// will be modified to indicate that, so the DB entry for this WithdrawalStatus
+// must be updated (via Pool.saveWithdrawal()) after this method returns.
+// This method must be called with the manager unlocked.
+func (s *WithdrawalStatus) maybeBroadcastTxs(mgr *waddrmgr.Manager, store *wtxmgr.Store) error {
+	for ntxid, tx := range s.transactions {
+		err := SignTx(tx.MsgTx, s.sigs[ntxid], mgr, store)
+		if err != nil && err.(Error).ErrorCode == ErrNotEnoughSigs {
+			log.Debugf("Not enough signatures for all inputs of tx %s; not broadcasting it", ntxid)
+			continue
+		} else if err != nil {
+			log.Debugf("Error attempting to sign tx %s", ntxid)
+			return err
+		}
+		// NOTE: Transactions are added one by one to wtxmgr, but if this
+		// method returns an error the callsites will not update this
+		// WithdrawalStatus in the DB and we may end up with broadcast
+		// transactions that are not marked as such in the votingpool DB. That
+		// shouldn't be a problem as wallet clients will retry the operation
+		// and tx.addToStore() is a no-op for transactions that have already
+		// been added.
+		if err := tx.addToStore(store); err != nil {
+			return err
+		}
+		log.Debugf("Successfully signed and broadcast tx %s", ntxid)
+		// tx.addSelfToStore() will have modified tx fields, but we're working
+		// on a copy of the original one thanks to the for/range loop, so we
+		// need to overwrite the original one in the map.
+		s.transactions[ntxid] = tx
+	}
+	return nil
+}
+
+func (s *WithdrawalStatus) mergeSigs(sigs map[Ntxid]TxSigs) error {
+	if len(s.sigs) != len(sigs) {
+		msg := fmt.Sprintf("number of new TxSigs (%d) does not match existing ones (%d)",
+			len(s.sigs), len(sigs))
+		return newError(ErrSigsListMismatch, msg, nil)
+	}
+	for ntxid, txSigs := range sigs {
+		existingSigs, ok := s.sigs[ntxid]
+		if !ok {
+			return newError(ErrSigsListMismatch, fmt.Sprintf("missing sigs for tx %s", ntxid), nil)
+		}
+		if len(existingSigs) != len(txSigs) {
+			msg := fmt.Sprintf("number of new siglists (%d) for tx %s does not match existing "+
+				"ones (%d)", len(txSigs), ntxid, len(existingSigs))
+			return newError(ErrSigsListMismatch, msg, nil)
+		}
+		for input, txInSigs := range txSigs {
+			if len(txInSigs.Sigs) != len(existingSigs[input].Sigs) {
+				msg := fmt.Sprintf("number of new sigs (%d) for tx %s, input %d "+
+					"does not match existing ones (%d)", len(txInSigs.Sigs), ntxid,
+					input, len(existingSigs[input].Sigs))
+				return newError(ErrSigsListMismatch, msg, nil)
+			}
+			for branch, sig := range txInSigs.Sigs {
+				if bytes.Equal(sig, emptyRawSig) {
+					continue
+				}
+				existingSig := existingSigs[input].Sigs[branch]
+				if bytes.Equal(existingSig, emptyRawSig) {
+					log.Debugf("Adding raw sig for tx %v, input %d, branch %d", ntxid, input, branch)
+					existingSigs[input].Sigs[branch] = sig
+				} else if !bytes.Equal(existingSig, sig) {
+					// Neither the new sig nor the existing one are empty, and
+					// they don't match. Since we use deterministic signatures,
+					// this could only happen if there's a bug in the code that
+					// generates the signature lists or in the signature
+					// construction itself.
+					msg := fmt.Sprintf("cannot merge signatures: both existing and new sig for "+
+						"tx %s, input %d, branch %d are non-empty but they don't match.",
+						ntxid, input, branch)
+					return newError(ErrSigsListMismatch, msg, nil)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (p *Pool) saveWithdrawal(roundID uint32, requests []OutputRequest,
+	startAddress WithdrawalAddress, lastSeriesID uint32, changeStart ChangeAddress,
+	dustThreshold btcutil.Amount, status WithdrawalStatus) error {
+	serialized, err := serializeWithdrawal(requests, startAddress, lastSeriesID, changeStart,
+		dustThreshold, status)
+	if err != nil {
+		return err
+	}
+	return p.namespace.Update(
+		func(tx walletdb.Tx) error {
+			return putWithdrawal(tx, p.ID, roundID, serialized)
+		})
 }
 
 // popRequest removes and returns the first request from the stack of pending
@@ -861,12 +1002,27 @@ func (wi *withdrawalInfo) match(requests []OutputRequest, startAddress Withdrawa
 }
 
 // getWithdrawalStatus returns the existing WithdrawalStatus for the given
-// withdrawal parameters, if one exists. This function must be called with the
-// address manager unlocked.
-func getWithdrawalStatus(p *Pool, roundID uint32, requests []OutputRequest,
+// withdrawal parameters, if one exists and has attributes matching all the
+// arguments passed here. This function must be called with the address
+// manager unlocked.
+func getWithdrawalStatusMatching(p *Pool, roundID uint32, requests []OutputRequest,
 	startAddress WithdrawalAddress, lastSeriesID uint32, changeStart ChangeAddress,
 	dustThreshold btcutil.Amount) (*WithdrawalStatus, error) {
 
+	wInfo, err := getWithdrawalInfo(p, roundID)
+	if err != nil {
+		return nil, err
+	}
+	if wInfo == nil {
+		return nil, nil
+	}
+	if wInfo.match(requests, startAddress, lastSeriesID, changeStart, dustThreshold) {
+		return &wInfo.status, nil
+	}
+	return nil, nil
+}
+
+func getWithdrawalInfo(p *Pool, roundID uint32) (*withdrawalInfo, error) {
 	var serialized []byte
 	err := p.namespace.View(
 		func(tx walletdb.Tx) error {
@@ -879,14 +1035,7 @@ func getWithdrawalStatus(p *Pool, roundID uint32, requests []OutputRequest,
 	if bytes.Equal(serialized, []byte{}) {
 		return nil, nil
 	}
-	wInfo, err := deserializeWithdrawal(p, serialized)
-	if err != nil {
-		return nil, err
-	}
-	if wInfo.match(requests, startAddress, lastSeriesID, changeStart, dustThreshold) {
-		return &wInfo.status, nil
-	}
-	return nil, nil
+	return deserializeWithdrawal(p, serialized)
 }
 
 // getRawSigs iterates over the inputs of each transaction given, constructing the
@@ -934,7 +1083,7 @@ func getRawSigs(transactions map[Ntxid]changeAwareTx) (map[Ntxid]TxSigs, error) 
 				} else {
 					log.Debugf("Not generating raw sig for input %d of %s because private key "+
 						"for %s is not available: %v", inputIdx, ntxid, pubKey.String(), err)
-					sig = []byte{}
+					sig = emptyRawSig
 				}
 				txInSigs.Sigs[i] = sig
 			}
@@ -959,6 +1108,11 @@ func SignTx(msgtx *wire.MsgTx, sigs TxSigs, mgr *waddrmgr.Manager, store *wtxmgr
 	pkScripts, err := store.PreviousPkScripts(rec, nil)
 	if err != nil {
 		return newError(ErrTxSigning, "failed to obtain pkScripts for signing", err)
+	}
+	if len(pkScripts) != len(sigs) {
+		msg := fmt.Sprintf("number of pkScripts (%d) do not match number of sigs (%d)",
+			len(pkScripts), len(sigs))
+		return newError(ErrTxSigning, msg, nil)
 	}
 	for i, pkScript := range pkScripts {
 		if err = signMultiSigUTXO(mgr, msgtx, i, pkScript, sigs[i]); err != nil {
@@ -1005,16 +1159,22 @@ func signMultiSigUTXO(mgr *waddrmgr.Manager, tx *wire.MsgTx, idx int, pkScript [
 	if class != txscript.MultiSigTy {
 		return newError(ErrTxSigning, fmt.Sprintf("redeem script is not multi-sig: %v", class), nil)
 	}
-	if len(sigs.Sigs) < nRequired {
+	var nonEmptySigs []RawSig
+	for _, sig := range sigs.Sigs {
+		if !bytes.Equal(sig, emptyRawSig) {
+			nonEmptySigs = append(nonEmptySigs, sig)
+		}
+	}
+	if len(nonEmptySigs) < nRequired {
 		errStr := fmt.Sprintf("not enough signatures; need %d but got only %d", nRequired,
-			len(sigs.Sigs))
-		return newError(ErrTxSigning, errStr, nil)
+			len(nonEmptySigs))
+		return newError(ErrNotEnoughSigs, errStr, nil)
 	}
 
 	// Construct the unlocking script.
 	// Start with an OP_0 because of the bug in bitcoind, then add nRequired signatures.
 	unlockingScript := txscript.NewScriptBuilder().AddOp(txscript.OP_FALSE)
-	for _, sig := range sigs.Sigs[:nRequired] {
+	for _, sig := range nonEmptySigs[:nRequired] {
 		unlockingScript.AddData(sig)
 	}
 
@@ -1035,8 +1195,7 @@ func signMultiSigUTXO(mgr *waddrmgr.Manager, tx *wire.MsgTx, idx int, pkScript [
 // validateSigScripts executes the signature script of the tx input with the
 // given index, returning an error if it fails.
 func validateSigScript(msgtx *wire.MsgTx, idx int, pkScript []byte) error {
-	vm, err := txscript.NewEngine(pkScript, msgtx, idx,
-		txscript.StandardVerifyFlags)
+	vm, err := txscript.NewEngine(pkScript, msgtx, idx, txscript.StandardVerifyFlags)
 	if err != nil {
 		return newError(ErrTxSigning, "cannot create script engine", err)
 	}
@@ -1087,13 +1246,4 @@ func nextChangeAddress(a ChangeAddress) (ChangeAddress, error) {
 	}
 	addr, err := a.pool.ChangeAddress(seriesID, index)
 	return *addr, err
-}
-
-func storeTransactions(store *wtxmgr.Store, transactions []*changeAwareTx) error {
-	for _, tx := range transactions {
-		if err := tx.addSelfToStore(store); err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/votingpool/withdrawal_test.go
+++ b/votingpool/withdrawal_test.go
@@ -107,7 +107,7 @@ func TestStartWithdrawal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	vp.TstCheckWithdrawalStatusMatches(t, *status, *status2)
+	vp.TstCheckWithdrawalStatusMatches(t, *status2, *status)
 }
 
 func checkWithdrawalOutputs(

--- a/votingpool/withdrawal_wb_test.go
+++ b/votingpool/withdrawal_wb_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/txscript"
@@ -784,24 +785,23 @@ func TestGetWithdrawalStatus(t *testing.T) {
 }
 
 func TestSignMultiSigUTXO(t *testing.T) {
-	tearDown, pool, _ := TstCreatePoolAndTxStore(t)
+	tearDown, pool, store := TstCreatePoolAndTxStore(t)
 	defer tearDown()
 
 	// Create a new tx with a single input that we're going to sign.
 	mgr := pool.Manager()
-	tx := createWithdrawalTx(t, pool, []int64{4e6}, []int64{4e6})
-	sigs, err := getRawSigs([]*withdrawalTx{tx})
+	tx := createChangeAwareTx(t, store, pool, []int64{4e6}, []int64{4e6})
+	ntxid := Ntxid("ntxid")
+	sigs, err := getRawSigs(map[Ntxid]changeAwareTx{ntxid: tx})
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	msgtx := tx.toMsgTx()
-	txSigs := sigs[tx.ntxid()]
+	txSigs := sigs[ntxid]
 
 	idx := 0 // The index of the tx input we're going to sign.
-	pkScript := tx.inputs[idx].PkScript
+	pkScript := getTxInPkScript(t, store, tx.MsgTx, idx)
 	TstRunWithManagerUnlocked(t, mgr, func() {
-		if err = signMultiSigUTXO(mgr, msgtx, idx, pkScript, txSigs[idx]); err != nil {
+		if err = signMultiSigUTXO(mgr, tx.MsgTx, idx, pkScript, txSigs[idx]); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -857,121 +857,125 @@ func TestSignMultiSigUTXORedeemScriptNotFound(t *testing.T) {
 }
 
 func TestSignMultiSigUTXONotEnoughSigs(t *testing.T) {
-	tearDown, pool, _ := TstCreatePoolAndTxStore(t)
+	tearDown, pool, store := TstCreatePoolAndTxStore(t)
 	defer tearDown()
 
 	mgr := pool.Manager()
-	tx := createWithdrawalTx(t, pool, []int64{4e6}, []int64{})
-	sigs, err := getRawSigs([]*withdrawalTx{tx})
+	tx := createChangeAwareTx(t, store, pool, []int64{4e6}, []int64{})
+	ntxid := Ntxid("ntxid")
+	sigs, err := getRawSigs(map[Ntxid]changeAwareTx{ntxid: tx})
 	if err != nil {
 		t.Fatal(err)
 	}
-	msgtx := tx.toMsgTx()
-	txSigs := sigs[tx.ntxid()]
+	txSigs := sigs[ntxid]
 
 	idx := 0 // The index of the tx input we're going to sign.
 	// Here we provide reqSigs-1 signatures to SignMultiSigUTXO()
 	txInSigs := txSigs[idx]
 	txInSigs.Sigs = txInSigs.Sigs[:txInSigs.Required-1]
-	pkScript := tx.inputs[idx].PkScript
+	pkScript := getTxInPkScript(t, store, tx.MsgTx, idx)
+
 	TstRunWithManagerUnlocked(t, mgr, func() {
-		err = signMultiSigUTXO(mgr, msgtx, idx, pkScript, txInSigs)
+		err = signMultiSigUTXO(mgr, tx.MsgTx, idx, pkScript, txInSigs)
 	})
 
 	TstCheckError(t, "", err, ErrTxSigning)
 }
 
 func TestSignMultiSigUTXOWrongRawSigs(t *testing.T) {
-	tearDown, pool, _ := TstCreatePoolAndTxStore(t)
+	tearDown, pool, store := TstCreatePoolAndTxStore(t)
 	defer tearDown()
 
 	mgr := pool.Manager()
-	tx := createWithdrawalTx(t, pool, []int64{4e6}, []int64{})
+	tx := createChangeAwareTx(t, store, pool, []int64{4e6}, []int64{})
 	sigs := newTxInSigs(1, 2)
 	sigs.Sigs = []RawSig{RawSig{0x00}, RawSig{0x01}}
 
 	idx := 0 // The index of the tx input we're going to sign.
-	pkScript := tx.inputs[idx].PkScript
+	pkScript := getTxInPkScript(t, store, tx.MsgTx, idx)
 	var err error
 	TstRunWithManagerUnlocked(t, mgr, func() {
-		err = signMultiSigUTXO(mgr, tx.toMsgTx(), idx, pkScript, sigs)
+		err = signMultiSigUTXO(mgr, tx.MsgTx, idx, pkScript, sigs)
 	})
 
 	TstCheckError(t, "", err, ErrTxSigning)
 }
 
 func TestGetRawSigs(t *testing.T) {
-	tearDown, pool, _ := TstCreatePoolAndTxStore(t)
+	tearDown, pool, store := TstCreatePoolAndTxStore(t)
 	defer tearDown()
 
-	tx := createWithdrawalTx(t, pool, []int64{5e6, 4e6}, []int64{})
-
-	sigs, err := getRawSigs([]*withdrawalTx{tx})
+	tx := createChangeAwareTx(t, store, pool, []int64{5e6, 4e6}, []int64{})
+	ntxid := Ntxid("ntxid")
+	sigs, err := getRawSigs(map[Ntxid]changeAwareTx{ntxid: tx})
 	if err != nil {
 		t.Fatal(err)
 	}
-	msgtx := tx.toMsgTx()
-	txSigs := sigs[tx.ntxid()]
-	if len(txSigs) != len(tx.inputs) {
-		t.Fatalf("Unexpected number of sig lists; got %d, want %d", len(txSigs), len(tx.inputs))
+	txSigs := sigs[ntxid]
+	if len(txSigs) != len(tx.TxIn) {
+		t.Fatalf("Unexpected number of sig lists; got %d, want %d", len(txSigs), len(tx.TxIn))
 	}
 
-	checkNonEmptySigsForPrivKeys(t, txSigs, tx.inputs[0].addr.series().privateKeys)
+	privKeys := tx.addrs[tx.TxIn[0].PreviousOutPoint].series().privateKeys
+	checkNonEmptySigsForPrivKeys(t, txSigs, privKeys)
 
 	// Since we have all the necessary signatures (m-of-n), we construct the
 	// sigsnature scripts and execute them to make sure the raw signatures are
 	// valid.
-	signTxAndValidate(t, pool.Manager(), msgtx, txSigs, tx.inputs)
+	signTxAndValidate(t, pool.Manager(), store, tx.MsgTx, txSigs)
 }
 
 func TestGetRawSigsOnlyOnePrivKeyAvailable(t *testing.T) {
-	tearDown, pool, _ := TstCreatePoolAndTxStore(t)
+	tearDown, pool, store := TstCreatePoolAndTxStore(t)
 	defer tearDown()
 
-	tx := createWithdrawalTx(t, pool, []int64{5e6, 4e6}, []int64{})
+	tx := createChangeAwareTx(t, store, pool, []int64{5e6, 4e6}, []int64{})
+	ntxid := Ntxid("ntxid")
 	// Remove all private keys but the first one from the credit's series.
-	series := tx.inputs[0].addr.series()
+	series := tx.addrs[tx.TxIn[0].PreviousOutPoint].series()
 	for i := range series.privateKeys[1:] {
 		series.privateKeys[i] = nil
 	}
 
-	sigs, err := getRawSigs([]*withdrawalTx{tx})
+	sigs, err := getRawSigs(map[Ntxid]changeAwareTx{ntxid: tx})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	txSigs := sigs[tx.ntxid()]
-	if len(txSigs) != len(tx.inputs) {
-		t.Fatalf("Unexpected number of sig lists; got %d, want %d", len(txSigs), len(tx.inputs))
+	txSigs := sigs[ntxid]
+	if len(txSigs) != len(tx.TxIn) {
+		t.Fatalf("Unexpected number of sig lists; got %d, want %d", len(txSigs), len(tx.TxIn))
 	}
 
 	checkNonEmptySigsForPrivKeys(t, txSigs, series.privateKeys)
 }
 
 func TestGetRawSigsUnparseableRedeemScript(t *testing.T) {
-	tearDown, pool, _ := TstCreatePoolAndTxStore(t)
+	tearDown, pool, store := TstCreatePoolAndTxStore(t)
 	defer tearDown()
 
-	tx := createWithdrawalTx(t, pool, []int64{5e6, 4e6}, []int64{})
+	tx := createChangeAwareTx(t, store, pool, []int64{5e6, 4e6}, []int64{})
+	ntxid := Ntxid("ntxid")
 	// Change the redeem script for one of our tx inputs, to force an error in
 	// getRawSigs().
-	tx.inputs[0].addr.script = []byte{0x01}
+	tx.addrs[tx.TxIn[0].PreviousOutPoint].script = []byte{0x01}
 
-	_, err := getRawSigs([]*withdrawalTx{tx})
+	_, err := getRawSigs(map[Ntxid]changeAwareTx{ntxid: tx})
 
 	TstCheckError(t, "", err, ErrRawSigning)
 }
 
 func TestGetRawSigsInvalidAddrBranch(t *testing.T) {
-	tearDown, pool, _ := TstCreatePoolAndTxStore(t)
+	tearDown, pool, store := TstCreatePoolAndTxStore(t)
 	defer tearDown()
 
-	tx := createWithdrawalTx(t, pool, []int64{5e6, 4e6}, []int64{})
+	tx := createChangeAwareTx(t, store, pool, []int64{5e6, 4e6}, []int64{})
+	ntxid := Ntxid("ntxid")
 	// Change the branch of our input's address to an invalid value, to force
 	// an error in getRawSigs().
-	tx.inputs[0].addr.branch = Branch(999)
+	tx.addrs[tx.TxIn[0].PreviousOutPoint].branch = Branch(999)
 
-	_, err := getRawSigs([]*withdrawalTx{tx})
+	_, err := getRawSigs(map[Ntxid]changeAwareTx{ntxid: tx})
 
 	TstCheckError(t, "", err, ErrInvalidBranch)
 }
@@ -1021,10 +1025,11 @@ func TestTxTooBig(t *testing.T) {
 }
 
 func TestTxSizeCalculation(t *testing.T) {
-	tearDown, pool, _ := TstCreatePoolAndTxStore(t)
+	tearDown, pool, store := TstCreatePoolAndTxStore(t)
 	defer tearDown()
 
-	tx := createWithdrawalTx(t, pool, []int64{1, 5}, []int64{2})
+	tx := createWithdrawalTxWithStoreCredits(t, store, pool, []int64{1, 5}, []int64{2})
+	ntxid := tx.ntxid()
 
 	size := tx.calculateSize()
 
@@ -1035,12 +1040,13 @@ func TestTxSizeCalculation(t *testing.T) {
 	tx.calculateFee = TstConstantFee(1)
 	seriesID := tx.inputs[0].addr.SeriesID()
 	tx.addChange(TstNewChangeAddress(t, pool, seriesID, 0).addr.ScriptAddress())
-	msgtx := tx.toMsgTx()
-	sigs, err := getRawSigs([]*withdrawalTx{tx})
+	cTx := changeAwareTxFromWithdrawalTx(tx)
+	msgtx := cTx.MsgTx
+	sigs, err := getRawSigs(map[Ntxid]changeAwareTx{ntxid: cTx})
 	if err != nil {
 		t.Fatal(err)
 	}
-	signTxAndValidate(t, pool.Manager(), msgtx, sigs[tx.ntxid()], tx.inputs)
+	signTxAndValidate(t, pool.Manager(), store, msgtx, sigs[ntxid])
 
 	// ECDSA signatures have variable length (71-73 bytes) but in
 	// calculateSize() we use a dummy signature for the worst-case scenario (73
@@ -1166,31 +1172,6 @@ func TestStoreTransactionsWithChangeOutput(t *testing.T) {
 	}
 }
 
-// createWithdrawalTxWithStoreCredits creates a new Credit in the given store
-// for each entry in inputAmounts, and uses them to construct a withdrawalTx
-// with one output for every entry in outputAmounts.
-func createWithdrawalTxWithStoreCredits(t *testing.T, store *wtxmgr.Store, pool *Pool,
-	inputAmounts []int64, outputAmounts []int64) *withdrawalTx {
-	masters := []*hdkeychain.ExtendedKey{
-		TstCreateMasterKey(t, bytes.Repeat(uint32ToBytes(getUniqueID()), 4)),
-		TstCreateMasterKey(t, bytes.Repeat(uint32ToBytes(getUniqueID()), 4)),
-		TstCreateMasterKey(t, bytes.Repeat(uint32ToBytes(getUniqueID()), 4)),
-	}
-	def := TstCreateSeriesDef(t, pool, 2, masters)
-	TstCreateSeries(t, pool, []TstSeriesDef{def})
-	net := pool.Manager().ChainParams()
-	tx := newWithdrawalTx(defaultTxOptions)
-	for _, c := range TstCreateSeriesCreditsOnStore(t, pool, def.SeriesID, inputAmounts, store) {
-		tx.addInput(c)
-	}
-	for i, amount := range outputAmounts {
-		request := TstNewOutputRequest(
-			t, uint32(i), "34eVkREKgvvGASZW7hkgE2uNc1yycntMK6", btcutil.Amount(amount), net)
-		tx.addOutput(request)
-	}
-	return tx
-}
-
 // checkNonEmptySigsForPrivKeys checks that every signature list in txSigs has
 // one non-empty signature for every non-nil private key in the given list. This
 // is to make sure every signature list matches the specification at
@@ -1263,12 +1244,11 @@ func checkTxInputs(t *testing.T, tx *withdrawalTx, inputs []credit) {
 }
 
 // signTxAndValidate will construct the signature script for each input of the given
-// transaction (using the given raw signatures and the pkScripts from credits) and execute
-// those scripts to validate them.
-func signTxAndValidate(t *testing.T, mgr *waddrmgr.Manager, tx *wire.MsgTx, txSigs TxSigs,
-	credits []credit) {
+// transaction (using the given raw signatures, and looking up the pkScript
+// from the wtxmgr.Store) and execute those scripts to validate them.
+func signTxAndValidate(t *testing.T, mgr *waddrmgr.Manager, store *wtxmgr.Store, tx *wire.MsgTx, txSigs TxSigs) {
 	for i := range tx.TxIn {
-		pkScript := credits[i].PkScript
+		pkScript := getTxInPkScript(t, store, tx, i)
 		TstRunWithManagerUnlocked(t, mgr, func() {
 			if err := signMultiSigUTXO(mgr, tx, i, pkScript, txSigs[i]); err != nil {
 				t.Fatal(err)
@@ -1374,4 +1354,16 @@ func checkLastOutputWasSplit(t *testing.T, w *withdrawal, tx *withdrawalTx,
 	if status != statusPartial {
 		t.Fatalf("Wrong output status; got '%s', want '%s'", status, statusPartial)
 	}
+}
+
+func getTxInPkScript(t *testing.T, store *wtxmgr.Store, tx *wire.MsgTx, idx int) []byte {
+	rec, err := wtxmgr.NewTxRecordFromMsgTx(tx, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkScripts, err := store.PreviousPkScripts(rec, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pkScripts[idx]
 }


### PR DESCRIPTION
This is the API that will eventually be exposed over the websocket interface so that members of a votingpool can pass on to the wallet the new signature lists (for a given withdrawal round) they received from other members

This depends on #305 