### PR TITLE
Fix addresses from non-default scope being detected

### DIFF
--- a/waddrmgr/scoped_manager.go
+++ b/waddrmgr/scoped_manager.go
@@ -246,6 +246,18 @@ var (
 	}
 )
 
+// IsDefaultScope return true if the given scope belongs to the list of default
+// scopes.
+func IsDefaultScope(scope KeyScope) bool {
+	for _, defaultScope := range DefaultKeyScopes {
+		if defaultScope == scope {
+			return true
+		}
+	}
+
+	return false
+}
+
 // ScopedKeyManager is a sub key manager under the main root key manager. The
 // root key manager will handle the root HD key (m/), while each sub scoped key
 // manager will handle the cointype key for a particular key scope
@@ -596,13 +608,7 @@ func (s *ScopedKeyManager) AccountProperties(ns walletdb.ReadBucket,
 		// the account public key consistent with what the caller
 		// provided. Note that his is only done for the default key
 		// scopes, as we only know the HD versions for those.
-		isDefaultKeyScope := false
-		for _, scope := range DefaultKeyScopes {
-			if s.scope == scope {
-				isDefaultKeyScope = true
-				break
-			}
-		}
+		isDefaultKeyScope := IsDefaultScope(s.scope)
 		if acctInfo.acctType == accountDefault && isDefaultKeyScope {
 			props.AccountPubKey, err = s.cloneKeyWithVersion(
 				acctInfo.acctKeyPub,


### PR DESCRIPTION
Fixes https://github.com/lightningnetwork/lnd/issues/6434.

This PR fixes a bug where we'd detect funds sent to a non-default
scope address when adding a relevant TX for another output (e.g. the
change from sending to the non-default scope address). This would lead
to not recognizing the spend of that output later on and the output
would remain as a "ghost UTXO".