### PR TITLE
feat: add regtest to btcwallet

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -90,6 +90,9 @@ linters:
     # will also catch magic numbers that make sense to extract.
     - gomnd
 
+    # Disable tagalign
+    - tagalign
+
 issues:
   # Only check issues in the new code.
   new-from-rev: 3f48b446215c751ea4ba0c30fb04413ab9f1a7c7

--- a/cmd/sweepaccount/main.go
+++ b/cmd/sweepaccount/main.go
@@ -43,6 +43,7 @@ func errContext(err error, context string) error {
 var opts = struct {
 	TestNet3              bool                `long:"testnet" description:"Use the test bitcoin network (version 3)"`
 	SimNet                bool                `long:"simnet" description:"Use the simulation bitcoin network"`
+	RegressionNet         bool                `long:"regtest" description:"Use the regression bitcoin network"`
 	RPCConnect            string              `short:"c" long:"connect" description:"Hostname[:port] of wallet RPC server"`
 	RPCUsername           string              `short:"u" long:"rpcuser" description:"Wallet RPC username"`
 	RPCCertificateFile    string              `long:"cafile" description:"Wallet RPC TLS certificate"`
@@ -53,6 +54,7 @@ var opts = struct {
 }{
 	TestNet3:              false,
 	SimNet:                false,
+	RegressionNet:         false,
 	RPCConnect:            "localhost",
 	RPCUsername:           "",
 	RPCCertificateFile:    filepath.Join(walletDataDirectory, "rpc.cert"),
@@ -79,7 +81,17 @@ func init() {
 		os.Exit(1)
 	}
 
-	if opts.TestNet3 && opts.SimNet {
+	numNets := 0
+	if opts.TestNet3 {
+		numNets++
+	}
+	if opts.SimNet {
+		numNets++
+	}
+	if opts.RegressionNet {
+		numNets++
+	}
+	if numNets > 1 {
 		fatalf("Multiple bitcoin networks may not be used simultaneously")
 	}
 	var activeNet = &netparams.MainNetParams
@@ -87,6 +99,8 @@ func init() {
 		activeNet = &netparams.TestNet3Params
 	} else if opts.SimNet {
 		activeNet = &netparams.SimNetParams
+	} else if opts.RegressionNet {
+		activeNet = &netparams.RegressionNetParams
 	}
 
 	if opts.RPCConnect == "" {

--- a/config.go
+++ b/config.go
@@ -410,9 +410,13 @@ func loadConfig() (*config, []string, error) {
 		)
 		activeNet.Params = &chainParams
 	}
+	if cfg.RegressionNet {
+		activeNet = &netparams.RegressionNetParams
+		numNets++
+	}
 	if numNets > 1 {
-		str := "%s: The testnet, signet and simnet params can't be " +
-			"used together -- choose one"
+		str := "%s: The testnet, signet, simnet, and regtest params " +
+			"can't be used together -- choose one"
 		err := fmt.Errorf(str, "loadConfig")
 		fmt.Fprintln(os.Stderr, err)
 		parser.WriteHelp(os.Stderr)

--- a/config.go
+++ b/config.go
@@ -45,6 +45,7 @@ var (
 	defaultLogDir      = filepath.Join(defaultAppDataDir, defaultLogDirname)
 )
 
+//nolint:lll
 type config struct {
 	// General application behavior
 	ConfigFile      *cfgutil.ExplicitString `short:"C" long:"configfile" description:"Path to configuration file"`

--- a/config.go
+++ b/config.go
@@ -57,6 +57,7 @@ type config struct {
 	SigNet          bool                    `long:"signet" description:"Use the signet test network (default mainnet)"`
 	SigNetChallenge string                  `long:"signetchallenge" description:"Connect to a custom signet network defined by this challenge instead of using the global default signet test network -- Can be specified multiple times"`
 	SigNetSeedNode  []string                `long:"signetseednode" description:"Specify a seed node for the signet network instead of using the global default signet network seed nodes"`
+	RegressionNet   bool                    `long:"regtest" description:"Use the regression test network (default mainnet)"`
 	NoInitialLoad   bool                    `long:"noinitialload" description:"Defer wallet creation/opening on startup and enable loading wallets over RPC"`
 	DebugLevel      string                  `short:"d" long:"debuglevel" description:"Logging level {trace, debug, info, warn, error, critical}"`
 	LogDir          string                  `long:"logdir" description:"Directory to log output."`
@@ -67,7 +68,7 @@ type config struct {
 	WalletPass string `long:"walletpass" default-mask:"-" description:"The public wallet password -- Only required if the wallet was created with one"`
 
 	// RPC client options
-	RPCConnect       string                  `short:"c" long:"rpcconnect" description:"Hostname/IP and port of btcd RPC server to connect to (default localhost:8334, testnet: localhost:18334, simnet: localhost:18556)"`
+	RPCConnect       string                  `short:"c" long:"rpcconnect" description:"Hostname/IP and port of btcd RPC server to connect to (default localhost:8334, testnet: localhost:18334, simnet: localhost:18556, regtest: localhost:18334)"`
 	CAFile           *cfgutil.ExplicitString `long:"cafile" description:"File containing root certificates to authenticate a TLS connections with btcd"`
 	DisableClientTLS bool                    `long:"noclienttls" description:"Disable TLS for the RPC client -- NOTE: This is only allowed if the RPC client is connecting to localhost"`
 	BtcdUsername     string                  `long:"btcdusername" description:"Username for btcd authentication"`
@@ -96,7 +97,7 @@ type config struct {
 	RPCKey                 *cfgutil.ExplicitString `long:"rpckey" description:"File containing the certificate key"`
 	OneTimeTLSKey          bool                    `long:"onetimetlskey" description:"Generate a new TLS certpair at startup, but only write the certificate to disk"`
 	DisableServerTLS       bool                    `long:"noservertls" description:"Disable TLS for the RPC server -- NOTE: This is only allowed if the RPC server is bound to localhost"`
-	LegacyRPCListeners     []string                `long:"rpclisten" description:"Listen for legacy RPC connections on this interface/port (default port: 8332, testnet: 18332, simnet: 18554)"`
+	LegacyRPCListeners     []string                `long:"rpclisten" description:"Listen for legacy RPC connections on this interface/port (default port: 8332, testnet: 18332, simnet: 18554, regtest: 18332)"`
 	LegacyRPCMaxClients    int64                   `long:"rpcmaxclients" description:"Max number of legacy RPC clients for standard connections"`
 	LegacyRPCMaxWebsockets int64                   `long:"rpcmaxwebsockets" description:"Max number of legacy RPC websocket connections"`
 	Username               string                  `short:"u" long:"username" description:"Username for legacy RPC and btcd authentication (if btcdusername is unset)"`

--- a/internal/legacy/keystore/keystore.go
+++ b/internal/legacy/keystore/keystore.go
@@ -494,6 +494,8 @@ func (net *netParams) ReadFrom(r io.Reader) (int64, error) {
 		*net = (netParams)(chaincfg.TestNet3Params)
 	case wire.SimNet:
 		*net = (netParams)(chaincfg.SimNetParams)
+	case wire.TestNet:
+		*net = (netParams)(chaincfg.RegressionNetParams)
 
 	// The legacy key store won't be compatible with custom signets, only
 	// the main public one.

--- a/netparams/params.go
+++ b/netparams/params.go
@@ -60,3 +60,11 @@ func SigNetWire(params *chaincfg.Params) wire.BitcoinNet {
 
 	return 0
 }
+
+// RegressionNetParams contains parameters specific to the regression test
+// network (wire.RegressionNet).
+var RegressionNetParams = Params{
+	Params:        &chaincfg.RegressionNetParams,
+	RPCClientPort: "18334",
+	RPCServerPort: "18332",
+}

--- a/sample-btcwallet.conf
+++ b/sample-btcwallet.conf
@@ -4,11 +4,14 @@
 ; Bitcoin wallet settings
 ; ------------------------------------------------------------------------------
 
-; Use testnet (cannot be used with simnet=1).
+; Use testnet (cannot be used with simnet=1 or regtest=1).
 ; testnet=0
 
-; Use simnet (cannot be used with testnet=1).
+; Use simnet (cannot be used with testnet=1 or regtest=1).
 ; simnet=0
+
+; Use regtest (cannot be used with testnet=1 or simnet=1).
+; regtest=0
 
 ; The directory to open and save wallet, transaction, and unspent transaction
 ; output files.  Two directories, `mainnet` and `testnet` are used in this


### PR DESCRIPTION
closes #955 

Following up on the [comment](https://github.com/btcsuite/btcwallet/issues/955#issuecomment-2356618570), In this PR we add `regtest` support to btcwallet. 

A regtest environment can benefit users who want to test their applications or programs. Specifically, I am working on a project to add [BTCD support in Polar](https://github.com/jamaljsr/polar/issues/302), which depends on this, as all other node implementations operate on regtest. This becomes a blocker as highlighted in this [comment](https://github.com/jamaljsr/polar/pull/1092#issuecomment-2593675239):

> The second blocker is that btcwallet does not support regtest currently, meanwhile all the other node implementations in Polar use regtest. I think this is the real challenge.


### Steps to test
- Start BTCD in regtest
```bash
btcd --regtest
```
- Initialize `btcwallet` on regtest
```bash
btcwallet --regtest --create
```
- Finally start btcwallet
```bash
btcwallet --regtest
```

You can access `btcwallet` using the default port, which is set as `18332`.