### PR TITLE
Add witness script address support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/btcsuite/btcwallet
 require (
 	github.com/btcsuite/btcd v0.22.0-beta.0.20210803133449-f5a1fb9965e4
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
-	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
-	github.com/btcsuite/btcutil/psbt v1.0.3-0.20201208143702-a53e38424cce
+	github.com/btcsuite/btcutil v1.0.3-0.20210929233259-9cdf59f60c51
+	github.com/btcsuite/btcutil/psbt v1.0.3-0.20210929233259-9cdf59f60c51
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.1.0
 	github.com/btcsuite/btcwallet/wallet/txrules v1.1.0
 	github.com/btcsuite/btcwallet/wallet/txsizes v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -10,10 +10,11 @@ github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
 github.com/btcsuite/btcutil v1.0.2/go.mod h1:j9HUFwoQRsZL3V4n+qG+CUnEGHOarIxfC3Le2Yhbcts=
-github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce h1:YtWJF7RHm2pYCvA5t0RPmAaLUhREsKuKd+SLhxFbFeQ=
 github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce/go.mod h1:0DVlHczLPewLcPGEIeUEzfOJhqGPQ0mJJRDBtD307+o=
-github.com/btcsuite/btcutil/psbt v1.0.3-0.20201208143702-a53e38424cce h1:3PRwz+js0AMMV1fHRrCdQ55akoomx4Q3ulozHC3BDDY=
-github.com/btcsuite/btcutil/psbt v1.0.3-0.20201208143702-a53e38424cce/go.mod h1:LVveMu4VaNSkIRTZu2+ut0HDBRuYjqGocxDMNS1KuGQ=
+github.com/btcsuite/btcutil v1.0.3-0.20210929233259-9cdf59f60c51 h1:6XGSs4BMDRlNR9k+tpr1g2S6ZfQhKQl/Xr276yAEfP0=
+github.com/btcsuite/btcutil v1.0.3-0.20210929233259-9cdf59f60c51/go.mod h1:0DVlHczLPewLcPGEIeUEzfOJhqGPQ0mJJRDBtD307+o=
+github.com/btcsuite/btcutil/psbt v1.0.3-0.20210929233259-9cdf59f60c51 h1:NPiODiJszw7wgDeizXPaaZKrN3qFLOyNg+wPkbpAEhQ=
+github.com/btcsuite/btcutil/psbt v1.0.3-0.20210929233259-9cdf59f60c51/go.mod h1:LVveMu4VaNSkIRTZu2+ut0HDBRuYjqGocxDMNS1KuGQ=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd h1:R/opQEbFEy9JGkIguV40SvRY1uliPX8ifOvi6ICsFCw=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd/go.mod h1:HHNXQzUsZCxOoE+CPiyCTO6x34Zs86zZUiwtpXoGdtg=
 github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVaaLLH7j4eDXPRvw78tMflu7Ie2bzYOH4Y8rRKBY=

--- a/waddrmgr/address.go
+++ b/waddrmgr/address.go
@@ -508,7 +508,7 @@ type scriptAddress struct {
 	account         uint32
 	address         *btcutil.AddressScriptHash
 	scriptEncrypted []byte
-	scriptCT        []byte
+	scriptClearText []byte
 	scriptMutex     sync.Mutex
 }
 
@@ -524,7 +524,7 @@ func (a *scriptAddress) unlock(key EncryptorDecryptor) ([]byte, error) {
 	a.scriptMutex.Lock()
 	defer a.scriptMutex.Unlock()
 
-	if len(a.scriptCT) == 0 {
+	if len(a.scriptClearText) == 0 {
 		script, err := key.Decrypt(a.scriptEncrypted)
 		if err != nil {
 			str := fmt.Sprintf("failed to decrypt script for %s",
@@ -532,20 +532,20 @@ func (a *scriptAddress) unlock(key EncryptorDecryptor) ([]byte, error) {
 			return nil, managerError(ErrCrypto, str, err)
 		}
 
-		a.scriptCT = script
+		a.scriptClearText = script
 	}
 
-	scriptCopy := make([]byte, len(a.scriptCT))
-	copy(scriptCopy, a.scriptCT)
+	scriptCopy := make([]byte, len(a.scriptClearText))
+	copy(scriptCopy, a.scriptClearText)
 	return scriptCopy, nil
 }
 
-// lock zeroes the associated clear text private key.
+// lock zeroes the associated clear text script.
 func (a *scriptAddress) lock() {
 	// Zero and nil the clear text script associated with this address.
 	a.scriptMutex.Lock()
-	zero.Bytes(a.scriptCT)
-	a.scriptCT = nil
+	zero.Bytes(a.scriptClearText)
+	a.scriptClearText = nil
 	a.scriptMutex.Unlock()
 }
 

--- a/waddrmgr/scoped_manager.go
+++ b/waddrmgr/scoped_manager.go
@@ -2114,8 +2114,8 @@ func (s *ScopedKeyManager) ImportScript(ns walletdb.ReadWriteBucket,
 		return nil, err
 	}
 	if !s.rootManager.WatchOnly() {
-		scriptAddr.scriptCT = make([]byte, len(script))
-		copy(scriptAddr.scriptCT, script)
+		scriptAddr.scriptClearText = make([]byte, len(script))
+		copy(scriptAddr.scriptClearText, script)
 	}
 
 	// Add the new managed address to the cache of recent addresses and


### PR DESCRIPTION
Replaces/continues https://github.com/btcsuite/btcwallet/pull/625.

Adds a new witness script address type with witness v0 and v1 support.
We also add a flag `isSecretScript` that can be set to false to make it possible to use a script address in a watch-only wallet.

cc @Roasbeef, @positiveblue