### PR TITLE
chain: fix NeutrinoClient segfault on NotifyReceived call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor
 .idea
 coverage.txt
 *.swp
+.vscode

--- a/chain/chainservice.go
+++ b/chain/chainservice.go
@@ -1,0 +1,40 @@
+package chain
+
+import (
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/gcs"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/neutrino"
+	"github.com/lightninglabs/neutrino/banman"
+	"github.com/lightninglabs/neutrino/headerfs"
+)
+
+// NeutrinoChainService is an interface that encapsulates all the public
+// methods of a *neutrino.ChainService
+type NeutrinoChainService interface {
+	Start() error
+	GetBlock(chainhash.Hash, ...neutrino.QueryOption) (*btcutil.Block, error)
+	GetBlockHeight(*chainhash.Hash) (int32, error)
+	BestBlock() (*headerfs.BlockStamp, error)
+	GetBlockHash(int64) (*chainhash.Hash, error)
+	GetBlockHeader(*chainhash.Hash) (*wire.BlockHeader, error)
+	IsCurrent() bool
+	SendTransaction(*wire.MsgTx) error
+	GetCFilter(chainhash.Hash, wire.FilterType,
+		...neutrino.QueryOption) (*gcs.Filter, error)
+	GetUtxo(...neutrino.RescanOption) (*neutrino.SpendReport, error)
+	BanPeer(string, banman.Reason) error
+	IsBanned(addr string) bool
+	AddPeer(*neutrino.ServerPeer)
+	AddBytesSent(uint64)
+	AddBytesReceived(uint64)
+	NetTotals() (uint64, uint64)
+	UpdatePeerHeights(*chainhash.Hash, int32, *neutrino.ServerPeer)
+	ChainParams() chaincfg.Params
+	Stop() error
+	PeerByAddr(string) *neutrino.ServerPeer
+}
+
+var _ NeutrinoChainService = (*neutrino.ChainService)(nil)

