### PR TITLE
Revert "chain+wallet: skip rescan if address batch is empty"

### DIFF
--- a/chain/bitcoind_client.go
+++ b/chain/bitcoind_client.go
@@ -468,8 +468,7 @@ func (c *BitcoindClient) RescanBlocks(
 // Rescan rescans from the block with the given hash until the current block,
 // after adding the passed addresses and outpoints to the client's watch list.
 func (c *BitcoindClient) Rescan(blockHash *chainhash.Hash,
-	addresses []btcutil.Address,
-	outPoints map[wire.OutPoint]btcutil.Address) error {
+	addresses []btcutil.Address, outPoints map[wire.OutPoint]btcutil.Address) error {
 
 	// A block hash is required to use as the starting point of the rescan.
 	if blockHash == nil {
@@ -477,30 +476,8 @@ func (c *BitcoindClient) Rescan(blockHash *chainhash.Hash,
 	}
 
 	// We'll then update our filters with the given outpoints and addresses.
-	numWatchedAddresses := c.updateWatchedFilters(addresses)
-	numWatchedOutPoints := c.updateWatchedFilters(outPoints)
-
-	// If after adding the new addresses and outpoints there still is
-	// nothing to rescan (empty wallet and no previously ongoing re-scan),
-	// then it doesn't make sense to proceed with scanning the chain. But we
-	// need to notify any listeners that the rescan has finished, otherwise
-	// they'll wait forever.
-	if numWatchedAddresses == 0 && numWatchedOutPoints == 0 {
-		bestHash, bestHeight, err := c.GetBestBlock()
-		if err != nil {
-			return err
-		}
-		bestHeader, err := c.GetBlockHeaderVerbose(bestHash)
-		if err != nil {
-			return err
-		}
-
-		c.onRescanFinished(
-			bestHash, bestHeight, time.Unix(bestHeader.Time, 0),
-		)
-
-		return nil
-	}
+	c.updateWatchedFilters(addresses)
+	c.updateWatchedFilters(outPoints)
 
 	// Once the filters have been updated, we can begin the rescan.
 	c.wg.Add(1)
@@ -1370,9 +1347,8 @@ func (c *BitcoindClient) resetWatchedFilters() {
 }
 
 // updateWatchedFilters is used to update the internal maps that track the
-// watched addresses, outpoints, or txns. It returns the number of watched
-// elements after the update.
-func (c *BitcoindClient) updateWatchedFilters(update any) int {
+// watched addresses, outpoints, or txns.
+func (c *BitcoindClient) updateWatchedFilters(update any) {
 	c.watchMtx.Lock()
 	defer c.watchMtx.Unlock()
 
@@ -1383,22 +1359,16 @@ func (c *BitcoindClient) updateWatchedFilters(update any) int {
 			c.watchedAddresses[addr.String()] = struct{}{}
 		}
 
-		return len(c.watchedAddresses)
-
 	// We're adding the outpoints to our filter.
 	case []wire.OutPoint:
 		for _, op := range update {
 			c.watchedOutPoints[op] = struct{}{}
 		}
 
-		return len(c.watchedOutPoints)
-
 	case []*wire.OutPoint:
 		for _, op := range update {
 			c.watchedOutPoints[*op] = struct{}{}
 		}
-
-		return len(c.watchedOutPoints)
 
 	// We're adding the outpoints that map to the scripts
 	// that we should scan for to our filter.
@@ -1407,23 +1377,15 @@ func (c *BitcoindClient) updateWatchedFilters(update any) int {
 			c.watchedOutPoints[op] = struct{}{}
 		}
 
-		return len(c.watchedOutPoints)
-
 	// We're adding the transactions to our filter.
 	case []chainhash.Hash:
 		for _, txid := range update {
 			c.watchedTxs[txid] = struct{}{}
 		}
 
-		return len(c.watchedTxs)
-
 	case []*chainhash.Hash:
 		for _, txid := range update {
 			c.watchedTxs[*txid] = struct{}{}
 		}
-
-		return len(c.watchedTxs)
 	}
-
-	return 0
 }

--- a/chain/btcd.go
+++ b/chain/btcd.go
@@ -272,12 +272,6 @@ func (c *RPCClient) IsCurrent() bool {
 func (c *RPCClient) Rescan(startHash *chainhash.Hash, addrs []btcutil.Address,
 	outPoints map[wire.OutPoint]btcutil.Address) error {
 
-	// If there are no addresses or outpoints, we don't need to do a
-	// specific check here, as that's already handled by btcd:
-	// https://github.com/btcsuite/btcd/blob/95330bc1/rpcwebsocket.go#L2895
-	// So we don't add a skip check here, because we still want to receive
-	// the best block notification, which is sent even if there are no
-	// addresses or outpoints to rescan for.
 	flatOutpoints := make([]*wire.OutPoint, 0, len(outPoints))
 	for ops := range outPoints {
 		ops := ops


### PR DESCRIPTION
This reverts commit fc2ac82500abb778caf13847c2e1f170b9621951. Even after adding backend specific workarounds, the changes in above commit still lead to weird errors in the `lnd` CI. So we just revert the changes in the `chain` package (but keep the formatting changes in `wallet`).
