### PR TITLE
wtxmgr: remove unconfirmed input reference for confirmed transcation …

### DIFF
--- a/wtxmgr/tx.go
+++ b/wtxmgr/tx.go
@@ -279,6 +279,13 @@ func (s *Store) updateMinedBalance(ns walletdb.ReadWriteBucket, rec *TxRecord,
 //
 // NOTE: This should only be used once the transaction has been mined.
 func (s *Store) deleteUnminedTx(ns walletdb.ReadWriteBucket, rec *TxRecord) error {
+	for _, input := range rec.MsgTx.TxIn {
+		prevOut := input.PreviousOutPoint
+		k := canonicalOutPoint(&prevOut.Hash, prevOut.Index)
+		if err := deleteRawUnminedInput(ns, k, rec.Hash); err != nil {
+			return err
+		}
+	}
 	for i := range rec.MsgTx.TxOut {
 		k := canonicalOutPoint(&rec.Hash, uint32(i))
 		if err := deleteRawUnminedCredit(ns, k); err != nil {


### PR DESCRIPTION
Previously, inserting a transaction as unconfirmed into the store and later confirming it would leave a lingering unconfirmed input record. This was discovered as part of #655. This issue would only affect the wallet if it tracked spent transaction outputs, which it doesn't. We aim to resolve it in any case for the sake of internal consistency.
