### PR TITLE
Follow specification for FundTransaction RPC.

### DIFF
--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -348,10 +348,6 @@ func (s *walletServer) FundTransaction(ctx context.Context, req *pb.FundTransact
 
 	}
 
-	if req.TargetAmount != 0 && totalAmount < btcutil.Amount(req.TargetAmount) {
-		return nil, errors.New("insufficient output value to reach target")
-	}
-
 	var changeScript []byte
 	if req.IncludeChangeScript && totalAmount > btcutil.Amount(req.TargetAmount) {
 		changeAddr, err := s.wallet.NewChangeAddress(req.Account)


### PR DESCRIPTION
The specification states that even when the target output amount
cannot be reached, all available outputs should still be included in
the response and it is up to the caller to check that the target can
be satisified or not.  Follow this behavior by not erroring when the
target was not met.