### PR TITLE
dropwtxmgr: add drop labels option

### DIFF
--- a/cmd/dropwtxmgr/main.go
+++ b/cmd/dropwtxmgr/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/walletdb"
@@ -24,8 +25,9 @@ var datadir = btcutil.AppDataDir("btcwallet", false)
 
 // Flags.
 var opts = struct {
-	Force  bool   `short:"f" description:"Force removal without prompt"`
-	DbPath string `long:"db" description:"Path to wallet database"`
+	Force      bool   `short:"f" description:"Force removal without prompt"`
+	DbPath     string `long:"db" description:"Path to wallet database"`
+	DropLabels bool   `long:"droplabels" description:"Drop transaction labels"`
 }{
 	Force:  false,
 	DbPath: filepath.Join(datadir, defaultNet, "wallet.db"),
@@ -42,6 +44,9 @@ var (
 	// Namespace keys.
 	waddrmgrNamespace = []byte("waddrmgr")
 	wtxmgrNamespace   = []byte("wtxmgr")
+
+	// Bucket names.
+	bucketTxLabels = []byte("l")
 )
 
 func yes(s string) bool {
@@ -109,6 +114,16 @@ func mainInt() int {
 	fmt.Println("Dropping btcwallet transaction history")
 
 	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		// If we want to keep our tx labels, we read them out so we
+		// can re-add them after we have deleted our wtxmgr.
+		var labels map[chainhash.Hash]string
+		if !opts.DropLabels {
+			labels, err = fetchAllLabels(tx)
+			if err != nil {
+				return err
+			}
+		}
+
 		err := tx.DeleteTopLevelBucket(wtxmgrNamespace)
 		if err != nil && err != walletdb.ErrBucketNotFound {
 			return err
@@ -120,6 +135,13 @@ func mainInt() int {
 		err = wtxmgr.Create(ns)
 		if err != nil {
 			return err
+		}
+
+		// If we want to re-add our labels, we do so now.
+		if !opts.DropLabels {
+			if err := putTxLabels(ns, labels); err != nil {
+				return err
+			}
 		}
 
 		ns = tx.ReadWriteBucket(waddrmgrNamespace)
@@ -153,4 +175,70 @@ func mainInt() int {
 	}
 
 	return 0
+}
+
+// fetchAllLabels returns a map of hex-encoded txid to label.
+func fetchAllLabels(tx walletdb.ReadWriteTx) (map[chainhash.Hash]string,
+	error) {
+
+	// Get our top level bucket, if it does not exist we just exit.
+	txBucket := tx.ReadBucket(wtxmgrNamespace)
+	if txBucket == nil {
+		return nil, nil
+	}
+
+	// If we do not have a labels bucket, there are no labels so we exit.
+	labelsBucket := txBucket.NestedReadBucket(bucketTxLabels)
+	if labelsBucket == nil {
+		return nil, nil
+	}
+
+	labels := make(map[chainhash.Hash]string)
+	if err := labelsBucket.ForEach(func(k, v []byte) error {
+		txid, err := chainhash.NewHash(k)
+		if err != nil {
+			return err
+		}
+
+		label, err := wtxmgr.DeserializeLabel(v)
+		if err != nil {
+			return err
+		}
+
+		// Add an entry to our map of labels.
+		labels[*txid] = label
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return labels, nil
+}
+
+// putTxLabels re-adds a nested labels bucket and entries to the bucket provided
+// if there are any labels present.
+func putTxLabels(ns walletdb.ReadWriteBucket,
+	labels map[chainhash.Hash]string) error {
+
+	// If there are no labels, exit early.
+	if len(labels) == 0 {
+		return nil
+	}
+
+	// First, we create a labels bucket which we will add all labels to.
+	labelBucket, err := ns.CreateBucketIfNotExists(bucketTxLabels)
+	if err != nil {
+		return err
+	}
+
+	// Next, we re-add every label to the bucket.
+	for txid, label := range labels {
+		err := wtxmgr.PutTxLabel(labelBucket, txid, label)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/wtxmgr/tx.go
+++ b/wtxmgr/tx.go
@@ -984,6 +984,15 @@ func (s *Store) PutTxLabel(ns walletdb.ReadWriteBucket, txid chainhash.Hash,
 		return err
 	}
 
+	return PutTxLabel(labelBucket, txid, label)
+}
+
+// PutTxLabel writes a label for a tx to the bucket provided. Note that it does
+// not perform any validation on the label provided, or check whether there is
+// an existing label for the txid.
+func PutTxLabel(labelBucket walletdb.ReadWriteBucket, txid chainhash.Hash,
+	label string) error {
+
 	// We expect the label length to be limited on creation, so we can
 	// store the label's length as a uint16.
 	labelLen := uint16(len(label))

--- a/wtxmgr/tx.go
+++ b/wtxmgr/tx.go
@@ -1025,6 +1025,12 @@ func FetchTxLabel(ns walletdb.ReadBucket, txid chainhash.Hash) (string, error) {
 		return "", ErrTxLabelNotFound
 	}
 
+	return DeserializeLabel(v)
+}
+
+// DeserializeLabel reads a deserializes a length-value encoded label from the
+// byte array provided.
+func DeserializeLabel(v []byte) (string, error) {
 	// If the label is empty, return an error.
 	length := binary.BigEndian.Uint16(v[0:2])
 	if length == 0 {


### PR DESCRIPTION
Add an option to drop your tx labels in `dropwtxmgr`. By default, we keep labels to prevent accidental deletion of important tx information that cannot be obtained from chain. This change pulls some of the label read/write logic out into separate logic in `wtxmgr` so we do not have to duplicate it. 

Tested with some labelled txns in lnd - drop wtxmgr, labels remain; drop with `--droplables` and labels are gone. 