### PR TITLE
waddrmgr: make sure to create `imported` account for watchonly

### DIFF
--- a/waddrmgr/manager.go
+++ b/waddrmgr/manager.go
@@ -590,6 +590,14 @@ func (m *Manager) NewScopedKeyManager(ns walletdb.ReadWriteBucket,
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		err := putDefaultAccountInfo(
+			ns, &scope, ImportedAddrAccount, nil, nil, 0, 0,
+			ImportedAddrAccountName,
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Finally, we'll register this new scoped manager with the root

--- a/wallet/import_test.go
+++ b/wallet/import_test.go
@@ -210,14 +210,16 @@ func testImportAccount(t *testing.T, w *Wallet, tc *testCase, watchOnly bool,
 	// If the wallet is watch only, there is no default account and our
 	// imported account will be index 0.
 	firstAccountIndex := uint32(1)
+	numAccounts := 2
 	if watchOnly {
 		firstAccountIndex = 0
+		numAccounts = 1
 	}
 
-	// We should have 3 additional accounts now.
+	// We should have 2 additional accounts now.
 	acctResult, err := w.Accounts(tc.expectedScope)
 	require.NoError(t, err)
-	require.Len(t, acctResult.Accounts, int(firstAccountIndex*2)+2)
+	require.Len(t, acctResult.Accounts, numAccounts+2)
 
 	// Validate the state of the accounts.
 	require.Equal(t, firstAccountIndex, acct1.AccountNumber)


### PR DESCRIPTION
The `NewScopedKeyManager` will skip creating the `imported` account when the watch is watch-only. We now fix it by always creating it even if it's watch-only.