### PR TITLE
waddrmgr+wallet: allow account import for simnet wallets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LINT_BIN := $(GO_BIN)/golangci-lint
 GOACC_BIN := $(GO_BIN)/go-acc
 
 LINT_COMMIT := v1.18.0
-GOACC_COMMIT := ddc355013f90fea78d83d3a6c71f1d37ac07ecd5
+GOACC_COMMIT := 80342ae2e0fcf265e99e76bcc4efd022c7c3811b
 
 DEPGET := cd /tmp && GO111MODULE=on go get -v
 GOBUILD := GO111MODULE=on go build -v

--- a/waddrmgr/scoped_manager.go
+++ b/waddrmgr/scoped_manager.go
@@ -43,6 +43,11 @@ const (
 	// HDVersionTestNetBIP0084 is the HDVersion for BIP-0084 on the test
 	// network.
 	HDVersionTestNetBIP0084 HDVersion = 0x045f1cf6 // vpub
+
+	// HDVersionSimNetBIP0044 is the HDVersion for BIP-0044 on the
+	// simulation test network. There aren't any other versions defined for
+	// the simulation test network.
+	HDVersionSimNetBIP0044 HDVersion = 0x0420bd3a // spub
 )
 
 // DerivationPath represents a derivation path from a particular key manager's
@@ -2234,6 +2239,21 @@ func (s *ScopedKeyManager) cloneKeyWithVersion(key *hdkeychain.ExtendedKey) (
 			version = HDVersionTestNetBIP0049
 		case KeyScopeBIP0084:
 			version = HDVersionTestNetBIP0084
+		default:
+			return nil, fmt.Errorf("unsupported scope %v", s.scope)
+		}
+
+	case wire.SimNet:
+		switch s.scope {
+		case KeyScopeBIP0044:
+			version = HDVersionSimNetBIP0044
+		// We use the mainnet versions for simnet keys when the keys
+		// belong to a key scope which simnet doesn't have a defined
+		// version for.
+		case KeyScopeBIP0049Plus:
+			version = HDVersionMainNetBIP0049
+		case KeyScopeBIP0084:
+			version = HDVersionMainNetBIP0084
 		default:
 			return nil, fmt.Errorf("unsupported scope %v", s.scope)
 		}

--- a/wallet/import.go
+++ b/wallet/import.go
@@ -37,7 +37,9 @@ func keyScopeFromPubKey(pubKey *hdkeychain.ExtendedKey,
 	// force the standard BIP-0049 derivation scheme (nested witness pubkeys
 	// everywhere), while a witness address type will force the standard
 	// BIP-0084 derivation scheme.
-	case waddrmgr.HDVersionMainNetBIP0044, waddrmgr.HDVersionTestNetBIP0044:
+	case waddrmgr.HDVersionMainNetBIP0044, waddrmgr.HDVersionTestNetBIP0044,
+		waddrmgr.HDVersionSimNetBIP0044:
+
 		if addrType == nil {
 			return waddrmgr.KeyScope{}, nil, errors.New("address " +
 				"type must be specified for account public " +
@@ -110,6 +112,15 @@ func (w *Wallet) isPubKeyForNet(pubKey *hdkeychain.ExtendedKey) bool {
 		return version == waddrmgr.HDVersionTestNetBIP0044 ||
 			version == waddrmgr.HDVersionTestNetBIP0049 ||
 			version == waddrmgr.HDVersionTestNetBIP0084
+
+	// For simnet, we'll also allow the mainnet versions since simnet
+	// doesn't have defined versions for some of our key scopes, and the
+	// mainnet versions are usually used as the default regardless of the
+	// network/key scope.
+	case wire.SimNet:
+		return version == waddrmgr.HDVersionSimNetBIP0044 ||
+			version == waddrmgr.HDVersionMainNetBIP0049 ||
+			version == waddrmgr.HDVersionMainNetBIP0084
 
 	default:
 		return false


### PR DESCRIPTION
Simnet was previously left out as it didn't have defined HD versions for some of our key scopes. To allow testing importing accounts into simnet wallets, we fall back to use the mainnet HD versions.

This commit also addresses an issue with simnet wallets that would arise whenever ScopedKeyManager.AccountProperties was invoked:
`failed to retrieve account public key: unsupported net SimNet`