### PR TITLE
Make chain.Client an interface to allow for swapable back ends

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -65,7 +65,7 @@ type Wallet struct {
 	Manager *waddrmgr.Manager
 	TxStore *wtxmgr.Store
 
-	chainSvr        *chain.Client
+	chainSvr        chain.Client
 	chainSvrLock    sync.Mutex
 	chainSvrSynced  bool
 	chainSvrSyncMtx sync.Mutex
@@ -263,7 +263,7 @@ func (w *Wallet) notifyRelevantTx(relevantTx chain.RelevantTx) {
 }
 
 // Start starts the goroutines necessary to manage a wallet.
-func (w *Wallet) Start(chainServer *chain.Client) {
+func (w *Wallet) Start(chainServer chain.Client) {
 	w.quitMu.Lock()
 	select {
 	case <-w.quit:


### PR DESCRIPTION
Hi, 
I'm trying to make a simple bitcoin handling library using btcwallet and [Electrum](https://electrum.org/).
https://github.com/d4l3k/go-electrum

These are some refactors to make chain.Client into an interface and the existing Client into BTCRPCClient. This allows for other back ends besides btcrpcclient such as Electrum which doesn't require the entire blockchain to be stored locally.

This is an initial refactor with the fewest changes possible since I'm not that familiar with the btcwallet code base. If you think this isn't the best way to do this, please let me know which direction to look.

Thanks!