### PR TITLE
wallet: allow manually setting the wallet birthday

### DIFF
--- a/config.go
+++ b/config.go
@@ -43,6 +43,7 @@ var (
 	defaultRPCKeyFile  = filepath.Join(defaultAppDataDir, "rpc.key")
 	defaultRPCCertFile = filepath.Join(defaultAppDataDir, "rpc.cert")
 	defaultLogDir      = filepath.Join(defaultAppDataDir, defaultLogDirname)
+	defaultBirthday    = time.Now().Unix()
 )
 
 type config struct {
@@ -65,6 +66,7 @@ type config struct {
 
 	// Wallet options
 	WalletPass string `long:"walletpass" default-mask:"-" description:"The public wallet password -- Only required if the wallet was created with one"`
+	Birthday   int64  `long:"birthday" default-mask:"-" description:"Specify a unix timestamp to be the wallet birthday -- Will be used as the approximate starting time for wallet rescans"`
 
 	// RPC client options
 	RPCConnect       string                  `short:"c" long:"rpcconnect" description:"Hostname/IP and port of btcd RPC server to connect to (default localhost:8334, testnet: localhost:18334, simnet: localhost:18556)"`
@@ -278,6 +280,7 @@ func loadConfig() (*config, []string, error) {
 		BanDuration:            neutrino.BanDuration,
 		BanThreshold:           neutrino.BanThreshold,
 		DBTimeout:              wallet.DefaultDBTimeout,
+		Birthday:               defaultBirthday,
 	}
 
 	// Pre-parse the command line options to see if an alternative config

--- a/rpc/api.proto
+++ b/rpc/api.proto
@@ -292,6 +292,7 @@ message CreateWalletRequest {
 	bytes public_passphrase = 1;
 	bytes private_passphrase = 2;
 	bytes seed = 3;
+	int64 birthday = 4;
 }
 message CreateWalletResponse {}
 

--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -694,13 +694,13 @@ func (s *loaderServer) CreateWallet(ctx context.Context, req *pb.CreateWalletReq
 	}
 
 	// Use the current time for the birthday when the request's is empty.
-	bday := req.Birthday
-	if bday == 0 {
-		bday = time.Now().Unix()
+	bday := time.Now()
+	if req.Birthday != 0 {
+		bday = time.Unix(req.Birthday, 0)
 	}
 
 	wallet, err := s.loader.CreateNewWallet(
-		pubPassphrase, req.PrivatePassphrase, req.Seed, time.Unix(bday, 0),
+		pubPassphrase, req.PrivatePassphrase, req.Seed, bday,
 	)
 	if err != nil {
 		return nil, translateError(err)

--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -693,8 +693,14 @@ func (s *loaderServer) CreateWallet(ctx context.Context, req *pb.CreateWalletReq
 		pubPassphrase = []byte(wallet.InsecurePubPassphrase)
 	}
 
+	// Use the current time for the birthday when the request's is empty.
+	bday := req.Birthday
+	if bday == 0 {
+		bday = time.Now().Unix()
+	}
+
 	wallet, err := s.loader.CreateNewWallet(
-		pubPassphrase, req.PrivatePassphrase, req.Seed, time.Now(),
+		pubPassphrase, req.PrivatePassphrase, req.Seed, time.Unix(bday, 0),
 	)
 	if err != nil {
 		return nil, translateError(err)

--- a/rpc/walletrpc/api.pb.go
+++ b/rpc/walletrpc/api.pb.go
@@ -1329,6 +1329,7 @@ type CreateWalletRequest struct {
 	PublicPassphrase  []byte `protobuf:"bytes,1,opt,name=public_passphrase,json=publicPassphrase,proto3" json:"public_passphrase,omitempty"`
 	PrivatePassphrase []byte `protobuf:"bytes,2,opt,name=private_passphrase,json=privatePassphrase,proto3" json:"private_passphrase,omitempty"`
 	Seed              []byte `protobuf:"bytes,3,opt,name=seed,proto3" json:"seed,omitempty"`
+	Birthday          int64  `protobuf:"varint,4,opt,name=birthday,proto3" json:"birthday,omitempty"`
 }
 
 func (m *CreateWalletRequest) Reset()                    { *m = CreateWalletRequest{} }

--- a/sample-btcwallet.conf
+++ b/sample-btcwallet.conf
@@ -15,6 +15,12 @@
 ; directory for mainnet and testnet wallets, respectively.
 ; appdata=~/.btcwallet
 
+; Unix timestamp representing when the wallet was created, and therefore
+; the earliest time the wallet could have participated in any transactions.
+; This timestamp will be used to estimate a block height that is an appropriate
+; starting place to scan for transactions related to this wallet.
+; birthday=1231006505
+
 
 ; ------------------------------------------------------------------------------
 ; RPC client settings

--- a/sample-btcwallet.conf
+++ b/sample-btcwallet.conf
@@ -18,7 +18,9 @@
 ; Unix timestamp representing when the wallet was created, and therefore
 ; the earliest time the wallet could have participated in any transactions.
 ; This timestamp will be used to estimate a block height that is an appropriate
-; starting place to scan for transactions related to this wallet.
+; starting place to scan for transactions related to this wallet. The default
+; birthday will be the current time at the moment the wallet is created, if this
+; parameter is not set.
 ; birthday=1231006505
 
 

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -188,7 +188,7 @@ func createWallet(cfg *config) error {
 	}
 
 	fmt.Println("Creating the wallet...")
-	w, err := loader.CreateNewWallet(pubPass, privPass, seed, time.Now())
+	w, err := loader.CreateNewWallet(pubPass, privPass, seed, time.Unix(cfg.Birthday, 0))
 	if err != nil {
 		return err
 	}
@@ -221,7 +221,7 @@ func createSimulationWallet(cfg *config) error {
 	defer db.Close()
 
 	// Create the wallet.
-	err = wallet.Create(db, pubPass, privPass, nil, activeNet.Params, time.Now())
+	err = wallet.Create(db, pubPass, privPass, nil, activeNet.Params, time.Unix(cfg.Birthday, 0))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds a flag that allows for the wallet's birthday to be specified when being created. This gives the user control over where rescans begin for a BTC wallet that is recovered with a seed. This is meant to resolve #883.