### PR TITLE
wtxmgr: add labels to transactions

### DIFF
--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -1378,7 +1378,7 @@ func sendPairs(w *wallet.Wallet, amounts map[string]btcutil.Amount,
 	if err != nil {
 		return "", err
 	}
-	tx, err := w.SendOutputs(outputs, account, minconf, feeSatPerKb)
+	tx, err := w.SendOutputs(outputs, account, minconf, feeSatPerKb, "")
 	if err != nil {
 		if err == txrules.ErrAmountNegative {
 			return "", ErrNeedPositiveAmount

--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -519,7 +519,7 @@ func (s *walletServer) PublishTransaction(ctx context.Context, req *pb.PublishTr
 			"Bytes do not represent a valid raw transaction: %v", err)
 	}
 
-	err = s.wallet.PublishTransaction(&msgTx)
+	err = s.wallet.PublishTransaction(&msgTx, "")
 	if err != nil {
 		return nil, translateError(err)
 	}

--- a/wallet/createtx_test.go
+++ b/wallet/createtx_test.go
@@ -6,16 +6,12 @@ package wallet
 
 import (
 	"bytes"
-	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
-	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcutil/hdkeychain"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/walletdb"
 	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
@@ -26,31 +22,8 @@ import (
 // request a dry run of the txToOutputs call. It also makes sure a subsequent
 // non-dry run call produces a similar transaction to the dry-run.
 func TestTxToOutputsDryRun(t *testing.T) {
-	// Set up a wallet.
-	dir, err := ioutil.TempDir("", "createtx_test")
-	if err != nil {
-		t.Fatalf("Failed to create db dir: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
-	seed, err := hdkeychain.GenerateSeed(hdkeychain.MinSeedBytes)
-	if err != nil {
-		t.Fatalf("unable to create seed: %v", err)
-	}
-
-	pubPass := []byte("hello")
-	privPass := []byte("world")
-
-	loader := NewLoader(&chaincfg.TestNet3Params, dir, true, 250)
-	w, err := loader.CreateNewWallet(pubPass, privPass, seed, time.Now())
-	if err != nil {
-		t.Fatalf("unable to create wallet: %v", err)
-	}
-	chainClient := &mockChainClient{}
-	w.chainClient = chainClient
-	if err := w.Unlock(privPass, time.After(10*time.Minute)); err != nil {
-		t.Fatalf("unable to unlock wallet: %v", err)
-	}
+	w, cleanup := testWallet(t)
+	defer cleanup()
 
 	// Create an address we can use to send some coins to.
 	addr, err := w.CurrentAddress(0, waddrmgr.KeyScopeBIP0044)

--- a/wallet/example_test.go
+++ b/wallet/example_test.go
@@ -1,0 +1,47 @@
+package wallet
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcutil/hdkeychain"
+)
+
+// testWallet creates a test wallet and unlocks it.
+func testWallet(t *testing.T) (*Wallet, func()) {
+	// Set up a wallet.
+	dir, err := ioutil.TempDir("", "test_wallet")
+	if err != nil {
+		t.Fatalf("Failed to create db dir: %v", err)
+	}
+
+	cleanup := func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Fatalf("could not cleanup test: %v", err)
+		}
+	}
+
+	seed, err := hdkeychain.GenerateSeed(hdkeychain.MinSeedBytes)
+	if err != nil {
+		t.Fatalf("unable to create seed: %v", err)
+	}
+
+	pubPass := []byte("hello")
+	privPass := []byte("world")
+
+	loader := NewLoader(&chaincfg.TestNet3Params, dir, true, 250)
+	w, err := loader.CreateNewWallet(pubPass, privPass, seed, time.Now())
+	if err != nil {
+		t.Fatalf("unable to create wallet: %v", err)
+	}
+	chainClient := &mockChainClient{}
+	w.chainClient = chainClient
+	if err := w.Unlock(privPass, time.After(10*time.Minute)); err != nil {
+		t.Fatalf("unable to unlock wallet: %v", err)
+	}
+
+	return w, cleanup
+}

--- a/wallet/notifications.go
+++ b/wallet/notifications.go
@@ -148,6 +148,7 @@ func makeTxSummary(dbtx walletdb.ReadTx, w *Wallet, details *wtxmgr.TxDetails) T
 		MyOutputs:   outputs,
 		Fee:         fee,
 		Timestamp:   details.Received.Unix(),
+		Label:       details.Label,
 	}
 }
 
@@ -365,6 +366,7 @@ type TransactionSummary struct {
 	MyOutputs   []TransactionSummaryOutput
 	Fee         btcutil.Amount
 	Timestamp   int64
+	Label       string
 }
 
 // TransactionSummaryInput describes a transaction input that is relevant to the

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -65,6 +65,16 @@ var (
 	// down.
 	ErrWalletShuttingDown = errors.New("wallet shutting down")
 
+	// ErrUnknownTransaction is returned when an attempt is made to label
+	// a transaction that is not known to the wallet.
+	ErrUnknownTransaction = errors.New("cannot label transaction not " +
+		"known to wallet")
+
+	// ErrTxLabelExists is returned when a transaction already has a label
+	// and an attempt has been made to label it without setting overwrite
+	// to true.
+	ErrTxLabelExists = errors.New("transaction already labelled")
+
 	// Namespace bucket keys.
 	waddrmgrNamespaceKey = []byte("waddrmgr")
 	wtxmgrNamespaceKey   = []byte("wtxmgr")
@@ -1589,6 +1599,58 @@ func (w *Wallet) PubKeyForAddress(a btcutil.Address) (*btcec.PublicKey, error) {
 		return nil
 	})
 	return pubKey, err
+}
+
+// LabelTransaction adds a label to the transaction with the hash provided. The
+// call will fail if the label is too long, or if the transaction already has
+// a label and the overwrite boolean is not set.
+func (w *Wallet) LabelTransaction(hash chainhash.Hash, label string,
+	overwrite bool) error {
+
+	// Check that the transaction is known to the wallet, and fail if it is
+	// unknown. If the transaction is known, check whether it already has
+	// a label.
+	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
+
+		dbTx, err := w.TxStore.TxDetails(txmgrNs, &hash)
+		if err != nil {
+			return err
+		}
+
+		// If the transaction looked up is nil, it was not found. We
+		// do not allow labelling of unknown transactions so we fail.
+		if dbTx == nil {
+			return ErrUnknownTransaction
+		}
+
+		_, err = wtxmgr.FetchTxLabel(txmgrNs, hash)
+		return err
+	})
+
+	switch err {
+	// If no labels have been written yet, we can silence the error.
+	// Likewise if there is no label, we do not need to do any overwrite
+	// checks.
+	case wtxmgr.ErrNoLabelBucket:
+	case wtxmgr.ErrTxLabelNotFound:
+
+	// If we successfully looked up a label, fail if the overwrite param
+	// is not set.
+	case nil:
+		if !overwrite {
+			return ErrTxLabelExists
+		}
+
+	// In another unrelated error occurred, return it.
+	default:
+		return err
+	}
+
+	return walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+		txmgrNs := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+		return w.TxStore.PutTxLabel(txmgrNs, hash, label)
+	})
 }
 
 // PrivKeyForAddress looks up the associated private key for a P2PKH or P2PK

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -3094,7 +3094,7 @@ func (w *Wallet) TotalReceivedForAddr(addr btcutil.Address, minConf int32) (btcu
 // SendOutputs creates and sends payment transactions. It returns the
 // transaction upon success.
 func (w *Wallet) SendOutputs(outputs []*wire.TxOut, account uint32,
-	minconf int32, satPerKb btcutil.Amount) (*wire.MsgTx, error) {
+	minconf int32, satPerKb btcutil.Amount, label string) (*wire.MsgTx, error) {
 
 	// Ensure the outputs to be created adhere to the network's consensus
 	// rules.
@@ -3118,7 +3118,7 @@ func (w *Wallet) SendOutputs(outputs []*wire.TxOut, account uint32,
 		return nil, err
 	}
 
-	txHash, err := w.reliablyPublishTransaction(createdTx.Tx, "")
+	txHash, err := w.reliablyPublishTransaction(createdTx.Tx, label)
 	if err != nil {
 		return nil, err
 	}

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1,8 +1,20 @@
 package wallet
 
 import (
+	"encoding/hex"
 	"testing"
 	"time"
+
+	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+
+	"github.com/btcsuite/btcutil"
+)
+
+var (
+	TstSerializedTx, _ = hex.DecodeString("010000000114d9ff358894c486b4ae11c2a8cf7851b1df64c53d2e511278eff17c22fb7373000000008c493046022100995447baec31ee9f6d4ec0e05cb2a44f6b817a99d5f6de167d1c75354a946410022100c9ffc23b64d770b0e01e7ff4d25fbc2f1ca8091053078a247905c39fce3760b601410458b8e267add3c1e374cf40f1de02b59213a82e1d84c2b94096e22e2f09387009c96debe1d0bcb2356ffdcf65d2a83d4b34e72c62eccd8490dbf2110167783b2bffffffff0280969800000000001976a914479ed307831d0ac19ebc5f63de7d5f1a430ddb9d88ac38bfaa00000000001976a914dadf9e3484f28b385ddeaa6c575c0c0d18e9788a88ac00000000")
+	TstTx, _           = btcutil.NewTxFromBytes(TstSerializedTx)
+	TstTxHash          = TstTx.Hash()
 )
 
 // TestLocateBirthdayBlock ensures we can properly map a block in the chain to a
@@ -81,5 +93,112 @@ func TestLocateBirthdayBlock(t *testing.T) {
 		if !success {
 			break
 		}
+	}
+}
+
+// TestLabelTransaction tests labelling of transactions with invalid labels,
+// and failure to label a transaction when it already has a label.
+func TestLabelTransaction(t *testing.T) {
+	tests := []struct {
+		name string
+
+		// Whether the transaction should be known to the wallet.
+		txKnown bool
+
+		// Whether the test should write an existing label to disk.
+		existingLabel bool
+
+		// The overwrite parameter to call label transaction with.
+		overwrite bool
+
+		// The error we expect to be returned.
+		expectedErr error
+	}{
+		{
+			name:          "existing label, not overwrite",
+			txKnown:       true,
+			existingLabel: true,
+			overwrite:     false,
+			expectedErr:   ErrTxLabelExists,
+		},
+		{
+			name:          "existing label, overwritten",
+			txKnown:       true,
+			existingLabel: true,
+			overwrite:     true,
+			expectedErr:   nil,
+		},
+		{
+			name:          "no prexisting label, ok",
+			txKnown:       true,
+			existingLabel: false,
+			overwrite:     false,
+			expectedErr:   nil,
+		},
+		{
+			name:          "transaction unknown",
+			txKnown:       false,
+			existingLabel: false,
+			overwrite:     false,
+			expectedErr:   ErrUnknownTransaction,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			w, cleanup := testWallet(t)
+			defer cleanup()
+
+			// If the transaction should be known to the store, we
+			// write txdetail to disk.
+			if test.txKnown {
+				rec, err := wtxmgr.NewTxRecord(
+					TstSerializedTx, time.Now(),
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				err = walletdb.Update(w.db,
+					func(tx walletdb.ReadWriteTx) error {
+
+						ns := tx.ReadWriteBucket(
+							wtxmgrNamespaceKey,
+						)
+
+						return w.TxStore.InsertTx(
+							ns, rec, nil,
+						)
+					})
+				if err != nil {
+					t.Fatalf("could not insert tx: %v", err)
+				}
+			}
+
+			// If we want to setup an existing label for the purpose
+			// of the test, write one to disk.
+			if test.existingLabel {
+				err := w.LabelTransaction(
+					*TstTxHash, "existing label", false,
+				)
+				if err != nil {
+					t.Fatalf("could not write label: %v",
+						err)
+				}
+			}
+
+			newLabel := "new label"
+			err := w.LabelTransaction(
+				*TstTxHash, newLabel, test.overwrite,
+			)
+			if err != test.expectedErr {
+				t.Fatalf("expected: %v, got: %v",
+					test.expectedErr, err)
+			}
+		})
 	}
 }

--- a/wtxmgr/db.go
+++ b/wtxmgr/db.go
@@ -62,6 +62,7 @@ var _ [32]byte = chainhash.Hash{}
 var (
 	bucketBlocks         = []byte("b")
 	bucketTxRecords      = []byte("t")
+	bucketTxLabels       = []byte("l")
 	bucketCredits        = []byte("c")
 	bucketUnspent        = []byte("u")
 	bucketDebits         = []byte("d")

--- a/wtxmgr/query.go
+++ b/wtxmgr/query.go
@@ -296,52 +296,13 @@ func (s *Store) rangeBlockTransactions(ns walletdb.ReadBucket, begin, end int32,
 					"block %v", txHash, block.Height)
 				return false, storeError(ErrData, str, nil)
 			}
-			detail := TxDetails{
-				Block: BlockMeta{
-					Block: block.Block,
-					Time:  block.Time,
-				},
-			}
-			err := readRawTxRecord(&txHash, v, &detail.TxRecord)
+
+			detail, err := s.minedTxDetails(ns, &txHash, k, v)
 			if err != nil {
 				return false, err
 			}
 
-			credIter := makeReadCreditIterator(ns, k)
-			for credIter.next() {
-				if int(credIter.elem.Index) >= len(detail.MsgTx.TxOut) {
-					str := "saved credit index exceeds number of outputs"
-					return false, storeError(ErrData, str, nil)
-				}
-
-				// The credit iterator does not record whether
-				// this credit was spent by an unmined
-				// transaction, so check that here.
-				if !credIter.elem.Spent {
-					k := canonicalOutPoint(&txHash, credIter.elem.Index)
-					spent := existsRawUnminedInput(ns, k) != nil
-					credIter.elem.Spent = spent
-				}
-				detail.Credits = append(detail.Credits, credIter.elem)
-			}
-			if credIter.err != nil {
-				return false, credIter.err
-			}
-
-			debIter := makeReadDebitIterator(ns, k)
-			for debIter.next() {
-				if int(debIter.elem.Index) >= len(detail.MsgTx.TxIn) {
-					str := "saved debit index exceeds number of inputs"
-					return false, storeError(ErrData, str, nil)
-				}
-
-				detail.Debits = append(detail.Debits, debIter.elem)
-			}
-			if debIter.err != nil {
-				return false, debIter.err
-			}
-
-			details = append(details, detail)
+			details = append(details, *detail)
 		}
 
 		// Every block record must have at least one transaction, so it


### PR DESCRIPTION
This change adds optional, user provided labels to transactions. Labels are written to their own bucket, keyed by transaction hash. This approach was taken to avoid the need for migration in the `TxRecord`. 

For the legacy rpc, the existing `Comment` parameter is used. Some fields also have a `CommentTo` field; I'm unsure what this field is for, and it is not present for all send endpoints so I have left it as unimplemented. 

Ready for a first pass of review, however I suspect that my I've generated the protos with the wrong protoc version. `serverchanges.md` does not mention a specific version?

Fixes #693