### PR TITLE
Protect the relay fee field with a mutex.

### DIFF
--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -512,7 +512,7 @@ func GetInfo(icmd interface{}, w *wallet.Wallet, chainClient *chain.RPCClient) (
 	// to using the manager version.
 	info.WalletVersion = int32(waddrmgr.LatestMgrVersion)
 	info.Balance = bal.ToBTC()
-	info.PaytxFee = w.RelayFee.ToBTC()
+	info.PaytxFee = w.RelayFee().ToBTC()
 	// We don't set the following since they don't make much sense in the
 	// wallet architecture:
 	//  - unlocked_until
@@ -1572,11 +1572,11 @@ func SetTxFee(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 		return nil, ErrNeedPositiveAmount
 	}
 
-	incr, err := btcutil.NewAmount(cmd.Amount)
+	relayFee, err := btcutil.NewAmount(cmd.Amount)
 	if err != nil {
 		return nil, err
 	}
-	w.RelayFee = incr
+	w.SetRelayFee(relayFee)
 
 	// A boolean true result is returned upon success.
 	return true, nil

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -134,7 +134,7 @@ func (w *Wallet) txToOutputs(outputs []*wire.TxOut, account uint32, minconf int3
 		}
 		return txscript.PayToAddrScript(changeAddr)
 	}
-	tx, err := txauthor.NewUnsignedTransaction(outputs, w.RelayFee,
+	tx, err := txauthor.NewUnsignedTransaction(outputs, w.RelayFee(),
 		inputSource, changeSource)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This prevents races when setting a new relay fee through the legacy
RPC server (settxfee).

Fixes #379.