### PR TITLE
mod: fix submodule versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ require (
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
 	github.com/btcsuite/btcutil/psbt v1.0.3-0.20201208143702-a53e38424cce
-	github.com/btcsuite/btcwallet/wallet/txauthor v1.0.0
+	github.com/btcsuite/btcwallet/wallet/txauthor v1.0.1-0.20210329233242-e0607006dce6
 	github.com/btcsuite/btcwallet/wallet/txrules v1.0.0
-	github.com/btcsuite/btcwallet/wallet/txsizes v1.0.0
+	github.com/btcsuite/btcwallet/wallet/txsizes v1.0.1-0.20210519225359-6ab9b615576f
 	github.com/btcsuite/btcwallet/walletdb v1.3.5
 	github.com/btcsuite/btcwallet/wtxmgr v1.3.0
 	github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792


### PR DESCRIPTION
Fixes #750.

The submodules wallet/txauthor and wallet/txsizes were updated without a
new tag being created. This works fine when compiling btcwallet from
source but fails when using "go get" as that ignores the replace
directives.

@Roasbeef we should push new tags, `wallet/txauthor/v1.0.1` and `wallet/txsizes/v1.0.1` to fix this properly.