### PR TITLE
Default to mainnet.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,6 @@ Wallet clients can use one of two RPC servers:
      notifications for changes to the wallet, this is the RPC server to use.
      The gRPC server is documented [here](./rpc/documentation/README.md).
 
-Mainnet support is currently disabled by default.  Use of btcwallet on
-mainnet requires passing the `--mainnet` flag on the command line or
-adding `mainnet=1` to the configuration file.  Mainnet will be enabled
-by default in a future release after further database changes and
-testing.
-
 ## Installation and updating
 
 ### Windows - MSIs Available
@@ -85,14 +79,14 @@ go get -u -v github.com/btcsuite/btcwallet/...
 
 ## Getting Started
 
-The following instructions detail how to get started with btcwallet
-connecting to a localhost btcd.  Commands should be run in `cmd.exe`
-or PowerShell on Windows, or any terminal emulator on *nix.
+The following instructions detail how to get started with btcwallet connecting
+to a localhost btcd.  Commands should be run in `cmd.exe` or PowerShell on
+Windows, or any terminal emulator on *nix.
 
 - Run the following command to start btcd:
 
 ```
-btcd --testnet -u rpcuser -P rpcpass
+btcd -u rpcuser -P rpcpass
 ```
 
 - Run the following command to create a wallet:

--- a/config.go
+++ b/config.go
@@ -50,8 +50,8 @@ type config struct {
 	Create        bool   `long:"create" description:"Create the wallet if it does not exist"`
 	CreateTemp    bool   `long:"createtemp" description:"Create a temporary simulation wallet (pass=password) in the data directory indicated; must call with --datadir"`
 	DataDir       string `short:"b" long:"datadir" description:"Directory to store wallets and transactions"`
-	MainNet       bool   `long:"mainnet" description:"Use the main Bitcoin network (default testnet3)"`
-	SimNet        bool   `long:"simnet" description:"Use the simulation test network (default testnet3)"`
+	TestNet3      bool   `long:"testnet" description:"Use the test Bitcoin network (version 3) (default mainnet)"`
+	SimNet        bool   `long:"simnet" description:"Use the simulation test network (default mainnet)"`
 	NoInitialLoad bool   `long:"noinitialload" description:"Defer wallet creation/opening on startup and enable loading wallets over RPC"`
 	DebugLevel    string `short:"d" long:"debuglevel" description:"Logging level {trace, debug, info, warn, error, critical}"`
 	LogDir        string `long:"logdir" description:"Directory to log output."`
@@ -61,7 +61,7 @@ type config struct {
 	WalletPass string `long:"walletpass" default-mask:"-" description:"The public wallet password -- Only required if the wallet was created with one"`
 
 	// RPC client options
-	RPCConnect       string `short:"c" long:"rpcconnect" description:"Hostname/IP and port of btcd RPC server to connect to (default localhost:18334, mainnet: localhost:8334, simnet: localhost:18556)"`
+	RPCConnect       string `short:"c" long:"rpcconnect" description:"Hostname/IP and port of btcd RPC server to connect to (default localhost:8334, testnet: localhost:18334, simnet: localhost:18556)"`
 	CAFile           string `long:"cafile" description:"File containing root certificates to authenticate a TLS connections with btcd"`
 	DisableClientTLS bool   `long:"noclienttls" description:"Disable TLS for the RPC client -- NOTE: This is only allowed if the RPC client is connecting to localhost"`
 	BtcdUsername     string `long:"btcdusername" description:"Username for btcd authentication"`
@@ -82,7 +82,7 @@ type config struct {
 	RPCKey                 string   `long:"rpckey" description:"File containing the certificate key"`
 	OneTimeTLSKey          bool     `long:"onetimetlskey" description:"Generate a new TLS certpair at startup, but only write the certificate to disk"`
 	DisableServerTLS       bool     `long:"noservertls" description:"Disable TLS for the RPC server -- NOTE: This is only allowed if the RPC server is bound to localhost"`
-	LegacyRPCListeners     []string `long:"rpclisten" description:"Listen for legacy RPC connections on this interface/port (default port: 18332, mainnet: 8332, simnet: 18554)"`
+	LegacyRPCListeners     []string `long:"rpclisten" description:"Listen for legacy RPC connections on this interface/port (default port: 8332, testnet: 18332, simnet: 18554)"`
 	LegacyRPCMaxClients    int64    `long:"rpcmaxclients" description:"Max number of legacy RPC clients for standard connections"`
 	LegacyRPCMaxWebsockets int64    `long:"rpcmaxwebsockets" description:"Max number of legacy RPC websocket connections"`
 	Username               string   `short:"u" long:"username" description:"Username for legacy RPC and btcd authentication (if btcdusername is unset)"`
@@ -93,10 +93,6 @@ type config struct {
 	// These options will change (and require changes to config files, etc.)
 	// when the new gRPC server is enabled.
 	ExperimentalRPCListeners []string `long:"experimentalrpclisten" description:"Listen for RPC connections on this interface/port"`
-
-	// Deprecated options
-	DisallowFree bool `long:"disallowfree" description:"DEPRECATED -- Force transactions to always include a fee"`
-	KeypoolSize  uint `short:"k" long:"keypoolsize" description:"DEPRECATED -- Maximum number of addresses in keypool"`
 }
 
 // cleanAndExpandPath expands environement variables and leading ~ in the
@@ -300,8 +296,8 @@ func loadConfig() (*config, []string, error) {
 	// Choose the active network params based on the selected network.
 	// Multiple networks can't be selected simultaneously.
 	numNets := 0
-	if cfg.MainNet {
-		activeNet = &netparams.MainNetParams
+	if cfg.TestNet3 {
+		activeNet = &netparams.TestNet3Params
 		numNets++
 	}
 	if cfg.SimNet {
@@ -309,7 +305,7 @@ func loadConfig() (*config, []string, error) {
 		numNets++
 	}
 	if numNets > 1 {
-		str := "%s: The mainnet and simnet params can't be used " +
+		str := "%s: The testnet and simnet params can't be used " +
 			"together -- choose one"
 		err := fmt.Errorf(str, "loadConfig")
 		fmt.Fprintln(os.Stderr, err)

--- a/params.go
+++ b/params.go
@@ -6,4 +6,4 @@ package main
 
 import "github.com/btcsuite/btcwallet/netparams"
 
-var activeNet = &netparams.TestNet3Params
+var activeNet = &netparams.MainNetParams

--- a/sample-btcwallet.conf
+++ b/sample-btcwallet.conf
@@ -4,23 +4,16 @@
 ; Bitcoin wallet settings
 ; ------------------------------------------------------------------------------
 
-; Use mainnet (cannot be used with simnet=1).
-; mainnet=0
+; Use testnet (cannot be used with simnet=1).
+; testnet=0
 
-; Use simnet (cannot be used with mainnet=1).
+; Use simnet (cannot be used with testnet=1).
 ; simnet=0
 
 ; The directory to open and save wallet, transaction, and unspent transaction
 ; output files.  Two directories, `mainnet` and `testnet` are used in this
 ; directory for mainnet and testnet wallets, respectively.
 ; datadir=~/.btcwallet
-
-; Maximum number of addresses to generate for the keypool (DEPRECATED)
-; keypoolsize=100
-
-; Whether transactions must be created with some minimum fee, even if the
-; calculated transaction priority is high enough to allow a free tx
-; disallowfree = false
 
 
 ; ------------------------------------------------------------------------------
@@ -62,21 +55,21 @@
 ; Specify the interfaces for the RPC server listen on.  One rpclisten address
 ; per line.  Multiple rpclisten options may be set in the same configuration,
 ; and each will be used to listen for connections.  NOTE: The default port is
-; modified by some options such as 'mainnet', so it is recommended to not
+; modified by some options such as 'testnet', so it is recommended to not
 ; specify a port and allow a proper default to be chosen unless you have a
 ; specific reason to do otherwise.
 ; rpclisten=                ; all interfaces on default port
 ; rpclisten=0.0.0.0         ; all ipv4 interfaces on default port
 ; rpclisten=::              ; all ipv6 interfaces on default port
-; rpclisten=:18332          ; all interfaces on port 18332
-; rpclisten=0.0.0.0:18332   ; all ipv4 interfaces on port 18332
-; rpclisten=[::]:18332      ; all ipv6 interfaces on port 18332
-; rpclisten=127.0.0.1:18332 ; only ipv4 localhost on port 18332 (this is a default)
-; rpclisten=[::1]:18332     ; only ipv6 localhost on port 18332 (this is a default)
-; rpclisten=127.0.0.1:18337 ; only ipv4 localhost on non-standard port 18337
-; rpclisten=:18337          ; all interfaces on non-standard port 18337
-; rpclisten=0.0.0.0:18337   ; all ipv4 interfaces on non-standard port 18337
-; rpclisten=[::]:18337      ; all ipv6 interfaces on non-standard port 18337
+; rpclisten=:8332           ; all interfaces on port 8332
+; rpclisten=0.0.0.0:8332    ; all ipv4 interfaces on port 8332
+; rpclisten=[::]:8332       ; all ipv6 interfaces on port 8332
+; rpclisten=127.0.0.1:8332  ; only ipv4 localhost on port 8332 (this is a default)
+; rpclisten=[::1]:8332      ; only ipv6 localhost on port 8332 (this is a default)
+; rpclisten=127.0.0.1:8337  ; only ipv4 localhost on non-standard port 8337
+; rpclisten=:8337           ; all interfaces on non-standard port 8337
+; rpclisten=0.0.0.0:8337    ; all ipv4 interfaces on non-standard port 8337
+; rpclisten=[::]:8337       ; all ipv6 interfaces on non-standard port 8337
 
 ; Legacy (Bitcoin Core-compatible) RPC listener addresses.  Addresses without a
 ; port specified use the same default port as the new server.  Listeners cannot


### PR DESCRIPTION
Note that this is a breaking change since it removes the mainnet
config option, replacing it with a testnet option.  Old configuration
files that set mainnet=1 will cause the wallet to error during startup
since extraneous flags are treated as errors.

Closes #383.