### PR TITLE
wallet: export coin selection strategy code for re-use

### DIFF
--- a/wallet/createtx_test.go
+++ b/wallet/createtx_test.go
@@ -216,8 +216,8 @@ func TestInputYield(t *testing.T) {
 	pkScript, err := txscript.PayToAddrScript(addr)
 	require.NoError(t, err)
 
-	credit := &wtxmgr.Credit{
-		Amount:   1000,
+	credit := &wire.TxOut{
+		Value:    1000,
 		PkScript: pkScript,
 	}
 

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -89,17 +89,33 @@ var (
 	wtxmgrNamespaceKey   = []byte("wtxmgr")
 )
 
-type CoinSelectionStrategy int
+// Coin represents a spendable UTXO which is available for coin selection.
+type Coin struct {
+	wire.TxOut
 
-const (
+	wire.OutPoint
+}
+
+// CoinSelectionStrategy is an interface that represents a coin selection
+// strategy. A coin selection strategy is responsible for ordering, shuffling or
+// filtering a list of coins before they are passed to the coin selection
+// algorithm.
+type CoinSelectionStrategy interface {
+	// ArrangeCoins takes a list of coins and arranges them according to the
+	// specified coin selection strategy and fee rate.
+	ArrangeCoins(eligible []Coin, feeSatPerKb btcutil.Amount) ([]Coin,
+		error)
+}
+
+var (
 	// CoinSelectionLargest always picks the largest available utxo to add
 	// to the transaction next.
-	CoinSelectionLargest CoinSelectionStrategy = iota
+	CoinSelectionLargest CoinSelectionStrategy = &LargestFirstCoinSelector{}
 
 	// CoinSelectionRandom randomly selects the next utxo to add to the
 	// transaction. This strategy prevents the creation of ever smaller
 	// utxos over time.
-	CoinSelectionRandom
+	CoinSelectionRandom CoinSelectionStrategy = &RandomCoinSelector{}
 )
 
 // Wallet is a structure containing all the components for a


### PR DESCRIPTION
We want to be able to use the available coin selection strategies outside of just the coin selection methods offered by the wallet. So this PR refactors the code to be re-used.