### PR TITLE
internal/prompt: allow compilation in js/wasm environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ check: unit
 
 unit:
 	@$(call print, "Running unit tests.")
-	$(GOLIST) | $(XARGS) env $(GOTEST)
+	$(GOLIST) | $(XARGS) env $(GOTEST) -test.timeout=20m
 
 unit-cover: $(GOACC_BIN)
 	@$(call print, "Running unit coverage tests.")
@@ -89,7 +89,7 @@ unit-cover: $(GOACC_BIN)
 
 unit-race:
 	@$(call print, "Running unit race tests.")
-	env CGO_ENABLED=1 GORACE="history_size=7 halt_on_errors=1" $(GOLIST) | $(XARGS) env $(GOTEST) -race
+	env CGO_ENABLED=1 GORACE="history_size=7 halt_on_errors=1" $(GOLIST) | $(XARGS) env $(GOTEST) -race -test.timeout=20m
 
 # =========
 # UTILITIES

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
+// +build !js
+
 package prompt
 
 import (

--- a/internal/prompt/prompt_js.go
+++ b/internal/prompt/prompt_js.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2015-2021 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package prompt
+
+import (
+	"bufio"
+	"fmt"
+
+	"github.com/btcsuite/btcwallet/internal/legacy/keystore"
+)
+
+func ProvideSeed() ([]byte, error) {
+	return nil, fmt.Errorf("prompt not supported in WebAssembly")
+}
+
+func ProvidePrivPassphrase() ([]byte, error) {
+	return nil, fmt.Errorf("prompt not supported in WebAssembly")
+}
+
+func PrivatePass(_ *bufio.Reader, _ *keystore.Store) ([]byte, error) {
+	return nil, fmt.Errorf("prompt not supported in WebAssembly")
+}
+
+func PublicPass(_ *bufio.Reader, _, _, _ []byte) ([]byte, error) {
+	return nil, fmt.Errorf("prompt not supported in WebAssembly")
+}
+
+func Seed(_ *bufio.Reader) ([]byte, error) {
+	return nil, fmt.Errorf("prompt not supported in WebAssembly")
+}


### PR DESCRIPTION
The wallet loader has a dependency to the internal/prompt package for
prompting the user for certain inputs (e.g. wallet password or new
seed).
This makes it impossible for projects that use the wallet as a
dependency and always provide those inputs as parameters to compile for
JavaScript/WebAssembly targets because the prompt code uses some
terminal functionality that is not available in JS syscalls.
By providing a JS specific implementation that just returns an error we
can compile the dependent projects.
Adding acutal support for prompting the user in the browser is currently
not planned as that can easily be circumvented by providing all inputs
as parameters.

cc @Roasbeef @wpaulino 