### PR TITLE
wallet: ensure bestHeight is updated before isCurrent check

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -505,14 +505,19 @@ func (w *Wallet) scanChain(startHeight int32,
 			return err
 		}
 
-		// If we've reached our best height and we're not current, we'll
-		// wait for blocks at tip to ensure we go through all existent
-		// blocks.
-		for height == bestHeight && !isCurrent(bestHeight) {
+		// If we've reached our best height, we'll wait for blocks at
+		// tip to ensure we go through all existent blocks in the chain.
+		// We'll update our bestHeight before checking if we're current
+		// with the chain to ensure we process any additional blocks
+		// that came in while we were scanning from our starting point.
+		for height == bestHeight {
 			time.Sleep(100 * time.Millisecond)
 			_, bestHeight, err = chainClient.GetBestBlock()
 			if err != nil {
 				return err
+			}
+			if isCurrent(bestHeight) {
+				break
 			}
 		}
 	}


### PR DESCRIPTION
In this commit, we fix an issue with the wallet's initial sync logic
where we'd miss processing all of the blocks in the chain. This can
happen if the backend is considered current while we're still catching
up. To address this, we make sure we update our best height to process
those missed blocks.

Co-authored-by: Roei Erez <roeierez@gmail.com>