### PR TITLE
fix: typos in documentation files

### DIFF
--- a/config.go
+++ b/config.go
@@ -114,7 +114,7 @@ type config struct {
 	DataDir *cfgutil.ExplicitString `short:"b" long:"datadir" default-mask:"-" description:"DEPRECATED -- use appdata instead"`
 }
 
-// cleanAndExpandPath expands environement variables and leading ~ in the
+// cleanAndExpandPath expands environment variables and leading ~ in the
 // passed path, cleans the result, and returns it.
 func cleanAndExpandPath(path string) string {
 	// NOTE: The os.ExpandEnv doesn't work with Windows cmd.exe-style

--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -129,7 +129,7 @@ var rpcHandlers = map[string]struct {
 	// This was an extension but the reference implementation added it as
 	// well, but with a different API (no account parameter).  It's listed
 	// here because it hasn't been update to use the reference
-	// implemenation's API.
+	// implementation's API.
 	"getunconfirmedbalance":   {handler: getUnconfirmedBalance},
 	"listaddresstransactions": {handler: listAddressTransactions},
 	"listalltransactions":     {handler: listAllTransactions},

--- a/walletdb/bdb/driver.go
+++ b/walletdb/bdb/driver.go
@@ -80,7 +80,7 @@ func init() {
 		Open:   openDBDriver,
 	}
 	if err := walletdb.RegisterDriver(driver); err != nil {
-		panic(fmt.Sprintf("Failed to regiser database driver '%s': %v",
+		panic(fmt.Sprintf("Failed to register database driver '%s': %v",
 			dbType, err))
 	}
 }

--- a/walletdb/walletdbtest/interface.go
+++ b/walletdb/walletdbtest/interface.go
@@ -304,7 +304,7 @@ func testManualTxInterface(tc *testContext, bucketKey []byte) bool {
 
 	// populateValues tests that populating values works as expected.
 	//
-	// When the writable flag is false, a read-only tranasction is created,
+	// When the writable flag is false, a read-only transaction is created,
 	// standard bucket tests for read-only transactions are performed, and
 	// the Commit function is checked to ensure it fails as expected.
 	//


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `environement` to `environment`
Corrected `implemenation` to `implementation`
Corrected `regiser` to `register`
Corrected `tranasction` to `transaction`