### PR TITLE
chain/rpc: remove unnecessary ping keep alive

### DIFF
--- a/chain/rpc.go
+++ b/chain/rpc.go
@@ -386,8 +386,6 @@ func (c *RPCClient) handler() {
 	enqueue := c.enqueueNotification
 	var dequeue chan interface{}
 	var next interface{}
-	pingChan := time.After(time.Minute)
-	pingChanReset := make(chan (<-chan time.Time))
 out:
 	for {
 		select {
@@ -407,7 +405,6 @@ out:
 				dequeue = c.dequeueNotification
 			}
 			notifications = append(notifications, n)
-			pingChan = time.After(time.Minute)
 
 		case dequeue <- next:
 			if n, ok := next.(BlockConnected); ok {
@@ -429,47 +426,6 @@ out:
 				}
 				dequeue = nil
 			}
-
-		case <-pingChan:
-			// No notifications were received in the last 60s. Ensure the
-			// connection is still active by making a new request to the server.
-			//
-			// This MUST wait for the response in a new goroutine so as to not
-			// block channel sends enqueueing more notifications.  Doing so
-			// would cause a deadlock and after the timeout expires, the client
-			// would be shut down.
-			//
-			// TODO: A minute timeout is used to prevent the handler loop from
-			// blocking here forever, but this is much larger than it needs to
-			// be due to dcrd processing websocket requests synchronously (see
-			// https://github.com/btcsuite/btcd/issues/504).  Decrease this to
-			// something saner like 3s when the above issue is fixed.
-			type sessionResult struct {
-				err error
-			}
-			sessionResponse := make(chan sessionResult, 1)
-			go func() {
-				_, err := c.Session()
-				sessionResponse <- sessionResult{err}
-			}()
-			go func() {
-				select {
-				case resp := <-sessionResponse:
-					if resp.err != nil {
-						log.Errorf("Failed to receive session "+
-							"result: %v", resp.err)
-						c.Stop()
-					}
-					pingChanReset <- time.After(time.Minute)
-
-				case <-time.After(time.Minute):
-					log.Errorf("Timeout waiting for session RPC")
-					c.Stop()
-				}
-			}()
-
-		case ch := <-pingChanReset:
-			pingChan = ch
 
 		case c.currentBlock <- bs:
 


### PR DESCRIPTION
In this commit, we remove the keep-alive logic within the handler of the
RPCClient struct as this logic already exists within the backing
rpclient.Client instance. In this case, we'd completely stop the
connection after the ping timeout (1 min), which would render the
reconnection logic within rpcclient.Client useless.

Fixes https://github.com/lightningnetwork/lnd/issues/1775.