--- a/chain/mocks_test.go
+++ b/chain/mocks_test.go
@@ -1,0 +1,157 @@
+package chain
+
+import (
+	"container/list"
+	"errors"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/gcs"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/lightninglabs/neutrino"
+	"github.com/lightninglabs/neutrino/banman"
+	"github.com/lightninglabs/neutrino/headerfs"
+)
+
+var (
+	errNotImplemented = errors.New("not implemented")
+	testBestBlock     = &headerfs.BlockStamp{
+		Height: 42,
+	}
+)
+
+var (
+	_ rescanner            = (*mockRescanner)(nil)
+	_ NeutrinoChainService = (*mockChainService)(nil)
+)
+
+// newMockNeutrinoClient constructs a neutrino client with a mock chain
+// service implementation and mock rescanner interface implementation.
+func newMockNeutrinoClient() *NeutrinoClient {
+	// newRescanFunc returns a mockRescanner
+	newRescanFunc := func(ro ...neutrino.RescanOption) rescanner {
+		return &mockRescanner{
+			updateArgs: list.New(),
+		}
+	}
+
+	return &NeutrinoClient{
+		CS:        &mockChainService{},
+		newRescan: newRescanFunc,
+	}
+}
+
+// mockRescanner is a mock implementation of a rescanner interface for use in
+// tests.  Only the Update method is implemented.
+type mockRescanner struct {
+	updateArgs *list.List
+}
+
+func (m *mockRescanner) Update(opts ...neutrino.UpdateOption) error {
+	m.updateArgs.PushBack(opts)
+	return nil
+}
+
+func (m *mockRescanner) Start() <-chan error {
+	return nil
+}
+
+func (m *mockRescanner) WaitForShutdown() {
+	// no-op
+}
+
+// mockChainService is a mock implementation of a chain service for use in
+// tests.  Only the Start, GetBlockHeader and BestBlock methods are implemented.
+type mockChainService struct {
+}
+
+func (m *mockChainService) Start() error {
+	return nil
+}
+
+func (m *mockChainService) BestBlock() (*headerfs.BlockStamp, error) {
+	return testBestBlock, nil
+}
+
+func (m *mockChainService) GetBlockHeader(
+	*chainhash.Hash) (*wire.BlockHeader, error) {
+
+	return &wire.BlockHeader{}, nil
+}
+
+func (m *mockChainService) GetBlock(chainhash.Hash,
+	...neutrino.QueryOption) (*btcutil.Block, error) {
+
+	return nil, errNotImplemented
+}
+
+func (m *mockChainService) GetBlockHeight(*chainhash.Hash) (int32, error) {
+	return 0, errNotImplemented
+}
+
+func (m *mockChainService) GetBlockHash(int64) (*chainhash.Hash, error) {
+	return nil, errNotImplemented
+}
+
+func (m *mockChainService) IsCurrent() bool {
+	return false
+}
+
+func (m *mockChainService) SendTransaction(*wire.MsgTx) error {
+	return errNotImplemented
+}
+
+func (m *mockChainService) GetCFilter(chainhash.Hash,
+	wire.FilterType, ...neutrino.QueryOption) (*gcs.Filter, error) {
+
+	return nil, errNotImplemented
+}
+
+func (m *mockChainService) GetUtxo(
+	_ ...neutrino.RescanOption) (*neutrino.SpendReport, error) {
+
+	return nil, errNotImplemented
+}
+
+func (m *mockChainService) BanPeer(string, banman.Reason) error {
+	return errNotImplemented
+}
+
+func (m *mockChainService) IsBanned(addr string) bool {
+	panic(errNotImplemented)
+}
+
+func (m *mockChainService) AddPeer(*neutrino.ServerPeer) {
+	panic(errNotImplemented)
+}
+
+func (m *mockChainService) AddBytesSent(uint64) {
+	panic(errNotImplemented)
+}
+
+func (m *mockChainService) AddBytesReceived(uint64) {
+	panic(errNotImplemented)
+}
+
+func (m *mockChainService) NetTotals() (uint64, uint64) {
+	panic(errNotImplemented)
+}
+
+func (m *mockChainService) UpdatePeerHeights(*chainhash.Hash,
+	int32, *neutrino.ServerPeer,
+) {
+	panic(errNotImplemented)
+}
+
+func (m *mockChainService) ChainParams() chaincfg.Params {
+	panic(errNotImplemented)
+}
+
+func (m *mockChainService) Stop() error {
+	panic(errNotImplemented)
+}
+
+func (m *mockChainService) PeerByAddr(string) *neutrino.ServerPeer {
+	panic(errNotImplemented)
+}

--- a/chain/neutrino.go
+++ b/chain/neutrino.go
@@ -20,9 +20,9 @@ import (
 	"github.com/lightninglabs/neutrino/headerfs"
 )
 
