### PR TITLE
wtxmgr: add HasSpendingTx method

### DIFF
--- a/wtxmgr/db.go
+++ b/wtxmgr/db.go
@@ -52,13 +52,6 @@ import (
 // keys iterating in order.
 var byteOrder = binary.BigEndian
 
-// Database versions.  Versions start at 1 and increment for each database
-// change.
-const (
-	// LatestVersion is the most recent store version.
-	LatestVersion = 1
-)
-
 // This package makes assumptions that the width of a chainhash.Hash is always
 // 32 bytes.  If this is ever changed (unlikely for bitcoin, possible for alts),
 // offsets have to be rewritten.  Use a compile-time assertion that this
@@ -1269,16 +1262,17 @@ func openStore(ns walletdb.ReadBucket) error {
 		return err
 	}
 
-	if version < LatestVersion {
+	latestVersion := getLatestDBVersion()
+	if version < latestVersion {
 		str := fmt.Sprintf("a database upgrade is required to upgrade "+
 			"wtxmgr from recorded version %d to the latest version %d",
-			version, LatestVersion)
+			version, latestVersion)
 		return storeError(ErrNeedsUpgrade, str, nil)
 	}
 
-	if version > LatestVersion {
+	if version > latestVersion {
 		str := fmt.Sprintf("version recorded version %d is newer that "+
-			"latest understood version %d", version, LatestVersion)
+			"latest understood version %d", version, latestVersion)
 		return storeError(ErrUnknownVersion, str, nil)
 	}
 
@@ -1296,7 +1290,7 @@ func createStore(ns walletdb.ReadWriteBucket) error {
 	}
 
 	// Write the latest store version.
-	if err := putVersion(ns, LatestVersion); err != nil {
+	if err := putVersion(ns, getLatestDBVersion()); err != nil {
 		return err
 	}
 

--- a/wtxmgr/db.go
+++ b/wtxmgr/db.go
@@ -1264,12 +1264,10 @@ func deleteRawUnminedInput(ns walletdb.ReadWriteBucket, k []byte) error {
 
 // openStore opens an existing transaction store from the passed namespace.
 func openStore(ns walletdb.ReadBucket) error {
-	v := ns.Get(rootVersion)
-	if len(v) != 4 {
-		str := "no transaction store exists in namespace"
-		return storeError(ErrNoExists, str, nil)
+	version, err := fetchVersion(ns)
+	if err != nil {
+		return err
 	}
-	version := byteOrder.Uint32(v)
 
 	if version < LatestVersion {
 		str := fmt.Sprintf("a database upgrade is required to upgrade "+
@@ -1279,23 +1277,10 @@ func openStore(ns walletdb.ReadBucket) error {
 	}
 
 	if version > LatestVersion {
-		str := fmt.Sprintf("version recorded version %d is newer that latest "+
-			"understood version %d", version, LatestVersion)
+		str := fmt.Sprintf("version recorded version %d is newer that "+
+			"latest understood version %d", version, LatestVersion)
 		return storeError(ErrUnknownVersion, str, nil)
 	}
-
-	// Upgrade the tx store as needed, one version at a time, until
-	// LatestVersion is reached.  Versions are not skipped when performing
-	// database upgrades, and each upgrade is done in its own transaction.
-	//
-	// No upgrades yet.
-	//if version < LatestVersion {
-	//	err := scopedUpdate(namespace, func(ns walletdb.Bucket) error {
-	//	})
-	//	if err != nil {
-	//		// Handle err
-	//	}
-	//}
 
 	return nil
 }
@@ -1311,12 +1296,8 @@ func createStore(ns walletdb.ReadWriteBucket) error {
 	}
 
 	// Write the latest store version.
-	v := make([]byte, 4)
-	byteOrder.PutUint32(v, LatestVersion)
-	err := ns.Put(rootVersion, v)
-	if err != nil {
-		str := "failed to store latest database version"
-		return storeError(ErrDatabase, str, err)
+	if err := putVersion(ns, LatestVersion); err != nil {
+		return err
 	}
 
 	// Save the creation date of the store.
@@ -1385,6 +1366,30 @@ func createStore(ns walletdb.ReadWriteBucket) error {
 	}
 
 	return nil
+}
+
+// putVersion modifies the version of the store to reflect the given version
+// number.
+func putVersion(ns walletdb.ReadWriteBucket, version uint32) error {
+	v := make([]byte, 4)
+	byteOrder.PutUint32(v, version)
+	if err := ns.Put(rootVersion, v); err != nil {
+		str := "failed to store database version"
+		return storeError(ErrDatabase, str, err)
+	}
+
+	return nil
+}
+
+// fetchVersion fetches the current version of the store.
+func fetchVersion(ns walletdb.ReadBucket) (uint32, error) {
+	v := ns.Get(rootVersion)
+	if len(v) != 4 {
+		str := "no transaction store exists in namespace"
+		return 0, storeError(ErrNoExists, str, nil)
+	}
+
+	return byteOrder.Uint32(v), nil
 }
 
 func scopedUpdate(db walletdb.DB, namespaceKey []byte, f func(walletdb.ReadWriteBucket) error) error {

--- a/wtxmgr/migrations.go
+++ b/wtxmgr/migrations.go
@@ -16,6 +16,10 @@ var dbVersions = []dbVersion{
 		version:   1,
 		migration: nil,
 	},
+	{
+		version:   2,
+		migration: migrationBucketMinedInputs,
+	},
 }
 
 // getLatestDBVersion retrieves the most recent recent of the store.
@@ -35,4 +39,64 @@ func getMigrationsToApply(version uint32) []dbVersion {
 		}
 	}
 	return migrations
+}
+
+// migrationBucketMinedInputs is the migration responsible for creating a new
+// bucket which will store a mapping of a spent output to its spending
+// transaction.
+func migrationBucketMinedInputs(ns walletdb.ReadWriteBucket) error {
+	log.Infof("Populating index of outputs to spending transactions")
+
+	// We'll start by creating the bucket that will represent the index.
+	if _, err := ns.CreateBucket(bucketMinedInputs); err != nil {
+		str := "failed to create mined inputs bucket"
+		return storeError(ErrDatabase, str, err)
+	}
+
+	// We'll define a helper struct to coalesce all outputs and their
+	// confirmed spending transactions. The members will need to be
+	// serialized in the expected format of the new bucket.
+	type bucketEntry struct {
+		outpointSpent []byte
+		spendTx       []byte
+	}
+
+	var bucketEntries []bucketEntry
+
+	// Then, we'll iterate over the debits bucket. This bucket includes all
+	// the inputs that have spent outputs controlled by the wallet. Each
+	// entry then maps to the output it spends, which will allow us to
+	// populate the new bucket.
+	c := ns.NestedReadBucket(bucketDebits).ReadCursor()
+	for k, v := c.First(); k != nil; k, v = c.Next() {
+		// Each value of the debits bucket includes the block at which
+		// the spent output confirmed at. We're not interested in all of
+		// the information, so we'll omit it and only grab what we need
+		// (transaction hash and output index).
+		outpointSpent := make([]byte, 32+4)
+		copy(outpointSpent[:32], v[8:40])
+		copy(outpointSpent[32:], v[76:80])
+
+		bucketEntries = append(bucketEntries, bucketEntry{
+			outpointSpent: outpointSpent,
+			spendTx:       k,
+		})
+	}
+
+	// Now that we've gathered all of our results, we'll insert them into
+	// our new bucket. Once they've all been inserted, we can consider the
+	// migration complete.
+	for _, bucketEntry := range bucketEntries {
+		err := putRawMinedInput(
+			ns, bucketEntry.outpointSpent, bucketEntry.spendTx,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	log.Info("Migration to populate index of outputs to spending " +
+		"transaction complete!")
+
+	return nil
 }

--- a/wtxmgr/migrations.go
+++ b/wtxmgr/migrations.go
@@ -1,0 +1,38 @@
+package wtxmgr
+
+import "github.com/btcsuite/btcwallet/walletdb"
+
+// dbVersion encapsulates a version along with a migration closure that, once
+// complete, will reflect the current version of the store.
+type dbVersion struct {
+	version   uint32
+	migration func(walletdb.ReadWriteBucket) error
+}
+
+// dbVersions represents the different versions of the store, along with the
+// migrations allowing them to proceed to said versions.
+var dbVersions = []dbVersion{
+	{
+		version:   1,
+		migration: nil,
+	},
+}
+
+// getLatestDBVersion retrieves the most recent recent of the store.
+func getLatestDBVersion() uint32 {
+	return dbVersions[len(dbVersions)-1].version
+}
+
+// getMigrationsToApply determines the migrations that need to be applied in
+// order for the given version to catch up to the latest version.
+func getMigrationsToApply(version uint32) []dbVersion {
+	// Assuming the migration versions are in increasing order, we'll apply
+	// any migrations that have a version
+	var migrations []dbVersion
+	for _, dbVersion := range dbVersions {
+		if dbVersion.version > version {
+			migrations = append(migrations, dbVersion)
+		}
+	}
+	return migrations
+}

--- a/wtxmgr/tx.go
+++ b/wtxmgr/tx.go
@@ -631,6 +631,10 @@ func (s *Store) rollback(ns walletdb.ReadWriteBucket, height int32) error {
 				if err != nil {
 					return err
 				}
+				err = deleteRawMinedInput(ns, prevOutKey)
+				if err != nil {
+					return err
+				}
 
 				// If the credit was previously removed in the
 				// rollback, the credit amount is zero.  Only


### PR DESCRIPTION
In this PR, we add a new method to the transaction store: `HasSpendingTx`. This will allow the store to quickly determine whether it knows of a transaction that spends an output. This is done through the `bucketMinedInputs` bucket that was also added as a part of this PR. Due to existing wallets not previously having this bucket created, migration support has been added to the store, along with a migration to actually populate this new bucket.