### PR TITLE
chain: handle replacement and duplicate txes properly

### DIFF
--- a/chain/bitcoind_events.go
+++ b/chain/bitcoind_events.go
@@ -30,6 +30,9 @@ type BitcoindEvents interface {
 	Stop() error
 }
 
+// Ensure rpcclient.Client implements the rpcClient interface at compile time.
+var _ rpcClient = (*rpcclient.Client)(nil)
+
 // NewBitcoindEventSubscriber initialises a new BitcoinEvents object impl
 // depending on the config passed.
 func NewBitcoindEventSubscriber(cfg *BitcoindConfig,

--- a/chain/interface.go
+++ b/chain/interface.go
@@ -123,3 +123,9 @@ type (
 		Time   time.Time
 	}
 )
+
+// rpcClient defines an interface that is used to interact with the RPC client.
+type rpcClient interface {
+	GetRawMempool() ([]*chainhash.Hash, error)
+	GetRawTransaction(txHash *chainhash.Hash) (*btcutil.Tx, error)
+}

--- a/chain/mempool.go
+++ b/chain/mempool.go
@@ -52,11 +52,19 @@ func (c *cachedInputs) addInput(op wire.OutPoint, txid chainhash.Hash) {
 	// Check if the input already exists.
 	oldTxid, existed := c.inputs[op]
 
-	// If existed, update the old txid to remove the input.
-	if existed {
+	// If the oldTxid exists and is different from the current txid, we
+	// need to update the oldTxid's inputs map.
+	isReplacement := false
+	if existed && oldTxid != txid {
+		isReplacement = true
+	}
+
+	// If the input is replaced, update the old txid to remove the input.
+	if isReplacement {
 		log.Tracef("Input %s was spent in tx %s, now spent in %s",
 			op, oldTxid, txid)
 
+		// Delete the input from the nested map under this old tx.
 		delete(c.txids[oldTxid], op)
 	}
 

--- a/chain/mempool.go
+++ b/chain/mempool.go
@@ -178,6 +178,12 @@ func (m *mempool) containsInput(op wire.OutPoint) (chainhash.Hash, bool) {
 //
 // NOTE: must be used inside a lock.
 func (m *mempool) add(tx *wire.MsgTx) {
+	// Skip coinbase inputs.
+	if blockchain.IsCoinBaseTx(tx) {
+		log.Debugf("Skipping coinbase tx %v", tx.TxHash())
+		return
+	}
+
 	hash := tx.TxHash()
 
 	// Add the txid to the mempool map.
@@ -268,12 +274,6 @@ func (m *mempool) removeInputs(tx chainhash.Hash) {
 //
 // NOTE: must be used inside a lock.
 func (m *mempool) updateInputs(tx *wire.MsgTx) {
-	// Skip coinbase inputs.
-	if blockchain.IsCoinBaseTx(tx) {
-		log.Debugf("Skipping coinbase tx %v", tx.TxHash())
-		return
-	}
-
 	// Iterate the tx's inputs.
 	for _, input := range tx.TxIn {
 		outpoint := input.PreviousOutPoint

--- a/chain/mempool.go
+++ b/chain/mempool.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/wire"
 	"golang.org/x/sync/errgroup"
 )
@@ -101,7 +100,7 @@ type mempool struct {
 	inputs *cachedInputs
 
 	// client is the rpc client that we'll use to query for the mempool.
-	client *rpcclient.Client
+	client rpcClient
 
 	// initFin is a channel that will be closed once the mempool has been
 	// initialized.
@@ -109,7 +108,7 @@ type mempool struct {
 }
 
 // newMempool creates a new mempool object.
-func newMempool(client *rpcclient.Client) *mempool {
+func newMempool(client rpcClient) *mempool {
 	return &mempool{
 		txs:     make(map[chainhash.Hash]bool),
 		inputs:  newCachedInputs(),

--- a/chain/mempool_test.go
+++ b/chain/mempool_test.go
@@ -54,7 +54,54 @@ func TestCachedInputs(t *testing.T) {
 	require.Zero(txid)
 }
 
-func TestCachedInputsAddInput(t *testing.T) {
+// TestCachedInputsAddInputDifferent checks that when adding two different txes
+// the internal state of cachedInputs is updated as expected.
+func TestCachedInputsAddInputDifferent(t *testing.T) {
+	require := require.New(t)
+
+	// Create a test input and tx.
+	op1 := wire.OutPoint{Hash: chainhash.Hash{1}}
+	tx1 := &wire.MsgTx{
+		LockTime: 1,
+		TxIn:     []*wire.TxIn{{PreviousOutPoint: op1}},
+	}
+
+	// Create another test input and tx.
+	op2 := wire.OutPoint{Hash: chainhash.Hash{2}}
+	tx2 := &wire.MsgTx{
+		LockTime: 1,
+		TxIn:     []*wire.TxIn{{PreviousOutPoint: op2}},
+	}
+
+	c := newCachedInputs()
+
+	// Add the input.
+	c.addInput(op1, tx1.TxHash())
+	c.addInput(op2, tx2.TxHash())
+
+	// Lookup should now give us the txid.
+	txid, ok := c.hasInput(op1)
+	require.True(ok)
+	require.Equal(tx1.TxHash(), txid)
+
+	txid, ok = c.hasInput(op2)
+	require.True(ok)
+	require.Equal(tx2.TxHash(), txid)
+
+	// Check the internal state.
+	//
+	// We should only have two inputs and two txids.
+	require.Len(c.inputs, 2)
+	require.Len(c.txids, 2)
+
+	// Each txid's nested map should have one entry.
+	require.Len(c.txids[tx1.TxHash()], 1)
+	require.Len(c.txids[tx2.TxHash()], 1)
+}
+
+// TestCachedInputsAddInputReplacement checks that when a replacement tx is
+// added, the internal state of cachedInputs is updated as expected.
+func TestCachedInputsAddInputReplacement(t *testing.T) {
 	require := require.New(t)
 
 	// Create a test input and tx.
@@ -81,6 +128,12 @@ func TestCachedInputsAddInput(t *testing.T) {
 	require.True(ok)
 	require.Equal(tx.TxHash(), txid)
 
+	// Check the internal state. Since we've just added one input, there
+	// should be exactly one item in each map.
+	require.Len(c.inputs, 1)
+	require.Len(c.txids, 1)
+	require.Len(c.txids[tx.TxHash()], 1)
+
 	// Add the input again using the replacement tx.
 	c.addInput(op, replacedTx.TxHash())
 
@@ -88,6 +141,63 @@ func TestCachedInputsAddInput(t *testing.T) {
 	txid, ok = c.hasInput(op)
 	require.True(ok)
 	require.Equal(replacedTx.TxHash(), txid)
+
+	// Check the internal state.
+	//
+	// We should only have one input.
+	require.Len(c.inputs, 1)
+
+	// Expect two transactions.
+	require.Len(c.txids, 2)
+
+	// The new txid should be present.
+	require.Len(c.txids[replacedTx.TxHash()], 1)
+
+	// The old txid should be an empty map.
+	require.Empty(c.txids[tx.TxHash()])
+}
+
+// TestCachedInputsAddInputTwice checks that when the same tx is added again it
+// won't change the cachedInputs's internal state.
+func TestCachedInputsAddInputTwice(t *testing.T) {
+	require := require.New(t)
+
+	// Create a test input and tx.
+	op := wire.OutPoint{Hash: chainhash.Hash{1}}
+	tx := &wire.MsgTx{
+		LockTime: 1,
+		TxIn:     []*wire.TxIn{{PreviousOutPoint: op}},
+	}
+
+	c := newCachedInputs()
+
+	// Add the input.
+	c.addInput(op, tx.TxHash())
+
+	// Lookup should now give us the txid.
+	txid, ok := c.hasInput(op)
+	require.True(ok)
+	require.Equal(tx.TxHash(), txid)
+
+	// Check the internal state. Since we've just added one input, there
+	// should be exactly one item in each map.
+	require.Len(c.inputs, 1)
+	require.Len(c.txids, 1)
+	require.Len(c.txids[tx.TxHash()], 1)
+
+	// Add the input again.
+	c.addInput(op, tx.TxHash())
+
+	// Lookup should now give us same result.
+	txid, ok = c.hasInput(op)
+	require.True(ok)
+	require.Equal(tx.TxHash(), txid)
+
+	// Check the internal state. Since it's the same tx we should have the
+	// same state.
+	require.Len(c.inputs, 1)
+	require.Len(c.txids, 1)
+	require.Len(c.txids[tx.TxHash()], 1)
 }
 
 // TestMempool tests that each method of the mempool struct works as expected.

--- a/chain/mocks_test.go
+++ b/chain/mocks_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lightninglabs/neutrino"
 	"github.com/lightninglabs/neutrino/banman"
 	"github.com/lightninglabs/neutrino/headerfs"
+	"github.com/stretchr/testify/mock"
 )
 
 var (
@@ -154,4 +155,24 @@ func (m *mockChainService) Stop() error {
 
 func (m *mockChainService) PeerByAddr(string) *neutrino.ServerPeer {
 	panic(errNotImplemented)
+}
+
+// mockRPCClient mocks the rpcClient interface.
+type mockRPCClient struct {
+	mock.Mock
+}
+
+// Compile time assertion that MockPeer implements lnpeer.Peer.
+var _ rpcClient = (*mockRPCClient)(nil)
+
+func (m *mockRPCClient) GetRawMempool() ([]*chainhash.Hash, error) {
+	args := m.Called()
+	return args.Get(0).([]*chainhash.Hash), args.Error(1)
+}
+
+func (m *mockRPCClient) GetRawTransaction(
+	txHash *chainhash.Hash) (*btcutil.Tx, error) {
+
+	args := m.Called(txHash)
+	return args.Get(0).(*btcutil.Tx), args.Error(1)
 }

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/lightningnetwork/lnd/clock v1.0.1 // indirect
 	github.com/lightningnetwork/lnd/queue v1.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	go.etcd.io/bbolt v1.3.5-0.20200615073812-232d8fc87f50 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	golang.org/x/text v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=


### PR DESCRIPTION
Previously when adding a replacement tx to the local mempool, when the txid's nested map becomes empty, we forgot to delete the key from the root map. And when adding the same tx to the `txids` map(which happens in ZMQ), we may treat the tx as a replacement tx. These are now fixed and the related unit tests are added/updated to reflect the fix.