### PR TITLE
fix package name from bbolt to bolt

### DIFF
--- a/walletdb/bdb/db.go
+++ b/walletdb/bdb/db.go
@@ -9,7 +9,7 @@ import (
 	"os"
 
 	"github.com/btcsuite/btcwallet/walletdb"
-	"github.com/coreos/bbolt"
+	bolt "github.com/coreos/bbolt"
 )
 
 // convertErr converts some bolt errors to the equivalent walletdb error.


### PR DESCRIPTION
Fix the issue #558 
The package has been switched from bolt to bbolt without changing other lines in the file.
https://github.com/btcsuite/btcwallet/commit/321c2fac2b7bc98ff6b1b5ccaea19182bf096371#diff-07f73f57148e0afbefa8bf350a93ef94