### PR TITLE
Add options --nopass and --seed.

### DIFF
--- a/btcwallet.go
+++ b/btcwallet.go
@@ -86,7 +86,7 @@ func walletMain() error {
 	if !cfg.NoInitialLoad {
 		// Load the wallet database.  It must have been created already
 		// or this will return an appropriate error.
-		_, err = loader.OpenExistingWallet([]byte(cfg.WalletPass), true)
+		_, err = loader.OpenExistingWallet([]byte(cfg.WalletPass), !cfg.NoPass)
 		if err != nil {
 			log.Error(err)
 			return err

--- a/wallet/loader.go
+++ b/wallet/loader.go
@@ -138,6 +138,10 @@ func noConsole() ([]byte, error) {
 	return nil, errNoConsole
 }
 
+func defaultPassword() ([]byte, error) {
+	return []byte(InsecurePrivPassphrase), nil
+}
+
 // OpenExistingWallet opens the wallet from the loader's wallet database path
 // and the public passphrase.  If the loader is being called by a context where
 // standard input prompts may be used during wallet upgrades, setting
@@ -172,7 +176,7 @@ func (l *Loader) OpenExistingWallet(pubPassphrase []byte, canConsolePrompt bool)
 	} else {
 		cbs = &waddrmgr.OpenCallbacks{
 			ObtainSeed:        noConsole,
-			ObtainPrivatePass: noConsole,
+			ObtainPrivatePass: defaultPassword,
 		}
 	}
 	w, err := Open(db, pubPassphrase, cbs, l.chainParams)

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -46,6 +46,9 @@ const (
 	// data in the waddrmgr namespace.  Transactions are not yet encrypted.
 	InsecurePubPassphrase = "public"
 
+	// InsecurePrivPassphrase is used if option 'nopass' is set.
+	InsecurePrivPassphrase = "priv"
+
 	walletDbWatchingOnlyName = "wowallet.db"
 )
 


### PR DESCRIPTION
Both of these options are used with --create, and they are intended
to make it easier to manage wallet creation from the command line.

--nopass means that the user is not prompted for a password to
encrypt the wallet (a default password is used instead).

--seed enables the user to provide the seed to the wallet from the
command line.