### PR TITLE
Fix reported spendable balances from coinbase outputs.

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -700,11 +700,9 @@ func (w *Wallet) CalculateAccountBalances(account uint32, confirms int32) (Balan
 		}
 
 		bals.Total += output.Amount
-		if output.FromCoinBase {
-			target := int32(w.chainParams.CoinbaseMaturity)
-			if !confirmed(target, output.Height, syncBlock.Height) {
-				bals.ImmatureReward += output.Amount
-			}
+		if output.FromCoinBase && !confirmed(int32(w.chainParams.CoinbaseMaturity),
+			output.Height, syncBlock.Height) {
+			bals.ImmatureReward += output.Amount
 		} else if confirmed(confirms, output.Height, syncBlock.Height) {
 			bals.Spendable += output.Amount
 		}


### PR DESCRIPTION
Previously, this would not increment the spendable balance for matured
coinbase outputs and would only increment the immature balance if the
output was still immature.