### PR TITLE
wallet: speed up bare wallet init when using the btcd backend

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -359,17 +359,7 @@ func (w *Wallet) syncWithChain(birthdayStamp *waddrmgr.BlockStamp) error {
 		// arbitrary height, rather than all the blocks from genesis, so
 		// we persist this height to ensure we don't store any blocks
 		// before it.
-		_, bestHeight, err := chainClient.GetBestBlock()
-		if err != nil {
-			return err
-		}
-		startHeight := bestHeight - waddrmgr.MaxReorgDepth + 1
-		if startHeight < 0 {
-			startHeight = 0
-		}
-		if birthdayStamp.Height < startHeight {
-			startHeight = birthdayStamp.Height
-		}
+		startHeight := birthdayStamp.Height
 
 		// With the starting height obtained, get the remaining block
 		// details required by the wallet.


### PR DESCRIPTION
In this commit, we speed up creating a fresh wallet when using the btcd
backend. Before this commit, we would need to rescan 10k or so blocks
when creating a new wallet with the btcd backend. btcd will actually
fully scan all the blocks even though we have zero addresses or UTXOs to
look for. As a result, this can take quite some time.

In this commit we modify the starting height of the initial rescan to
start at the birthday height, and only modify it if it's unset, or the
best height of the chain is before this birthday height. As a result, we
won't always have the full 10k block re org safety horizon on disk, but
will tend to this level after we begin to sync forward.