### PR TITLE
Manage wallet db namespaces from wallet package.

### DIFF
--- a/votingpool/factory_test.go
+++ b/votingpool/factory_test.go
@@ -149,9 +149,13 @@ func TstCreateTxStore(t *testing.T) (store *wtxmgr.Store, tearDown func()) {
 	if err != nil {
 		t.Fatalf("Failed to create walletdb namespace: %v", err)
 	}
-	s, err := wtxmgr.Create(wtxmgrNamespace)
+	err = wtxmgr.Create(wtxmgrNamespace)
 	if err != nil {
 		t.Fatalf("Failed to create txstore: %v", err)
+	}
+	s, err := wtxmgr.Open(wtxmgrNamespace)
+	if err != nil {
+		t.Fatalf("Failed to open txstore: %v", err)
 	}
 	return s, func() { os.RemoveAll(dir) }
 }
@@ -345,8 +349,12 @@ func TstCreatePool(t *testing.T) (tearDownFunc func(), mgr *waddrmgr.Manager, po
 		t.Fatalf("Failed to create addr manager DB namespace: %v", err)
 	}
 	var fastScrypt = &waddrmgr.ScryptOptions{N: 16, R: 8, P: 1}
-	mgr, err = waddrmgr.Create(mgrNamespace, seed, pubPassphrase, privPassphrase,
+	err = waddrmgr.Create(mgrNamespace, seed, pubPassphrase, privPassphrase,
 		&chaincfg.MainNetParams, fastScrypt)
+	if err == nil {
+		mgr, err = waddrmgr.Open(mgrNamespace, pubPassphrase,
+			&chaincfg.MainNetParams, nil)
+	}
 	if err != nil {
 		t.Fatalf("Failed to create addr manager: %v", err)
 	}

--- a/waddrmgr/common_test.go
+++ b/waddrmgr/common_test.go
@@ -234,8 +234,12 @@ func setupManager(t *testing.T) (tearDownFunc func(), mgr *waddrmgr.Manager) {
 		_ = os.RemoveAll(dirName)
 		t.Fatalf("createDbNamespace: unexpected error: %v", err)
 	}
-	mgr, err = waddrmgr.Create(namespace, seed, pubPassphrase,
+	err = waddrmgr.Create(namespace, seed, pubPassphrase,
 		privPassphrase, &chaincfg.MainNetParams, fastScrypt)
+	if err == nil {
+		mgr, err = waddrmgr.Open(namespace, pubPassphrase,
+			&chaincfg.MainNetParams, nil)
+	}
 	if err != nil {
 		db.Close()
 		_ = os.RemoveAll(dirName)

--- a/waddrmgr/manager_test.go
+++ b/waddrmgr/manager_test.go
@@ -1706,10 +1706,16 @@ func TestManager(t *testing.T) {
 	}
 
 	// Create a new manager.
-	mgr, err := waddrmgr.Create(mgrNamespace, seed, pubPassphrase,
+	err = waddrmgr.Create(mgrNamespace, seed, pubPassphrase,
 		privPassphrase, &chaincfg.MainNetParams, fastScrypt)
 	if err != nil {
 		t.Errorf("Create: unexpected error: %v", err)
+		return
+	}
+	mgr, err := waddrmgr.Open(mgrNamespace, pubPassphrase,
+		&chaincfg.MainNetParams, nil)
+	if err != nil {
+		t.Errorf("Open: unexpected error: %v", err)
 		return
 	}
 
@@ -1718,7 +1724,7 @@ func TestManager(t *testing.T) {
 
 	// Attempt to create the manager again to ensure the expected error is
 	// returned.
-	_, err = waddrmgr.Create(mgrNamespace, seed, pubPassphrase,
+	err = waddrmgr.Create(mgrNamespace, seed, pubPassphrase,
 		privPassphrase, &chaincfg.MainNetParams, fastScrypt)
 	if !checkManagerError(t, "Create existing", err, waddrmgr.ErrAlreadyExists) {
 		mgr.Close()

--- a/walletdb/interface.go
+++ b/walletdb/interface.go
@@ -171,6 +171,18 @@ type Namespace interface {
 	Update(fn func(Tx) error) error
 }
 
+// NamespaceIsEmpty returns whether the namespace is empty, that is, whether there
+// are no key/value pairs or nested buckets.
+func NamespaceIsEmpty(namespace Namespace) (bool, error) {
+	var empty bool
+	err := namespace.View(func(tx Tx) error {
+		k, v := tx.RootBucket().Cursor().First()
+		empty = k == nil && v == nil
+		return nil
+	})
+	return empty, err
+}
+
 // DB represents a collection of namespaces which are persisted.  All database
 // access is performed through transactions which are obtained through the
 // specific Namespace.

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -14,19 +14,12 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
-	"github.com/btcsuite/btcutil/hdkeychain"
 	"github.com/btcsuite/btcwallet/internal/legacy/keystore"
 	"github.com/btcsuite/btcwallet/internal/prompt"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet"
 	"github.com/btcsuite/btcwallet/walletdb"
 	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
-)
-
-// Namespace keys
-var (
-	waddrmgrNamespaceKey = []byte("waddrmgr")
-	wtxmgrNamespaceKey   = []byte("wtxmgr")
 )
 
 // networkDir returns the directory name of a network directory to hold wallet
@@ -214,12 +207,6 @@ func createSimulationWallet(cfg *config) error {
 	// Public passphrase is the default.
 	pubPass := []byte(wallet.InsecurePubPassphrase)
 
-	// Generate a random seed.
-	seed, err := hdkeychain.GenerateSeed(hdkeychain.RecommendedSeedLen)
-	if err != nil {
-		return err
-	}
-
 	netDir := networkDir(cfg.DataDir, activeNet.Params)
 
 	// Create the wallet.
@@ -233,19 +220,11 @@ func createSimulationWallet(cfg *config) error {
 	}
 	defer db.Close()
 
-	// Create the address manager.
-	waddrmgrNamespace, err := db.Namespace(waddrmgrNamespaceKey)
+	// Create the wallet.
+	err = wallet.Create(db, pubPass, privPass, nil, activeNet.Params)
 	if err != nil {
 		return err
 	}
-
-	manager, err := waddrmgr.Create(waddrmgrNamespace, seed, []byte(pubPass),
-		[]byte(privPass), activeNet.Params, nil)
-	if err != nil {
-		return err
-	}
-
-	manager.Close()
 
 	fmt.Println("The wallet has been created successfully.")
 	return nil

--- a/wtxmgr/example_test.go
+++ b/wtxmgr/example_test.go
@@ -155,7 +155,12 @@ func Example_basicUsage() {
 	}
 
 	// Create (or open) the transaction store in the provided namespace.
-	s, err := wtxmgr.Create(ns)
+	err = wtxmgr.Create(ns)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	s, err := wtxmgr.Open(ns)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/wtxmgr/tx.go
+++ b/wtxmgr/tx.go
@@ -148,15 +148,11 @@ func Open(namespace walletdb.Namespace) (*Store, error) {
 	return &Store{namespace, nil}, nil // TODO: set callbacks
 }
 
-// Create creates and opens a new persistent transaction store in the walletdb
-// namespace.  Creating the store when one already exists in this namespace will
-// error with ErrAlreadyExists.
-func Create(namespace walletdb.Namespace) (*Store, error) {
-	err := createStore(namespace)
-	if err != nil {
-		return nil, err
-	}
-	return &Store{namespace, nil}, nil // TODO: set callbacks
+// Create creates a new persistent transaction store in the walletdb namespace.
+// Creating the store when one already exists in this namespace will error with
+// ErrAlreadyExists.
+func Create(namespace walletdb.Namespace) error {
+	return createStore(namespace)
 }
 
 // moveMinedTx moves a transaction record from the unmined buckets to block

--- a/wtxmgr/tx_test.go
+++ b/wtxmgr/tx_test.go
@@ -75,7 +75,11 @@ func testStore() (*Store, func(), error) {
 	if err != nil {
 		return nil, teardown, err
 	}
-	s, err := Create(ns)
+	err = Create(ns)
+	if err != nil {
+		return nil, teardown, err
+	}
+	s, err := Open(ns)
 	return s, teardown, err
 }
 


### PR DESCRIPTION
This changes the wallet.Open function signature to remove the database
namespace parameters.  This is done so that the wallet package itself
is responsible for the location and opening of these namespaces from
the database, rather than requiring the caller to open these ahead of
time.

A new wallet.Create function has also been added.  This function
initializes a new wallet in an empty database, using the same
namespaces as wallet.Open will eventually use.  This relieves the
caller from needing to manage wallet database namespaces explicitly.

Fixes #397.