### PR TITLE
waddrmgr: add Taproot pubkey import, add new tapscript partial info types

### DIFF
--- a/waddrmgr/scoped_manager.go
+++ b/waddrmgr/scoped_manager.go
@@ -1973,6 +1973,16 @@ func (s *ScopedKeyManager) importPublicKey(ns walletdb.ReadWriteBucket,
 		}
 		addressID = btcutil.Hash160(witnessScript)
 
+	case TaprootPubKey:
+		internalPubKey, err := btcec.ParsePubKey(serializedPubKey)
+		if err != nil {
+			return err
+		}
+		taprootPubKey := txscript.ComputeTaprootKeyNoScript(
+			internalPubKey,
+		)
+		addressID = schnorr.SerializePubKey(taprootPubKey)
+
 	default:
 		return fmt.Errorf("unsupported address type %v", addrType)
 	}

--- a/waddrmgr/tapscript_test.go
+++ b/waddrmgr/tapscript_test.go
@@ -31,6 +31,10 @@ var (
 		"e15405aab8fd601206a3848b0ec495df75d8a602465d8dbba42a7493bd88" +
 			"9b78",
 	)
+	testTaprootKey2 = hexToBytes(
+		"b1ef5fafd9a55b8c4bb3c2eee3fcf033194891ebf89b1d9b666c6306acc3" +
+			"a3df",
+	)
 )
 
 // TestTaprootKey tests that the taproot tweaked key can be calculated correctly
@@ -69,6 +73,16 @@ func TestTaprootKey(t *testing.T) {
 			},
 		},
 		expected: testTaprootKey,
+	}, {
+		name: "root hash only",
+		given: &Tapscript{
+			Type: TaprootKeySpendRootHash,
+			ControlBlock: &txscript.ControlBlock{
+				InternalKey: testInternalKey,
+			},
+			RootHash: []byte("I could be a root hash"),
+		},
+		expected: testTaprootKey2,
 	}}
 
 	for _, tc := range testCases {

--- a/waddrmgr/tapscript_test.go
+++ b/waddrmgr/tapscript_test.go
@@ -83,6 +83,13 @@ func TestTaprootKey(t *testing.T) {
 			RootHash: []byte("I could be a root hash"),
 		},
 		expected: testTaprootKey2,
+	}, {
+		name: "full key only",
+		given: &Tapscript{
+			Type:          TaprootFullKeyOnly,
+			FullOutputKey: testInternalKey,
+		},
+		expected: schnorr.SerializePubKey(testInternalKey),
 	}}
 
 	for _, tc := range testCases {

--- a/waddrmgr/tlv.go
+++ b/waddrmgr/tlv.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/lightningnetwork/lnd/tlv"
 )
@@ -15,6 +16,7 @@ const (
 	typeTapscriptLeaves         tlv.Type = 3
 	typeTapscriptRevealedScript tlv.Type = 4
 	typeTapscriptRootHash       tlv.Type = 5
+	typeTapscriptFullOutputKey  tlv.Type = 6
 
 	typeTapLeafVersion tlv.Type = 1
 	typeTapLeafScript  tlv.Type = 2
@@ -68,6 +70,13 @@ func tlvEncodeTaprootScript(s *Tapscript) ([]byte, error) {
 		))
 	}
 
+	if s.FullOutputKey != nil {
+		keyBytes := schnorr.SerializePubKey(s.FullOutputKey)
+		tlvRecords = append(tlvRecords, tlv.MakePrimitiveRecord(
+			typeTapscriptFullOutputKey, &keyBytes,
+		))
+	}
+
 	tlvStream, err := tlv.NewStream(tlvRecords...)
 	if err != nil {
 		return nil, err
@@ -88,9 +97,10 @@ func tlvEncodeTaprootScript(s *Tapscript) ([]byte, error) {
 func tlvDecodeTaprootTaprootScript(tlvData []byte) (*Tapscript, error) {
 
 	var (
-		typ               uint8
-		controlBlockBytes []byte
-		s                 = &Tapscript{}
+		typ                uint8
+		controlBlockBytes  []byte
+		fullOutputKeyBytes []byte
+		s                  = &Tapscript{}
 	)
 
 	tlvStream, err := tlv.NewStream(
@@ -108,6 +118,9 @@ func tlvDecodeTaprootTaprootScript(tlvData []byte) (*Tapscript, error) {
 		),
 		tlv.MakePrimitiveRecord(
 			typeTapscriptRootHash, &s.RootHash,
+		),
+		tlv.MakePrimitiveRecord(
+			typeTapscriptFullOutputKey, &fullOutputKeyBytes,
 		),
 	)
 	if err != nil {
@@ -129,6 +142,14 @@ func tlvDecodeTaprootTaprootScript(tlvData []byte) (*Tapscript, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error decoding control block: "+
 				"%v", err)
+		}
+	}
+
+	if t, ok := parsedTypes[typeTapscriptFullOutputKey]; ok && t == nil {
+		s.FullOutputKey, err = schnorr.ParsePubKey(fullOutputKeyBytes)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding full output "+
+				"key: %v", err)
 		}
 	}
 

