### PR TITLE
Prevent duplicate notifications for (un)confirmed transactions

### DIFF
--- a/wtxmgr/tx_test.go
+++ b/wtxmgr/tx_test.go
@@ -7,6 +7,7 @@ package wtxmgr
 import (
 	"bytes"
 	"encoding/hex"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -192,6 +193,13 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 					return nil, err
 				}
 
+				// Check that the duplicate transaction is found.
+				if exists, _ := s.InsertTxCheckIfExists(ns, rec, nil); !exists {
+					return nil, fmt.Errorf(
+						"duplicate transaction was not found as already recorded",
+					)
+				}
+
 				err = s.AddCredit(ns, rec, nil, 0, false)
 				return s, err
 			},
@@ -242,6 +250,13 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 				err = s.InsertTx(ns, rec, TstRecvTxBlockDetails)
 				if err != nil {
 					return nil, err
+				}
+
+				// Make sure the duplicate transaction is found.
+				if exists, _ := s.InsertTxCheckIfExists(ns, rec, TstRecvTxBlockDetails); !exists {
+					return nil, fmt.Errorf(
+						"duplicate transaction was not found as already recorded",
+					)
 				}
 
 				err = s.AddCredit(ns, rec, TstRecvTxBlockDetails, 0, false)

--- a/wtxmgr/unconfirmed.go
+++ b/wtxmgr/unconfirmed.go
@@ -22,7 +22,7 @@ func (s *Store) insertMemPoolTx(ns walletdb.ReadWriteBucket, rec *TxRecord) erro
 	// TODO: compare serialized txs to ensure this isn't a hash
 	// collision?
 	if txDetails, _ := s.TxDetails(ns, &rec.Hash); txDetails != nil {
-		return nil
+		return ErrDuplicateTx
 	}
 
 	// Since transaction records within the store are keyed by their


### PR DESCRIPTION
### Background

Relevant confirmed and unconfirmed transactions may be notified multiple times. The reason seems to be that there are multiple paths that lead to entrance into the `addRelevantTx` function. This will then always trigger a notification regardless if the transaction was already recorded or not.

This PR addresses this issue by adding a new method `InsertTxCheckIfExists` to the `TxStore`, which allows `addRelevantTx` to skip all the logic only required for new transactions, including notification of transactions that were already recorded.

This should fix lightningnetwork/lnd#2267

Arguably adding better testing of this can be added, which I have only done in this PR in a simplistic manner but would improve on.