### PR TITLE
chain: optimize removal of inputs in mempool

### DIFF
--- a/chain/bitcoind_rpc_events.go
+++ b/chain/bitcoind_rpc_events.go
@@ -241,7 +241,7 @@ func (b *bitcoindRPCPollingEvents) txEventHandlerRPC() {
 	for {
 		select {
 		case <-ticker.C:
-			log.Debugf("Reconciling mempool spends with node " +
+			log.Tracef("Reconciling mempool spends with node " +
 				"mempool...")
 
 			now := time.Now()
@@ -258,7 +258,7 @@ func (b *bitcoindRPCPollingEvents) txEventHandlerRPC() {
 			// Update our local mempool with the new mempool.
 			newTxs := b.mempool.UpdateMempoolTxes(txs)
 
-			log.Debugf("Reconciled mempool spends in %v",
+			log.Tracef("Reconciled mempool spends in %v",
 				time.Since(now))
 
 			// Notify the client of each new transaction.

--- a/chain/bitcoind_zmq_events.go
+++ b/chain/bitcoind_zmq_events.go
@@ -403,7 +403,7 @@ func (b *bitcoindZMQEvents) mempoolPoller() {
 	for {
 		select {
 		case <-ticker.C:
-			log.Debugf("Reconciling mempool spends with node " +
+			log.Tracef("Reconciling mempool spends with node " +
 				"mempool...")
 
 			now := time.Now()
@@ -420,7 +420,7 @@ func (b *bitcoindZMQEvents) mempoolPoller() {
 			// Update our local mempool with the new mempool.
 			b.mempool.UpdateMempoolTxes(txs)
 
-			log.Debugf("Reconciled mempool spends in %v",
+			log.Tracef("Reconciled mempool spends in %v",
 				time.Since(now))
 
 		case <-b.quit:


### PR DESCRIPTION
This commit implements a new struct, `cachedInputs`, to provide faster lookup when removing inputs based on a given transaction. Instead of iterating all the inputs to decide whether they should be removed, we now cache `txid -> inputs` so we can update our local mempool faster by iterating much less data.