### PR TITLE
wallet: add dryrun arg to tx create, rolling back db if set

### DIFF
--- a/wallet/createtx_test.go
+++ b/wallet/createtx_test.go
@@ -1,0 +1,204 @@
+// Copyright (c) 2018 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil/hdkeychain"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/walletdb"
+	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+)
+
+// TestTxToOutput checks that no new address is added to he database if we
+// request a dry run of the txToOutputs call. It also makes sure a subsequent
+// non-dry run call produces a similar transaction to the dry-run.
+func TestTxToOutputsDryRun(t *testing.T) {
+	// Set up a wallet.
+	dir, err := ioutil.TempDir("", "createtx_test")
+	if err != nil {
+		t.Fatalf("Failed to create db dir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	seed, err := hdkeychain.GenerateSeed(hdkeychain.MinSeedBytes)
+	if err != nil {
+		t.Fatalf("unable to create seed: %v", err)
+	}
+
+	pubPass := []byte("hello")
+	privPass := []byte("world")
+
+	loader := NewLoader(&chaincfg.TestNet3Params, dir, 250)
+	w, err := loader.CreateNewWallet(pubPass, privPass, seed, time.Now())
+	if err != nil {
+		t.Fatalf("unable to create wallet: %v", err)
+	}
+	chainClient := &mockChainClient{}
+	w.chainClient = chainClient
+	if err := w.Unlock(privPass, time.After(10*time.Minute)); err != nil {
+		t.Fatalf("unable to unlock wallet: %v", err)
+	}
+
+	// Create an address we can use to send some coins to.
+	addr, err := w.CurrentAddress(0, waddrmgr.KeyScopeBIP0044)
+	if err != nil {
+		t.Fatalf("unable to get current address: %v", addr)
+	}
+	p2shAddr, err := txscript.PayToAddrScript(addr)
+	if err != nil {
+		t.Fatalf("unable to convert wallet address to p2sh: %v", err)
+	}
+
+	// Add an output paying to the wallet's address to the database.
+	txOut := wire.NewTxOut(100000, p2shAddr)
+	incomingTx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{
+			{},
+		},
+		TxOut: []*wire.TxOut{
+			txOut,
+		},
+	}
+
+	var b bytes.Buffer
+	if err := incomingTx.Serialize(&b); err != nil {
+		t.Fatalf("unable to serialize tx: %v", err)
+	}
+	txBytes := b.Bytes()
+
+	rec, err := wtxmgr.NewTxRecord(txBytes, time.Now())
+	if err != nil {
+		t.Fatalf("unable to create tx record: %v", err)
+	}
+
+	// The block meta will be inserted to tell the wallet this is a
+	// confirmed transaction.
+	blockHash, _ := chainhash.NewHashFromStr(
+		"00000000000000017188b968a371bab95aa43522665353b646e41865abae02a4")
+	block := &wtxmgr.BlockMeta{
+		Block: wtxmgr.Block{Hash: *blockHash, Height: 276425},
+		Time:  time.Unix(1387737310, 0),
+	}
+
+	if err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+		err = w.TxStore.InsertTx(ns, rec, block)
+		if err != nil {
+			return err
+		}
+		err = w.TxStore.AddCredit(ns, rec, block, 0, false)
+		if err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("failed inserting tx: %v", err)
+	}
+
+	// Now tell the wallet to create a transaction paying to the specified
+	// outputs.
+	txOuts := []*wire.TxOut{
+		{
+			PkScript: p2shAddr,
+			Value:    10000,
+		},
+		{
+			PkScript: p2shAddr,
+			Value:    20000,
+		},
+	}
+
+	// First do a few dry-runs, making sure the number of addresses in the
+	// database us not inflated.
+	dryRunTx, err := w.txToOutputs(txOuts, 0, 1, 1000, true)
+	if err != nil {
+		t.Fatalf("unable to author tx: %v", err)
+	}
+	change := dryRunTx.Tx.TxOut[dryRunTx.ChangeIndex]
+
+	addresses, err := w.AccountAddresses(0)
+	if err != nil {
+		t.Fatalf("unable to get addresses: %v", err)
+	}
+
+	if len(addresses) != 1 {
+		t.Fatalf("expected 1 address, found %v", len(addresses))
+	}
+
+	dryRunTx2, err := w.txToOutputs(txOuts, 0, 1, 1000, true)
+	if err != nil {
+		t.Fatalf("unable to author tx: %v", err)
+	}
+	change2 := dryRunTx2.Tx.TxOut[dryRunTx2.ChangeIndex]
+
+	addresses, err = w.AccountAddresses(0)
+	if err != nil {
+		t.Fatalf("unable to get addresses: %v", err)
+	}
+
+	if len(addresses) != 1 {
+		t.Fatalf("expected 1 address, found %v", len(addresses))
+	}
+
+	// The two dry-run TXs should be invalid, since they don't have
+	// signatures.
+	err = validateMsgTx(
+		dryRunTx.Tx, dryRunTx.PrevScripts, dryRunTx.PrevInputValues,
+	)
+	if err == nil {
+		t.Fatalf("Expected tx to be invalid")
+	}
+
+	err = validateMsgTx(
+		dryRunTx2.Tx, dryRunTx2.PrevScripts, dryRunTx2.PrevInputValues,
+	)
+	if err == nil {
+		t.Fatalf("Expected tx to be invalid")
+	}
+
+	// Now we do a proper, non-dry run. This should add a change address
+	// to the database.
+	tx, err := w.txToOutputs(txOuts, 0, 1, 1000, false)
+	if err != nil {
+		t.Fatalf("unable to author tx: %v", err)
+	}
+	change3 := tx.Tx.TxOut[tx.ChangeIndex]
+
+	addresses, err = w.AccountAddresses(0)
+	if err != nil {
+		t.Fatalf("unable to get addresses: %v", err)
+	}
+
+	if len(addresses) != 2 {
+		t.Fatalf("expected 2 addresses, found %v", len(addresses))
+	}
+
+	err = validateMsgTx(tx.Tx, tx.PrevScripts, tx.PrevInputValues)
+	if err != nil {
+		t.Fatalf("Expected tx to be valid: %v", err)
+	}
+
+	// Finally, we check that all the transaction were using the same
+	// change address.
+	if !bytes.Equal(change.PkScript, change2.PkScript) {
+		t.Fatalf("first dry-run using different change address " +
+			"than second")
+	}
+	if !bytes.Equal(change2.PkScript, change3.PkScript) {
+		t.Fatalf("dry-run using different change address " +
+			"than wet run")
+	}
+}

