### PR TITLE
wallet: start recovery from the wallet's best height

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -359,10 +359,20 @@ func (w *Wallet) syncWithChain(birthdayStamp *waddrmgr.BlockStamp) error {
 		// arbitrary height, rather than all the blocks from genesis, so
 		// we persist this height to ensure we don't store any blocks
 		// before it.
-		startHeight, _, err := w.getSyncRange(chainClient, birthdayStamp)
+		_, bestHeight, err := chainClient.GetBestBlock()
 		if err != nil {
 			return err
 		}
+		startHeight := bestHeight - waddrmgr.MaxReorgDepth + 1
+		if startHeight < 0 {
+			startHeight = 0
+		}
+		if birthdayStamp.Height < startHeight {
+			startHeight = birthdayStamp.Height
+		}
+
+		// With the starting height obtained, get the remaining block
+		// details required by the wallet.
 		startHash, err := chainClient.GetBlockHash(int64(startHeight))
 		if err != nil {
 			return err
@@ -722,36 +732,6 @@ func (w *Wallet) recovery(chainClient chain.Interface,
 	}
 
 	return nil
-}
-
-// getSyncRange determines the best height range to sync with the chain to
-// ensure we don't rescan blocks more than once.
-func (w *Wallet) getSyncRange(chainClient chain.Interface,
-	birthdayBlock *waddrmgr.BlockStamp) (int32, int32, error) {
-
-	// The wallet requires to store up to MaxReorgDepth blocks, so we'll
-	// start from there, unless our birthday is before it.
-	_, bestHeight, err := chainClient.GetBestBlock()
-	if err != nil {
-		return 0, 0, err
-	}
-	startHeight := bestHeight - waddrmgr.MaxReorgDepth + 1
-	if startHeight < 0 {
-		startHeight = 0
-	}
-	if birthdayBlock.Height < startHeight {
-		startHeight = birthdayBlock.Height
-	}
-
-	// If the wallet's tip has surpassed our starting height, then we'll
-	// start there as we don't need to rescan blocks we've already
-	// processed.
-	walletHeight := w.Manager.SyncedTo().Height
-	if walletHeight > startHeight {
-		startHeight = walletHeight
-	}
-
-	return startHeight, bestHeight, nil
 }
 
 // defaultScopeManagers fetches the ScopedKeyManagers from the wallet using the


### PR DESCRIPTION
Previously, the wallet would attempt to store the same block it checkpointed during its initial sync when performing a recovery. This would cause the previous block existence validation check to be in place, which would ultimately fail because the previous block was not stored intentionally.

To address this, we always start/resume our recovery from the wallet's best height. This also ensures that we do not rescan the same block again when resuming a recovery after a shutdown.

Fixes https://github.com/lightningnetwork/lnd/issues/3223.