### PR TITLE
wallet: don't panic, retry instead

### DIFF
--- a/wallet/example_test.go
+++ b/wallet/example_test.go
@@ -39,6 +39,7 @@ func testWallet(t *testing.T) (*Wallet, func()) {
 
 	loader := NewLoader(
 		&chaincfg.TestNet3Params, dir, true, defaultDBTimeout, 250,
+		WithWalletSyncRetryInterval(10*time.Millisecond),
 	)
 	w, err := loader.CreateNewWallet(pubPass, privPass, seed, time.Now())
 	if err != nil {
@@ -70,6 +71,7 @@ func testWalletWatchingOnly(t *testing.T) (*Wallet, func()) {
 	pubPass := []byte("hello")
 	loader := NewLoader(
 		&chaincfg.TestNet3Params, dir, true, defaultDBTimeout, 250,
+		WithWalletSyncRetryInterval(10*time.Millisecond),
 	)
 	w, err := loader.CreateNewWatchingOnlyWallet(pubPass, time.Now())
 	if err != nil {

--- a/wallet/watchingonly_test.go
+++ b/wallet/watchingonly_test.go
@@ -27,6 +27,7 @@ func TestCreateWatchingOnly(t *testing.T) {
 
 	loader := NewLoader(
 		&chaincfg.TestNet3Params, dir, true, defaultDBTimeout, 250,
+		WithWalletSyncRetryInterval(10*time.Millisecond),
 	)
 	_, err = loader.CreateNewWatchingOnlyWallet(pubPass, time.Now())
 	if err != nil {


### PR DESCRIPTION
Replaces #840.

Fixes https://github.com/btcsuite/btcwallet/issues/827.

Main diff vs. #840:
 - Don't expose the sync retry interval to the user level config, choose a sane default instead (5 seconds sounds reasonable to me for most cases)
 - Make all changes non-breaking to existing API users (add new `OpenWithRetry()` function to wallet, add functional options to loader)

cc  @JoeGruffins, @chappjc, @Roasbeef 