### PR TITLE
wallet: only log block batch if non-empty

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -732,8 +732,10 @@ func (w *Wallet) recovery(startHeight int32) error {
 		return err
 	}
 
-	log.Infof("Recovered addresses from blocks %d-%d", blockBatch[0].Height,
-		blockBatch[len(blockBatch)-1].Height)
+	if len(blockBatch) > 0 {
+		log.Infof("Recovered addresses from blocks %d-%d", blockBatch[0].Height,
+			blockBatch[len(blockBatch)-1].Height)
+	}
 
 	return nil
 }


### PR DESCRIPTION
This fixes an issue reputed by a user that would cause btcwallet to
panic if the full node was stopped while btcwallet was still restoring
the wallet.