### PR TITLE
wallet+waddrmgr: add migration & sanity check to populate birthday block

### DIFF
--- a/waddrmgr/db.go
+++ b/waddrmgr/db.go
@@ -8,6 +8,7 @@ package waddrmgr
 import (
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"time"
 
@@ -1876,6 +1877,10 @@ func fetchBlockHash(ns walletdb.ReadBucket, height int32) (*chainhash.Hash, erro
 	heightBytes := make([]byte, 4)
 	binary.BigEndian.PutUint32(heightBytes, uint32(height))
 	hashBytes := bucket.Get(heightBytes)
+	if hashBytes == nil {
+		err := errors.New("block not found")
+		return nil, managerError(ErrBlockNotFound, errStr, err)
+	}
 	if len(hashBytes) != 32 {
 		err := fmt.Errorf("couldn't get hash from database")
 		return nil, managerError(ErrDatabase, errStr, err)

--- a/waddrmgr/error.go
+++ b/waddrmgr/error.go
@@ -131,6 +131,10 @@ const (
 	// ErrScopeNotFound is returned when a target scope cannot be found
 	// within the database.
 	ErrScopeNotFound
+
+	// ErrBirthdayBlockNotSet is returned when we attempt to retrieve the
+	// wallet's birthday but it has not been set yet.
+	ErrBirthdayBlockNotSet
 )
 
 // Map of ErrorCode values back to their constant names for pretty printing.

--- a/waddrmgr/error.go
+++ b/waddrmgr/error.go
@@ -135,6 +135,10 @@ const (
 	// ErrBirthdayBlockNotSet is returned when we attempt to retrieve the
 	// wallet's birthday but it has not been set yet.
 	ErrBirthdayBlockNotSet
+
+	// ErrBlockNotFound is returned when we attempt to retrieve the hash for
+	// a block that we do not know of.
+	ErrBlockNotFound
 )
 
 // Map of ErrorCode values back to their constant names for pretty printing.

--- a/waddrmgr/log.go
+++ b/waddrmgr/log.go
@@ -1,14 +1,6 @@
-// Copyright (c) 2015 The btcsuite developers
-// Use of this source code is governed by an ISC
-// license that can be found in the LICENSE file.
+package waddrmgr
 
-package wallet
-
-import (
-	"github.com/btcsuite/btclog"
-	"github.com/btcsuite/btcwallet/waddrmgr"
-	"github.com/btcsuite/btcwallet/walletdb/migration"
-)
+import "github.com/btcsuite/btclog"
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
@@ -31,9 +23,6 @@ func DisableLog() {
 // using btclog.
 func UseLogger(logger btclog.Logger) {
 	log = logger
-
-	migration.UseLogger(logger)
-	waddrmgr.UseLogger(logger)
 }
 
 // LogClosure is a closure that can be printed with %v to be used to
@@ -51,13 +40,4 @@ func (c logClosure) String() string {
 // the logging level is such that the message will actually be logged.
 func newLogClosure(c func() string) logClosure {
 	return logClosure(c)
-}
-
-// pickNoun returns the singular or plural form of a noun depending
-// on the count n.
-func pickNoun(n int, singular, plural string) string {
-	if n == 1 {
-		return singular
-	}
-	return plural
 }

--- a/waddrmgr/migrations_test.go
+++ b/waddrmgr/migrations_test.go
@@ -1,0 +1,217 @@
+package waddrmgr
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcwallet/walletdb"
+)
+
+// applyMigration is a helper function that allows us to assert the state of the
+// top-level bucket before and after a migration. This can be used to ensure
+// the correctness of migrations.
+func applyMigration(t *testing.T, beforeMigration, afterMigration,
+	migration func(walletdb.ReadWriteBucket) error, shouldFail bool) {
+
+	t.Helper()
+
+	// We'll start by setting up our address manager backed by a database.
+	teardown, db, _ := setupManager(t)
+	defer teardown()
+
+	// First, we'll run the beforeMigration closure, which contains the
+	// database modifications/assertions needed before proceeding with the
+	// migration.
+	err := walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+		if ns == nil {
+			return errors.New("top-level namespace does not exist")
+		}
+		return beforeMigration(ns)
+	})
+	if err != nil {
+		t.Fatalf("unable to run beforeMigration func: %v", err)
+	}
+
+	// Then, we'll run the migration itself and fail if it does not match
+	// its expected result.
+	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+		if ns == nil {
+			return errors.New("top-level namespace does not exist")
+		}
+		return migration(ns)
+	})
+	if err != nil && !shouldFail {
+		t.Fatalf("unable to perform migration: %v", err)
+	} else if err == nil && shouldFail {
+		t.Fatal("expected migration to fail, but did not")
+	}
+
+	// Finally, we'll run the afterMigration closure, which contains the
+	// assertions needed in order to guarantee than the migration was
+	// successful.
+	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+		if ns == nil {
+			return errors.New("top-level namespace does not exist")
+		}
+		return afterMigration(ns)
+	})
+	if err != nil {
+		t.Fatalf("unable to run afterMigration func: %v", err)
+	}
+}
+
+// TestMigrationPupulateBirthdayBlock ensures that the migration to populate the
+// wallet's birthday block works as intended.
+func TestMigrationPopulateBirthdayBlock(t *testing.T) {
+	t.Parallel()
+
+	var expectedHeight int32
+	beforeMigration := func(ns walletdb.ReadWriteBucket) error {
+		// To test this migration, we'll start by writing to disk 10
+		// random blocks.
+		block := &BlockStamp{}
+		for i := int32(1); i <= 10; i++ {
+			block.Height = i
+			blockHash := bytes.Repeat([]byte(string(i)), 32)
+			copy(block.Hash[:], blockHash)
+			if err := putSyncedTo(ns, block); err != nil {
+				return err
+			}
+		}
+
+		// With the blocks inserted, we'll assume that the birthday
+		// block corresponds to the 7th block (out of 11) in the chain.
+		// To do this, we'll need to set our birthday timestamp to the
+		// estimated timestamp of a block that's 6 blocks after genesis.
+		genesisTimestamp := chaincfg.MainNetParams.GenesisBlock.Header.Timestamp
+		delta := time.Hour
+		expectedHeight = int32(delta.Seconds() / 600)
+		birthday := genesisTimestamp.Add(delta)
+		if err := putBirthday(ns, birthday); err != nil {
+			return err
+		}
+
+		// Finally, since the migration has not yet started, we should
+		// not be able to find the birthday block within the database.
+		_, err := fetchBirthdayBlock(ns)
+		if !IsError(err, ErrBirthdayBlockNotSet) {
+			return fmt.Errorf("expected ErrBirthdayBlockNotSet, "+
+				"got %v", err)
+		}
+
+		return nil
+	}
+
+	// After the migration has completed, we should see that the birthday
+	// block now exists and is set to the correct expected height.
+	afterMigration := func(ns walletdb.ReadWriteBucket) error {
+		birthdayBlock, err := fetchBirthdayBlock(ns)
+		if err != nil {
+			return err
+		}
+
+		if birthdayBlock.Height != expectedHeight {
+			return fmt.Errorf("expected birthday block with "+
+				"height %d, got %d", expectedHeight,
+				birthdayBlock.Height)
+		}
+
+		return nil
+	}
+
+	// We can now apply the migration and expect it not to fail.
+	applyMigration(
+		t, beforeMigration, afterMigration, populateBirthdayBlock,
+		false,
+	)
+}
+
+// TestMigrationPopulateBirthdayBlockEstimateTooFar ensures that the migration
+// can properly detect a height estimate which the chain from our point of view
+// has not yet reached.
+func TestMigrationPopulateBirthdayBlockEstimateTooFar(t *testing.T) {
+	t.Parallel()
+
+	const numBlocks = 1000
+	chainParams := chaincfg.MainNetParams
+
+	var expectedHeight int32
+	beforeMigration := func(ns walletdb.ReadWriteBucket) error {
+		// To test this migration, we'll start by writing to disk 999
+		// random blocks to simulate a synced chain with height 1000.
+		block := &BlockStamp{}
+		for i := int32(1); i < numBlocks; i++ {
+			block.Height = i
+			blockHash := bytes.Repeat([]byte(string(i)), 32)
+			copy(block.Hash[:], blockHash)
+			if err := putSyncedTo(ns, block); err != nil {
+				return err
+			}
+		}
+
+		// With the blocks inserted, we'll assume that the birthday
+		// block corresponds to the 900th block in the chain. To do
+		// this, we'd need to set our birthday timestamp to the
+		// estimated timestamp of a block that's 899 blocks after
+		// genesis. However, this will not work if the average block
+		// time is not 10 mins, which can throw off the height estimate
+		// with a height longer than the chain in the event of test
+		// networks (testnet, regtest, etc. and not fully synced
+		// wallets). Instead the migration should be able to handle this
+		// by subtracting a days worth of blocks until finding a block
+		// that it is aware of.
+		//
+		// We'll have the migration assume that our birthday is at block
+		// 1001 in the chain. Since this block doesn't exist from the
+		// database's point of view, a days worth of blocks will be
+		// subtracted from the estimate, which should give us a valid
+		// block height.
+		genesisTimestamp := chainParams.GenesisBlock.Header.Timestamp
+		delta := numBlocks * 10 * time.Minute
+		expectedHeight = numBlocks - 144
+
+		birthday := genesisTimestamp.Add(delta)
+		if err := putBirthday(ns, birthday); err != nil {
+			return err
+		}
+
+		// Finally, since the migration has not yet started, we should
+		// not be able to find the birthday block within the database.
+		_, err := fetchBirthdayBlock(ns)
+		if !IsError(err, ErrBirthdayBlockNotSet) {
+			return fmt.Errorf("expected ErrBirthdayBlockNotSet, "+
+				"got %v", err)
+		}
+
+		return nil
+	}
+
+	// After the migration has completed, we should see that the birthday
+	// block now exists and is set to the correct expected height.
+	afterMigration := func(ns walletdb.ReadWriteBucket) error {
+		birthdayBlock, err := fetchBirthdayBlock(ns)
+		if err != nil {
+			return err
+		}
+
+		if birthdayBlock.Height != expectedHeight {
+			return fmt.Errorf("expected birthday block height %d, "+
+				"got %d", expectedHeight, birthdayBlock.Height)
+		}
+
+		return nil
+	}
+
+	// We can now apply the migration and expect it not to fail.
+	applyMigration(
+		t, beforeMigration, afterMigration, populateBirthdayBlock,
+		false,
+	)
+}

