### PR TITLE
Create watch-only address managers and accounts

### DIFF
--- a/waddrmgr/README.md
+++ b/waddrmgr/README.md
@@ -32,8 +32,9 @@ report.  Package waddrmgr is licensed under the liberal ISC license.
   - Import WIF keys
   - Import pay-to-script-hash scripts for things such as multi-signature
     transactions
-  - Ability to export a watching-only version which does not contain any private
+  - Ability to start in watching-only mode which does not contain any private
     key material
+  - Ability to convert to watching-only mode
   - Programmatically detectable errors, including encapsulation of errors from
     packages it relies on
   - Address synchronization capabilities

--- a/waddrmgr/db.go
+++ b/waddrmgr/db.go
@@ -850,6 +850,7 @@ func forEachAccount(ns walletdb.ReadBucket, scope *KeyScope,
 }
 
 // fetchLastAccount retrieves the last account from the database.
+// If no accounts, returns twos-complement representation of -1, so that the next account is zero
 func fetchLastAccount(ns walletdb.ReadBucket, scope *KeyScope) (uint32, error) {
 	scopedBucket, err := fetchReadScopeBucket(ns, scope)
 	if err != nil {
@@ -859,6 +860,9 @@ func fetchLastAccount(ns walletdb.ReadBucket, scope *KeyScope) (uint32, error) {
 	metaBucket := scopedBucket.NestedReadBucket(metaBucketName)
 
 	val := metaBucket.Get(lastAccountName)
+	if val == nil {
+		return (1 << 32) - 1, nil
+	}
 	if len(val) != 4 {
 		str := fmt.Sprintf("malformed metadata '%s' stored in database",
 			lastAccountName)

--- a/waddrmgr/error.go
+++ b/waddrmgr/error.go
@@ -33,10 +33,6 @@ var (
 	// errWatchingOnly is the common error description used for the
 	// ErrWatchingOnly error code.
 	errWatchingOnly = "address manager is watching-only"
-
-	// errMustBeWatchingOnly is the common error description used for the
-	// ErrMustBeWatchingOnly error code.
-	errMustBeWatchingOnly = "address manager must be watching-only"
 )
 
 // ErrorCode identifies a kind of error.
@@ -94,11 +90,6 @@ const (
 	// account manager to have access to private data, was requested on
 	// a watching-only account manager.
 	ErrWatchingOnly
-
-	// ErrMustBeWatchingOnly indicates that an operation, which requires the
-	// account manager to be watching only, was requested on
-	// a non-watching-only account manager.
-	ErrMustBeWatchingOnly
 
 	// ErrInvalidAccount indicates that the requested account is not valid.
 	ErrInvalidAccount

--- a/waddrmgr/error.go
+++ b/waddrmgr/error.go
@@ -33,6 +33,10 @@ var (
 	// errWatchingOnly is the common error description used for the
 	// ErrWatchingOnly error code.
 	errWatchingOnly = "address manager is watching-only"
+
+	// errMustBeWatchingOnly is the common error description used for the
+	// ErrMustBeWatchingOnly error code.
+	errMustBeWatchingOnly = "address manager must be watching-only"
 )
 
 // ErrorCode identifies a kind of error.
@@ -90,6 +94,11 @@ const (
 	// account manager to have access to private data, was requested on
 	// a watching-only account manager.
 	ErrWatchingOnly
+
+	// ErrMustBeWatchingOnly indicates that an operation, which requires the
+	// account manager to be watching only, was requested on
+	// a non-watching-only account manager.
+	ErrMustBeWatchingOnly
 
 	// ErrInvalidAccount indicates that the requested account is not valid.
 	ErrInvalidAccount

--- a/waddrmgr/scoped_manager.go
+++ b/waddrmgr/scoped_manager.go
@@ -1187,7 +1187,7 @@ func (s *ScopedKeyManager) LastInternalAddress(ns walletdb.ReadBucket,
 }
 
 // NewRawAccount creates a new account for the scoped manager. This method
-// differs from the NewAccount method in that this method takes the acount
+// differs from the NewAccount method in that this method takes the account
 // number *directly*, rather than taking a string name for the account, then
 // mapping that to the next highest account number.
 func (s *ScopedKeyManager) NewRawAccount(ns walletdb.ReadWriteBucket, number uint32) error {
@@ -1207,6 +1207,22 @@ func (s *ScopedKeyManager) NewRawAccount(ns walletdb.ReadWriteBucket, number uin
 	// the account number.
 	name := fmt.Sprintf("act:%v", number)
 	return s.newAccount(ns, number, name)
+}
+
+// NewRawAccountWatchingOnly creates a new watching only account for the scoped manager.
+// This method differs from the NewAccountWatchingOnly method in that this method takes the account
+// number *directly*, rather than taking a string name for the account, then
+// mapping that to the next highest account number.
+func (s *ScopedKeyManager) NewRawAccountWatchingOnly(ns walletdb.ReadWriteBucket, number uint32,
+	pubKey *hdkeychain.ExtendedKey) error {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	// As this is an ad hoc account that may not follow our normal linear
+	// derivation, we'll create a new name for this account based off of
+	// the account number.
+	name := fmt.Sprintf("act:%v", number)
+	return s.newAccountWatchingOnly(ns, number, name, pubKey)
 }
 
 // NewAccount creates and returns a new account stored in the manager based on
@@ -1317,6 +1333,74 @@ func (s *ScopedKeyManager) newAccount(ns walletdb.ReadWriteBucket,
 	// database
 	err = putAccountInfo(
 		ns, &s.scope, account, acctPubEnc, acctPrivEnc, 0, 0, name,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Save last account metadata
+	return putLastAccount(ns, &s.scope, account)
+}
+
+// NewAccountWatchingOnly is similar to NewAccount, but for watch-only wallets.
+func (s *ScopedKeyManager) NewAccountWatchingOnly(ns walletdb.ReadWriteBucket, name string,
+	pubKey *hdkeychain.ExtendedKey) (uint32, error) {
+	if !s.rootManager.WatchOnly() {
+		return 0, managerError(ErrMustBeWatchingOnly, errMustBeWatchingOnly, nil)
+	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	// Fetch latest account, and create a new account in the same
+	// transaction Fetch the latest account number to generate the next
+	// account number
+	account, err := fetchLastAccount(ns, &s.scope)
+	if err != nil {
+		return 0, err
+	}
+	account++
+
+	// With the name validated, we'll create a new account for the new
+	// contiguous account.
+	if err := s.newAccountWatchingOnly(ns, account, name, pubKey); err != nil {
+		return 0, err
+	}
+
+	return account, nil
+}
+
+// newAccountWatchingOnly is similar to newAccount, but for watching-only wallets.
+//
+// NOTE: This function MUST be called with the manager lock held for writes.
+func (s *ScopedKeyManager) newAccountWatchingOnly(ns walletdb.ReadWriteBucket, account uint32, name string,
+	pubKey *hdkeychain.ExtendedKey) error {
+
+	// Validate the account name.
+	if err := ValidateAccountName(name); err != nil {
+		return err
+	}
+
+	// Check that account with the same name does not exist
+	_, err := s.lookupAccount(ns, name)
+	if err == nil {
+		str := fmt.Sprintf("account with the same name already exists")
+		return managerError(ErrDuplicateAccount, str, err)
+	}
+
+	// Encrypt the default account keys with the associated crypto keys.
+	acctPubEnc, err := s.rootManager.cryptoKeyPub.Encrypt(
+		[]byte(pubKey.String()),
+	)
+	if err != nil {
+		str := "failed to  encrypt public key for account"
+		return managerError(ErrCrypto, str, err)
+	}
+
+	// We have the encrypted account extended keys, so save them to the
+	// database
+	err = putAccountInfo(
+		ns, &s.scope, account, acctPubEnc, nil, 0, 0, name,
 	)
 	if err != nil {
 		return err
@@ -1700,6 +1784,7 @@ func (s *ScopedKeyManager) ForEachAccount(ns walletdb.ReadBucket,
 }
 
 // LastAccount returns the last account stored in the manager.
+// If no accounts, returns twos-complement representation of -1
 func (s *ScopedKeyManager) LastAccount(ns walletdb.ReadBucket) (uint32, error) {
 	return fetchLastAccount(ns, &s.scope)
 }

--- a/waddrmgr/scoped_manager.go
+++ b/waddrmgr/scoped_manager.go
@@ -1209,11 +1209,13 @@ func (s *ScopedKeyManager) NewRawAccount(ns walletdb.ReadWriteBucket, number uin
 	return s.newAccount(ns, number, name)
 }
 
-// NewRawAccountWatchingOnly creates a new watching only account for the scoped manager.
-// This method differs from the NewAccountWatchingOnly method in that this method takes the account
-// number *directly*, rather than taking a string name for the account, then
-// mapping that to the next highest account number.
-func (s *ScopedKeyManager) NewRawAccountWatchingOnly(ns walletdb.ReadWriteBucket, number uint32,
+// NewRawAccountWatchingOnly creates a new watching only account for
+// the scoped manager.  This method differs from the
+// NewAccountWatchingOnly method in that this method takes the account
+// number *directly*, rather than taking a string name for the
+// account, then mapping that to the next highest account number.
+func (s *ScopedKeyManager) NewRawAccountWatchingOnly(
+	ns walletdb.ReadWriteBucket, number uint32,
 	pubKey *hdkeychain.ExtendedKey) error {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()

--- a/waddrmgr/scoped_manager.go
+++ b/waddrmgr/scoped_manager.go
@@ -1345,10 +1345,6 @@ func (s *ScopedKeyManager) newAccount(ns walletdb.ReadWriteBucket,
 // NewAccountWatchingOnly is similar to NewAccount, but for watch-only wallets.
 func (s *ScopedKeyManager) NewAccountWatchingOnly(ns walletdb.ReadWriteBucket, name string,
 	pubKey *hdkeychain.ExtendedKey) (uint32, error) {
-	if !s.rootManager.WatchOnly() {
-		return 0, managerError(ErrMustBeWatchingOnly, errMustBeWatchingOnly, nil)
-	}
-
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 

--- a/wallet/loader.go
+++ b/wallet/loader.go
@@ -100,7 +100,7 @@ func (l *Loader) RunAfterLoad(fn func(*Wallet)) {
 func (l *Loader) CreateNewWallet(pubPassphrase, privPassphrase, seed []byte,
 	bday time.Time) (*Wallet, error) {
 
-	return l.createNewWalletInternal(
+	return l.createNewWallet(
 		pubPassphrase, privPassphrase, seed, bday, false,
 	)
 }
@@ -111,12 +111,12 @@ func (l *Loader) CreateNewWallet(pubPassphrase, privPassphrase, seed []byte,
 func (l *Loader) CreateNewWatchingOnlyWallet(pubPassphrase []byte,
 	bday time.Time) (*Wallet, error) {
 
-	return l.createNewWalletInternal(
+	return l.createNewWallet(
 		pubPassphrase, nil, nil, bday, true,
 	)
 }
 
-func (l *Loader) createNewWalletInternal(pubPassphrase, privPassphrase,
+func (l *Loader) createNewWallet(pubPassphrase, privPassphrase,
 	seed []byte, bday time.Time, isWatchingOnly bool) (*Wallet, error) {
 
 	defer l.mu.Unlock()

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -3582,7 +3582,7 @@ func (w *Wallet) Database() walletdb.DB {
 func Create(db walletdb.DB, pubPass, privPass, seed []byte,
 	params *chaincfg.Params, birthday time.Time) error {
 
-	return createInternal(
+	return create(
 		db, pubPass, privPass, seed, params, birthday, false,
 	)
 }
@@ -3594,12 +3594,12 @@ func Create(db walletdb.DB, pubPass, privPass, seed []byte,
 func CreateWatchingOnly(db walletdb.DB, pubPass []byte,
 	params *chaincfg.Params, birthday time.Time) error {
 
-	return createInternal(
+	return create(
 		db, pubPass, nil, nil, params, birthday, true,
 	)
 }
 
-func createInternal(db walletdb.DB, pubPass, privPass, seed []byte,
+func create(db walletdb.DB, pubPass, privPass, seed []byte,
 	params *chaincfg.Params, birthday time.Time, isWatchingOnly bool) error {
 
 	if !isWatchingOnly {

--- a/wallet/watchingonly_test.go
+++ b/wallet/watchingonly_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2018 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
+)
+
+// TestCreateWatchingOnly checks that we can construct a watching-only
+// wallet.
+func TestCreateWatchingOnly(t *testing.T) {
+	// Set up a wallet.
+	dir, err := ioutil.TempDir("", "watchingonly_test")
+	if err != nil {
+		t.Fatalf("Failed to create db dir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	pubPass := []byte("hello")
+
+	loader := NewLoader(&chaincfg.TestNet3Params, dir, true, 250)
+	_, err = loader.CreateNewWatchingOnlyWallet(pubPass, time.Now())
+	if err != nil {
+		t.Fatalf("unable to create wallet: %v", err)
+	}
+}


### PR DESCRIPTION
This PR allows the creation of managers and accounts that are watch-only.  The state of the database after creation would be identical to the state after calling `Manager.ConvertToWatchingOnly`, assuming accounts with the right xpubs were created in the former case.

Of course, creating a watch-only database is safer, since you don't have to worry about private data ending up in a swap file or the system having been compromised before creation.