### PR TITLE
Fix credit slice indexing for transaction notifications.

### DIFF
--- a/rpc/documentation/api.md
+++ b/rpc/documentation/api.md
@@ -1,6 +1,6 @@
 # RPC API Specification
 
-Version: 2.0.0
+Version: 2.0.1
 
 **Note:** This document assumes the reader is familiar with gRPC concepts.
 Refer to the [gRPC Concepts documentation](http://www.grpc.io/docs/guides/concepts.html)

--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -43,10 +43,10 @@ import (
 
 // Public API version constants
 const (
-	semverString = "2.0.0"
+	semverString = "2.0.1"
 	semverMajor  = 2
 	semverMinor  = 0
-	semverPatch  = 0
+	semverPatch  = 1
 )
 
 // translateError creates a new gRPC error with an appropiate error code for

--- a/wallet/notifications.go
+++ b/wallet/notifications.go
@@ -118,8 +118,8 @@ func makeTxSummary(w *Wallet, details *wtxmgr.TxDetails) TransactionSummary {
 		}
 	}
 	outputs := make([]TransactionSummaryOutput, 0, len(details.MsgTx.TxOut))
-	var credIndex int
 	for i := range details.MsgTx.TxOut {
+		credIndex := len(outputs)
 		mine := len(details.Credits) > credIndex && details.Credits[credIndex].Index == uint32(i)
 		if !mine {
 			continue


### PR DESCRIPTION
Previously, this would always check a transaction output index against
the 0th credit's index.