### PR TITLE
chain: dispatch RescanFinished notification after BlockConnected

### DIFF
--- a/chain/neutrino.go
+++ b/chain/neutrino.go
@@ -587,6 +587,10 @@ func (s *NeutrinoClient) onBlockConnected(hash *chainhash.Hash, height int32,
 		case <-s.rescanQuit:
 		}
 	}
+
+	// Check if we're able to dispatch our final RescanFinished notification
+	// after processing this block.
+	s.dispatchRescanFinished()
 }
 
 // dispatchRescanFinished determines whether we're able to dispatch our final

--- a/chain/neutrino.go
+++ b/chain/neutrino.go
@@ -28,11 +28,12 @@ type NeutrinoClient struct {
 	// We currently support one rescan/notifiction goroutine per client
 	rescan *neutrino.Rescan
 
-	enqueueNotification chan interface{}
-	dequeueNotification chan interface{}
-	startTime           time.Time
-	lastProgressSent    bool
-	currentBlock        chan *waddrmgr.BlockStamp
+	enqueueNotification     chan interface{}
+	dequeueNotification     chan interface{}
+	startTime               time.Time
+	lastProgressSent        bool
+	lastFilteredBlockHeader *wire.BlockHeader
+	currentBlock            chan *waddrmgr.BlockStamp
 
 	quit       chan struct{}
 	rescanQuit chan struct{}
@@ -339,6 +340,7 @@ func (s *NeutrinoClient) Rescan(startHash *chainhash.Hash, addrs []btcutil.Addre
 	s.scanning = true
 	s.finished = false
 	s.lastProgressSent = false
+	s.lastFilteredBlockHeader = nil
 	s.isRescan = true
 
 	bestBlock, err := s.CS.BestBlock()
@@ -432,6 +434,7 @@ func (s *NeutrinoClient) NotifyReceived(addrs []btcutil.Address) error {
 	// Don't need RescanFinished or RescanProgress notifications.
 	s.finished = true
 	s.lastProgressSent = true
+	s.lastFilteredBlockHeader = nil
 
 	// Rescan with just the specified addresses.
 	newRescan := neutrino.NewRescan(
@@ -495,6 +498,7 @@ func (s *NeutrinoClient) onFilteredBlockConnected(height int32,
 		}
 		ntfn.RelevantTxs = append(ntfn.RelevantTxs, rec)
 	}
+
 	select {
 	case s.enqueueNotification <- ntfn:
 	case <-s.quit:
@@ -502,6 +506,10 @@ func (s *NeutrinoClient) onFilteredBlockConnected(height int32,
 	case <-s.rescanQuit:
 		return
 	}
+
+	s.clientMtx.Lock()
+	s.lastFilteredBlockHeader = header
+	s.clientMtx.Unlock()
 
 	// Handle RescanFinished notification if required.
 	bs, err := s.CS.BestBlock()


### PR DESCRIPTION
In this PR, we address a bug within the wallet when running with Neutrino where it wouldn't be able to mark it as synced with the chain due to not receiving a RescanFinished notification if it was a block behind the chain. This happened because of the order in which the notifications are delivered within the underlying Neutrino ChainService, FilteredBlockConnected gets dispatched before BlockConnected. This doesn't always work however because there is an implicit dependency between them in which BlockConnected must occur first.

To address it, rather than switching the order in which the notifications are dispatched, we just check if we can dispatch the final RescanFinished notification after dispatching BlockConnected.