### PR TITLE
Fix:nil pointer

### DIFF
--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -1713,6 +1713,9 @@ func signRawTransaction(icmd interface{}, w *wallet.Wallet, chainClient *chain.R
 		if err != nil {
 			return nil, err
 		}
+		if result == nil {
+			return nil, errors.New("the utxo has been spent")
+		}
 		script, err := hex.DecodeString(result.ScriptPubKey.Hex)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Error when spending an already used UTXO: **“runtime error: invalid memory address or nil pointer dereference”**

According to my observation, in **btcwallet/rpc/legacyrpc/methods.go:1716** the call to hex.DecodeString(result.ScriptPubKey.Hex) with the parameter **“result” is nil**. This is because when calling resp.Receive() on line 1712, if you use a spent UTXO, it will return (nil,nil), so need to handle the error if result is nil.