### PR TITLE
wallet: allow zero output psbt funding

### DIFF
--- a/wallet/psbt.go
+++ b/wallet/psbt.go
@@ -45,10 +45,15 @@ func (w *Wallet) FundPsbt(packet *psbt.Packet, keyScope *waddrmgr.KeyScope,
 	coinSelectionStrategy CoinSelectionStrategy) (int32, error) {
 
 	// Make sure the packet is well formed. We only require there to be at
-	// least one output but not necessarily any inputs.
-	err := psbt.VerifyInputOutputLen(packet, false, true)
+	// least one input or output.
+	err := psbt.VerifyInputOutputLen(packet, false, false)
 	if err != nil {
 		return 0, err
+	}
+
+	if len(packet.UnsignedTx.TxIn) == 0 && len(packet.UnsignedTx.TxOut) == 0 {
+		return 0, fmt.Errorf("PSBT packet must contain at least one " +
+			"input or output")
 	}
 
 	txOut := packet.UnsignedTx.TxOut

--- a/wallet/psbt_test.go
+++ b/wallet/psbt_test.go
@@ -89,7 +89,22 @@ func TestFundPsbt(t *testing.T) {
 			UnsignedTx: &wire.MsgTx{},
 		},
 		feeRateSatPerKB: 0,
-		expectedErr:     "must contain at least one output",
+		expectedErr:     "PSBT packet must contain at least one input or output",
+	}, {
+		name: "single input, no outputs",
+		packet: &psbt.Packet{
+			UnsignedTx: &wire.MsgTx{
+				TxIn: []*wire.TxIn{{
+					PreviousOutPoint: utxo1,
+				}},
+			},
+			Inputs: []psbt.PInput{{}},
+		},
+		feeRateSatPerKB: 20000,
+		validatePackage: true,
+		expectedInputs:  []wire.OutPoint{utxo1},
+		expectedFee:     2200,
+		expectedChange:  997800,
 	}, {
 		name: "no dust outputs",
 		packet: &psbt.Packet{


### PR DESCRIPTION
To support the cpfp fee bump use case where no external outputs are required.