### PR TITLE
CI: fix Makefile not working with go 1.18

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,37 +11,29 @@ linters-settings:
     simplify: true
 
 linters:
-  enable-all: true
-  disable:
-    # Global variables are used in many places throughout the code base.
-    - gochecknoglobals
-
-    # Some lines are over 80 characters on purpose and we don't want to make them
-    # even longer by marking them as 'nolint'.
-    - lll
-
-    # We don't care (enough) about misaligned structs to lint that.
-    - maligned
-
-    # We have long functions, especially in tests. Moving or renaming those would
-    # trigger funlen problems that we may not want to solve at that time.
-    - funlen
-
-    # Disable for now as we haven't yet tuned the sensitivity to our codebase
-    # yet.  Enabling by default for example, would also force new contributors to
-    # potentially extensively refactor code, when they want to smaller change to
-    # land.
-    - gocyclo
-
-    # Instances of table driven tests that don't pre-allocate shouldn't trigger
-    # the linter.
+  disable-all: true
+  enable:
+    - asciicheck
+    - deadcode
+    - dupl
+    - errcheck
+    - goimports
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - nolintlint
     - prealloc
-
-    # Init functions are used by loggers throughout the codebase.
-    - gochecknoinits
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unconvert
+    - unused
+    - varcheck
     
-    # Explicit types are okay.
-    - interfacer
+    # Others to consider that do not pass presently:
+    # - nilerr
+    # - makezero
 
 issues:
   exclude-rules:

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ GOACC_BIN := $(GO_BIN)/go-acc
 
 LINT_COMMIT := v1.18.0
 GOACC_COMMIT := 80342ae2e0fcf265e99e76bcc4efd022c7c3811b
+GOIMPORTS_COMMIT := v0.1.10
 
-DEPGET := cd /tmp && GO111MODULE=on go get -v
 GOBUILD := GO111MODULE=on go build -v
 GOINSTALL := GO111MODULE=on go install -v
 GOTEST := GO111MODULE=on go test 
@@ -49,15 +49,15 @@ all: build check
 
 $(LINT_BIN):
 	@$(call print, "Fetching linter")
-	$(DEPGET) $(LINT_PKG)@$(LINT_COMMIT)
+	$(GOINSTALL) $(LINT_PKG)@$(LINT_COMMIT)
 
 $(GOACC_BIN):
 	@$(call print, "Fetching go-acc")
-	$(DEPGET) $(GOACC_PKG)@$(GOACC_COMMIT)
+	$(GOINSTALL) $(GOACC_PKG)@$(GOACC_COMMIT)
 
 goimports:
 	@$(call print, "Installing goimports.")
-	$(DEPGET) $(GOIMPORTS_PKG)
+	$(GOINSTALL) $(GOIMPORTS_PKG)@${GOIMPORTS_COMMIT}
 
 # ============
 # INSTALLATION

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GO_BIN := ${GOPATH}/bin
 LINT_BIN := $(GO_BIN)/golangci-lint
 GOACC_BIN := $(GO_BIN)/go-acc
 
-LINT_COMMIT := v1.18.0
+LINT_COMMIT := v1.45.2
 GOACC_COMMIT := 80342ae2e0fcf265e99e76bcc4efd022c7c3811b
 GOIMPORTS_COMMIT := v0.1.10
 

--- a/btcwallet.go
+++ b/btcwallet.go
@@ -8,7 +8,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	_ "net/http/pprof"
+	_ "net/http/pprof" // nolint:gosec
 	"os"
 	"path/filepath"
 	"runtime"

--- a/chain/neutrino.go
+++ b/chain/neutrino.go
@@ -397,7 +397,7 @@ func (s *NeutrinoClient) Rescan(startHash *chainhash.Hash, addrs []btcutil.Addre
 		}
 	}
 
