### PR TITLE
chain: RPC polling for block and tx events

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,8 @@ env:
   GO111MODULE: on
 
   GO_VERSION: '^1.17.0'
+  BITCOIND_VERSION: '22.0'
+  BITCOIND_IMAGE: 'lightninglabs/bitcoin-core'
 
 jobs:
   ########################
@@ -59,6 +61,13 @@ jobs:
           - unit-race
           - unit-cover
     steps:
+      - name: extract bitcoind from docker image
+        run: |-
+          docker pull ${{ env.BITCOIND_IMAGE }}:${{ env.BITCOIND_VERSION }}
+          CONTAINER_ID=$(docker create ${{ env.BITCOIND_IMAGE }}:${{ env.BITCOIND_VERSION }})
+          sudo docker cp $CONTAINER_ID:/opt/bitcoin-${{ env.BITCOIND_VERSION }}/bin/bitcoind /usr/local/bin/bitcoind
+          docker rm $CONTAINER_ID
+
       - name: git checkout
         uses: actions/checkout@v2
 

--- a/chain/bitcoind_conn.go
+++ b/chain/bitcoind_conn.go
@@ -61,6 +61,11 @@ type BitcoindConfig struct {
 	// zmq connections to bitcoind.
 	ZMQConfig *ZMQConfig
 
+	// PollingConfig holds the configuration settings required for using
+	// RPC polling for block and transaction notifications instead of the
+	// ZMQ interface.
+	PollingConfig *PollingConfig
+
 	// Dialer is a closure we'll use to dial Bitcoin peers. If the chain
 	// backend is running over Tor, this must support dialing peers over Tor
 	// as well.
@@ -177,7 +182,7 @@ func NewBitcoindConn(cfg *BitcoindConfig) (*BitcoindConn, error) {
 		quit:                  make(chan struct{}),
 	}
 
-	bc.events, err = NewBitcoindEventSubscriber(cfg)
+	bc.events, err = NewBitcoindEventSubscriber(cfg, client)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/bitcoind_conn.go
+++ b/chain/bitcoind_conn.go
@@ -339,8 +339,8 @@ func (c *BitcoindConn) NewBitcoindClient() *BitcoindClient {
 		watchedTxs:       make(map[chainhash.Hash]struct{}),
 
 		notificationQueue: NewConcurrentQueue(20),
-		txNtfns:           make(chan *wire.MsgTx),
-		blockNtfns:        make(chan *wire.MsgBlock),
+		txNtfns:           make(chan *wire.MsgTx, 1000),
+		blockNtfns:        make(chan *wire.MsgBlock, 100),
 
 		mempool:        make(map[chainhash.Hash]struct{}),
 		expiredMempool: make(map[int32]map[chainhash.Hash]struct{}),

--- a/chain/bitcoind_events.go
+++ b/chain/bitcoind_events.go
@@ -8,8 +8,20 @@ import (
 	"sync"
 	"time"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/gozmq"
+)
+
+const (
+	// defaultBlockPollInterval is the default interval used for querying
+	// for new blocks.
+	defaultBlockPollInterval = time.Second * 10
+
+	// defaultTxPollInterval is the default interval used for querying
+	// for new mempool transactions.
+	defaultTxPollInterval = time.Second * 10
 )
 
 // BitcoindEvents is the interface that must be satisfied by any type that
@@ -32,7 +44,33 @@ type BitcoindEvents interface {
 
 // NewBitcoindEventSubscriber initialises a new BitcoinEvents object impl
 // depending on the config passed.
-func NewBitcoindEventSubscriber(cfg *BitcoindConfig) (BitcoindEvents, error) {
+func NewBitcoindEventSubscriber(cfg *BitcoindConfig,
+	client *rpcclient.Client) (BitcoindEvents, error) {
+
+	if cfg.PollingConfig != nil && cfg.ZMQConfig != nil {
+		return nil, fmt.Errorf("either PollingConfig or ZMQConfig " +
+			"should be specified, not both")
+	}
+
+	if cfg.PollingConfig != nil {
+		if client == nil {
+			return nil, fmt.Errorf("rpc client must be given " +
+				"if rpc polling is to be used for event " +
+				"subscriptions")
+		}
+
+		pollingEvents := newBitcoindRPCPollingEvents(
+			cfg.PollingConfig, client,
+		)
+
+		return pollingEvents, nil
+	}
+
+	if cfg.ZMQConfig == nil {
+		return nil, fmt.Errorf("ZMQConfig must be specified if " +
+			"rpcpolling is disabled")
+	}
+
 	return newBitcoindZMQEvents(cfg.ZMQConfig)
 }
 
@@ -337,5 +375,331 @@ func (b *bitcoindZMQEvents) txEventHandler() {
 			log.Warnf("Received unexpected event type from %v "+
 				"subscription: %v", rawTxZMQCommand, eventType)
 		}
+	}
+}
+
+// PollingConfig holds all the config options used for setting up
+// bitcoindRPCPollingEvents.
+type PollingConfig struct {
+	// BlockPollingInterval is the interval that will be used to poll
+	// bitcoind for new blocks.
+	BlockPollingInterval time.Duration
+
+	// TxPollingInterval is the interval that will be used to poll bitcoind
+	// for new transactions.
+	TxPollingInterval time.Duration
+}
+
+// bitcoindRPCPollingEvents delivers block and transaction notifications that
+// it gets by polling bitcoind's rpc interface at regular intervals.
+type bitcoindRPCPollingEvents struct {
+	cfg *PollingConfig
+
+	client *rpcclient.Client
+
+	// mempool holds all the transactions that we currently see as being in
+	// the mempool. This is used so that we know which transactions we have
+	// already sent notifications for.
+	mempool *mempool
+
+	// blockNtfns is a channel to which any new blocks will be sent.
+	blockNtfns chan *wire.MsgBlock
+
+	// txNtfns is a channel to which any new transactions will be sent.
+	txNtfns chan *wire.MsgTx
+
+	wg   sync.WaitGroup
+	quit chan struct{}
+}
+
+// newBitcoindRPCPollingEvents instantiates a new bitcoindRPCPollingEvents
+// object.
+func newBitcoindRPCPollingEvents(cfg *PollingConfig,
+	client *rpcclient.Client) *bitcoindRPCPollingEvents {
+
+	if cfg.BlockPollingInterval == 0 {
+		cfg.BlockPollingInterval = defaultBlockPollInterval
+	}
+
+	if cfg.TxPollingInterval == 0 {
+		cfg.TxPollingInterval = defaultTxPollInterval
+	}
+
+	return &bitcoindRPCPollingEvents{
+		cfg:        cfg,
+		client:     client,
+		txNtfns:    make(chan *wire.MsgTx),
+		blockNtfns: make(chan *wire.MsgBlock),
+		mempool:    newMempool(),
+		quit:       make(chan struct{}),
+	}
+}
+
+// Start kicks off all the bitcoindRPCPollingEvents goroutines.
+func (b *bitcoindRPCPollingEvents) Start() error {
+	info, err := b.client.GetBlockChainInfo()
+	if err != nil {
+		return err
+	}
+
+	b.wg.Add(2)
+	go b.blockEventHandlerRPC(info.Blocks)
+	go b.txEventHandlerRPC()
+	return nil
+}
+
+// Stop cleans up all the bitcoindRPCPollingEvents resources and goroutines.
+func (b *bitcoindRPCPollingEvents) Stop() error {
+	close(b.quit)
+	b.wg.Wait()
+	return nil
+}
+
+// TxNotifications returns a channel which will deliver new transactions.
+func (b *bitcoindRPCPollingEvents) TxNotifications() <-chan *wire.MsgTx {
+	return b.txNtfns
+}
+
+// BlockNotifications returns a channel which will deliver new blocks.
+func (b *bitcoindRPCPollingEvents) BlockNotifications() <-chan *wire.MsgBlock {
+	return b.blockNtfns
+}
+
+// blockEventHandlerRPC is a goroutine that uses the rpc client to check if we
+// have a new block every so often.
+func (b *bitcoindRPCPollingEvents) blockEventHandlerRPC(startHeight int32) {
+	defer b.wg.Done()
+
+	ticker := time.NewTicker(b.cfg.BlockPollingInterval)
+	defer ticker.Stop()
+
+	height := startHeight
+	log.Infof("Started polling for new bitcoind blocks via RPC at "+
+		"height %d", height)
+
+	for {
+		select {
+		case <-ticker.C:
+			// At every interval, we poll to see if there's a block
+			// with a height that exceeds the height that we
+			// previously recorded.
+			info, err := b.client.GetBlockChainInfo()
+			if err != nil {
+				log.Errorf("Unable to retrieve best block: "+
+					"%v", err)
+				continue
+			}
+
+			// If the block isn't new, we continue and wait for the
+			// next interval tick. In order to replicate the
+			// behaviour of the zmq block subscription, we only do
+			// a height based check here. We only deliver
+			// notifications if the new block has a height above the
+			// one we previously saw. The caller is left to
+			// determine if there has been a reorg.
+			if info.Blocks <= height {
+				continue
+			}
+
+			// Since we do a height based check, we send
+			// notifications for each block with a height between
+			// the last height we recorded and the new height.
+			for i := height + 1; i <= info.Blocks; i++ {
+				newHash, err := b.client.GetBlockHash(int64(i))
+				if err != nil {
+					log.Errorf("Unable to retrieve "+
+						"block hash: %v", err)
+					continue
+				}
+
+				newBlock, err := b.client.GetBlock(newHash)
+				if err != nil {
+					log.Errorf("Unable to retrieve "+
+						"block: %v", err)
+					continue
+				}
+
+				// notify the client of the new block.
+				select {
+				case b.blockNtfns <- newBlock:
+				case <-b.quit:
+					return
+				}
+
+				// From our local mempool map, let's remove each
+				// of the transactions that are confirmed in
+				// this new block, since they are no longer in
+				// the mempool.
+				b.mempool.clean(newBlock.Transactions)
+
+				height++
+			}
+
+		case <-b.quit:
+			return
+		}
+	}
+}
+
+// txEventHandlerRPC is a goroutine that uses the RPC client to check the
+// mempool for new transactions.
+func (b *bitcoindRPCPollingEvents) txEventHandlerRPC() {
+	defer b.wg.Done()
+
+	log.Info("Started polling for new bitcoind transactions via RPC.")
+	ticker := time.NewTicker(b.cfg.TxPollingInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			// After each ticker interval, we poll the mempool to
+			// check for transactions we haven't seen yet.
+			txs, err := b.client.GetRawMempool()
+			if err != nil {
+				log.Errorf("Unable to retrieve mempool txs: "+
+					"%v", err)
+				continue
+			}
+
+			// Set all mempool txs to false.
+			b.mempool.unmarkAll()
+
+			// We'll scan through the most recent txs in the
+			// mempool to see whether there are new txs that we
+			// need to send to the client.
+			for _, txHash := range txs {
+				// If the transaction is already in our local
+				// mempool, then we have already sent it to the
+				// client.
+				if b.mempool.contains(*txHash) {
+					// Mark the tx as true so that we know
+					// not to remove it from our internal
+					// mempool.
+					b.mempool.mark(*txHash)
+					continue
+				}
+
+				// Grab full mempool transaction from hash.
+				tx, err := b.client.GetRawTransaction(txHash)
+				if err != nil {
+					log.Errorf("unable to fetch "+
+						"transaction %s from "+
+						"mempool: %v", txHash, err)
+					continue
+				}
+
+				// Add the transaction to our local mempool.
+				// Note that we only do this after fetching
+				// the full raw transaction from bitcoind.
+				// We do this so that if that call happens to
+				// initially fail, then we will retry it on the
+				// next interval since it is still not in our
+				// local mempool.
+				b.mempool.add(*txHash)
+
+				select {
+				case b.txNtfns <- tx.MsgTx():
+				case <-b.quit:
+					return
+				}
+			}
+
+			// Now, we clear our internal mempool of any unmarked
+			// transactions. These are all the transactions that
+			// we still have in the mempool but that were not
+			// returned in the latest GetRawMempool query.
+			b.mempool.deleteUnmarked()
+
+		case <-b.quit:
+			return
+		}
+	}
+}
+
+// mempool represents our view of the mempool and helps to keep track of which
+// mempool transactions we already know about. The boolean in the txs map is
+// used to indicate if we should remove the tx from our local mempool due to
+// the chain backend's mempool no longer containing it.
+type mempool struct {
+	sync.RWMutex
+	txs map[chainhash.Hash]bool
+}
+
+// newMempool creates a new mempool object.
+func newMempool() *mempool {
+	return &mempool{
+		txs: make(map[chainhash.Hash]bool),
+	}
+}
+
+// clean removes any of the given transactions from the mempool if they are
+// found there.
+func (m *mempool) clean(txs []*wire.MsgTx) {
+	m.Lock()
+	defer m.Unlock()
+
+	for _, tx := range txs {
+		// If the transaction is in our mempool map, we need to delete
+		// it.
+		delete(m.txs, tx.TxHash())
+	}
+}
+
+// contains returns true if the given transaction hash is already in our
+// mempool.
+func (m *mempool) contains(hash chainhash.Hash) bool {
+	m.RLock()
+	defer m.RUnlock()
+
+	_, ok := m.txs[hash]
+	return ok
+}
+
+// add inserts the given hash into our mempool and marks it to indicate that it
+// should not be deleted.
+func (m *mempool) add(hash chainhash.Hash) {
+	m.Lock()
+	defer m.Unlock()
+
+	m.txs[hash] = true
+}
+
+// unmarkAll un-marks all the transactions in the mempool. This should be done
+// just before we re-evaluate the contents of our local mempool comared to the
+// chain backend's mempool.
+func (m *mempool) unmarkAll() {
+	m.Lock()
+	defer m.Unlock()
+
+	for hash := range m.txs {
+		m.txs[hash] = false
+	}
+}
+
+// mark marks the transaction of the given hash to indicate that it is still
+// present in the chain backend's mempool.
+func (m *mempool) mark(hash chainhash.Hash) {
+	m.Lock()
+	defer m.Unlock()
+
+	if _, ok := m.txs[hash]; !ok {
+		return
+	}
+
+	m.txs[hash] = true
+}
+
+// deleteUnmarked removes all the unmarked transactions from our local mempool.
+func (m *mempool) deleteUnmarked() {
+	m.Lock()
+	defer m.Unlock()
+
+	for hash, marked := range m.txs {
+		if marked {
+			continue
+		}
+
+		delete(m.txs, hash)
 	}
 }

--- a/chain/bitcoind_events.go
+++ b/chain/bitcoind_events.go
@@ -1,0 +1,341 @@
+package chain
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/gozmq"
+)
+
+// BitcoindEvents is the interface that must be satisfied by any type that
+// serves bitcoind block and transactions events.
+type BitcoindEvents interface {
+	// TxNotifications will return a channel which will deliver new
+	// transactions.
+	TxNotifications() <-chan *wire.MsgTx
+
+	// BlockNotifications will return a channel which will deliver new
+	// blocks.
+	BlockNotifications() <-chan *wire.MsgBlock
+
+	// Start will kick off any goroutines required for operation.
+	Start() error
+
+	// Stop will clean up any resources and goroutines.
+	Stop() error
+}
+
+// NewBitcoindEventSubscriber initialises a new BitcoinEvents object impl
+// depending on the config passed.
+func NewBitcoindEventSubscriber(cfg *BitcoindConfig) (BitcoindEvents, error) {
+	return newBitcoindZMQEvents(cfg.ZMQConfig)
+}
+
+// ZMQConfig holds all the config values needed to set up a ZMQ connection to
+// bitcoind.
+type ZMQConfig struct {
+	// ZMQBlockHost is the IP address and port of the bitcoind's rawblock
+	// listener.
+	ZMQBlockHost string
+
+	// ZMQTxHost is the IP address and port of the bitcoind's rawtx
+	// listener.
+	ZMQTxHost string
+
+	// ZMQReadDeadline represents the read deadline we'll apply when reading
+	// ZMQ messages from either subscription.
+	ZMQReadDeadline time.Duration
+}
+
+// bitcoindZMQEvents delivers block and transaction notifications that it gets
+// from ZMQ connections to bitcoind.
+type bitcoindZMQEvents struct {
+	cfg *ZMQConfig
+
+	// blockConn is the ZMQ connection we'll use to read raw block events.
+	blockConn *gozmq.Conn
+
+	// txConn is the ZMQ connection we'll use to read raw transaction
+	// events.
+	txConn *gozmq.Conn
+
+	// blockNtfns is a channel to which any new blocks will be sent.
+	blockNtfns chan *wire.MsgBlock
+
+	// txNtfns is a channel to which any new transactions will be sent.
+	txNtfns chan *wire.MsgTx
+
+	wg   sync.WaitGroup
+	quit chan struct{}
+}
+
+// newBitcoindZMQEvents initialises the necessary zmq connections to bitcoind.
+func newBitcoindZMQEvents(cfg *ZMQConfig) (*bitcoindZMQEvents, error) {
+	// Establish two different ZMQ connections to bitcoind to retrieve block
+	// and transaction event notifications. We'll use two as a separation of
+	// concern to ensure one type of event isn't dropped from the connection
+	// queue due to another type of event filling it up.
+	zmqBlockConn, err := gozmq.Subscribe(
+		cfg.ZMQBlockHost, []string{rawBlockZMQCommand},
+		cfg.ZMQReadDeadline,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to subscribe for zmq block "+
+			"events: %v", err)
+	}
+
+	zmqTxConn, err := gozmq.Subscribe(
+		cfg.ZMQTxHost, []string{rawTxZMQCommand}, cfg.ZMQReadDeadline,
+	)
+	if err != nil {
+		// Ensure that the block zmq connection is closed in the case
+		// that it succeeded but the tx zmq connection failed.
+		if err := zmqBlockConn.Close(); err != nil {
+			log.Errorf("could not close zmq block conn: %v", err)
+		}
+
+		return nil, fmt.Errorf("unable to subscribe for zmq tx "+
+			"events: %v", err)
+	}
+
+	return &bitcoindZMQEvents{
+		cfg:        cfg,
+		blockConn:  zmqBlockConn,
+		txConn:     zmqTxConn,
+		blockNtfns: make(chan *wire.MsgBlock),
+		txNtfns:    make(chan *wire.MsgTx),
+		quit:       make(chan struct{}),
+	}, nil
+}
+
+// Start spins off the bitcoindZMQEvent goroutines.
+func (b *bitcoindZMQEvents) Start() error {
+	b.wg.Add(2)
+	go b.blockEventHandler()
+	go b.txEventHandler()
+	return nil
+}
+
+// Stop cleans up any of the resources and goroutines held by bitcoindZMQEvents.
+func (b *bitcoindZMQEvents) Stop() error {
+	var returnErr error
+	if err := b.txConn.Close(); err != nil {
+		returnErr = err
+	}
+
+	if err := b.blockConn.Close(); err != nil {
+		returnErr = err
+	}
+
+	close(b.quit)
+	b.wg.Wait()
+	return returnErr
+}
+
+// TxNotifications returns a channel which will deliver new transactions.
+func (b *bitcoindZMQEvents) TxNotifications() <-chan *wire.MsgTx {
+	return b.txNtfns
+}
+
+// BlockNotifications returns a channel which will deliver new blocks.
+func (b *bitcoindZMQEvents) BlockNotifications() <-chan *wire.MsgBlock {
+	return b.blockNtfns
+}
+
+// blockEventHandler reads raw blocks events from the ZMQ block socket and
+// forwards them along to the current rescan clients.
+//
+// NOTE: This must be run as a goroutine.
+func (b *bitcoindZMQEvents) blockEventHandler() {
+	defer b.wg.Done()
+
+	log.Info("Started listening for bitcoind block notifications via ZMQ "+
+		"on", b.blockConn.RemoteAddr())
+
+	// Set up the buffers we expect our messages to consume. ZMQ
+	// messages from bitcoind include three parts: the command, the
+	// data, and the sequence number.
+	//
+	// We'll allocate a fixed data slice that we'll reuse when reading
+	// blocks from bitcoind through ZMQ. There's no need to recycle this
+	// slice (zero out) after using it, as further reads will overwrite the
+	// slice and we'll only be deserializing the bytes needed.
+	var (
+		command [len(rawBlockZMQCommand)]byte
+		seqNum  [seqNumLen]byte
+		data    = make([]byte, maxRawBlockSize)
+	)
+
+	for {
+		// Before attempting to read from the ZMQ socket, we'll make
+		// sure to check if we've been requested to shut down.
+		select {
+		case <-b.quit:
+			return
+		default:
+		}
+
+		// Poll an event from the ZMQ socket.
+		var (
+			bufs = [][]byte{command[:], data, seqNum[:]}
+			err  error
+		)
+		bufs, err = b.blockConn.Receive(bufs)
+		if err != nil {
+			// EOF should only be returned if the connection was
+			// explicitly closed, so we can exit at this point.
+			if err == io.EOF {
+				return
+			}
+
+			// It's possible that the connection to the socket
+			// continuously times out, so we'll prevent logging this
+			// error to prevent spamming the logs.
+			netErr, ok := err.(net.Error)
+			if ok && netErr.Timeout() {
+				log.Trace("Re-establishing timed out ZMQ " +
+					"block connection")
+				continue
+			}
+
+			log.Errorf("Unable to receive ZMQ %v message: %v",
+				rawBlockZMQCommand, err)
+			continue
+		}
+
+		// We have an event! We'll now ensure it is a block event,
+		// deserialize it, and report it to the different rescan
+		// clients.
+		eventType := string(bufs[0])
+		switch eventType {
+		case rawBlockZMQCommand:
+			block := &wire.MsgBlock{}
+			r := bytes.NewReader(bufs[1])
+			if err := block.Deserialize(r); err != nil {
+				log.Errorf("Unable to deserialize block: %v",
+					err)
+				continue
+			}
+
+			select {
+			case b.blockNtfns <- block:
+			case <-b.quit:
+				return
+			}
+
+		default:
+			// It's possible that the message wasn't fully read if
+			// bitcoind shuts down, which will produce an unreadable
+			// event type. To prevent from logging it, we'll make
+			// sure it conforms to the ASCII standard.
+			if eventType == "" || !isASCII(eventType) {
+				continue
+			}
+
+			log.Warnf("Received unexpected event type from %v "+
+				"subscription: %v", rawBlockZMQCommand,
+				eventType)
+		}
+	}
+}
+
+// txEventHandler reads raw blocks events from the ZMQ block socket and forwards
+// them along to the current rescan clients.
+//
+// NOTE: This must be run as a goroutine.
+func (b *bitcoindZMQEvents) txEventHandler() {
+	defer b.wg.Done()
+
+	log.Info("Started listening for bitcoind transaction notifications "+
+		"via ZMQ on", b.txConn.RemoteAddr())
+
+	// Set up the buffers we expect our messages to consume. ZMQ
+	// messages from bitcoind include three parts: the command, the
+	// data, and the sequence number.
+	//
+	// We'll allocate a fixed data slice that we'll reuse when reading
+	// transactions from bitcoind through ZMQ. There's no need to recycle
+	// this slice (zero out) after using it, as further reads will overwrite
+	// the slice and we'll only be deserializing the bytes needed.
+	var (
+		command [len(rawTxZMQCommand)]byte
+		seqNum  [seqNumLen]byte
+		data    = make([]byte, maxRawTxSize)
+	)
+
+	for {
+		// Before attempting to read from the ZMQ socket, we'll make
+		// sure to check if we've been requested to shut down.
+		select {
+		case <-b.quit:
+			return
+		default:
+		}
+
+		// Poll an event from the ZMQ socket.
+		var (
+			bufs = [][]byte{command[:], data, seqNum[:]}
+			err  error
+		)
+		bufs, err = b.txConn.Receive(bufs)
+		if err != nil {
+			// EOF should only be returned if the connection was
+			// explicitly closed, so we can exit at this point.
+			if err == io.EOF {
+				return
+			}
+
+			// It's possible that the connection to the socket
+			// continuously times out, so we'll prevent logging this
+			// error to prevent spamming the logs.
+			netErr, ok := err.(net.Error)
+			if ok && netErr.Timeout() {
+				log.Trace("Re-establishing timed out ZMQ " +
+					"transaction connection")
+				continue
+			}
+
+			log.Errorf("Unable to receive ZMQ %v message: %v",
+				rawTxZMQCommand, err)
+			continue
+		}
+
+		// We have an event! We'll now ensure it is a transaction event,
+		// deserialize it, and report it to the different rescan
+		// clients.
+		eventType := string(bufs[0])
+		switch eventType {
+		case rawTxZMQCommand:
+			tx := &wire.MsgTx{}
+			r := bytes.NewReader(bufs[1])
+			if err := tx.Deserialize(r); err != nil {
+				log.Errorf("Unable to deserialize "+
+					"transaction: %v", err)
+				continue
+			}
+
+			select {
+			case b.txNtfns <- tx:
+			case <-b.quit:
+				return
+			}
+
+		default:
+			// It's possible that the message wasn't fully read if
+			// bitcoind shuts down, which will produce an unreadable
+			// event type. To prevent from logging it, we'll make
+			// sure it conforms to the ASCII standard.
+			if eventType == "" || !isASCII(eventType) {
+				continue
+			}
+
+			log.Warnf("Received unexpected event type from %v "+
+				"subscription: %v", rawTxZMQCommand, eventType)
+		}
+	}
+}