--- a/waddrmgr/sync.go
+++ b/waddrmgr/sync.go
@@ -110,3 +110,17 @@ func (m *Manager) SetBirthday(ns walletdb.ReadWriteBucket,
 	m.birthday = birthday
 	return putBirthday(ns, birthday)
 }
+
+// BirthdayBlock returns the birthday block, or earliest block a key could have
+// been used, for the manager.
+func (m *Manager) BirthdayBlock(ns walletdb.ReadBucket) (BlockStamp, error) {
+	return fetchBirthdayBlock(ns)
+}
+
+// SetBirthdayBlock sets the birthday block, or earliest time a key could have
+// been used, for the manager.
+func (m *Manager) SetBirthdayBlock(ns walletdb.ReadWriteBucket,
+	block BlockStamp) error {
+
+	return putBirthdayBlock(ns, block)
+}

--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -31,7 +31,7 @@ func (w *Wallet) handleChainNotifications() {
 		// some reason, however, the wallet will not be marked synced
 		// and many methods will error early since the wallet is known
 		// to be out of date.
-		err := w.syncWithChain()
+		err := w.syncWithChain(birthdayStamp)
 		if err != nil && !w.ShuttingDown() {
 			log.Warnf("Unable to synchronize wallet to chain: %v", err)
 		}

--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -6,7 +6,9 @@ package wallet
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
+	"time"
 
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcwallet/chain"
@@ -24,7 +26,7 @@ func (w *Wallet) handleChainNotifications() {
 		return
 	}
 
-	sync := func(w *Wallet) {
+	sync := func(w *Wallet, birthdayStamp *waddrmgr.BlockStamp) {
 		// At the moment there is no recourse if the rescan fails for
 		// some reason, however, the wallet will not be marked synced
 		// and many methods will error early since the wallet is known
@@ -96,7 +98,20 @@ func (w *Wallet) handleChainNotifications() {
 			var err error
 			switch n := n.(type) {
 			case chain.ClientConnected:
-				go sync(w)
+				// Before attempting to sync with our backend,
+				// we'll make sure that our birthday block has
+				// been set correctly to potentially prevent
+				// missing relevant events.
+				birthdayBlock, err := w.birthdaySanityCheck()
+				if err != nil {
+					err := fmt.Errorf("unable to sanity "+
+						"check wallet birthday block: %v",
+						err)
+					log.Error(err)
+					panic(err)
+				}
+
+				go sync(w, birthdayBlock)
 			case chain.BlockConnected:
 				err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
 					return w.connectBlock(tx, wtxmgr.BlockMeta(n))
@@ -328,4 +343,190 @@ func (w *Wallet) addRelevantTx(dbtx walletdb.ReadWriteTx, rec *wtxmgr.TxRecord, 
 	}
 
 	return nil
+}
+
+// birthdaySanityCheck is a helper function that ensures our birthday block
+// correctly reflects the birthday timestamp within a reasonable timestamp
+// delta. It will be run after the wallet establishes its connection with the
+// backend, but before it begins syncing.  This is done as the second part to
+// the wallet's address manager migration where we populate the birthday block
+// to ensure we do not miss any relevant events throughout rescans.
+func (w *Wallet) birthdaySanityCheck() (*waddrmgr.BlockStamp, error) {
+	// We'll start by acquiring our chain backend client as we'll be
+	// querying it for blocks.
+	chainClient, err := w.requireChainClient()
+	if err != nil {
+		return nil, err
+	}
+
+	// We'll then fetch our wallet's birthday timestamp and block.
+	birthdayTimestamp := w.Manager.Birthday()
+	var birthdayBlock waddrmgr.BlockStamp
+	err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+		var err error
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+		birthdayBlock, err = w.Manager.BirthdayBlock(ns)
+		return err
+	})
+
+	switch {
+	// If our wallet's birthday block has not been set yet, then this is our
+	// initial sync, so we'll defer setting it until then.
+	case waddrmgr.IsError(err, waddrmgr.ErrBirthdayBlockNotSet):
+		return nil, nil
+
+	// Otherwise, we'll return the error if there was one.
+	case err != nil:
+		return nil, err
+	}
+
+	log.Debugf("Starting sanity check for the wallet's birthday block "+
+		"from: height=%d, hash=%v", birthdayBlock.Height,
+		birthdayBlock.Hash)
+
+	// Now, we'll need to determine if our block correctly reflects our
+	// timestamp. To do so, we'll fetch the block header and check its
+	// timestamp in the event that the birthday block's timestamp was not
+	// set (this is possible if it was set through the migration, since we
+	// do not store block timestamps).
+	candidate := birthdayBlock
+	header, err := chainClient.GetBlockHeader(&candidate.Hash)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get header for block hash "+
+			"%v: %v", candidate.Hash, err)
+	}
+	candidate.Timestamp = header.Timestamp
+
+	// We'll go back a day worth of blocks in the chain until we find a
+	// block whose timestamp is below our birthday timestamp.
+	heightDelta := int32(144)
+	for birthdayTimestamp.Before(candidate.Timestamp) {
+		// If the birthday block has reached genesis, then we can exit
+		// our search as there exists no data before this point.
+		if candidate.Height == 0 {
+			break
+		}
+
+		// To prevent requesting blocks out of range, we'll use a lower
+		// bound of the first block in the chain.
+		newCandidateHeight := int64(candidate.Height - heightDelta)
+		if newCandidateHeight < 0 {
+			newCandidateHeight = 0
+		}
+
+		// Then, we'll fetch the current candidate's hash and header to
+		// determine if it is valid.
+		hash, err := chainClient.GetBlockHash(newCandidateHeight)
+		if err != nil {
+			return nil, fmt.Errorf("unable to get block hash for "+
+				"height %d: %v", candidate.Height, err)
+		}
+		header, err := chainClient.GetBlockHeader(hash)
+		if err != nil {
+			return nil, fmt.Errorf("unable to get header for "+
+				"block hash %v: %v", candidate.Hash, err)
+		}
+
+		candidate.Hash = *hash
+		candidate.Timestamp = header.Timestamp
+
+		log.Debugf("Checking next birthday block candidate: "+
+			"height=%d, hash=%v, timestamp=%v",
+			candidate.Height, candidate.Hash,
+			candidate.Timestamp)
+	}
+
+	// To ensure we have a reasonable birthday block, we'll make sure it
+	// respects our birthday timestamp and it is within a reasonable delta.
+	// The birthday has already been adjusted to two days in the past of the
+	// actual birthday, so we'll make our expected delta to be within two
+	// hours of it to account for the network-adjusted time and prevent
+	// fetching more unnecessary blocks.
+	_, bestHeight, err := chainClient.GetBestBlock()
+	if err != nil {
+		return nil, err
+	}
+	timestampDelta := birthdayTimestamp.Sub(candidate.Timestamp)
+	for timestampDelta > 2*time.Hour {
+		// We'll determine the height for our next candidate and make
+		// sure it is not out of range. If it is, we'll lower our height
+		// delta until finding a height within range.
+		newHeight := candidate.Height + heightDelta
+		if newHeight > bestHeight {
+			heightDelta /= 2
+
+			// If we've exhausted all of our possible options at a
+			// later height, then we can assume the current birthday
+			// block is our best estimate.
+			if heightDelta == 0 {
+				break
+			}
+
+			continue
+		}
+
+		// We'll fetch the header for the next candidate and compare its
+		// timestamp.
+		hash, err := chainClient.GetBlockHash(int64(newHeight))
+		if err != nil {
+			return nil, fmt.Errorf("unable to get block hash for "+
+				"height %d: %v", candidate.Height, err)
+		}
+		header, err := chainClient.GetBlockHeader(hash)
+		if err != nil {
+			return nil, fmt.Errorf("unable to get header for "+
+				"block hash %v: %v", hash, err)
+		}
+
+		log.Debugf("Checking next birthday block candidate: "+
+			"height=%d, hash=%v, timestamp=%v", newHeight, hash,
+			header.Timestamp)
+
+		// If this block has exceeded our birthday timestamp, we'll look
+		// for the next candidate with a lower height delta.
+		if birthdayTimestamp.Before(header.Timestamp) {
+			heightDelta /= 2
+
+			// If we've exhausted all of our possible options at a
+			// later height, then we can assume the current birthday
+			// block is our best estimate.
+			if heightDelta == 0 {
+				break
+			}
+
+			continue
+		}
+
+		// Otherwise, this is a valid candidate, so we'll check to see
+		// if it meets our expected timestamp delta.
+		candidate.Hash = *hash
+		candidate.Height = newHeight
+		candidate.Timestamp = header.Timestamp
+		timestampDelta = birthdayTimestamp.Sub(header.Timestamp)
+	}
+
+	// At this point, we've found a valid candidate that satisfies our
+	// conditions above. If this is our current birthday block, then we can
+	// exit to avoid the additional database transaction.
+	if candidate.Hash.IsEqual(&birthdayBlock.Hash) {
+		return &candidate, nil
+	}
+
+	// Otherwise, we have a new, better candidate, so we'll write it to
+	// disk.
+	log.Debugf("Found a new valid wallet birthday block: height=%d, hash=%v",
+		candidate.Height, candidate.Hash)
+
+	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+		if err := w.Manager.SetBirthdayBlock(ns, candidate); err != nil {
+			return err
+		}
+		return w.Manager.SetSyncedTo(ns, &candidate)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &candidate, nil
 }


### PR DESCRIPTION
In this PR, we add a new migration to the `waddrmgr` to populate the birthday block for existing wallets. This will deem useful when performing rescans for whatever reason, as we'll now be able to start from this point rather than the genesis block, incurring a longer rescan.

The migration is not reliable since we do not store block timestamps, so we'll need to estimate our height by looking at the genesis timestamp and assuming a block occurs every 10 minutes. This can be unsafe, and cause us to actually miss on-chain events, so a sanity check has also been added to ensure its correctness.

This sanity check performs two main checks: whether the birthday block timestamp reflects a time before the birthday timestamp and whether the delta between these two timestamps is a reasonable amount. The birthday block is then found as the first candidate that satisfies both of these conditions.

Depends on #570.