### PR TITLE
Added ability to use gRPC in insecure mode for testing purposes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,25 @@
-btcwallet
-vendor
+# Binaries for programs and plugins
+*.exe
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
+.glide/
+
+# IDEA
+.idea/
+.gradle/
+
+# Security/Certificate madness
+deployment/security/index.*
+deployment/security/serial*
+*.pem
+*index.txt*
+*serial*


### PR DESCRIPTION
Added ability to use gRPC in insecure mode for testing purposes.

I did this by expanding out the if/else statement where there is a test for --noservertls.  Rather than not doing gRPC, I instead created a grpc service without a TLS config.

It still conforms to your requirements of a localhost address.

I also added a .gitignore :)