### PR TITLE
README.md: add badge for GitHubActions CI status too

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 btcwallet
 =========
 
+[![Build Status](https://github.com/btcsuite/btcwallet/workflows/CI/badge.svg)](https://github.com/btcsuite/btcwallet/actions?query=workflow%3A%22CI%22)
 [![Build Status](https://travis-ci.org/btcsuite/btcwallet.png?branch=master)](https://travis-ci.org/btcsuite/btcwallet)
 [![Build status](https://ci.appveyor.com/api/projects/status/88nxvckdj8upqr36/branch/master?svg=true)](https://ci.appveyor.com/project/jrick/btcwallet/branch/master)
 


### PR DESCRIPTION
There were only 2 badges for Travis & AppVeyor, but this repo also has GitHubActions.