### PR TITLE
Wallet refactor pr - WIP

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -26,8 +26,8 @@ type RPCClient struct {
 	chainParams       *chaincfg.Params
 	reconnectAttempts int
 
-	enqueueNotification chan interface{}
-	dequeueNotification chan interface{}
+	enqueueNotification chan Notification
+	dequeueNotification chan Notification
 	currentBlock        chan *waddrmgr.BlockStamp
 
 	quit    chan struct{}
@@ -62,8 +62,8 @@ func NewRPCClient(chainParams *chaincfg.Params, connect, user, pass string, cert
 		},
 		chainParams:         chainParams,
 		reconnectAttempts:   reconnectAttempts,
-		enqueueNotification: make(chan interface{}),
-		dequeueNotification: make(chan interface{}),
+		enqueueNotification: make(chan Notification),
+		dequeueNotification: make(chan Notification),
 		currentBlock:        make(chan *waddrmgr.BlockStamp),
 		quit:                make(chan struct{}),
 	}
@@ -139,11 +139,18 @@ func (c *RPCClient) WaitForShutdown() {
 	c.wg.Wait()
 }
 
-// Notification types.  These are defined here and processed from from reading
+// Notification types.  These are defined here and processed from reading
 // a notificationChan to avoid handling these notifications directly in
 // btcrpcclient callbacks, which isn't very Go-like and doesn't allow
 // blocking client calls.
 type (
+	// Notification is an abstract type representing any notification.
+	// It contains an exported function that doesn't do anything to ensure
+	// that only those types defined here can be notification types.
+	Notification interface {
+		isChainNotification()
+	}
+
 	// ClientConnected is a notification for when a client connection is
 	// opened or reestablished to the chain server.
 	ClientConnected struct{}
@@ -180,11 +187,19 @@ type (
 	}
 )
 
+// Define isChanNotification for each notification type.
+func (x ClientConnected) isChainNotification()   {}
+func (x BlockConnected) isChainNotification()    {}
+func (x BlockDisconnected) isChainNotification() {}
+func (x RelevantTx) isChainNotification()        {}
+func (x RescanProgress) isChainNotification()    {}
+func (x RescanFinished) isChainNotification()    {}
+
 // Notifications returns a channel of parsed notifications sent by the remote
 // bitcoin RPC server.  This channel must be continually read or the process
 // may abort for running out memory, as unread notifications are queued for
 // later reads.
