### PR TITLE
Detect silent network drops.

### DIFF
--- a/btcwallet.go
+++ b/btcwallet.go
@@ -123,7 +123,7 @@ func walletMain() error {
 			server.SetChainServer(rpcc)
 
 			// Start wallet goroutines and handle RPC client notifications
-			// if the wallet is not shutting down.
+			// if the server is not shutting down.
 			select {
 			case <-server.quit:
 				return
@@ -134,6 +134,7 @@ func walletMain() error {
 			// Block goroutine until the client is finished.
 			rpcc.WaitForShutdown()
 
+			wallet.SetChainSynced(false)
 			wallet.Stop()
 
 			// Reconnect only if the server is not shutting down.

--- a/btcwallet.go
+++ b/btcwallet.go
@@ -91,52 +91,57 @@ func walletMain() error {
 	// Shutdown the server if an interrupt signal is received.
 	addInterruptHandler(server.Stop)
 
-	// Create channel so that the goroutine which opens the chain server
-	// connection can pass the conn to the goroutine which opens the wallet.
-	// Buffer the channel so sends are not blocked, since if the wallet is
-	// not yet created, the wallet open goroutine does not read this.
-	chainSvrChan := make(chan *chain.Client, 1)
-
 	go func() {
-		// Read CA certs and create the RPC client.
-		var certs []byte
-		if !cfg.DisableClientTLS {
-			certs, err = ioutil.ReadFile(cfg.CAFile)
-			if err != nil {
-				log.Warnf("Cannot open CA file: %v", err)
-				// If there's an error reading the CA file, continue
-				// with nil certs and without the client connection
-				certs = nil
+		for {
+			// Read CA certs and create the RPC client.
+			var certs []byte
+			if !cfg.DisableClientTLS {
+				certs, err = ioutil.ReadFile(cfg.CAFile)
+				if err != nil {
+					log.Warnf("Cannot open CA file: %v", err)
+					// If there's an error reading the CA file, continue
+					// with nil certs and without the client connection
+					certs = nil
+				}
+			} else {
+				log.Info("Client TLS is disabled")
 			}
-		} else {
-			log.Info("Client TLS is disabled")
-		}
-		rpcc, err := chain.NewClient(activeNet.Params, cfg.RPCConnect,
-			cfg.BtcdUsername, cfg.BtcdPassword, certs, cfg.DisableClientTLS)
-		if err != nil {
-			log.Errorf("Cannot create chain server RPC client: %v", err)
-			return
-		}
-		err = rpcc.Start()
-		if err != nil {
-			log.Warnf("Connection to Bitcoin RPC chain server " +
-				"unsuccessful -- available RPC methods will be limited")
-		}
-		// Even if Start errored, we still add the server disconnected.
-		// All client methods will then error, so it's obvious to a
-		// client that the there was a connection problem.
-		server.SetChainServer(rpcc)
+			rpcc, err := chain.NewClient(activeNet.Params, cfg.RPCConnect,
+				cfg.BtcdUsername, cfg.BtcdPassword, certs, cfg.DisableClientTLS)
+			if err != nil {
+				log.Errorf("Cannot create chain server RPC client: %v", err)
+				return
+			}
+			err = rpcc.Start()
+			if err != nil {
+				log.Warnf("Connection to Bitcoin RPC chain server " +
+					"unsuccessful -- available RPC methods will be limited")
+			}
+			// Even if Start errored, we still add the server disconnected.
+			// All client methods will then error, so it's obvious to a
+			// client that the there was a connection problem.
+			server.SetChainServer(rpcc)
 
-		chainSvrChan <- rpcc
-	}()
+			// Start wallet goroutines and handle RPC client notifications
+			// if the wallet is not shutting down.
+			select {
+			case <-server.quit:
+				return
+			default:
+				wallet.Start(rpcc)
+			}
 
-	go func() {
-		// Start wallet goroutines and handle RPC client notifications
-		// if the chain server connection was opened.
-		select {
-		case chainSvr := <-chainSvrChan:
-			wallet.Start(chainSvr)
-		case <-server.quit:
+			// Block goroutine until the client is finished.
+			rpcc.WaitForShutdown()
+
+			wallet.Stop()
+
+			// Reconnect only if the server is not shutting down.
+			select {
+			case <-server.quit:
+				return
+			default:
+			}
 		}
 	}()
 

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -413,7 +413,7 @@ out:
 			case resp := <-sessionResponse:
 				if resp.err != nil {
 					log.Errorf("Failed to receive session "+
-						"result: %v", err)
+						"result: %v", resp.err)
 					c.Stop()
 					break out
 				}


### PR DESCRIPTION
This change introduces additional network activity with the btcd
process to ensure that the network connection is not silently dropped.
Previously, if the connection was lost (e.g. wallet runs on a laptop
and connects to remote btcd, and the laptop is suspended/resumed) the
lost connection would not be detectable since all normal RPC activity
(excluding requests from btcwallet to btcd made by the user) is in the
direction of btcd to wallet in the form of websocket notifications.

Rather than simply pinging the server and waiting for the response, a
unique session ID has been added for each websocket client connection.
These session IDs are randomly generated by the btcd RPC server when a
new websocket connection is established, and are queried using the
session RPC.  If the session ID changes, it is assumed that the
connection silently reconnected, and the client is shutdown for this
case as well.

Requires btcsuite/btcd#500 and btcsuite/btcrpcclient#62