### PR TITLE
Make walletpassphrase with timeout=0 never lock the wallet.

### DIFF
--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -1956,7 +1956,11 @@ func WalletPassphrase(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 	cmd := icmd.(*btcjson.WalletPassphraseCmd)
 
 	timeout := time.Second * time.Duration(cmd.Timeout)
-	err := w.Unlock([]byte(cmd.Passphrase), time.After(timeout))
+	var unlockAfter <-chan time.Time
+	if timeout != 0 {
+		unlockAfter = time.After(timeout)
+	}
+	err := w.Unlock([]byte(cmd.Passphrase), unlockAfter)
 	return nil, err
 }
 


### PR DESCRIPTION
This broke when the Unlock API changed to replace the timeout in
seconds with a time.Time channel.