### PR TITLE
Don't use go install $(glide novendor) in examples.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ install:
   - go get -v github.com/davecgh/go-spew/spew
 script:
   - export PATH=$PATH:$HOME/gopath/bin
+  - export GO15VENDOREXPERIMENT=1
   - ./goclean.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
   - 1.5.4
-  - 1.6.1
+  - 1.6.2
 sudo: false
 before_install:
   - gotools=golang.org/x/tools

--- a/README.md
+++ b/README.md
@@ -114,15 +114,14 @@ glide install
 
 The `go` tool is used to build or install (to `GOPATH`) the project.  Some
 example build instructions are provided below (all must run from the `btcwallet`
-project directory) in a `sh`-compatible shell on Unix, or PowerShell on Windows
-(`$()` subshells are not supported by `cmd`).
+project directory).
 
 To build and install `btcwallet` and all helper commands (in the `cmd`
 directory) to `$GOPATH/bin/`, as well as installing all compiled packages to
 `$GOPATH/pkg/` (**use this if you are unsure which command to run**):
 
 ```
-go install $(glide novendor)
+go install . ./cmd/...
 ```
 
 To build a `btcwallet` executable and install it to `$GOPATH/bin/`:


### PR DESCRIPTION
This will build all (non-vendored) packages recursively, even if they
are not used in any of the binaries (e.g. votingpool).  Additionally,
since a subshell is no longer used, the example commands can be run in
a Windows command prompt.  I don't encourage the use cmd.exe over
alternatives such as PowerShell, but there's no reason this command
could not be run there.