### PR TITLE
Update TravisCI configs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ before_install:
 install:
   - go get -d -t -v ./...
   - go get -v $gotools/cmd/cover
-  - go get -v $gotools/cmd/vet
   - go get -v github.com/bradfitz/goimports
   - go get -v github.com/golang/lint/golint
 script:


### PR DESCRIPTION
The vet tool moved to the Go tree as of go1.5 so it does not
need to be installed seperately.  With the x/tools repo now gone,
remove the install step for vet since it fails.