### PR TITLE
Bug/rescan datarace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ btcwallet
 vendor
 .idea
 coverage.txt
+.vscode

--- a/chain/internal/rescan/rescan.go
+++ b/chain/internal/rescan/rescan.go
@@ -2,6 +2,8 @@ package rescan
 
 import "github.com/lightninglabs/neutrino"
 
+var _ Interface = (*neutrino.Rescan)(nil)
+
 type Updater interface {
 	Update(...neutrino.UpdateOption) error
 }

--- a/chain/internal/rescan/rescan.go
+++ b/chain/internal/rescan/rescan.go
@@ -20,3 +20,5 @@ type Interface interface {
 
 	WaitForShutdown()
 }
+
+type New func(...neutrino.RescanOption) Interface

--- a/chain/internal/rescan/rescan.go
+++ b/chain/internal/rescan/rescan.go
@@ -1,0 +1,20 @@
+package rescan
+
+import "github.com/lightninglabs/neutrino"
+
+type Updater interface {
+	Update(...neutrino.UpdateOption) error
+}
+
+type Starter interface {
+	Start() <-chan error
+}
+
+// Interface encapsulates the public
+// methods of a *neutrino.Rescan used by the NeutrinoClient.
+type Interface interface {
+	Starter
+	Updater
+
+	WaitForShutdown()
+}

--- a/chain/internal/rescan/rescan.go
+++ b/chain/internal/rescan/rescan.go
@@ -18,7 +18,11 @@ type Interface interface {
 	Starter
 	Updater
 
+	// WaitForShutdown blocks until the underlying rescan object is shutdown.
+	// Close the quit channel before calling WaitForShutdown.
 	WaitForShutdown()
 }
 
-type New func(...neutrino.RescanOption) Interface
+// NewFunc defines a constructor that accepts rescan options and returns a
+// struct that satisfies Interface
+type NewFunc func(...neutrino.RescanOption) Interface

--- a/chain/mocks_test.go
+++ b/chain/mocks_test.go
@@ -30,6 +30,8 @@ var (
 	_ NeutrinoChainService = (*mockChainService)(nil)
 )
 
+// newMockNeutrinoClient constructs a neutrino client with a mock chain
+// service implementation and mock rescan Interface implementation.
 func newMockNeutrinoClient(t *testing.T,
 	opts ...func(*mockRescanner)) *NeutrinoClient {
 	t.Helper()
@@ -54,10 +56,10 @@ func newMockNeutrinoClient(t *testing.T,
 	}
 }
 
