### PR TITLE
chain: add mempool lookup for outpoints

### DIFF
--- a/chain/bitcoind_client.go
+++ b/chain/bitcoind_client.go
@@ -1400,3 +1400,11 @@ func (c *BitcoindClient) filterTx(txDetails *btcutil.Tx,
 
 	return true, rec, nil
 }
+
+// LookupInputMempoolSpend returns the transaction hash and true if the given
+// input is found being spent in mempool, otherwise it returns nil and false.
+func (c *BitcoindClient) LookupInputMempoolSpend(op wire.OutPoint) (
+	chainhash.Hash, bool) {
+
+	return c.chainConn.events.LookupInputSpend(op)
+}

--- a/chain/btcd.go
+++ b/chain/btcd.go
@@ -465,3 +465,11 @@ func (c *RPCClient) POSTClient() (*rpcclient.Client, error) {
 	configCopy.HTTPPostMode = true
 	return rpcclient.New(&configCopy, nil)
 }
+
+// LookupInputMempoolSpend returns the transaction hash and true if the given
+// input is found being spent in mempool, otherwise it returns nil and false.
+func (c *RPCClient) LookupInputMempoolSpend(op wire.OutPoint) (
+	chainhash.Hash, bool) {
+
+	return getTxSpendingPrevOut(op, c.Client)
+}

--- a/chain/btcd_test.go
+++ b/chain/btcd_test.go
@@ -1,0 +1,58 @@
+package chain
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/rpcclient"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateConfig checks the `validate` method on the RPCClientConfig
+// behaves as expected.
+func TestValidateConfig(t *testing.T) {
+	t.Parallel()
+
+	rt := require.New(t)
+
+	// ReconnectAttempts must be positive.
+	cfg := &RPCClientConfig{
+		ReconnectAttempts: -1,
+	}
+	rt.ErrorContains(cfg.validate(), "reconnectAttempts")
+
+	// Must specify a chain params.
+	cfg = &RPCClientConfig{
+		ReconnectAttempts: 1,
+	}
+	rt.ErrorContains(cfg.validate(), "chain params")
+
+	// Must specify a connection config.
+	cfg = &RPCClientConfig{
+		ReconnectAttempts: 1,
+		Chain:             &chaincfg.Params{},
+	}
+	rt.ErrorContains(cfg.validate(), "conn config")
+
+	// Must specify a certificate when using TLS.
+	cfg = &RPCClientConfig{
+		ReconnectAttempts: 1,
+		Chain:             &chaincfg.Params{},
+		Conn:              &rpcclient.ConnConfig{},
+	}
+	rt.ErrorContains(cfg.validate(), "certs")
+
+	// Validate config.
+	cfg = &RPCClientConfig{
+		ReconnectAttempts: 1,
+		Chain:             &chaincfg.Params{},
+		Conn: &rpcclient.ConnConfig{
+			DisableTLS: true,
+		},
+	}
+	rt.NoError(cfg.validate())
+
+	// When a nil config is provided, it should return an error.
+	_, err := NewRPCClientWithConfig(nil)
+	rt.ErrorContains(err, "missing rpc config")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/btcsuite/btcwallet
 
 require (
-	github.com/btcsuite/btcd v0.24.1-0.20240116200649-17fdc5219b36
+	github.com/btcsuite/btcd v0.24.1-0.20240301210420-1a2b599bf1af
 	github.com/btcsuite/btcd/btcec/v2 v2.2.2
 	github.com/btcsuite/btcd/btcutil v1.1.5
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.8

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13P
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220207191057-4dc4ff7963b4/go.mod h1:7alexyj/lHlOtr2PJK7L/+HDJZpcGDn/pAU98r7DY08=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=
-github.com/btcsuite/btcd v0.24.1-0.20240116200649-17fdc5219b36 h1:Us/FoCuHjjn1OfE278h9QTGuuydc0n+SA+NlycvfNsM=
-github.com/btcsuite/btcd v0.24.1-0.20240116200649-17fdc5219b36/go.mod h1:5C8ChTkl5ejr3WHj8tkQSCmydiMEPB0ZhQhehpq7Dgg=
+github.com/btcsuite/btcd v0.24.1-0.20240301210420-1a2b599bf1af h1:F60A3wst4/fy9Yr1Vn8MYmFlfn7DNLxp8o8UTvhqgBE=
+github.com/btcsuite/btcd v0.24.1-0.20240301210420-1a2b599bf1af/go.mod h1:5C8ChTkl5ejr3WHj8tkQSCmydiMEPB0ZhQhehpq7Dgg=
 github.com/btcsuite/btcd/btcec/v2 v2.1.0/go.mod h1:2VzYrv4Gm4apmbVVsSq5bqf1Ec8v56E48Vt0Y/umPgA=
 github.com/btcsuite/btcd/btcec/v2 v2.1.3/go.mod h1:ctjw4H1kknNJmRN4iP1R7bTQ+v3GJkZBd6mui8ZsAZE=
 github.com/btcsuite/btcd/btcec/v2 v2.2.2 h1:5uxe5YjoCq+JeOpg0gZSNHuFgeogrocBYxvg6w9sAgc=


### PR DESCRIPTION
This PR adds a new method `LookupInputMempoolSpend` to directly check whether a given input has been spent or not in the mempool.