### PR TITLE
chain+wallet: set bitcoind client birthday after wallet init

### DIFF
--- a/chain/bitcoind_client.go
+++ b/chain/bitcoind_client.go
@@ -108,6 +108,10 @@ type BitcoindClient struct {
 	wg   sync.WaitGroup
 }
 
+// A compile-time check to ensure that BitcoindClient satisfies the
+// chain.Interface interface.
+var _ Interface = (*BitcoindClient)(nil)
+
 // BackEnd returns the name of the driver.
 func (c *BitcoindClient) BackEnd() string {
 	return "bitcoind"
@@ -594,6 +598,14 @@ func (c *BitcoindClient) ntfnHandler() {
 			return
 		}
 	}
+}
+
+// SetBirthday sets the birthday of the bitcoind rescan client.
+//
+// NOTE: This should be done before the client has been started in order for it
+// to properly carry its duties.
+func (c *BitcoindClient) SetBirthday(t time.Time) {
+	c.birthday = t
 }
 
 // BlockStamp returns the latest block notified by the client, or an error

--- a/chain/bitcoind_conn.go
+++ b/chain/bitcoind_conn.go
@@ -333,15 +333,13 @@ func (c *BitcoindConn) getCurrentNet() (wire.BitcoinNet, error) {
 
 // NewBitcoindClient returns a bitcoind client using the current bitcoind
 // connection. This allows us to share the same connection using multiple
-// clients. The birthday signifies the earliest time for which we should begin
-// scanning the chain.
-func (c *BitcoindConn) NewBitcoindClient(birthday time.Time) *BitcoindClient {
+// clients.
+func (c *BitcoindConn) NewBitcoindClient() *BitcoindClient {
 	return &BitcoindClient{
 		quit: make(chan struct{}),
 
 		id: atomic.AddUint64(&c.rescanClientCounter, 1),
 
-		birthday:    birthday,
 		chainParams: c.chainParams,
 		chainConn:   c,
 

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -173,6 +173,8 @@ func (w *Wallet) SynchronizeRPC(chainClient chain.Interface) {
 	switch cc := chainClient.(type) {
 	case *chain.NeutrinoClient:
 		cc.SetStartTime(w.Manager.Birthday())
+	case *chain.BitcoindClient:
+		cc.SetBirthday(w.Manager.Birthday())
 	}
 	w.chainClientLock.Unlock()
 


### PR DESCRIPTION
In this PR, we modify the wallet to also set the birthday for its chain client when using a bitcoind backend. We do this to ensure that the client's birthday is set correctly, which will allow it to properly carry its duties.