### PR TITLE
Lookup actual home directory when expanding ~.

### DIFF
--- a/config.go
+++ b/config.go
@@ -283,7 +283,8 @@ func loadConfig() (*config, []string, error) {
 	// Load additional config from file.
 	var configFileError error
 	parser := flags.NewParser(&cfg, flags.Default)
-	err = flags.NewIniParser(parser).ParseFile(preCfg.ConfigFile)
+	configFilePath := cleanAndExpandPath(preCfg.ConfigFile)
+	err = flags.NewIniParser(parser).ParseFile(configFilePath)
 	if err != nil {
 		if _, ok := err.(*os.PathError); !ok {
 			fmt.Fprintln(os.Stderr, err)
@@ -323,6 +324,7 @@ func loadConfig() (*config, []string, error) {
 	// relative to the data dir are unchanged, modify each path to be
 	// relative to the new data dir.
 	if cfg.AppDataDir != defaultAppDataDir {
+		cfg.AppDataDir = cleanAndExpandPath(cfg.AppDataDir)
 		if cfg.RPCKey == defaultRPCKeyFile {
 			cfg.RPCKey = filepath.Join(cfg.AppDataDir, "rpc.key")
 		}
@@ -613,6 +615,8 @@ func loadConfig() (*config, []string, error) {
 
 	// Expand environment variable and leading ~ for filepaths.
 	cfg.CAFile = cleanAndExpandPath(cfg.CAFile)
+	cfg.RPCCert = cleanAndExpandPath(cfg.RPCCert)
+	cfg.RPCKey = cleanAndExpandPath(cfg.RPCKey)
 
 	// If the btcd username or password are unset, use the same auth as for
 	// the client.  The two settings were previously shared for btcd and

--- a/config.go
+++ b/config.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/user"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -99,16 +101,50 @@ type config struct {
 // cleanAndExpandPath expands environement variables and leading ~ in the
 // passed path, cleans the result, and returns it.
 func cleanAndExpandPath(path string) string {
-	// Expand initial ~ to OS specific home directory.
-	if strings.HasPrefix(path, "~") {
-		homeDir := filepath.Dir(defaultAppDataDir)
-		path = strings.Replace(path, "~", homeDir, 1)
-	}
-
 	// NOTE: The os.ExpandEnv doesn't work with Windows cmd.exe-style
 	// %VARIABLE%, but they variables can still be expanded via POSIX-style
 	// $VARIABLE.
-	return filepath.Clean(os.ExpandEnv(path))
+	path = os.ExpandEnv(path)
+
+	if !strings.HasPrefix(path, "~") {
+		return filepath.Clean(path)
+	}
+
+	// Expand initial ~ to the current user's home directory, or ~otheruser
+	// to otheruser's home directory.  On Windows, both forward and backward
+	// slashes can be used.
+	path = path[1:]
+
+	var pathSeparators string
+	if runtime.GOOS == "windows" {
+		pathSeparators = string(os.PathSeparator) + "/"
+	} else {
+		pathSeparators = string(os.PathSeparator)
+	}
+
+	userName := ""
+	if i := strings.IndexAny(path, pathSeparators); i != -1 {
+		userName = path[:i]
+		path = path[i:]
+	}
+
+	homeDir := ""
+	var u *user.User
+	var err error
+	if userName == "" {
+		u, err = user.Current()
+	} else {
+		u, err = user.Lookup(userName)
+	}
+	if err == nil {
+		homeDir = u.HomeDir
+	}
+	// Fallback to CWD if user lookup fails or user has no home directory.
+	if homeDir == "" {
+		homeDir = "."
+	}
+
+	return filepath.Join(homeDir, path)
 }
 
 // validLogLevel returns whether or not logLevel is a valid debug log level.


### PR DESCRIPTION
This fixes home directory expansion on Windows and OS X.  Previously
on these platforms, a leading ~ would expand to %LOCALAPPDATA% on
Windows or ~/Library/Application Support/ on OS X.

While here, add support for ~otheruser expansion to expand to
otheruser's home directory.