### PR TITLE
chain: remove warning log for mempool polling

### DIFF
--- a/chain/mocks_test.go
+++ b/chain/mocks_test.go
@@ -174,5 +174,11 @@ func (m *mockRPCClient) GetRawTransaction(
 	txHash *chainhash.Hash) (*btcutil.Tx, error) {
 
 	args := m.Called(txHash)
+
+	tx := args.Get(0)
+	if tx == nil {
+		return nil, args.Error(1)
+	}
+
 	return args.Get(0).(*btcutil.Tx), args.Error(1)
 }


### PR DESCRIPTION
Depends on #872, only the last commit is new. We now remove the warning log when querying mempool transactions as it's expected that some of them are not found.