### PR TITLE
Add option to allow for dust when checking outputs

### DIFF
--- a/wallet/txrules/rules.go
+++ b/wallet/txrules/rules.go
@@ -39,14 +39,14 @@ var (
 
 // CheckOutput performs simple consensus and policy tests on a transaction
 // output.
-func CheckOutput(output *wire.TxOut, relayFeePerKb btcutil.Amount) error {
+func CheckOutput(output *wire.TxOut, relayFeePerKb btcutil.Amount, allowDust bool) error {
 	if output.Value < 0 {
 		return ErrAmountNegative
 	}
 	if output.Value > btcutil.MaxSatoshi {
 		return ErrAmountExceedsMax
 	}
-	if IsDustOutput(output, relayFeePerKb) {
+	if !allowDust && IsDustOutput(output, relayFeePerKb) {
 		return ErrOutputIsDust
 	}
 	return nil


### PR DESCRIPTION
This seems standard in most wallet libraries nowadays to give users the option to allow for dust if they know what they are doing.

Particularly for my usecase I am trying to make OP_RETURNs larger than 80 bytes and btcwallet will mark it as a non-standard dust tx, so this would allow me to get around it.