### PR TITLE
chain: fix double-spend removal not being triggered

### DIFF
--- a/chain/bitcoind_conn.go
+++ b/chain/bitcoind_conn.go
@@ -338,10 +338,11 @@ func (c *BitcoindConn) NewBitcoindClient() *BitcoindClient {
 
 		chainConn: c,
 
-		rescanUpdate:     make(chan interface{}),
-		watchedAddresses: make(map[string]struct{}),
-		watchedOutPoints: make(map[wire.OutPoint]struct{}),
-		watchedTxs:       make(map[chainhash.Hash]struct{}),
+		rescanUpdate:         make(chan interface{}),
+		watchedAddresses:     make(map[string]struct{}),
+		watchedOutPoints:     make(map[wire.OutPoint]struct{}),
+		watchedTxs:           make(map[chainhash.Hash]struct{}),
+		watchedRelatedInputs: make(map[wire.OutPoint]struct{}),
 
 		notificationQueue: NewConcurrentQueue(20),
 		txNtfns:           make(chan *wire.MsgTx, 1000),


### PR DESCRIPTION
Unspent txns that are double-spent to an address not controlled by us (hence, not being watched) are not detected by the wallet and remain listed by `ListUnspent` even when the block has been confirmed and does not include the initial (double-spent) tx.

The fix has been implemented on the bitcoin client but with some expansion in `chain.Interface` it could be extracted out, probably by using `NotifySpent`.

Related to https://github.com/lightningnetwork/lnd/issues/5244