### PR TITLE
chain: implement GetNodeAddresses fallback for PrunedBlockDispatcher

### DIFF
--- a/chain/bitcoind_conn.go
+++ b/chain/bitcoind_conn.go
@@ -192,15 +192,14 @@ func NewBitcoindConn(cfg *BitcoindConfig) (*BitcoindConn, error) {
 	if chainInfo.Pruned {
 		prunedBlockDispatcher, err = NewPrunedBlockDispatcher(
 			&PrunedBlockDispatcherConfig{
-				ChainParams:      cfg.ChainParams,
-				NumTargetPeers:   cfg.PrunedModeMaxPeers,
-				Dial:             cfg.Dialer,
-				GetPeers:         client.GetPeerInfo,
-				PeerReadyTimeout: defaultPeerReadyTimeout,
-				RefreshPeersTicker: ticker.New(
-					defaultRefreshPeersInterval,
-				),
-				MaxRequestInvs: wire.MaxInvPerMsg,
+				ChainParams:        cfg.ChainParams,
+				NumTargetPeers:     cfg.PrunedModeMaxPeers,
+				Dial:               cfg.Dialer,
+				GetPeers:           client.GetPeerInfo,
+				GetNodeAddresses:   client.GetNodeAddresses,
+				PeerReadyTimeout:   defaultPeerReadyTimeout,
+				RefreshPeersTicker: ticker.New(defaultRefreshPeersInterval),
+				MaxRequestInvs:     wire.MaxInvPerMsg,
 			},
 		)
 		if err != nil {

--- a/chain/pruned_block_dispatcher.go
+++ b/chain/pruned_block_dispatcher.go
@@ -392,7 +392,8 @@ func (d *PrunedBlockDispatcher) newQueryPeer(
 				switch msg := msg.(type) {
 				case *wire.MsgBlock:
 					block = msg
-				case *wire.MsgVersion, *wire.MsgVerAck:
+				case *wire.MsgVersion, *wire.MsgVerAck,
+					*wire.MsgPing, *wire.MsgPong:
 					return
 				default:
 					log.Debugf("Received unexpected message "+

--- a/chain/pruned_block_dispatcher.go
+++ b/chain/pruned_block_dispatcher.go
@@ -37,8 +37,10 @@ const (
 	requiredServices = wire.SFNodeNetwork | wire.SFNodeWitness
 
 	// prunedNodeService is the service bit signaled by pruned nodes on the
-	// network.
-	prunedNodeService wire.ServiceFlag = 1 << 11
+	// network. Note that this service bit can also be signaled by full
+	// nodes, except that they also signal wire.SFNodeNetwork, where as
+	// pruned nodes don't.
+	prunedNodeService wire.ServiceFlag = 1 << 10
 )
 
 // queryPeer represents a Bitcoin network peer that we'll query for blocks.


### PR DESCRIPTION
It's possible for bitcoind instances to only have connections to pruned nodes after its initial block download, which are incompatible with the PrunedBlockDispatcher. This would result in GetBlock requests for pruned blocks to never resolve. Since bitcoind also exposes a GetNodeAddresses RPC, which returns random reachable addresses from its address manager, we can leverage it to obtain a new candidate set of peers that we otherwise wouldn't obtain through GetPeers.