### PR TITLE
rpcserver+btcwallet: serve after wallet register

### DIFF
--- a/btcwallet.go
+++ b/btcwallet.go
@@ -88,6 +88,20 @@ func walletMain() error {
 
 	loader.RunAfterLoad(func(w *wallet.Wallet) {
 		startWalletRPCServices(w, rpcs, legacyRPCServer)
+
+		if len(cfg.ExperimentalRPCListeners) != 0 {
+			listeners := makeListeners(cfg.ExperimentalRPCListeners, net.Listen)
+			for _, lis := range listeners {
+				lis := lis
+				go func() {
+					log.Infof("Experimental RPC server listening on %s",
+						lis.Addr())
+					err := rpcs.Serve(lis)
+					log.Tracef("Finished serving expimental RPC: %v",
+						err)
+				}()
+			}
+		}
 	})
 
 	if !cfg.NoInitialLoad {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -138,16 +138,6 @@ func startRPCServers(walletLoader *wallet.Loader) (*grpc.Server, *legacyrpc.Serv
 			server = grpc.NewServer(grpc.Creds(creds))
 			rpcserver.StartVersionService(server)
 			rpcserver.StartWalletLoaderService(server, walletLoader, activeNet)
-			for _, lis := range listeners {
-				lis := lis
-				go func() {
-					log.Infof("Experimental RPC server listening on %s",
-						lis.Addr())
-					err := server.Serve(lis)
-					log.Tracef("Finished serving expimental RPC: %v",
-						err)
-				}()
-			}
 		}
 	}
 


### PR DESCRIPTION
May or may not be the best approach, but ran into https://github.com/btcsuite/btcwallet/issues/670 and https://github.com/btcsuite/btcwallet/issues/592 myself. Seems like `--experimentalrpclisten` doesn't work at all right now in master? Is it unsupported or not used at all anymore?

This PR moves the `server.serve()` to after the wallet loader loads the wallet, that way the wallet service gets registered. Before, the wallet service would register after the wallet loaded, which would end up happening after the `serve()`. 

Might not be the cleanest approach, unfamiliar with this codebase, but should at least make `experimentalrpclisten` usable again. 