### PR TITLE
[2/8][AccountManager]: benchmark `ListAccounts` API against deprecated `Accounts` wrapper API

### DIFF
--- a/wallet/account_manager_benchmark_test.go
+++ b/wallet/account_manager_benchmark_test.go
@@ -60,3 +60,55 @@ func BenchmarkListAccountsByScopeAPI(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkListAccountsAPI benchmarks ListAccounts API and a deprecated variant
+// of it using same key scopes and identical test data across multiple dataset
+// sizes. Test names start with dataset size to group API comparisons for
+// benchstat analysis.
+func BenchmarkListAccountsAPI(b *testing.B) {
+	benchmarkSizes, namingInfo := generateBenchmarkSizes(
+		benchmarkConfig{
+			accountGrowth: linearGrowth,
+			utxoGrowth:    exponentialGrowth,
+			maxIterations: 14,
+			startIndex:    0,
+		},
+	)
+	scopes := waddrmgr.DefaultKeyScopes
+
+	for _, size := range benchmarkSizes {
+		b.Run(size.name(namingInfo)+"/0-Before", func(b *testing.B) {
+			w := setupBenchmarkWallet(
+				b, benchmarkWalletConfig{
+					scopes:      scopes,
+					numAccounts: size.numAccounts,
+					numUTXOs:    size.numUTXOs,
+				},
+			)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				_, err := listAccountsDeprecated(w)
+				require.NoError(b, err)
+			}
+		})
+
+		b.Run(size.name(namingInfo)+"/1-After", func(b *testing.B) {
+			w := setupBenchmarkWallet(
+				b, benchmarkWalletConfig{
+					scopes:      scopes,
+					numAccounts: size.numAccounts,
+					numUTXOs:    size.numUTXOs,
+				},
+			)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				_, err := w.ListAccounts(b.Context())
+				require.NoError(b, err)
+			}
+		})
+	}
+}

--- a/wallet/benchmark_helpers_test.go
+++ b/wallet/benchmark_helpers_test.go
@@ -287,3 +287,34 @@ func createTestUTXOs(t testing.TB, w *Wallet,
 
 	require.NoError(t, err, "failed to create test UTXOs: %v", err)
 }
+
+// listAccountsDeprecated wraps the deprecated Accounts API to satisfy the same
+// contract as ListAccounts by calling Accounts API across all active key scopes
+// and aggregating the results.
+func listAccountsDeprecated(w *Wallet) (*AccountsResult, error) {
+	var (
+		allAccounts      []AccountResult
+		finalBlockHash   chainhash.Hash
+		finalBlockHeight int32
+		scopeManagers    = w.addrStore.ActiveScopedKeyManagers()
+	)
+
+	for _, scopeMgr := range scopeManagers {
+		scope := scopeMgr.Scope()
+		result, err := w.Accounts(scope)
+		if err != nil {
+			return nil, err
+		}
+
+		allAccounts = append(allAccounts, result.Accounts...)
+
+		finalBlockHash = result.CurrentBlockHash
+		finalBlockHeight = result.CurrentBlockHeight
+	}
+
+	return &AccountsResult{
+		Accounts:           allAccounts,
+		CurrentBlockHash:   finalBlockHash,
+		CurrentBlockHeight: finalBlockHeight,
+	}, nil
+}


### PR DESCRIPTION
## Change Description

In this PR, we benchmark the new `ListAccountsAPI` against a wrapper API around the deprecated `Accounts` to make sure there are no regressions in terms of performance. That deprecation API process happening in upstream PR https://github.com/btcsuite/btcwallet/pull/1050.

Towards https://github.com/btcsuite/btcwallet/issues/1066.
Towards https://github.com/btcsuite/btcwallet/issues/1067.
Towards #1015.
Prev https://github.com/btcsuite/btcwallet/pull/1068.
Next https://github.com/btcsuite/btcwallet/pull/1070.

## Benchmarking Report

<div align="center">
  <table>
    <tr>
      <td align="center">