--- a/wallet/mock.go
+++ b/wallet/mock.go
@@ -1,0 +1,81 @@
+package wallet
+
+import (
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+	"github.com/btcsuite/btcwallet/chain"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+)
+
+type mockChainClient struct {
+}
+
+var _ chain.Interface = (*mockChainClient)(nil)
+
+func (m *mockChainClient) Start() error {
+	return nil
+}
+
+func (m *mockChainClient) Stop() {
+}
+
+func (m *mockChainClient) WaitForShutdown() {}
+
+func (m *mockChainClient) GetBestBlock() (*chainhash.Hash, int32, error) {
+	return nil, 0, nil
+}
+
+func (m *mockChainClient) GetBlock(*chainhash.Hash) (*wire.MsgBlock, error) {
+	return nil, nil
+}
+
+func (m *mockChainClient) GetBlockHash(int64) (*chainhash.Hash, error) {
+	return nil, nil
+}
+
+func (m *mockChainClient) GetBlockHeader(*chainhash.Hash) (*wire.BlockHeader,
+	error) {
+	return nil, nil
+}
+
+func (m *mockChainClient) FilterBlocks(*chain.FilterBlocksRequest) (
+	*chain.FilterBlocksResponse, error) {
+	return nil, nil
+}
+
+func (m *mockChainClient) BlockStamp() (*waddrmgr.BlockStamp, error) {
+	return &waddrmgr.BlockStamp{
+		Height:    500000,
+		Hash:      chainhash.Hash{},
+		Timestamp: time.Unix(1234, 0),
+	}, nil
+}
+
+func (m *mockChainClient) SendRawTransaction(*wire.MsgTx, bool) (
+	*chainhash.Hash, error) {
+	return nil, nil
+}
+
+func (m *mockChainClient) Rescan(*chainhash.Hash, []btcutil.Address,
+	map[wire.OutPoint]btcutil.Address) error {
+	return nil
+}
+
+func (m *mockChainClient) NotifyReceived([]btcutil.Address) error {
+	return nil
+}
+
+func (m *mockChainClient) NotifyBlocks() error {
+	return nil
+}
+
+func (m *mockChainClient) Notifications() <-chan interface{} {
+	return nil
+}
+
+func (m *mockChainClient) BackEnd() string {
+	return "mock"
+}

--- a/walletdb/bdb/db.go
+++ b/walletdb/bdb/db.go
@@ -99,6 +99,14 @@ func (tx *transaction) Rollback() error {
 	return convertErr(tx.boltTx.Rollback())
 }
 
+// OnCommit takes a function closure that will be executed when the transaction
+// successfully gets committed.
+//
+// This function is part of the walletdb.ReadWriteTx interface implementation.
+func (tx *transaction) OnCommit(f func()) {
+	tx.boltTx.OnCommit(f)
+}
+
 // bucket is an internal type used to represent a collection of key/value pairs
 // and implements the walletdb Bucket interfaces.
 type bucket bbolt.Bucket
