### PR TITLE
fix(chain): add missing spaces on ZMQ connection logs.

### DIFF
--- a/chain/bitcoind_zmq_events.go
+++ b/chain/bitcoind_zmq_events.go
@@ -243,8 +243,8 @@ func (b *bitcoindZMQEvents) LookupInputSpend(
 func (b *bitcoindZMQEvents) blockEventHandler() {
 	defer b.wg.Done()
 
-	log.Info("Started listening for bitcoind block notifications via ZMQ "+
-		"on", b.blockConn.RemoteAddr())
+	log.Infof("Started listening for bitcoind block notifications via ZMQ "+
+		"on %s", b.blockConn.RemoteAddr())
 
 	// Set up the buffers we expect our messages to consume. ZMQ
 	// messages from bitcoind include three parts: the command, the
@@ -340,8 +340,8 @@ func (b *bitcoindZMQEvents) blockEventHandler() {
 func (b *bitcoindZMQEvents) txEventHandler() {
 	defer b.wg.Done()
 
-	log.Info("Started listening for bitcoind transaction notifications "+
-		"via ZMQ on", b.txConn.RemoteAddr())
+	log.Infof("Started listening for bitcoind transaction notifications "+
+		"via ZMQ on %s", b.txConn.RemoteAddr())
 
 	// Set up the buffers we expect our messages to consume. ZMQ
 	// messages from bitcoind include three parts: the command, the


### PR DESCRIPTION
## Change Description

Add missing spaces on ZMQ connection log.

Currently: 
```
2025-06-03 14:13:38.555 [INF] BTWL: Started listening for bitcoind block notifications via ZMQ on10.99.99.99:28332
2025-06-03 14:13:38.555 [INF] BTWL: Started listening for bitcoind transaction notifications via ZMQ on10.99.99.99:28333
```

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.