### PR TITLE
wallet/txauthor: fix call to EstimateVirtualSize

### DIFF
--- a/wallet/txauthor/author.go
+++ b/wallet/txauthor/author.go
@@ -95,7 +95,7 @@ func NewUnsignedTransaction(outputs []*wire.TxOut, feeRatePerKb btcutil.Amount,
 
 	targetAmount := SumOutputValues(outputs)
 	estimatedSize := txsizes.EstimateVirtualSize(
-		0, 1, 0, outputs, changeSource.ScriptSize,
+		0, 0, 1, 0, outputs, changeSource.ScriptSize,
 	)
 	targetFee := txrules.FeeForSerializeSize(feeRatePerKb, estimatedSize)
 


### PR DESCRIPTION
The CI didn't pick this up before since the main wallet was still using an older version. We'll tag a new txauthor version after this, which'll let us actually update the wallet and eventually lnd.