### PR TITLE
wallet: ensure change scope is uniform if coin select scope is set

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1279,6 +1279,12 @@ func (w *Wallet) CreateSimpleTx(coinSelectKeyScope *waddrmgr.KeyScope,
 		optFunc(opts)
 	}
 
+	// If the change scope isn't set, then it should be the same as the
+	// coin selection scope in order to match existing behavior.
+	if opts.changeKeyScope == nil {
+		opts.changeKeyScope = coinSelectKeyScope
+	}
+
 	req := createTxRequest{
 		coinSelectKeyScope:    coinSelectKeyScope,
 		changeKeyScope:        opts.changeKeyScope,


### PR DESCRIPTION
In this commit, we fix a regression that was introduced as a result of the new change scope param. Of cases like spending from an imported account with PSBT, the change scope should be the same as the coin selection scope to ensure that a proper change address is available.

Example failure scenario: imported account uses the p2wkh scope, no other imported accounts, but then we fail when we go to make a change addr as the imported account hasn't had a p2tr account created.