### PR TITLE
Disallow naming accounts the empty string.

### DIFF
--- a/waddrmgr/manager.go
+++ b/waddrmgr/manager.go
@@ -1711,6 +1711,10 @@ func (m *Manager) LastInternalAddress(account uint32) (ManagedAddress, error) {
 
 // ValidateAccountName validates the given account name and returns an error, if any.
 func ValidateAccountName(name string) error {
+	if name == "" {
+		str := "accounts may not be named the empty string"
+		return managerError(ErrInvalidAccount, str, nil)
+	}
 	if isReservedAccountName(name) {
 		str := "reserved account name"
 		return managerError(ErrInvalidAccount, str, nil)

--- a/waddrmgr/manager_test.go
+++ b/waddrmgr/manager_test.go
@@ -1138,6 +1138,12 @@ func testNewAccount(tc *testContext) bool {
 		return false
 	}
 	// Test account name validation
+	testName = "" // Empty account names are not allowed
+	_, err = tc.manager.NewAccount(testName)
+	wantErrCode = waddrmgr.ErrInvalidAccount
+	if !checkManagerError(tc.t, testName, err, wantErrCode) {
+		return false
+	}
 	testName = "imported" // A reserved account name
 	_, err = tc.manager.NewAccount(testName)
 	wantErrCode = waddrmgr.ErrInvalidAccount


### PR DESCRIPTION
This change only prevents creating new accounts with the empty name or
renaming an existing account to one.  Any accounts in the DB that are
already named the empty string are left untouched (and should be
renamed to something meaningful by the user).

Fixes #369.