### PR TITLE
chain: make sure to `WaitForShutdown`

### DIFF
--- a/chain/btcd.go
+++ b/chain/btcd.go
@@ -242,6 +242,7 @@ func (c *RPCClient) Stop() {
 	default:
 		close(c.quit)
 		c.Client.Shutdown()
+		c.Client.WaitForShutdown()
 
 		if !c.started {
 			close(c.dequeueNotification)


### PR DESCRIPTION
Simple fix - looks like we forgot to call `WaitForShutdown` and, add a nil bucket check which was found panic in one of `lnd`'s itests.