### PR TITLE
chain: init subpackage loggers under the same name

### DIFF
--- a/chain/log.go
+++ b/chain/log.go
@@ -5,6 +5,10 @@
 package chain
 
 import (
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/peer"
+	"github.com/btcsuite/btcd/rpcclient"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btclog"
 	"github.com/lightninglabs/neutrino/query"
 )
@@ -31,4 +35,8 @@ func DisableLog() {
 func UseLogger(logger btclog.Logger) {
 	log = logger
 	query.UseLogger(logger)
+	peer.UseLogger(logger)
+	blockchain.UseLogger(logger)
+	txscript.UseLogger(logger)
+	rpcclient.UseLogger(logger)
 }


### PR DESCRIPTION
This commit makes sure the loggers used in subpackages share the same name initialized by the `chain` package, which is set by upper layer systems.