### PR TITLE
end recovery on shutdown

### DIFF
--- a/wallet/mock.go
+++ b/wallet/mock.go
@@ -12,6 +12,9 @@ import (
 )
 
 type mockChainClient struct {
+	getBestBlockHeight int32
+	getBlockHashFunc   func() (*chainhash.Hash, error)
+	getBlockHeader     *wire.BlockHeader
 }
 
 var _ chain.Interface = (*mockChainClient)(nil)
@@ -26,7 +29,7 @@ func (m *mockChainClient) Stop() {
 func (m *mockChainClient) WaitForShutdown() {}
 
 func (m *mockChainClient) GetBestBlock() (*chainhash.Hash, int32, error) {
-	return nil, 0, nil
+	return nil, m.getBestBlockHeight, nil
 }
 
 func (m *mockChainClient) GetBlock(*chainhash.Hash) (*wire.MsgBlock, error) {
@@ -34,12 +37,15 @@ func (m *mockChainClient) GetBlock(*chainhash.Hash) (*wire.MsgBlock, error) {
 }
 
 func (m *mockChainClient) GetBlockHash(int64) (*chainhash.Hash, error) {
+	if m.getBlockHashFunc != nil {
+		return m.getBlockHashFunc()
+	}
 	return nil, nil
 }
 
 func (m *mockChainClient) GetBlockHeader(*chainhash.Hash) (*wire.BlockHeader,
 	error) {
-	return nil, nil
+	return m.getBlockHeader, nil
 }
 
 func (m *mockChainClient) IsCurrent() bool {


### PR DESCRIPTION
The `(*Wallet).recovery` loop is unmonitored, and shutting down the wallet during recovery without locking the wallet first will hang. This change ensures that the recovery loop is ended when `(*Wallet).Stop` is called.