### PR TITLE
chain: fix alignment of atomic integers in bitcoind conn struct

### DIFF
--- a/chain/bitcoind_conn.go
+++ b/chain/bitcoind_conn.go
@@ -91,12 +91,12 @@ type BitcoindConn struct {
 	started int32 // To be used atomically.
 	stopped int32 // To be used atomically.
 
-	cfg BitcoindConfig
-
 	// rescanClientCounter is an atomic counter that assigns a unique ID to
 	// each new bitcoind rescan client using the current bitcoind
 	// connection.
 	rescanClientCounter uint64
+
+	cfg BitcoindConfig
 
 	// client is the RPC client to the bitcoind node.
 	client *rpcclient.Client


### PR DESCRIPTION
As reported by https://github.com/lightningnetwork/lnd/issues/5196, the
new atomic integer isn't properly aligned which can caus panics on
32-bit operating systems.. Tof fix this issue, we move the 64-bit
integer to lay after the two 32-bit integers at the top of the struct.