### PR TITLE
wallet: add script size for P2TR change output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.3.2
 	github.com/btcsuite/btcwallet/wallet/txrules v1.2.0
-	github.com/btcsuite/btcwallet/wallet/txsizes v1.2.2
+	github.com/btcsuite/btcwallet/wallet/txsizes v1.2.3
 	github.com/btcsuite/btcwallet/walletdb v1.4.0
 	github.com/btcsuite/btcwallet/wtxmgr v1.5.0
 	github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -382,6 +382,8 @@ func (w *Wallet) addrMgrWithChangeSource(dbtx walletdb.ReadWriteTx,
 		scriptSize = txsizes.NestedP2WPKHPkScriptSize
 	case waddrmgr.WitnessPubKey:
 		scriptSize = txsizes.P2WPKHPkScriptSize
+	case waddrmgr.TaprootPubKey:
+		scriptSize = txsizes.P2TRPkScriptSize
 	}
 
 	newChangeScript := func() ([]byte, error) {


### PR DESCRIPTION
This commit adds a script size for a P2TR change output. Without it, the change size for a P2TR output will always be counted as 0 which leads to invalid transactions.

Depends on https://github.com/btcsuite/btcwallet/pull/816.

cc @Roasbeef, @benthecarman.