### PR TITLE
wallet: use relay fee to check for dust not fee rate

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -3172,7 +3172,10 @@ func (w *Wallet) SendOutputs(outputs []*wire.TxOut, account uint32,
 	// Ensure the outputs to be created adhere to the network's consensus
 	// rules.
 	for _, output := range outputs {
-		if err := txrules.CheckOutput(output, satPerKb); err != nil {
+		err := txrules.CheckOutput(
+			output, txrules.DefaultRelayFeePerKb,
+		)
+		if err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
In this commit we fix a lingering bug in our output sanity checks that
would only show up during time periods of persistently higher fees.
Before this commit we would incorrectly use the fee rate instead of the
min relay fee when checking an output for dust. This would cause us to
mistakenly reject a transaction for having a dust output.

We fix this by falling back to using the current min-relayfee.