### PR TITLE
refactor: add `make help` to display the usage for project Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,10 @@ define print
 	echo $(GREEN)$1$(NC)
 endef
 
+#? default: Run `make build`
 default: build
 
+#? all: Run `make build` and `make check`
 all: build check
 
 # ============
@@ -55,6 +57,7 @@ $(GOACC_BIN):
 	@$(call print, "Fetching go-acc")
 	$(GOINSTALL) $(GOACC_PKG)@$(GOACC_COMMIT)
 
+#? goimports: Install goimports
 goimports:
 	@$(call print, "Installing goimports.")
 	$(GOINSTALL) $(GOIMPORTS_PKG)@${GOIMPORTS_COMMIT}
@@ -63,10 +66,12 @@ goimports:
 # INSTALLATION
 # ============
 
+#? build: Compile and build btcwallet
 build:
 	@$(call print, "Compiling btcwallet.")
 	$(GOBUILD) $(PKG)/...
 
+#? install: Install btcwallet, dropwtxmgr and sweepaccount, place them in $GOPATH/bin
 install:
 	@$(call print, "Installing btcwallet.")
 	$(GOINSTALL) $(PKG)
@@ -77,16 +82,20 @@ install:
 # TESTING
 # =======
 
+#? check: Run `make unit`
 check: unit
 
+#? unit: Run unit tests
 unit:
 	@$(call print, "Running unit tests.")
 	$(GOLIST) | $(XARGS) env $(GOTEST) -test.timeout=20m
 
+#? unit-cover: Run unit coverage tests
 unit-cover: $(GOACC_BIN)
 	@$(call print, "Running unit coverage tests.")
 	$(GOACC_BIN) $(GOLIST_COVER)
 
+#? unit-race: Run unit race tests
 unit-race:
 	@$(call print, "Running unit race tests.")
 	env CGO_ENABLED=1 GORACE="history_size=7 halt_on_errors=1" $(GOLIST) | $(XARGS) env $(GOTEST) -race -test.timeout=20m
@@ -95,24 +104,29 @@ unit-race:
 # UTILITIES
 # =========
 
+#? fmt: Fix imports and formatting source
 fmt: goimports
 	@$(call print, "Fixing imports.")
 	goimports -w $(GOFILES_NOVENDOR)
 	@$(call print, "Formatting source.")
 	gofmt -l -w -s $(GOFILES_NOVENDOR)
 
+#? lint: Lint source
 lint: $(LINT_BIN)
 	@$(call print, "Linting source.")
 	$(LINT)
 
+#? clean: Clean source
 clean:
 	@$(call print, "Cleaning source.$(NC)")
 	$(RM) coverage.txt
 
+#? tidy-module: Run 'go mod tidy' for all modules
 tidy-module:
 	echo "Running 'go mod tidy' for all modules"
 	scripts/tidy_modules.sh
 
+#? tidy-module-check: Run 'go mod tidy' for all modules and check results
 tidy-module-check: tidy-module
 	if test -n "$$(git status --porcelain)"; then echo "modules not updated, please run `make tidy-module` again!"; git status; exit 1; fi
 
@@ -126,3 +140,10 @@ tidy-module-check: tidy-module
 	fmt \
 	lint \
 	clean
+
+#? help: Get more info on make commands
+help: Makefile
+	@echo " Choose a command run in btcwallet:"
+	@sed -n 's/^#?//p' $< | column -t -s ':' |  sort | sed -e 's/^/ /'
+
+.PHONY: help


### PR DESCRIPTION
Similar to btcsuite/btcd#2107

This pr added a new `help` target for displaying which commonly used commands that the Makefile supported. This is useful when a new developer goes to find a helpful tool for testing or building etc.

![image](https://github.com/btcsuite/btcwallet/assets/25278203/03e73ad0-360b-42a8-a6ac-dbc0b8f4bcea)