--- a/waddrmgr/tlv.go
+++ b/waddrmgr/tlv.go
@@ -14,6 +14,7 @@ const (
 	typeTapscriptControlBlock   tlv.Type = 2
 	typeTapscriptLeaves         tlv.Type = 3
 	typeTapscriptRevealedScript tlv.Type = 4
+	typeTapscriptRootHash       tlv.Type = 5
 
 	typeTapLeafVersion tlv.Type = 1
 	typeTapLeafScript  tlv.Type = 2
@@ -61,6 +62,12 @@ func tlvEncodeTaprootScript(s *Tapscript) ([]byte, error) {
 		))
 	}
 
+	if len(s.RootHash) > 0 {
+		tlvRecords = append(tlvRecords, tlv.MakePrimitiveRecord(
+			typeTapscriptRootHash, &s.RootHash,
+		))
+	}
+
 	tlvStream, err := tlv.NewStream(tlvRecords...)
 	if err != nil {
 		return nil, err
@@ -98,6 +105,9 @@ func tlvDecodeTaprootTaprootScript(tlvData []byte) (*Tapscript, error) {
 		),
 		tlv.MakePrimitiveRecord(
 			typeTapscriptRevealedScript, &s.RevealedScript,
+		),
+		tlv.MakePrimitiveRecord(
+			typeTapscriptRootHash, &s.RootHash,
 		),
 	)
 	if err != nil {

--- a/waddrmgr/tlv_test.go
+++ b/waddrmgr/tlv_test.go
@@ -141,6 +141,16 @@ func TestTlvEncodeDecode(t *testing.T) {
 			},
 			RootHash: testScript,
 		},
+	}, {
+		name: "full key only",
+		given: &Tapscript{
+			Type:          TapscriptTypeFullTree,
+			FullOutputKey: testPubKey,
+		},
+		expected: &Tapscript{
+			Type:          TapscriptTypeFullTree,
+			FullOutputKey: testPubKey,
+		},
 	}}
 
 	for _, tc := range testCases {

--- a/waddrmgr/tlv_test.go
+++ b/waddrmgr/tlv_test.go
@@ -124,6 +124,23 @@ func TestTlvEncodeDecode(t *testing.T) {
 			},
 			RevealedScript: testScript,
 		},
+	}, {
+		name: "root hash only",
+		given: &Tapscript{
+			Type: TaprootKeySpendRootHash,
+			ControlBlock: &txscript.ControlBlock{
+				InternalKey: testPubKey,
+			},
+			RootHash: testScript,
+		},
+		expected: &Tapscript{
+			Type: TaprootKeySpendRootHash,
+			ControlBlock: &txscript.ControlBlock{
+				InternalKey:    testPubKey,
+				InclusionProof: []byte{},
+			},
+			RootHash: testScript,
+		},
 	}}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Makes it possible to also import a public key as a Taproot output with `ImportPublicKey`. NOTE: This will only ever treat the public key as a BIP-0086 key and derive the Taproot public key accordingly.

All non-BIP-0086 use cases need to use the `ImportTaprootScript` method.

We also add two new use cases where only partial information is available with a `ImportTaprootScript`:
1. Only the internal key and the merkle root key is known (`TaprootKeySpendRootHash`)
2. Only the final Taproot key is known, no information about the tap tweak is available (`TaprootFullKeyOnly`)