### PR TITLE
Rollback namespace transactions when bucket is not found.

### DIFF
--- a/walletdb/bdb/db.go
+++ b/walletdb/bdb/db.go
@@ -290,6 +290,7 @@ func (ns *namespace) Begin(writable bool) (walletdb.Tx, error) {
 
 	bucket := boltTx.Bucket(ns.key)
 	if bucket == nil {
+		boltTx.Rollback()
 		return nil, walletdb.ErrBucketNotFound
 	}
 


### PR DESCRIPTION
This fixes a deadlock where failed transactions due to the namespaces'
bucket being missing would cause deadlocks due to bolt's mmap rwmutex
still being read locked (and no way to unlock it, since the underlying
bolt tx was not returned on failure).