### PR TITLE
wallet: don't block db at height 0 on simnet

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -463,17 +463,19 @@ func (w *Wallet) scanChain(startHeight int32,
 
 	// isCurrent is a helper function that we'll use to determine if the
 	// chain backend is currently synced. When running with a btcd or
-	// bitcoind backend, It will use the height of the latest checkpoint as
+	// bitcoind backend. It will use the height of the latest checkpoint as
 	// its lower bound.
 	var latestCheckptHeight int32
 	if len(w.chainParams.Checkpoints) > 0 {
 		latestCheckptHeight = w.chainParams.
 			Checkpoints[len(w.chainParams.Checkpoints)-1].Height
 	}
+	isSimNet := w.ChainParams().Net == wire.SimNet
 	isCurrent := func(bestHeight int32) bool {
 		// If the best height is zero, we assume the chain backend
-		// still is looking for peers to sync to.
-		if bestHeight == 0 {
+		// still is looking for peers to sync to, unless we are on
+		// SimNet, in which case our bestHeight is assumed to be current.
+		if bestHeight == 0 && !isSimNet {
 			return false
 		}
 


### PR DESCRIPTION
#591 introduced an edge case where when starting a new chain, like on simnet, a DB mutex is being held waiting for the chain to sync above a height of 0. This results in calls to `NewAddress` being blocked - which is needed in order to get an address for mining - causing a chicken-or-the-egg problem. We need an address to generate a block, but we can't get an address until there is a block.

I suspect this PR isn't the best solution, since it's specifically calling out `simnet` - but I wanted to put it out there to get feedback.

addresses #594 