+// mockRescanner is a mock implementation of a rescan Interface for use in
+// tests.
 type mockRescanner struct {
 	updateArgs *list.List
-	errs       []error
-	rescanQuit <-chan struct{}
 }
 
 func (m *mockRescanner) Start() <-chan error {
@@ -74,6 +76,8 @@ func (m *mockRescanner) Update(opts ...neutrino.UpdateOption) error {
 	return nil
 }
 
+// mockChainService is a mock implementation of a chain service for use in
+// tests.
 type mockChainService struct{}
 
 func (m *mockChainService) Start() error {

--- a/chain/mocks_test.go
+++ b/chain/mocks_test.go
@@ -49,10 +49,10 @@ func newMockNeutrinoClient(t *testing.T,
 	}
 
 	return &NeutrinoClient{
-		CS:           &mockChainService{},
-		newRescanner: newRescanner,
-		rescanCh:     make(chan rescan.Interface, 1),
-		rescanQuitCh: make(chan chan struct{}, 1),
+		CS:            &mockChainService{},
+		newRescanFunc: newRescanner,
+		rescanCh:      make(chan rescan.Interface, 1),
+		rescanQuitCh:  make(chan chan struct{}, 1),
 	}
 }
 

--- a/chain/mocks_test.go
+++ b/chain/mocks_test.go
@@ -34,8 +34,21 @@ func newMockNeutrinoClient(t *testing.T,
 	opts ...func(*mockRescanner)) *NeutrinoClient {
 	t.Helper()
 
+	// newRescanner returns a mockRescanner with options set by the
+	// newMockNeutrinoClient function
+	newRescanner := func(ro ...neutrino.RescanOption) rescan.Interface {
+		mrs := &mockRescanner{
+			updateArgs: list.New(),
+		}
+		for _, o := range opts {
+			o(mrs)
+		}
+		return mrs
+	}
+
 	return &NeutrinoClient{
-		CS: &mockChainService{},
+		CS:           &mockChainService{},
+		newRescanner: newRescanner,
 	}
 }
 

--- a/chain/mocks_test.go
+++ b/chain/mocks_test.go
@@ -1,0 +1,152 @@
+package chain
+
+import (
+	"container/list"
+	"errors"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/gcs"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/chain/internal/rescan"
+	"github.com/lightninglabs/neutrino"
+	"github.com/lightninglabs/neutrino/banman"
+	"github.com/lightninglabs/neutrino/headerfs"
+)
+
+// Define variables for mocks
+var (
+	ErrNotImplemented = errors.New("not implemented")
+	testBestBlock     = &headerfs.BlockStamp{
+		Height: 42,
+	}
+)
+
+// Define static type checks
+var (
+	_ rescan.Interface     = (*mockRescanner)(nil)
+	_ NeutrinoChainService = (*mockChainService)(nil)
+)
+
+func newMockNeutrinoClient(t *testing.T,
+	opts ...func(*mockRescanner)) *NeutrinoClient {
+	t.Helper()
+
+	return &NeutrinoClient{
+		CS: &mockChainService{},
+	}
+}
+
+type mockRescanner struct {
+	updateArgs *list.List
+	errs       []error
+	rescanQuit <-chan struct{}
+}
+
+func (m *mockRescanner) Start() <-chan error {
+	errs := make(chan error)
+	return errs
+}
+
+func (m *mockRescanner) WaitForShutdown() {
+	// no-op
+}
+
+func (m *mockRescanner) Update(opts ...neutrino.UpdateOption) error {
+	m.updateArgs.PushBack(opts)
+	return nil
+}
+
+type mockChainService struct{}
+
+func (m *mockChainService) Start() error {
+	return nil
+}
+
+func (m *mockChainService) GetBlock(chainhash.Hash,
+	...neutrino.QueryOption) (*btcutil.Block, error) {
+	return nil, ErrNotImplemented
+}
+
+func (m *mockChainService) GetBlockHeight(*chainhash.Hash) (int32, error) {
+	return 0, ErrNotImplemented
+}
+
+func (m *mockChainService) BestBlock() (*headerfs.BlockStamp, error) {
+	return m.getBestBlock(), nil
+}
+
+func (m *mockChainService) getBestBlock() *headerfs.BlockStamp {
+	return testBestBlock
+}
+
+func (m *mockChainService) GetBlockHash(int64) (*chainhash.Hash, error) {
+	return nil, ErrNotImplemented
+}
+
+func (m *mockChainService) GetBlockHeader(
+	*chainhash.Hash) (*wire.BlockHeader, error) {
+	return &wire.BlockHeader{}, nil
+}
+
+func (m *mockChainService) IsCurrent() bool {
+	return false
+}
+
+func (m *mockChainService) SendTransaction(*wire.MsgTx) error {
+	return ErrNotImplemented
+}
+
+func (m *mockChainService) GetCFilter(chainhash.Hash,
+	wire.FilterType, ...neutrino.QueryOption) (*gcs.Filter, error) {
+	return nil, ErrNotImplemented
+}
+
+func (m *mockChainService) GetUtxo(
+	_ ...neutrino.RescanOption) (*neutrino.SpendReport, error) {
+	return nil, ErrNotImplemented
+}
+
+func (m *mockChainService) BanPeer(string, banman.Reason) error {
+	return ErrNotImplemented
+}
+
+func (m *mockChainService) IsBanned(addr string) bool {
+	panic(ErrNotImplemented)
+}
+
+func (m *mockChainService) AddPeer(*neutrino.ServerPeer) {
+	panic(ErrNotImplemented)
+}
+
+func (m *mockChainService) AddBytesSent(uint64) {
+	panic(ErrNotImplemented)
+}
+
+func (m *mockChainService) AddBytesReceived(uint64) {
+	panic(ErrNotImplemented)
+}
+
+func (m *mockChainService) NetTotals() (uint64, uint64) {
+	panic(ErrNotImplemented)
+}
+
+func (m *mockChainService) UpdatePeerHeights(*chainhash.Hash,
+	int32, *neutrino.ServerPeer,
+) {
+	panic(ErrNotImplemented)
+}
+
+func (m *mockChainService) ChainParams() chaincfg.Params {
+	panic(ErrNotImplemented)
+}
+
+func (m *mockChainService) Stop() error {
+	panic(ErrNotImplemented)
+}
+
+func (m *mockChainService) PeerByAddr(string) *neutrino.ServerPeer {
+	panic(ErrNotImplemented)
+}

--- a/chain/mocks_test.go
+++ b/chain/mocks_test.go
@@ -50,6 +50,7 @@ func newMockNeutrinoClient(t *testing.T,
 		CS:           &mockChainService{},
 		newRescanner: newRescanner,
 		rescanCh:     make(chan rescan.Interface, 1),
+		rescanQuitCh: make(chan chan struct{}, 1),
 	}
 }
 

