### PR TITLE
chain: add additional logging around new mempool logic

### DIFF
--- a/chain/bitcoind_rpc_events.go
+++ b/chain/bitcoind_rpc_events.go
@@ -237,6 +237,11 @@ func (b *bitcoindRPCPollingEvents) txEventHandlerRPC() {
 	for {
 		select {
 		case <-ticker.C:
+			log.Debugf("Reconciling mempool spends with node " +
+				"mempool...")
+
+			now := time.Now()
+
 			// After each ticker interval, we poll the mempool to
 			// check for transactions we haven't seen yet.
 			txs, err := b.client.GetRawMempool()
@@ -248,6 +253,9 @@ func (b *bitcoindRPCPollingEvents) txEventHandlerRPC() {
 
 			// Update our local mempool with the new mempool.
 			newTxs := b.mempool.UpdateMempoolTxes(txs)
+
+			log.Debugf("Reconciled mempool spends in %v",
+				time.Since(now))
 
 			// Notify the client of each new transaction.
 			for _, tx := range newTxs {

--- a/chain/bitcoind_zmq_events.go
+++ b/chain/bitcoind_zmq_events.go
@@ -399,6 +399,11 @@ func (b *bitcoindZMQEvents) mempoolPoller() {
 	for {
 		select {
 		case <-ticker.C:
+			log.Debugf("Reconciling mempool spends with node " +
+				"mempool...")
+
+			now := time.Now()
+
 			// After each ticker interval, we poll the mempool to
 			// check for transactions we haven't seen yet.
 			txs, err := b.mempool.client.GetRawMempool()
@@ -410,6 +415,9 @@ func (b *bitcoindZMQEvents) mempoolPoller() {
 
 			// Update our local mempool with the new mempool.
 			b.mempool.UpdateMempoolTxes(txs)
+
+			log.Debugf("Reconciled mempool spends in %v",
+				time.Since(now))
 
 		case <-b.quit:
 			return

--- a/chain/mempool.go
+++ b/chain/mempool.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"sync"
+	"time"
 
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -187,6 +188,10 @@ func (m *mempool) updateInputs(tx *wire.MsgTx) {
 
 // LoadMempool loads all the raw transactions found in mempool.
 func (m *mempool) LoadMempool() error {
+	log.Debugf("Loading mempool spends...")
+
+	now := time.Now()
+
 	txs, err := m.client.GetRawMempool()
 	if err != nil {
 		log.Errorf("Unable to get raw mempool txs: %v", err)
@@ -200,7 +205,7 @@ func (m *mempool) LoadMempool() error {
 		// Grab full mempool transaction from hash.
 		tx, err := m.client.GetRawTransaction(txHash)
 		if err != nil {
-			log.Errorf("unable to fetch transaction %s for "+
+			log.Warnf("unable to fetch transaction %s for "+
 				"mempool: %v", txHash, err)
 			continue
 		}
@@ -208,6 +213,8 @@ func (m *mempool) LoadMempool() error {
 		// Add the transaction to our local mempool.
 		m.add(tx.MsgTx())
 	}
+
+	log.Debugf("Loaded mempool spends in %v", time.Since(now))
 
 	return nil
 }
@@ -240,7 +247,7 @@ func (m *mempool) UpdateMempoolTxes(txids []*chainhash.Hash) []*wire.MsgTx {
 		// Grab full mempool transaction from hash.
 		tx, err := m.client.GetRawTransaction(txHash)
 		if err != nil {
-			log.Errorf("unable to fetch transaction %s from "+
+			log.Warnf("unable to fetch transaction %s from "+
 				"mempool: %v", txHash, err)
 			continue
 		}


### PR DESCRIPTION
In this commit, we start to log how long it takes to load+synchronize the mempool. We also demote some logs to the warn logging level. We've seen these calls fail, seemingly due to active replacement attempts in the mempool.