### PR TITLE
Include vendored packages when recursively installing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 install:
   - go get -v github.com/Masterminds/glide
   - glide install
-  - go get -v $(glide novendor)
+  - go get -v ./...
   - go get -v $gotools/cmd/cover
   - go get -v github.com/golang/lint/golint
   - go get -v github.com/davecgh/go-spew/spew

--- a/README.md
+++ b/README.md
@@ -114,16 +114,14 @@ glide install
 
 The `go` tool is used to build or install (to `GOPATH`) the project.  Some
 example build instructions are provided below (all must run from the `btcwallet`
-project directory) in a `sh`-compatible shell on Unix, or PowerShell on Windows
-(`$()` subshells are not supported by `cmd`).
+project directory).
 
 To build and install `btcwallet` and all helper commands (in the `cmd`
-directory) to `$GOPATH/bin/`, as well as installing all compiled non-vendored
-packages to `$GOPATH/pkg/` (**use this if you are unsure which command to
-run**):
+directory) to `$GOPATH/bin/`, as well as installing all compiled packages to
+`$GOPATH/pkg/` (**use this if you are unsure which command to run**):
 
 ```
-go install $(glide novendor)
+go install ./...
 ```
 
 To build a `btcwallet` executable and install it to `$GOPATH/bin/`:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ install:
  - glide install
 
 build_script:
- - ps: go get $(glide novendor)
+ - go get ./...
 
 test_script:
  - ps: go test -race $(glide novendor)


### PR DESCRIPTION
This improves incremental compilation times since these packages are
not recompiled unless changed.  The README and CI scripts have been
updated for these new recommended instructions.

The $(glide novendor) trick is now only used in order to run tests in
the btcwallet project itself, not tests of its vendored dependencies.