### PR TITLE
waddrmgr: fix used address detection for p2tr addrs

### DIFF
--- a/waddrmgr/address.go
+++ b/waddrmgr/address.go
@@ -255,6 +255,8 @@ func (a *managedAddress) AddrHash() []byte {
 		hash = n.Hash160()[:]
 	case *btcutil.AddressWitnessPubKeyHash:
 		hash = n.Hash160()[:]
+	case *btcutil.AddressTaproot:
+		hash = n.WitnessProgram()
 	}
 
 	return hash


### PR DESCRIPTION
This patch makes sure that p2tr addresses are detected as being used
correctly.
