### PR TITLE
walletdb: generic param passing for walletdb test

### DIFF
--- a/walletdb/bdb/interface_test.go
+++ b/walletdb/bdb/interface_test.go
@@ -23,5 +23,5 @@ import (
 func TestInterface(t *testing.T) {
 	dbPath := "interfacetest.db"
 	defer os.RemoveAll(dbPath)
-	walletdbtest.TestInterface(t, dbType, dbPath)
+	walletdbtest.TestInterface(t, dbType, dbPath, true)
 }

--- a/walletdb/walletdbtest/interface.go
+++ b/walletdb/walletdbtest/interface.go
@@ -7,7 +7,6 @@ package walletdbtest
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"reflect"
 	"sync"
 
@@ -793,13 +792,12 @@ func testBatchInterface(tc *testContext) bool {
 }
 
 // TestInterface performs all interfaces tests for this database driver.
-func TestInterface(t Tester, dbType, dbPath string) {
-	db, err := walletdb.Create(dbType, dbPath, true)
+func TestInterface(t Tester, dbType string, args ...interface{}) {
+	db, err := walletdb.Create(dbType, args...)
 	if err != nil {
 		t.Errorf("Failed to create test database (%s) %v", dbType, err)
 		return
 	}
-	defer os.Remove(dbPath)
 	defer db.Close()
 
 	// Run all of the interface tests against the database.


### PR DESCRIPTION
This PR removes bbolt specific parameters from interface test to
enable testing of other DB drivers trough the same entry point.