<img width="1058" height="500" alt="ListAccountsAPI - Allocations_op" src="https://github.com/user-attachments/assets/f64b6316-dd38-479b-80b6-6d02e77cbae6" />
        <br>
        <sub><b>Allocations per Operation</b></sub>
      </td>
      <td align="center">
<img width="1058" height="500" alt="ListAccountsAPI - Execution Time (ns_op)" src="https://github.com/user-attachments/assets/a27dd2cf-516a-4ca9-8f08-508c8a1e3603" />
        <br>
        <sub><b>Execution Time (ns/op)</b></sub>
      </td>
      <td align="center">
<img width="1058" height="500" alt="ListAccountsAPI - Memory Usage (B_op)" src="https://github.com/user-attachments/assets/22827738-73f3-495b-b525-970bb8925ae7" />
        <br>
        <sub><b>Memory Usage (B/op)</b></sub>
      </td>
    </tr>
  </table>
</div>

<details closed>
  <summary>Benchmarks in Raw Format</summary>
  </br>
 
```bash
dev@dev:~/btcwallet/wallet$ go test -benchmem -run=^$ -bench ^BenchmarkListAccountsAPI$ github.com/btcsuite/btcwallet/wallet
goos: linux
goarch: amd64
pkg: github.com/btcsuite/btcwallet/wallet
cpu: Intel Xeon Processor (Skylake, IBRS, no TSX)
BenchmarkListAccountsAPI/05-Accounts-00001-UTXOs/0-Before-8         	   12856	     90020 ns/op	   29811 B/op	     476 allocs/op
BenchmarkListAccountsAPI/05-Accounts-00001-UTXOs/1-After-8          	   36600	     30099 ns/op	   11307 B/op	     166 allocs/op
BenchmarkListAccountsAPI/10-Accounts-00002-UTXOs/0-Before-8         	    8904	    137727 ns/op	   48982 B/op	     725 allocs/op
BenchmarkListAccountsAPI/10-Accounts-00002-UTXOs/1-After-8          	   23037	     51151 ns/op	   18613 B/op	     242 allocs/op
BenchmarkListAccountsAPI/15-Accounts-00004-UTXOs/0-Before-8         	    4915	    249987 ns/op	   76570 B/op	    1179 allocs/op
BenchmarkListAccountsAPI/15-Accounts-00004-UTXOs/1-After-8          	   13617	     79110 ns/op	   27946 B/op	     369 allocs/op
BenchmarkListAccountsAPI/20-Accounts-00008-UTXOs/0-Before-8         	    2888	    403668 ns/op	  110470 B/op	    2075 allocs/op
BenchmarkListAccountsAPI/20-Accounts-00008-UTXOs/1-After-8          	    9319	    122242 ns/op	   39011 B/op	     603 allocs/op
BenchmarkListAccountsAPI/25-Accounts-00016-UTXOs/0-Before-8         	    1501	    793758 ns/op	  217572 B/op	    3928 allocs/op
BenchmarkListAccountsAPI/25-Accounts-00016-UTXOs/1-After-8          	    5454	    220271 ns/op	   68215 B/op	    1078 allocs/op
BenchmarkListAccountsAPI/30-Accounts-00032-UTXOs/0-Before-8         	     716	   1451018 ns/op	  349397 B/op	    7800 allocs/op
BenchmarkListAccountsAPI/30-Accounts-00032-UTXOs/1-After-8          	    2943	    402564 ns/op	  102909 B/op	    2056 allocs/op
BenchmarkListAccountsAPI/35-Accounts-00064-UTXOs/0-Before-8         	     414	   2878159 ns/op	  685641 B/op	   15653 allocs/op
BenchmarkListAccountsAPI/35-Accounts-00064-UTXOs/1-After-8          	    1489	    789103 ns/op	  195370 B/op	    4038 allocs/op
BenchmarkListAccountsAPI/40-Accounts-00128-UTXOs/0-Before-8         	     184	   6284074 ns/op	 1402984 B/op	   32692 allocs/op
BenchmarkListAccountsAPI/40-Accounts-00128-UTXOs/1-After-8          	     798	   1552629 ns/op	  372878 B/op	    8309 allocs/op
BenchmarkListAccountsAPI/45-Accounts-00256-UTXOs/0-Before-8         	     105	  10703103 ns/op	 2445105 B/op	   55733 allocs/op
BenchmarkListAccountsAPI/45-Accounts-00256-UTXOs/1-After-8          	     448	   2542383 ns/op	  634835 B/op	   14073 allocs/op
BenchmarkListAccountsAPI/50-Accounts-00512-UTXOs/0-Before-8         	     108	  11366888 ns/op	 2723781 B/op	   62660 allocs/op
BenchmarkListAccountsAPI/50-Accounts-00512-UTXOs/1-After-8          	     391	   2934293 ns/op	  705039 B/op	   15831 allocs/op
BenchmarkListAccountsAPI/55-Accounts-01024-UTXOs/0-Before-8         	      92	  12414262 ns/op	 2953946 B/op	   68835 allocs/op
BenchmarkListAccountsAPI/55-Accounts-01024-UTXOs/1-After-8          	     337	   3298117 ns/op	  766266 B/op	   17401 allocs/op
BenchmarkListAccountsAPI/60-Accounts-02048-UTXOs/0-Before-8         	      85	  14012339 ns/op	 3577483 B/op	   75054 allocs/op
BenchmarkListAccountsAPI/60-Accounts-02048-UTXOs/1-After-8          	     308	   3608570 ns/op	  924624 B/op	   18957 allocs/op
BenchmarkListAccountsAPI/65-Accounts-04096-UTXOs/0-Before-8         	      70	  15859478 ns/op	 3820736 B/op	   81692 allocs/op
BenchmarkListAccountsAPI/65-Accounts-04096-UTXOs/1-After-8          	     243	   4251487 ns/op	  988012 B/op	   20663 allocs/op
BenchmarkListAccountsAPI/70-Accounts-08192-UTXOs/0-Before-8         	      74	  15762917 ns/op	 4038784 B/op	   87017 allocs/op
BenchmarkListAccountsAPI/70-Accounts-08192-UTXOs/1-After-8          	     298	   4293131 ns/op	 1051054 B/op	   21970 allocs/op
BenchmarkListAccountsAPI/75-Accounts-16384-UTXOs/0-Before-8         	      70	  17375907 ns/op	 4294077 B/op	   94493 allocs/op
BenchmarkListAccountsAPI/75-Accounts-16384-UTXOs/1-After-8          	     248	   4355638 ns/op	 1117036 B/op	   23848 allocs/op
PASS
ok  	github.com/btcsuite/btcwallet/wallet	203.660s
```

</details>

<details open>
  <summary>Conclusions</summary>
  </br>

- **Execution time reduced by 66-75%** across all test scenarios, with the most dramatic improvement in the 5-account case (90,020 ns to 30,099 ns = 66.6% reduction) and consistent ~75% reductions in larger scenarios (e.g., 75-account case: 17,375,907 ns to 4,355,638 ns = 74.9% reduction)
- **Memory allocations decreased by 62-74%** depending on scenario size, with smaller datasets showing the largest relative improvement (5-account case: 29,811 B to 11,307 B = 62.1% reduction) and larger datasets maintaining strong gains (75-account case: 4,294,077 B to 1,117,036 B = 74.0% reduction)
- **Allocation count reduced by 65-75%** consistently across all test scales, demonstrating that the optimization maintains its effectiveness as data size increases from 1 UTXO (476 to 166 allocations = 65.1% reduction) to 16,384 UTXOs (94,493 to 23,848 allocations = 74.8% reduction)

</details>


## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/btcsuite/btcwallet/blob/master/docs/contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcwallet/blob/master/docs/contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcwallet/blob/master/docs/contribution_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcwallet/blob/master/docs/contribution_guidelines.md) for further guidance.
