### PR TITLE
Fix --usespv

### DIFF
--- a/btcwallet.go
+++ b/btcwallet.go
@@ -161,7 +161,7 @@ func rpcClientConnectLoop(legacyRPCServer *legacyrpc.Server, loader *wallet.Load
 			)
 			netDir := networkDir(cfg.AppDataDir.Value, activeNet.Params)
 			spvdb, err = walletdb.Create("bdb",
-				filepath.Join(netDir, "neutrino.db"))
+				filepath.Join(netDir, "neutrino.db"), true)
 			if err != nil {
 				log.Errorf("Unable to create Neutrino DB: %s", err)
 				continue


### PR DESCRIPTION
Neutrino is broken in the latest release. 
```
$ ./btcwallet --testnet --usespv
2019-12-17 04:33:20.382 [INF] BTCW: Version 0.11.0-alpha
2019-12-17 04:33:20.394 [INF] RPCS: Listening on 127.0.0.1:18332
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xa8a8f4]

goroutine 22 [running]:
main.rpcClientConnectLoop(0xc000324000, 0xc000082240)
```
This PR fixes it.