### PR TITLE
wallet: export ScriptForOutput

### DIFF
--- a/wallet/psbt.go
+++ b/wallet/psbt.go
@@ -117,7 +117,7 @@ func (w *Wallet) FundPsbt(packet *psbt.Packet, keyScope *waddrmgr.KeyScope,
 			// For nested P2WKH we need to add the redeem script to
 			// the input, otherwise an offline wallet won't be able
 			// to sign for it. For normal P2WKH this will be nil.
-			addr, witnessProgram, _, err := w.scriptForOutput(utxo)
+			addr, witnessProgram, _, err := w.ScriptForOutput(utxo)
 			if err != nil {
 				return fmt.Errorf("error fetching UTXO "+
 					"script: %v", err)

--- a/wallet/signer.go
+++ b/wallet/signer.go
@@ -14,10 +14,10 @@ import (
 	"github.com/btcsuite/btcwallet/waddrmgr"
 )
 
-// scriptForOutput returns the address, witness program and redeem script for a
+// ScriptForOutput returns the address, witness program and redeem script for a
 // given UTXO. An error is returned if the UTXO does not belong to our wallet or
 // it is not a managed pubKey address.
-func (w *Wallet) scriptForOutput(output *wire.TxOut) (
+func (w *Wallet) ScriptForOutput(output *wire.TxOut) (
 	waddrmgr.ManagedPubKeyAddress, []byte, []byte, error) {
 
 	// First make sure we can sign for the input by making sure the script
@@ -92,7 +92,7 @@ func (w *Wallet) ComputeInputScript(tx *wire.MsgTx, output *wire.TxOut,
 	hashType txscript.SigHashType, tweaker PrivKeyTweaker) (wire.TxWitness,
 	[]byte, error) {
 
-	walletAddr, witnessProgram, sigScript, err := w.scriptForOutput(output)
+	walletAddr, witnessProgram, sigScript, err := w.ScriptForOutput(output)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
We need to be able to call ScriptForOutput in external code, so we
export it.

cc @yyforyongyu, @Roasbeef 