### PR TITLE
Close wallet db on shutdown

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -24,17 +24,6 @@ func (w *Wallet) handleChainNotifications() {
 		return
 	}
 
-	sync := func(w *Wallet) {
-		// At the moment there is no recourse if the rescan fails for
-		// some reason, however, the wallet will not be marked synced
-		// and many methods will error early since the wallet is known
-		// to be out of date.
-		err := w.syncWithChain()
-		if err != nil && !w.ShuttingDown() {
-			log.Warnf("Unable to synchronize wallet to chain: %v", err)
-		}
-	}
-
 	catchUpHashes := func(w *Wallet, client chain.Interface,
 		height int32) error {
 		// TODO(aakselrod): There's a race conditon here, which
@@ -96,7 +85,7 @@ func (w *Wallet) handleChainNotifications() {
 			var err error
 			switch n := n.(type) {
 			case chain.ClientConnected:
-				go sync(w)
+				w.onClientConnected()
 			case chain.BlockConnected:
 				err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
 					return w.connectBlock(tx, wtxmgr.BlockMeta(n))

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -261,6 +261,10 @@ func (w *Wallet) WaitForShutdown() {
 	}
 	w.chainClientLock.Unlock()
 	w.wg.Wait()
+
+	//We can close the db now that we know all go routines have exited and
+	//we are sure no further attempts to write to the wallet db will be done.
+	w.db.Close()
 }
 
 // SynchronizingToNetwork returns whether the wallet is currently synchronizing
@@ -315,6 +319,21 @@ func (w *Wallet) activeData(dbtx walletdb.ReadTx) ([]btcutil.Address, []wtxmgr.C
 	}
 	unspent, err := w.TxStore.UnspentOutputs(txmgrNs)
 	return addrs, unspent, err
+}
+
+func (w *Wallet) onClientConnected() {
+	w.wg.Add(1)
+	go func() {
+		// At the moment there is no recourse if the rescan fails for
+		// some reason, however, the wallet will not be marked synced
+		// and many methods will error early since the wallet is known
+		// to be out of date.
+		defer w.wg.Done()
+		err := w.syncWithChain()
+		if err != nil && !w.ShuttingDown() {
+			log.Warnf("Unable to synchronize wallet to chain: %v", err)
+		}
+	}()
 }
 
 // syncWithChain brings the wallet up to date with the current chain server


### PR DESCRIPTION
This PR ensure that after the wallet is shut down the database will be closed as well.
To do so the "syncWithChain" go routine was added to the wait group to make sure it competes before we attempt to close the wallet db.
In addition I added explicit db.Close call after all go routines have exited.
This is crucial to be able to use dependent systems such LND as library (such as in mobile) and run it multiple times on the same process.