### PR TITLE
refactor: use t.TempDir() instead of os.MkdirTemp

### DIFF
--- a/chain/bitcoind_events_test.go
+++ b/chain/bitcoind_events_test.go
@@ -3,7 +3,6 @@ package chain
 import (
 	"fmt"
 	"math/rand"
-	"os"
 	"os/exec"
 	"testing"
 	"time"
@@ -459,14 +458,10 @@ func setupBitcoind(t *testing.T, minerAddr string,
 	rpcPolling bool) *BitcoindClient {
 
 	// Start a bitcoind instance and connect it to miner1.
-	tempBitcoindDir, err := os.MkdirTemp("", "bitcoind")
-	require.NoError(t, err)
+	tempBitcoindDir := t.TempDir()
 
 	zmqBlockHost := "ipc:///" + tempBitcoindDir + "/blocks.socket"
 	zmqTxHost := "ipc:///" + tempBitcoindDir + "/tx.socket"
-	t.Cleanup(func() {
-		os.RemoveAll(tempBitcoindDir)
-	})
 
 	rpcPort := rand.Int()%(65536-1024) + 1024
 	bitcoind := exec.Command(

--- a/waddrmgr/common_test.go
+++ b/waddrmgr/common_test.go
@@ -249,19 +249,15 @@ func hexToBytes(origHex string) []byte {
 }
 
 func emptyDB(t *testing.T) (tearDownFunc func(), db walletdb.DB) {
-	dirName, err := os.MkdirTemp("", "mgrtest")
-	if err != nil {
-		t.Fatalf("Failed to create db temp dir: %v", err)
-	}
+	dirName := t.TempDir()
 	dbPath := filepath.Join(dirName, "mgrtest.db")
-	db, err = walletdb.Create("bdb", dbPath, true, defaultDBTimeout)
+	db, err := walletdb.Create("bdb", dbPath, true, defaultDBTimeout)
 	if err != nil {
 		_ = os.RemoveAll(dirName)
 		t.Fatalf("createDbNamespace: unexpected error: %v", err)
 	}
 	tearDownFunc = func() {
 		db.Close()
-		_ = os.RemoveAll(dirName)
 	}
 	return
 }
@@ -270,12 +266,10 @@ func emptyDB(t *testing.T) (tearDownFunc func(), db walletdb.DB) {
 // that should be invoked to ensure it is closed and removed upon completion.
 func setupManager(t *testing.T) (tearDownFunc func(), db walletdb.DB, mgr *Manager) {
 	// Create a new manager in a temp directory.
-	dirName, err := os.MkdirTemp("", "mgrtest")
-	if err != nil {
-		t.Fatalf("Failed to create db temp dir: %v", err)
-	}
+	dirName := t.TempDir()
+
 	dbPath := filepath.Join(dirName, "mgrtest.db")
-	db, err = walletdb.Create("bdb", dbPath, true, defaultDBTimeout)
+	db, err := walletdb.Create("bdb", dbPath, true, defaultDBTimeout)
 	if err != nil {
 		_ = os.RemoveAll(dirName)
 		t.Fatalf("createDbNamespace: unexpected error: %v", err)
@@ -303,7 +297,6 @@ func setupManager(t *testing.T) (tearDownFunc func(), db walletdb.DB, mgr *Manag
 	tearDownFunc = func() {
 		mgr.Close()
 		db.Close()
-		_ = os.RemoveAll(dirName)
 	}
 	return tearDownFunc, db, mgr
 }

--- a/wallet/example_test.go
+++ b/wallet/example_test.go
@@ -1,7 +1,6 @@
 package wallet
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -18,16 +17,7 @@ var defaultDBTimeout = 10 * time.Second
 // testWallet creates a test wallet and unlocks it.
 func testWallet(t *testing.T) (*Wallet, func()) {
 	// Set up a wallet.
-	dir, err := os.MkdirTemp("", "test_wallet")
-	if err != nil {
-		t.Fatalf("Failed to create db dir: %v", err)
-	}
-
-	cleanup := func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatalf("could not cleanup test: %v", err)
-		}
-	}
+	dir := t.TempDir()
 
 	seed, err := hdkeychain.GenerateSeed(hdkeychain.MinSeedBytes)
 	if err != nil {
@@ -51,22 +41,13 @@ func testWallet(t *testing.T) (*Wallet, func()) {
 		t.Fatalf("unable to unlock wallet: %v", err)
 	}
 
-	return w, cleanup
+	return w, func() {}
 }
 
 // testWalletWatchingOnly creates a test watch only wallet and unlocks it.
 func testWalletWatchingOnly(t *testing.T) (*Wallet, func()) {
 	// Set up a wallet.
-	dir, err := os.MkdirTemp("", "test_wallet_watch_only")
-	if err != nil {
-		t.Fatalf("Failed to create db dir: %v", err)
-	}
-
-	cleanup := func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Fatalf("could not cleanup test: %v", err)
-		}
-	}
+	dir := t.TempDir()
 
 	pubPass := []byte("hello")
 	loader := NewLoader(
@@ -97,5 +78,5 @@ func testWalletWatchingOnly(t *testing.T) (*Wallet, func()) {
 		t.Fatalf("unable to create default scopes: %v", err)
 	}
 
-	return w, cleanup
+	return w, func() {}
 }

--- a/wallet/watchingonly_test.go
+++ b/wallet/watchingonly_test.go
@@ -5,7 +5,6 @@
 package wallet
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -17,11 +16,7 @@ import (
 // wallet.
 func TestCreateWatchingOnly(t *testing.T) {
 	// Set up a wallet.
-	dir, err := os.MkdirTemp("", "watchingonly_test")
-	if err != nil {
-		t.Fatalf("Failed to create db dir: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	pubPass := []byte("hello")
 
@@ -29,7 +24,7 @@ func TestCreateWatchingOnly(t *testing.T) {
 		&chaincfg.TestNet3Params, dir, true, defaultDBTimeout, 250,
 		WithWalletSyncRetryInterval(10*time.Millisecond),
 	)
-	_, err = loader.CreateNewWatchingOnlyWallet(pubPass, time.Now())
+	_, err := loader.CreateNewWatchingOnlyWallet(pubPass, time.Now())
 	if err != nil {
 		t.Fatalf("unable to create wallet: %v", err)
 	}

--- a/walletdb/bdb/driver_test.go
+++ b/walletdb/bdb/driver_test.go
@@ -6,7 +6,6 @@ package bdb_test
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -145,12 +144,7 @@ func TestCreateOpenFail(t *testing.T) {
 
 	// Ensure operations against a closed database return the expected
 	// error.
-	tempDir, err := os.MkdirTemp("", "createfail")
-	if err != nil {
-		t.Errorf("unable to create temp dir: %v", err)
-		return
-	}
-	defer os.Remove(tempDir)
+	tempDir := t.TempDir()
 
 	dbPath := filepath.Join(tempDir, "db")
 	db, err := walletdb.Create(dbType, dbPath, true, defaultDBTimeout)
@@ -172,12 +166,7 @@ func TestCreateOpenFail(t *testing.T) {
 // reopening the database.
 func TestPersistence(t *testing.T) {
 	// Create a new database to run tests against.
-	tempDir, err := os.MkdirTemp("", "persistencetest")
-	if err != nil {
-		t.Errorf("unable to create temp dir: %v", err)
-		return
-	}
-	defer os.Remove(tempDir)
+	tempDir := t.TempDir()
 
 	dbPath := filepath.Join(tempDir, "db")
 	db, err := walletdb.Create(dbType, dbPath, true, defaultDBTimeout)

--- a/walletdb/bdb/interface_test.go
+++ b/walletdb/bdb/interface_test.go
@@ -22,12 +22,7 @@ import (
 
 // TestInterface performs all interfaces tests for this database driver.
 func TestInterface(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "interfacetest")
-	if err != nil {
-		t.Errorf("unable to create temp dir: %v", err)
-		return
-	}
-	defer os.Remove(tempDir)
+	tempDir := t.TempDir()
 
 	dbPath := filepath.Join(tempDir, "db")
 	defer os.RemoveAll(dbPath)

--- a/walletdb/db_test.go
+++ b/walletdb/db_test.go
@@ -6,7 +6,6 @@ package walletdb_test
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -60,12 +59,7 @@ func TestAddDuplicateDriver(t *testing.T) {
 			"got %v, want %v", err, walletdb.ErrDbTypeRegistered)
 	}
 
-	tempDir, err := os.MkdirTemp("", "dupdrivertest")
-	if err != nil {
-		t.Errorf("unable to create temp dir: %v", err)
-		return
-	}
-	defer os.Remove(tempDir)
+	tempDir := t.TempDir()
 
 	dbPath := filepath.Join(tempDir, "db")
 	db, err := walletdb.Create(dbType, dbPath, true, defaultDBTimeout)

--- a/wtxmgr/example_test.go
+++ b/wtxmgr/example_test.go
@@ -6,6 +6,7 @@ package wtxmgr
 
 import (
 	"fmt"
+	"testing"
 
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -43,8 +44,8 @@ var exampleBlock100 = makeBlockMeta(100)
 
 // This example demonstrates reporting the Store balance given an unmined and
 // mined transaction given 0, 1, and 6 block confirmations.
-func ExampleStore_Balance() {
-	s, db, teardown, err := testStore()
+func ExampleStore_Balance(t *testing.T) {
+	s, db, teardown, err := testStore(t)
 	defer teardown()
 	if err != nil {
 		fmt.Println(err)
@@ -114,8 +115,8 @@ func ExampleStore_Balance() {
 	// 10 BTC, 10 BTC, 10 BTC
 }
 
-func ExampleStore_Rollback() {
-	s, db, teardown, err := testStore()
+func ExampleStore_Rollback(t *testing.T) {
+	s, db, teardown, err := testStore(t)
 	defer teardown()
 	if err != nil {
 		fmt.Println(err)
@@ -157,9 +158,9 @@ func ExampleStore_Rollback() {
 	// -1
 }
 
-func Example_basicUsage() {
+func Example_basicUsage(t *testing.T) {
 	// Open the database.
-	db, dbTeardown, err := testDB()
+	db, dbTeardown, err := testDB(t)
 	defer dbTeardown()
 	if err != nil {
 		fmt.Println(err)

--- a/wtxmgr/tx_test.go
+++ b/wtxmgr/tx_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -51,36 +50,24 @@ var (
 	defaultDBTimeout = 10 * time.Second
 )
 
-func testDB() (walletdb.DB, func(), error) {
-	tmpDir, err := os.MkdirTemp("", "wtxmgr_test")
-	if err != nil {
-		return nil, func() {}, err
-	}
+func testDB(t *testing.T) (walletdb.DB, error) {
+	tmpDir := t.TempDir()
 	db, err := walletdb.Create(
 		"bdb", filepath.Join(tmpDir, "db"), true, defaultDBTimeout,
 	)
-	return db, func() { os.RemoveAll(tmpDir) }, err
+	return db, err
 }
 
 var namespaceKey = []byte("txstore")
 
-func testStore() (*Store, walletdb.DB, func(), error) {
-	tmpDir, err := os.MkdirTemp("", "wtxmgr_test")
-	if err != nil {
-		return nil, nil, func() {}, err
-	}
+func testStore(t *testing.T) (*Store, walletdb.DB, error) {
+	tmpDir := t.TempDir()
 
 	db, err := walletdb.Create(
 		"bdb", filepath.Join(tmpDir, "db"), true, defaultDBTimeout,
 	)
 	if err != nil {
-		os.RemoveAll(tmpDir)
-		return nil, nil, nil, err
-	}
-
-	teardown := func() {
-		db.Close()
-		os.RemoveAll(tmpDir)
+		return nil, nil, err
 	}
 
 	var s *Store
@@ -97,7 +84,7 @@ func testStore() (*Store, walletdb.DB, func(), error) {
 		return err
 	})
 
-	return s, db, teardown, err
+	return s, db, err
 }
 
 func serializeTx(tx *btcutil.Tx) []byte {
@@ -511,11 +498,11 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 		},
 	}
 
-	s, db, teardown, err := testStore()
+	s, db, err := testStore(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer teardown()
+	defer db.Close()
 
 	for _, test := range tests {
 		err := walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
@@ -582,11 +569,11 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 func TestFindingSpentCredits(t *testing.T) {
 	t.Parallel()
 
-	s, db, teardown, err := testStore()
+	s, db, err := testStore(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer teardown()
+	defer db.Close()
 
 	dbtx, err := db.BeginReadWriteTx()
 	if err != nil {
@@ -689,11 +676,11 @@ func spendOutputs(outputs []wire.OutPoint, outputValues ...int64) *wire.MsgTx {
 func TestCoinbases(t *testing.T) {
 	t.Parallel()
 
-	s, db, teardown, err := testStore()
+	s, db, err := testStore(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer teardown()
+	defer db.Close()
 
 	dbtx, err := db.BeginReadWriteTx()
 	if err != nil {
@@ -1095,11 +1082,11 @@ func TestCoinbases(t *testing.T) {
 func TestMoveMultipleToSameBlock(t *testing.T) {
 	t.Parallel()
 
-	s, db, teardown, err := testStore()
+	s, db, err := testStore(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer teardown()
+	defer db.Close()
 
 	dbtx, err := db.BeginReadWriteTx()
 	if err != nil {
@@ -1272,11 +1259,11 @@ func TestMoveMultipleToSameBlock(t *testing.T) {
 func TestInsertUnserializedTx(t *testing.T) {
 	t.Parallel()
 
-	s, db, teardown, err := testStore()
+	s, db, err := testStore(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer teardown()
+	defer db.Close()
 
 	dbtx, err := db.BeginReadWriteTx()
 	if err != nil {
@@ -1339,11 +1326,11 @@ func TestInsertUnserializedTx(t *testing.T) {
 func TestRemoveUnminedTx(t *testing.T) {
 	t.Parallel()
 
-	store, db, teardown, err := testStore()
+	store, db, err := testStore(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer teardown()
+	defer db.Close()
 
 	// In order to reproduce real-world scenarios, we'll use a new database
 	// transaction for each interaction with the wallet.
@@ -1488,11 +1475,11 @@ func TestRemoveUnminedTx(t *testing.T) {
 func TestInsertMempoolTxAlreadyConfirmed(t *testing.T) {
 	t.Parallel()
 
-	store, db, teardown, err := testStore()
+	store, db, err := testStore(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer teardown()
+	defer db.Close()
 
 	// In order to reproduce real-world scenarios, we'll use a new database
 	// transaction for each interaction with the wallet.
@@ -1550,11 +1537,11 @@ func TestInsertMempoolTxAlreadyConfirmed(t *testing.T) {
 func TestInsertMempoolTxAfterSpentOutput(t *testing.T) {
 	t.Parallel()
 
-	store, db, teardown, err := testStore()
+	store, db, err := testStore(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer teardown()
+	defer db.Close()
 
 	// First we add a confirmed transaction to the wallet.
 	b100 := BlockMeta{
@@ -1627,11 +1614,11 @@ func TestInsertMempoolTxAfterSpentOutput(t *testing.T) {
 func TestOutputsAfterRemoveDoubleSpend(t *testing.T) {
 	t.Parallel()
 
-	store, db, teardown, err := testStore()
+	store, db, err := testStore(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer teardown()
+	defer db.Close()
 
 	// In order to reproduce real-world scenarios, we'll use a new database
 	// transaction for each interaction with the wallet.
@@ -1760,11 +1747,11 @@ func commitDBTx(t *testing.T, store *Store, db walletdb.DB,
 // then the remaining conflicting transactions within the mempool should be
 // removed from the wallet's store.
 func testInsertMempoolDoubleSpendTx(t *testing.T, first bool) {
-	store, db, teardown, err := testStore()
+	store, db, err := testStore(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer teardown()
+	defer db.Close()
 
 	// In order to reproduce real-world scenarios, we'll use a new database
 	// transaction for each interaction with the wallet.
@@ -1918,11 +1905,11 @@ func TestInsertMempoolDoubleSpendConfirmSecondTx(t *testing.T) {
 func TestInsertConfirmedDoubleSpendTx(t *testing.T) {
 	t.Parallel()
 
-	store, db, teardown, err := testStore()
+	store, db, err := testStore(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer teardown()
+	defer db.Close()
 
 	// In order to reproduce real-world scenarios, we'll use a new database
 	// transaction for each interaction with the wallet.
@@ -2092,11 +2079,11 @@ func TestInsertConfirmedDoubleSpendTx(t *testing.T) {
 func TestAddDuplicateCreditAfterConfirm(t *testing.T) {
 	t.Parallel()
 
-	store, db, teardown, err := testStore()
+	store, db, err := testStore(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer teardown()
+	defer db.Close()
 
 	// In order to reproduce real-world scenarios, we'll use a new database
 	// transaction for each interaction with the wallet.
@@ -2225,11 +2212,11 @@ func TestAddDuplicateCreditAfterConfirm(t *testing.T) {
 func TestInsertMempoolTxAndConfirm(t *testing.T) {
 	t.Parallel()
 
-	store, db, teardown, err := testStore()
+	store, db, err := testStore(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer teardown()
+	defer db.Close()
 
 	// Create a transaction which we'll insert into the store as
 	// unconfirmed.
@@ -2291,11 +2278,11 @@ func TestInsertMempoolTxAndConfirm(t *testing.T) {
 func TestTxLabel(t *testing.T) {
 	t.Parallel()
 
-	store, db, teardown, err := testStore()
+	store, db, err := testStore(t)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer teardown()
+	defer db.Close()
 
 	// txid is the transaction hash we will use to write and get labels for.
 	txid := &chainhash.Hash{1}
@@ -2825,11 +2812,11 @@ func TestOutputLocks(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			store, db, teardown, err := testStore()
+			store, db, err := testStore(t)
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer teardown()
+			defer db.Close()
 
 			// Replace the store's default clock with a mock one in
 			// order to simulate a real clock and speed up our


### PR DESCRIPTION
## Change Description

 TempDir returns a temporary directory for the test to use.The directory is automatically removed when the test and
all its subtests complete. More info  https://pkg.go.dev/testing#B.TempDir

Inspired by https://github.com/btcsuite/btcd/pull/2334

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
