### PR TITLE
Remove Wallet from Notification server to avoid a loop of pointers.

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -70,7 +70,7 @@ func (w *Wallet) connectBlock(b wtxmgr.BlockMeta) {
 	}
 
 	// Notify interested clients of the connected block.
-	w.NtfnServer.notifyAttachedBlock(&b)
+	w.NtfnServer.notifyAttachedBlock(w, &b)
 }
 
 // disconnectBlock handles a chain server reorganize by rolling back all
@@ -201,14 +201,14 @@ func (w *Wallet) addRelevantTx(rec *wtxmgr.TxRecord, block *wtxmgr.BlockMeta) er
 		if err != nil {
 			log.Errorf("Cannot query transaction details for notifiation: %v", err)
 		} else {
-			w.NtfnServer.notifyUnminedTransaction(details)
+			w.NtfnServer.notifyUnminedTransaction(w, details)
 		}
 	} else {
 		details, err := w.TxStore.UniqueTxDetails(&rec.Hash, &block.Block)
 		if err != nil {
 			log.Errorf("Cannot query transaction details for notifiation: %v", err)
 		} else {
-			w.NtfnServer.notifyMinedTransaction(details, block)
+			w.NtfnServer.notifyMinedTransaction(w, details, block)
 		}
 	}
 

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -2155,7 +2155,7 @@ func Open(db walletdb.DB, pubPass []byte, cbs *waddrmgr.OpenCallbacks, params *c
 		chainParams:         params,
 		quit:                make(chan struct{}),
 	}
-	w.NtfnServer = newNotificationServer(w)
+	w.NtfnServer = newNotificationServer()
 	w.TxStore.NotifyUnspent = func(hash *chainhash.Hash, index uint32) {
 		w.NtfnServer.notifyUnspentOutput(0, hash, index)
 	}


### PR DESCRIPTION
Wallet has a pointer to a type called NotificationServer and NotificationServer has a pointer back to the same Wallet. There is a comment that says "smells like hacks". I have resolved this by redefining the NotificationServer so that it has no pointer to the wallet and it simply takes a pointer to the wallet in every function that requires it. This works fine because the Wallet totally controls the NotificationServer. 