### PR TITLE
multi: update neutrino gcs filter format

### DIFF
--- a/chain/bitcoind.go
+++ b/chain/bitcoind.go
@@ -313,7 +313,7 @@ func (c *BitcoindClient) RescanBlocks(blockHashes []chainhash.Hash) (
 // Rescan rescans from the block with the given hash until the current block,
 // after adding the passed addresses and outpoints to the client's watch list.
 func (c *BitcoindClient) Rescan(blockHash *chainhash.Hash,
-	addrs []btcutil.Address, outPoints []*wire.OutPoint) error {
+	addrs []btcutil.Address, outPoints map[wire.OutPoint]btcutil.Address) error {
 
 	if blockHash == nil {
 		return errors.New("rescan requires a starting block hash")
@@ -592,10 +592,10 @@ mainLoop:
 						c.watchOutPoints[*op] = struct{}{}
 					}
 					c.clientMtx.Unlock()
-				case []wire.OutPoint:
+				case map[wire.OutPoint]btcutil.Address:
 					// We're updating monitored outpoints.
 					c.clientMtx.Lock()
-					for _, op := range e {
+					for op := range e {
 						c.watchOutPoints[op] = struct{}{}
 					}
 					c.clientMtx.Unlock()

--- a/chain/block_filterer.go
+++ b/chain/block_filterer.go
@@ -42,7 +42,7 @@ type BlockFilterer struct {
 	// WathcedOutPoints is a global set of outpoints being tracked by the
 	// wallet. This allows the block filterer to check for spends from an
 	// outpoint we own.
-	WatchedOutPoints map[wire.OutPoint]struct{}
+	WatchedOutPoints map[wire.OutPoint]btcutil.Address
 
 	// FoundExternal is a two-layer map recording the scope and index of
 	// external addresses found in a single block.
@@ -54,7 +54,7 @@ type BlockFilterer struct {
 
 	// FoundOutPoints is a set of outpoints found in a single block whose
 	// address belongs to the wallet.
-	FoundOutPoints map[wire.OutPoint]struct{}
+	FoundOutPoints map[wire.OutPoint]btcutil.Address
 
 	// RelevantTxns records the transactions found in a particular block
 	// that contained matches from an address in either ExReverseFilter or
@@ -87,7 +87,7 @@ func NewBlockFilterer(params *chaincfg.Params,
 
 	foundExternal := make(map[waddrmgr.KeyScope]map[uint32]struct{})
 	foundInternal := make(map[waddrmgr.KeyScope]map[uint32]struct{})
-	foundOutPoints := make(map[wire.OutPoint]struct{})
+	foundOutPoints := make(map[wire.OutPoint]btcutil.Address)
 
 	return &BlockFilterer{
 		Params:           params,
@@ -168,7 +168,7 @@ func (bf *BlockFilterer) FilterTx(tx *wire.MsgTx) bool {
 			Index: uint32(i),
 		}
 
-		bf.FoundOutPoints[outPoint] = struct{}{}
+		bf.FoundOutPoints[outPoint] = addrs[0]
 	}
 
 	return isRelevant

--- a/chain/block_filterer_test.go
+++ b/chain/block_filterer_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcwallet/chain"
 )
 
@@ -272,9 +273,9 @@ func TestBlockFiltererOneInOneOut(t *testing.T) {
 
 	// Add each of their single previous outpoints to the set of watched
 	// outpoints to filter for.
-	watchedOutPoints := make(map[wire.OutPoint]struct{})
-	watchedOutPoints[firstTx.TxIn[0].PreviousOutPoint] = struct{}{}
-	watchedOutPoints[lastTx.TxIn[0].PreviousOutPoint] = struct{}{}
+	watchedOutPoints := make(map[wire.OutPoint]btcutil.Address)
+	watchedOutPoints[firstTx.TxIn[0].PreviousOutPoint] = &btcutil.AddressWitnessPubKeyHash{}
+	watchedOutPoints[lastTx.TxIn[0].PreviousOutPoint] = &btcutil.AddressWitnessPubKeyHash{}
 
 	// Construct a filter request, watching only for the outpoints above,
 	// and construct a block filterer.

--- a/chain/interface.go
+++ b/chain/interface.go
@@ -34,7 +34,7 @@ type Interface interface {
 	FilterBlocks(*FilterBlocksRequest) (*FilterBlocksResponse, error)
 	BlockStamp() (*waddrmgr.BlockStamp, error)
 	SendRawTransaction(*wire.MsgTx, bool) (*chainhash.Hash, error)
-	Rescan(*chainhash.Hash, []btcutil.Address, []*wire.OutPoint) error
+	Rescan(*chainhash.Hash, []btcutil.Address, map[wire.OutPoint]btcutil.Address) error
 	NotifyReceived([]btcutil.Address) error
 	NotifyBlocks() error
 	Notifications() <-chan interface{}

--- a/chain/interface.go
+++ b/chain/interface.go
@@ -70,7 +70,7 @@ type (
 		Blocks           []wtxmgr.BlockMeta
 		ExternalAddrs    map[waddrmgr.ScopedIndex]btcutil.Address
 		InternalAddrs    map[waddrmgr.ScopedIndex]btcutil.Address
-		WatchedOutPoints map[wire.OutPoint]struct{}
+		WatchedOutPoints map[wire.OutPoint]btcutil.Address
 	}
 
 	// FilterBlocksResponse reports the set of all internal and external
@@ -85,7 +85,7 @@ type (
 		BlockMeta          wtxmgr.BlockMeta
 		FoundExternalAddrs map[waddrmgr.KeyScope]map[uint32]struct{}
 		FoundInternalAddrs map[waddrmgr.KeyScope]map[uint32]struct{}
-		FoundOutPoints     map[wire.OutPoint]struct{}
+		FoundOutPoints     map[wire.OutPoint]btcutil.Address
 		RelevantTxns       []*wire.MsgTx
 	}
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
-hash: bf4995932938ecadf07df881693930a34d975fce4e87c1181a03378af7613f63
-updated: 2018-07-13T16:43:56.234399716-07:00
+hash: a3732c6a9a04a851beea6fb11c77d593c8297e37efcbab29190cb57edb5cae2b
+updated: 2018-07-16T19:02:33.363613705-07:00
 imports:
 - name: github.com/aead/siphash
   version: e404fcfc888570cadd1610538e2dbc89f66af814
 - name: github.com/btcsuite/btcd
-  version: 991d32e72fe84d5fbf9c47cd604d793a0cd3a072
+  version: fdfc19097e7ac6b57035062056f5b7b4638b8898
   subpackages:
   - addrmgr
   - blockchain
@@ -21,7 +21,7 @@ imports:
 - name: github.com/btcsuite/btclog
   version: 84c8d2346e9fc8c7b947e243b9c24e6df9fd206a
 - name: github.com/btcsuite/btcutil
-  version: d4cc87b860166d00d6b5b9e0d3b3d71d6088d4d4
+  version: ab6388e0c60ae4834a1f57511e20c17b5f78be4b
   subpackages:
   - base58
   - bech32
@@ -51,7 +51,7 @@ imports:
   subpackages:
   - spew
 - name: github.com/golang/protobuf
-  version: 70b3af33377e7aa25ae42977bed93cc6b90f0373
+  version: 14aad3d5ea4c323bcd7a2137e735da24a76e814c
   subpackages:
   - proto
   - ptypes
@@ -69,7 +69,7 @@ imports:
 - name: github.com/lightninglabs/gozmq
   version: 462a8a75388506b68f76661af8d649f0b88e5301
 - name: github.com/lightninglabs/neutrino
-  version: 03f4c660ea0d1586331f32561185d45eab1ba4c9
+  version: 8401b99f3f0698bc6aa26c3d702dd583e51f70c2
   subpackages:
   - filterdb
   - headerfs
@@ -89,7 +89,7 @@ imports:
   - internal/timeseries
   - trace
 - name: golang.org/x/sys
-  version: 1b2967e3c290b7c545b3db0deeda16e9be4f98a2
+  version: ac767d655b305d4e9612f5f6e33120b9176c4ad4
   subpackages:
   - unix
   - windows
@@ -101,7 +101,7 @@ imports:
   - unicode/bidi
   - unicode/norm
 - name: google.golang.org/genproto
-  version: e92b116572682a5b432ddd840aeaba2a559eeff1
+  version: 2731d4fa720b67f9fe38e9051a2a9b38e4609260
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: github.com/coreos/bbolt
   version: 4f5275f4ebbf6fe7cb772de987fa96ee674460a7
 - package: github.com/btcsuite/btcd
-  version: 991d32e72fe84d5fbf9c47cd604d793a0cd3a072
+  version: fdfc19097e7ac6b57035062056f5b7b4638b8898
   subpackages:
   - blockchain
   - btcec
@@ -14,11 +14,11 @@ import:
   - wire
 - package: github.com/btcsuite/btclog
 - package: github.com/btcsuite/btcutil
-  version: d4cc87b860166d00d6b5b9e0d3b3d71d6088d4d4
+  version: ab6388e0c60ae4834a1f57511e20c17b5f78be4b
   subpackages:
   - hdkeychain
 - package: github.com/lightninglabs/neutrino
-  version: 03f4c660ea0d1586331f32561185d45eab1ba4c9
+  version: 8401b99f3f0698bc6aa26c3d702dd583e51f70c2
 - package: github.com/btcsuite/golangcrypto
   subpackages:
   - nacl/secretbox

--- a/wallet/rescan.go
+++ b/wallet/rescan.go
@@ -255,9 +255,6 @@ func (w *Wallet) Rescan(addrs []btcutil.Address, unspent []wtxmgr.Credit) error 
 		}
 
 		outpoints[output.OutPoint] = outputAddrs[0]
-		if err != nil {
-			return err
-		}
 	}
 
 	job := &RescanJob{

--- a/wallet/rescan.go
+++ b/wallet/rescan.go
@@ -5,6 +5,7 @@
 package wallet
 
 import (
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcwallet/chain"
@@ -34,7 +35,7 @@ type RescanFinishedMsg struct {
 type RescanJob struct {
 	InitialSync bool
 	Addrs       []btcutil.Address
-	OutPoints   []*wire.OutPoint
+	OutPoints   map[wire.OutPoint]btcutil.Address
 	BlockStamp  waddrmgr.BlockStamp
 	err         chan error
 }
@@ -44,7 +45,7 @@ type RescanJob struct {
 type rescanBatch struct {
 	initialSync bool
 	addrs       []btcutil.Address
-	outpoints   []*wire.OutPoint
+	outpoints   map[wire.OutPoint]btcutil.Address
 	bs          waddrmgr.BlockStamp
 	errChans    []chan error
 }
@@ -78,7 +79,11 @@ func (b *rescanBatch) merge(job *RescanJob) {
 		b.initialSync = true
 	}
 	b.addrs = append(b.addrs, job.Addrs...)
-	b.outpoints = append(b.outpoints, job.OutPoints...)
+
+	for op, addr := range job.OutPoints {
+		b.outpoints[op] = addr
+	}
+
 	if job.BlockStamp.Height < b.bs.Height {
 		b.bs = job.BlockStamp
 	}
@@ -240,9 +245,19 @@ out:
 // current best block in the main chain, and is considered an initial sync
 // rescan.
 func (w *Wallet) Rescan(addrs []btcutil.Address, unspent []wtxmgr.Credit) error {
-	outpoints := make([]*wire.OutPoint, len(unspent))
-	for i, output := range unspent {
-		outpoints[i] = &output.OutPoint
+	outpoints := make(map[wire.OutPoint]btcutil.Address, len(unspent))
+	for _, output := range unspent {
+		_, outputAddrs, _, err := txscript.ExtractPkScriptAddrs(
+			output.PkScript, w.chainParams,
+		)
+		if err != nil {
+			return err
+		}
+
+		outpoints[output.OutPoint] = outputAddrs[0]
+		if err != nil {
+			return err
+		}
 	}
 
 	job := &RescanJob{

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -403,6 +403,7 @@ func (w *Wallet) syncWithChain() error {
 			// size of 2000.
 			recoveryMgr = NewRecoveryManager(
 				w.recoveryWindow, recoveryBatchSize,
+				w.chainParams,
 			)
 
 			// In the event that this recovery is being resumed, we
@@ -743,8 +744,8 @@ expandHorizons:
 
 	// Update the global set of watched outpoints with any that were found
 	// in the block.
-	for outPoint := range filterResp.FoundOutPoints {
-		recoveryState.AddWatchedOutPoint(&outPoint)
+	for outPoint, addr := range filterResp.FoundOutPoints {
+		recoveryState.AddWatchedOutPoint(&outPoint, addr)
 	}
 
 	// Finally, record all of the relevant transactions that were returned


### PR DESCRIPTION
In this PR, we update the backends, and also chain recovery logic to be aware of the new neutrino API as a result of the modifications to BIP 158. The major change is that we must now carry along the previous output script along with the outpoint everywhere as we'll now match on the prev output script, but then actually dispatch notifications based on the outpoint.

Replaces #518