### PR TITLE
Add option for one time TLS keys.

### DIFF
--- a/config.go
+++ b/config.go
@@ -94,6 +94,7 @@ type config struct {
 	// aren't considered legacy.
 	RPCCert                string   `long:"rpccert" description:"File containing the certificate file"`
 	RPCKey                 string   `long:"rpckey" description:"File containing the certificate key"`
+	OneTimeTLSKey          bool     `long:"onetimetlskey" description:"Generate a new TLS certpair at startup, but only write the certificate to disk"`
 	DisableServerTLS       bool     `long:"noservertls" description:"Disable TLS for the RPC server -- NOTE: This is only allowed if the RPC server is bound to localhost"`
 	LegacyRPCListeners     []string `long:"rpclisten" description:"Listen for legacy RPC connections on this interface/port (default port: 18332, mainnet: 8332, simnet: 18554)"`
 	LegacyRPCMaxClients    int64    `long:"rpcmaxclients" description:"Max number of legacy RPC clients for standard connections"`

--- a/sample-btcwallet.conf
+++ b/sample-btcwallet.conf
@@ -50,6 +50,15 @@
 ; rpccert=~/.btcwallet/rpc.cert
 ; rpckey=~/.btcwallet/rpc.key
 
+; Enable one time TLS keys.  This option results in the process generating
+; a new certificate pair each startup, writing only the certificate file
+; to disk.  This is a more secure option for clients that only interact with
+; a local wallet process where persistent certs are not needed.
+;
+; This option will error at startup if the key specified by the rpckey option
+; already exists.
+; onetimetlskey=0
+
 ; Specify the interfaces for the RPC server listen on.  One rpclisten address
 ; per line.  Multiple rpclisten options may be set in the same configuration,
 ; and each will be used to listen for connections.  NOTE: The default port is


### PR DESCRIPTION
This option prevents the RPC server TLS key from ever being written to
disk.  This is performed by generating a new certificate pair each
startup and writing (possibly overwriting) the certificate but not the
key.

Closes #359.