### PR TITLE
chain: Match for error code instead of text.

### DIFF
--- a/chain/mempool.go
+++ b/chain/mempool.go
@@ -15,7 +15,8 @@ import (
 const (
 	// txNotFoundErr is an error returned from bitcoind's
 	// `getrawtransaction` RPC when the requested txid cannot be found.
-	txNotFoundErr = "-5: No such mempool or blockchain transaction"
+	// https://github.com/bitcoin/bitcoin/blob/fa05a726c225dc65dee79367bb67f099ae4f99e6/src/rpc/rawtransaction.cpp#L366
+	txNotFoundErr = "-5: No such mempool"
 
 	// DefaultGetRawTxBatchSize specifies the default number of requests to
 	// be batched before sending them to the bitcoind client.


### PR DESCRIPTION
Fixes #892.

The return value of bitcoind did not change, bitcoind will return a different error if the `txindex` is not set (e.g. pruned nodes) so we check for the error code now instead of the specific text and include a direct reference of the bitcoind code.