### PR TITLE
 wallet: add `AddressManager` interface

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,9 @@ run:
 linters:
   default: all
   disable:
+    # TODO(yy): Re-enable this linter once the refactoring series is done.
+    - ireturn
+
     # Global variables are used in many places throughout the code base.
     - gochecknoglobals
 

--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -1778,7 +1778,7 @@ func validateAddress(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 	result.Address = addr.EncodeAddress()
 	result.IsValid = true
 
-	ainfo, err := w.AddressInfo(addr)
+	ainfo, err := w.AddressInfoDeprecated(addr)
 	if err != nil {
 		if waddrmgr.IsError(err, waddrmgr.ErrAddressNotFound) {
 			// No additional information available about the address.

--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -702,7 +702,7 @@ func getNewAddress(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	addr, err := w.NewAddress(account, keyScope)
+	addr, err := w.NewAddressDeprecated(account, keyScope)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -234,7 +234,9 @@ func (s *walletServer) NextAddress(ctx context.Context, req *pb.NextAddressReque
 	)
 	switch req.Kind {
 	case pb.NextAddressRequest_BIP0044_EXTERNAL:
-		addr, err = s.wallet.NewAddressDeprecated(req.GetAccount(), waddrmgr.KeyScopeBIP0044)
+		addr, err = s.wallet.NewAddressDeprecated(
+			req.GetAccount(), waddrmgr.KeyScopeBIP0044,
+		)
 	case pb.NextAddressRequest_BIP0044_INTERNAL:
 		addr, err = s.wallet.NewChangeAddress(req.Account, waddrmgr.KeyScopeBIP0044)
 	default:

--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -234,7 +234,7 @@ func (s *walletServer) NextAddress(ctx context.Context, req *pb.NextAddressReque
 	)
 	switch req.Kind {
 	case pb.NextAddressRequest_BIP0044_EXTERNAL:
-		addr, err = s.wallet.NewAddress(req.Account, waddrmgr.KeyScopeBIP0044)
+		addr, err = s.wallet.NewAddressDeprecated(req.GetAccount(), waddrmgr.KeyScopeBIP0044)
 	case pb.NextAddressRequest_BIP0044_INTERNAL:
 		addr, err = s.wallet.NewChangeAddress(req.Account, waddrmgr.KeyScopeBIP0044)
 	default:

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -347,7 +347,7 @@ func TestBalance(t *testing.T) {
 	require.Equal(t, btcutil.Amount(0), balance)
 
 	// Now, we'll add a UTXO to the account.
-	addr, err := w.NewAddress(1, scope)
+	addr, err := w.NewAddressDeprecated(1, scope)
 	require.NoError(t, err)
 	pkScript, err := txscript.PayToAddrScript(addr)
 	require.NoError(t, err)
@@ -577,7 +577,7 @@ func addTestUTXOForBalance(t *testing.T, w *Wallet, scope waddrmgr.KeyScope,
 
 	t.Helper()
 
-	addr, err := w.NewAddress(account, scope)
+	addr, err := w.NewAddressDeprecated(account, scope)
 	require.NoError(t, err)
 
 	pkScript, err := txscript.PayToAddrScript(addr)

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -31,7 +31,7 @@ func TestNewAccount(t *testing.T) {
 
 	// Create a new test wallet.
 	w, cleanup := testWallet(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	// We'll start by creating a new account under the BIP0084 scope. We
 	// expect this to succeed.
@@ -71,7 +71,7 @@ func TestListAccounts(t *testing.T) {
 
 	// Create a new test wallet.
 	w, cleanup := testWallet(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	// We'll start by creating a new account under the BIP0084 scope.
 	scope := waddrmgr.KeyScopeBIP0084
@@ -128,7 +128,7 @@ func TestListAccountsByScope(t *testing.T) {
 
 	// Create a new test wallet.
 	w, cleanup := testWallet(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	// We'll create two new accounts, one under the BIP0084 scope and one
 	// under the BIP0049 scope.
@@ -186,7 +186,7 @@ func TestListAccountsByName(t *testing.T) {
 
 	// Create a new test wallet.
 	w, cleanup := testWallet(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	// We'll create two new accounts, one under the BIP0084 scope and one
 	// under the BIP0049 scope.
@@ -243,7 +243,7 @@ func TestGetAccount(t *testing.T) {
 
 	// Create a new test wallet.
 	w, cleanup := testWallet(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	// We'll create a new account under the BIP0084 scope.
 	scope := waddrmgr.KeyScopeBIP0084
@@ -281,7 +281,7 @@ func TestRenameAccount(t *testing.T) {
 
 	// Create a new test wallet.
 	w, cleanup := testWallet(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	// We'll create a new account under the BIP0084 scope.
 	scope := waddrmgr.KeyScopeBIP0084
@@ -332,7 +332,7 @@ func TestBalance(t *testing.T) {
 
 	// Create a new test wallet.
 	w, cleanup := testWallet(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	// We'll create a new account under the BIP0084 scope.
 	scope := waddrmgr.KeyScopeBIP0084
@@ -420,7 +420,7 @@ func TestImportAccount(t *testing.T) {
 
 	// Create a new test wallet.
 	w, cleanup := testWallet(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	// We'll start by creating a new account under the BIP0084 scope.
 	scope := waddrmgr.KeyScopeBIP0084
@@ -749,7 +749,7 @@ func TestFetchAccountBalances(t *testing.T) {
 			t.Parallel()
 
 			w, cleanup := setupTestCase(t)
-			defer cleanup()
+			t.Cleanup(cleanup)
 
 			if tc.setup != nil {
 				tc.setup(t, w)
@@ -781,7 +781,7 @@ func TestListAccountsWithBalances(t *testing.T) {
 
 	// Create a new test wallet.
 	w, cleanup := testWallet(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	// We'll create two new accounts under the BIP0084 scope to have a
 	// predictable state.

--- a/wallet/address_manager.go
+++ b/wallet/address_manager.go
@@ -6,11 +6,25 @@ package wallet
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/walletdb"
+)
+
+var (
+	// ErrUnknownAddrType is an error returned when a wallet function is
+	// called with an unknown address type.
+	ErrUnknownAddrType = errors.New("unknown address type")
+
+	// ErrImportedAccountNoAddrGen is an error returned when a new address
+	// is requested for the default imported account within the wallet.
+	ErrImportedAccountNoAddrGen = errors.New("addresses cannot be " +
+		"generated for the default imported account")
 )
 
 // AddressProperty represents an address and its balance.
@@ -71,4 +85,133 @@ type AddressManager interface {
 	// script for a given UTXO.
 	ScriptForOutput(ctx context.Context, output wire.TxOut) (
 		waddrmgr.ManagedPubKeyAddress, []byte, []byte, error)
+}
+
+// NewAddress returns the next external or internal address for the wallet
+// dictated by the value of the `change` parameter. If change is true, then an
+// internal address will be returned, otherwise an external address should be
+// returned. The account parameter is the name of the account from which the
+// address should be generated. The addrType parameter specifies the type of
+// address to be generated.
+func (w *Wallet) NewAddress(_ context.Context, accountName string,
+	addrType waddrmgr.AddressType, change bool) (btcutil.Address, error) {
+
+	// Addresses cannot be derived from the catch-all imported accounts.
+	if accountName == waddrmgr.ImportedAddrAccountName {
+		return nil, ErrImportedAccountNoAddrGen
+	}
+
+	keyScope, err := w.keyScopeFromAddrType(addrType)
+	if err != nil {
+		return nil, err
+	}
+
+	chainClient, err := w.requireChainClient()
+	if err != nil {
+		return nil, err
+	}
+
+	manager, err := w.addrStore.FetchScopedKeyManager(keyScope)
+	if err != nil {
+		return nil, err
+	}
+
+	addr, err := w.newAddress(manager, accountName, change)
+	if err != nil {
+		return nil, err
+	}
+
+	// Notify the rpc server about the newly created address.
+	err = chainClient.NotifyReceived([]btcutil.Address{addr})
+	if err != nil {
+		return nil, err
+	}
+
+	return addr, nil
+}
+
+// keyScopeFromAddrType determines the appropriate key scope for a given
+// address type.
+//
+// NOTE: While it may seem intuitive to iterate over the waddrmgr.ScopeAddrMap
+// to act as a single source of truth, doing so is unsafe. The map contains
+// ambiguities where a single address type, such as waddrmgr.WitnessPubKey, can
+// map to multiple key scopes (e.g., KeyScopeBIP0084 and
+// KeyScopeBIP0049Plus). Because map iteration in Go is non-deterministic, this
+// would lead to unpredictable behavior. The switch statement is used here
+// intentionally to enforce a clear, deterministic policy, ensuring that
+// ambiguous types always resolve to their preferred, modern key scope.
+func (w *Wallet) keyScopeFromAddrType(
+	addrType waddrmgr.AddressType) (waddrmgr.KeyScope, error) {
+
+	// Map the requested address type to its key scope.
+	var addrKeyScope waddrmgr.KeyScope
+	switch addrType {
+	case waddrmgr.PubKeyHash:
+		addrKeyScope = waddrmgr.KeyScopeBIP0044
+
+	case waddrmgr.WitnessPubKey:
+		addrKeyScope = waddrmgr.KeyScopeBIP0084
+
+	case waddrmgr.NestedWitnessPubKey:
+		addrKeyScope = waddrmgr.KeyScopeBIP0049Plus
+
+	case waddrmgr.TaprootPubKey:
+		addrKeyScope = waddrmgr.KeyScopeBIP0086
+
+	// The following address types are not supported by this function as
+	// they are not derived from a single public key using a key scope.
+	// They are typically imported or involve more complex script-based
+	// constructions.
+	case waddrmgr.Script, waddrmgr.RawPubKey,
+		waddrmgr.WitnessScript, waddrmgr.TaprootScript:
+		return waddrmgr.KeyScope{}, fmt.Errorf("%w: %v",
+			ErrUnknownAddrType, addrType)
+	default:
+		return waddrmgr.KeyScope{}, fmt.Errorf("%w: %v",
+			ErrUnknownAddrType, addrType)
+	}
+
+	return addrKeyScope, nil
+}
+
+// newAddress returns the next external chained address for a wallet. It
+// wraps the database transaction and the call to the scoped key manager's
+// NewAddress method. A mutex is used to protect the in-memory state of the
+// address manager from concurrent access during address creation.
+func (w *Wallet) newAddress(manager *waddrmgr.ScopedKeyManager,
+	accountName string, change bool) (btcutil.Address, error) {
+
+	// The address manager uses OnCommit on the walletdb tx to update the
+	// in-memory state of the account state. But because the commit happens
+	// _after_ the account manager internal lock has been released, there
+	// is a chance for the address index to be accessed concurrently, even
+	// though the closure in OnCommit re-acquires the lock. To avoid this
+	// issue, we surround the whole address creation process with a lock.
+	//
+	// TODO(yy): remove the lock - we should separate the db action and
+	// memory cache.
+	w.newAddrMtx.Lock()
+	defer w.newAddrMtx.Unlock()
+
+	var (
+		addr btcutil.Address
+		err  error
+	)
+
+	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+		addr, err = manager.NewAddress(addrmgrNs, accountName, change)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return addr, nil
 }

--- a/wallet/address_manager.go
+++ b/wallet/address_manager.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2025 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"context"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+)
+
+// AddressProperty represents an address and its balance.
+type AddressProperty struct {
+	// Address is the address.
+	Address btcutil.Address
+
+	// Balance is the total unspent balance of the address, including both
+	// confirmed and unconfirmed funds.
+	Balance btcutil.Amount
+}
+
+// AddressManager provides an interface for generating and inspecting wallet
+// addresses and scripts.
+type AddressManager interface {
+	// NewAddress returns a new address for the given account and address
+	// type.
+	//
+	// NOTE: This method should be used with caution. Unlike
+	// GetUnusedAddress, it does not scan for previously derived but unused
+	// addresses. Using this method repeatedly can create gaps in the
+	// address chain, which may negatively impact wallet recovery under
+	// BIP44. It is primarily intended for advanced use cases such as bulk
+	// address generation.
+	NewAddress(ctx context.Context, accountName string,
+		addrType waddrmgr.AddressType,
+		change bool) (btcutil.Address, error)
+
+	// GetUnusedAddress returns the first, oldest, unused address by
+	// scanning forward from the start of the derivation path. This method
+	// is the recommended default for obtaining a new receiving address, as
+	// it prevents address reuse and avoids creating gaps in the address
+	// chain that could impact wallet recovery.
+	GetUnusedAddress(ctx context.Context, accountName string,
+		addrType waddrmgr.AddressType, change bool) (
+		btcutil.Address, error)
+
+	// AddressInfo returns detailed information about a managed address. If
+	// the address is not known to the wallet, an error is returned.
+	AddressInfo(ctx context.Context,
+		a btcutil.Address) (waddrmgr.ManagedAddress, error)
+
+	// ListAddresses lists all addresses for a given account, including
+	// their balances.
+	ListAddresses(ctx context.Context, accountName string,
+		addrType waddrmgr.AddressType) ([]AddressProperty, error)
+
+	// ImportPublicKey imports a single public key as a watch-only address.
+	ImportPublicKey(ctx context.Context, pubKey *btcec.PublicKey,
+		addrType waddrmgr.AddressType) error
+
+	// ImportTaprootScript imports a taproot script for tracking and
+	// spending.
+	ImportTaprootScript(ctx context.Context,
+		tapscript waddrmgr.Tapscript) (waddrmgr.ManagedAddress, error)
+
+	// ScriptForOutput returns the address, witness program, and redeem
+	// script for a given UTXO.
+	ScriptForOutput(ctx context.Context, output wire.TxOut) (
+		waddrmgr.ManagedPubKeyAddress, []byte, []byte, error)
+}

--- a/wallet/address_manager.go
+++ b/wallet/address_manager.go
@@ -87,12 +87,43 @@ type AddressManager interface {
 		waddrmgr.ManagedPubKeyAddress, []byte, []byte, error)
 }
 
-// NewAddress returns the next external or internal address for the wallet
-// dictated by the value of the `change` parameter. If change is true, then an
-// internal address will be returned, otherwise an external address should be
-// returned. The account parameter is the name of the account from which the
-// address should be generated. The addrType parameter specifies the type of
-// address to be generated.
+// TODO(yy): The current implementation of NewAddress has several architectural
+// issues that should be addressed:
+//
+//  1. **Lack of Separation of Concerns:** The method tightly couples the
+//     database logic with the address generation and chain backend
+//     notification logic. The `waddrmgr` package currently handles both
+//     derivation and persistence within a single database transaction, which
+//     makes the transaction larger and longer than necessary.
+//
+// 2. **Incorrect Ordering of Operations:** The current flow is:
+//  1. Create DB transaction.
+//  2. Derive address.
+//  3. Save address to DB.
+//  4. Commit DB transaction.
+//  5. Notify the chain backend to watch the new address.
+//     This creates a potential race condition. If the program crashes after
+//     committing the address to the database but before successfully
+//     notifying the chain backend, the wallet will own an address that the
+//     backend is not aware of. This could lead to a permanent loss of funds
+//     if coins are sent to that address.
+//
+// Refactoring Plan:
+//   - **Decouple `waddrmgr`:** The `waddrmgr` package should be refactored to
+//     separate its concerns. It should provide:
+//   - A pure, stateless function to derive an address from account info.
+//   - A simple method to persist a newly derived address to the database.
+//   - **Improve Operation Ordering in `wallet`:** The `NewAddress` method in
+//     the `wallet` package should be updated to follow a more robust
+//     sequence:
+//     1. Start a DB transaction to read the required account information.
+//     2. Use the pure derivation function from `waddrmgr` to generate the
+//     new address *outside* of any DB transaction.
+//     3. Notify the chain backend to watch the new address.
+//     4. If the notification is successful, start a *second*, short-lived DB
+//     transaction to persist the new address.
+//     This ensures that we only save an address after we are confident that
+//     it is being watched by the backend, preventing fund loss.
 func (w *Wallet) NewAddress(_ context.Context, accountName string,
 	addrType waddrmgr.AddressType, change bool) (btcutil.Address, error) {
 

--- a/wallet/address_manager.go
+++ b/wallet/address_manager.go
@@ -2,6 +2,12 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
+// Package wallet provides the AddressManager interface for generating and
+// inspecting wallet addresses and scripts.
+//
+// TODO(yy): bring wrapcheck back when implementing the `Store` interface.
+//
+//nolint:wrapcheck
 package wallet
 
 import (

--- a/wallet/address_manager.go
+++ b/wallet/address_manager.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/walletdb"
@@ -97,6 +98,28 @@ type AddressManager interface {
 		waddrmgr.ManagedPubKeyAddress, []byte, []byte, error)
 }
 
+// A compile time check to ensure that Wallet implements the interface.
+var _ AddressManager = (*Wallet)(nil)
+
+// NewAddress returns a new address for the given account and address type.
+// This method is a low-level primitive that will always derive a new, unused
+// address from the end of the address chain.
+//
+// It returns the next external or internal address for the wallet dictated by
+// the value of the `change` parameter. If change is true, then an internal
+// address will be returned, otherwise an external address should be returned.
+// The account parameter is the name of the account from which the address
+// should be generated. The addrType parameter specifies the type of address to
+// be generated.
+//
+// NOTE: This method should be used with caution. Unlike GetUnusedAddress, it
+// does not scan for previously derived but unused addresses. Using this method
+// repeatedly can create gaps in the address chain. If a gap of 20 consecutive
+// unused addresses is created, wallet recovery from seed may fail under BIP44.
+// It is primarily intended for advanced use cases such as bulk address
+// generation. For most applications, GetUnusedAddress is the recommended
+// method for obtaining a receiving address.
+//
 // TODO(yy): The current implementation of NewAddress has several architectural
 // issues that should be addressed:
 //
@@ -605,4 +628,99 @@ func (w *Wallet) ImportTaprootScript(_ context.Context,
 	}
 
 	return addr, nil
+}
+
+// ScriptForOutput returns the address, witness program, and redeem script
+// for a given UTXO.
+//
+// This method is essential for constructing the necessary scripts to spend a
+// transaction output. It provides the components required to build the
+// scriptSig and witness fields of a transaction input.
+//
+// How it works:
+// The method first identifies which of the wallet's addresses corresponds to
+// the output's script. It then determines the correct script format (redeem
+// script, witness program) based on the address type.
+//
+// Logical Steps:
+//  1. Look up the output's pkScript in the database to find the
+//     corresponding managed address.
+//  2. Verify that the address is a public key address that the wallet can
+//     sign for (e.g., P2WKH, NP2WKH, P2TR).
+//  3. Based on the address type, construct the appropriate scripts:
+//     - For nested P2WKH (NP2WKH), it creates a redeem script
+//     (`sigScript`) that contains the P2WKH witness program.
+//     - For native SegWit outputs (P2WKH, P2TR), the `witnessProgram` is
+//     the output's `pkScript`, and the `sigScript` is nil.
+//
+// Database Actions:
+//   - This method performs a read-only database access to fetch address
+//     details from the `waddrmgr` namespace.
+//
+// Time Complexity:
+//   - The operation is dominated by the database lookup for the address, which
+//     is typically fast (O(log N) or O(1) with indexing). The script
+//     generation is a constant-time operation.
+func (w *Wallet) ScriptForOutput(_ context.Context, output wire.TxOut) (
+	waddrmgr.ManagedPubKeyAddress, []byte, []byte, error) {
+
+	// First make sure we can sign for the input by making sure the script
+	// in the UTXO belongs to our wallet and we have the private key for it.
+	walletAddr, err := w.fetchOutputAddr(output.PkScript)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	pubKeyAddr, ok := walletAddr.(waddrmgr.ManagedPubKeyAddress)
+	if !ok {
+		return nil, nil, nil, fmt.Errorf("address %s is not a "+
+			"p2wkh or np2wkh address", walletAddr.Address())
+	}
+
+	var (
+		witnessProgram []byte
+		sigScript      []byte
+	)
+
+	switch {
+	// If we're spending p2wkh output nested within a p2sh output, then
+	// we'll need to attach a sigScript in addition to witness data.
+	case walletAddr.AddrType() == waddrmgr.NestedWitnessPubKey:
+		pubKey := pubKeyAddr.PubKey()
+		pubKeyHash := btcutil.Hash160(pubKey.SerializeCompressed())
+
+		// Next, we'll generate a valid sigScript that will allow us to
+		// spend the p2sh output. The sigScript will contain only a
+		// single push of the p2wkh witness program corresponding to
+		// the matching public key of this address.
+		p2wkhAddr, err := btcutil.NewAddressWitnessPubKeyHash(
+			pubKeyHash, w.chainParams,
+		)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		witnessProgram, err = txscript.PayToAddrScript(p2wkhAddr)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		bldr := txscript.NewScriptBuilder()
+		bldr.AddData(witnessProgram)
+
+		sigScript, err = bldr.Script()
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+	// Otherwise, this is a regular p2wkh or p2tr output, so we include the
+	// witness program itself as the subscript to generate the proper
+	// sighash digest. As part of the new sighash digest algorithm, the
+	// p2wkh witness program will be expanded into a regular p2kh
+	// script.
+	default:
+		witnessProgram = output.PkScript
+	}
+
+	return pubKeyAddr, witnessProgram, sigScript, nil
 }

--- a/wallet/address_manager_test.go
+++ b/wallet/address_manager_test.go
@@ -164,7 +164,9 @@ func TestNewAddress(t *testing.T) {
 
 			// Verify that the address is correctly marked as
 			// internal or external.
-			addrInfo, err := w.AddressInfo(context.Background(), addr)
+			addrInfo, err := w.AddressInfo(
+				context.Background(), addr,
+			)
 			require.NoError(t, err)
 			require.Equal(t, tc.change, addrInfo.Internal())
 		})

--- a/wallet/address_manager_test.go
+++ b/wallet/address_manager_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2025 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"context"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/stretchr/testify/require"
+)
+
+// TestKeyScopeFromAddrType tests the keyScopeFromAddrType method to ensure
+// it correctly maps address types to their corresponding key scopes.
+func TestKeyScopeFromAddrType(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		addrType      waddrmgr.AddressType
+		expectedScope waddrmgr.KeyScope
+		expectedErr   error
+	}{
+		{
+			name:          "pubkey hash",
+			addrType:      waddrmgr.PubKeyHash,
+			expectedScope: waddrmgr.KeyScopeBIP0044,
+			expectedErr:   nil,
+		},
+		{
+			name:          "witness pubkey",
+			addrType:      waddrmgr.WitnessPubKey,
+			expectedScope: waddrmgr.KeyScopeBIP0084,
+			expectedErr:   nil,
+		},
+		{
+			name:          "nested witness pubkey",
+			addrType:      waddrmgr.NestedWitnessPubKey,
+			expectedScope: waddrmgr.KeyScopeBIP0049Plus,
+			expectedErr:   nil,
+		},
+		{
+			name:          "taproot pubkey",
+			addrType:      waddrmgr.TaprootPubKey,
+			expectedScope: waddrmgr.KeyScopeBIP0086,
+			expectedErr:   nil,
+		},
+		{
+			name:        "unknown address type",
+			addrType:    waddrmgr.WitnessScript,
+			expectedErr: ErrUnknownAddrType,
+		},
+	}
+
+	w := &Wallet{}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			scope, err := w.keyScopeFromAddrType(tc.addrType)
+			require.ErrorIs(t, err, tc.expectedErr)
+			require.Equal(t, tc.expectedScope, scope)
+		})
+	}
+}
+
+// TestNewAddress tests the NewAddress method, ensuring it can generate
+// various address types for different accounts and correctly handles both
+// internal and external address generation.
+func TestNewAddress(t *testing.T) {
+	t.Parallel()
+
+	// Create a new test wallet.
+	w, cleanup := testWallet(t)
+	defer cleanup()
+
+	// Define a set of test cases to cover different address types and
+	// scenarios.
+	testCases := []struct {
+		name             string
+		accountName      string
+		addrType         waddrmgr.AddressType
+		change           bool
+		expectErr        bool
+		expectedAddrType btcutil.Address
+	}{
+		{
+			name:             "default account p2wkh",
+			accountName:      "default",
+			addrType:         waddrmgr.WitnessPubKey,
+			change:           false,
+			expectedAddrType: &btcutil.AddressWitnessPubKeyHash{},
+		},
+		{
+			name:             "p2wkh change address",
+			accountName:      "default",
+			addrType:         waddrmgr.WitnessPubKey,
+			change:           true,
+			expectedAddrType: &btcutil.AddressWitnessPubKeyHash{},
+		},
+		{
+			name:             "default account np2wkh",
+			accountName:      "default",
+			addrType:         waddrmgr.NestedWitnessPubKey,
+			change:           false,
+			expectedAddrType: &btcutil.AddressScriptHash{},
+		},
+		{
+			name:             "default account p2tr",
+			accountName:      "default",
+			addrType:         waddrmgr.TaprootPubKey,
+			change:           false,
+			expectedAddrType: &btcutil.AddressTaproot{},
+		},
+		{
+			name:        "unknown address type",
+			accountName: "default",
+			addrType:    waddrmgr.WitnessScript,
+			expectErr:   true,
+		},
+		{
+			name:        "imported account",
+			accountName: waddrmgr.ImportedAddrAccountName,
+			addrType:    waddrmgr.WitnessPubKey,
+			expectErr:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Attempt to generate a new address with the specified
+			// parameters.
+			addr, err := w.NewAddress(
+				context.Background(), tc.accountName,
+				tc.addrType, tc.change,
+			)
+
+			// If an error is expected, assert that it occurs.
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			// If no error is expected, assert that the address is
+			// generated successfully and perform any
+			// additional checks.
+			require.NoError(t, err)
+			require.NotNil(t, addr)
+
+			// Verify that the address is of the correct type.
+			require.IsType(t, tc.expectedAddrType, addr)
+
+			// Verify that the address is correctly marked as
+			// internal or external.
+			addrInfo, err := w.AddressInfo(addr)
+			require.NoError(t, err)
+			require.Equal(t, tc.change, addrInfo.Internal())
+		})
+	}
+}

--- a/wallet/address_manager_test.go
+++ b/wallet/address_manager_test.go
@@ -162,7 +162,7 @@ func TestNewAddress(t *testing.T) {
 
 			// Verify that the address is correctly marked as
 			// internal or external.
-			addrInfo, err := w.AddressInfoDeprecated(addr)
+			addrInfo, err := w.AddressInfo(context.Background(), addr)
 			require.NoError(t, err)
 			require.Equal(t, tc.change, addrInfo.Internal())
 		})
@@ -250,4 +250,48 @@ func TestGetUnusedAddress(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, changeAddr.String(), unusedChangeAddr.String())
+}
+
+// TestAddressInfo tests the AddressInfo method to ensure it returns correct
+// information for both internal and external addresses.
+func TestAddressInfo(t *testing.T) {
+	t.Parallel()
+
+	// Create a new test wallet.
+	w, cleanup := testWallet(t)
+	defer cleanup()
+
+	// Get a new external address to test with.
+	extAddr, err := w.NewAddress(
+		context.Background(), "default", waddrmgr.WitnessPubKey, false,
+	)
+	require.NoError(t, err)
+
+	// Get the address info for the external address.
+	extInfo, err := w.AddressInfo(context.Background(), extAddr)
+	require.NoError(t, err)
+
+	// Check the external address info.
+	require.Equal(t, extAddr.String(), extInfo.Address().String())
+	require.False(t, extInfo.Internal())
+	require.True(t, extInfo.Compressed())
+	require.False(t, extInfo.Imported())
+	require.Equal(t, waddrmgr.WitnessPubKey, extInfo.AddrType())
+
+	// Get a new internal address to test with.
+	intAddr, err := w.NewAddress(
+		context.Background(), "default", waddrmgr.WitnessPubKey, true,
+	)
+	require.NoError(t, err)
+
+	// Get the address info for the internal address.
+	intInfo, err := w.AddressInfo(context.Background(), intAddr)
+	require.NoError(t, err)
+
+	// Check the internal address info.
+	require.Equal(t, intAddr.String(), intInfo.Address().String())
+	require.True(t, intInfo.Internal())
+	require.True(t, intInfo.Compressed())
+	require.False(t, intInfo.Imported())
+	require.Equal(t, waddrmgr.WitnessPubKey, intInfo.AddrType())
 }

--- a/wallet/address_manager_test.go
+++ b/wallet/address_manager_test.go
@@ -440,3 +440,36 @@ func TestImportTaprootScript(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, managed)
 }
+
+// TestScriptForOutput tests the ScriptForOutput method to ensure it returns the
+// correct script for a given output.
+func TestScriptForOutput(t *testing.T) {
+	t.Parallel()
+
+	// Create a new test wallet.
+	w, cleanup := testWallet(t)
+	defer cleanup()
+
+	// Create a new p2wkh address and output.
+	addr, err := w.NewAddress(
+		context.Background(), "default", waddrmgr.WitnessPubKey, false,
+	)
+	require.NoError(t, err)
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	output := wire.TxOut{
+		Value:    1000,
+		PkScript: pkScript,
+	}
+
+	// Get the script for the output.
+	_, witnessProgram, sigScript, err := w.ScriptForOutput(
+		context.Background(), output,
+	)
+	require.NoError(t, err)
+
+	// Check that the script is correct.
+	require.Equal(t, pkScript, witnessProgram)
+	require.Nil(t, sigScript)
+}

--- a/wallet/address_manager_test.go
+++ b/wallet/address_manager_test.go
@@ -464,12 +464,10 @@ func TestScriptForOutput(t *testing.T) {
 	}
 
 	// Get the script for the output.
-	_, witnessProgram, sigScript, err := w.ScriptForOutput(
-		context.Background(), output,
-	)
+	script, err := w.ScriptForOutput(context.Background(), output)
 	require.NoError(t, err)
 
 	// Check that the script is correct.
-	require.Equal(t, pkScript, witnessProgram)
-	require.Nil(t, sigScript)
+	require.Equal(t, pkScript, script.WitnessProgram)
+	require.Nil(t, script.RedeemScript)
 }

--- a/wallet/address_manager_test.go
+++ b/wallet/address_manager_test.go
@@ -83,7 +83,7 @@ func TestNewAddress(t *testing.T) {
 
 	// Create a new test wallet.
 	w, cleanup := testWallet(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	// Define a set of test cases to cover different address types and
 	// scenarios.
@@ -178,7 +178,7 @@ func TestGetUnusedAddress(t *testing.T) {
 
 	// Create a new test wallet.
 	w, cleanup := testWallet(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	// Get a new address to start with.
 	addr, err := w.NewAddress(
@@ -261,7 +261,7 @@ func TestAddressInfo(t *testing.T) {
 
 	// Create a new test wallet.
 	w, cleanup := testWallet(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	// Get a new external address to test with.
 	extAddr, err := w.NewAddress(
@@ -305,7 +305,7 @@ func TestListAddresses(t *testing.T) {
 
 	// Create a new test wallet.
 	w, cleanup := testWallet(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	// Get a new address and give it a balance.
 	addr, err := w.NewAddress(
@@ -370,7 +370,7 @@ func TestImportPublicKey(t *testing.T) {
 
 	// Create a new test wallet.
 	w, cleanup := testWallet(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	// Create a new public key to import.
 	privKey, err := btcec.NewPrivateKey()
@@ -401,7 +401,7 @@ func TestImportTaprootScript(t *testing.T) {
 
 	// Create a new test wallet.
 	w, cleanup := testWallet(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	// Create a new tapscript to import.
 	privKey, err := btcec.NewPrivateKey()
@@ -448,7 +448,7 @@ func TestScriptForOutput(t *testing.T) {
 
 	// Create a new test wallet.
 	w, cleanup := testWallet(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	// Create a new p2wkh address and output.
 	addr, err := w.NewAddress(

--- a/wallet/address_manager_test.go
+++ b/wallet/address_manager_test.go
@@ -162,7 +162,7 @@ func TestNewAddress(t *testing.T) {
 
 			// Verify that the address is correctly marked as
 			// internal or external.
-			addrInfo, err := w.AddressInfo(addr)
+			addrInfo, err := w.AddressInfoDeprecated(addr)
 			require.NoError(t, err)
 			require.Equal(t, tc.change, addrInfo.Internal())
 		})

--- a/wallet/import.go
+++ b/wallet/import.go
@@ -440,9 +440,11 @@ func (w *Wallet) ImportPublicKeyDeprecated(pubKey *btcec.PublicKey,
 	return nil
 }
 
-// ImportTaprootScript imports a user-provided taproot script into the address
-// manager. The imported script will act as a pay-to-taproot address.
-func (w *Wallet) ImportTaprootScript(scope waddrmgr.KeyScope,
+// ImportTaprootScriptDeprecated imports a user-provided taproot script into the
+// address manager. The imported script will act as a pay-to-taproot address.
+//
+// Deprecated: Use AddressManager.ImportTaprootScript instead.
+func (w *Wallet) ImportTaprootScriptDeprecated(scope waddrmgr.KeyScope,
 	tapscript *waddrmgr.Tapscript, bs *waddrmgr.BlockStamp,
 	witnessVersion byte, isSecretScript bool) (waddrmgr.ManagedAddress,
 	error) {

--- a/wallet/import.go
+++ b/wallet/import.go
@@ -393,7 +393,7 @@ func (w *Wallet) ImportAccountDryRun(name string,
 // case of legacy versions (xpub, tpub), an address type must be specified as we
 // intend to not support importing BIP-44 keys into the wallet using the legacy
 // pay-to-pubkey-hash (P2PKH) scheme.
-func (w *Wallet) ImportPublicKey(pubKey *btcec.PublicKey,
+func (w *Wallet) ImportPublicKeyDeprecated(pubKey *btcec.PublicKey,
 	addrType waddrmgr.AddressType) error {
 
 	// Determine what key scope the public key should belong to and import

--- a/wallet/import_test.go
+++ b/wallet/import_test.go
@@ -204,7 +204,7 @@ func testImportAccount(t *testing.T, w *Wallet, tc *testCase, watchOnly bool,
 	require.NoError(t, err)
 	require.Equal(t, tc.expectedScope, acct2.KeyScope)
 
-	err = w.ImportPublicKey(acct3ExternalPub, tc.addrType)
+	err = w.ImportPublicKeyDeprecated(acct3ExternalPub, tc.addrType)
 	require.NoError(t, err)
 
 	// If the wallet is watch only, there is no default account and our

--- a/wallet/import_test.go
+++ b/wallet/import_test.go
@@ -243,7 +243,7 @@ func testImportAccount(t *testing.T, w *Wallet, tc *testCase, watchOnly bool,
 	require.Equal(t, uint32(0), acct2.ImportedKeyCount)
 
 	// Test address derivation.
-	extAddr, err := w.NewAddress(acct1.AccountNumber, tc.expectedScope)
+	extAddr, err := w.NewAddressDeprecated(acct1.AccountNumber, tc.expectedScope)
 	require.NoError(t, err)
 	require.Equal(t, tc.expectedAddr, extAddr.String())
 	intAddr, err := w.NewChangeAddress(acct1.AccountNumber, tc.expectedScope)

--- a/wallet/import_test.go
+++ b/wallet/import_test.go
@@ -289,7 +289,7 @@ func testImportAccount(t *testing.T, w *Wallet, tc *testCase, watchOnly bool,
 		t.Fatalf("unhandled address type %v", tc.addrType)
 	}
 
-	addrManaged, err := w.AddressInfo(intAddr)
+	addrManaged, err := w.AddressInfoDeprecated(intAddr)
 	require.NoError(t, err)
 	require.Equal(t, true, addrManaged.Imported())
 }

--- a/wallet/import_test.go
+++ b/wallet/import_test.go
@@ -243,7 +243,9 @@ func testImportAccount(t *testing.T, w *Wallet, tc *testCase, watchOnly bool,
 	require.Equal(t, uint32(0), acct2.ImportedKeyCount)
 
 	// Test address derivation.
-	extAddr, err := w.NewAddressDeprecated(acct1.AccountNumber, tc.expectedScope)
+	extAddr, err := w.NewAddressDeprecated(
+		acct1.AccountNumber, tc.expectedScope,
+	)
 	require.NoError(t, err)
 	require.Equal(t, tc.expectedAddr, extAddr.String())
 	intAddr, err := w.NewChangeAddress(acct1.AccountNumber, tc.expectedScope)
@@ -257,7 +259,8 @@ func testImportAccount(t *testing.T, w *Wallet, tc *testCase, watchOnly bool,
 	require.Equal(t, uint32(1), acct1.ExternalKeyCount)
 	require.Equal(t, uint32(0), acct1.ImportedKeyCount)
 
-	// Make sure we can't get private keys for the imported accounts.
+	// Make sure we can't get private keys for the imported
+	// accounts.
 	_, err = w.DumpWIFPrivateKey(intAddr)
 	require.True(t, waddrmgr.IsError(err, waddrmgr.ErrWatchingOnly))
 

--- a/wallet/interface.go
+++ b/wallet/interface.go
@@ -180,8 +180,11 @@ type Interface interface {
 	// HaveAddress returns whether the wallet is the owner of the address.
 	HaveAddress(a btcutil.Address) (bool, error)
 
-	// ImportPublicKey imports a public key as a watch-only address.
-	ImportPublicKey(pubKey *btcec.PublicKey,
+	// ImportPublicKeyDeprecated imports a public key as a watch-only
+	// address.
+	//
+	// Deprecated: Use AddressManager.ImportPublicKey instead.
+	ImportPublicKeyDeprecated(pubKey *btcec.PublicKey,
 		addrType waddrmgr.AddressType) error
 
 	// ImportTaprootScript imports a taproot script into the wallet.

--- a/wallet/interface.go
+++ b/wallet/interface.go
@@ -187,8 +187,11 @@ type Interface interface {
 	ImportPublicKeyDeprecated(pubKey *btcec.PublicKey,
 		addrType waddrmgr.AddressType) error
 
-	// ImportTaprootScript imports a taproot script into the wallet.
-	ImportTaprootScript(scope waddrmgr.KeyScope,
+	// ImportTaprootScriptDeprecated imports a taproot script into the
+	// wallet.
+	//
+	// Deprecated: Use AddressManager.ImportTaprootScript instead.
+	ImportTaprootScriptDeprecated(scope waddrmgr.KeyScope,
 		tapscript *waddrmgr.Tapscript, bs *waddrmgr.BlockStamp,
 		witnessVersion byte, isSecretScript bool) (
 		waddrmgr.ManagedAddress, error)

--- a/wallet/interface.go
+++ b/wallet/interface.go
@@ -154,8 +154,12 @@ type Interface interface {
 	CurrentAddress(account uint32, scope waddrmgr.KeyScope) (
 		btcutil.Address, error)
 
-	// NewAddress returns a new address for a given account and scope.
-	NewAddress(account uint32, scope waddrmgr.KeyScope) (
+	// NewAddressDeprecated returns a new address for a given account and
+	// scope.
+	//
+	// Deprecated: This method will be removed in a future release. Use the
+	// AddressManager interface instead.
+	NewAddressDeprecated(account uint32, scope waddrmgr.KeyScope) (
 		btcutil.Address, error)
 
 	// NewChangeAddress returns a new change address for a given account

--- a/wallet/interface.go
+++ b/wallet/interface.go
@@ -167,9 +167,15 @@ type Interface interface {
 	NewChangeAddress(account uint32, scope waddrmgr.KeyScope) (
 		btcutil.Address, error)
 
-	// AddressInfo returns detailed information about a managed address,
-	// including its derivation path and whether it's compressed.
-	AddressInfo(a btcutil.Address) (waddrmgr.ManagedAddress, error)
+	// AddressInfoDeprecated returns detailed information about a managed
+	// address, including its derivation path and whether it's compressed.
+	//
+	// Deprecated: This method leaks internal waddrmgr types. Callers
+	// should use specific methods such as AccountOfAddress,
+	// IsInternalAddress, etc. instead.
+	AddressInfoDeprecated(a btcutil.Address) (
+		waddrmgr.ManagedAddress, error,
+	)
 
 	// HaveAddress returns whether the wallet is the owner of the address.
 	HaveAddress(a btcutil.Address) (bool, error)

--- a/wallet/interface.go
+++ b/wallet/interface.go
@@ -329,9 +329,9 @@ type Interface interface {
 	DeriveFromKeyPathAddAccount(scope waddrmgr.KeyScope,
 		path waddrmgr.DerivationPath) (*btcec.PrivateKey, error)
 
-	// ComputeInputScript generates a complete InputScript for the passed
-	// transaction with the signature as defined within the passed
-	// SignDescriptor.
+	// ComputeInputScript generates a complete InputScript for the
+	// passed transaction with the signature as defined within the
+	// passed SignDescriptor.
 	ComputeInputScript(tx *wire.MsgTx, output *wire.TxOut,
 		inputIndex int, sigHashes *txscript.TxSigHashes,
 		hashType txscript.SigHashType,
@@ -341,8 +341,8 @@ type Interface interface {
 	// redeem script for a given UTXO.
 	//
 	// Deprecated: Use AddressManager.ScriptForOutput instead.
-	ScriptForOutputDeprecated(output *wire.TxOut) (waddrmgr.ManagedPubKeyAddress,
-		[]byte, []byte, error)
+	ScriptForOutputDeprecated(output *wire.TxOut) (
+		waddrmgr.ManagedPubKeyAddress, []byte, []byte, error)
 }
 
 // A compile time check to ensure that Wallet implements the interface.

--- a/wallet/interface.go
+++ b/wallet/interface.go
@@ -337,9 +337,11 @@ type Interface interface {
 		hashType txscript.SigHashType,
 		tweaker PrivKeyTweaker) (wire.TxWitness, []byte, error)
 
-	// ScriptForOutput returns the address, witness program and redeem
-	// script for a given UTXO.
-	ScriptForOutput(output *wire.TxOut) (waddrmgr.ManagedPubKeyAddress,
+	// ScriptForOutputDeprecated returns the address, witness program and
+	// redeem script for a given UTXO.
+	//
+	// Deprecated: Use AddressManager.ScriptForOutput instead.
+	ScriptForOutputDeprecated(output *wire.TxOut) (waddrmgr.ManagedPubKeyAddress,
 		[]byte, []byte, error)
 }
 

--- a/wallet/psbt.go
+++ b/wallet/psbt.go
@@ -278,7 +278,9 @@ func (w *Wallet) DecorateInputs(packet *psbt.Packet, failOnUnknown bool) error {
 			return fmt.Errorf("error fetching UTXO: %w", err)
 		}
 
-		addr, witnessProgram, _, err := w.ScriptForOutputDeprecated(utxo)
+		addr, witnessProgram, _, err := w.ScriptForOutputDeprecated(
+			utxo,
+		)
 		if err != nil {
 			return fmt.Errorf("error fetching UTXO script: %w", err)
 		}
@@ -300,8 +302,9 @@ func (w *Wallet) DecorateInputs(packet *psbt.Packet, failOnUnknown bool) error {
 	return nil
 }
 
-// addInputInfoSegWitV0 adds the UTXO and BIP32 derivation info for a SegWit v0
-// PSBT input (p2wkh, np2wkh) from the given wallet information.
+// addInputInfoSegWitV0 adds the UTXO and BIP32 derivation info for a
+// SegWit v0 PSBT input (p2wkh, np2wkh) from the given wallet
+// information.
 func addInputInfoSegWitV0(in *psbt.PInput, prevTx *wire.MsgTx, utxo *wire.TxOut,
 	derivationInfo *psbt.Bip32Derivation, addr waddrmgr.ManagedAddress,
 	witnessProgram []byte) {

--- a/wallet/psbt.go
+++ b/wallet/psbt.go
@@ -217,7 +217,7 @@ func (w *Wallet) FundPsbt(packet *psbt.Packet, keyScope *waddrmgr.KeyScope,
 			packet.UnsignedTx.TxOut, changeTxOut,
 		)
 
-		addr, _, _, err := w.ScriptForOutput(changeTxOut)
+		addr, _, _, err := w.ScriptForOutputDeprecated(changeTxOut)
 		if err != nil {
 			return 0, fmt.Errorf("error querying wallet for "+
 				"change addr: %w", err)
@@ -278,7 +278,7 @@ func (w *Wallet) DecorateInputs(packet *psbt.Packet, failOnUnknown bool) error {
 			return fmt.Errorf("error fetching UTXO: %w", err)
 		}
 
-		addr, witnessProgram, _, err := w.ScriptForOutput(utxo)
+		addr, witnessProgram, _, err := w.ScriptForOutputDeprecated(utxo)
 		if err != nil {
 			return fmt.Errorf("error fetching UTXO script: %w", err)
 		}

--- a/wallet/signer.go
+++ b/wallet/signer.go
@@ -34,15 +34,19 @@ func (w *Wallet) ScriptForOutputDeprecated(output *wire.TxOut) (
 type PrivKeyTweaker func(*btcec.PrivateKey) (*btcec.PrivateKey, error)
 
 // ComputeInputScript generates a complete InputScript for the passed
-// transaction with the signature as defined within the passed SignDescriptor.
-// This method is capable of generating the proper input script for both
-// regular p2wkh output and p2wkh outputs nested within a regular p2sh output.
+// transaction with the signature as defined within the passed
+// SignDescriptor. This method is capable of generating the proper input
+// script for both regular p2wkh output and p2wkh outputs nested within a
+// regular p2sh output.
 func (w *Wallet) ComputeInputScript(tx *wire.MsgTx, output *wire.TxOut,
 	inputIndex int, sigHashes *txscript.TxSigHashes,
 	hashType txscript.SigHashType, tweaker PrivKeyTweaker) (wire.TxWitness,
 	[]byte, error) {
 
-	walletAddr, witnessProgram, sigScript, err := w.ScriptForOutputDeprecated(output)
+	walletAddr, witnessProgram, sigScript, err :=
+		w.ScriptForOutputDeprecated(
+			output,
+		)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/wallet/signer.go
+++ b/wallet/signer.go
@@ -14,10 +14,12 @@ import (
 	"github.com/btcsuite/btcwallet/waddrmgr"
 )
 
-// ScriptForOutput returns the address, witness program and redeem script for a
-// given UTXO. An error is returned if the UTXO does not belong to our wallet or
-// it is not a managed pubKey address.
-func (w *Wallet) ScriptForOutput(output *wire.TxOut) (
+// ScriptForOutputDeprecated returns the address, witness program and redeem
+// script for a given UTXO. An error is returned if the UTXO does not
+// belong to our wallet or it is not a managed pubKey address.
+//
+// Deprecated: Use AddressManager.ScriptForOutput instead.
+func (w *Wallet) ScriptForOutputDeprecated(output *wire.TxOut) (
 	waddrmgr.ManagedPubKeyAddress, []byte, []byte, error) {
 
 	// First make sure we can sign for the input by making sure the script
@@ -92,7 +94,7 @@ func (w *Wallet) ComputeInputScript(tx *wire.MsgTx, output *wire.TxOut,
 	hashType txscript.SigHashType, tweaker PrivKeyTweaker) (wire.TxWitness,
 	[]byte, error) {
 
-	walletAddr, witnessProgram, sigScript, err := w.ScriptForOutput(output)
+	walletAddr, witnessProgram, sigScript, err := w.ScriptForOutputDeprecated(output)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/wallet/signer.go
+++ b/wallet/signer.go
@@ -21,7 +21,12 @@ import (
 func (w *Wallet) ScriptForOutputDeprecated(output *wire.TxOut) (
 	waddrmgr.ManagedPubKeyAddress, []byte, []byte, error) {
 
-	return w.ScriptForOutput(context.Background(), *output)
+	script, err := w.ScriptForOutput(context.Background(), *output)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return script.Addr, script.WitnessProgram, script.RedeemScript, nil
 }
 
 // PrivKeyTweaker is a function type that can be used to pass in a callback for

--- a/wallet/utxos.go
+++ b/wallet/utxos.go
@@ -142,7 +142,7 @@ func (w *Wallet) fetchOutputAddr(script []byte) (waddrmgr.ManagedAddress, error)
 	// Therefore, we simply select the key for the first address we know
 	// of.
 	for _, addr := range addrs {
-		addr, err := w.AddressInfo(addr)
+		addr, err := w.AddressInfoDeprecated(addr)
 		if err == nil {
 			return addr, nil
 		}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1950,8 +1950,8 @@ func (w *Wallet) AccountOfAddress(a btcutil.Address) (uint32, error) {
 	return account, err
 }
 
-// AddressInfo returns detailed information regarding a wallet address.
-func (w *Wallet) AddressInfo(a btcutil.Address) (waddrmgr.ManagedAddress, error) {
+// AddressInfoDeprecated returns detailed information regarding a wallet address.
+func (w *Wallet) AddressInfoDeprecated(a btcutil.Address) (waddrmgr.ManagedAddress, error) {
 	var managedAddress waddrmgr.ManagedAddress
 	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
 		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -90,6 +90,11 @@ var (
 	// watch-only mode where we can select coins but not sign any inputs.
 	ErrTxUnsigned = errors.New("watch-only wallet, transaction not signed")
 
+	// ErrNoAssocPrivateKey is returned when a private key is requested for
+	// an address that has no associated private key.
+	ErrNoAssocPrivateKey = errors.New("address does not have an " +
+		"associated private key")
+
 	// Namespace bucket keys.
 	waddrmgrNamespaceKey = []byte("waddrmgr")
 	wtxmgrNamespaceKey   = []byte("wtxmgr")
@@ -1565,6 +1570,7 @@ func (w *Wallet) Locked() bool {
 //
 // TODO: To prevent the above scenario, perhaps closures should be passed
 // to the walletLocker goroutine and disallow callers from explicitly
+
 // handling the locking mechanism.
 func (w *Wallet) holdUnlock() (heldUnlock, error) {
 	req := make(chan heldUnlock)
@@ -1907,17 +1913,20 @@ func (w *Wallet) PrivKeyForAddress(a btcutil.Address) (*btcec.PrivateKey, error)
 	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
 		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
 
-		managedAddr, err := w.addrStore.Address(addrmgrNs, a)
+		addr, err := w.addrStore.Address(addrmgrNs, a)
 		if err != nil {
 			return err
 		}
-		managedPubKeyAddr, ok := managedAddr.(waddrmgr.ManagedPubKeyAddress)
+
+		managedPubKeyAddr, ok := addr.(waddrmgr.ManagedPubKeyAddress)
 		if !ok {
-			return errors.New("address does not have an associated private key")
+			return ErrNoAssocPrivateKey
 		}
+
 		privKey, err = managedPubKeyAddr.PrivKey()
 		return err
 	})
+
 	return privKey, err
 }
 
@@ -1950,8 +1959,11 @@ func (w *Wallet) AccountOfAddress(a btcutil.Address) (uint32, error) {
 	return account, err
 }
 
-// AddressInfoDeprecated returns detailed information regarding a wallet address.
-func (w *Wallet) AddressInfoDeprecated(a btcutil.Address) (waddrmgr.ManagedAddress, error) {
+// AddressInfoDeprecated returns detailed information regarding a wallet
+// address.
+func (w *Wallet) AddressInfoDeprecated(a btcutil.Address) (
+	waddrmgr.ManagedAddress, error) {
+
 	var managedAddress waddrmgr.ManagedAddress
 	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
 		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
@@ -4016,8 +4028,8 @@ func (w *Wallet) DeriveFromKeyPath(scope waddrmgr.KeyScope,
 
 			return err
 		}
-		privKey, err = mpka.PrivKey()
 
+		privKey, err = mpka.PrivKey()
 		return err
 	})
 	if err != nil {

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -331,7 +331,7 @@ func TestDuplicateAddressDerivation(t *testing.T) {
 			eg.Go(func() error {
 				addrs := make([]btcutil.Address, 10)
 				for i := 0; i < 10; i++ {
-					addr, err := w.NewAddress(
+					addr, err := w.NewAddressDeprecated(
 						0, waddrmgr.KeyScopeBIP0084,
 					)
 					if err != nil {


### PR DESCRIPTION
This PR fixes #1032 - the old design has evolved here, detailed below.

## Initial State: A Flexible but Low-Level API

The initial design, as captured in `05-address_manager.md`, was a direct and logical grouping of address-related functions. Its key characteristics were:

-   **Low-Level Identifiers**: Methods relied on internal identifiers like `account uint32` and `waddrmgr.KeyScope`. This required the client to have intimate knowledge of the wallet's internal structure, such as BIP derivation schemes.
-   **Flexible but Risky Primitives**: The inclusion of `ListUnusedAddresses` provided flexibility by returning a pool of available addresses. However, it placed the burden of safe address management entirely on the client.
-   **Redundant Parameters**: Some methods required parameters that could be inferred or were constant for a given operation, such as the `KeyScope` for Taproot imports.

While functional, this design exposed implementation details and created potential pitfalls for developers using the API.

## The Design Evolution: Prioritizing Safety and Ergonomics

The API was refined through a series of key insights aimed at improving safety, abstracting implementation details, and enhancing developer experience.

### Insight 1: Abstracting Internal Identifiers for a Cleaner API

The first major refinement was to replace low-level, internal identifiers with higher-level, more intuitive concepts.

-   **From `account uint32` to `account string`**: The account identifier was changed from an internal integer to a human-readable string. This decouples the client from the wallet's internal numbering scheme and aligns the API with how users think about accounts.

-   **From `KeyScope` to `AddressType`**: Instead of requiring the client to specify a BIP-defined `KeyScope`, the API now uses `waddrmgr.AddressType`. Callers are typically concerned with the *format* of the address they need (e.g., P2WKH, P2TR), not the specific derivation path. The wallet is better equipped to handle the internal mapping from `AddressType` to the correct `KeyScope`, simplifying the client's logic.

### Insight 2: Promoting Safe Address Usage by Default

The concept of fetching unused addresses was re-evaluated with a strong focus on safety.

-   **From `ListUnusedAddresses` to `GetUnusedAddress`**: The original plan to return a list of all unused addresses was identified as a potential footgun. If a client fetches a list, uses an address from the middle, and the application state is lost, a gap is created in the address chain. Repeatedly creating such gaps can exceed the BIP44 gap limit (typically 20), which can lead to **permanent fund loss** during wallet recovery from seed.

-   The final API provides `GetUnusedAddress`, which returns only the single, *earliest* unused address. This promotes a safer, sequential address usage pattern that is correct for the vast majority of use cases. The lower-level `NewAddress` primitive remains for advanced scenarios where non-sequential generation is explicitly required and the risks are understood.

### Insight 3: Simplifying the API Through Contextual Inference

The interface was further streamlined by removing parameters that were redundant or could be inferred.

-   **Simplifying `ImportTaprootScript`**: The initial design required a `KeyScope` parameter. However, Taproot scripts have a standardized derivation path (BIP-0086). The `scope` parameter was therefore removed from the final interface, as the implementation can and should always use the correct, hardcoded scope. This reduces complexity and the chance of caller error.

## The Final API: Safer, More Ergonomic, and Better Encapsulated

The final, implemented design prioritizes safety and developer experience by abstracting away internal complexity.

```go
// AddressManager provides an interface for generating and inspecting wallet
// addresses and scripts.
type AddressManager interface {
	// NewAddress returns a new address for the given account and address
	// type...
	NewAddress(ctx context.Context, account string,
		addrType waddrmgr.AddressType,
		change bool) (btcutil.Address, error)

	// GetUnusedAddress returns the earliest unused address for the given
	// account and address type...
	GetUnusedAddress(ctx context.Context, account string,
		addrType waddrmgr.AddressType) (btcutil.Address, error)

	// AddressInfo returns detailed information about a managed address...
	AddressInfo(ctx context.Context,
		a btcutil.Address) (waddrmgr.ManagedAddress, error)

	// ListAddresses lists all addresses for a given account, including
	// their balances.
	ListAddresses(ctx context.Context, account string,
		addrType waddrmgr.AddressType) ([]AddressProperty, error)

	// ImportPublicKey imports a single public key as a watch-only address.
	ImportPublicKey(ctx context.Context, pubKey *btcec.PublicKey,
		addrType waddrmgr.AddressType) error

	// ImportTaprootScript imports a taproot script for tracking and
	// spending.
	ImportTaprootScript(ctx context.Context,
		tapscript *waddrmgr.Tapscript) (waddrmgr.ManagedAddress, error)

	// ScriptForOutput returns the address, witness program, and redeem
	// script for a given UTXO.
	ScriptForOutput(ctx context.Context, output *wire.TxOut) (
		waddrmgr.ManagedPubKeyAddress, []byte, []byte, error)
}
```

### Why This Design is Superior:

1.  **Safer by Default**: `GetUnusedAddress` promotes safe address management practices that protect against fund loss due to the BIP44 gap limit.
2.  **More Ergonomic**: Using `string` for accounts and `AddressType` for address types makes the API more intuitive and less error-prone for developers.
3.  **Better Encapsulation**: It hides internal implementation details like `uint32` account numbers and the mapping between `AddressType` and `KeyScope`.
4.  **Clearer Intent**: The API is more declarative. The client asks for what it wants (an address of a certain type for a named account), and the wallet handles the internal mechanics.