### PR TITLE
psbt: don't add scriptSig to txIn

### DIFF
--- a/wallet/psbt.go
+++ b/wallet/psbt.go
@@ -91,8 +91,10 @@ func (w *Wallet) FundPsbt(packet *psbt.Packet, account uint32,
 			}
 			packet.Inputs[idx].SighashType = txscript.SigHashAll
 
-			// We don't want to include the witness just yet.
+			// We don't want to include the witness or any script
+			// just yet.
 			packet.UnsignedTx.TxIn[idx].Witness = wire.TxWitness{}
+			packet.UnsignedTx.TxIn[idx].SignatureScript = nil
 		}
 
 		return nil


### PR DESCRIPTION
Because of an incorrect test, it wasn't discovered that the scriptSig
field was being set on the unsigned TX inputs for a nested SegWit input.
This PR fixes the bug and also refactors the test so it would have
caught this specific bug.