@@ -212,6 +220,15 @@ func (b *bucket) ReadCursor() walletdb.ReadCursor {
 // This function is part of the walletdb.ReadWriteBucket interface implementation.
 func (b *bucket) ReadWriteCursor() walletdb.ReadWriteCursor {
 	return (*cursor)((*bbolt.Bucket)(b).Cursor())
+}
+
+// Tx returns the bucket's transaction.
+//
+// This function is part of the walletdb.ReadWriteBucket interface implementation.
+func (b *bucket) Tx() walletdb.ReadWriteTx {
+	return &transaction{
+		(*bbolt.Bucket)(b).Tx(),
+	}
 }
 
 // cursor represents a cursor over key/value pairs and nested buckets of a

--- a/walletdb/bdb/db.go
+++ b/walletdb/bdb/db.go
@@ -86,7 +86,7 @@ func (tx *transaction) DeleteTopLevelBucket(key []byte) error {
 // Commit commits all changes that have been made through the root bucket and
 // all of its sub-buckets to persistent storage.
 //
-// This function is part of the walletdb.Tx interface implementation.
+// This function is part of the walletdb.ReadWriteTx interface implementation.
 func (tx *transaction) Commit() error {
 	return convertErr(tx.boltTx.Commit())
 }
@@ -94,7 +94,7 @@ func (tx *transaction) Commit() error {
 // Rollback undoes all changes that have been made to the root bucket and all of
 // its sub-buckets.
 //
-// This function is part of the walletdb.Tx interface implementation.
+// This function is part of the walletdb.ReadTx interface implementation.
 func (tx *transaction) Rollback() error {
 	return convertErr(tx.boltTx.Rollback())
 }
@@ -128,7 +128,7 @@ func (b *bucket) NestedReadBucket(key []byte) walletdb.ReadBucket {
 // if the key is empty, or ErrIncompatibleValue if the key value is otherwise
 // invalid.
 //
-// This function is part of the walletdb.Bucket interface implementation.
+// This function is part of the walletdb.ReadWriteBucket interface implementation.
 func (b *bucket) CreateBucket(key []byte) (walletdb.ReadWriteBucket, error) {
 	boltBucket, err := (*bbolt.Bucket)(b).CreateBucket(key)
 	if err != nil {
@@ -141,7 +141,7 @@ func (b *bucket) CreateBucket(key []byte) (walletdb.ReadWriteBucket, error) {
 // given key if it does not already exist.  Returns ErrBucketNameRequired if the
 // key is empty or ErrIncompatibleValue if the key value is otherwise invalid.
 //
-// This function is part of the walletdb.Bucket interface implementation.
+// This function is part of the walletdb.ReadWriteBucket interface implementation.
 func (b *bucket) CreateBucketIfNotExists(key []byte) (walletdb.ReadWriteBucket, error) {
 	boltBucket, err := (*bbolt.Bucket)(b).CreateBucketIfNotExists(key)
 	if err != nil {
@@ -154,7 +154,7 @@ func (b *bucket) CreateBucketIfNotExists(key []byte) (walletdb.ReadWriteBucket, 
 // ErrTxNotWritable if attempted against a read-only transaction and
 // ErrBucketNotFound if the specified bucket does not exist.
 //
-// This function is part of the walletdb.Bucket interface implementation.
+// This function is part of the walletdb.ReadWriteBucket interface implementation.
 func (b *bucket) DeleteNestedBucket(key []byte) error {
 	return convertErr((*bbolt.Bucket)(b).DeleteBucket(key))
 }
@@ -167,7 +167,7 @@ func (b *bucket) DeleteNestedBucket(key []byte) error {
 // transaction.  Attempting to access them after a transaction has ended will
 // likely result in an access violation.
 //
-// This function is part of the walletdb.Bucket interface implementation.
+// This function is part of the walletdb.ReadBucket interface implementation.
 func (b *bucket) ForEach(fn func(k, v []byte) error) error {
 	return convertErr((*bbolt.Bucket)(b).ForEach(fn))
 }
@@ -176,7 +176,7 @@ func (b *bucket) ForEach(fn func(k, v []byte) error) error {
 // already exist are added and keys that already exist are overwritten.  Returns
 // ErrTxNotWritable if attempted against a read-only transaction.
 //
-// This function is part of the walletdb.Bucket interface implementation.
+// This function is part of the walletdb.ReadWriteBucket interface implementation.
 func (b *bucket) Put(key, value []byte) error {
 	return convertErr((*bbolt.Bucket)(b).Put(key, value))
 }
@@ -188,7 +188,7 @@ func (b *bucket) Put(key, value []byte) error {
 // transaction.  Attempting to access it after a transaction has ended
 // will likely result in an access violation.
 //
-// This function is part of the walletdb.Bucket interface implementation.
+// This function is part of the walletdb.ReadBucket interface implementation.
 func (b *bucket) Get(key []byte) []byte {
 	return (*bbolt.Bucket)(b).Get(key)
 }
@@ -197,7 +197,7 @@ func (b *bucket) Get(key []byte) []byte {
 // not exist does not return an error.  Returns ErrTxNotWritable if attempted
 // against a read-only transaction.
 //
-// This function is part of the walletdb.Bucket interface implementation.
+// This function is part of the walletdb.ReadWriteBucket interface implementation.
 func (b *bucket) Delete(key []byte) error {
 	return convertErr((*bbolt.Bucket)(b).Delete(key))
 }
@@ -209,7 +209,7 @@ func (b *bucket) ReadCursor() walletdb.ReadCursor {
 // ReadWriteCursor returns a new cursor, allowing for iteration over the bucket's
 // key/value pairs and nested buckets in forward or backward order.
 //
-// This function is part of the walletdb.Bucket interface implementation.
+// This function is part of the walletdb.ReadWriteBucket interface implementation.
 func (b *bucket) ReadWriteCursor() walletdb.ReadWriteCursor {
 	return (*cursor)((*bbolt.Bucket)(b).Cursor())
 }
@@ -228,35 +228,35 @@ type cursor bbolt.Cursor
 // transaction, or ErrIncompatibleValue if attempted when the cursor points to a
 // nested bucket.
 //
-// This function is part of the walletdb.Cursor interface implementation.
+// This function is part of the walletdb.ReadWriteCursor interface implementation.
 func (c *cursor) Delete() error {
 	return convertErr((*bbolt.Cursor)(c).Delete())
 }
 
 // First positions the cursor at the first key/value pair and returns the pair.
 //
-// This function is part of the walletdb.Cursor interface implementation.
+// This function is part of the walletdb.ReadCursor interface implementation.
 func (c *cursor) First() (key, value []byte) {
 	return (*bbolt.Cursor)(c).First()
 }
 
 // Last positions the cursor at the last key/value pair and returns the pair.
 //
-// This function is part of the walletdb.Cursor interface implementation.
+// This function is part of the walletdb.ReadCursor interface implementation.
 func (c *cursor) Last() (key, value []byte) {
 	return (*bbolt.Cursor)(c).Last()
 }
 
 // Next moves the cursor one key/value pair forward and returns the new pair.
 //
-// This function is part of the walletdb.Cursor interface implementation.
+// This function is part of the walletdb.ReadCursor interface implementation.
 func (c *cursor) Next() (key, value []byte) {
 	return (*bbolt.Cursor)(c).Next()
 }
 
 // Prev moves the cursor one key/value pair backward and returns the new pair.
 //
-// This function is part of the walletdb.Cursor interface implementation.
+// This function is part of the walletdb.ReadCursor interface implementation.
 func (c *cursor) Prev() (key, value []byte) {
 	return (*bbolt.Cursor)(c).Prev()
 }
@@ -264,7 +264,7 @@ func (c *cursor) Prev() (key, value []byte) {
 // Seek positions the cursor at the passed seek key. If the key does not exist,
 // the cursor is moved to the next key after seek. Returns the new pair.
 //
-// This function is part of the walletdb.Cursor interface implementation.
+// This function is part of the walletdb.ReadCursor interface implementation.
 func (c *cursor) Seek(seek []byte) (key, value []byte) {
 	return (*bbolt.Cursor)(c).Seek(seek)
 }

--- a/walletdb/interface.go
+++ b/walletdb/interface.go
@@ -42,6 +42,10 @@ type ReadWriteTx interface {
 	// Commit commits all changes that have been on the transaction's root
 	// buckets and all of their sub-buckets to persistent storage.
 	Commit() error
+
+	// OnCommit takes a function closure that will be executed when the
+	// transaction successfully gets committed.
+	OnCommit(func())
 }
 
 // ReadBucket represents a bucket (a hierarchical structure within the database)
@@ -119,6 +123,9 @@ type ReadWriteBucket interface {
 	// Cursor returns a new cursor, allowing for iteration over the bucket's
 	// key/value pairs and nested buckets in forward or backward order.
 	ReadWriteCursor() ReadWriteCursor
+
+	// Tx returns the bucket's transaction.
+	Tx() ReadWriteTx
 }
 
 // ReadCursor represents a bucket cursor that can be positioned at the start or


### PR DESCRIPTION
Useful for creating transactions for fee estimation, e.g.