### PR TITLE
btcwallet: add missing noFreelistSync in spv mode and temp wallet

### DIFF
--- a/btcwallet.go
+++ b/btcwallet.go
@@ -161,7 +161,7 @@ func rpcClientConnectLoop(legacyRPCServer *legacyrpc.Server, loader *wallet.Load
 			)
 			netDir := networkDir(cfg.AppDataDir.Value, activeNet.Params)
 			spvdb, err = walletdb.Create("bdb",
-				filepath.Join(netDir, "neutrino.db"))
+				filepath.Join(netDir, "neutrino.db"), true)
 			defer spvdb.Close()
 			if err != nil {
 				log.Errorf("Unable to create Neutrino DB: %s", err)

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -219,7 +219,7 @@ func createSimulationWallet(cfg *config) error {
 	fmt.Println("Creating the wallet...")
 
 	// Create the wallet database backed by bolt db.
-	db, err := walletdb.Create("bdb", dbPath)
+	db, err := walletdb.Create("bdb", dbPath, true)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Running with `--usespv` got an error,
```
2020-08-11 20:54:57.642 [INF] BTCW: Version 0.11.0-alpha
2020-08-11 20:54:57.656 [INF] RPCS: Listening on 127.0.0.1:8332
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1692a94]

goroutine 26 [running]:
main.rpcClientConnectLoop(0xc0002b6000, 0xc0000841e0)
	/.../btcsuite/btcwallet/btcwallet.go:165 +0x234
created by main.walletMain
	/.../btcsuite/btcwallet/btcwallet.go:86 +0x77a
```

Running with `--createtemp` got an error,
```
Creating the wallet...
Unable to create wallet: invalid arguments to bdb.Create -- expected database path and no-freelist-sync option
```

This PR fixes it.