### PR TITLE
waddrmgr: fix deadlock

### DIFF
--- a/waddrmgr/manager_test.go
+++ b/waddrmgr/manager_test.go
@@ -2439,6 +2439,14 @@ func TestScopedKeyManagerManagement(t *testing.T) {
 	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
 		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
 
+		// For this test, since we've fetched the scoped key manager,
+		// we want to check that this runs correctly while the root
+		// manager is locked for another task. This will be possible
+		// with Postgres-backed wallets having multiple connections to
+		// the database backend, executing transactions in parallel.
+		mgr.mtx.Lock()
+		defer mgr.mtx.Unlock()
+
 		// We'll now create a new external address to ensure we
 		// retrieve the proper type.
 		externalAddr, err = scopedMgr.NextExternalAddresses(

--- a/waddrmgr/scoped_manager.go
+++ b/waddrmgr/scoped_manager.go
@@ -447,7 +447,7 @@ func (s *ScopedKeyManager) loadAccountInfo(ns walletdb.ReadBucket,
 
 	// The wallet will only contain private keys for default accounts if the
 	// wallet's not set up as watch-only and it's been unlocked.
-	watchOnly := s.rootManager.watchOnly()
+	watchOnly := s.rootManager.WatchOnly()
 	hasPrivateKey := !s.rootManager.isLocked() && !watchOnly
 
 	// Create the new account info with the known information. The rest of
@@ -777,7 +777,7 @@ func (s *ScopedKeyManager) chainAddressRowToManaged(ns walletdb.ReadBucket,
 
 	// Since the manger's mutex is assumed to held when invoking this
 	// function, we use the internal isLocked to avoid a deadlock.
-	private := !s.rootManager.isLocked() && !s.rootManager.watchOnly()
+	private := !s.rootManager.isLocked() && !s.rootManager.WatchOnly()
 
 	addressKey, acctKey, masterKeyFingerprint, err := s.deriveKeyFromPath(
 		ns, row.account, row.branch, row.index, private,

--- a/waddrmgr/scoped_manager.go
+++ b/waddrmgr/scoped_manager.go
@@ -448,7 +448,7 @@ func (s *ScopedKeyManager) loadAccountInfo(ns walletdb.ReadBucket,
 	// The wallet will only contain private keys for default accounts if the
 	// wallet's not set up as watch-only and it's been unlocked.
 	watchOnly := s.rootManager.WatchOnly()
-	hasPrivateKey := !s.rootManager.isLocked() && !watchOnly
+	hasPrivateKey := !s.rootManager.IsLocked() && !watchOnly
 
 	// Create the new account info with the known information. The rest of
 	// the fields are filled out below.
@@ -775,9 +775,7 @@ func (s *ScopedKeyManager) deriveKeyFromPath(ns walletdb.ReadBucket,
 func (s *ScopedKeyManager) chainAddressRowToManaged(ns walletdb.ReadBucket,
 	row *dbChainAddressRow) (ManagedAddress, error) {
 
-	// Since the manger's mutex is assumed to held when invoking this
-	// function, we use the internal isLocked to avoid a deadlock.
-	private := !s.rootManager.isLocked() && !s.rootManager.WatchOnly()
+	private := !s.rootManager.IsLocked() && !s.rootManager.WatchOnly()
 
 	addressKey, acctKey, masterKeyFingerprint, err := s.deriveKeyFromPath(
 		ns, row.account, row.branch, row.index, private,
@@ -1203,7 +1201,7 @@ func (s *ScopedKeyManager) nextAddresses(ns walletdb.ReadWriteBucket,
 			// Add the new managed address to the list of addresses
 			// that need their private keys derived when the
 			// address manager is next unlocked.
-			if s.rootManager.isLocked() && !watchOnly {
+			if s.rootManager.IsLocked() && !watchOnly {
 				s.deriveOnUnlock = append(s.deriveOnUnlock, info)
 			}
 		}


### PR DESCRIPTION
This PR fixes a deadlock caused by methods of `ScopedManager` read-locking the root manager for `WatchOnly()` and `Locked()` calls while the `ScopedManager` itself is locked. This is the reverse order from the normal way of taking locks, but has been hidden by the fact that DB transactions have never happened in parallel until the upcoming postgres changes in LND.

See discussion [here](https://github.com/lightningnetwork/lnd/pull/9242#issuecomment-2495544838) for more details.

The first commit updates a test to cause this failure. The following commits, pushed after CI completes/tests fail, contain the fix.