### PR TITLE
waddrmgr: add MasterKeyFingerprint to new addresses

### DIFF
--- a/waddrmgr/scoped_manager.go
+++ b/waddrmgr/scoped_manager.go
@@ -1007,7 +1007,8 @@ func (s *ScopedKeyManager) accountAddrType(acctInfo *accountInfo,
 //
 // This function MUST be called with the manager lock held for writes.
 func (s *ScopedKeyManager) nextAddresses(ns walletdb.ReadWriteBucket,
-	account uint32, numAddresses uint32, internal bool) ([]ManagedAddress, error) {
+	account uint32, numAddresses uint32, internal bool) ([]ManagedAddress,
+	error) {
 
 	// The next address can only be generated for accounts that have
 	// already been created.
@@ -1089,10 +1090,11 @@ func (s *ScopedKeyManager) nextAddresses(ns walletdb.ReadWriteBucket,
 		// proper derivation path so this information can be available
 		// to callers.
 		derivationPath := DerivationPath{
-			InternalAccount: account,
-			Account:         acctKey.ChildIndex(),
-			Branch:          branchNum,
-			Index:           nextIndex - 1,
+			InternalAccount:      account,
+			Account:              acctKey.ChildIndex(),
+			Branch:               branchNum,
+			Index:                nextIndex - 1,
+			MasterKeyFingerprint: acctInfo.masterKeyFingerprint,
 		}
 
 		// Create a new managed address based on the public or private


### PR DESCRIPTION
Related to https://github.com/lightningnetwork/lnd/issues/8626.

When deriving a new address, we'll want to store the correct master key fingerprint from the account it's derived from.
This makes sure PSBT signing succeeds even for imported accounts and their change addresses.
