### PR TITLE
txsizes: count change output in estimating tx size

### DIFF
--- a/wallet/txsizes/size.go
+++ b/wallet/txsizes/size.go
@@ -178,7 +178,7 @@ func EstimateVirtualSize(numP2PKHIns, numP2WPKHIns, numNestedP2WPKHIns int,
 	baseSize := 8 +
 		wire.VarIntSerializeSize(
 			uint64(numP2PKHIns+numP2WPKHIns+numNestedP2WPKHIns)) +
-		wire.VarIntSerializeSize(uint64(len(txOuts))) +
+		wire.VarIntSerializeSize(uint64(outputCount)) +
 		numP2PKHIns*RedeemP2PKHInputSize +
 		numP2WPKHIns*RedeemP2WPKHInputSize +
 		numNestedP2WPKHIns*RedeemNestedP2WPKHInputSize +


### PR DESCRIPTION
In the estimation of transaction size, there is an uncommon scenario in which the required space for serializing the count of outputs is calculated wrong since the change output is not counted in the count of outputs.

The source of the problem is just an unused variable which this PR fixes it.