--- a/chain/mocks_test.go
+++ b/chain/mocks_test.go
@@ -49,6 +49,7 @@ func newMockNeutrinoClient(t *testing.T,
 	return &NeutrinoClient{
 		CS:           &mockChainService{},
 		newRescanner: newRescanner,
+		rescanCh:     make(chan rescan.Interface, 1),
 	}
 }
 

--- a/chain/neutrino.go
+++ b/chain/neutrino.go
@@ -14,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/chain/internal/rescan"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/lightninglabs/neutrino"
@@ -54,7 +55,7 @@ type NeutrinoClient struct {
 	chainParams *chaincfg.Params
 
 	// We currently support one rescan/notifiction goroutine per client
-	rescan *neutrino.Rescan
+	rescan rescan.Interface
 
 	enqueueNotification     chan interface{}
 	dequeueNotification     chan interface{}

--- a/chain/neutrino.go
+++ b/chain/neutrino.go
@@ -58,7 +58,7 @@ type NeutrinoClient struct {
 
 	// We currently support one rescan/notifiction goroutine per client
 	rescan       rescan.Interface
-	newRescanner rescan.New
+	newRescanner rescan.NewFunc
 
 	enqueueNotification     chan interface{}
 	dequeueNotification     chan interface{}
@@ -785,7 +785,7 @@ out:
 
 // getNewRescanner injects the Rescanner constructor when called and defaults
 // to using neutrino.NewRescan when unspecified.
-func (s *NeutrinoClient) getNewRescanner() rescan.New {
+func (s *NeutrinoClient) getNewRescanner() rescan.NewFunc {
 	if s.newRescanner == nil {
 		s.newRescanner = func(ropts ...neutrino.RescanOption) rescan.Interface {
 			cs := &neutrino.RescanChainSource{

--- a/chain/neutrino.go
+++ b/chain/neutrino.go
@@ -48,6 +48,8 @@ type NeutrinoChainService interface {
 	PeerByAddr(string) *neutrino.ServerPeer
 }
 
+var _ NeutrinoChainService = (*neutrino.ChainService)(nil)
+
 // NeutrinoClient is an implementation of the btcwalet chain.Interface interface.
 type NeutrinoClient struct {
 	CS NeutrinoChainService

--- a/chain/neutrino_test.go
+++ b/chain/neutrino_test.go
@@ -72,7 +72,8 @@ func TestNeutrinoClientNotifyReceived(t *testing.T) {
 	case <-done:
 		// Require that the expected number of calls to Update were made
 		// once done sending all NotifyReceived calls.
-		mockRescan := nc.rescan.(*mockRescanner)
+		maybeRescan := <-nc.rescanCh
+		mockRescan := maybeRescan.(*mockRescanner)
 		gotUpdateCalls := mockRescan.updateArgs.Len()
 		require.Equal(t, wantUpdateCalls, gotUpdateCalls)
 	}

--- a/chain/neutrino_test.go
+++ b/chain/neutrino_test.go
@@ -1,0 +1,41 @@
+package chain
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNeutrinoClientSequentialStartStop ensures that the client
+// can sequentially Start and Stop without errors or races.
+func TestNeutrinoClientSequentialStartStop(t *testing.T) {
+	var (
+		ctx, cancel   = context.WithTimeout(context.Background(), 1*time.Second)
+		nc            = newMockNeutrinoClient(t)
+		callStartStop = func() <-chan struct{} {
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				err := nc.Start()
+				require.NoError(t, err)
+				nc.Stop()
+				nc.WaitForShutdown()
+			}()
+			return done
+		}
+		numRestarts = 5
+	)
+
+	t.Cleanup(cancel)
+
+	for i := 0; i < numRestarts; i++ {
+		done := callStartStop()
+		select {
+		case <-ctx.Done():
+			t.Fatal("timed out")
+		case <-done:
+		}
+	}
+}

--- a/chain/neutrino_test.go
+++ b/chain/neutrino_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,5 +38,41 @@ func TestNeutrinoClientSequentialStartStop(t *testing.T) {
 			t.Fatal("timed out")
 		case <-done:
 		}
+	}
+}
+
+// TestNeutrinoClientNotifyReceived verifies that a call to NotifyReceived sets
+// the client into the scanning state and that subsequent calls while scanning
+// will call Update on the client's Rescanner.
+func TestNeutrinoClientNotifyReceived(t *testing.T) {
+	var (
+		ctx, cancel = context.WithTimeout(context.Background(),
+			1*time.Second)
+		addrs                   []btcutil.Address
+		done                    = make(chan struct{})
+		nc                      = newMockNeutrinoClient(t)
+		wantNotifyReceivedCalls = 4
+		wantUpdateCalls         = wantNotifyReceivedCalls - 1
+	)
+	t.Cleanup(cancel)
+
+	go func() {
+		defer close(done)
+		for i := 0; i < wantNotifyReceivedCalls; i++ {
+			err := nc.NotifyReceived(addrs)
+			require.NoError(t, err)
+		}
+	}()
+
+	// Wait for all calls to complete or test to time out.
+	select {
+	case <-ctx.Done():
+		t.Fatal("timed out")
+	case <-done:
+		// Require that the expected number of calls to Update were made
+		// once done sending all NotifyReceived calls.
+		mockRescan := nc.rescan.(*mockRescanner)
+		gotUpdateCalls := mockRescan.updateArgs.Len()
+		require.Equal(t, wantUpdateCalls, gotUpdateCalls)
 	}
 }

--- a/chain/neutrino_test.go
+++ b/chain/neutrino_test.go
@@ -14,7 +14,8 @@ import (
 // can sequentially Start and Stop without errors or races.
 func TestNeutrinoClientSequentialStartStop(t *testing.T) {
 	var (
-		ctx, cancel   = context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel = context.WithTimeout(context.Background(),
+			1*time.Second)
 		nc            = newMockNeutrinoClient(t)
 		callStartStop = func() <-chan struct{} {
 			done := make(chan struct{})
@@ -84,12 +85,13 @@ func TestNeutrinoClientNotifyReceived(t *testing.T) {
 // panic on replacing the Rescanner.
 func TestNeutrinoClientNotifyReceivedRescan(t *testing.T) {
 	var (
-		ctx, cancel = context.WithTimeout(context.Background(), 1*time.Second)
-		wg          sync.WaitGroup
-		addrs       []btcutil.Address
-		startHash   = testBestBlock.Hash
-		done        = make(chan struct{})
-		nc          = newMockNeutrinoClient(t)
+		ctx, cancel = context.WithTimeout(context.Background(),
+			1*time.Second)
+		wg        sync.WaitGroup
+		addrs     []btcutil.Address
+		startHash = testBestBlock.Hash
+		done      = make(chan struct{})
+		nc        = newMockNeutrinoClient(t)
 
 		callRescan = func() {
 			defer wg.Done()


### PR DESCRIPTION
### Background
There is datarace in the neutrino client implementation that
is causing test flakes in `lnd`.  Specifically, there was a shared
struct property `rescan` whose updates resulted in a data race with
the possibility of a panic when `rescan` was `nil`.  Further investigation
revealed race conditions on the `rescanQuit` and `rescanErr`
props of the client as well.

### Changes
This PR modifies the design of the neutrino client to better reflect
the requirement that only a single `Rescan` object instance be
running at a time.  To that end, this PR removes the `rescan` property
on the client and replaces it with two buffered channels (`cap` = 1), one each for
a rescanner and the rescanner's signal channel.  In this way there is no
need to maintain the state `scanning`.  Now any method can
infer that the client is scanning if it is able to read a scanner from the channel.

This PR resolves a data race on the `rescanErr` channel via a
new error chan consumer method that takes all new error channels
from rescanner restarts and feeds any read errors onto `rescanErr`.

### Testing
This PR adds two interfaces `rescan.Interface` and `NeutrinoChainService`
to abstract out the dependency on structs from the `neutrino` package.

This PR adds a file of mock implementations for these interfaces and uses them
in a new unit test file.  The unit tests added are not intended to capture all
the functionality of the client, but to demonstrate that the data races are resolved
and these tests should be run with the `-race` flag enabled.

### Reviewing
1. Checkout 93ca6856b389ea492e787250c2fb3beaa3ece411 and run tests.
`TestNeutrinoClientNotifyReceivedRescan` will fail with a segmentation fault 
in the neutrino client due to`rescan` being set to `nil`.

2. Checkout 6e1d604ce18c21c9e9f08a500301248a5b466739 and verify that
the segmentation fault is fixed and `TestNeutrinoClientNotifyReceivedRescan`
passes, but that `-race` flag testing fails.

3. Checkout 56af455326cbe9dfacf81dfbb19ef3c3b8043501 run tests and
verify that `TestNeutrinoClientNotifyReceivedRescan` passes with `-race` flag enabled.

All changes after 56af455326cbe9dfacf81dfbb19ef3c3b8043501 are cosmetic and
cleanup related.



fixes #819 