### PR TITLE
Fix retrieval of public key addresses from address manager

### DIFF
--- a/waddrmgr/manager.go
+++ b/waddrmgr/manager.go
@@ -678,6 +678,15 @@ func (m *Manager) loadAndCacheAddress(address btcutil.Address) (ManagedAddress, 
 // pay-to-pubkey-hash addresses and the script associated with
 // pay-to-script-hash addresses.
 func (m *Manager) Address(address btcutil.Address) (ManagedAddress, error) {
+	// ScriptAddress will only return a script hash if we're
+	// accessing an address that is either PKH or SH. In
+	// the event we're passed a PK address, convert the
+	// PK to PKH address so that we can access it from
+	// the addrs map and database.
+	if pka, ok := address.(*btcutil.AddressPubKey); ok {
+		address = pka.AddressPubKeyHash()
+	}
+
 	// Return the address from cache if it's available.
 	//
 	// NOTE: Not using a defer on the lock here since a write lock is


### PR DESCRIPTION
The behaviour of function Address() in waddrmgr has been updated such that
it now displays the correct behaviour as described in the comments. That is,
when a public key address is given as a btcutil.Address, the key is converted
to a public key hash address so that serializing with ScriptAddress() yields
the corresponding public key hash. This allows the address manager to find
the corresponding private key, and fixes the signing of multisignature
transactions.

Another minor addition is the returning of an error for failing to fully
sign a P2SH multisignature input, rather than the non-descript txscript
error for a stack underflow.