### PR TITLE
Move Sequence func to the read interface

### DIFF
--- a/walletdb/bdb/db.go
+++ b/walletdb/bdb/db.go
@@ -224,6 +224,11 @@ func (b *bucket) ReadCursor() walletdb.ReadCursor {
 	return b.ReadWriteCursor()
 }
 
+// Sequence returns the current integer for the bucket without incrementing it.
+func (b *bucket) Sequence() uint64 {
+	return (*bbolt.Bucket)(b).Sequence()
+}
+
 // ReadWriteCursor returns a new cursor, allowing for iteration over the bucket's
 // key/value pairs and nested buckets in forward or backward order.
 //
@@ -249,11 +254,6 @@ func (b *bucket) NextSequence() (uint64, error) {
 // SetSequence updates the sequence number for the bucket.
 func (b *bucket) SetSequence(v uint64) error {
 	return (*bbolt.Bucket)(b).SetSequence(v)
-}
-
-// Sequence returns the current integer for the bucket without incrementing it.
-func (b *bucket) Sequence() uint64 {
-	return (*bbolt.Bucket)(b).Sequence()
 }
 
 // cursor represents a cursor over key/value pairs and nested buckets of a

--- a/walletdb/interface.go
+++ b/walletdb/interface.go
@@ -84,6 +84,10 @@ type ReadBucket interface {
 	Get(key []byte) []byte
 
 	ReadCursor() ReadCursor
+
+	// Sequence returns the current integer for the bucket without
+	// incrementing it.
+	Sequence() uint64
 }
 
 // ReadWriteBucket represents a bucket (a hierarchical structure within the
@@ -139,10 +143,6 @@ type ReadWriteBucket interface {
 
 	// SetSequence updates the sequence number for the bucket.
 	SetSequence(v uint64) error
-
-	// Sequence returns the current integer for the bucket without
-	// incrementing it.
-	Sequence() uint64
 }
 
 // ReadCursor represents a bucket cursor that can be positioned at the start or


### PR DESCRIPTION
We do not need a write log to read the sequence number in bbolt so we change the interface and make it less strict.