### PR TITLE
Update for wire.NewMsgTx API change.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
 hash: 5efa5cef5495a0b5256f45ecb2456ea21101934ed56e780a46b1c16e30177ebc
-updated: 2016-10-27T11:04:37.4161268-04:00
+updated: 2016-10-27T11:54:19.492811-05:00
 imports:
 - name: github.com/boltdb/bolt
   version: 583e8937c61f1af6513608ccc75c97b6abdf4ff9
 - name: github.com/btcsuite/btcd
-  version: e3eeb4a34a04c8ec40298fee9f9d8fe2ce0c13ca
+  version: f6ad7eb2c963151c71de2bd37d04d9af644a891d
   subpackages:
   - blockchain
   - btcec
@@ -19,7 +19,7 @@ imports:
 - name: github.com/btcsuite/btcrpcclient
   version: 2b780d16b042054d07aa322146194118fd7f7b81
 - name: github.com/btcsuite/btcutil
-  version: 68e5965458062d031a6e333b35c778ce464fb73f
+  version: 9b9ce80a2edafc6198569550fcc01df11d214425
   subpackages:
   - base58
   - hdkeychain

--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -1631,7 +1631,7 @@ func signRawTransaction(icmd interface{}, w *wallet.Wallet, chainClient *chain.R
 	if err != nil {
 		return nil, err
 	}
-	tx := wire.NewMsgTx()
+	var tx wire.MsgTx
 	err = tx.Deserialize(bytes.NewBuffer(serializedTx))
 	if err != nil {
 		e := errors.New("TX decode failed")
@@ -1764,7 +1764,7 @@ func signRawTransaction(icmd interface{}, w *wallet.Wallet, chainClient *chain.R
 	// `complete' denotes that we successfully signed all outputs and that
 	// all scripts will run to completion. This is returned as part of the
 	// reply.
-	signErrs, err := w.SignTransaction(tx, hashType, inputs, keys, scripts)
+	signErrs, err := w.SignTransaction(&tx, hashType, inputs, keys, scripts)
 	if err != nil {
 		return nil, err
 	}

--- a/votingpool/db.go
+++ b/votingpool/db.go
@@ -552,12 +552,12 @@ func deserializeWithdrawal(p *Pool, serialized []byte) (*withdrawalInfo, error) 
 		}
 	}
 	for ntxid, tx := range row.Status.Transactions {
-		msgtx := wire.NewMsgTx()
+		var msgtx wire.MsgTx
 		if err := msgtx.Deserialize(bytes.NewBuffer(tx.SerializedMsgTx)); err != nil {
 			return nil, newError(ErrWithdrawalStorage, "cannot deserialize transaction", err)
 		}
 		wInfo.status.transactions[ntxid] = changeAwareTx{
-			MsgTx:     msgtx,
+			MsgTx:     &msgtx,
 			changeIdx: tx.ChangeIdx,
 		}
 	}

--- a/votingpool/withdrawal.go
+++ b/votingpool/withdrawal.go
@@ -358,7 +358,7 @@ func (tx *withdrawalTx) hasChange() bool {
 
 // toMsgTx generates a btcwire.MsgTx with this tx's inputs and outputs.
 func (tx *withdrawalTx) toMsgTx() *wire.MsgTx {
-	msgtx := wire.NewMsgTx()
+	msgtx := wire.NewMsgTx(wire.TxVersion)
 	for _, o := range tx.outputs {
 		msgtx.AddTxOut(wire.NewTxOut(int64(o.amount), o.pkScript()))
 	}

--- a/wtxmgr/tx_test.go
+++ b/wtxmgr/tx_test.go
@@ -109,7 +109,7 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 
 	// Create a "signed" (with invalid sigs) tx that spends output 0 of
 	// the double spend.
-	spendingTx := wire.NewMsgTx()
+	spendingTx := wire.NewMsgTx(wire.TxVersion)
 	spendingTxIn := wire.NewTxIn(wire.NewOutPoint(TstDoubleSpendTx.Hash(), 0), []byte{0, 1, 2, 3, 4})
 	spendingTx.AddTxIn(spendingTxIn)
 	spendingTxOut1 := wire.NewTxOut(1e7, []byte{5, 6, 7, 8, 9})


### PR DESCRIPTION
**Requires PRs btcsuite/btcutil#82 and btcsuite/btcd#817**

Also, bump glide.lock to ensure the appropriate deps are pulled in.

**NOTE: I modified `glide.yaml` and `glide.lock` temporarily until the upstream deps are in so this PR builds in the mean time.  Those will need to be reverted before this is merged**