### PR TITLE
Switch from forked to upstream flags package.

### DIFF
--- a/cmd/dropwtxmgr/main.go
+++ b/cmd/dropwtxmgr/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 The btcsuite developers
+// Copyright (c) 2015-2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -13,7 +13,7 @@ import (
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcwallet/walletdb"
 	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
-	"github.com/btcsuite/go-flags"
+	"github.com/jessevdk/go-flags"
 )
 
 const defaultNet = "mainnet"

--- a/cmd/sweepaccount/main.go
+++ b/cmd/sweepaccount/main.go
@@ -19,8 +19,8 @@ import (
 	"github.com/btcsuite/btcwallet/netparams"
 	"github.com/btcsuite/btcwallet/wallet/txauthor"
 	"github.com/btcsuite/btcwallet/wallet/txrules"
-	"github.com/btcsuite/go-flags"
 	"github.com/btcsuite/golangcrypto/ssh/terminal"
+	"github.com/jessevdk/go-flags"
 )
 
 var (

--- a/config.go
+++ b/config.go
@@ -19,7 +19,7 @@ import (
 	"github.com/btcsuite/btcwallet/internal/legacy/keystore"
 	"github.com/btcsuite/btcwallet/netparams"
 	"github.com/btcsuite/btcwallet/wallet"
-	flags "github.com/btcsuite/go-flags"
+	flags "github.com/jessevdk/go-flags"
 )
 
 const (

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 340dfe35ff5fb371aef999130fa60b2d7c84384c0c23bed06bbfd712139a6b3e
-updated: 2016-04-19T15:13:03.285169879-04:00
+hash: 6a47c00739ba9fbc894ee07dfb332058610482cdbc5d57ca22114b1df8d14a77
+updated: 2016-05-06T12:41:29.3972329-04:00
 imports:
 - name: github.com/btcsuite/bolt
   version: 38b9bbfde72d4b62b6a038a3adfca64c44da0133
@@ -24,8 +24,6 @@ imports:
   - base58
 - name: github.com/btcsuite/fastsha256
   version: 302ad4db268b46f9ebda3078f6f7397f96047735
-- name: github.com/btcsuite/go-flags
-  version: 6c288d648c1cc1befcb90cb5511dcacf64ae8e61
 - name: github.com/btcsuite/go-socks
   version: cfe8b59e565c1a5bd4e2005d77cd9aa8b2e14524
   subpackages:
@@ -48,6 +46,8 @@ imports:
   version: 2ebff28ac76fb19e2d25e5ddd4885708dfdd5611
   subpackages:
   - proto
+- name: github.com/jessevdk/go-flags
+  version: 1679536dcc895411a9f5848d9a0250be7856448c
 - name: golang.org/x/net
   version: fb93926129b8ec0056f2f458b1f519654814edf0
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -15,7 +15,6 @@ import:
   subpackages:
   - hdkeychain
 - package: github.com/btcsuite/fastsha256
-- package: github.com/btcsuite/go-flags
 - package: github.com/btcsuite/golangcrypto
   subpackages:
   - nacl/secretbox
@@ -35,3 +34,5 @@ import:
   - codes
   - credentials
   - grpclog
+- package: github.com/jessevdk/go-flags
+  version: 1679536dcc895411a9f5848d9a0250be7856448c


### PR DESCRIPTION
In https://github.com/btcsuite/btcwallet/pull/419#issuecomment-212482492
I mentioned that btcwallet should wait until btcd also switches back
to upstream package paths so that duplicate packages are not included
in and bloat the btcwallet binary.  Even while btcd has not yet
switched to the upstream flags package, this change can still be made
now since it is only used by btcd's main package, which is not
included in btcwallet.