### PR TITLE
refactor: use maps.Copy for cleaner map handling

### DIFF
--- a/wallet/rescan.go
+++ b/wallet/rescan.go
@@ -5,6 +5,8 @@
 package wallet
 
 import (
+	"maps"
+
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
@@ -84,9 +86,7 @@ func (b *rescanBatch) merge(job *RescanJob) {
 	}
 	b.addrs = append(b.addrs, job.Addrs...)
 
-	for op, addr := range job.OutPoints {
-		b.outpoints[op] = addr
-	}
+	maps.Copy(b.outpoints, job.OutPoints)
 
 	if job.BlockStamp.Height < b.bs.Height {
 		b.bs = job.BlockStamp


### PR DESCRIPTION
## Change Description


```shell
Map-to-map copy: /Users/xhz/learn/btcwallet/wallet/rescan.go:88
```

The same as https://github.com/btcsuite/btcd/pull/2343

Use the built-in methods from the standard library to simplify the code, while also conducting a global check for replaceable cases.

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/btcsuite/btcwallet/blob/master/docs/contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcwallet/blob/master/docs/contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcwallet/blob/master/docs/contribution_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcwallet/blob/master/docs/contribution_guidelines.md) for further guidance.
