### PR TITLE
chain: match on new bitcoind v28.0 errors

### DIFF
--- a/chain/bitcoind_client.go
+++ b/chain/bitcoind_client.go
@@ -233,6 +233,15 @@ func (c *BitcoindClient) MapRPCErr(rpcErr error) error {
 		}
 	}
 
+	// Perhaps the backend is a newer version of bitcoind, try to match it
+	// against the v28.0 and later errors.
+	for btcdErr, matchedErr := range Bitcoind28ErrMap {
+		// Match it against btcd's error.
+		if matchErrStr(rpcErr, btcdErr) {
+			return matchedErr
+		}
+	}
+
 	// If not matched, return the original error wrapped.
 	return fmt.Errorf("%w: %v", ErrUndefined, rpcErr)
 }

--- a/chain/errors.go
+++ b/chain/errors.go
@@ -337,6 +337,14 @@ func (r RPCErr) Error() string {
 	return "unknown error"
 }
 
+// Bitcoind28ErrMap contains error messages from bitcoind version v28.0 (and
+// later) that are returned from the `testmempoolaccept` and are different than
+// in previous versions.
+var Bitcoind28ErrMap = map[string]error{
+	// https://github.com/bitcoin/bitcoin/pull/30212
+	"transaction outputs already in utxo set": ErrTxAlreadyConfirmed,
+}
+
 // BtcdErrMap takes the errors returned from btcd's `testmempoolaccept` and
 // `sendrawtransaction` RPCs and map them to the errors defined above, which
 // are results from calling either `testmempoolaccept` or `sendrawtransaction`


### PR DESCRIPTION
An error message was renamed in https://github.com/bitcoin/bitcoin/pull/30212.

We should probably start matching on the [`reject-reason`](https://github.com/bitcoin/bitcoin/blob/4c526f575cde43cc49c0236f4d2b15a5fbb6d7ab/src/rpc/mempool.cpp#L146) returned by `testmempoolaccept` RPC instead, as that's less likely to change in the future.