### PR TITLE
wallet: log txid:index for leases where tx is unknown

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -795,13 +795,13 @@ func (w *Wallet) recovery(chainClient chain.Interface,
 // previously used addresses for a particular account derivation path. At a high
 // level, the algorithm works as follows:
 //
-//  1) Ensure internal and external branch horizons are fully expanded.
-//  2) Filter the entire range of blocks, stopping if a non-zero number of
-//       address are contained in a particular block.
-//  3) Record all internal and external addresses found in the block.
-//  4) Record any outpoints found in the block that should be watched for spends
-//  5) Trim the range of blocks up to and including the one reporting the addrs.
-//  6) Repeat from (1) if there are still more blocks in the range.
+//  1. Ensure internal and external branch horizons are fully expanded.
+//  2. Filter the entire range of blocks, stopping if a non-zero number of
+//     address are contained in a particular block.
+//  3. Record all internal and external addresses found in the block.
+//  4. Record any outpoints found in the block that should be watched for spends
+//  5. Trim the range of blocks up to and including the one reporting the addrs.
+//  6. Repeat from (1) if there are still more blocks in the range.
 //
 // TODO(conner): parallelize/pipeline/cache intermediate network requests
 func (w *Wallet) recoverScopedAddresses(
@@ -2771,6 +2771,13 @@ func (w *Wallet) ListLeasedOutputs() ([]*ListLeasedOutputResult, error) {
 			details, err := w.TxStore.TxDetails(ns, &output.Outpoint.Hash)
 			if err != nil {
 				return err
+			}
+
+			if details == nil {
+				log.Infof("unable to find tx details for "+
+					"%v:%v", output.Outpoint.Hash,
+					output.Outpoint.Index)
+				continue
 			}
 
 			txOut := details.MsgTx.TxOut[output.Outpoint.Index]


### PR DESCRIPTION
Debugging a scenario where a lease exists on disk, but the tx associated with that output no longer does. This can potentially happen if a leased output is somehow spent before the lease, or if the lease itself was for an unconfirmed output which was RBF'd (thus the txid changed).