### PR TITLE
Print version string at startup.

### DIFF
--- a/btcwallet.go
+++ b/btcwallet.go
@@ -47,6 +47,9 @@ func walletMain() error {
 	cfg = tcfg
 	defer backendLog.Flush()
 
+	// Show version at startup.
+	log.Infof("Version %s", version())
+
 	if cfg.Profile != "" {
 		go func() {
 			listenAddr := net.JoinHostPort("", cfg.Profile)


### PR DESCRIPTION
This makes btcwallet match btcd's behavior.

Initially pointed out in:
decred/dcrwallet#125