### PR TITLE
Add logging option for btcrpcclient as subsystem RPCC.

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -224,7 +224,6 @@ func parseBlock(block *btcjson.BlockDetails) (*wtxmgr.BlockMeta, error) {
 }
 
 func (c *Client) onClientConnect() {
-	log.Info("Established websocket RPC connection to btcd")
 	select {
 	case c.enqueueNotification <- ClientConnected{}:
 	case <-c.quit:

--- a/log.go
+++ b/log.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btcrpcclient"
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/btcsuite/btcwallet/wallet"
 	"github.com/btcsuite/btcwallet/wtxmgr"
@@ -92,6 +93,7 @@ func useLogger(subsystemID string, logger btclog.Logger) {
 	case "CHNS":
 		chainLog = logger
 		chain.UseLogger(logger)
+		btcrpcclient.UseLogger(logger)
 	}
 }
 


### PR DESCRIPTION
This isn't really a subsystem, rather a dependency, but being able to
turn the logging on from the command line can greatly simplify debugging
of connectivity issues.