### PR TITLE
wallet: fix argument order in call to txToOutputs

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1211,7 +1211,7 @@ out:
 			}
 
 			tx, err := w.txToOutputs(
-				txr.outputs, txr.changeKeyScope, txr.coinSelectKeyScope,
+				txr.outputs, txr.coinSelectKeyScope, txr.changeKeyScope,
 				txr.account, txr.minconf, txr.feeSatPerKB,
 				txr.coinSelectionStrategy, txr.dryRun,
 			)


### PR DESCRIPTION
The initial version had the arguments swapped. This doesn't show up if both are nil, but can cause some instances to fail that otherwise wouldn't.