### PR TITLE
wallet: downgrade `spew` log to debug and limit its size

### DIFF
--- a/wallet/log.go
+++ b/wallet/log.go
@@ -46,3 +46,20 @@ func pickNoun(n int, singular, plural string) string {
 	}
 	return plural
 }
+
+// LogClosure is a closure that can be printed with %v to be used to
+// generate expensive-to-create data for a detailed log level and avoid doing
+// the work if the data isn't printed.
+type logClosure func() string
+
+// String invokes the log closure and returns the results string.
+func (c logClosure) String() string {
+	return c()
+}
+
+// newLogClosure returns a new closure over the passed function which allows
+// it to be used as a parameter in a logging function that is only invoked when
+// the logging level is such that the message will actually be logged.
+func newLogClosure(c func() string) logClosure {
+	return logClosure(c)
+}


### PR DESCRIPTION
This commit removes using `spew` on production as the tx log can be extremely large. For instance, when running [this build](https://github.com/lightningnetwork/lnd/actions/runs/7656820228/job/20866038765) the CI crashed because of this [test](https://github.com/lightningnetwork/lnd/pull/8345/commits/11bafe84ff624e0d7a2d56ef00be89567a7d4cbd), that also caused my local terminal to crash, because we are printing a very large invalid tx.