### PR TITLE
waddrmgr+wallet: use fast scrypt options for regtest and simnet

### DIFF
--- a/waddrmgr/common_test.go
+++ b/waddrmgr/common_test.go
@@ -33,11 +33,7 @@ var (
 
 	// fastScrypt are parameters used throughout the tests to speed up the
 	// scrypt operations.
-	fastScrypt = &ScryptOptions{
-		N: 16,
-		R: 8,
-		P: 1,
-	}
+	fastScrypt = &FastScryptOptions
 
 	// waddrmgrNamespaceKey is the namespace key for the waddrmgr package.
 	waddrmgrNamespaceKey = []byte("waddrmgrNamespace")

--- a/waddrmgr/manager.go
+++ b/waddrmgr/manager.go
@@ -123,6 +123,15 @@ var DefaultScryptOptions = ScryptOptions{
 	P: 1,
 }
 
+// FastScryptOptions are the scrypt options that are used for testing
+// purposes where speed is more important than security. These options are used
+// when creating a new wallet for regtest or simnet.
+var FastScryptOptions = ScryptOptions{
+	N: 16,
+	R: 8,
+	P: 1,
+}
+
 // addrKey is used to uniquely identify an address even when those addresses
 // would end up being the same bitcoin address (as is the case for
 // pay-to-pubkey and pay-to-pubkey-hash style of addresses).


### PR DESCRIPTION
In unit tests we can pass in the fast scrypt options directly.
This is not true for integration tests of external projects that
use btcwallet. But we can speed up these tests by using the fast
scrypt options if the regtest or simnet chain params are used as
they should never be set in production wallet creation.