### PR TITLE
waddrmgr: fix concurrent map access

### DIFF
--- a/waddrmgr/scoped_manager.go
+++ b/waddrmgr/scoped_manager.go
@@ -518,8 +518,8 @@ func (s *ScopedKeyManager) loadAccountInfo(ns walletdb.ReadBucket,
 func (s *ScopedKeyManager) AccountProperties(ns walletdb.ReadBucket,
 	account uint32) (*AccountProperties, error) {
 
-	defer s.mtx.RUnlock()
-	s.mtx.RLock()
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
 
 	props := &AccountProperties{
 		AccountNumber: account,


### PR DESCRIPTION
Fixes lightningnetwork/lnd#5864.
The loadAccountInfo does load an account as its name suggests. But after
loading it, the account is also added to a map to cache it. That map
write should be seen as a writing operation and therefore the _write_
lock must be held, not just the read lock.