### PR TITLE
Stop wallet and close wallet DB on interrupt.

### DIFF
--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -806,13 +806,13 @@ func (s *loaderServer) WalletExists(ctx context.Context, req *pb.WalletExistsReq
 func (s *loaderServer) CloseWallet(ctx context.Context, req *pb.CloseWalletRequest) (
 	*pb.CloseWalletResponse, error) {
 
-	loadedWallet, ok := s.loader.LoadedWallet()
-	if !ok {
+	err := s.loader.UnloadWallet()
+	if err == wallet.ErrNotLoaded {
 		return nil, grpc.Errorf(codes.FailedPrecondition, "wallet is not loaded")
 	}
-
-	loadedWallet.Stop()
-	loadedWallet.WaitForShutdown()
+	if err != nil {
+		return nil, translateError(err)
+	}
 
 	return &pb.CloseWalletResponse{}, nil
 }

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -148,7 +148,7 @@ func createWallet(cfg *config) error {
 
 		// Import the addresses in the legacy keystore to the new wallet if
 		// any exist, locking each wallet again when finished.
-		loader.RunAfterLoad(func(w *wallet.Wallet, db walletdb.DB) {
+		loader.RunAfterLoad(func(w *wallet.Wallet) {
 			defer legacyKeyStore.Lock()
 
 			fmt.Println("Importing addresses from existing wallet...")


### PR DESCRIPTION
This corrects and simplifies the shutdown logic for interrupts, the
walletrpc.WalletLoaderService/CloseWallet RPC, and the legacy stop RPC
by both stopping all wallet processes and closing the wallet database.
It appears that this behavior broke as part of the wallet package
refactor, causing occasional nil pointer panics and memory faults when
closing the wallet database with active transactions.

Fixes #282.

Fixes #283.