### PR TITLE
Enhance Seed Handling: Support Both Hex and BIP39 Mnemonic Import

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/lightningnetwork/lnd/ticker v1.0.0
 	github.com/lightningnetwork/lnd/tlv v1.0.2
 	github.com/stretchr/testify v1.9.0
+	github.com/tyler-smith/go-bip39 v1.1.0
 	golang.org/x/crypto v0.22.0
 	golang.org/x/net v0.24.0
 	golang.org/x/sync v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
+github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
+github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 go.etcd.io/bbolt v1.3.11 h1:yGEzV1wPz2yVCLsD8ZAiGHhHVlczyC9d1rP43/VCRJ0=
 go.etcd.io/bbolt v1.3.11/go.mod h1:dksAq7YMXoljX0xu6VF5DMZGbhYYoLUalEiSySYAS4I=
 golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=


### PR DESCRIPTION

## Description
This PR updates the Seed function to improve wallet setup and restore experience.

## Changes
- When generating a new seed:
  - Seed is displayed in hex format.
  - Seed is also displayed as a BIP39 mnemonic.
- When restoring an existing wallet:
  - User can now enter either a hexadecimal seed or a BIP39 mnemonic phrase.
- Validation added for both input types.
- User flow is preserved (prompt for "OK" confirmation before proceeding).

## Motivation
- Allow interoperability: users can restore wallets using their mnemonic across different wallets (Electrum, BlueWallet, Sparrow, etc).

## Dependencies
- Adds a dependency on [github.com/tyler-smith/go-bip39](https://github.com/tyler-smith/go-bip39) for BIP39 mnemonic support.

## Example Usage

**New wallet flow:**
```
Do you have an existing wallet seed you want to use? (no): no
> Generated seed (hex): a1b2c3...
> Mnemonic: "squirrel envelope moon ..."
> (User types OK after saving)
```

**Restore wallet flow:**
```
Do you have an existing wallet seed you want to use? (no): yes
> Enter mnemonic or hex: "squirrel envelope moon ..."
> Wallet restored from mnemonic!
```
