### PR TITLE
waddrmgr+wallet: only watch addresses within default key scopes

### DIFF
--- a/waddrmgr/manager.go
+++ b/waddrmgr/manager.go
@@ -748,6 +748,29 @@ func (m *Manager) ForEachAccountAddress(ns walletdb.ReadBucket, account uint32,
 	return nil
 }
 
+// ForEachDefaultScopeActiveAddress calls the given function with each active
+// address stored in the manager within the default scopes, breaking early on
+// error.
+func (m *Manager) ForEachDefaultScopeActiveAddress(ns walletdb.ReadBucket,
+	fn func(addr btcutil.Address) error) error {
+
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	for _, keyScope := range DefaultKeyScopes {
+		scopedMgr, ok := m.scopedManagers[keyScope]
+		if !ok {
+			return fmt.Errorf("manager for default key scope with "+
+				"purpose %v not found", keyScope.Purpose)
+		}
+		if err := scopedMgr.ForEachActiveAddress(ns, fn); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // ChainParams returns the chain parameters for this address manager.
 func (m *Manager) ChainParams() *chaincfg.Params {
 	// NOTE: No need for mutex here since the net field does not change


### PR DESCRIPTION
It was discovered that the wallet can scan the chain for unnecessary additional addresses that are derived by higher-level applications for custom scripts. This isn't much of an issue for full nodes, but it can cause light clients to scan more than what's required, triggering more false positive matches which lead to block retrieval.

Now, we'll only scan the chain for addresses that belong to each scope's default account, as those are the only one the wallet should be concerned about.