-	var inputsToWatch []neutrino.InputWithScript
+	inputsToWatch := make([]neutrino.InputWithScript, 0, len(outPoints))
 	for op, addr := range outPoints {
 		addrScript, err := txscript.PayToAddrScript(addr)
 		if err != nil {

--- a/chain/pruned_block_dispatcher.go
+++ b/chain/pruned_block_dispatcher.go
@@ -386,7 +386,7 @@ func (d *PrunedBlockDispatcher) connectToPeer(addr string) (bool, error) {
 // requests, i.e., any peer which is not considered a segwit-enabled
 // "full-node".
 func filterPeers(peers []btcjson.GetPeerInfoResult) ([]string, error) {
-	var eligible []string
+	var eligible []string // nolint:prealloc
 	for _, peer := range peers {
 		rawServices, err := hex.DecodeString(peer.Services)
 		if err != nil {
@@ -405,7 +405,7 @@ func filterPeers(peers []btcjson.GetPeerInfoResult) ([]string, error) {
 // block requests, i.e., any peer which is not considered a segwit-enabled
 // "full-node".
 func filterNodeAddrs(nodeAddrs []btcjson.GetNodeAddressesResult) []string {
-	var eligible []string
+	var eligible []string // nolint:prealloc
 	for _, nodeAddr := range nodeAddrs {
 		services := wire.ServiceFlag(nodeAddr.Services)
 		if !satisfiesRequiredServices(services) {

--- a/internal/legacy/keystore/keystore.go
+++ b/internal/legacy/keystore/keystore.go
@@ -22,7 +22,8 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/crypto/ripemd160"
+	// consider vendoring this deprecated ripemd160 package
+	"golang.org/x/crypto/ripemd160" // nolint:staticcheck
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
@@ -64,9 +65,9 @@ var fileID = [8]byte{0xba, 'W', 'A', 'L', 'L', 'E', 'T', 0x00}
 type entryHeader byte
 
 const (
-	addrCommentHeader entryHeader = 1 << iota //nolint:varcheck,deadcode,unused
-	txCommentHeader                           // nolint:varcheck,deadcode,unused
-	deletedHeader                             // nolint:varcheck,deadcode,unused
+	addrCommentHeader entryHeader = 1 << iota // nolint:varcheck,deadcode
+	txCommentHeader                           // nolint:varcheck,deadcode
+	deletedHeader                             // nolint:varcheck,deadcode
 	scriptHeader
 	addrHeader entryHeader = 0
 )

--- a/internal/legacy/keystore/keystore_test.go
+++ b/internal/legacy/keystore/keystore_test.go
@@ -984,20 +984,20 @@ func TestImportScript(t *testing.T) {
 	}
 
 	if !bytes.Equal(sinfo.Script(), sinfo2.Script()) {
-		t.Error("original and serailised scriptinfo scripts "+
+		t.Errorf("original and serailised scriptinfo scripts "+
 			"don't match %s != %s", spew.Sdump(sinfo.Script()),
 			spew.Sdump(sinfo2.Script()))
 	}
 
 	if sinfo.ScriptClass() != sinfo2.ScriptClass() {
-		t.Error("original and serailised scriptinfo class "+
+		t.Errorf("original and serailised scriptinfo class "+
 			"don't match: %s != %s", sinfo.ScriptClass(),
 			sinfo2.ScriptClass())
 		return
 	}
 
 	if !reflect.DeepEqual(sinfo.Addresses(), sinfo2.Addresses()) {
-		t.Error("original and serailised scriptinfo addresses "+
+		t.Errorf("original and serailised scriptinfo addresses "+
 			"don't match (%s) != (%s)", spew.Sdump(sinfo.Addresses),
 			spew.Sdump(sinfo2.Addresses()))
 		return

--- a/waddrmgr/db.go
+++ b/waddrmgr/db.go
@@ -61,7 +61,7 @@ type syncStatus uint8
 // of supporting sync status on a per-address basis.
 const (
 	ssNone    syncStatus = 0 // not iota as they need to be stable for db
-	ssPartial syncStatus = 1 // nolint:varcheck,deadcode,unused
+	ssPartial syncStatus = 1 // nolint:varcheck,deadcode
 	ssFull    syncStatus = 2
 )
 
@@ -372,7 +372,7 @@ func fetchScopeAddrSchema(ns walletdb.ReadBucket,
 
 	schemaBucket := ns.NestedReadBucket(scopeSchemaBucketName)
 	if schemaBucket == nil {
-		str := fmt.Sprintf("unable to find scope schema bucket")
+		str := "unable to find scope schema bucket"
 		return nil, managerError(ErrScopeNotFound, str, nil)
 	}
 

--- a/waddrmgr/manager.go
+++ b/waddrmgr/manager.go
@@ -643,7 +643,7 @@ func (m *Manager) ActiveScopedKeyManagers() []*ScopedKeyManager {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
-	var scopedManagers []*ScopedKeyManager
+	scopedManagers := make([]*ScopedKeyManager, 0, len(m.scopedManagers))
 	for _, smgr := range m.scopedManagers {
 		scopedManagers = append(scopedManagers, smgr)
 	}

--- a/waddrmgr/scoped_manager.go
+++ b/waddrmgr/scoped_manager.go
@@ -1619,7 +1619,7 @@ func (s *ScopedKeyManager) newAccount(ns walletdb.ReadWriteBucket,
 	// Check that account with the same name does not exist
 	_, err := s.lookupAccount(ns, name)
 	if err == nil {
-		str := fmt.Sprintf("account with the same name already exists")
+		str := "account with the same name already exists"
 		return managerError(ErrDuplicateAccount, str, err)
 	}
 
@@ -1633,13 +1633,13 @@ func (s *ScopedKeyManager) newAccount(ns walletdb.ReadWriteBucket,
 	// Decrypt the cointype key.
 	serializedKeyPriv, err := s.rootManager.cryptoKeyPriv.Decrypt(coinTypePrivEnc)
 	if err != nil {
-		str := fmt.Sprintf("failed to decrypt cointype serialized private key")
+		str := "failed to decrypt cointype serialized private key"
 		return managerError(ErrLocked, str, err)
 	}
 	coinTypeKeyPriv, err := hdkeychain.NewKeyFromString(string(serializedKeyPriv))
 	zero.Bytes(serializedKeyPriv)
 	if err != nil {
-		str := fmt.Sprintf("failed to create cointype extended private key")
+		str := "failed to create cointype extended private key"
 		return managerError(ErrKeyChain, str, err)
 	}
 
@@ -1747,7 +1747,7 @@ func (s *ScopedKeyManager) newAccountWatchingOnly(ns walletdb.ReadWriteBucket,
 	// Check that account with the same name does not exist
 	_, err := s.lookupAccount(ns, name)
 	if err == nil {
-		str := fmt.Sprintf("account with the same name already exists")
+		str := "account with the same name already exists"
 		return managerError(ErrDuplicateAccount, str, err)
 	}
 
@@ -1792,7 +1792,7 @@ func (s *ScopedKeyManager) RenameAccount(ns walletdb.ReadWriteBucket,
 	// Check that account with the new name does not exist
 	_, err := s.lookupAccount(ns, name)
 	if err == nil {
-		str := fmt.Sprintf("account with the same name already exists")
+		str := "account with the same name already exists"
 		return managerError(ErrDuplicateAccount, str, err)
 	}
 

--- a/wallet/notifications.go
+++ b/wallet/notifications.go
@@ -254,7 +254,7 @@ func (s *NotificationServer) notifyMinedTransaction(dbtx walletdb.ReadTx, detail
 	}
 	txs := s.currentTxNtfn.AttachedBlocks[n-1].Transactions
 	s.currentTxNtfn.AttachedBlocks[n-1].Transactions =
-		append(txs, makeTxSummary(dbtx, s.wallet, details)) //  nolint:gocritic
+		append(txs, makeTxSummary(dbtx, s.wallet, details)) // nolint:gocritic
 }
 
 func (s *NotificationServer) notifyAttachedBlock(dbtx walletdb.ReadTx, block *wtxmgr.BlockMeta) {


### PR DESCRIPTION
go get is no longer used to install or build things. Use go install
instead.  Also specify a version so the module's go.mod is not
touched when installing the CI tools.