### PR TITLE
Rename datadir/-b options to appdata/-A.

### DIFF
--- a/btcwallet.go
+++ b/btcwallet.go
@@ -61,7 +61,7 @@ func walletMain() error {
 		}()
 	}
 
-	dbDir := networkDir(cfg.DataDir, activeNet.Params)
+	dbDir := networkDir(cfg.AppDataDir, activeNet.Params)
 	loader := wallet.NewLoader(activeNet.Params, dbDir)
 
 	// Create and start HTTP server to serve wallet client connections.

--- a/sample-btcwallet.conf
+++ b/sample-btcwallet.conf
@@ -13,7 +13,7 @@
 ; The directory to open and save wallet, transaction, and unspent transaction
 ; output files.  Two directories, `mainnet` and `testnet` are used in this
 ; directory for mainnet and testnet wallets, respectively.
-; datadir=~/.btcwallet
+; appdata=~/.btcwallet
 
 
 ; ------------------------------------------------------------------------------

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -99,13 +99,13 @@ func convertLegacyKeystore(legacyKeyStore *keystore.Store, manager *waddrmgr.Man
 // and generates the wallet accordingly.  The new wallet will reside at the
 // provided path.
 func createWallet(cfg *config) error {
-	dbDir := networkDir(cfg.DataDir, activeNet.Params)
+	dbDir := networkDir(cfg.AppDataDir, activeNet.Params)
 	loader := wallet.NewLoader(activeNet.Params, dbDir)
 
 	// When there is a legacy keystore, open it now to ensure any errors
 	// don't end up exiting the process after the user has spent time
 	// entering a bunch of information.
-	netDir := networkDir(cfg.DataDir, activeNet.Params)
+	netDir := networkDir(cfg.AppDataDir, activeNet.Params)
 	keystorePath := filepath.Join(netDir, keystore.Filename)
 	var legacyKeyStore *keystore.Store
 	_, err := os.Stat(keystorePath)
@@ -207,7 +207,7 @@ func createSimulationWallet(cfg *config) error {
 	// Public passphrase is the default.
 	pubPass := []byte(wallet.InsecurePubPassphrase)
 
-	netDir := networkDir(cfg.DataDir, activeNet.Params)
+	netDir := networkDir(cfg.AppDataDir, activeNet.Params)
 
 	// Create the wallet.
 	dbPath := filepath.Join(netDir, walletDbName)


### PR DESCRIPTION
This removes an inconsistency with the datadir option from btcd, which
only set the directory containing the blockchain data and indexes.