-// NeutrinoClient is an implementation of the btcwalet chain.Interface interface.
+// NeutrinoClient is an implementation of the btcwallet chain.Interface interface.
 type NeutrinoClient struct {
-	CS *neutrino.ChainService
+	CS NeutrinoChainService
 
 	chainParams *chaincfg.Params
 

--- a/chain/neutrino_test.go
+++ b/chain/neutrino_test.go
@@ -1,0 +1,218 @@
+package chain
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// maxDur is the max duration a test has to execute successfully.
+var maxDur = 5 * time.Second
+
+// TestNeutrinoClientSequentialStartStop ensures that the client
+// can sequentially Start and Stop without errors or races.
+func TestNeutrinoClientSequentialStartStop(t *testing.T) {
+	var (
+		nc           = newMockNeutrinoClient()
+		wantRestarts = 50
+	)
+
+	// callStartStop starts the neutrino client, requires no error on
+	// startup, immediately stops the client and waits for shutdown.
+	// The returned channel is closed once shutdown is complete.
+	callStartStop := func() <-chan struct{} {
+		done := make(chan struct{})
+
+		go func() {
+			defer close(done)
+
+			err := nc.Start()
+			require.NoError(t, err)
+			nc.Stop()
+			nc.WaitForShutdown()
+		}()
+
+		return done
+	}
+
+	// For each wanted restart, execute callStartStop and wait until the
+	// call is done before continuing to the next execution.  Waiting for
+	// a read from done forces all executions of callStartStop to be done
+	// sequentially.
+	//
+	// The test fails if all of the wanted restarts cannot be completed
+	// sequentially before the timeout is reached.
+	timeout := time.After(maxDur)
+	for i := 0; i < wantRestarts; i++ {
+		select {
+		case <-timeout:
+			t.Fatal("timed out")
+		case <-callStartStop():
+		}
+	}
+}
+
+// TestNeutrinoClientNotifyReceived verifies that a call to NotifyReceived sets
+// the client into the scanning state and that subsequent calls while scanning
+// will call Update on the client's Rescanner.
+func TestNeutrinoClientNotifyReceived(t *testing.T) {
+	var (
+		nc                      = newMockNeutrinoClient()
+		wantNotifyReceivedCalls = 50
+		wantUpdateCalls         = wantNotifyReceivedCalls - 1
+	)
+
+	// executeCalls calls NotifyReceived() synchronously n times without
+	// blocking the test and requires no error after each call.
+	executeCalls := func(n int) <-chan struct{} {
+		done := make(chan struct{})
+
+		go func() {
+			defer close(done)
+
+			var addrs []btcutil.Address
+			for i := 0; i < n; i++ {
+				err := nc.NotifyReceived(addrs)
+				require.NoError(t, err)
+			}
+		}()
+
+		return done
+	}
+
+	// Wait for all calls to complete or test to time out.
+	timeout := time.After(maxDur)
+	select {
+	case <-timeout:
+		t.Fatal("timed out")
+	case <-executeCalls(wantNotifyReceivedCalls):
+		// Require that the expected number of calls to Update were made
+		// once done sending all NotifyReceived calls.
+		mockRescan := nc.rescan.(*mockRescanner)
+		gotUpdateCalls := mockRescan.updateArgs.Len()
+		require.Equal(t, wantUpdateCalls, gotUpdateCalls)
+	}
+}
+
+// TestNeutrinoClientNotifyReceivedRescan verifies concurrent calls to
+// NotifyBlocks, NotifyReceived and Rescan do not result in a data race
+// and that there is no panic on replacing the rescan goroutine single instance.
+//
+// Each successful method call writes a success message to a buffered channel.
+// The channel is buffered so that no concurrent reader is needed.  The buffer
+// size is exactly the number of goroutines launched because each goroutine
+// must finish successfully or else this test will fail.  Each message is read
+// out of the channel to verify the number of messages received is the number
+// expected (i.e., wantMsgs == gotMsgs).
+func TestNeutrinoClientNotifyReceivedRescan(t *testing.T) {
+	var (
+		addrs     []btcutil.Address
+		nc        = newMockNeutrinoClient()
+		wantMsgs  = 100
+		gotMsgs   = 0
+		msgCh     = make(chan string, wantMsgs)
+		msgPrefix = "successfully called"
+
+		// sendMsg writes a message to the buffered message channel.
+		sendMsg = func(s string) {
+			msgCh <- fmt.Sprintf("%s %s", msgPrefix, s)
+		}
+	)
+
+	// Define closures to wrap desired neutrino client method calls.
+
+	// cleanup is the shared cleanup function for a closure executing
+	// a neutrino client method call.  It sends a message and then
+	// decrements the wait group counter.
+	cleanup := func(wg *sync.WaitGroup, s string) {
+		defer wg.Done()
+		sendMsg(s)
+	}
+
+	// callRescan calls the Rescan() method and asserts it completes
+	// with no errors. Rescan() is called with the hash of an empty header
+	// on each call.
+	startHash := new(wire.BlockHeader).BlockHash()
+	callRescan := func(wg *sync.WaitGroup) {
+		defer cleanup(wg, "rescan")
+
+		err := nc.Rescan(&startHash, addrs, nil)
+		require.NoError(t, err)
+	}
+
+	// callNotifyReceived calls the NotifyReceived() method and asserts it
+	// completes with no errors.
+	callNotifyReceived := func(wg *sync.WaitGroup) {
+		defer cleanup(wg, "notify received")
+
+		err := nc.NotifyReceived(addrs)
+		require.NoError(t, err)
+	}
+
+	// callNotifyBlocks calls the NotifyBlocks() method and asserts it
+	// completes with no errors.
+	callNotifyBlocks := func(wg *sync.WaitGroup) {
+		defer cleanup(wg, "notify blocks")
+
+		err := nc.NotifyBlocks()
+		require.NoError(t, err)
+	}
+
+	// executeCalls launches the wanted number of goroutines, waits
+	// for them to finish and signals all done by closing the returned
+	// channel.
+	executeCalls := func(n int) <-chan struct{} {
+		done := make(chan struct{})
+
+		go func() {
+			defer close(done)
+
+			var wg sync.WaitGroup
+			defer wg.Wait()
+
+			wg.Add(n)
+			for i := 0; i < n; i++ {
+				if i%3 == 0 {
+					go callRescan(&wg)
+					continue
+				}
+
+				if i%10 == 0 {
+					go callNotifyBlocks(&wg)
+					continue
+				}
+
+				go callNotifyReceived(&wg)
+			}
+		}()
+
+		return done
+	}
+
+	// Start the client.
+	err := nc.Start()
+	require.NoError(t, err)
+
+	// Wait for all calls to complete or test to time out.
+	timeout := time.After(maxDur)
+	select {
+	case <-timeout:
+		t.Fatal("timed out")
+	case <-executeCalls(wantMsgs):
+		// Ensure that exactly wantRoutines number of calls were made
+		// by counting the results on the message channel.
+		close(msgCh)
+		for str := range msgCh {
+			assert.Contains(t, str, msgPrefix)
+			gotMsgs++
+		}
+
+		require.Equal(t, wantMsgs, gotMsgs)
+	}
+}

--- a/chain/rescan.go
+++ b/chain/rescan.go
@@ -1,0 +1,39 @@
+package chain
+
+import "github.com/lightninglabs/neutrino"
+
+var _ rescanner = (*neutrino.Rescan)(nil)
+
+// rescanner is an interface that abstractly defines the public methods of
+// a *neutrino.Rescan.  The interface is private because it is only ever
+// intended to be implemented by a *neutrino.Rescan.
+type rescanner interface {
+	starter
+	updater
+
+	// WaitForShutdown blocks until the underlying rescan object is shutdown.
+	// Close the quit channel before calling WaitForShutdown.
+	WaitForShutdown()
+}
+
+// updater is the interface that wraps the Update method of a rescan object.
+type updater interface {
+	// Update targets a long-running rescan/notification client with
+	// updateable filters.  Attempts to update the filters will fail
+	// if either the rescan is no longer running or the shutdown signal is
+	// received prior to sending the update.
+	Update(...neutrino.UpdateOption) error
+}
+
+// starter is the interface that wraps the Start method of a rescan object.
+type starter interface {
+	// Start initializes the rescan goroutine, which will begin to scan the chain
+	// according to the specified rescan options.  Start returns a channel that
+	// communicates any startup errors.  Attempts to start a running rescan
+	// goroutine will error.
+	Start() <-chan error
+}
+
+// newRescanFunc defines a constructor that accepts rescan options and returns
+// an object that satisfies rescanner interface.
+type newRescanFunc func(...neutrino.RescanOption) rescanner


### PR DESCRIPTION
Fixes #819
Replaces #820

### Background

There is datarace in the neutrino client implementation that is causing test
flakes in `lnd`. The shared `rescan` object and the granular
locking strategy allow for the possibility of a segmentation fault when
`NotifyReceived` attempts to call `Update` on a `rescan` that is `nil`.  This
is because the `clientMtx` lock is released after `rescan` is set to `nil`.

### Changes

The solution here is to be minimally invasive.  Add a new `rescanMtx` mutex
and require that the `NotifyReceived` method and the `Rescan` method
hold the `rescanMtx` lock for the duration of their execution.  Locking and
unlocking of the client is unaffected and changes to the `rescan` object
become atomic.


### Testing

This PR adds two interfaces `rescanner` and `nutrinoChainService`
to abstract out the dependency on structs from the `neutrino` package.

This PR adds a file of mock implementations for these interfaces and uses them
in a new unit test file.
