### PR TITLE
wtxmgr: add method `OutputsToWatch`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage.txt
 *.swp
 .vscode
 .DS_Store
+.aider*


### PR DESCRIPTION
This commit adds a new method `OutputsToWatch`, which returns a list of outpoints the rescan process should be watching for during the startup.