### PR TITLE
wtxmgr: ignore ErrBucketNotFound error upon locked outputs bucket deletion

### DIFF
--- a/wtxmgr/db.go
+++ b/wtxmgr/db.go
@@ -1543,7 +1543,8 @@ func deleteBuckets(ns walletdb.ReadWriteBucket) error {
 		str := "failed to delete unmined inputs bucket"
 		return storeError(ErrDatabase, str, err)
 	}
-	if err := ns.DeleteNestedBucket(bucketLockedOutputs); err != nil {
+	err := ns.DeleteNestedBucket(bucketLockedOutputs)
+	if err != nil && err != walletdb.ErrBucketNotFound {
 		str := "failed to delete locked outputs bucket"
 		return storeError(ErrDatabase, str, err)
 	}


### PR DESCRIPTION
This error would be seen when an old wallet that has yet to update is performing the latest wtxmgr migration. It's possible for the locked outputs bucket to not exist if outputs haven't been locked before, so we should its deletion correctly.