### PR TITLE
wallet: return full tx from SendOutputs

### DIFF
--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -1378,7 +1378,7 @@ func sendPairs(w *wallet.Wallet, amounts map[string]btcutil.Amount,
 	if err != nil {
 		return "", err
 	}
-	txHash, err := w.SendOutputs(outputs, account, minconf, feeSatPerKb)
+	tx, err := w.SendOutputs(outputs, account, minconf, feeSatPerKb)
 	if err != nil {
 		if err == txrules.ErrAmountNegative {
 			return "", ErrNeedPositiveAmount
@@ -1397,7 +1397,7 @@ func sendPairs(w *wallet.Wallet, amounts map[string]btcutil.Amount,
 		}
 	}
 
-	txHashStr := txHash.String()
+	txHashStr := tx.TxHash().String()
 	log.Infof("Successfully sent transaction %v", txHashStr)
 	return txHashStr, nil
 }

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -3079,9 +3079,9 @@ func (w *Wallet) TotalReceivedForAddr(addr btcutil.Address, minConf int32) (btcu
 }
 
 // SendOutputs creates and sends payment transactions. It returns the
-// transaction hash upon success.
+// transaction upon success.
 func (w *Wallet) SendOutputs(outputs []*wire.TxOut, account uint32,
-	minconf int32, satPerKb btcutil.Amount) (*chainhash.Hash, error) {
+	minconf int32, satPerKb btcutil.Amount) (*wire.MsgTx, error) {
 
 	// Ensure the outputs to be created adhere to the network's consensus
 	// rules.
@@ -3100,7 +3100,17 @@ func (w *Wallet) SendOutputs(outputs []*wire.TxOut, account uint32,
 		return nil, err
 	}
 
-	return w.publishTransaction(createdTx.Tx)
+	txHash, err := w.publishTransaction(createdTx.Tx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Sanity check on the returned tx hash.
+	if *txHash != createdTx.Tx.TxHash() {
+		return nil, errors.New("tx hash mismatch")
+	}
+
+	return createdTx.Tx, nil
 }
 
 // SignatureError records the underlying error when validating a transaction


### PR DESCRIPTION
Sometimes it is needed to spend a specific output from the SendOutputs tx. It could be that the tx is still unconfirmed at that point. To do this, the full tx needs to be looked up by using the returned tx hash and the tx outs need to be searched to find the output indices.

This PR adds an output index mapping return value to SendOutputs.