### PR TITLE
chain: update `Start` method to take `context`

### DIFF
--- a/chain/chainservice.go
+++ b/chain/chainservice.go
@@ -1,6 +1,8 @@
 package chain
 
 import (
+	"context"
+
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/gcs"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -14,7 +16,7 @@ import (
 // NeutrinoChainService is an interface that encapsulates all the public
 // methods of a *neutrino.ChainService
 type NeutrinoChainService interface {
-	Start() error
+	Start(context.Context) error
 	GetBlock(chainhash.Hash, ...neutrino.QueryOption) (*btcutil.Block, error)
 	GetBlockHeight(*chainhash.Hash) (int32, error)
 	BestBlock() (*headerfs.BlockStamp, error)

--- a/chain/mocks_test.go
+++ b/chain/mocks_test.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"container/list"
+	"context"
 	"errors"
 
 	"github.com/btcsuite/btcd/btcutil"
@@ -68,7 +69,7 @@ func (m *mockRescanner) WaitForShutdown() {
 type mockChainService struct {
 }
 
-func (m *mockChainService) Start() error {
+func (m *mockChainService) Start(_ context.Context) error {
 	return nil
 }
 

--- a/chain/neutrino.go
+++ b/chain/neutrino.go
@@ -1,6 +1,7 @@
 package chain
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -102,7 +103,7 @@ func (s *NeutrinoClient) BackEnd() string {
 
 // Start replicates the RPC client's Start method.
 func (s *NeutrinoClient) Start() error {
-	if err := s.CS.Start(); err != nil {
+	if err := s.CS.Start(context.TODO()); err != nil {
 		return fmt.Errorf("error starting chain service: %w", err)
 	}
 


### PR DESCRIPTION
This PR https://github.com/lightninglabs/neutrino/pull/317 changed the signature of `Start`, so we now need to pass a context to it.