### PR TITLE
Ensure best block is up to date during initial sync

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -515,6 +515,17 @@ func (w *Wallet) scanChain(startHeight int32,
 				return err
 			}
 		}
+
+		// if we have reached our initial bestHeight then we might be in a case
+		// where isCurrent is true but we have an "old" bestHeight.
+		// Therefore, we refresh the bestHeight at this point to ensure we
+		// won't exit early the scan loop.
+		if height == bestHeight {
+			_, bestHeight, err = chainClient.GetBestBlock()
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This PR fixes a case during the initial sync of the wallet where the code stops too early to scan the chain and as a consequence fails to reach the birthday block, causing the initial start to stop
with error.

The scan is done in a loop until reaches the "bestHeight", where at that point the code only exits if the chain backend also reports it is synchronized at tip. 
Problem is that since the "bestHeight" is initialized before the loop it might contain an old value causing the main loop to exit too early.

The solution is to refresh the bestHeight on every iteration and by doing so making sure it is always called after isCurrent is called and might return true.