### PR TITLE
wallet: add gettransaction

### DIFF
--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -7,14 +7,25 @@ import (
 
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
+	"github.com/stretchr/testify/require"
 
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 )
 
 var (
 	TstSerializedTx, _ = hex.DecodeString("010000000114d9ff358894c486b4ae11c2a8cf7851b1df64c53d2e511278eff17c22fb7373000000008c493046022100995447baec31ee9f6d4ec0e05cb2a44f6b817a99d5f6de167d1c75354a946410022100c9ffc23b64d770b0e01e7ff4d25fbc2f1ca8091053078a247905c39fce3760b601410458b8e267add3c1e374cf40f1de02b59213a82e1d84c2b94096e22e2f09387009c96debe1d0bcb2356ffdcf65d2a83d4b34e72c62eccd8490dbf2110167783b2bffffffff0280969800000000001976a914479ed307831d0ac19ebc5f63de7d5f1a430ddb9d88ac38bfaa00000000001976a914dadf9e3484f28b385ddeaa6c575c0c0d18e9788a88ac00000000")
 	TstTx, _           = btcutil.NewTxFromBytes(TstSerializedTx)
 	TstTxHash          = TstTx.Hash()
+
+	TstMinedTxBlockHeight        = int32(279143)
+	TstMinedSignedTxBlockDetails = &wtxmgr.BlockMeta{
+		Block: wtxmgr.Block{
+			Hash:   *TstTxHash,
+			Height: TstMinedTxBlockHeight,
+		},
+		Time: time.Now(),
+	}
 )
 
 // TestLocateBirthdayBlock ensures we can properly map a block in the chain to a
@@ -202,6 +213,95 @@ func TestLabelTransaction(t *testing.T) {
 				t.Fatalf("expected: %v, got: %v",
 					test.expectedErr, err)
 			}
+		})
+	}
+}
+
+// TestGetTransaction tests if we can fetch a mined, an existing
+// and a non-existing transaction from the wallet like we expect.
+func TestGetTransaction(t *testing.T) {
+	t.Parallel()
+	rec, err := wtxmgr.NewTxRecord(TstSerializedTx, time.Now())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+
+		// Transaction id.
+		txid chainhash.Hash
+
+		// Expected height.
+		expectedHeight int32
+
+		// Store function.
+		f func(*wtxmgr.Store, walletdb.ReadWriteBucket) (*wtxmgr.Store, error)
+
+		// The error we expect to be returned.
+		expectedErr error
+	}{
+		{
+			name: "existing unmined transaction",
+			txid: *TstTxHash,
+			// We write txdetail for the tx to disk.
+			f: func(s *wtxmgr.Store, ns walletdb.ReadWriteBucket) (
+				*wtxmgr.Store, error) {
+
+				err = s.InsertTx(ns, rec, nil)
+				return s, err
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "existing mined transaction",
+			txid: *TstTxHash,
+			// We write txdetail for the tx to disk.
+			f: func(s *wtxmgr.Store, ns walletdb.ReadWriteBucket) (
+				*wtxmgr.Store, error) {
+
+				err = s.InsertTx(ns, rec, TstMinedSignedTxBlockDetails)
+				return s, err
+			},
+			expectedHeight: TstMinedTxBlockHeight,
+			expectedErr:    nil,
+		},
+		{
+			name: "non-existing transaction",
+			txid: *TstTxHash,
+			// Write no txdetail to disk.
+			f: func(s *wtxmgr.Store, ns walletdb.ReadWriteBucket) (
+				*wtxmgr.Store, error) {
+
+				return s, nil
+			},
+			expectedErr: ErrNoTx,
+		},
+	}
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			w, cleanup := testWallet(t)
+			defer cleanup()
+
+			err := walletdb.Update(w.db, func(rw walletdb.ReadWriteTx) error {
+				ns := rw.ReadWriteBucket(wtxmgrNamespaceKey)
+				_, err := test.f(w.TxStore, ns)
+				return err
+			})
+			require.NoError(t, err)
+			tx, err := w.GetTransaction(test.txid)
+			require.ErrorIs(t, err, test.expectedErr)
+
+			// Discontinue if no transaction were found.
+			if err != nil {
+				return
+			}
+
+			// Check if we get the expected hash.
+			require.Equal(t, &test.txid, tx.Summary.Hash)
+
+			// Check the block height.
+			require.Equal(t, test.expectedHeight, tx.Height)
 		})
 	}
 }


### PR DESCRIPTION
This PR adds a method to the wallet that allows to get transaction data on any transaction given its ID. Useful for (https://github.com/lightningnetwork/lnd/pull/7654).