### PR TITLE
Use -b for deprecated --datadir short option.

### DIFF
--- a/config.go
+++ b/config.go
@@ -95,7 +95,7 @@ type config struct {
 	ExperimentalRPCListeners []string `long:"experimentalrpclisten" description:"Listen for RPC connections on this interface/port"`
 
 	// Deprecated options
-	DataDir string `short:"D" long:"datadir" default-mask:"-" description:"DEPRECATED -- use appdata instead"`
+	DataDir string `short:"b" long:"datadir" default-mask:"-" description:"DEPRECATED -- use appdata instead"`
 }
 
 // cleanAndExpandPath expands environement variables and leading ~ in the


### PR DESCRIPTION
When 29f31725ee57fcf4a1118b420f8c115c2742da0a deprecated the datadir
option, replacing it with --appdata/-A, the short --datadir option was
unintentinally changed from -b to -D.  It was previously changed to -b
in fda2e14b99bba7e8ff4cf0f7434e1f5e8b130205 for consistency with
btcd's --datadir short option.

This change reverts the unintentional switch back to -D.