### PR TITLE
Update for recent chainhash-related API changes.

### DIFF
--- a/cmd/sweepaccount/main.go
+++ b/cmd/sweepaccount/main.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 
 	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcrpcclient"
@@ -333,7 +334,7 @@ func saneOutputValue(amount btcutil.Amount) bool {
 }
 
 func parseOutPoint(input *btcjson.ListUnspentResult) (wire.OutPoint, error) {
-	txHash, err := wire.NewShaHashFromStr(input.TxID)
+	txHash, err := chainhash.NewHashFromStr(input.TxID)
 	if err != nil {
 		return wire.OutPoint{}, err
 	}

--- a/glide.lock
+++ b/glide.lock
@@ -1,27 +1,28 @@
 hash: 0cff4a723566a3e33910785c104bddde49d1e0ba2d51f3833599a423140f5163
-updated: 2016-05-06T14:41:32.674803-04:00
+updated: 2016-08-08T14:07:48.6427885-05:00
 imports:
 - name: github.com/boltdb/bolt
   version: 831b652a7f8dbefaf94da0eb66abd46c0c4bcf23
 - name: github.com/btcsuite/btcd
-  version: 474547b211c8f5566d094478318fcfd3c2c838d4
+  version: bd4e64d1d43bad445dd8e6577907c0c265cd83c2
   subpackages:
   - blockchain
   - btcec
   - btcjson
   - chaincfg
+  - chaincfg/chainhash
+  - database
   - txscript
   - wire
-  - database
 - name: github.com/btcsuite/btclog
   version: f96df2375f37300305f329b8e5258764b4f19a7f
 - name: github.com/btcsuite/btcrpcclient
-  version: 64922553b5c21f333438edaed6e0ba2b5a7760ee
+  version: c39e35318d5dc8d7e5e4171a34a17bc03dce06b4
 - name: github.com/btcsuite/btcutil
-  version: bdf4400ecafb82f0c121ed5db1ae70639e7f4018
+  version: 22c91fa80a5e90e3feda26cf6d43adc249306188
   subpackages:
-  - hdkeychain
   - base58
+  - hdkeychain
 - name: github.com/btcsuite/fastsha256
   version: 302ad4db268b46f9ebda3078f6f7397f96047735
 - name: github.com/btcsuite/go-socks
@@ -32,12 +33,12 @@ imports:
   version: 53f62d9b43e87a6c56975cf862af7edf33a8d0df
   subpackages:
   - nacl/secretbox
+  - pbkdf2
+  - poly1305
   - ripemd160
+  - salsa20/salsa
   - scrypt
   - ssh/terminal
-  - poly1305
-  - salsa20/salsa
-  - pbkdf2
 - name: github.com/btcsuite/seelog
   version: 313961b101eb55f65ae0f03ddd4e322731763b6c
 - name: github.com/btcsuite/websocket
@@ -53,9 +54,9 @@ imports:
   subpackages:
   - context
   - http2
-  - trace
   - http2/hpack
   - internal/timeseries
+  - trace
 - name: golang.org/x/sys
   version: f64b50fbea64174967a8882830d621a18ee1548e
   subpackages:
@@ -71,4 +72,8 @@ imports:
   - naming
   - transport
   - peer
-devImports: []
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  subpackages:
+  - spew

--- a/internal/legacy/keystore/keystore_test.go
+++ b/internal/legacy/keystore/keystore_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2014 The btcsuite developers
+// Copyright (c) 2013-2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -13,8 +13,8 @@ import (
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
-	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 
 	"github.com/davecgh/go-spew/spew"
@@ -26,7 +26,7 @@ var tstNetParams = &chaincfg.MainNetParams
 
 func makeBS(height int32) *BlockStamp {
 	return &BlockStamp{
-		Hash:   new(wire.ShaHash),
+		Hash:   new(chainhash.Hash),
 		Height: height,
 	}
 }

--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcrpcclient"
@@ -417,7 +418,7 @@ func (s *walletServer) GetTransactions(ctx context.Context, req *pb.GetTransacti
 		return nil, errors.New(
 			"starting block hash and height may not be specified simultaneously")
 	} else if req.StartingBlockHash != nil {
-		startBlockHash, err := wire.NewShaHash(req.StartingBlockHash)
+		startBlockHash, err := chainhash.NewHash(req.StartingBlockHash)
 		if err != nil {
 			return nil, grpc.Errorf(codes.InvalidArgument, "%s", err.Error())
 		}
@@ -430,7 +431,7 @@ func (s *walletServer) GetTransactions(ctx context.Context, req *pb.GetTransacti
 		return nil, grpc.Errorf(codes.InvalidArgument,
 			"ending block hash and height may not be specified simultaneously")
 	} else if req.EndingBlockHash != nil {
-		endBlockHash, err := wire.NewShaHash(req.EndingBlockHash)
+		endBlockHash, err := chainhash.NewHash(req.EndingBlockHash)
 		if err != nil {
 			return nil, grpc.Errorf(codes.InvalidArgument, "%s", err.Error())
 		}
@@ -607,7 +608,7 @@ func marshalBlocks(v []wallet.Block) []*pb.BlockDetails {
 	return blocks
 }
 
-func marshalHashes(v []*wire.ShaHash) [][]byte {
+func marshalHashes(v []*chainhash.Hash) [][]byte {
 	hashes := make([][]byte, len(v))
 	for i, hash := range v {
 		hashes[i] = hash[:]

--- a/votingpool/factory_test.go
+++ b/votingpool/factory_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 The btcsuite developers
+ * Copyright (c) 2014-2016 The btcsuite developers
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
@@ -73,7 +74,7 @@ func createMsgTx(pkScript []byte, amts []int64) *wire.MsgTx {
 		TxIn: []*wire.TxIn{
 			{
 				PreviousOutPoint: wire.OutPoint{
-					Hash:  wire.ShaHash{},
+					Hash:  chainhash.Hash{},
 					Index: 0xffffffff,
 				},
 				SignatureScript: []byte{txscript.OP_NOP},
@@ -255,12 +256,12 @@ func TstCreateSeriesCredits(t *testing.T, pool *Pool, seriesID uint32, amounts [
 		t.Fatal(err)
 	}
 	msgTx := createMsgTx(pkScript, amounts)
-	txSha := msgTx.TxSha()
+	txHash := msgTx.TxHash()
 	credits := make([]credit, len(amounts))
 	for i := range msgTx.TxOut {
 		c := wtxmgr.Credit{
 			OutPoint: wire.OutPoint{
-				Hash:  txSha,
+				Hash:  txHash,
 				Index: uint32(i),
 			},
 			BlockMeta: wtxmgr.BlockMeta{

--- a/votingpool/input_selection.go
+++ b/votingpool/input_selection.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 The btcsuite developers
+ * Copyright (c) 2015-2016 The btcsuite developers
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -82,7 +82,7 @@ func (c byAddress) Less(i, j int) bool {
 	}
 
 	// The seriesID, index, and branch are equal, so compare hash.
-	txidComparison := bytes.Compare(c[i].OutPoint.Hash.Bytes(), c[j].OutPoint.Hash.Bytes())
+	txidComparison := bytes.Compare(c[i].OutPoint.Hash[:], c[j].OutPoint.Hash[:])
 	if txidComparison < 0 {
 		return true
 	}

--- a/votingpool/input_selection_wb_test.go
+++ b/votingpool/input_selection_wb_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 The btcsuite developers
+// Copyright (c) 2015-2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcwallet/wtxmgr"
@@ -292,9 +293,9 @@ func TestCreditSortingByAddress(t *testing.T) {
 // locked to the votingpool address identified by the given
 // series/index/branch.
 func newDummyCredit(t *testing.T, pool *Pool, series uint32, index Index, branch Branch,
-	txSha []byte, outpointIdx uint32) credit {
-	var hash wire.ShaHash
-	if err := hash.SetBytes(txSha); err != nil {
+	txHash []byte, outpointIdx uint32) credit {
+	var hash chainhash.Hash
+	if err := hash.SetBytes(txHash); err != nil {
 		t.Fatal(err)
 	}
 	// Ensure the address defined by the given series/branch/index is present on
@@ -315,7 +316,7 @@ func checkUniqueness(t *testing.T, credits byAddress) {
 		series      uint32
 		branch      Branch
 		index       Index
-		hash        wire.ShaHash
+		hash        chainhash.Hash
 		outputIndex uint32
 	}
 

--- a/votingpool/withdrawal.go
+++ b/votingpool/withdrawal.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 The btcsuite developers
+// Copyright (c) 2015-2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -322,7 +322,7 @@ func (tx *withdrawalTx) ntxid() Ntxid {
 	for _, txin := range msgtx.TxIn {
 		txin.SignatureScript = empty
 	}
-	return Ntxid(msgtx.TxSha().String())
+	return Ntxid(msgtx.TxHash().String())
 }
 
 // isTooBig returns true if the size (in bytes) of the given tx is greater

--- a/votingpool/withdrawal_wb_test.go
+++ b/votingpool/withdrawal_wb_test.go
@@ -1111,8 +1111,8 @@ func TestStoreTransactionsWithChangeOutput(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sha := msgtx.TxSha()
-	txDetails, err := store.TxDetails(&sha)
+	hash := msgtx.TxHash()
+	txDetails, err := store.TxDetails(&hash)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1146,7 +1146,7 @@ func TestStoreTransactionsWithChangeOutput(t *testing.T) {
 	if len(credits) != 1 {
 		t.Fatalf("Unexpected number of credits in txstore; got %d, want 1", len(credits))
 	}
-	changeOutpoint := wire.OutPoint{Hash: sha, Index: uint32(tx.changeIdx)}
+	changeOutpoint := wire.OutPoint{Hash: hash, Index: uint32(tx.changeIdx)}
 	if credits[0].OutPoint != changeOutpoint {
 		t.Fatalf("Credit's outpoint (%v) doesn't match the one from change output (%v)",
 			credits[0].OutPoint, changeOutpoint)

--- a/waddrmgr/db.go
+++ b/waddrmgr/db.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 The btcsuite developers
+// Copyright (c) 2014-2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcutil/hdkeychain"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/fastsha256"
@@ -1448,7 +1448,7 @@ func putStartBlock(tx walletdb.Tx, bs *BlockStamp) error {
 
 // fetchRecentBlocks returns the height of the most recent block height and
 // hashes of the most recent blocks.
-func fetchRecentBlocks(tx walletdb.Tx) (int32, []wire.ShaHash, error) {
+func fetchRecentBlocks(tx walletdb.Tx) (int32, []chainhash.Hash, error) {
 	bucket := tx.RootBucket().Bucket(syncBucketName)
 
 	// The serialized recent blocks format is:
@@ -1467,7 +1467,7 @@ func fetchRecentBlocks(tx walletdb.Tx) (int32, []wire.ShaHash, error) {
 
 	recentHeight := int32(binary.LittleEndian.Uint32(buf[0:4]))
 	numHashes := binary.LittleEndian.Uint32(buf[4:8])
-	recentHashes := make([]wire.ShaHash, numHashes)
+	recentHashes := make([]chainhash.Hash, numHashes)
 	offset := 8
 	for i := uint32(0); i < numHashes; i++ {
 		copy(recentHashes[i][:], buf[offset:offset+32])
@@ -1478,7 +1478,7 @@ func fetchRecentBlocks(tx walletdb.Tx) (int32, []wire.ShaHash, error) {
 }
 
 // putRecentBlocks stores the provided start block stamp to the database.
-func putRecentBlocks(tx walletdb.Tx, recentHeight int32, recentHashes []wire.ShaHash) error {
+func putRecentBlocks(tx walletdb.Tx, recentHeight int32, recentHashes []chainhash.Hash) error {
 	bucket := tx.RootBucket().Bucket(syncBucketName)
 
 	// The serialized recent blocks format is:

--- a/waddrmgr/manager.go
+++ b/waddrmgr/manager.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcutil/hdkeychain"
 	"github.com/btcsuite/btcwallet/internal/zero"
@@ -2147,7 +2147,7 @@ func loadManager(namespace walletdb.Namespace, pubPassphrase []byte, chainParams
 	var cryptoKeyPubEnc, cryptoKeyPrivEnc, cryptoKeyScriptEnc []byte
 	var syncedTo, startBlock *BlockStamp
 	var recentHeight int32
-	var recentHashes []wire.ShaHash
+	var recentHashes []chainhash.Hash
 	err := namespace.View(func(tx walletdb.Tx) error {
 		// Load whether or not the manager is watching-only from the db.
 		var err error
@@ -2463,7 +2463,7 @@ func Create(namespace walletdb.Namespace, seed, pubPassphrase, privPassphrase []
 	createdAt := &BlockStamp{Hash: *chainParams.GenesisHash, Height: 0}
 
 	// Create the initial sync state.
-	recentHashes := []wire.ShaHash{createdAt.Hash}
+	recentHashes := []chainhash.Hash{createdAt.Hash}
 	recentHeight := createdAt.Height
 	syncInfo := newSyncState(createdAt, createdAt, recentHeight, recentHashes)
 

--- a/waddrmgr/manager_test.go
+++ b/waddrmgr/manager_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 The btcsuite developers
+// Copyright (c) 2014-2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -12,22 +12,22 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/walletdb"
 )
 
-// newShaHash converts the passed big-endian hex string into a wire.ShaHash.
+// newHash converts the passed big-endian hex string into a chainhash.Hash.
 // It only differs from the one available in wire in that it panics on an
 // error since it will only (and must only) be called with hard-coded, and
 // therefore known good, hashes.
-func newShaHash(hexStr string) *wire.ShaHash {
-	sha, err := wire.NewShaHashFromStr(hexStr)
+func newHash(hexStr string) *chainhash.Hash {
+	hash, err := chainhash.NewHashFromStr(hexStr)
 	if err != nil {
 		panic(err)
 	}
-	return sha
+	return hash
 }
 
 // testContext is used to store context information about a running test which
@@ -1439,91 +1439,91 @@ func testWatchingOnly(tc *testContext) bool {
 func testSync(tc *testContext) bool {
 	tests := []struct {
 		name string
-		hash *wire.ShaHash
+		hash *chainhash.Hash
 	}{
 		{
 			name: "Block 1",
-			hash: newShaHash("00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048"),
+			hash: newHash("00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048"),
 		},
 		{
 			name: "Block 2",
-			hash: newShaHash("000000006a625f06636b8bb6ac7b960a8d03705d1ace08b1a19da3fdcc99ddbd"),
+			hash: newHash("000000006a625f06636b8bb6ac7b960a8d03705d1ace08b1a19da3fdcc99ddbd"),
 		},
 		{
 			name: "Block 3",
-			hash: newShaHash("0000000082b5015589a3fdf2d4baff403e6f0be035a5d9742c1cae6295464449"),
+			hash: newHash("0000000082b5015589a3fdf2d4baff403e6f0be035a5d9742c1cae6295464449"),
 		},
 		{
 			name: "Block 4",
-			hash: newShaHash("000000004ebadb55ee9096c9a2f8880e09da59c0d68b1c228da88e48844a1485"),
+			hash: newHash("000000004ebadb55ee9096c9a2f8880e09da59c0d68b1c228da88e48844a1485"),
 		},
 		{
 			name: "Block 5",
-			hash: newShaHash("000000009b7262315dbf071787ad3656097b892abffd1f95a1a022f896f533fc"),
+			hash: newHash("000000009b7262315dbf071787ad3656097b892abffd1f95a1a022f896f533fc"),
 		},
 		{
 			name: "Block 6",
-			hash: newShaHash("000000003031a0e73735690c5a1ff2a4be82553b2a12b776fbd3a215dc8f778d"),
+			hash: newHash("000000003031a0e73735690c5a1ff2a4be82553b2a12b776fbd3a215dc8f778d"),
 		},
 		{
 			name: "Block 7",
-			hash: newShaHash("0000000071966c2b1d065fd446b1e485b2c9d9594acd2007ccbd5441cfc89444"),
+			hash: newHash("0000000071966c2b1d065fd446b1e485b2c9d9594acd2007ccbd5441cfc89444"),
 		},
 		{
 			name: "Block 8",
-			hash: newShaHash("00000000408c48f847aa786c2268fc3e6ec2af68e8468a34a28c61b7f1de0dc6"),
+			hash: newHash("00000000408c48f847aa786c2268fc3e6ec2af68e8468a34a28c61b7f1de0dc6"),
 		},
 		{
 			name: "Block 9",
-			hash: newShaHash("000000008d9dc510f23c2657fc4f67bea30078cc05a90eb89e84cc475c080805"),
+			hash: newHash("000000008d9dc510f23c2657fc4f67bea30078cc05a90eb89e84cc475c080805"),
 		},
 		{
 			name: "Block 10",
-			hash: newShaHash("000000002c05cc2e78923c34df87fd108b22221ac6076c18f3ade378a4d915e9"),
+			hash: newHash("000000002c05cc2e78923c34df87fd108b22221ac6076c18f3ade378a4d915e9"),
 		},
 		{
 			name: "Block 11",
-			hash: newShaHash("0000000097be56d606cdd9c54b04d4747e957d3608abe69198c661f2add73073"),
+			hash: newHash("0000000097be56d606cdd9c54b04d4747e957d3608abe69198c661f2add73073"),
 		},
 		{
 			name: "Block 12",
-			hash: newShaHash("0000000027c2488e2510d1acf4369787784fa20ee084c258b58d9fbd43802b5e"),
+			hash: newHash("0000000027c2488e2510d1acf4369787784fa20ee084c258b58d9fbd43802b5e"),
 		},
 		{
 			name: "Block 13",
-			hash: newShaHash("000000005c51de2031a895adc145ee2242e919a01c6d61fb222a54a54b4d3089"),
+			hash: newHash("000000005c51de2031a895adc145ee2242e919a01c6d61fb222a54a54b4d3089"),
 		},
 		{
 			name: "Block 14",
-			hash: newShaHash("0000000080f17a0c5a67f663a9bc9969eb37e81666d9321125f0e293656f8a37"),
+			hash: newHash("0000000080f17a0c5a67f663a9bc9969eb37e81666d9321125f0e293656f8a37"),
 		},
 		{
 			name: "Block 15",
-			hash: newShaHash("00000000b3322c8c3ef7d2cf6da009a776e6a99ee65ec5a32f3f345712238473"),
+			hash: newHash("00000000b3322c8c3ef7d2cf6da009a776e6a99ee65ec5a32f3f345712238473"),
 		},
 		{
 			name: "Block 16",
-			hash: newShaHash("00000000174a25bb399b009cc8deff1c4b3ea84df7e93affaaf60dc3416cc4f5"),
+			hash: newHash("00000000174a25bb399b009cc8deff1c4b3ea84df7e93affaaf60dc3416cc4f5"),
 		},
 		{
 			name: "Block 17",
-			hash: newShaHash("000000003ff1d0d70147acfbef5d6a87460ff5bcfce807c2d5b6f0a66bfdf809"),
+			hash: newHash("000000003ff1d0d70147acfbef5d6a87460ff5bcfce807c2d5b6f0a66bfdf809"),
 		},
 		{
 			name: "Block 18",
-			hash: newShaHash("000000008693e98cf893e4c85a446b410bb4dfa129bd1be582c09ed3f0261116"),
+			hash: newHash("000000008693e98cf893e4c85a446b410bb4dfa129bd1be582c09ed3f0261116"),
 		},
 		{
 			name: "Block 19",
-			hash: newShaHash("00000000841cb802ca97cf20fb9470480cae9e5daa5d06b4a18ae2d5dd7f186f"),
+			hash: newHash("00000000841cb802ca97cf20fb9470480cae9e5daa5d06b4a18ae2d5dd7f186f"),
 		},
 		{
 			name: "Block 20",
-			hash: newShaHash("0000000067a97a2a37b8f190a17f0221e9c3f4fa824ddffdc2e205eae834c8d7"),
+			hash: newHash("0000000067a97a2a37b8f190a17f0221e9c3f4fa824ddffdc2e205eae834c8d7"),
 		},
 		{
 			name: "Block 21",
-			hash: newShaHash("000000006f016342d1275be946166cff975c8b27542de70a7113ac6d1ef3294f"),
+			hash: newHash("000000006f016342d1275be946166cff975c8b27542de70a7113ac6d1ef3294f"),
 		},
 	}
 
@@ -1560,7 +1560,7 @@ func testSync(tc *testContext) bool {
 		iter := tc.manager.NewIterateRecentBlocks()
 		for cont := iter != nil; cont; cont = iter.Prev() {
 			wantHeight := int32(i) - int32(j) + 1
-			var wantHash *wire.ShaHash
+			var wantHash *chainhash.Hash
 			if wantHeight == 0 {
 				wantHash = chaincfg.MainNetParams.GenesisHash
 			} else {
@@ -1613,7 +1613,7 @@ func testSync(tc *testContext) bool {
 	// current  block stamp clears the old recent blocks.
 	blockStamp = waddrmgr.BlockStamp{
 		Height: 100,
-		Hash:   *newShaHash("000000007bc154e0fa7ea32218a72fe2c1bb9f86cf8c9ebf9a715ed27fdb229a"),
+		Hash:   *newHash("000000007bc154e0fa7ea32218a72fe2c1bb9f86cf8c9ebf9a715ed27fdb229a"),
 	}
 	if err := tc.manager.SetSyncedTo(&blockStamp); err != nil {
 		tc.t.Errorf("SetSyncedTo unexpected err on future block stamp: "+

--- a/waddrmgr/sync.go
+++ b/waddrmgr/sync.go
@@ -7,7 +7,7 @@ package waddrmgr
 import (
 	"sync"
 
-	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcwallet/walletdb"
 )
 
@@ -22,7 +22,7 @@ const (
 // synced to.
 type BlockStamp struct {
 	Height int32
-	Hash   wire.ShaHash
+	Hash   chainhash.Hash
 }
 
 // syncState houses the sync state of the manager.  It consists of the recently
@@ -41,7 +41,7 @@ type syncState struct {
 	recentHeight int32
 
 	// recentHashes is a list of the last several seen block hashes.
-	recentHashes []wire.ShaHash
+	recentHashes []chainhash.Hash
 }
 
 // iter returns a BlockIterator that can be used to iterate over the recently
@@ -60,7 +60,7 @@ func (s *syncState) iter(mtx *sync.RWMutex) *BlockIterator {
 
 // newSyncState returns a new sync state with the provided parameters.
 func newSyncState(startBlock, syncedTo *BlockStamp, recentHeight int32,
-	recentHashes []wire.ShaHash) *syncState {
+	recentHashes []chainhash.Hash) *syncState {
 
 	return &syncState{
 		startBlock:   *startBlock,

--- a/wallet/notifications.go
+++ b/wallet/notifications.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"sync"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
@@ -221,7 +222,7 @@ func (s *NotificationServer) notifyUnminedTransaction(details *wtxmgr.TxDetails)
 	}
 }
 
-func (s *NotificationServer) notifyDetachedBlock(hash *wire.ShaHash) {
+func (s *NotificationServer) notifyDetachedBlock(hash *chainhash.Hash) {
 	if s.currentTxNtfn == nil {
 		s.currentTxNtfn = &TransactionNotifications{}
 	}
@@ -328,16 +329,16 @@ func (s *NotificationServer) notifyAttachedBlock(block *wtxmgr.BlockMeta) {
 // changes to transactions, it needs a better name.
 type TransactionNotifications struct {
 	AttachedBlocks           []Block
-	DetachedBlocks           []*wire.ShaHash
+	DetachedBlocks           []*chainhash.Hash
 	UnminedTransactions      []TransactionSummary
-	UnminedTransactionHashes []*wire.ShaHash
+	UnminedTransactionHashes []*chainhash.Hash
 	NewBalances              []AccountBalance
 }
 
 // Block contains the properties and all relevant transactions of an attached
 // block.
 type Block struct {
-	Hash         *wire.ShaHash
+	Hash         *chainhash.Hash
 	Height       int32
 	Timestamp    int64
 	Transactions []TransactionSummary
@@ -346,7 +347,7 @@ type Block struct {
 // TransactionSummary contains a transaction relevant to the wallet and marks
 // which inputs and outputs were relevant.
 type TransactionSummary struct {
-	Hash        *wire.ShaHash
+	Hash        *chainhash.Hash
 	Transaction []byte
 	MyInputs    []TransactionSummaryInput
 	MyOutputs   []TransactionSummaryOutput
@@ -438,14 +439,14 @@ func (c *TransactionNotificationsClient) Done() {
 // now spent.  When spent, the notification includes the spending transaction's
 // hash and input index.
 type SpentnessNotifications struct {
-	hash         *wire.ShaHash
-	spenderHash  *wire.ShaHash
+	hash         *chainhash.Hash
+	spenderHash  *chainhash.Hash
 	index        uint32
 	spenderIndex uint32
 }
 
 // Hash returns the transaction hash of the spent output.
-func (n *SpentnessNotifications) Hash() *wire.ShaHash {
+func (n *SpentnessNotifications) Hash() *chainhash.Hash {
 	return n.hash
 }
 
@@ -456,13 +457,13 @@ func (n *SpentnessNotifications) Index() uint32 {
 
 // Spender returns the spending transction's hash and input index, if any.  If
 // the output is unspent, the final bool return is false.
-func (n *SpentnessNotifications) Spender() (*wire.ShaHash, uint32, bool) {
+func (n *SpentnessNotifications) Spender() (*chainhash.Hash, uint32, bool) {
 	return n.spenderHash, n.spenderIndex, n.spenderHash != nil
 }
 
 // notifyUnspentOutput notifies registered clients of a new unspent output that
 // is controlled by the wallet.
-func (s *NotificationServer) notifyUnspentOutput(account uint32, hash *wire.ShaHash, index uint32) {
+func (s *NotificationServer) notifyUnspentOutput(account uint32, hash *chainhash.Hash, index uint32) {
 	defer s.mu.Unlock()
 	s.mu.Lock()
 	clients := s.spentness[account]
@@ -481,7 +482,7 @@ func (s *NotificationServer) notifyUnspentOutput(account uint32, hash *wire.ShaH
 // notifySpentOutput notifies registered clients that a previously-unspent
 // output is now spent, and includes the spender hash and input index in the
 // notification.
-func (s *NotificationServer) notifySpentOutput(account uint32, op *wire.OutPoint, spenderHash *wire.ShaHash, spenderIndex uint32) {
+func (s *NotificationServer) notifySpentOutput(account uint32, op *wire.OutPoint, spenderHash *chainhash.Hash, spenderIndex uint32) {
 	defer s.mu.Unlock()
 	s.mu.Lock()
 	clients := s.spentness[account]

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -21,6 +21,7 @@ import (
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcrpcclient"
@@ -1086,7 +1087,7 @@ func (w *Wallet) ListAllTransactions() ([]btcjson.ListTransactionsResult, error)
 // BlockIdentifier identifies a block by either a height or a hash.
 type BlockIdentifier struct {
 	height int32
-	hash   *wire.ShaHash
+	hash   *chainhash.Hash
 }
 
 // NewBlockIdentifierFromHeight constructs a BlockIdentifier for a block height.
@@ -1095,7 +1096,7 @@ func NewBlockIdentifierFromHeight(height int32) *BlockIdentifier {
 }
 
 // NewBlockIdentifierFromHash constructs a BlockIdentifier for a block hash.
-func NewBlockIdentifierFromHash(hash *wire.ShaHash) *BlockIdentifier {
+func NewBlockIdentifierFromHash(hash *chainhash.Hash) *BlockIdentifier {
 	return &BlockIdentifier{hash: hash}
 }
 
@@ -1208,7 +1209,7 @@ type AccountResult struct {
 // method for more details.
 type AccountsResult struct {
 	Accounts           []AccountResult
-	CurrentBlockHash   *wire.ShaHash
+	CurrentBlockHash   *chainhash.Hash
 	CurrentBlockHeight int32
 }
 
@@ -1674,7 +1675,7 @@ func (w *Wallet) ResendUnminedTxs() {
 			// TODO(jrick): Check error for if this tx is a double spend,
 			// remove it if so.
 			log.Debugf("Could not resend transaction %v: %v",
-				tx.TxSha(), err)
+				tx.TxHash(), err)
 			continue
 		}
 		log.Debugf("Resent unmined transaction %v", resp)
@@ -1859,7 +1860,7 @@ func (w *Wallet) TotalReceivedForAddr(addr btcutil.Address, minConf int32) (btcu
 // SendOutputs creates and sends payment transactions. It returns the
 // transaction hash upon success.
 func (w *Wallet) SendOutputs(outputs []*wire.TxOut, account uint32,
-	minconf int32) (*wire.ShaHash, error) {
+	minconf int32) (*chainhash.Hash, error) {
 
 	chainClient, err := w.requireChainClient()
 	if err != nil {
@@ -2159,7 +2160,7 @@ func Open(db walletdb.DB, pubPass []byte, cbs *waddrmgr.OpenCallbacks, params *c
 		quit:                make(chan struct{}),
 	}
 	w.NtfnServer = newNotificationServer(w)
-	w.TxStore.NotifyUnspent = func(hash *wire.ShaHash, index uint32) {
+	w.TxStore.NotifyUnspent = func(hash *chainhash.Hash, index uint32) {
 		w.NtfnServer.notifyUnspentOutput(0, hash, index)
 	}
 	return w, nil

--- a/wtxmgr/db.go
+++ b/wtxmgr/db.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcwallet/walletdb"
@@ -57,11 +58,11 @@ const (
 	LatestVersion = 1
 )
 
-// This package makes assumptions that the width of a wire.ShaHash is always 32
-// bytes.  If this is ever changed (unlikely for bitcoin, possible for alts),
+// This package makes assumptions that the width of a chainhash.Hash is always
+// 32 bytes.  If this is ever changed (unlikely for bitcoin, possible for alts),
 // offsets have to be rewritten.  Use a compile-time assertion that this
 // assumption holds true.
-var _ [32]byte = wire.ShaHash{}
+var _ [32]byte = chainhash.Hash{}
 
 // Bucket names
 var (
@@ -120,7 +121,7 @@ func putMinedBalance(ns walletdb.Bucket, amt btcutil.Amount) error {
 //
 // The canonical transaction hash serialization is simply the hash.
 
-func canonicalOutPoint(txHash *wire.ShaHash, index uint32) []byte {
+func canonicalOutPoint(txHash *chainhash.Hash, index uint32) []byte {
 	k := make([]byte, 36)
 	copy(k, txHash[:])
 	byteOrder.PutUint32(k[32:36], index)
@@ -152,7 +153,7 @@ func keyBlockRecord(height int32) []byte {
 	return k
 }
 
-func valueBlockRecord(block *BlockMeta, txHash *wire.ShaHash) []byte {
+func valueBlockRecord(block *BlockMeta, txHash *chainhash.Hash) []byte {
 	v := make([]byte, 76)
 	copy(v, block.Hash[:])
 	byteOrder.PutUint64(v[32:40], uint64(block.Time.Unix()))
@@ -163,7 +164,7 @@ func valueBlockRecord(block *BlockMeta, txHash *wire.ShaHash) []byte {
 
 // appendRawBlockRecord returns a new block record value with a transaction
 // hash appended to the end and an incremented number of transactions.
-func appendRawBlockRecord(v []byte, txHash *wire.ShaHash) ([]byte, error) {
+func appendRawBlockRecord(v []byte, txHash *chainhash.Hash) ([]byte, error) {
 	if len(v) < 44 {
 		str := fmt.Sprintf("%s: short read (expected %d bytes, read %d)",
 			bucketBlocks, 44, len(v))
@@ -184,7 +185,7 @@ func putRawBlockRecord(ns walletdb.Bucket, k, v []byte) error {
 	return nil
 }
 
-func putBlockRecord(ns walletdb.Bucket, block *BlockMeta, txHash *wire.ShaHash) error {
+func putBlockRecord(ns walletdb.Bucket, block *BlockMeta, txHash *chainhash.Hash) error {
 	k := keyBlockRecord(block.Height)
 	v := valueBlockRecord(block, txHash)
 	return putRawBlockRecord(ns, k, v)
@@ -219,7 +220,7 @@ func readRawBlockRecord(k, v []byte, block *blockRecord) error {
 		return storeError(ErrData, str, nil)
 	}
 	numTransactions := int(byteOrder.Uint32(v[40:44]))
-	expectedLen := 44 + wire.HashSize*numTransactions
+	expectedLen := 44 + chainhash.HashSize*numTransactions
 	if len(v) < expectedLen {
 		str := fmt.Sprintf("%s: short read (expected %d bytes, read %d)",
 			bucketBlocks, expectedLen, len(v))
@@ -229,11 +230,11 @@ func readRawBlockRecord(k, v []byte, block *blockRecord) error {
 	block.Height = int32(byteOrder.Uint32(k))
 	copy(block.Hash[:], v)
 	block.Time = time.Unix(int64(byteOrder.Uint64(v[32:40])), 0)
-	block.transactions = make([]wire.ShaHash, numTransactions)
+	block.transactions = make([]chainhash.Hash, numTransactions)
 	off := 44
 	for i := range block.transactions {
 		copy(block.transactions[i][:], v[off:])
-		off += wire.HashSize
+		off += chainhash.HashSize
 	}
 
 	return nil
@@ -350,7 +351,7 @@ func (it *blockIterator) delete() error {
 //   [0:8]   Received time (8 bytes)
 //   [8:]    Serialized transaction (varies)
 
-func keyTxRecord(txHash *wire.ShaHash, block *Block) []byte {
+func keyTxRecord(txHash *chainhash.Hash, block *Block) []byte {
 	k := make([]byte, 68)
 	copy(k, txHash[:])
 	byteOrder.PutUint32(k[32:36], uint32(block.Height))
@@ -400,7 +401,7 @@ func putRawTxRecord(ns walletdb.Bucket, k, v []byte) error {
 	return nil
 }
 
-func readRawTxRecord(txHash *wire.ShaHash, v []byte, rec *TxRecord) error {
+func readRawTxRecord(txHash *chainhash.Hash, v []byte, rec *TxRecord) error {
 	if len(v) < 8 {
 		str := fmt.Sprintf("%s: short read (expected %d bytes, read %d)",
 			bucketTxRecords, 8, len(v))
@@ -428,7 +429,7 @@ func readRawTxRecordBlock(k []byte, block *Block) error {
 	return nil
 }
 
-func fetchTxRecord(ns walletdb.Bucket, txHash *wire.ShaHash, block *Block) (*TxRecord, error) {
+func fetchTxRecord(ns walletdb.Bucket, txHash *chainhash.Hash, block *Block) (*TxRecord, error) {
 	k := keyTxRecord(txHash, block)
 	v := ns.Bucket(bucketTxRecords).Get(k)
 
@@ -453,7 +454,7 @@ func fetchRawTxRecordPkScript(k, v []byte, index uint32) ([]byte, error) {
 	return rec.MsgTx.TxOut[index].PkScript, nil
 }
 
-func existsTxRecord(ns walletdb.Bucket, txHash *wire.ShaHash, block *Block) (k, v []byte) {
+func existsTxRecord(ns walletdb.Bucket, txHash *chainhash.Hash, block *Block) (k, v []byte) {
 	k = keyTxRecord(txHash, block)
 	v = ns.Bucket(bucketTxRecords).Get(k)
 	return
@@ -463,7 +464,7 @@ func existsRawTxRecord(ns walletdb.Bucket, k []byte) (v []byte) {
 	return ns.Bucket(bucketTxRecords).Get(k)
 }
 
-func deleteTxRecord(ns walletdb.Bucket, txHash *wire.ShaHash, block *Block) error {
+func deleteTxRecord(ns walletdb.Bucket, txHash *chainhash.Hash, block *Block) error {
 	k := keyTxRecord(txHash, block)
 	return ns.Bucket(bucketTxRecords).Delete(k)
 }
@@ -471,7 +472,7 @@ func deleteTxRecord(ns walletdb.Bucket, txHash *wire.ShaHash, block *Block) erro
 // latestTxRecord searches for the newest recorded mined transaction record with
 // a matching hash.  In case of a hash collision, the record from the newest
 // block is returned.  Returns (nil, nil) if no matching transactions are found.
-func latestTxRecord(ns walletdb.Bucket, txHash *wire.ShaHash) (k, v []byte) {
+func latestTxRecord(ns walletdb.Bucket, txHash *chainhash.Hash) (k, v []byte) {
 	prefix := txHash[:]
 	c := ns.Bucket(bucketTxRecords).Cursor()
 	ck, cv := c.Seek(prefix)
@@ -508,7 +509,7 @@ func latestTxRecord(ns walletdb.Bucket, txHash *wire.ShaHash) (k, v []byte) {
 // The optional debits key is only included if the credit is spent by another
 // mined debit.
 
-func keyCredit(txHash *wire.ShaHash, index uint32, block *Block) []byte {
+func keyCredit(txHash *chainhash.Hash, index uint32, block *Block) []byte {
 	k := make([]byte, 72)
 	copy(k, txHash[:])
 	byteOrder.PutUint32(k[32:36], uint32(block.Height))
@@ -636,7 +637,7 @@ func unspendRawCredit(ns walletdb.Bucket, k []byte) (btcutil.Amount, error) {
 	return btcutil.Amount(byteOrder.Uint64(v[0:8])), nil
 }
 
-func existsCredit(ns walletdb.Bucket, txHash *wire.ShaHash, index uint32, block *Block) (k, v []byte) {
+func existsCredit(ns walletdb.Bucket, txHash *chainhash.Hash, index uint32, block *Block) (k, v []byte) {
 	k = keyCredit(txHash, index, block)
 	v = ns.Bucket(bucketCredits).Get(k)
 	return
@@ -835,7 +836,7 @@ func deleteRawUnspent(ns walletdb.Bucket, k []byte) error {
 //             [44:76] Block hash (32 bytes)
 //             [76:80] Output index (4 bytes)
 
-func keyDebit(txHash *wire.ShaHash, index uint32, block *Block) []byte {
+func keyDebit(txHash *chainhash.Hash, index uint32, block *Block) []byte {
 	k := make([]byte, 72)
 	copy(k, txHash[:])
 	byteOrder.PutUint32(k[32:36], uint32(block.Height))
@@ -844,7 +845,7 @@ func keyDebit(txHash *wire.ShaHash, index uint32, block *Block) []byte {
 	return k
 }
 
-func putDebit(ns walletdb.Bucket, txHash *wire.ShaHash, index uint32, amount btcutil.Amount, block *Block, credKey []byte) error {
+func putDebit(ns walletdb.Bucket, txHash *chainhash.Hash, index uint32, amount btcutil.Amount, block *Block, credKey []byte) error {
 	k := keyDebit(txHash, index, block)
 
 	v := make([]byte, 80)
@@ -867,7 +868,7 @@ func extractRawDebitCreditKey(v []byte) []byte {
 // existsDebit checks for the existance of a debit.  If found, the debit and
 // previous credit keys are returned.  If the debit does not exist, both keys
 // are nil.
-func existsDebit(ns walletdb.Bucket, txHash *wire.ShaHash, index uint32, block *Block) (k, credKey []byte, err error) {
+func existsDebit(ns walletdb.Bucket, txHash *chainhash.Hash, index uint32, block *Block) (k, credKey []byte, err error) {
 	k = keyDebit(txHash, index, block)
 	v := ns.Bucket(bucketDebits).Get(k)
 	if v == nil {
@@ -972,7 +973,7 @@ func putRawUnmined(ns walletdb.Bucket, k, v []byte) error {
 	return nil
 }
 
-func readRawUnminedHash(k []byte, txHash *wire.ShaHash) error {
+func readRawUnminedHash(k []byte, txHash *chainhash.Hash) error {
 	if len(k) < 32 {
 		str := "short unmined key"
 		return storeError(ErrData, str, nil)
@@ -1092,7 +1093,7 @@ type unminedCreditIterator struct {
 	err    error
 }
 
-func makeUnminedCreditIterator(ns walletdb.Bucket, txHash *wire.ShaHash) unminedCreditIterator {
+func makeUnminedCreditIterator(ns walletdb.Bucket, txHash *chainhash.Hash) unminedCreditIterator {
 	c := ns.Bucket(bucketUnminedCredits).Cursor()
 	return unminedCreditIterator{c: c, prefix: txHash[:]}
 }

--- a/wtxmgr/example_test.go
+++ b/wtxmgr/example_test.go
@@ -7,6 +7,7 @@ package wtxmgr_test
 import (
 	"fmt"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 )
@@ -22,7 +23,7 @@ var (
 )
 
 func init() {
-	tx := spendOutput(&wire.ShaHash{}, 0, 10e8)
+	tx := spendOutput(&chainhash.Hash{}, 0, 10e8)
 	rec, err := wtxmgr.NewTxRecordFromMsgTx(tx, timeNow())
 	if err != nil {
 		panic(err)

--- a/wtxmgr/kahnsort.go
+++ b/wtxmgr/kahnsort.go
@@ -4,19 +4,17 @@
 
 package wtxmgr
 
-import (
-	"github.com/btcsuite/btcd/wire"
-)
+import "github.com/btcsuite/btcd/chaincfg/chainhash"
 
 type graphNode struct {
 	value    *TxRecord
-	outEdges []*wire.ShaHash
+	outEdges []*chainhash.Hash
 	inDegree int
 }
 
-type hashGraph map[wire.ShaHash]graphNode
+type hashGraph map[chainhash.Hash]graphNode
 
-func makeGraph(set map[wire.ShaHash]*TxRecord) hashGraph {
+func makeGraph(set map[chainhash.Hash]*TxRecord) hashGraph {
 	graph := make(hashGraph)
 
 	for _, rec := range set {
@@ -83,7 +81,7 @@ func graphRoots(graph hashGraph) []*TxRecord {
 
 // dependencySort topologically sorts a set of transaction records by their
 // dependency order.  It is implemented using Kahn's algorithm.
-func dependencySort(txs map[wire.ShaHash]*TxRecord) []*TxRecord {
+func dependencySort(txs map[chainhash.Hash]*TxRecord) []*TxRecord {
 	graph := makeGraph(txs)
 	s := graphRoots(graph)
 

--- a/wtxmgr/query.go
+++ b/wtxmgr/query.go
@@ -7,7 +7,7 @@ package wtxmgr
 import (
 	"fmt"
 
-	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcwallet/walletdb"
 )
@@ -42,7 +42,7 @@ type TxDetails struct {
 
 // minedTxDetails fetches the TxDetails for the mined transaction with hash
 // txHash and the passed tx record key and value.
-func (s *Store) minedTxDetails(ns walletdb.Bucket, txHash *wire.ShaHash, recKey, recVal []byte) (*TxDetails, error) {
+func (s *Store) minedTxDetails(ns walletdb.Bucket, txHash *chainhash.Hash, recKey, recVal []byte) (*TxDetails, error) {
 	var details TxDetails
 
 	// Parse transaction record k/v, lookup the full block record for the
@@ -94,7 +94,7 @@ func (s *Store) minedTxDetails(ns walletdb.Bucket, txHash *wire.ShaHash, recKey,
 
 // unminedTxDetails fetches the TxDetails for the unmined transaction with the
 // hash txHash and the passed unmined record value.
-func (s *Store) unminedTxDetails(ns walletdb.Bucket, txHash *wire.ShaHash, v []byte) (*TxDetails, error) {
+func (s *Store) unminedTxDetails(ns walletdb.Bucket, txHash *chainhash.Hash, v []byte) (*TxDetails, error) {
 	details := TxDetails{
 		Block: BlockMeta{Block: Block{Height: -1}},
 	}
@@ -166,7 +166,7 @@ func (s *Store) unminedTxDetails(ns walletdb.Bucket, txHash *wire.ShaHash, v []b
 //
 // Not finding a transaction with this hash is not an error.  In this case,
 // a nil TxDetails is returned.
-func (s *Store) TxDetails(txHash *wire.ShaHash) (*TxDetails, error) {
+func (s *Store) TxDetails(txHash *chainhash.Hash) (*TxDetails, error) {
 	var details *TxDetails
 	err := scopedView(s.namespace, func(ns walletdb.Bucket) error {
 		var err error
@@ -197,7 +197,7 @@ func (s *Store) TxDetails(txHash *wire.ShaHash) (*TxDetails, error) {
 //
 // Not finding a transaction with this hash from this block is not an error.  In
 // this case, a nil TxDetails is returned.
-func (s *Store) UniqueTxDetails(txHash *wire.ShaHash, block *Block) (*TxDetails, error) {
+func (s *Store) UniqueTxDetails(txHash *chainhash.Hash, block *Block) (*TxDetails, error) {
 	var details *TxDetails
 	err := scopedView(s.namespace, func(ns walletdb.Bucket) error {
 		var err error
@@ -234,7 +234,7 @@ func (s *Store) rangeUnminedTransactions(ns walletdb.Bucket, f func([]TxDetails)
 			return storeError(ErrData, str, nil)
 		}
 
-		var txHash wire.ShaHash
+		var txHash chainhash.Hash
 		copy(txHash[:], k)
 		detail, err := s.unminedTxDetails(ns, &txHash, v)
 		if err != nil {

--- a/wtxmgr/query_test.go
+++ b/wtxmgr/query_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 The btcsuite developers
+// Copyright (c) 2015-2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	. "github.com/btcsuite/btcwallet/wtxmgr"
@@ -19,12 +20,12 @@ import (
 type queryState struct {
 	// slice items are ordered by height, mempool comes last.
 	blocks    [][]TxDetails
-	txDetails map[wire.ShaHash][]TxDetails
+	txDetails map[chainhash.Hash][]TxDetails
 }
 
 func newQueryState() *queryState {
 	return &queryState{
-		txDetails: make(map[wire.ShaHash][]TxDetails),
+		txDetails: make(map[chainhash.Hash][]TxDetails),
 	}
 }
 
@@ -37,7 +38,7 @@ func (q *queryState) deepCopy() *queryState {
 		}
 		cpy.blocks = append(cpy.blocks, cpyDetails)
 	}
-	cpy.txDetails = make(map[wire.ShaHash][]TxDetails)
+	cpy.txDetails = make(map[chainhash.Hash][]TxDetails)
 	for txHash, details := range q.txDetails {
 		detailsSlice := make([]TxDetails, len(details))
 		for i, detail := range details {
@@ -282,7 +283,7 @@ func TestStoreQueries(t *testing.T) {
 	}
 
 	// Insert an unmined transaction.  Mark no credits yet.
-	txA := spendOutput(&wire.ShaHash{}, 0, 100e8)
+	txA := spendOutput(&chainhash.Hash{}, 0, 100e8)
 	recA := newTxRecordFromMsgTx(txA, timeNow())
 	newState := lastState.deepCopy()
 	newState.blocks = [][]TxDetails{
@@ -412,7 +413,7 @@ func TestStoreQueries(t *testing.T) {
 		t.Errorf("Expected no details, found details for tx %v", missingDetails.Hash)
 	}
 	missingUniqueTests := []struct {
-		hash  *wire.ShaHash
+		hash  *chainhash.Hash
 		block *Block
 	}{
 		{&missingRec.Hash, &b100.Block},
@@ -554,7 +555,7 @@ func TestPreviousPkScripts(t *testing.T) {
 
 	// Create a transaction spending two prevous outputs and generating two
 	// new outputs the passed pkScipts.  Spends outputs 0 and 1 from prevHash.
-	buildTx := func(prevHash *wire.ShaHash, script0, script1 []byte) *wire.MsgTx {
+	buildTx := func(prevHash *chainhash.Hash, script0, script1 []byte) *wire.MsgTx {
 		return &wire.MsgTx{
 			TxIn: []*wire.TxIn{
 				&wire.TxIn{PreviousOutPoint: wire.OutPoint{
@@ -582,7 +583,7 @@ func TestPreviousPkScripts(t *testing.T) {
 
 	// Create transactions with the fake output scripts.
 	var (
-		txA  = buildTx(&wire.ShaHash{}, scriptA0, scriptA1)
+		txA  = buildTx(&chainhash.Hash{}, scriptA0, scriptA1)
 		recA = newTxRecordFromMsgTx(txA)
 		txB  = buildTx(&recA.Hash, scriptB0, scriptB1)
 		recB = newTxRecordFromMsgTx(txB)

--- a/wtxmgr/tx_test.go
+++ b/wtxmgr/tx_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2015 The btcsuite developers
+// Copyright (c) 2013-2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcwallet/walletdb"
@@ -26,7 +27,7 @@ import (
 var (
 	TstRecvSerializedTx, _          = hex.DecodeString("010000000114d9ff358894c486b4ae11c2a8cf7851b1df64c53d2e511278eff17c22fb7373000000008c493046022100995447baec31ee9f6d4ec0e05cb2a44f6b817a99d5f6de167d1c75354a946410022100c9ffc23b64d770b0e01e7ff4d25fbc2f1ca8091053078a247905c39fce3760b601410458b8e267add3c1e374cf40f1de02b59213a82e1d84c2b94096e22e2f09387009c96debe1d0bcb2356ffdcf65d2a83d4b34e72c62eccd8490dbf2110167783b2bffffffff0280969800000000001976a914479ed307831d0ac19ebc5f63de7d5f1a430ddb9d88ac38bfaa00000000001976a914dadf9e3484f28b385ddeaa6c575c0c0d18e9788a88ac00000000")
 	TstRecvTx, _                    = btcutil.NewTxFromBytes(TstRecvSerializedTx)
-	TstRecvTxSpendingTxBlockHash, _ = wire.NewShaHashFromStr("00000000000000017188b968a371bab95aa43522665353b646e41865abae02a4")
+	TstRecvTxSpendingTxBlockHash, _ = chainhash.NewHashFromStr("00000000000000017188b968a371bab95aa43522665353b646e41865abae02a4")
 	TstRecvAmt                      = int64(10000000)
 	TstRecvTxBlockDetails           = &BlockMeta{
 		Block: Block{Hash: *TstRecvTxSpendingTxBlockHash, Height: 276425},
@@ -39,7 +40,7 @@ var (
 	TstSpendingSerializedTx, _ = hex.DecodeString("0100000003ad3fba7ebd67c09baa9538898e10d6726dcb8eadb006be0c7388c8e46d69d361000000006b4830450220702c4fbde5532575fed44f8d6e8c3432a2a9bd8cff2f966c3a79b2245a7c88db02210095d6505a57e350720cb52b89a9b56243c15ddfcea0596aedc1ba55d9fb7d5aa0012103cccb5c48a699d3efcca6dae277fee6b82e0229ed754b742659c3acdfed2651f9ffffffffdbd36173f5610e34de5c00ed092174603761595d90190f790e79cda3e5b45bc2010000006b483045022000fa20735e5875e64d05bed43d81b867f3bd8745008d3ff4331ef1617eac7c44022100ad82261fc57faac67fc482a37b6bf18158da0971e300abf5fe2f9fd39e107f58012102d4e1caf3e022757512c204bf09ff56a9981df483aba3c74bb60d3612077c9206ffffffff65536c9d964b6f89b8ef17e83c6666641bc495cb27bab60052f76cd4556ccd0d040000006a473044022068e3886e0299ffa69a1c3ee40f8b6700f5f6d463a9cf9dbf22c055a131fc4abc02202b58957fe19ff1be7a84c458d08016c53fbddec7184ac5e633f2b282ae3420ae012103b4e411b81d32a69fb81178a8ea1abaa12f613336923ee920ffbb1b313af1f4d2ffffffff02ab233200000000001976a91418808b2fbd8d2c6d022aed5cd61f0ce6c0a4cbb688ac4741f011000000001976a914f081088a300c80ce36b717a9914ab5ec8a7d283988ac00000000")
 	TstSpendingTx, _           = btcutil.NewTxFromBytes(TstSpendingSerializedTx)
 	TstSpendingTxBlockHeight   = int32(279143)
-	TstSignedTxBlockHash, _    = wire.NewShaHashFromStr("00000000000000017188b968a371bab95aa43522665353b646e41865abae02a4")
+	TstSignedTxBlockHash, _    = chainhash.NewHashFromStr("00000000000000017188b968a371bab95aa43522665353b646e41865abae02a4")
 	TstSignedTxBlockDetails    = &BlockMeta{
 		Block: Block{Hash: *TstSignedTxBlockHash, Height: TstSpendingTxBlockHeight},
 		Time:  time.Unix(1389114091, 0),
@@ -109,7 +110,7 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 	// Create a "signed" (with invalid sigs) tx that spends output 0 of
 	// the double spend.
 	spendingTx := wire.NewMsgTx()
-	spendingTxIn := wire.NewTxIn(wire.NewOutPoint(TstDoubleSpendTx.Sha(), 0), []byte{0, 1, 2, 3, 4})
+	spendingTxIn := wire.NewTxIn(wire.NewOutPoint(TstDoubleSpendTx.Hash(), 0), []byte{0, 1, 2, 3, 4})
 	spendingTx.AddTxIn(spendingTxIn)
 	spendingTxOut1 := wire.NewTxOut(1e7, []byte{5, 6, 7, 8, 9})
 	spendingTxOut2 := wire.NewTxOut(9e7, []byte{10, 11, 12, 13, 14})
@@ -124,7 +125,7 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 		f        func(*Store) (*Store, error)
 		bal, unc btcutil.Amount
 		unspents map[wire.OutPoint]struct{}
-		unmined  map[wire.ShaHash]struct{}
+		unmined  map[chainhash.Hash]struct{}
 	}{
 		{
 			name: "new store",
@@ -134,7 +135,7 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal:      0,
 			unc:      0,
 			unspents: map[wire.OutPoint]struct{}{},
-			unmined:  map[wire.ShaHash]struct{}{},
+			unmined:  map[chainhash.Hash]struct{}{},
 		},
 		{
 			name: "txout insert",
@@ -155,12 +156,12 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			unc: btcutil.Amount(TstRecvTx.MsgTx().TxOut[0].Value),
 			unspents: map[wire.OutPoint]struct{}{
 				wire.OutPoint{
-					Hash:  *TstRecvTx.Sha(),
+					Hash:  *TstRecvTx.Hash(),
 					Index: 0,
 				}: {},
 			},
-			unmined: map[wire.ShaHash]struct{}{
-				*TstRecvTx.Sha(): {},
+			unmined: map[chainhash.Hash]struct{}{
+				*TstRecvTx.Hash(): {},
 			},
 		},
 		{
@@ -182,12 +183,12 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			unc: btcutil.Amount(TstRecvTx.MsgTx().TxOut[0].Value),
 			unspents: map[wire.OutPoint]struct{}{
 				wire.OutPoint{
-					Hash:  *TstRecvTx.Sha(),
+					Hash:  *TstRecvTx.Hash(),
 					Index: 0,
 				}: {},
 			},
-			unmined: map[wire.ShaHash]struct{}{
-				*TstRecvTx.Sha(): {},
+			unmined: map[chainhash.Hash]struct{}{
+				*TstRecvTx.Hash(): {},
 			},
 		},
 		{
@@ -209,11 +210,11 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			unc: 0,
 			unspents: map[wire.OutPoint]struct{}{
 				wire.OutPoint{
-					Hash:  *TstRecvTx.Sha(),
+					Hash:  *TstRecvTx.Hash(),
 					Index: 0,
 				}: {},
 			},
-			unmined: map[wire.ShaHash]struct{}{},
+			unmined: map[chainhash.Hash]struct{}{},
 		},
 		{
 			name: "insert duplicate confirmed",
@@ -234,11 +235,11 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			unc: 0,
 			unspents: map[wire.OutPoint]struct{}{
 				wire.OutPoint{
-					Hash:  *TstRecvTx.Sha(),
+					Hash:  *TstRecvTx.Hash(),
 					Index: 0,
 				}: {},
 			},
-			unmined: map[wire.ShaHash]struct{}{},
+			unmined: map[chainhash.Hash]struct{}{},
 		},
 		{
 			name: "rollback confirmed credit",
@@ -250,12 +251,12 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			unc: btcutil.Amount(TstRecvTx.MsgTx().TxOut[0].Value),
 			unspents: map[wire.OutPoint]struct{}{
 				wire.OutPoint{
-					Hash:  *TstRecvTx.Sha(),
+					Hash:  *TstRecvTx.Hash(),
 					Index: 0,
 				}: {},
 			},
-			unmined: map[wire.ShaHash]struct{}{
-				*TstRecvTx.Sha(): {},
+			unmined: map[chainhash.Hash]struct{}{
+				*TstRecvTx.Hash(): {},
 			},
 		},
 		{
@@ -277,11 +278,11 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			unc: 0,
 			unspents: map[wire.OutPoint]struct{}{
 				wire.OutPoint{
-					Hash:  *TstDoubleSpendTx.Sha(),
+					Hash:  *TstDoubleSpendTx.Hash(),
 					Index: 0,
 				}: {},
 			},
-			unmined: map[wire.ShaHash]struct{}{},
+			unmined: map[chainhash.Hash]struct{}{},
 		},
 		{
 			name: "insert unconfirmed debit",
@@ -296,8 +297,8 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal:      0,
 			unc:      0,
 			unspents: map[wire.OutPoint]struct{}{},
-			unmined: map[wire.ShaHash]struct{}{
-				*TstSpendingTx.Sha(): {},
+			unmined: map[chainhash.Hash]struct{}{
+				*TstSpendingTx.Hash(): {},
 			},
 		},
 		{
@@ -313,8 +314,8 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal:      0,
 			unc:      0,
 			unspents: map[wire.OutPoint]struct{}{},
-			unmined: map[wire.ShaHash]struct{}{
-				*TstSpendingTx.Sha(): {},
+			unmined: map[chainhash.Hash]struct{}{
+				*TstSpendingTx.Hash(): {},
 			},
 		},
 		{
@@ -336,12 +337,12 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			unc: btcutil.Amount(TstSpendingTx.MsgTx().TxOut[0].Value),
 			unspents: map[wire.OutPoint]struct{}{
 				wire.OutPoint{
-					Hash:  *TstSpendingTx.Sha(),
+					Hash:  *TstSpendingTx.Hash(),
 					Index: 0,
 				}: {},
 			},
-			unmined: map[wire.ShaHash]struct{}{
-				*TstSpendingTx.Sha(): {},
+			unmined: map[chainhash.Hash]struct{}{
+				*TstSpendingTx.Hash(): {},
 			},
 		},
 		{
@@ -362,16 +363,16 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			unc: btcutil.Amount(TstSpendingTx.MsgTx().TxOut[0].Value + TstSpendingTx.MsgTx().TxOut[1].Value),
 			unspents: map[wire.OutPoint]struct{}{
 				wire.OutPoint{
-					Hash:  *TstSpendingTx.Sha(),
+					Hash:  *TstSpendingTx.Hash(),
 					Index: 0,
 				}: {},
 				wire.OutPoint{
-					Hash:  *TstSpendingTx.Sha(),
+					Hash:  *TstSpendingTx.Hash(),
 					Index: 1,
 				}: {},
 			},
-			unmined: map[wire.ShaHash]struct{}{
-				*TstSpendingTx.Sha(): {},
+			unmined: map[chainhash.Hash]struct{}{
+				*TstSpendingTx.Hash(): {},
 			},
 		},
 		{
@@ -388,15 +389,15 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			unc: 0,
 			unspents: map[wire.OutPoint]struct{}{
 				wire.OutPoint{
-					Hash:  *TstSpendingTx.Sha(),
+					Hash:  *TstSpendingTx.Hash(),
 					Index: 0,
 				}: {},
 				wire.OutPoint{
-					Hash:  *TstSpendingTx.Sha(),
+					Hash:  *TstSpendingTx.Hash(),
 					Index: 1,
 				}: {},
 			},
-			unmined: map[wire.ShaHash]struct{}{},
+			unmined: map[chainhash.Hash]struct{}{},
 		},
 		{
 			name: "rollback after spending tx",
@@ -408,15 +409,15 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			unc: 0,
 			unspents: map[wire.OutPoint]struct{}{
 				wire.OutPoint{
-					Hash:  *TstSpendingTx.Sha(),
+					Hash:  *TstSpendingTx.Hash(),
 					Index: 0,
 				}: {},
 				wire.OutPoint{
-					Hash:  *TstSpendingTx.Sha(),
+					Hash:  *TstSpendingTx.Hash(),
 					Index: 1,
 				}: {},
 			},
-			unmined: map[wire.ShaHash]struct{}{},
+			unmined: map[chainhash.Hash]struct{}{},
 		},
 		{
 			name: "rollback spending tx block",
@@ -428,16 +429,16 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			unc: btcutil.Amount(TstSpendingTx.MsgTx().TxOut[0].Value + TstSpendingTx.MsgTx().TxOut[1].Value),
 			unspents: map[wire.OutPoint]struct{}{
 				wire.OutPoint{
-					Hash:  *TstSpendingTx.Sha(),
+					Hash:  *TstSpendingTx.Hash(),
 					Index: 0,
 				}: {},
 				wire.OutPoint{
-					Hash:  *TstSpendingTx.Sha(),
+					Hash:  *TstSpendingTx.Hash(),
 					Index: 1,
 				}: {},
 			},
-			unmined: map[wire.ShaHash]struct{}{
-				*TstSpendingTx.Sha(): {},
+			unmined: map[chainhash.Hash]struct{}{
+				*TstSpendingTx.Hash(): {},
 			},
 		},
 		{
@@ -449,12 +450,12 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal: 0,
 			unc: btcutil.Amount(TstSpendingTx.MsgTx().TxOut[0].Value + TstSpendingTx.MsgTx().TxOut[1].Value),
 			unspents: map[wire.OutPoint]struct{}{
-				*wire.NewOutPoint(TstSpendingTx.Sha(), 0): {},
-				*wire.NewOutPoint(TstSpendingTx.Sha(), 1): {},
+				*wire.NewOutPoint(TstSpendingTx.Hash(), 0): {},
+				*wire.NewOutPoint(TstSpendingTx.Hash(), 1): {},
 			},
-			unmined: map[wire.ShaHash]struct{}{
-				*TstDoubleSpendTx.Sha(): {},
-				*TstSpendingTx.Sha():    {},
+			unmined: map[chainhash.Hash]struct{}{
+				*TstDoubleSpendTx.Hash(): {},
+				*TstSpendingTx.Hash():    {},
 			},
 		},
 		{
@@ -474,9 +475,9 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal: btcutil.Amount(TstRecvTx.MsgTx().TxOut[0].Value),
 			unc: 0,
 			unspents: map[wire.OutPoint]struct{}{
-				*wire.NewOutPoint(TstRecvTx.Sha(), 0): {},
+				*wire.NewOutPoint(TstRecvTx.Hash(), 0): {},
 			},
-			unmined: map[wire.ShaHash]struct{}{},
+			unmined: map[chainhash.Hash]struct{}{},
 		},
 	}
 
@@ -529,7 +530,7 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			t.Fatalf("%s: cannot load unmined transactions: %v", test.name, err)
 		}
 		for _, tx := range unmined {
-			txHash := tx.TxSha()
+			txHash := tx.TxHash()
 			if _, ok := test.unmined[txHash]; !ok {
 				t.Fatalf("%s: unexpected unmined tx: %v", test.name, txHash)
 			}
@@ -593,7 +594,7 @@ func TestFindingSpentCredits(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	op := wire.NewOutPoint(TstSpendingTx.Sha(), 0)
+	op := wire.NewOutPoint(TstSpendingTx.Hash(), 0)
 	if unspents[0].OutPoint != *op {
 		t.Fatal("unspent outpoint doesn't match expected")
 	}
@@ -616,7 +617,7 @@ func newCoinBase(outputValues ...int64) *wire.MsgTx {
 	return &tx
 }
 
-func spendOutput(txHash *wire.ShaHash, index uint32, outputValues ...int64) *wire.MsgTx {
+func spendOutput(txHash *chainhash.Hash, index uint32, outputValues ...int64) *wire.MsgTx {
 	tx := wire.MsgTx{
 		TxIn: []*wire.TxIn{
 			&wire.TxIn{

--- a/wtxmgr/unconfirmed.go
+++ b/wtxmgr/unconfirmed.go
@@ -5,6 +5,7 @@
 package wtxmgr
 
 import (
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/walletdb"
 )
@@ -126,7 +127,7 @@ func (s *Store) removeConflict(ns walletdb.Bucket, rec *TxRecord) error {
 // which are not known to have been mined in a block.  Transactions are
 // guaranteed to be sorted by their dependency order.
 func (s *Store) UnminedTxs() ([]*wire.MsgTx, error) {
-	var recSet map[wire.ShaHash]*TxRecord
+	var recSet map[chainhash.Hash]*TxRecord
 	err := scopedView(s.namespace, func(ns walletdb.Bucket) error {
 		var err error
 		recSet, err = s.unminedTxRecords(ns)
@@ -144,10 +145,10 @@ func (s *Store) UnminedTxs() ([]*wire.MsgTx, error) {
 	return txs, nil
 }
 
-func (s *Store) unminedTxRecords(ns walletdb.Bucket) (map[wire.ShaHash]*TxRecord, error) {
-	unmined := make(map[wire.ShaHash]*TxRecord)
+func (s *Store) unminedTxRecords(ns walletdb.Bucket) (map[chainhash.Hash]*TxRecord, error) {
+	unmined := make(map[chainhash.Hash]*TxRecord)
 	err := ns.Bucket(bucketUnmined).ForEach(func(k, v []byte) error {
-		var txHash wire.ShaHash
+		var txHash chainhash.Hash
 		err := readRawUnminedHash(k, &txHash)
 		if err != nil {
 			return err
@@ -166,8 +167,8 @@ func (s *Store) unminedTxRecords(ns walletdb.Bucket) (map[wire.ShaHash]*TxRecord
 
 // UnminedTxHashes returns the hashes of all transactions not known to have been
 // mined in a block.
-func (s *Store) UnminedTxHashes() ([]*wire.ShaHash, error) {
-	var hashes []*wire.ShaHash
+func (s *Store) UnminedTxHashes() ([]*chainhash.Hash, error) {
+	var hashes []*chainhash.Hash
 	err := scopedView(s.namespace, func(ns walletdb.Bucket) error {
 		var err error
 		hashes, err = s.unminedTxHashes(ns)
@@ -176,10 +177,10 @@ func (s *Store) UnminedTxHashes() ([]*wire.ShaHash, error) {
 	return hashes, err
 }
 
-func (s *Store) unminedTxHashes(ns walletdb.Bucket) ([]*wire.ShaHash, error) {
-	var hashes []*wire.ShaHash
+func (s *Store) unminedTxHashes(ns walletdb.Bucket) ([]*chainhash.Hash, error) {
+	var hashes []*chainhash.Hash
 	err := ns.Bucket(bucketUnmined).ForEach(func(k, v []byte) error {
-		hash := new(wire.ShaHash)
+		hash := new(chainhash.Hash)
 		err := readRawUnminedHash(k, hash)
 		if err == nil {
 			hashes = append(hashes, hash)


### PR DESCRIPTION
**This PR requires btcsuite/btcd#729 and btcsuite/btcutil#78.**

This updates all code to make use of the new `chainhash` package since the old `wire.ShaHash` type and related functions have been removed in favor of the abstracted package.

Also, while here, rename all variables that included `sha` in their name to include `hash` instead.

Finally, update `glide.lock` to use the required version of `btcd`, `btcutil`, and `btcrpcclient`.