### PR TITLE
wallet: add dry run implementation of ImportAccount

### DIFF
--- a/waddrmgr/scoped_manager.go
+++ b/waddrmgr/scoped_manager.go
@@ -2270,3 +2270,11 @@ func (s *ScopedKeyManager) cloneKeyWithVersion(key *hdkeychain.ExtendedKey) (
 
 	return key.CloneWithVersion(versionBytes[:])
 }
+
+// InvalidateAccountCache invalidates the cache for the given account, forcing a
+// database read to retrieve the account information.
+func (s *ScopedKeyManager) InvalidateAccountCache(account uint32) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	delete(s.acctInfo, account)
+}

--- a/wallet/import.go
+++ b/wallet/import.go
@@ -192,6 +192,24 @@ func (w *Wallet) ImportAccount(name string, accountPubKey *hdkeychain.ExtendedKe
 	masterKeyFingerprint uint32, addrType *waddrmgr.AddressType) (
 	*waddrmgr.AccountProperties, error) {
 
+	var accountProps *waddrmgr.AccountProperties
+	err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+		var err error
+		accountProps, err = w.importAccount(
+			ns, name, accountPubKey, masterKeyFingerprint, addrType,
+		)
+		return err
+	})
+	return accountProps, err
+}
+
+// importAccount is the internal implementation of ImportAccount -- one should
+// reference its documentation for this method.
+func (w *Wallet) importAccount(ns walletdb.ReadWriteBucket, name string,
+	accountPubKey *hdkeychain.ExtendedKey, masterKeyFingerprint uint32,
+	addrType *waddrmgr.AddressType) (*waddrmgr.AccountProperties, error) {
+
 	// Ensure we have a valid account public key.
 	if err := w.validateExtendedPubKey(accountPubKey, true); err != nil {
 		return nil, err
@@ -208,21 +226,80 @@ func (w *Wallet) ImportAccount(name string, accountPubKey *hdkeychain.ExtendedKe
 		return nil, err
 	}
 
-	// Store the account as watch-only within the database.
-	var accountProps *waddrmgr.AccountProperties
-	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		account, err := scopedMgr.NewAccountWatchingOnly(
-			ns, name, accountPubKey, masterKeyFingerprint,
-			addrSchema,
-		)
-		if err != nil {
-			return err
-		}
-		accountProps, err = scopedMgr.AccountProperties(ns, account)
-		return err
-	})
-	return accountProps, err
+	account, err := scopedMgr.NewAccountWatchingOnly(
+		ns, name, accountPubKey, masterKeyFingerprint, addrSchema,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return scopedMgr.AccountProperties(ns, account)
+}
+
+// ImportAccountDryRun serves as a dry run implementation of ImportAccount. This
+// method also returns the first N external and internal addresses, which can be
+// presented to users to confirm whether the account has been imported
+// correctly.
+func (w *Wallet) ImportAccountDryRun(name string,
+	accountPubKey *hdkeychain.ExtendedKey, masterKeyFingerprint uint32,
+	addrType *waddrmgr.AddressType, numAddrs uint32) (
+	*waddrmgr.AccountProperties, []waddrmgr.ManagedAddress,
+	[]waddrmgr.ManagedAddress, error) {
+
+	// Start a database transaction that we'll never commit and always
+	// rollback.
+	tx, err := w.db.BeginReadWriteTx()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+	ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+	// Import the account as usual.
+	accountProps, err := w.importAccount(
+		ns, name, accountPubKey, masterKeyFingerprint, addrType,
+	)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Derive the external and internal addresses. Note that we could do
+	// this based on the provided accountPubKey alone, but we go through the
+	// ScopedKeyManager instead to ensure addresses will be derived as
+	// expected from the wallet's point-of-view.
+	manager, err := w.Manager.FetchScopedKeyManager(accountProps.KeyScope)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// The importAccount method above will cache the imported account within
+	// the scoped manager. Since this is a dry-run attempt, we'll want to
+	// invalidate the cache for it.
+	defer manager.InvalidateAccountCache(accountProps.AccountNumber)
+
+	externalAddrs, err := manager.NextExternalAddresses(
+		ns, accountProps.AccountNumber, numAddrs,
+	)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	internalAddrs, err := manager.NextInternalAddresses(
+		ns, accountProps.AccountNumber, numAddrs,
+	)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Refresh the account's properties after generating the addresses.
+	accountProps, err = manager.AccountProperties(
+		ns, accountProps.AccountNumber,
+	)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return accountProps, externalAddrs, internalAddrs, nil
 }
 
 // ImportPublicKey imports a single derived public key into the address manager.


### PR DESCRIPTION
This method does not commit the database transaction importing the account and returns the first N external and internal addresses, which can be presented to users to confirm whether the account has been imported correctly.