### PR TITLE
Use selected Utxos while crafting txn

### DIFF
--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -139,8 +139,8 @@ func (s secretSource) GetScript(addr btcutil.Address) ([]byte, error) {
 func (w *Wallet) txToOutputs(outputs []*wire.TxOut,
 	coinSelectKeyScope, changeKeyScope *waddrmgr.KeyScope,
 	account uint32, minconf int32, feeSatPerKb btcutil.Amount,
-	coinSelectionStrategy CoinSelectionStrategy, dryRun bool) (
-	*txauthor.AuthoredTx, error) {
+	strategy CoinSelectionStrategy, dryRun bool,
+	selectedUtxos []wire.OutPoint) (*txauthor.AuthoredTx, error) {
 
 	chainClient, err := w.requireChainClient()
 	if err != nil {
@@ -154,8 +154,8 @@ func (w *Wallet) txToOutputs(outputs []*wire.TxOut,
 	}
 
 	// Fall back to default coin selection strategy if none is supplied.
-	if coinSelectionStrategy == nil {
-		coinSelectionStrategy = CoinSelectionLargest
+	if strategy == nil {
+		strategy = CoinSelectionLargest
 	}
 
 	var tx *txauthor.AuthoredTx
@@ -174,27 +174,57 @@ func (w *Wallet) txToOutputs(outputs []*wire.TxOut,
 			return err
 		}
 
-		// Wrap our coins in a type that implements the SelectableCoin
-		// interface, so we can arrange them according to the selected
-		// coin selection strategy.
-		wrappedEligible := make([]Coin, len(eligible))
-		for i := range eligible {
-			wrappedEligible[i] = Coin{
-				TxOut: wire.TxOut{
-					Value:    int64(eligible[i].Amount),
-					PkScript: eligible[i].PkScript,
-				},
-				OutPoint: eligible[i].OutPoint,
-			}
-		}
-		arrangedCoins, err := coinSelectionStrategy.ArrangeCoins(
-			wrappedEligible, feeSatPerKb,
-		)
-		if err != nil {
-			return err
-		}
+		var inputSource txauthor.InputSource
+		if len(selectedUtxos) > 0 {
+			eligibleByOutpoint := make(
+				map[wire.OutPoint]wtxmgr.Credit,
+			)
 
-		inputSource := makeInputSource(arrangedCoins)
+			for _, e := range eligible {
+				eligibleByOutpoint[e.OutPoint] = e
+			}
+
+			var eligibleSelectedUtxo []wtxmgr.Credit
+			for _, outpoint := range selectedUtxos {
+				e, ok := eligibleByOutpoint[outpoint]
+
+				if !ok {
+					return fmt.Errorf("selected outpoint "+
+						"not eligible for "+
+						"spending: %v", outpoint)
+				}
+				eligibleSelectedUtxo = append(
+					eligibleSelectedUtxo, e,
+				)
+			}
+
+			inputSource = constantInputSource(eligibleSelectedUtxo)
+
+		} else {
+			// Wrap our coins in a type that implements the
+			// SelectableCoin interface, so we can arrange them
+			// according to the selected coin selection strategy.
+			wrappedEligible := make([]Coin, len(eligible))
+			for i := range eligible {
+				wrappedEligible[i] = Coin{
+					TxOut: wire.TxOut{
+						Value: int64(
+							eligible[i].Amount,
+						),
+						PkScript: eligible[i].PkScript,
+					},
+					OutPoint: eligible[i].OutPoint,
+				}
+			}
+
+			arrangedCoins, err := strategy.ArrangeCoins(
+				wrappedEligible, feeSatPerKb,
+			)
+			if err != nil {
+				return err
+			}
+			inputSource = makeInputSource(arrangedCoins)
+		}
 
 		tx, err = txauthor.NewUnsignedTransaction(
 			outputs, feeSatPerKb, inputSource, changeSource,

--- a/wallet/psbt.go
+++ b/wallet/psbt.go
@@ -567,30 +567,3 @@ func PsbtPrevOutputFetcher(packet *psbt.Packet) *txscript.MultiPrevOutFetcher {
 
 	return fetcher
 }
-
-// constantInputSource creates an input source function that always returns the
-// static set of user-selected UTXOs.
-func constantInputSource(eligible []wtxmgr.Credit) txauthor.InputSource {
-	// Current inputs and their total value. These won't change over
-	// different invocations as we want our inputs to remain static since
-	// they're selected by the user.
-	currentTotal := btcutil.Amount(0)
-	currentInputs := make([]*wire.TxIn, 0, len(eligible))
-	currentScripts := make([][]byte, 0, len(eligible))
-	currentInputValues := make([]btcutil.Amount, 0, len(eligible))
-
-	for _, credit := range eligible {
-		nextInput := wire.NewTxIn(&credit.OutPoint, nil, nil)
-		currentTotal += credit.Amount
-		currentInputs = append(currentInputs, nextInput)
-		currentScripts = append(currentScripts, credit.PkScript)
-		currentInputValues = append(currentInputValues, credit.Amount)
-	}
-
-	return func(target btcutil.Amount) (btcutil.Amount, []*wire.TxIn,
-		[]btcutil.Amount, [][]byte, error) {
-
-		return currentTotal, currentInputs, currentInputValues,
-			currentScripts, nil
-	}
-}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1200,6 +1200,7 @@ type (
 		coinSelectionStrategy CoinSelectionStrategy
 		dryRun                bool
 		resp                  chan createTxResponse
+		selectUtxos           []wire.OutPoint
 	}
 	createTxResponse struct {
 		tx  *txauthor.AuthoredTx
@@ -1331,6 +1332,7 @@ func (w *Wallet) CreateSimpleTx(coinSelectKeyScope *waddrmgr.KeyScope,
 		coinSelectionStrategy: coinSelectionStrategy,
 		dryRun:                dryRun,
 		resp:                  make(chan createTxResponse),
+		selectUtxos:           opts.selectUtxos,
 	}
 	w.createTxRequests <- req
 	resp := <-req.resp

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1241,7 +1241,7 @@ out:
 			tx, err := w.txToOutputs(
 				txr.outputs, txr.coinSelectKeyScope, txr.changeKeyScope,
 				txr.account, txr.minconf, txr.feeSatPerKB,
-				txr.coinSelectionStrategy, txr.dryRun,
+				txr.coinSelectionStrategy, txr.dryRun, txr.selectUtxos,
 			)
 
 			release()
@@ -3414,8 +3414,8 @@ func (w *Wallet) SendOutputsWithInput(outputs []*wire.TxOut,
 		coinSelectionStrategy, label, selectedUtxos...)
 }
 
-// sendOutputs creates and sends payment transactions.It returns the transaction
-// upon success.
+// sendOutputs creates and sends payment transactions. It returns the
+// transaction upon success.
 func (w *Wallet) sendOutputs(outputs []*wire.TxOut, keyScope *waddrmgr.KeyScope,
 	account uint32, minconf int32, satPerKb btcutil.Amount,
 	coinSelectionStrategy CoinSelectionStrategy, label string,

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1257,6 +1257,7 @@ out:
 // scope, which otherwise will default to the specified coin selection scope.
 type txCreateOptions struct {
 	changeKeyScope *waddrmgr.KeyScope
+	selectUtxos    []wire.OutPoint
 }
 
 // TxCreateOption is a set of optional arguments to modify the tx creation
@@ -1276,6 +1277,14 @@ func defaultTxCreateOptions() *txCreateOptions {
 func WithCustomChangeScope(changeScope *waddrmgr.KeyScope) TxCreateOption {
 	return func(opts *txCreateOptions) {
 		opts.changeKeyScope = changeScope
+	}
+}
+
+// WithCustomSelectUtxos is used to specify the inputs to be used while
+// creating txns.
+func WithCustomSelectUtxos(utxos []wire.OutPoint) TxCreateOption {
+	return func(opts *txCreateOptions) {
+		opts.selectUtxos = utxos
 	}
 }
 


### PR DESCRIPTION
Related issue: https://github.com/lightningnetwork/lnd/issues/6949#issue-1386947921
and it is needed for https://github.com/lightningnetwork/lnd/pull/8516

This pull request enables `SendOutput` in the wallet to use passed UTXOS as inputs for transactions. All passed UTXOS would be used as inputs.