-func (c *RPCClient) Notifications() <-chan interface{} {
+func (c *RPCClient) Notifications() <-chan Notification {
 	return c.dequeueNotification
 }
 
@@ -320,10 +335,10 @@ func (c *RPCClient) handler() {
 	// The time we wait to hear back from the server after we ping it.
 	pingTimeout := 3 * time.Second
 
-	var notifications []interface{}
+	var notifications []Notification
 	enqueue := c.enqueueNotification
-	var dequeue chan interface{}
-	var next interface{}
+	var dequeue chan Notification
+	var next Notification
 	pingChan := time.After(pingInterval)
 out:
 	for {

--- a/log.go
+++ b/log.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btclog"
-	"github.com/btcsuite/btcrpcclient"
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/btcsuite/btcwallet/rpc/legacyrpc"
 	"github.com/btcsuite/btcwallet/rpc/rpcserver"
@@ -60,7 +60,7 @@ func init() {
 	wallet.UseLogger(walletLog)
 	wtxmgr.UseLogger(txmgrLog)
 	chain.UseLogger(chainLog)
-	btcrpcclient.UseLogger(chainLog)
+	rpcclient.UseLogger(chainLog)
 	rpcserver.UseLogger(grpcLog)
 	legacyrpc.UseLogger(legacyRPCLog)
 }

--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -18,9 +18,9 @@ import (
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcrpcclient"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/btcsuite/btcwallet/waddrmgr"
@@ -987,7 +987,7 @@ func help(icmd interface{}, w *wallet.Wallet, chainClient *chain.RPCClient) (int
 	//
 	// This is hacky and is probably better handled by exposing help usage
 	// texts in a non-internal btcd package.
-	postClient := func() *btcrpcclient.Client {
+	postClient := func() *rpcclient.Client {
 		if chainClient == nil {
 			return nil
 		}
@@ -1705,7 +1705,7 @@ func signRawTransaction(icmd interface{}, w *wallet.Wallet, chainClient *chain.R
 	// querying btcd with getrawtransaction. We queue up a bunch of async
 	// requests and will wait for replies after we have checked the rest of
 	// the arguments.
-	requested := make(map[wire.OutPoint]btcrpcclient.FutureGetTxOutResult)
+	requested := make(map[wire.OutPoint]rpcclient.FutureGetTxOutResult)
 	for _, txIn := range tx.TxIn {
 		// Did we get this outpoint from the arguments?
 		if _, ok := inputs[txIn.PreviousOutPoint]; ok {

--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -26,9 +26,9 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcrpcclient"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcutil/hdkeychain"
 	"github.com/btcsuite/btcwallet/chain"
@@ -842,7 +842,7 @@ func (s *loaderServer) StartConsensusRpc(ctx context.Context, req *pb.StartConse
 
 	err = rpcClient.Start()
 	if err != nil {
-		if err == btcrpcclient.ErrInvalidAuth {
+		if err == rpcclient.ErrInvalidAuth {
 			return nil, grpc.Errorf(codes.InvalidArgument,
 				"Invalid RPC credentials: %v", err)
 		}

--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -70,7 +70,7 @@ func (w *Wallet) connectBlock(b wtxmgr.BlockMeta) {
 	}
 
 	// Notify interested clients of the connected block.
-	w.NtfnServer.notifyAttachedBlock(&b)
+	w.NtfnServer.notifyAttachedBlock(w, &b)
 }
 
 // disconnectBlock handles a chain server reorganize by rolling back all
@@ -201,14 +201,14 @@ func (w *Wallet) addRelevantTx(rec *wtxmgr.TxRecord, block *wtxmgr.BlockMeta) er
 		if err != nil {
 			log.Errorf("Cannot query transaction details for notifiation: %v", err)
 		} else {
-			w.NtfnServer.notifyUnminedTransaction(details)
+			w.NtfnServer.notifyUnminedTransaction(w, details)
 		}
 	} else {
 		details, err := w.TxStore.UniqueTxDetails(&rec.Hash, &block.Block)
 		if err != nil {
 			log.Errorf("Cannot query transaction details for notifiation: %v", err)
 		} else {
-			w.NtfnServer.notifyMinedTransaction(details, block)
+			w.NtfnServer.notifyMinedTransaction(w, details, block)
 		}
 	}
 

--- a/wallet/session.go
+++ b/wallet/session.go
@@ -1,0 +1,460 @@
+// Copyright (c) 2017 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/rpcclient"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+	"github.com/btcsuite/btcwallet/chain"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/txauthor"
+	"github.com/btcsuite/btcwallet/wallet/txrules"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+)
+
+type Session struct {
+	Wallet *Wallet
+	quit   chan struct{}
+
+	chainClient        *chain.RPCClient
+	chainClientSynced  bool
+	chainClientSyncMtx sync.Mutex
+}
+
+// Stop signals all wallet goroutines to shutdown.
+func (s *Session) Stop() {
+	select {
+	case <-s.quit:
+	default:
+		close(s.quit)
+	}
+}
+
+// ShuttingDown returns whether the wallet is currently in the process of
+// shutting down or not.
+func (s *Session) ShuttingDown() bool {
+	select {
+	case <-s.quit:
+		return true
+	default:
+		return false
+	}
+}
+
+// SynchronizingToNetwork returns whether the wallet is currently synchronizing
+// with the Bitcoin network.
+func (s *Session) SynchronizingToNetwork() bool {
+	// At the moment, RPC is the only synchronization method.  In the
+	// future, when SPV is added, a separate check will also be needed, or
+	// SPV could always be enabled if RPC was not explicitly specified when
+	// creating the wallet.
+	return !s.ShuttingDown()
+}
+
+// ChainSynced returns whether the wallet has been attached to a chain server
+// and synced up to the best block on the main chain.
+func (s *Session) ChainSynced() bool {
+	s.chainClientSyncMtx.Lock()
+	synced := s.chainClientSynced
+	s.chainClientSyncMtx.Unlock()
+	return synced
+}
+
+// setChainSynced marks whether the wallet is connected to and currently in sync
+// with the latest block notified by the chain server.
+//
+// NOTE: Due to an API limitation with rpcclient, this may return true after
+// the client disconnected (and is attempting a reconnect).  This will be unknown
+// until the reconnect notification is received, at which point the wallet can be
+// marked out of sync again until after the next rescan completes.
+func (s *Session) setChainSynced(synced bool) {
+	s.chainClientSyncMtx.Lock()
+	s.chainClientSynced = synced
+	s.chainClientSyncMtx.Unlock()
+}
+
+func (s *Session) ChainClient() *chain.RPCClient {
+	return s.chainClient
+}
+
+// syncWithChain brings the wallet up to date with the current chain server
+// connection.  It creates a rescan request and blocks until the rescan has
+// finished.
+//
+func (s *Session) syncWithChain() error {
+	// Request notifications for connected and disconnected blocks.
+	//
+	// TODO(jrick): Either request this notification only once, or when
+	// rpcclient is modified to allow some notification request to not
+	// automatically resent on reconnect, include the notifyblocks request
+	// as well.  I am leaning towards allowing off all rpcclient
+	// notification re-registrations, in which case the code here should be
+	// left as is.
+	err := s.chainClient.NotifyBlocks()
+	if err != nil {
+		return err
+	}
+
+	// Request notifications for transactions sending to all wallet
+	// addresses.
+	addrs, unspent, err := s.Wallet.activeData()
+	if err != nil {
+		return err
+	}
+
+	// TODO(jrick): How should this handle a synced height earlier than
+	// the chain server best block?
+
+	// When no addresses have been generated for the wallet, the rescan can
+	// be skipped.
+	//
+	// TODO: This is only correct because activeData above returns all
+	// addresses ever created, including those that don't need to be watched
+	// anymore.  This code should be updated when this assumption is no
+	// longer true, but worst case would result in an unnecessary rescan.
+	if len(addrs) == 0 && len(unspent) == 0 {
+		// TODO: It would be ideal if on initial sync wallet saved the
+		// last several recent blocks rather than just one.  This would
+		// avoid a full rescan for a one block reorg of the current
+		// chain tip.
+		hash, height, err := s.chainClient.GetBestBlock()
+		if err != nil {
+			return err
+		}
+		return s.Wallet.Manager.SetSyncedTo(&waddrmgr.BlockStamp{
+			Hash:   *hash,
+			Height: height,
+		})
+	}
+
+	// Compare previously-seen blocks against the chain server.  If any of
+	// these blocks no longer exist, rollback all of the missing blocks
+	// before catching up with the rescan.
+	iter := s.Wallet.Manager.NewIterateRecentBlocks()
+	rollback := iter == nil
+	syncBlock := waddrmgr.BlockStamp{
+		Hash:   *s.Wallet.chainParams.GenesisHash,
+		Height: 0,
+	}
+	for cont := iter != nil; cont; cont = iter.Prev() {
+		bs := iter.BlockStamp()
+		log.Debugf("Checking for previous saved block with height %v hash %v",
+			bs.Height, bs.Hash)
+		_, err = s.chainClient.GetBlock(&bs.Hash)
+		if err != nil {
+			rollback = true
+			continue
+		}
+
+		log.Debug("Found matching block.")
+		syncBlock = bs
+		break
+	}
+	if rollback {
+		err = s.Wallet.Manager.SetSyncedTo(&syncBlock)
+		if err != nil {
+			return err
+		}
+		// Rollback unconfirms transactions at and beyond the passed
+		// height, so add one to the new synced-to height to prevent
+		// unconfirming txs from the synced-to block.
+		err = s.Wallet.TxStore.Rollback(syncBlock.Height + 1)
+		if err != nil {
+			return err
+		}
+	}
+
+	return s.Rescan(addrs, unspent)
+}
+
+type (
+	createTxRequest struct {
+		account uint32
+		outputs []*wire.TxOut
+		minconf int32
+		resp    chan createTxResponse
+	}
+	createTxResponse struct {
+		tx  *txauthor.AuthoredTx
+		err error
+	}
+)
+
+// txCreator is responsible for the input selection and creation of
+// transactions.  These functions are the responsibility of this method
+// (designed to be run as its own goroutine) since input selection must be
+// serialized, or else it is possible to create double spends by choosing the
+// same inputs for multiple transactions.  Along with input selection, this
+// method is also responsible for the signing of transactions, since we don't
+// want to end up in a situation where we run out of inputs as multiple
+// transactions are being created.  In this situation, it would then be possible
+// for both requests, rather than just one, to fail due to not enough available
+// inputs.
+func (s *Session) txCreator() {
+out:
+	for {
+		select {
+		case txr := <-s.Wallet.createTxRequests:
+			tx, err := s.txToOutputs(txr.outputs, txr.account, txr.minconf)
+			txr.resp <- createTxResponse{tx, err}
+
+		case <-s.quit:
+			break out
+		}
+	}
+
+	s.Wallet.wg.Done()
+}
+
+// GetTransactions returns transaction results between a starting and ending
+// block.  Blocks in the block range may be specified by either a height or a
+// hash.
+//
+// Because this is a possibly lenghtly operation, a cancel channel is provided
+// to cancel the task.  If this channel unblocks, the results created thus far
+// will be returned.
+//
+// Transaction results are organized by blocks in ascending order and unmined
+// transactions in an unspecified order.  Mined transactions are saved in a
+// Block structure which records properties about the block.
+func (s *Session) GetTransactions(startBlock, endBlock *BlockIdentifier, cancel <-chan struct{}) (*GetTransactionsResult, error) {
+	var start, end int32 = 0, -1
+
+	// TODO: Fetching block heights by their hashes is inherently racy
+	// because not all block headers are saved but when they are for SPV the
+	// db can be queried directly without this.
+	var startResp, endResp rpcclient.FutureGetBlockVerboseResult
+	if startBlock != nil {
+		if startBlock.hash == nil {
+			start = startBlock.height
+		} else {
+			if s.chainClient == nil {
+				return nil, errors.New("no chain server client")
+			}
+			startResp = s.chainClient.GetBlockVerboseAsync(startBlock.hash)
+		}
+	}
+	if endBlock != nil {
+		if endBlock.hash == nil {
+			end = endBlock.height
+		} else {
+			if s.chainClient == nil {
+				return nil, errors.New("no chain server client")
+			}
+			endResp = s.chainClient.GetBlockVerboseAsync(endBlock.hash)
+		}
+	}
+	if startResp != nil {
+		resp, err := startResp.Receive()
+		if err != nil {
+			return nil, err
+		}
+		start = int32(resp.Height)
+	}
+	if endResp != nil {
+		resp, err := endResp.Receive()
+		if err != nil {
+			return nil, err
+		}
+		end = int32(resp.Height)
+	}
+
+	var res GetTransactionsResult
+	err := s.Wallet.TxStore.RangeTransactions(start, end, func(details []wtxmgr.TxDetails) (bool, error) {
+		// TODO: probably should make RangeTransactions not reuse the
+		// details backing array memory.
+		dets := make([]wtxmgr.TxDetails, len(details))
+		copy(dets, details)
+		details = dets
+
+		txs := make([]TransactionSummary, 0, len(details))
+		for i := range details {
+			txs = append(txs, makeTxSummary(s.Wallet, &details[i]))
+		}
+
+		if details[0].Block.Height != -1 {
+			blockHash := details[0].Block.Hash
+			res.MinedTransactions = append(res.MinedTransactions, Block{
+				Hash:         &blockHash,
+				Height:       details[0].Block.Height,
+				Timestamp:    details[0].Block.Time.Unix(),
+				Transactions: txs,
+			})
+		} else {
+			res.UnminedTransactions = txs
+		}
+
+		select {
+		case <-cancel:
+			return true, nil
+		default:
+			return false, nil
+		}
+	})
+	return &res, err
+}
+
+// ResendUnminedTxs iterates through all transactions that spend from wallet
+// credits that are not known to have been mined into a block, and attempts
+// to send each to the chain server for relay.
+func (s *Session) ResendUnminedTxs() {
+	txs, err := s.Wallet.TxStore.UnminedTxs()
+	if err != nil {
+		log.Errorf("Cannot load unmined transactions for resending: %v", err)
+		return
+	}
+	for _, tx := range txs {
+		resp, err := s.chainClient.SendRawTransaction(tx, false)
+		if err != nil {
+			// TODO(jrick): Check error for if this tx is a double spend,
+			// remove it if so.
+			log.Debugf("Could not resend transaction %v: %v",
+				tx.TxHash(), err)
+			continue
+		}
+		log.Debugf("Resent unmined transaction %v", resp)
+	}
+}
+
+// NewAddress returns the next external chained address for a wallet.
+func (s *Session) NewAddress(account uint32) (btcutil.Address, error) {
+	// Get next address from wallet.
+	addrs, err := s.Wallet.Manager.NextExternalAddresses(account, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	// Request updates from btcd for new transactions sent to this address.
+	utilAddrs := make([]btcutil.Address, len(addrs))
+	for i, addr := range addrs {
+		utilAddrs[i] = addr.Address()
+	}
+
+	err = s.chainClient.NotifyReceived(utilAddrs)
+	if err != nil {
+		return nil, err
+	}
+
+	props, err := s.Wallet.Manager.AccountProperties(account)
+	if err != nil {
+		log.Errorf("Cannot fetch account properties for notification "+
+			"after deriving next external address: %v", err)
+	} else {
+		s.Wallet.NtfnServer.notifyAccountProperties(props)
+	}
+
+	return utilAddrs[0], nil
+}
+
+// NewChangeAddress returns a new change address for a wallet.
+func (s *Session) NewChangeAddress(account uint32) (btcutil.Address, error) {
+	// Get next chained change address from wallet for account.
+	addrs, err := s.Wallet.Manager.NextInternalAddresses(account, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	// Request updates from btcd for new transactions sent to this address.
+	utilAddrs := make([]btcutil.Address, len(addrs))
+	for i, addr := range addrs {
+		utilAddrs[i] = addr.Address()
+	}
+
+	err = s.chainClient.NotifyReceived(utilAddrs)
+	if err != nil {
+		return nil, err
+	}
+
+	return utilAddrs[0], nil
+}
+
+// CurrentAddress gets the most recently requested Bitcoin payment address
+// from a wallet.  If the address has already been used (there is at least
+// one transaction spending to it in the blockchain or btcd mempool), the next
+// chained address is returned.
+func (s *Session) CurrentAddress(account uint32) (btcutil.Address, error) {
+	addr, err := s.Wallet.Manager.LastExternalAddress(account)
+	if err != nil {
+		// If no address exists yet, create the first external address
+		if waddrmgr.IsError(err, waddrmgr.ErrAddressNotFound) {
+			return s.NewAddress(account)
+		}
+		return nil, err
+	}
+
+	// Get next chained address if the last one has already been used.
+	used, err := addr.Used()
+	if err != nil {
+		return nil, err
+	}
+	if used {
+		return s.NewAddress(account)
+	}
+
+	return addr.Address(), nil
+}
+
+// SendOutputs creates and sends payment transactions. It returns the
+// transaction hash upon success.
+func (s *Session) SendOutputs(outputs []*wire.TxOut, account uint32,
+	minconf int32) (*chainhash.Hash, error) {
+
+	var err error
+	relayFee := s.Wallet.RelayFee()
+	for _, output := range outputs {
+		err = txrules.CheckOutput(output, relayFee)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Create transaction, replying with an error if the creation
+	// was not successful.
+	createdTx, err := s.Wallet.CreateSimpleTx(account, outputs, minconf)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create transaction record and insert into the db.
+	rec, err := wtxmgr.NewTxRecordFromMsgTx(createdTx.Tx, time.Now())
+	if err != nil {
+		log.Errorf("Cannot create record for created transaction: %v", err)
+		return nil, err
+	}
+	err = s.Wallet.TxStore.InsertTx(rec, nil)
+	if err != nil {
+		log.Errorf("Error adding sent tx history: %v", err)
+		return nil, err
+	}
+
+	if createdTx.ChangeIndex >= 0 {
+		err = s.Wallet.TxStore.AddCredit(rec, nil, uint32(createdTx.ChangeIndex), true)
+		if err != nil {
+			log.Errorf("Error adding change address for sent "+
+				"tx: %v", err)
+			return nil, err
+		}
+	}
+
+	// TODO: The record already has the serialized tx, so no need to
+	// serialize it again.
+	return s.chainClient.SendRawTransaction(&rec.MsgTx, false)
+}
+
+// PublishTransaction sends the transaction to the consensus RPC server so it
+// can be propigated to other nodes and eventually mined.
+//
+// This function is unstable and will be removed once syncing code is moved out
+// of the wallet.
+func (s *Session) PublishTransaction(tx *wire.MsgTx) error {
+	_, err := s.chainClient.SendRawTransaction(tx, false)
+	return err
+}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -22,9 +22,9 @@ import (
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcrpcclient"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcutil/hdkeychain"
 	"github.com/btcsuite/btcwallet/chain"
@@ -285,7 +285,7 @@ func (w *Wallet) ChainSynced() bool {
 // SetChainSynced marks whether the wallet is connected to and currently in sync
 // with the latest block notified by the chain server.
 //
-// NOTE: Due to an API limitation with btcrpcclient, this may return true after
+// NOTE: Due to an API limitation with rpcclient, this may return true after
 // the client disconnected (and is attempting a reconnect).  This will be unknown
 // until the reconnect notification is received, at which point the wallet can be
 // marked out of sync again until after the next rescan completes.
@@ -324,9 +324,9 @@ func (w *Wallet) syncWithChain() error {
 	// Request notifications for connected and disconnected blocks.
 	//
 	// TODO(jrick): Either request this notification only once, or when
-	// btcrpcclient is modified to allow some notification request to not
+	// rpcclient is modified to allow some notification request to not
 	// automatically resent on reconnect, include the notifyblocks request
-	// as well.  I am leaning towards allowing off all btcrpcclient
+	// as well.  I am leaning towards allowing off all rpcclient
 	// notification re-registrations, in which case the code here should be
 	// left as is.
 	err = chainClient.NotifyBlocks()
@@ -1127,7 +1127,7 @@ func (w *Wallet) GetTransactions(startBlock, endBlock *BlockIdentifier, cancel <
 	// TODO: Fetching block heights by their hashes is inherently racy
 	// because not all block headers are saved but when they are for SPV the
 	// db can be queried directly without this.
-	var startResp, endResp btcrpcclient.FutureGetBlockVerboseResult
+	var startResp, endResp rpcclient.FutureGetBlockVerboseResult
 	if startBlock != nil {
 		if startBlock.hash == nil {
 			start = startBlock.height

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1927,6 +1927,7 @@ func (w *Wallet) SignTransaction(tx *wire.MsgTx, hashType txscript.SigHashType,
 
 	var signErrors []SignatureError
 	for i, txIn := range tx.TxIn {
+		var prevAmount int64
 		prevOutScript, ok := additionalPrevScripts[txIn.PreviousOutPoint]
 		if !ok {
 			prevHash := &txIn.PreviousOutPoint.Hash
@@ -2024,7 +2025,7 @@ func (w *Wallet) SignTransaction(tx *wire.MsgTx, hashType txscript.SigHashType,
 		// Either it was already signed or we just signed it.
 		// Find out if it is completely satisfied or still needs more.
 		vm, err := txscript.NewEngine(prevOutScript, tx, i,
-			txscript.StandardVerifyFlags, nil)
+			txscript.StandardVerifyFlags, nil, nil, prevAmount)
 		if err == nil {
 			err = vm.Execute()
 		}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -2155,7 +2155,7 @@ func Open(db walletdb.DB, pubPass []byte, cbs *waddrmgr.OpenCallbacks, params *c
 		chainParams:         params,
 		quit:                make(chan struct{}),
 	}
-	w.NtfnServer = newNotificationServer(w)
+	w.NtfnServer = newNotificationServer()
 	w.TxStore.NotifyUnspent = func(hash *chainhash.Hash, index uint32) {
 		w.NtfnServer.notifyUnspentOutput(0, hash, index)
 	}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -230,12 +230,6 @@ func (w *Wallet) Stop() {
 	case <-quit:
 	default:
 		close(quit)
-		w.chainClientLock.Lock()
-		if w.chainClient != nil {
-			w.chainClient.Stop()
-			w.chainClient = nil
-		}
-		w.chainClientLock.Unlock()
 	}
 }
 


### PR DESCRIPTION
Big refactor of btcwallet that makes everything make more sense. This pr takes care of a lot of issues but it was hard for me to separate it into different prs because everything here interacts with everything else. 

Quick overview: I have managed to remove the Wallet.requireChainClient, rpcClientConnectLoop, and Loader.RunAfterLoad and replace their functionality so as to make the program much easier to read and understand. 

This pr depends on https://github.com/btcsuite/btcwallet/pull/485, https://github.com/btcsuite/btcwallet/pull/486, and https://github.com/btcsuite/btcwallet/pull/488. 

There are also two commits for compatibility with the latest master of btcd just to get this to compile, which I presume will not be necessary in the near future. 

In detail: 

Problem: rpc connection can randomly drop and we want to automatically try to reconnect. 

Solution: this responsibility is subsumed by RPCClient itself. It provides a continuous stream of notifications to the wallet as if nothing happened if its connection is dropped and it is able to reconnect. 

Problem: Wallet closes rpc connection when it is shut down, but we don't necessarily want this to happen. We might want to reload the wallet or load a different wallet without shutting the program down. 

Solution: RPCClient is a resource that is owned by walletMain instead of Wallet. walletMain is responsible for opening it and shutting it down. 

Bonus: no more rpcClientConnectLoop

That means that every time rpcClientConnectLoop goes through its loop, it adds another closure to the loader with RunAfterLoad and every one is called every time Loader loads a wallet, but only the last one actually does anything. It's not like this is a huge drain on the system resources but jeez it's totally confusing. 

Problem: Some of the functions in Wallet require an active rpc connection and others do not, and we want to be able to use Wallet without the active rpc connection. Consequently, many functions in wallet call requireChainClient to see if an active rpc connection has been provided and must return with an error if no rpc connection exists. 

Solution: Separate Wallet into Wallet and Session. Session has a Wallet inside it and it provides all the functions that require a chain client. Session is created by Wallet when an rpc connection is given to it with synchronizeRPC.

Bonus: no more requireChainClient.

Problem: Loader.RunAfterLoad is a ridiculously confusing function. This function takes a closure and adds it to a list of closures that were previously given to RunAfterLoad and runs them all after a wallet is loaded. This is totally confusing because when I read the code I don't know what sort of things have been put into the Loader with RunAfterLoad arbitrarily distant in the past. This function makes it very difficult to know what has been going on. 

Solution: synchronizeRPC takes a closure which defines the entire lifecycle of the Session. This means that it is much easier to understand what is going to happen while the session with the rpc client is running. 

I have also made Loader into an explicit state machine so that it it's easier to tell what it is up to. 