### PR TITLE
wallet/chainntfns: avoid notifying txs if not found within the wallet

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -302,14 +302,27 @@ func (w *Wallet) addRelevantTx(dbtx walletdb.ReadWriteTx, rec *wtxmgr.TxRecord, 
 		details, err := w.TxStore.UniqueTxDetails(txmgrNs, &rec.Hash, nil)
 		if err != nil {
 			log.Errorf("Cannot query transaction details for notification: %v", err)
-		} else {
+		}
+
+		// It's possible that the transaction was not found within the
+		// wallet's set of unconfirmed transactions due to it already
+		// being confirmed, so we'll avoid notifying it.
+		//
+		// TODO(wilmer): ideally we should find the culprit to why we're
+		// receiving an additional unconfirmed chain.RelevantTx
+		// notification from the chain backend.
+		if details != nil {
 			w.NtfnServer.notifyUnminedTransaction(dbtx, details)
 		}
 	} else {
 		details, err := w.TxStore.UniqueTxDetails(txmgrNs, &rec.Hash, &block.Block)
 		if err != nil {
 			log.Errorf("Cannot query transaction details for notification: %v", err)
-		} else {
+		}
+
+		// We'll only notify the transaction if it was found within the
+		// wallet's set of confirmed transactions.
+		if details != nil {
 			w.NtfnServer.notifyMinedTransaction(dbtx, details, block)
 		}
 	}


### PR DESCRIPTION
In this commit, we avoid notifying clients of transactions that we've
received chain.RelevantTx notifications for, but are not found within
the wallet. This can happen as now we'll prevent adding an unconfirmed
transaction to the wallet that already exists as confirmed. Due to this,
UniqueTxDetails will be unable to find the transaction and return nil,
casuing a panic for potential callers.