### PR TITLE
waddrmgr: set timestamp for genesis block sync info

### DIFF
--- a/waddrmgr/manager.go
+++ b/waddrmgr/manager.go
@@ -1772,7 +1772,11 @@ func Create(ns walletdb.ReadWriteBucket,
 
 	// Use the genesis block for the passed chain as the created at block
 	// for the default.
-	createdAt := &BlockStamp{Hash: *chainParams.GenesisHash, Height: 0}
+	createdAt := &BlockStamp{
+		Hash:      *chainParams.GenesisHash,
+		Height:    0,
+		Timestamp: chainParams.GenesisBlock.Header.Timestamp,
+	}
 
 	// Create the initial sync state.
 	syncInfo := newSyncState(createdAt, createdAt)


### PR DESCRIPTION
Not setting this would result in a non-sensible unix timestamp (2288912640) being exposed when the wallet hasn't synced any blocks, like in the case when it's waiting for the backend to sync.

Fixes https://github.com/lightningnetwork/lnd/issues/3270.