### PR TITLE
txsize: add WU for stack size

### DIFF
--- a/wallet/txsizes/size.go
+++ b/wallet/txsizes/size.go
@@ -161,9 +161,10 @@ const (
 	// a witness for spending P2TR outputs. It
 	// is calculated as:
 	//
+	//   - 1 wu compact int encoding value 1 (number of items)
 	//   - 1 wu compact int encoding value 65
 	//   - 64 wu BIP-340 schnorr signature + 1 wu sighash
-	RedeemP2TRInputWitnessWeight = 1 + 65
+	RedeemP2TRInputWitnessWeight = 1 + 1 + 65
 )
 
 // SumOutputSerializeSizes sums up the serialized size of the supplied outputs.


### PR DESCRIPTION
The input witness estimation for a P2TR was missing the single weight unit for the stack size encoded as a compact int.
This was balanced out by the worst case estimation of the Schnorr signature which can contain the sighash flag, so this wasn't discovered earlier.

@Roasbeef this requires a new tag to be pushed: `wallet/txsizes/v1.2.3`.
cc @benthecarman.