### PR TITLE
Enable vendor experiment for Go 1.5 on Travis-CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ install:
   - go get -v github.com/davecgh/go-spew/spew
 script:
   - export PATH=$PATH:$HOME/gopath/bin
+  - export GO15VENDOREXPERIMENT=1
   - ./goclean.sh


### PR DESCRIPTION
Previously, the GO15VENDOREXPERIMENT environment variable was unset,
leaving travis to only use the vendored packages during builds for Go
1.6 which enabled the experiment by default.  Export the variable so
it also correctly tests under Go 1.5.