### PR TITLE
chain: send RescanFinished even if lastProgressSent is not set

### DIFF
--- a/chain/neutrino.go
+++ b/chain/neutrino.go
@@ -517,13 +517,15 @@ func (s *NeutrinoClient) onFilteredBlockConnected(height int32,
 			s.clientMtx.Unlock()
 			return
 		}
+
 		// Only send the RescanFinished notification once the
 		// underlying chain service sees itself as current.
-		current := s.CS.IsCurrent() && s.lastProgressSent
+		current := s.CS.IsCurrent()
 		if current {
 			s.finished = true
 		}
 		s.clientMtx.Unlock()
+
 		if current {
 			select {
 			case s.enqueueNotification <- &RescanFinished{


### PR DESCRIPTION
The dependence between sending a RescanFinished notification and lastProgressSent doesn't seem necessary, as it introduces an order when calling the notification callbacks OnFilteredBlockConnected and BlockConnected.

Fixes #585.
Alternative to #586.