### PR TITLE
Set account name for gettransaction results.

### DIFF
--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -911,19 +911,28 @@ func GetTransaction(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 			continue
 		}
 
-		var addr string
+		var address string
+		var accountName string
 		_, addrs, _, err := txscript.ExtractPkScriptAddrs(
 			details.MsgTx.TxOut[cred.Index].PkScript, w.ChainParams())
 		if err == nil && len(addrs) == 1 {
-			addr = addrs[0].EncodeAddress()
+			addr := addrs[0]
+			address = addr.EncodeAddress()
+			account, err := w.Manager.AddrAccount(addr)
+			if err == nil {
+				accountName, err = w.Manager.AccountName(account)
+				if err != nil {
+					accountName = ""
+				}
+			}
 		}
 
 		ret.Details = append(ret.Details, btcjson.GetTransactionDetailsResult{
 			// Fields left zeroed:
 			//   InvolvesWatchOnly
-			//   Account
 			//   Fee
-			Address:  addr,
+			Account:  accountName,
+			Address:  address,
 			Category: credCat,
 			Amount:   cred.Amount.ToBTC(),
 			Vout:     cred.Index,


### PR DESCRIPTION
This only sets the name for any kind of "receiving" category
(receive/immature/generate).

Fixes #360.