### PR TITLE
wallet/wallet: assume not current if best height is 0

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -471,6 +471,12 @@ func (w *Wallet) scanChain(startHeight int32,
 			Checkpoints[len(w.chainParams.Checkpoints)-1].Height
 	}
 	isCurrent := func(bestHeight int32) bool {
+		// If the best height is zero, we assume the chain backend
+		// still is looking for peers to sync to.
+		if bestHeight == 0 {
+			return false
+		}
+
 		switch c := chainClient.(type) {
 		case *chain.NeutrinoClient:
 			return c.CS.IsCurrent()


### PR DESCRIPTION
This is done to avoid the birthday rescan to fail if the chain backend
reports a bestheight of 0.

Earlier it could happen that we attempted to sync to the birthday, but
since only the genesis block was available, which would be rejected as
birthday block because of the timestamp, it would fail to find a block
and the sync would fail.