### PR TITLE
waddrmgr+cmd/dropwtxmgr: start rescan from birthday block

### DIFF
--- a/waddrmgr/db.go
+++ b/waddrmgr/db.go
@@ -1830,8 +1830,8 @@ func fetchSyncedTo(ns walletdb.ReadBucket) (*BlockStamp, error) {
 	return &bs, nil
 }
 
-// putSyncedTo stores the provided synced to blockstamp to the database.
-func putSyncedTo(ns walletdb.ReadWriteBucket, bs *BlockStamp) error {
+// PutSyncedTo stores the provided synced to blockstamp to the database.
+func PutSyncedTo(ns walletdb.ReadWriteBucket, bs *BlockStamp) error {
 	bucket := ns.NestedReadWriteBucket(syncBucketName)
 	errStr := fmt.Sprintf("failed to store sync information %v", bs.Hash)
 
@@ -1893,9 +1893,9 @@ func fetchBlockHash(ns walletdb.ReadBucket, height int32) (*chainhash.Hash, erro
 	return &hash, nil
 }
 
-// fetchStartBlock loads the start block stamp for the manager from the
+// FetchStartBlock loads the start block stamp for the manager from the
 // database.
-func fetchStartBlock(ns walletdb.ReadBucket) (*BlockStamp, error) {
+func FetchStartBlock(ns walletdb.ReadBucket) (*BlockStamp, error) {
 	bucket := ns.NestedReadBucket(syncBucketName)
 
 	// The serialized start block format is:
@@ -1964,13 +1964,13 @@ func putBirthday(ns walletdb.ReadWriteBucket, t time.Time) error {
 	return nil
 }
 
-// fetchBirthdayBlock retrieves the birthday block from the database.
+// FetchBirthdayBlock retrieves the birthday block from the database.
 //
 // The block is serialized as follows:
 //   [0:4]   block height
 //   [4:36]  block hash
 //   [36:44] block timestamp
-func fetchBirthdayBlock(ns walletdb.ReadBucket) (BlockStamp, error) {
+func FetchBirthdayBlock(ns walletdb.ReadBucket) (BlockStamp, error) {
 	var block BlockStamp
 
 	bucket := ns.NestedReadBucket(syncBucketName)

--- a/waddrmgr/manager.go
+++ b/waddrmgr/manager.go
@@ -1405,7 +1405,7 @@ func loadManager(ns walletdb.ReadBucket, pubPassphrase []byte,
 	if err != nil {
 		return nil, maybeConvertDbError(err)
 	}
-	startBlock, err := fetchStartBlock(ns)
+	startBlock, err := FetchStartBlock(ns)
 	if err != nil {
 		return nil, maybeConvertDbError(err)
 	}
@@ -1800,7 +1800,7 @@ func Create(ns walletdb.ReadWriteBucket, seed, pubPassphrase, privPassphrase []b
 	}
 
 	// Save the initial synced to state.
-	err = putSyncedTo(ns, &syncInfo.syncedTo)
+	err = PutSyncedTo(ns, &syncInfo.syncedTo)
 	if err != nil {
 		return maybeConvertDbError(err)
 	}

--- a/waddrmgr/migrations.go
+++ b/waddrmgr/migrations.go
@@ -365,10 +365,10 @@ func resetSyncedBlockToBirthday(ns walletdb.ReadWriteBucket) error {
 		return errors.New("sync bucket does not exist")
 	}
 
-	birthdayBlock, err := fetchBirthdayBlock(ns)
+	birthdayBlock, err := FetchBirthdayBlock(ns)
 	if err != nil {
 		return err
 	}
 
-	return putSyncedTo(ns, &birthdayBlock)
+	return PutSyncedTo(ns, &birthdayBlock)
 }

--- a/waddrmgr/migrations_test.go
+++ b/waddrmgr/migrations_test.go
@@ -81,7 +81,7 @@ func TestMigrationPopulateBirthdayBlock(t *testing.T) {
 			block.Height = i
 			blockHash := bytes.Repeat([]byte(string(i)), 32)
 			copy(block.Hash[:], blockHash)
-			if err := putSyncedTo(ns, block); err != nil {
+			if err := PutSyncedTo(ns, block); err != nil {
 				return err
 			}
 		}
@@ -100,7 +100,7 @@ func TestMigrationPopulateBirthdayBlock(t *testing.T) {
 
 		// Finally, since the migration has not yet started, we should
 		// not be able to find the birthday block within the database.
-		_, err := fetchBirthdayBlock(ns)
+		_, err := FetchBirthdayBlock(ns)
 		if !IsError(err, ErrBirthdayBlockNotSet) {
 			return fmt.Errorf("expected ErrBirthdayBlockNotSet, "+
 				"got %v", err)
@@ -112,7 +112,7 @@ func TestMigrationPopulateBirthdayBlock(t *testing.T) {
 	// After the migration has completed, we should see that the birthday
 	// block now exists and is set to the correct expected height.
 	afterMigration := func(ns walletdb.ReadWriteBucket) error {
-		birthdayBlock, err := fetchBirthdayBlock(ns)
+		birthdayBlock, err := FetchBirthdayBlock(ns)
 		if err != nil {
 			return err
 		}
@@ -151,7 +151,7 @@ func TestMigrationPopulateBirthdayBlockEstimateTooFar(t *testing.T) {
 			block.Height = i
 			blockHash := bytes.Repeat([]byte(string(i)), 32)
 			copy(block.Hash[:], blockHash)
-			if err := putSyncedTo(ns, block); err != nil {
+			if err := PutSyncedTo(ns, block); err != nil {
 				return err
 			}
 		}
@@ -184,7 +184,7 @@ func TestMigrationPopulateBirthdayBlockEstimateTooFar(t *testing.T) {
 
 		// Finally, since the migration has not yet started, we should
 		// not be able to find the birthday block within the database.
-		_, err := fetchBirthdayBlock(ns)
+		_, err := FetchBirthdayBlock(ns)
 		if !IsError(err, ErrBirthdayBlockNotSet) {
 			return fmt.Errorf("expected ErrBirthdayBlockNotSet, "+
 				"got %v", err)
@@ -196,7 +196,7 @@ func TestMigrationPopulateBirthdayBlockEstimateTooFar(t *testing.T) {
 	// After the migration has completed, we should see that the birthday
 	// block now exists and is set to the correct expected height.
 	afterMigration := func(ns walletdb.ReadWriteBucket) error {
-		birthdayBlock, err := fetchBirthdayBlock(ns)
+		birthdayBlock, err := FetchBirthdayBlock(ns)
 		if err != nil {
 			return err
 		}
@@ -230,7 +230,7 @@ func TestMigrationResetSyncedBlockToBirthday(t *testing.T) {
 			block.Height = i
 			blockHash := bytes.Repeat([]byte(string(i)), 32)
 			copy(block.Hash[:], blockHash)
-			if err := putSyncedTo(ns, block); err != nil {
+			if err := PutSyncedTo(ns, block); err != nil {
 				return err
 			}
 		}

--- a/waddrmgr/sync.go
+++ b/waddrmgr/sync.go
@@ -59,7 +59,7 @@ func (m *Manager) SetSyncedTo(ns walletdb.ReadWriteBucket, bs *BlockStamp) error
 	}
 
 	// Update the database.
-	err := putSyncedTo(ns, bs)
+	err := PutSyncedTo(ns, bs)
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,7 @@ func (m *Manager) SetBirthday(ns walletdb.ReadWriteBucket,
 // been used, for the manager. A boolean is also returned to indicate whether
 // the birthday block has been verified as correct.
 func (m *Manager) BirthdayBlock(ns walletdb.ReadBucket) (BlockStamp, bool, error) {
-	birthdayBlock, err := fetchBirthdayBlock(ns)
+	birthdayBlock, err := FetchBirthdayBlock(ns)
 	if err != nil {
 		return BlockStamp{}, false, err
 	}


### PR DESCRIPTION
In this commit, we modify the `dropwtxmgr` tool to force a rescan upon
restart from the wallet's birthday block, rather than the chain's
genesis block. We can safely do this as we expect that no on-chain
events relevant to the wallet should happen before this block.  For
older wallets which do not have their birthday block set, the rescan
should start from the genesis block.