### PR TITLE
chain: detect and use gettxspendingprevout RPC instead of mempool

### DIFF
--- a/chain/pruned_block_dispatcher_test.go
+++ b/chain/pruned_block_dispatcher_test.go
@@ -233,7 +233,7 @@ func (h *prunedBlockDispatcherHarness) newPeer() *peer.Peer {
 
 				for _, inv := range msg.InvList {
 					// Invs should always be for blocks.
-					require.Equal(h.t, wire.InvTypeBlock, inv.Type)
+					require.Equal(h.t, wire.InvTypeWitnessBlock, inv.Type)
 
 					// Invs should always be for known blocks.
 					block, ok := h.blocks[inv.Hash]


### PR DESCRIPTION
This change uses the gettxspendingprevout RPC if the bitcoind version is greater or equal to version 24.0.0. In this case, the mempool is no longer used for zmq clients. The original behavior must be kept for rpc polling clients since they notify on new transactions and can only learn about them from polling the bitcoind mempool and keeping track of its own btcwallet mempool.