### PR TITLE
wallet: add mutex for locked outpoints

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -95,7 +95,8 @@ type Wallet struct {
 	chainClientSynced  bool
 	chainClientSyncMtx sync.Mutex
 
-	lockedOutpoints map[wire.OutPoint]struct{}
+	lockedOutpoints    map[wire.OutPoint]struct{}
+	lockedOutpointsMtx sync.Mutex
 
 	recoveryWindow uint32
 
@@ -2826,6 +2827,9 @@ func (w *Wallet) ImportPrivateKey(scope waddrmgr.KeyScope, wif *btcutil.WIF,
 // LockedOutpoint returns whether an outpoint has been marked as locked and
 // should not be used as an input for created transactions.
 func (w *Wallet) LockedOutpoint(op wire.OutPoint) bool {
+	w.lockedOutpointsMtx.Lock()
+	defer w.lockedOutpointsMtx.Unlock()
+
 	_, locked := w.lockedOutpoints[op]
 	return locked
 }
@@ -2833,18 +2837,27 @@ func (w *Wallet) LockedOutpoint(op wire.OutPoint) bool {
 // LockOutpoint marks an outpoint as locked, that is, it should not be used as
 // an input for newly created transactions.
 func (w *Wallet) LockOutpoint(op wire.OutPoint) {
+	w.lockedOutpointsMtx.Lock()
+	defer w.lockedOutpointsMtx.Unlock()
+
 	w.lockedOutpoints[op] = struct{}{}
 }
 
 // UnlockOutpoint marks an outpoint as unlocked, that is, it may be used as an
 // input for newly created transactions.
 func (w *Wallet) UnlockOutpoint(op wire.OutPoint) {
+	w.lockedOutpointsMtx.Lock()
+	defer w.lockedOutpointsMtx.Unlock()
+
 	delete(w.lockedOutpoints, op)
 }
 
 // ResetLockedOutpoints resets the set of locked outpoints so all may be used
 // as inputs for new transactions.
 func (w *Wallet) ResetLockedOutpoints() {
+	w.lockedOutpointsMtx.Lock()
+	defer w.lockedOutpointsMtx.Unlock()
+
 	w.lockedOutpoints = map[wire.OutPoint]struct{}{}
 }
 
@@ -2852,6 +2865,9 @@ func (w *Wallet) ResetLockedOutpoints() {
 // intended to be used by marshaling the result as a JSON array for
 // listlockunspent RPC results.
 func (w *Wallet) LockedOutpoints() []btcjson.TransactionInput {
+	w.lockedOutpointsMtx.Lock()
+	defer w.lockedOutpointsMtx.Unlock()
+
 	locked := make([]btcjson.TransactionInput, len(w.lockedOutpoints))
 	i := 0
 	for op := range w.lockedOutpoints {


### PR DESCRIPTION
Fixes an error where querying the balance while a coin selection is happening accesses the map concurrently:

```
goroutine 250410745 [running]:
runtime.throw(0x12ab8d3, 0x21)
	/home/bitcoin/go1.14/src/runtime/panic.go:1112 +0x72 fp=0xc0ac7591f0 sp=0xc0ac7591c0 pc=0x4360b2
runtime.mapaccess2(0x10b1fe0, 0xc00051c8d0, 0xc0ac759304, 0x2c, 0xc02266a4b0)
	/home/bitcoin/go1.14/src/runtime/map.go:469 +0x258 fp=0xc0ac759230 sp=0xc0ac7591f0 pc=0x40fe48
github.com/btcsuite/btcwallet/wallet.(*Wallet).LockedOutpoint(...)
	/home/bitcoin/go/pkg/mod/github.com/btcsuite/btcwallet@v0.11.1-0.20200219004649-ae9416ad7623/wallet/wallet.go:2780
github.com/btcsuite/btcwallet/wallet.(*Wallet).ListUnspent.func1(0x1591fe0, 0xc0210a8a18, 0xc0210a8a18, 0x0)
	/home/bitcoin/go/pkg/mod/github.com/btcsuite/btcwallet@v0.11.1-0.20200219004649-ae9416ad7623/wallet/wallet.go:2515 +0x3c0 fp=0xc0ac7594e0 sp=0xc0ac759230 pc=0x9a77f0
github.com/btcsuite/btcwallet/walletdb.View(0x15a5100, 0xc000c3a200, 0xc0ac759598, 0x0, 0x0)
	/home/bitcoin/go/pkg/mod/github.com/btcsuite/btcwallet/walletdb@v1.2.0/interface.go:236 +0xb0 fp=0xc0ac759558 sp=0xc0ac7594e0 pc=0x7bc280
github.com/btcsuite/btcwallet/wallet.(*Wallet).ListUnspent(0xc0004e0000, 0x7fffffff00000000, 0x0, 0xc0b01108bc, 0x8, 0x415793, 0xc0d761ab08, 0x20300d)
```