### PR TITLE
Fix comment in txEventHandler to correctly describe transaction event handling

### DIFF
--- a/chain/bitcoind_zmq_events.go
+++ b/chain/bitcoind_zmq_events.go
@@ -333,7 +333,7 @@ func (b *bitcoindZMQEvents) blockEventHandler() {
 	}
 }
 
-// txEventHandler reads raw blocks events from the ZMQ block socket and forwards
+// txEventHandler reads raw transaction events from the ZMQ transaction socket and forwards
 // them along to the current rescan clients.
 //
 // NOTE: This must be run as a goroutine.


### PR DESCRIPTION
Corrected the comment at the beginning of the txEventHandler function in bitcoind_zmq_events.go. The comment previously stated that the function handles raw block events, but it actually processes raw transaction events from the ZMQ transaction socket. This change improves code clarity and accuracy for future maintainers. No functional code was modified.