### PR TITLE
Separate out default ports and utility funcs.

### DIFF
--- a/internal/cfgutil/file.go
+++ b/internal/cfgutil/file.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015 The btcsuite developers
+ * Copyright (c) 2015 The btcsuite developers
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -14,8 +14,18 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-package main
+package cfgutil
 
-import "github.com/btcsuite/btcwallet/netparams"
+import "os"
 
-var activeNet = &netparams.TestNet3Params
+// FilesExists reports whether the named file or directory exists.
+func FileExists(filePath string) (bool, error) {
+	_, err := os.Stat(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}

--- a/internal/cfgutil/normalization.go
+++ b/internal/cfgutil/normalization.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2015 The btcsuite developers
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package cfgutil
+
+import "net"
+
+// NormalizeAddress returns the normalized form of the address, adding a default
+// port if necessary.  An error is returned if the address, even without a port,
+// is not valid.
+func NormalizeAddress(addr string, defaultPort string) (hostport string, err error) {
+	// If the first SplitHostPort errors because of a missing port and not
+	// for an invalid host, add the port.  If the second SplitHostPort
+	// fails, then a port is not missing and the original error should be
+	// returned.
+	host, port, origErr := net.SplitHostPort(addr)
+	if origErr == nil {
+		return net.JoinHostPort(host, port), nil
+	}
+	addr = net.JoinHostPort(addr, defaultPort)
+	_, _, err = net.SplitHostPort(addr)
+	if err != nil {
+		return "", origErr
+	}
+	return addr, nil
+}
+
+// NormalizeAddresses returns a new slice with all the passed peer addresses
+// normalized with the given default port, and all duplicates removed.
+func NormalizeAddresses(addrs []string, defaultPort string) ([]string, error) {
+	var (
+		normalized = make([]string, 0, len(addrs))
+		seenSet    = make(map[string]struct{})
+	)
+
+	for _, addr := range addrs {
+		normalizedAddr, err := NormalizeAddress(addr, defaultPort)
+		if err != nil {
+			return nil, err
+		}
+		_, seen := seenSet[normalizedAddr]
+		if !seen {
+			normalized = append(normalized, normalizedAddr)
+			seenSet[normalizedAddr] = struct{}{}
+		}
+	}
+
+	return normalized, nil
+}

--- a/netparams/params.go
+++ b/netparams/params.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2013-2015 The btcsuite developers
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package netparams
+
+import "github.com/btcsuite/btcd/chaincfg"
+
+// Params is used to group parameters for various networks such as the main
+// network and test networks.
+type Params struct {
+	*chaincfg.Params
+	RPCClientPort string
+	RPCServerPort string
+}
+
+// MainNetParams contains parameters specific running btcwallet and
+// btcd on the main network (wire.MainNet).
+var MainNetParams = Params{
+	Params:        &chaincfg.MainNetParams,
+	RPCClientPort: "8334",
+	RPCServerPort: "8332",
+}
+
+// TestNet3Params contains parameters specific running btcwallet and
+// btcd on the test network (version 3) (wire.TestNet3).
+var TestNet3Params = Params{
+	Params:        &chaincfg.TestNet3Params,
+	RPCClientPort: "18334",
+	RPCServerPort: "18332",
+}
+
+// SimNetParams contains parameters specific to the simulation test network
+// (wire.SimNet).
+var SimNetParams = Params{
+	Params:        &chaincfg.SimNetParams,
+	RPCClientPort: "18556",
+	RPCServerPort: "18554",
+}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -322,9 +322,11 @@ func newRPCServer(listenAddrs []string, maxPost, maxWebsockets int64) (*rpcServe
 	// Setup TLS if not disabled.
 	listenFunc := net.Listen
 	if !cfg.DisableServerTLS {
-		// Check for existence of cert file and key file
-		if !fileExists(cfg.RPCKey) && !fileExists(cfg.RPCCert) {
-			// if both files do not exist, we generate them.
+		// Check for existence of cert file and key file.  Generate a
+		// new keypair if both are missing.
+		_, e1 := os.Stat(cfg.RPCKey)
+		_, e2 := os.Stat(cfg.RPCCert)
+		if os.IsNotExist(e1) && os.IsNotExist(e2) {
 			err := genCertPair(cfg.RPCCert, cfg.RPCKey)
 			if err != nil {
 				return nil, err

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -432,8 +432,13 @@ func createWallet(cfg *config) error {
 	netDir := networkDir(cfg.DataDir, activeNet.Params)
 	keystorePath := filepath.Join(netDir, keystore.Filename)
 	var legacyKeyStore *keystore.Store
-	if fileExists(keystorePath) {
-		var err error
+	_, err := os.Stat(keystorePath)
+	if err != nil && !os.IsNotExist(err) {
+		// A stat error not due to a non-existant file should be
+		// returned to the caller.
+		return err
+	} else if err == nil {
+		// Keystore file exists.
 		legacyKeyStore, err = keystore.OpenDir(netDir)
 		if err != nil {
 			return err


### PR DESCRIPTION
This change moves the chain and network parameter definitions, along
with the default client and server ports, to a package for reuse by
other utilities (most notably, tools in the cmd dir).  Along with it,
functions commonly used for config parsing and validation are moved to
an internal package since they will also be useful for distributed
tools.