### PR TITLE
waddrmgr: export fast scrypt options

### DIFF
--- a/waddrmgr/common_test.go
+++ b/waddrmgr/common_test.go
@@ -33,11 +33,7 @@ var (
 
 	// fastScrypt are parameters used throughout the tests to speed up the
 	// scrypt operations.
-	fastScrypt = &ScryptOptions{
-		N: 16,
-		R: 8,
-		P: 1,
-	}
+	fastScrypt = &FastScryptOptions
 
 	// waddrmgrNamespaceKey is the namespace key for the waddrmgr package.
 	waddrmgrNamespaceKey = []byte("waddrmgrNamespace")

--- a/waddrmgr/manager.go
+++ b/waddrmgr/manager.go
@@ -123,6 +123,14 @@ var DefaultScryptOptions = ScryptOptions{
 	P: 1,
 }
 
+// FastScryptOptions are the scrypt options that should be used for testing
+// purposes only where speed is more important than security.
+var FastScryptOptions = ScryptOptions{
+	N: 16,
+	R: 8,
+	P: 1,
+}
+
 // addrKey is used to uniquely identify an address even when those addresses
 // would end up being the same bitcoin address (as is the case for
 // pay-to-pubkey and pay-to-pubkey-hash style of addresses).


### PR DESCRIPTION
This trivial PR exports the fast scrypt options used in unit tests as a public variable so these values can easily be reused in depending projects.