### PR TITLE
[WIP] Add support for new Segregated Witness standard output types

### DIFF
--- a/waddrmgr/address.go
+++ b/waddrmgr/address.go
@@ -363,6 +363,9 @@ func newManagedAddressWithoutPrivKey(m *Manager, account uint32, pubKey *btcec.P
 		if err != nil {
 			return nil, err
 		}
+	case adtImport:
+		// TODO(roasbeef): truly proper?
+		fallthrough
 	case adtChain:
 		address, err = btcutil.NewAddressPubKeyHash(pubKeyHash, m.chainParams)
 		if err != nil {

--- a/waddrmgr/manager_test.go
+++ b/waddrmgr/manager_test.go
@@ -294,7 +294,8 @@ func testExternalAddresses(tc *testContext) bool {
 	if tc.create {
 		prefix := prefix + " NextExternalAddresses"
 		var err error
-		addrs, err = tc.manager.NextExternalAddresses(tc.account, 5)
+		addrs, err = tc.manager.NextExternalAddresses(tc.account, 5,
+			waddrmgr.PubKeyHash)
 		if err != nil {
 			tc.t.Errorf("%s: unexpected error: %v", prefix, err)
 			return false
@@ -421,7 +422,8 @@ func testInternalAddresses(tc *testContext) bool {
 	if tc.create {
 		prefix := prefix + " NextInternalAddress"
 		var err error
-		addrs, err = tc.manager.NextInternalAddresses(tc.account, 5)
+		addrs, err = tc.manager.NextInternalAddresses(tc.account, 5,
+			waddrmgr.PubKeyHash)
 		if err != nil {
 			tc.t.Errorf("%s: unexpected error: %v", prefix, err)
 			return false

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -40,7 +40,7 @@ func makeInputSource(eligible []wtxmgr.Credit) txauthor.InputSource {
 		for currentTotal < target && len(eligible) != 0 {
 			nextCredit := &eligible[0]
 			eligible = eligible[1:]
-			nextInput := wire.NewTxIn(&nextCredit.OutPoint, nil)
+			nextInput := wire.NewTxIn(&nextCredit.OutPoint, nil, nil)
 			currentTotal += nextCredit.Amount
 			currentInputs = append(currentInputs, nextInput)
 			currentScripts = append(currentScripts, nextCredit.PkScript)
@@ -224,7 +224,7 @@ func (w *Wallet) findEligibleOutputs(account uint32, minconf int32, bs *waddrmgr
 func validateMsgTx(tx *wire.MsgTx, prevScripts [][]byte) error {
 	for i, prevScript := range prevScripts {
 		vm, err := txscript.NewEngine(prevScript, tx, i,
-			txscript.StandardVerifyFlags, nil)
+			txscript.StandardVerifyFlags, nil, nil, 0)
 		if err != nil {
 			return fmt.Errorf("cannot create script engine: %s", err)
 		}

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -230,9 +230,10 @@ func (w *Wallet) findEligibleOutputs(account uint32, minconf int32, bs *waddrmgr
 // scripts from outputs redeemed by the transaction, in the same order they are
 // spent, must be passed in the prevScripts slice.
 func validateMsgTx(tx *wire.MsgTx, prevScripts [][]byte, inputValues []btcutil.Amount) error {
+	hashCache := txscript.NewTxSigHashes(tx)
 	for i, prevScript := range prevScripts {
 		vm, err := txscript.NewEngine(prevScript, tx, i,
-			txscript.StandardVerifyFlags, nil, nil, int64(inputValues[i]))
+			txscript.StandardVerifyFlags, nil, hashCache, int64(inputValues[i]))
 		if err != nil {
 			return fmt.Errorf("cannot create script engine: %s", err)
 		}

--- a/wallet/internal/txsizes/size.go
+++ b/wallet/internal/txsizes/size.go
@@ -52,7 +52,41 @@ const (
 	//   - 25 bytes P2PKH output script
 	P2PKHOutputSize = 8 + 1 + P2PKHPkScriptSize
 
-	// TODO(roasbeef): add estimates for nested p2wkh and p2pkh
+	// RedeemP2WPKHScriptSize is the worst case (largest) serialize size of
+	// a transaction input script redeeming a compressed P2WKH output. It
+	// is calculated as:
+	//
+	//   - 72 bytes DER signature + 1 byte sighash
+	//   - 33 bytes serialized compressed pubkey
+	RedeemP2WPKHScriptSize = 73 + 33
+
+	// P2WKHScriptSize is the size of a transaction output script that pays
+	// to a compressed witness pubkey hash.  It is calculated as:
+	//
+	//	- OP_0: 1 byte
+	//	- OP_DATA: 1 byte (PublicKeyHASH160 length)
+	//	- PublicKeyHASH160: 20 bytes
+	P2WPKHScriptSize = 1 + 1 + 20
+
+	// RedeemP2WKHInputSize is the worst case (largest) serialize size of a
+	// transaction input redeeming a compressed P2WKH output.  It is
+	// calculated as:
+	//
+	//   - 32 bytes previous tx
+	//   - 4 bytes output index
+	//   - 1 byte number of witness elements
+	//   - 2 bytes for both witness element lengths
+	//   - 106 bytes witness
+	//  - 4 bytes sequence
+	RedeemP2WKHInputSize = 32 + 4 + 1 + RedeemP2WPKHScriptSize + 4
+
+	// P2WKHOutputSize is the serialize size of a transaction output with a
+	// P2WKH output script.  It is calculated as:
+	//
+	//   - 8 bytes output value
+	//   - 1 byte compact int encoding value 25
+	//   - 22 bytes P2PKH output script
+	P2WKHOutputSize = 8 + 1 + P2WPKHScriptSize
 )
 
 // EstimateSerializeSize returns a worst case serialize size estimate for a

--- a/wallet/internal/txsizes/size.go
+++ b/wallet/internal/txsizes/size.go
@@ -78,15 +78,64 @@ const (
 	//   - 2 bytes for both witness element lengths
 	//   - 106 bytes witness
 	//  - 4 bytes sequence
-	RedeemP2WKHInputSize = 32 + 4 + 1 + RedeemP2WPKHScriptSize + 4
+	RedeemP2WKHInputSize = 32 + 4 + 1 + 2 + RedeemP2WPKHScriptSize + 4
 
 	// P2WKHOutputSize is the serialize size of a transaction output with a
 	// P2WKH output script.  It is calculated as:
 	//
 	//   - 8 bytes output value
-	//   - 1 byte compact int encoding value 25
+	//   - 1 byte compact int encoding value 22
 	//   - 22 bytes P2PKH output script
 	P2WKHOutputSize = 8 + 1 + P2WPKHScriptSize
+
+	// RedeemP2WPKHScriptSize is the worst case (largest) serialize size of
+	// a transaction input script redeeming nested p2wkh output. It is
+	// calculated as:
+	//
+	// Script Sig:
+	//   - OP_DATA_22: 1 byte
+	//   - P2WSH Witness Progam: 22 bytes
+	//
+	// Witness:
+	//   - 72 bytes DER signature + 1 byte sighash
+	//   - 33 bytes serialized compressed pubkey
+	RedeemNestedP2WPKHScriptSize = 1 + 22 + 73 + 33
+
+	// NestedP2WKHScriptSize is the size of a transaction output script
+	// that pays to a nested p2wkh output.  It is calculated as:
+	//
+	//      - OP_HASH160: 1 byte
+	//      - OP_DATA: 1 byte (20 bytes lenght)
+	//      - PubKeyHash160: 20 bytes
+	//      - OP_EQUAL: 1 byte
+	NestedP2WPKHScriptSize = 1 + 1 + 20 + 1
+
+	// RedeemP2WKHInputSize is the worst case (largest) serialize size of a
+	// transaction input redeeming a compressed P2WKH output.  It is
+	// calculated as:
+	//
+	//   - 32 bytes previous tx
+	//   - 4 bytes output index
+	//
+	// Witness:
+	//   - 1 byte number of witness elements
+	//   - 2 bytes for both witness element lengths
+	//   - 106 bytes witness
+	//
+	// Script Sig:
+	//   - 1 byte compact int encoding value 107
+	//   - 23 bytes signature script
+	//
+	//   - 4 bytes sequence
+	RedeemNestedP2WKHInputSize = 32 + 4 + 1 + 2 + 1 + RedeemNestedP2WPKHScriptSize + 4
+
+	// NestedP2WKHOutputSize is the serialize size of a transaction output
+	// with a nested P2WKH output script.  It is calculated as:
+	//
+	//   - 8 bytes output value
+	//   - 1 byte compact int encoding value 23
+	//   - 23 bytes P2SH output script
+	NestedP2WKHOutputSize = 8 + 1 + NestedP2WPKHScriptSize
 )
 
 // EstimateSerializeSize returns a worst case serialize size estimate for a

--- a/wallet/internal/txsizes/size.go
+++ b/wallet/internal/txsizes/size.go
@@ -51,6 +51,8 @@ const (
 	//   - 1 byte compact int encoding value 25
 	//   - 25 bytes P2PKH output script
 	P2PKHOutputSize = 8 + 1 + P2PKHPkScriptSize
+
+	// TODO(roasbeef): add estimates for nested p2wkh and p2pkh
 )
 
 // EstimateSerializeSize returns a worst case serialize size estimate for a

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -2024,7 +2024,7 @@ func (w *Wallet) SignTransaction(tx *wire.MsgTx, hashType txscript.SigHashType,
 		// Either it was already signed or we just signed it.
 		// Find out if it is completely satisfied or still needs more.
 		vm, err := txscript.NewEngine(prevOutScript, tx, i,
-			txscript.StandardVerifyFlags, nil)
+			txscript.StandardVerifyFlags, nil, nil, 0)
 		if err == nil {
 			err = vm.Execute()
 		}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -300,6 +300,7 @@ func (w *Wallet) SetChainSynced(synced bool) {
 // rescan request.
 func (w *Wallet) activeData() ([]btcutil.Address, []wtxmgr.Credit, error) {
 	var addrs []btcutil.Address
+	// TODO(roasbeef): lookahead?
 	err := w.Manager.ForEachActiveAddress(func(addr btcutil.Address) error {
 		addrs = append(addrs, addr)
 		return nil
@@ -336,6 +337,7 @@ func (w *Wallet) syncWithChain() error {
 
 	// Request notifications for transactions sending to all wallet
 	// addresses.
+	// TODO(roasbeef): need to check 3 versions of each key?
 	addrs, unspent, err := w.activeData()
 	if err != nil {
 		return err
@@ -719,7 +721,8 @@ func (w *Wallet) CurrentAddress(account uint32) (btcutil.Address, error) {
 	if err != nil {
 		// If no address exists yet, create the first external address
 		if waddrmgr.IsError(err, waddrmgr.ErrAddressNotFound) {
-			return w.NewAddress(account)
+			// TODO(roasbeef): what to default to ?
+			return w.NewAddress(account, waddrmgr.WitnessPubKey)
 		}
 		return nil, err
 	}
@@ -730,7 +733,7 @@ func (w *Wallet) CurrentAddress(account uint32) (btcutil.Address, error) {
 		return nil, err
 	}
 	if used {
-		return w.NewAddress(account)
+		return w.NewAddress(account, waddrmgr.WitnessPubKey)
 	}
 
 	return addr.Address(), nil
@@ -1401,6 +1404,8 @@ func (w *Wallet) ListUnspent(minconf, maxconf int32,
 			spendable = true
 		case txscript.PubKeyTy:
 			spendable = true
+		case txscript.WitnessPubKeyHashTy:
+			spendable = true
 		case txscript.ScriptHashTy:
 			spendable = true
 		case txscript.MultiSigTy:
@@ -1695,9 +1700,11 @@ func (w *Wallet) SortedActivePaymentAddresses() ([]string, error) {
 }
 
 // NewAddress returns the next external chained address for a wallet.
-func (w *Wallet) NewAddress(account uint32) (btcutil.Address, error) {
+func (w *Wallet) NewAddress(account uint32,
+	addrType waddrmgr.AddressType) (btcutil.Address, error) {
+
 	// Get next address from wallet.
-	addrs, err := w.Manager.NextExternalAddresses(account, 1)
+	addrs, err := w.Manager.NextExternalAddresses(account, 1, addrType)
 	if err != nil {
 		return nil, err
 	}
@@ -1729,9 +1736,11 @@ func (w *Wallet) NewAddress(account uint32) (btcutil.Address, error) {
 }
 
 // NewChangeAddress returns a new change address for a wallet.
-func (w *Wallet) NewChangeAddress(account uint32) (btcutil.Address, error) {
+func (w *Wallet) NewChangeAddress(account uint32,
+	addrType waddrmgr.AddressType) (btcutil.Address, error) {
+
 	// Get next chained change address from wallet for account.
-	addrs, err := w.Manager.NextInternalAddresses(account, 1)
+	addrs, err := w.Manager.NextInternalAddresses(account, 1, addrType)
 	if err != nil {
 		return nil, err
 	}
@@ -2005,6 +2014,8 @@ func (w *Wallet) SignTransaction(tx *wire.MsgTx, hashType txscript.SigHashType,
 		// so we always verify the output.
 		if (hashType&txscript.SigHashSingle) !=
 			txscript.SigHashSingle || i < len(tx.TxOut) {
+
+			// TODO(roasbeef): make aware of witness, and nested p2sh
 
 			script, err := txscript.SignTxOutput(w.ChainParams(),
 				tx, i, prevOutScript, hashType, getKey,

--- a/wtxmgr/tx.go
+++ b/wtxmgr/tx.go
@@ -111,8 +111,8 @@ func NewTxRecordFromMsgTx(msgTx *wire.MsgTx, received time.Time) (*TxRecord, err
 		MsgTx:        *msgTx,
 		Received:     received,
 		SerializedTx: buf.Bytes(),
+		Hash:         msgTx.TxHash(),
 	}
-	copy(rec.Hash[:], chainhash.DoubleHashB(rec.SerializedTx))
 	return rec, nil
 }
 


### PR DESCRIPTION
NOTE: This PR depends on both btcsuite/btcd#656 and btcsuite/btcutil#75

This PR introduces two new address types to the `waddrmgr`, and the wallet 
sub-package itself. The first address type is the native `p2wkh` (
pay-to-witness-key-hash) output type introduced as part of BIP0141 and 
the segwit soft-fork. The second address type is a `p2wkh` output nested 
_within_ a regular `p2sh` output. This second address allows older wallets
which are not yet aware of the new segwit output types to transparently 
pay to a wallet which does support them. Additionally, using this 
nested p2wkh output the wallet gains both the space+transaction
fee savings, as well as the nuisance malleability fixes.

Both address types have been implemented as special cases of the
`ManagedPubKeyAddress` since they share several traits, only
differentiating in the signing mechanism needed, and the concrete
implementation of `btcutil.Address` returned by the address.

Two new `addressType` constants have been added to `waddrmgr`’s db in
order to properly serialize and deserialize the new address types.

When spending a segwit output, the wallet also needs the input value of
the previous output script. Therefore when selecting outputs the input
value is now returned. Additionally when validating newly signed
outputs the input value as also passed into `txscript.Engine`. 

Additionally, the wallet is now able to properly spend nested and 
normal `p2wkh` outputs under its control. For regular `p2wkh` outputs, 
spending simply involves presenting the original pub key, and signature 
as the witness data. For nested `p2wkh` outputs, in addition to the above, 
the version zero witness `p2wkh` witness program is placed in the sigScript 
in order to allow clients who are aware of BIP 16 to validate the witness 
spend.

NOTE: This PR is still a WIP progress, the following work items need to
be reconciled before the tag is removed: 
- [x] Update the transaction fee and size estimates to account for `p2wkh` and nested 
  `p2wkh` outputs. 
- [ ] Both (?) RPC servers need to update to compile under the API changes. 
- [ ] Investigate adding a lookahead to the wallet which accounts for all three address types?
- [ ] Address lingering `TODO(roasbeef):` comments. 
