### PR TITLE
Always lock waddrmgr for every timeout or explicit request.

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -693,20 +693,17 @@ out:
 			break out
 
 		case <-w.lockRequests:
-			timeout = nil
 		case <-timeout:
 		}
 
 		// Select statement fell through by an explicit lock or the
 		// timer expiring.  Lock the manager here.
-		if timeout != nil {
-			timeout = nil
-			err := w.Manager.Lock()
-			if err != nil {
-				log.Errorf("Could not lock wallet: %v", err)
-			} else {
-				w.notifyLockStateChange(true)
-			}
+		timeout = nil
+		err := w.Manager.Lock()
+		if err != nil && !waddrmgr.IsError(err, waddrmgr.ErrLocked) {
+			log.Errorf("Could not lock wallet: %v", err)
+		} else {
+			w.notifyLockStateChange(true)
 		}
 	}
 	w.wg.Done()


### PR DESCRIPTION
Use waddrmgr.IsError to avoid logging errors when trying to lock an
already locked wallet.

Fixes #349.