### PR TITLE
Update for recent chaincfg API changes.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
 hash: 0cff4a723566a3e33910785c104bddde49d1e0ba2d51f3833599a423140f5163
-updated: 2016-08-08T14:07:48.6427885-05:00
+updated: 2016-08-12T09:43:45.22287-05:00
 imports:
 - name: github.com/boltdb/bolt
   version: 831b652a7f8dbefaf94da0eb66abd46c0c4bcf23
 - name: github.com/btcsuite/btcd
-  version: bd4e64d1d43bad445dd8e6577907c0c265cd83c2
+  version: a7b35d9f9e24f8cebf3dc30cf083668700690095
   subpackages:
   - blockchain
   - btcec

--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -894,7 +894,7 @@ func getTransaction(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 		ret.Fee = feeF64
 	}
 
-	credCat := wallet.RecvCategory(details, syncBlock.Height).String()
+	credCat := wallet.RecvCategory(details, syncBlock.Height, w.ChainParams()).String()
 	for _, cred := range details.Credits {
 		// Change is ignored.
 		if cred.Change {

--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -25,7 +25,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
-	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
@@ -341,8 +340,9 @@ func (s *walletServer) FundTransaction(ctx context.Context, req *pb.FundTransact
 		if !confirmed(req.RequiredConfirmations, output.Height, syncBlock.Height) {
 			continue
 		}
+		target := int32(s.wallet.ChainParams().CoinbaseMaturity)
 		if !req.IncludeImmatureCoinbases && output.FromCoinBase &&
-			!confirmed(blockchain.CoinbaseMaturity, output.Height, syncBlock.Height) {
+			!confirmed(target, output.Height, syncBlock.Height) {
 			continue
 		}
 

--- a/votingpool/example_test.go
+++ b/votingpool/example_test.go
@@ -340,7 +340,7 @@ func exampleCreateTxStore() (*wtxmgr.Store, func(), error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	s, err := wtxmgr.Open(wtxmgrNamespace)
+	s, err := wtxmgr.Open(wtxmgrNamespace, &chaincfg.MainNetParams)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/votingpool/factory_test.go
+++ b/votingpool/factory_test.go
@@ -154,7 +154,7 @@ func TstCreateTxStore(t *testing.T) (store *wtxmgr.Store, tearDown func()) {
 	if err != nil {
 		t.Fatalf("Failed to create txstore: %v", err)
 	}
-	s, err := wtxmgr.Open(wtxmgrNamespace)
+	s, err := wtxmgr.Open(wtxmgrNamespace, &chaincfg.MainNetParams)
 	if err != nil {
 		t.Fatalf("Failed to open txstore: %v", err)
 	}

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
@@ -188,7 +187,7 @@ func (w *Wallet) findEligibleOutputs(account uint32, minconf int32, bs *waddrmgr
 			continue
 		}
 		if output.FromCoinBase {
-			const target = blockchain.CoinbaseMaturity
+			target := int32(w.chainParams.CoinbaseMaturity)
 			if !confirmed(target, output.Height, bs.Height) {
 				continue
 			}

--- a/wtxmgr/example_test.go
+++ b/wtxmgr/example_test.go
@@ -7,6 +7,7 @@ package wtxmgr_test
 import (
 	"fmt"
 
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/wtxmgr"
@@ -161,7 +162,7 @@ func Example_basicUsage() {
 		fmt.Println(err)
 		return
 	}
-	s, err := wtxmgr.Open(ns)
+	s, err := wtxmgr.Open(ns, &chaincfg.TestNet3Params)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/wtxmgr/tx_test.go
+++ b/wtxmgr/tx_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
@@ -80,7 +80,7 @@ func testStore() (*Store, func(), error) {
 	if err != nil {
 		return nil, teardown, err
 	}
-	s, err := Open(ns)
+	s, err := Open(ns, &chaincfg.TestNet3Params)
 	return s, teardown, err
 }
 
@@ -665,6 +665,8 @@ func TestCoinbases(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	coinbaseMaturity := int32(chaincfg.TestNet3Params.CoinbaseMaturity)
+
 	// Balance should be 0 if the coinbase is immature, 50 BTC at and beyond
 	// maturity.
 	//
@@ -679,67 +681,67 @@ func TestCoinbases(t *testing.T) {
 	balTests := []balTest{
 		// Next block it is still immature
 		{
-			height:  b100.Height + blockchain.CoinbaseMaturity - 2,
+			height:  b100.Height + coinbaseMaturity - 2,
 			minConf: 0,
 			bal:     0,
 		},
 		{
-			height:  b100.Height + blockchain.CoinbaseMaturity - 2,
-			minConf: blockchain.CoinbaseMaturity,
+			height:  b100.Height + coinbaseMaturity - 2,
+			minConf: coinbaseMaturity,
 			bal:     0,
 		},
 
 		// Next block it matures
 		{
-			height:  b100.Height + blockchain.CoinbaseMaturity - 1,
+			height:  b100.Height + coinbaseMaturity - 1,
 			minConf: 0,
 			bal:     50e8,
 		},
 		{
-			height:  b100.Height + blockchain.CoinbaseMaturity - 1,
+			height:  b100.Height + coinbaseMaturity - 1,
 			minConf: 1,
 			bal:     50e8,
 		},
 		{
-			height:  b100.Height + blockchain.CoinbaseMaturity - 1,
-			minConf: blockchain.CoinbaseMaturity - 1,
+			height:  b100.Height + coinbaseMaturity - 1,
+			minConf: coinbaseMaturity - 1,
 			bal:     50e8,
 		},
 		{
-			height:  b100.Height + blockchain.CoinbaseMaturity - 1,
-			minConf: blockchain.CoinbaseMaturity,
+			height:  b100.Height + coinbaseMaturity - 1,
+			minConf: coinbaseMaturity,
 			bal:     50e8,
 		},
 		{
-			height:  b100.Height + blockchain.CoinbaseMaturity - 1,
-			minConf: blockchain.CoinbaseMaturity + 1,
+			height:  b100.Height + coinbaseMaturity - 1,
+			minConf: coinbaseMaturity + 1,
 			bal:     0,
 		},
 
 		// Matures at this block
 		{
-			height:  b100.Height + blockchain.CoinbaseMaturity,
+			height:  b100.Height + coinbaseMaturity,
 			minConf: 0,
 			bal:     50e8,
 		},
 		{
-			height:  b100.Height + blockchain.CoinbaseMaturity,
+			height:  b100.Height + coinbaseMaturity,
 			minConf: 1,
 			bal:     50e8,
 		},
 		{
-			height:  b100.Height + blockchain.CoinbaseMaturity,
-			minConf: blockchain.CoinbaseMaturity,
+			height:  b100.Height + coinbaseMaturity,
+			minConf: coinbaseMaturity,
 			bal:     50e8,
 		},
 		{
-			height:  b100.Height + blockchain.CoinbaseMaturity,
-			minConf: blockchain.CoinbaseMaturity + 1,
+			height:  b100.Height + coinbaseMaturity,
+			minConf: coinbaseMaturity + 1,
 			bal:     50e8,
 		},
 		{
-			height:  b100.Height + blockchain.CoinbaseMaturity,
-			minConf: blockchain.CoinbaseMaturity + 2,
+			height:  b100.Height + coinbaseMaturity,
+			minConf: coinbaseMaturity + 2,
 			bal:     0,
 		},
 	}
@@ -776,50 +778,50 @@ func TestCoinbases(t *testing.T) {
 	balTests = []balTest{
 		// Next block it matures
 		{
-			height:  b100.Height + blockchain.CoinbaseMaturity - 1,
+			height:  b100.Height + coinbaseMaturity - 1,
 			minConf: 0,
 			bal:     35e8,
 		},
 		{
-			height:  b100.Height + blockchain.CoinbaseMaturity - 1,
+			height:  b100.Height + coinbaseMaturity - 1,
 			minConf: 1,
 			bal:     30e8,
 		},
 		{
-			height:  b100.Height + blockchain.CoinbaseMaturity - 1,
-			minConf: blockchain.CoinbaseMaturity,
+			height:  b100.Height + coinbaseMaturity - 1,
+			minConf: coinbaseMaturity,
 			bal:     30e8,
 		},
 		{
-			height:  b100.Height + blockchain.CoinbaseMaturity - 1,
-			minConf: blockchain.CoinbaseMaturity + 1,
+			height:  b100.Height + coinbaseMaturity - 1,
+			minConf: coinbaseMaturity + 1,
 			bal:     0,
 		},
 
 		// Matures at this block
 		{
-			height:  b100.Height + blockchain.CoinbaseMaturity,
+			height:  b100.Height + coinbaseMaturity,
 			minConf: 0,
 			bal:     35e8,
 		},
 		{
-			height:  b100.Height + blockchain.CoinbaseMaturity,
+			height:  b100.Height + coinbaseMaturity,
 			minConf: 1,
 			bal:     30e8,
 		},
 		{
-			height:  b100.Height + blockchain.CoinbaseMaturity,
-			minConf: blockchain.CoinbaseMaturity,
+			height:  b100.Height + coinbaseMaturity,
+			minConf: coinbaseMaturity,
 			bal:     30e8,
 		},
 		{
-			height:  b100.Height + blockchain.CoinbaseMaturity,
-			minConf: blockchain.CoinbaseMaturity + 1,
+			height:  b100.Height + coinbaseMaturity,
+			minConf: coinbaseMaturity + 1,
 			bal:     30e8,
 		},
 		{
-			height:  b100.Height + blockchain.CoinbaseMaturity,
-			minConf: blockchain.CoinbaseMaturity + 2,
+			height:  b100.Height + coinbaseMaturity,
+			minConf: coinbaseMaturity + 2,
 			bal:     0,
 		},
 	}
@@ -839,7 +841,7 @@ func TestCoinbases(t *testing.T) {
 
 	// Mine the spending transaction in the block the coinbase matures.
 	bMaturity := BlockMeta{
-		Block: Block{Height: b100.Height + blockchain.CoinbaseMaturity},
+		Block: Block{Height: b100.Height + coinbaseMaturity},
 		Time:  time.Now(),
 	}
 	err = s.InsertTx(spenderARec, &bMaturity)
@@ -866,17 +868,17 @@ func TestCoinbases(t *testing.T) {
 		},
 		{
 			height:  bMaturity.Height,
-			minConf: blockchain.CoinbaseMaturity,
+			minConf: coinbaseMaturity,
 			bal:     30e8,
 		},
 		{
 			height:  bMaturity.Height,
-			minConf: blockchain.CoinbaseMaturity + 1,
+			minConf: coinbaseMaturity + 1,
 			bal:     30e8,
 		},
 		{
 			height:  bMaturity.Height,
-			minConf: blockchain.CoinbaseMaturity + 2,
+			minConf: coinbaseMaturity + 2,
 			bal:     0,
 		},
 
@@ -898,12 +900,12 @@ func TestCoinbases(t *testing.T) {
 		},
 		{
 			height:  bMaturity.Height + 1,
-			minConf: blockchain.CoinbaseMaturity + 2,
+			minConf: coinbaseMaturity + 2,
 			bal:     30e8,
 		},
 		{
 			height:  bMaturity.Height + 1,
-			minConf: blockchain.CoinbaseMaturity + 3,
+			minConf: coinbaseMaturity + 3,
 			bal:     0,
 		},
 	}
@@ -1101,9 +1103,11 @@ func TestMoveMultipleToSameBlock(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	coinbaseMaturity := int32(chaincfg.TestNet3Params.CoinbaseMaturity)
+
 	// Mine both transactions in the block that matures the coinbase.
 	bMaturity := BlockMeta{
-		Block: Block{Height: b100.Height + blockchain.CoinbaseMaturity},
+		Block: Block{Height: b100.Height + coinbaseMaturity},
 		Time:  time.Now(),
 	}
 	err = s.InsertTx(spenderARec, &bMaturity)


### PR DESCRIPTION
**This pull request requires btcsuite/btcd#732** 

Since the coinbase maturity is now allowed to be defined per chain and the old `blockchain.CoinbaseMaturity` constant has been removed, this updates the code accordingly.