### PR TITLE
wallet: return ErrNotMine for script addresses

### DIFF
--- a/wallet/utxos.go
+++ b/wallet/utxos.go
@@ -135,7 +135,7 @@ func (w *Wallet) FetchInputInfo(prevOut *wire.OutPoint) (*wire.MsgTx,
 	}
 	pubKeyAddr, ok := addr.(waddrmgr.ManagedPubKeyAddress)
 	if !ok {
-		return nil, nil, nil, 0, err
+		return nil, nil, nil, 0, ErrNotMine
 	}
 	keyScope, derivationPath, _ := pubKeyAddr.DerivationInfo()
 


### PR DESCRIPTION
We recently added the ManagedTaprootScriptAddress type which is not a ManagedPubKeyAddress and therefore doesn't store the derivation info. When trying to fetch the input info for such an address we run into the case where we return nil as the error which causes issues further up in the call stack.
This commit fixes the problem by returning an actual error and not the err variable that is nil due to the previous check.