### PR TITLE
Set gRPC cipher suites sooner in node.js example.

### DIFF
--- a/rpc/documentation/clientusage.md
+++ b/rpc/documentation/clientusage.md
@@ -144,7 +144,7 @@ auto read_file(std::string const& file_path) -> std::string {
 
 auto main() -> int {
     // Before the gRPC native library (gRPC Core) is lazily loaded and
-    // initialized, an environment variable must be set so OpenSSL is
+    // initialized, an environment variable must be set so BoringSSL is
     // configured to use ECDSA TLS certificates (required by btcwallet).
     setenv("GRPC_SSL_CIPHER_SUITES", "HIGH+ECDSA", 1);
 
@@ -244,7 +244,7 @@ namespace Example
         static async Task ExampleAsync()
         {
             // Before the gRPC native library (gRPC Core) is lazily loaded and initialized,
-            // an environment variable must be set so OpenSSL is configured to use ECDSA TLS
+            // an environment variable must be set so BoringSSL is configured to use ECDSA TLS
             // certificates (required by btcwallet).
             Environment.SetEnvironmentVariable("GRPC_SSL_CIPHER_SUITES", "HIGH+ECDSA");
 
@@ -345,17 +345,17 @@ the client project directory, or reference the file from the
 `btcwallet` project directory.
 
 ```JavaScript
+// Before the gRPC native library (gRPC Core) is lazily loaded and
+// initialized, an environment variable must be set so BoringSSL is
+// configured to use ECDSA TLS certificates (required by btcwallet).
+process.env['GRPC_SSL_CIPHER_SUITES'] = 'HIGH+ECDSA';
+
 var fs = require('fs');
 var path = require('path');
 var os = require('os');
 var grpc = require('grpc');
 var protoDescriptor = grpc.load('./api.proto');
 var walletrpc = protoDescriptor.walletrpc;
-
-// Before the gRPC native library (gRPC Core) is lazily loaded and
-// initialized, an environment variable must be set so OpenSSL is
-// configured to use ECDSA TLS certificates (required by btcwallet).
-process.env['GRPC_SSL_CIPHER_SUITES'] = 'HIGH+ECDSA';
 
 var certPath = path.join(process.env.HOME, '.btcwallet', 'rpc.cert');
 if (os.platform == 'win32') {
@@ -412,7 +412,7 @@ timeout = 1 # seconds
 
 def main():
     # Before the gRPC native library (gRPC Core) is lazily loaded and
-    # initialized, an environment variable must be set so OpenSSL is
+    # initialized, an environment variable must be set so BoringSSL is
     # configured to use ECDSA TLS certificates (required by btcwallet).
     os.environ['GRPC_SSL_CIPHER_SUITES'] = 'HIGH+ECDSA'
 


### PR DESCRIPTION
While here, also rename OpenSSL to BoringSSL since gRPC Core has
switched to that.

Fixes #429.