### PR TITLE
waddrmgr/wallet: synchronize recovery shutdown with locking

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/btcsuite/btcd/blockchain"
@@ -113,6 +114,7 @@ type Wallet struct {
 	lockedOutpoints    map[wire.OutPoint]struct{}
 	lockedOutpointsMtx sync.Mutex
 
+	recovering     atomic.Value
 	recoveryWindow uint32
 
 	// Channels for rescan processing.  Requests are added and merged with
@@ -651,6 +653,15 @@ func locateBirthdayBlock(chainClient chainConn,
 	return birthdayBlock, nil
 }
 
+// recoverySyncer is used to synchronize wallet and address manager locking
+// with the end of recovery. (*Wallet).recovery will store a recoverySyncer
+// when invoked, and will close the done chan upon exit. Setting the quit flag
+// will cause recovery to end after the current batch of blocks.
+type recoverySyncer struct {
+	done chan struct{}
+	quit uint32 // atomic
+}
+
 // recovery attempts to recover any unspent outputs that pay to any of our
 // addresses starting from our birthday, or the wallet's tip (if higher), which
 // would indicate resuming a recovery after a restart.
@@ -659,6 +670,13 @@ func (w *Wallet) recovery(chainClient chain.Interface,
 
 	log.Infof("RECOVERY MODE ENABLED -- rescanning for used addresses "+
 		"with recovery_window=%d", w.recoveryWindow)
+
+	// Wallet locking must synchronize with the end of recovery, since use of
+	// keys in recovery is racy with manager IsLocked checks, which could
+	// result in enrypting data with a zeroed key.
+	syncer := &recoverySyncer{done: make(chan struct{})}
+	w.recovering.Store(syncer)
+	defer close(syncer.done)
 
 	// We'll initialize the recovery manager with a default batch size of
 	// 2000.
@@ -707,6 +725,10 @@ func (w *Wallet) recovery(chainClient chain.Interface,
 	var blocks []*waddrmgr.BlockStamp
 	startHeight := w.Manager.SyncedTo().Height + 1
 	for height := startHeight; height <= bestHeight; height++ {
+		if atomic.LoadUint32(&syncer.quit) == 1 {
+			return errors.New("recovery: forced shutdown")
+		}
+
 		hash, err := chainClient.GetBlockHash(int64(height))
 		if err != nil {
 			return err
@@ -1351,6 +1373,17 @@ out:
 
 		// Select statement fell through by an explicit lock or the
 		// timer expiring.  Lock the manager here.
+
+		// We can't lock the manager if recovery is active because we use
+		// cryptoKeyPriv and cryptoKeyScript in recovery.
+		if recoverySyncI := w.recovering.Load(); recoverySyncI != nil {
+			recoverySync := recoverySyncI.(*recoverySyncer)
+			// If recovery is still running, it will end early with an error
+			// once we set the quit flag.
+			atomic.StoreUint32(&recoverySync.quit, 1)
+			<-recoverySync.done
+		}
+
 		timeout = nil
 		err := w.Manager.Lock()
 		if err != nil && !waddrmgr.IsError(err, waddrmgr.ErrLocked) {

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1381,7 +1381,13 @@ out:
 			// If recovery is still running, it will end early with an error
 			// once we set the quit flag.
 			atomic.StoreUint32(&recoverySync.quit, 1)
-			<-recoverySync.done
+
+			select {
+			case <-recoverySync.done:
+			case <-quit:
+				break out
+			}
+
 		}
 
 		timeout = nil


### PR DESCRIPTION
`(*Wallet).recovery` is the only internal consumer of `(*RecoveryManager).Resurrect`
and `(*Wallet).recoverScopedAddresses`, which together account for all uses
of `(*ScopedKeyManager).DeriveFromKeyPath`. The `(*ScopedKeyManager).mtx` is locked
there, but not the `(*ScopedKeyManager).rootManager.mtx`, which protects
the `cryptoKeyPriv` and `cryptoKeyScript` while being zeroed during `(*Manager).Lock`. There is
some care taken to prevent operations with these keys with the `(*Manager).mtx`
locked, but the actual operations involving the keys are done outside
of the `rootManager.mtx` lock, meaning a `(*Manager).Lock` could occur after
a `(*Manager).IsLocked` check, resulting in a race condition with the keys being zeroed as
they're being read, or even with data being encrypted with a zeroed key. [The race was observed](https://gist.github.com/chappjc/df4637a374fbc067af09e6df3fe3c819)
in testing.

Other approaches were considered. Unfortunately, the `ScopedKeyManager`
cannot forego its own mutex and share the Manager's mutex, since there
are multiple recursions. We could carefully lock `(*Manager).mtx`
only around the places it's used, and check the `(*Manager).locked`
every time after locking and before use, returning an error if
locked, but that's pretty tedious and doesn't solve the larger
issue of synchronizing wallet locking with a clean end of recovery.

This PR does not address the general issue of unsafe uses of the `cryptoKeyPriv`/`cryptoKeyScript` by `ScopedKeyManager`, but does fix the issues that we observed in testing.