### PR TITLE
wallet/wallet: notify addrs+props after db commit

### DIFF
--- a/waddrmgr/internal_test.go
+++ b/waddrmgr/internal_test.go
@@ -21,20 +21,6 @@ import (
 // for change when the tests are run.
 var TstLatestMgrVersion = &latestMgrVersion
 
-// Replace the Manager.newSecretKey function with the given one and calls
-// the callback function. Afterwards the original newSecretKey
-// function will be restored.
-func TstRunWithReplacedNewSecretKey(callback func()) {
-	orig := newSecretKey
-	defer func() {
-		newSecretKey = orig
-	}()
-	newSecretKey = func(passphrase *[]byte, config *ScryptOptions) (*snacl.SecretKey, error) {
-		return nil, snacl.ErrDecryptFailed
-	}
-	callback()
-}
-
 // TstCheckPublicPassphrase returns true if the provided public passphrase is
 // correct for the manager.
 func (m *Manager) TstCheckPublicPassphrase(pubPassphrase []byte) bool {

--- a/waddrmgr/manager.go
+++ b/waddrmgr/manager.go
@@ -174,15 +174,46 @@ type unlockDeriveInfo struct {
 	index       uint32
 }
 
+// SecretKeyGenerator is the function signature of a method that can generate
+// secret keys for the address manager.
+type SecretKeyGenerator func(
+	passphrase *[]byte, config *ScryptOptions) (*snacl.SecretKey, error)
+
 // defaultNewSecretKey returns a new secret key.  See newSecretKey.
-func defaultNewSecretKey(passphrase *[]byte, config *ScryptOptions) (*snacl.SecretKey, error) {
+func defaultNewSecretKey(passphrase *[]byte,
+	config *ScryptOptions) (*snacl.SecretKey, error) {
 	return snacl.NewSecretKey(passphrase, config.N, config.R, config.P)
 }
 
-// newSecretKey is used as a way to replace the new secret key generation
-// function used so tests can provide a version that fails for testing error
-// paths.
-var newSecretKey = defaultNewSecretKey
+var (
+	// secretKeyGen is the inner method that is executed when calling
+	// newSecretKey.
+	secretKeyGen = defaultNewSecretKey
+
+	// secretKeyGenMtx protects access to secretKeyGen, so that it can be
+	// replaced in testing.
+	secretKeyGenMtx sync.RWMutex
+)
+
+// SetSecretKeyGen replaces the existing secret key generator, and returns the
+// previous generator.
+func SetSecretKeyGen(keyGen SecretKeyGenerator) SecretKeyGenerator {
+	secretKeyGenMtx.Lock()
+	oldKeyGen := secretKeyGen
+	secretKeyGen = keyGen
+	secretKeyGenMtx.Unlock()
+
+	return oldKeyGen
+}
+
+// newSecretKey generates a new secret key using the active secretKeyGen.
+func newSecretKey(passphrase *[]byte,
+	config *ScryptOptions) (*snacl.SecretKey, error) {
+
+	secretKeyGenMtx.RLock()
+	defer secretKeyGenMtx.RUnlock()
+	return secretKeyGen(passphrase, config)
+}
 
 // EncryptorDecryptor provides an abstraction on top of snacl.CryptoKey so that
 // our tests can use dependency injection to force the behaviour they need.

--- a/waddrmgr/manager_test.go
+++ b/waddrmgr/manager_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcutil"
+	"github.com/btcsuite/btcwallet/snacl"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/davecgh/go-spew/spew"
@@ -31,6 +32,13 @@ func newHash(hexStr string) *chainhash.Hash {
 		panic(err)
 	}
 	return hash
+}
+
+// failingSecretKeyGen is a waddrmgr.SecretKeyGenerator that always returns
+// snacl.ErrDecryptFailed.
+func failingSecretKeyGen(passphrase *[]byte,
+	config *waddrmgr.ScryptOptions) (*snacl.SecretKey, error) {
+	return nil, snacl.ErrDecryptFailed
 }
 
 // testContext is used to store context information about a running test which
@@ -1099,14 +1107,12 @@ func testChangePassphrase(tc *testContext) bool {
 	// that intentionally errors.
 	testName := "ChangePassphrase (public) with invalid new secret key"
 
-	var err error
-	waddrmgr.TstRunWithReplacedNewSecretKey(func() {
-		err = walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
-			ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-			return tc.rootManager.ChangePassphrase(
-				ns, pubPassphrase, pubPassphrase2, false, fastScrypt,
-			)
-		})
+	oldKeyGen := waddrmgr.SetSecretKeyGen(failingSecretKeyGen)
+	err := walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+		return tc.rootManager.ChangePassphrase(
+			ns, pubPassphrase, pubPassphrase2, false, fastScrypt,
+		)
 	})
 	if !checkManagerError(tc.t, testName, err, waddrmgr.ErrCrypto) {
 		return false
@@ -1114,6 +1120,7 @@ func testChangePassphrase(tc *testContext) bool {
 
 	// Attempt to change public passphrase with invalid old passphrase.
 	testName = "ChangePassphrase (public) with invalid old passphrase"
+	waddrmgr.SetSecretKeyGen(oldKeyGen)
 	err = walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
 		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
 		return tc.rootManager.ChangePassphrase(


### PR DESCRIPTION
This PR moves any address notifications outside of the
db transaction that creates them. This is known to have
resulted in deadlocks, since `chainClient.NotifyReceived`
could block the db transaction from committing.

Doing so also prevents the situation where we send
notifications about the new addresses, but the db txn
fails to commit and the addresses are in fact never
created.