--- a/chain/bitcoind_events_test.go
+++ b/chain/bitcoind_events_test.go
@@ -342,13 +342,15 @@ func setupBitcoind(t *testing.T, minerAddr string) *BitcoindClient {
 
 	host := fmt.Sprintf("127.0.0.1:%d", rpcPort)
 	cfg := &BitcoindConfig{
-		ChainParams:     &chaincfg.RegressionNetParams,
-		Host:            host,
-		User:            "weks",
-		Pass:            "weks",
-		ZMQBlockHost:    zmqBlockHost,
-		ZMQTxHost:       zmqTxHost,
-		ZMQReadDeadline: 5 * time.Second,
+		ChainParams: &chaincfg.RegressionNetParams,
+		Host:        host,
+		User:        "weks",
+		Pass:        "weks",
+		ZMQConfig: &ZMQConfig{
+			ZMQBlockHost:    zmqBlockHost,
+			ZMQTxHost:       zmqTxHost,
+			ZMQReadDeadline: 5 * time.Second,
+		},
 		// Fields only required for pruned nodes, not
 		// needed for these tests.
 		Dialer:             nil,

--- a/chain/bitcoind_events_test.go
+++ b/chain/bitcoind_events_test.go
@@ -1,0 +1,401 @@
+package chain
+
+import (
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/integration/rpctest"
+	"github.com/btcsuite/btcd/rpcclient"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBitcoindEvents ensures that the BitcoindClient correctly delivers tx and
+// block notifications during normal chain growth and during a reorg.
+func TestBitcoindEvents(t *testing.T) {
+	// Set up 2 btcd miners.
+	miner1, miner2 := setupMiners(t)
+
+	// Set up a bitcoind node and connect it to miner 1.
+	btcClient := setupBitcoind(t, miner1.P2PAddress())
+
+	// Test that the correct block `Connect` and `Disconnect` notifications
+	// are received during a re-org.
+	testReorg(t, miner1, miner2, btcClient)
+
+	// Test that the expected block and transaction notifications are
+	// received.
+	testNotifications(t, miner1, btcClient)
+}
+
+// testNotifications tests that the correct notifications are received for
+// blocks and transactions in the simple non-reorg case.
+func testNotifications(t *testing.T, miner *rpctest.Harness,
+	client *BitcoindClient) {
+
+	script, _, err := randPubKeyHashScript()
+	require.NoError(t, err)
+
+	tx, err := miner.CreateTransaction(
+		[]*wire.TxOut{{Value: 1000, PkScript: script}}, 5, false,
+	)
+	require.NoError(t, err)
+
+	hash := tx.TxHash()
+
+	err = client.NotifyTx([]chainhash.Hash{hash})
+	require.NoError(t, err)
+
+	_, err = client.SendRawTransaction(tx, true)
+	require.NoError(t, err)
+
+	ntfns := client.Notifications()
+
+	miner.Client.Generate(1)
+
+	// First, we expect to get a RelevantTx notification.
+	select {
+	case ntfn := <-ntfns:
+		tx, ok := ntfn.(RelevantTx)
+		if !ok {
+			t.Fatalf("Expected a notification of type "+
+				"RelevantTx, got %T", ntfn)
+		}
+
+		require.True(t, tx.TxRecord.Hash.IsEqual(&hash))
+
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for RelevantTx notification")
+	}
+
+	// Then, we expect to get a FilteredBlockConnected notification.
+	select {
+	case ntfn := <-ntfns:
+		_, ok := ntfn.(FilteredBlockConnected)
+		if !ok {
+			t.Fatalf("Expected a notification of type "+
+				"FilteredBlockConnected, got %T", ntfn)
+		}
+
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for FilteredBlockConnected " +
+			"notification")
+	}
+
+	// Lastly, we expect to get a BlockConnected notification.
+	select {
+	case ntfn := <-ntfns:
+		_, ok := ntfn.(BlockConnected)
+		if !ok {
+			t.Fatalf("Expected a notification of type "+
+				"BlockConnected, got %T", ntfn)
+		}
+
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for BlockConnected notification")
+	}
+}
+
+// testReorg tests that the given BitcoindClient correctly responds to a chain
+// re-org.
+func testReorg(t *testing.T, miner1, miner2 *rpctest.Harness,
+	client *BitcoindClient) {
+
+	miner1Hash, commonHeight, err := miner1.Client.GetBestBlock()
+	require.NoError(t, err)
+
+	miner2Hash, miner2Height, err := miner2.Client.GetBestBlock()
+	require.NoError(t, err)
+
+	require.Equal(t, commonHeight, miner2Height)
+	require.Equal(t, miner1Hash, miner2Hash)
+
+	// Let miner2 generate a few blocks and ensure that our bitcoind client
+	// is notified of this block.
+	hashes, err := miner2.Client.Generate(5)
+	require.NoError(t, err)
+	require.Len(t, hashes, 5)
+
+	ntfns := client.Notifications()
+
+	for i := 0; i < 5; i++ {
+		commonHeight++
+		ntfnHash := waitForBlockNtfn(t, ntfns, commonHeight, true)
+		require.True(t, ntfnHash.IsEqual(hashes[i]))
+	}
+
+	// Now disconnect the two miners.
+	err = miner1.Client.AddNode(miner2.P2PAddress(), rpcclient.ANRemove)
+	require.NoError(t, err)
+
+	// Generate 5 blocks on miner2.
+	_, err = miner2.Client.Generate(5)
+	require.NoError(t, err)
+
+	// Since the miners have been disconnected, we expect not to get any
+	// notifications from our client since our client is connected to
+	// miner1.
+	select {
+	case ntfn := <-ntfns:
+		t.Fatalf("received a notification of type %T but expected, "+
+			"none", ntfn)
+
+	case <-time.After(time.Millisecond * 500):
+	}
+
+	// Now generate 3 blocks on miner1. Note that to force our client to
+	// experience a re-org, miner1 must generate fewer blocks here than
+	// miner2 so that when they reconnect, miner1 does a re-org to switch
+	// to the longer chain.
+	_, err = miner1.Client.Generate(3)
+	require.NoError(t, err)
+
+	// Read the notifications for the new blocks
+	for i := 0; i < 3; i++ {
+		_ = waitForBlockNtfn(t, ntfns, commonHeight+int32(i+1), true)
+	}
+
+	// Ensure that the two miners have different ideas of what the best
+	// block is.
+	hash1, height1, err := miner1.Client.GetBestBlock()
+	require.NoError(t, err)
+	require.Equal(t, commonHeight+3, height1)
+
+	hash2, height2, err := miner2.Client.GetBestBlock()
+	require.NoError(t, err)
+	require.Equal(t, commonHeight+5, height2)
+
+	require.False(t, hash1.IsEqual(hash2))
+
+	// Reconnect the miners. This should result in miner1 reorging to match
+	// miner2. Since our client is connected to a node connected to miner1,
+	// we should get the expected disconnected and connected notifications.
+	err = rpctest.ConnectNode(miner1, miner2)
+	require.NoError(t, err)
+
+	err = rpctest.JoinNodes(
+		[]*rpctest.Harness{miner1, miner2}, rpctest.Blocks,
+	)
+	require.NoError(t, err)
+
+	// Check that the miners are now on the same page.
+	hash1, height1, err = miner1.Client.GetBestBlock()
+	require.NoError(t, err)
+
+	hash2, height2, err = miner2.Client.GetBestBlock()
+	require.NoError(t, err)
+
+	require.Equal(t, commonHeight+5, height2)
+	require.Equal(t, commonHeight+5, height1)
+	require.True(t, hash1.IsEqual(hash2))
+
+	// We expect our client to get 3 BlockDisconnected notifications first
+	// signaling the unwinding of its top 3 blocks.
+	for i := 0; i < 3; i++ {
+		_ = waitForBlockNtfn(t, ntfns, commonHeight+int32(3-i), false)
+	}
+
+	// Now we expect 5 BlockConnected notifications.
+	for i := 0; i < 5; i++ {
+		_ = waitForBlockNtfn(t, ntfns, commonHeight+int32(i+1), true)
+	}
+}
+
+// waitForBlockNtfn waits on the passed channel for a BlockConnected or
+// BlockDisconnected notification for a block of the expectedHeight. It returns
+// hash of the notification if received. If the expected notification is not
+// received within 2 seconds, the test is failed. Use the `connected` parameter
+// to set whether a Connected or Disconnected notification is expected.
+func waitForBlockNtfn(t *testing.T, ntfns <-chan interface{},
+	expectedHeight int32, connected bool) chainhash.Hash {
+
+	timer := time.NewTimer(2 * time.Second)
+	for {
+		select {
+		case nftn := <-ntfns:
+			switch ntfnType := nftn.(type) {
+			case BlockConnected:
+				if !connected {
+					fmt.Println("???")
+					continue
+				}
+
+				if ntfnType.Height < expectedHeight {
+					continue
+				} else if ntfnType.Height != expectedHeight {
+					t.Fatalf("expected notification for "+
+						"height %d, got height %d",
+						expectedHeight, ntfnType.Height)
+				}
+
+				return ntfnType.Hash
+
+			case BlockDisconnected:
+				if connected {
+					continue
+				}
+
+				if ntfnType.Height > expectedHeight {
+					continue
+				} else if ntfnType.Height != expectedHeight {
+					t.Fatalf("expected notification for "+
+						"height %d, got height %d",
+						expectedHeight, ntfnType.Height)
+				}
+
+				return ntfnType.Hash
+
+			default:
+			}
+
+		case <-timer.C:
+			t.Fatalf("timed out waiting for block notification")
+		}
+	}
+}
+
+// setUpMiners sets up two miners that can be used for a re-org test.
+func setupMiners(t *testing.T) (*rpctest.Harness, *rpctest.Harness) {
+	trickle := fmt.Sprintf("--trickleinterval=%v", 10*time.Millisecond)
+	args := []string{trickle}
+
+	miner1, err := rpctest.New(
+		&chaincfg.RegressionNetParams, nil, args, "",
+	)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		miner1.TearDown()
+	})
+
+	require.NoError(t, miner1.SetUp(true, 1))
+
+	miner2, err := rpctest.New(
+		&chaincfg.RegressionNetParams, nil, args, "",
+	)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		miner2.TearDown()
+	})
+
+	require.NoError(t, miner2.SetUp(false, 0))
+
+	// Connect the miners.
+	require.NoError(t, rpctest.ConnectNode(miner1, miner2))
+
+	err = rpctest.JoinNodes(
+		[]*rpctest.Harness{miner1, miner2}, rpctest.Blocks,
+	)
+	require.NoError(t, err)
+
+	return miner1, miner2
+}
+
+// setupBitcoind starts up a bitcoind node with either a zmq connection or
+// rpc polling connection and returns a client wrapper of this connection.
+func setupBitcoind(t *testing.T, minerAddr string) *BitcoindClient {
+	// Start a bitcoind instance and connect it to miner1.
+	tempBitcoindDir, err := ioutil.TempDir("", "bitcoind")
+	require.NoError(t, err)
+
+	zmqBlockHost := "ipc:///" + tempBitcoindDir + "/blocks.socket"
+	zmqTxHost := "ipc:///" + tempBitcoindDir + "/tx.socket"
+	t.Cleanup(func() {
+		os.RemoveAll(tempBitcoindDir)
+	})
+
+	rpcPort := rand.Int()%(65536-1024) + 1024
+	bitcoind := exec.Command(
+		"bitcoind",
+		"-datadir="+tempBitcoindDir,
+		"-regtest",
+		"-connect="+minerAddr,
+		"-txindex",
+		"-rpcauth=weks:469e9bb14ab2360f8e226efed5ca6f"+
+			"d$507c670e800a95284294edb5773b05544b"+
+			"220110063096c221be9933c82d38e1",
+		fmt.Sprintf("-rpcport=%d", rpcPort),
+		"-disablewallet",
+		"-zmqpubrawblock="+zmqBlockHost,
+		"-zmqpubrawtx="+zmqTxHost,
+	)
+	require.NoError(t, bitcoind.Start())
+
+	t.Cleanup(func() {
+		bitcoind.Process.Kill()
+		bitcoind.Wait()
+	})
+
+	// Wait for the bitcoind instance to start up.
+	time.Sleep(time.Second)
+
+	host := fmt.Sprintf("127.0.0.1:%d", rpcPort)
+	cfg := &BitcoindConfig{
+		ChainParams:     &chaincfg.RegressionNetParams,
+		Host:            host,
+		User:            "weks",
+		Pass:            "weks",
+		ZMQBlockHost:    zmqBlockHost,
+		ZMQTxHost:       zmqTxHost,
+		ZMQReadDeadline: 5 * time.Second,
+		// Fields only required for pruned nodes, not
+		// needed for these tests.
+		Dialer:             nil,
+		PrunedModeMaxPeers: 0,
+	}
+
+	chainConn, err := NewBitcoindConn(cfg)
+	require.NoError(t, err)
+	require.NoError(t, chainConn.Start())
+
+	t.Cleanup(func() {
+		chainConn.Stop()
+	})
+
+	// Create a bitcoind client.
+	btcClient := chainConn.NewBitcoindClient()
+	require.NoError(t, btcClient.Start())
+
+	t.Cleanup(func() {
+		btcClient.Stop()
+	})
+
+	require.NoError(t, btcClient.NotifyBlocks())
+
+	return btcClient
+}
+
+// randPubKeyHashScript generates a P2PKH script that pays to the public key of
+// a randomly-generated private key.
+func randPubKeyHashScript() ([]byte, *btcec.PrivateKey, error) {
+	privKey, err := btcec.NewPrivateKey()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pubKeyHash := btcutil.Hash160(privKey.PubKey().SerializeCompressed())
+	addrScript, err := btcutil.NewAddressPubKeyHash(
+		pubKeyHash, &chaincfg.RegressionNetParams,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pkScript, err := txscript.PayToAddrScript(addrScript)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return pkScript, privKey, nil
+}

--- a/chain/interface.go
+++ b/chain/interface.go
@@ -22,6 +22,7 @@ func BackEnds() []string {
 		"bitcoind",
 		"btcd",
 		"neutrino",
+		"bitcoind-rpc-polling",
 	}
 }
 


### PR DESCRIPTION
This PR reworks and replaces #784. It allows you to poll Bitcoind's RPC interface for new blocks and transactions instead of using the ZMQ interface. 

Thanks to @orbitalturtle for the original PR! 

Closes #784 