### PR TITLE
wtxmgr: filter out expired leases

### DIFF
--- a/wtxmgr/tx.go
+++ b/wtxmgr/tx.go
@@ -1240,6 +1240,12 @@ func (s *Store) ListLockedOutputs(ns walletdb.ReadBucket) ([]*LockedOutput,
 	var outputs []*LockedOutput
 	err := forEachLockedOutput(
 		ns, func(op wire.OutPoint, id LockID, expiration time.Time) {
+			// Skip expired leases. They will be cleaned up with the
+			// next call to DeleteExpiredLockedOutputs.
+			if !s.clock.Now().Before(expiration) {
+				return
+			}
+
 			outputs = append(outputs, &LockedOutput{
 				Outpoint:   op,
 				LockID:     id,

--- a/wtxmgr/tx_test.go
+++ b/wtxmgr/tx_test.go
@@ -2780,6 +2780,16 @@ func TestOutputLocks(t *testing.T) {
 				// Let the output lock expired.
 				s.clock.(*clock.TestClock).SetTime(expiry)
 
+				// Lock should not longer be listed.
+				assertOutputLocksExist(t, s, ns)
+
+				// But the lock should still exist and active
+				// when time is turned back.
+				assertLocked(
+					t, ns, confirmedOutPoint, time.Time{},
+					true,
+				)
+
 				// Delete all expired locked outputs. We should
 				// no longer see any locked outputs.
 				err = s.DeleteExpiredLockedOutputs(ns)
@@ -2788,6 +2798,10 @@ func TestOutputLocks(t *testing.T) {
 						"locked outputs: %v", err)
 				}
 				assertOutputLocksExist(t, s, ns)
+				assertLocked(
+					t, ns, confirmedOutPoint, time.Time{},
+					false,
+				)
 			},
 		},
 	}


### PR DESCRIPTION
Expired leases are kept in the database until the next cleaning round. This commit makes sure that expired leases look like they do not exist to outside callers.