### PR TITLE
wallet/wallet: prevent always rescanning from birthday block

### DIFF
--- a/waddrmgr/sync.go
+++ b/waddrmgr/sync.go
@@ -112,15 +112,26 @@ func (m *Manager) SetBirthday(ns walletdb.ReadWriteBucket,
 }
 
 // BirthdayBlock returns the birthday block, or earliest block a key could have
-// been used, for the manager.
-func (m *Manager) BirthdayBlock(ns walletdb.ReadBucket) (BlockStamp, error) {
-	return fetchBirthdayBlock(ns)
+// been used, for the manager. A boolean is also returned to indicate whether
+// the birthday block has been verified as correct.
+func (m *Manager) BirthdayBlock(ns walletdb.ReadBucket) (BlockStamp, bool, error) {
+	birthdayBlock, err := fetchBirthdayBlock(ns)
+	if err != nil {
+		return BlockStamp{}, false, err
+	}
+
+	return birthdayBlock, fetchBirthdayBlockVerification(ns), nil
 }
 
 // SetBirthdayBlock sets the birthday block, or earliest time a key could have
-// been used, for the manager.
+// been used, for the manager. The verified boolean can be used to specify
+// whether this birthday block should be sanity checked to determine if there
+// exists a better candidate to prevent less block fetching.
 func (m *Manager) SetBirthdayBlock(ns walletdb.ReadWriteBucket,
-	block BlockStamp) error {
+	block BlockStamp, verified bool) error {
 
-	return putBirthdayBlock(ns, block)
+	if err := putBirthdayBlock(ns, block); err != nil {
+		return err
+	}
+	return putBirthdayBlockVerification(ns, verified)
 }

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -498,7 +498,7 @@ func (w *Wallet) syncWithChain(birthdayStamp *waddrmgr.BlockStamp) error {
 						birthdayStamp.Hash)
 
 					err := w.Manager.SetBirthdayBlock(
-						ns, *birthdayStamp,
+						ns, *birthdayStamp, true,
 					)
 					if err != nil {
 						tx.Rollback()
@@ -664,7 +664,9 @@ func (w *Wallet) syncWithChain(birthdayStamp *waddrmgr.BlockStamp) error {
 
 		err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
 			ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-			return w.Manager.SetBirthdayBlock(ns, *birthdayStamp)
+			return w.Manager.SetBirthdayBlock(
+				ns, *birthdayStamp, true,
+			)
 		})
 		if err != nil {
 			return nil

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -2684,7 +2684,7 @@ func (w *Wallet) ImportPrivateKey(scope waddrmgr.KeyScope, wif *btcutil.WIF,
 		// before our current one. Otherwise, if we do, we can
 		// potentially miss detecting relevant chain events that
 		// occurred between them while rescanning.
-		birthdayBlock, err := w.Manager.BirthdayBlock(addrmgrNs)
+		birthdayBlock, _, err := w.Manager.BirthdayBlock(addrmgrNs)
 		if err != nil {
 			return err
 		}
@@ -2696,7 +2696,11 @@ func (w *Wallet) ImportPrivateKey(scope waddrmgr.KeyScope, wif *btcutil.WIF,
 		if err != nil {
 			return err
 		}
-		return w.Manager.SetBirthdayBlock(addrmgrNs, *bs)
+
+		// To ensure this birthday block is correct, we'll mark it as
+		// unverified to prompt a sanity check at the next restart to
+		// ensure it is correct as it was provided by the caller.
+		return w.Manager.SetBirthdayBlock(addrmgrNs, *bs, false)
 	})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
In this commit, we address an issue with the wallet where it would
always request a rescan from the birthday block. This is very crucial
for older wallets, as it'll potentially go through thousands of blocks.
To address this, we'll now only request a rescan from our birthday if
we're recovering our wallet from our seed, the birthday block was rolled
back, or if we're performing our initial sync. Otherwise, we'll request
a rescan from tip.