### PR TITLE
.github: ignore Send coverage errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,6 +99,7 @@ jobs:
       - name: Send coverage
         uses: shogo82148/actions-goveralls@v1
         if: matrix.unit_type == 'unit-cover'
+        continue-on-error: true
         with:
           path-to-profile: coverage.txt
           parallel: true


### PR DESCRIPTION
As done in https://github.com/lightningnetwork/lnd/pull/9508, we skip this error, an example is this [build](https://github.com/btcsuite/btcwallet/actions/runs/13303231024/job/37162045847).