### PR TITLE
[3/8][AccountManager]: benchmark `ListAccountsByName` API against deprecated `Accounts` wrapper API

### DIFF
--- a/wallet/account_manager_benchmark_test.go
+++ b/wallet/account_manager_benchmark_test.go
@@ -34,6 +34,7 @@ func BenchmarkListAccountsByScopeAPI(b *testing.B) {
 
 			b.ReportAllocs()
 			b.ResetTimer()
+
 			for b.Loop() {
 				_, err := w.Accounts(scopes[0])
 				require.NoError(b, err)
@@ -51,6 +52,7 @@ func BenchmarkListAccountsByScopeAPI(b *testing.B) {
 
 			b.ReportAllocs()
 			b.ResetTimer()
+
 			for b.Loop() {
 				_, err := w.ListAccountsByScope(
 					b.Context(), scopes[0],
@@ -88,6 +90,7 @@ func BenchmarkListAccountsAPI(b *testing.B) {
 
 			b.ReportAllocs()
 			b.ResetTimer()
+
 			for b.Loop() {
 				_, err := listAccountsDeprecated(w)
 				require.NoError(b, err)
@@ -105,6 +108,7 @@ func BenchmarkListAccountsAPI(b *testing.B) {
 
 			b.ReportAllocs()
 			b.ResetTimer()
+
 			for b.Loop() {
 				_, err := w.ListAccounts(b.Context())
 				require.NoError(b, err)
@@ -142,6 +146,7 @@ func BenchmarkListAccountsByNameAPI(b *testing.B) {
 
 			b.ReportAllocs()
 			b.ResetTimer()
+
 			for b.Loop() {
 				_, err := listAccountsByNameDeprecated(
 					w, accountName,
@@ -161,6 +166,7 @@ func BenchmarkListAccountsByNameAPI(b *testing.B) {
 
 			b.ReportAllocs()
 			b.ResetTimer()
+
 			for b.Loop() {
 				_, err := w.ListAccountsByName(
 					b.Context(), accountName,


### PR DESCRIPTION
## Change Description

In this PR, we benchmark the new `ListAccountsByName` API against a wrapper API around the deprecated `Accounts` API to make sure there are no regressions in terms of performance. That deprecation API process happening in upstream PR https://github.com/btcsuite/btcwallet/pull/1050.

Towards https://github.com/btcsuite/btcwallet/issues/1066.
Towards https://github.com/btcsuite/btcwallet/issues/1067.
Towards #1015.
Prev https://github.com/btcsuite/btcwallet/pull/1069.
Next https://github.com/btcsuite/btcwallet/pull/1071.

## Benchmarking Report

<div align="center">
  <table>
    <tr>
      <td align="center">
<img width="1056" height="500" alt="ListAccountsByNameAPI - Allocations_op" src="https://github.com/user-attachments/assets/377418d1-3036-40f6-b2c0-9c6ffce6e685" />
        <br>
        <sub><b>Allocations per Operation</b></sub>
      </td>
      <td align="center">
<img width="1056" height="500" alt="ListAccountsByNameAPI - Execution Time (ns_op)" src="https://github.com/user-attachments/assets/be540e34-ed28-4ee5-81bc-9f1b46b004cb" />
        <br>
        <sub><b>Execution Time (ns/op)</b></sub>
      </td>
      <td align="center">
<img width="1056" height="500" alt="ListAccountsByNameAPI - Memory Usage (B_op)" src="https://github.com/user-attachments/assets/7a9ef1f7-7ad6-44a7-85da-80ff726ed4e2" />
        <br>
        <sub><b>Memory Usage (B/op)</b></sub>
      </td>
    </tr>
  </table>
</div>

<details closed>
  <summary>Benchmarks in Raw Format</summary>
  </br>
 
```bash
dev@dev:~/btcwallet/wallet$ go test -benchmem -run=^$ -bench ^BenchmarkListAccountsByNameAPI$ github.com/btcsuite/btcwallet/wallet
goos: linux
goarch: amd64
pkg: github.com/btcsuite/btcwallet/wallet
cpu: Intel Xeon Processor (Skylake, IBRS, no TSX)
BenchmarkListAccountsByNameAPI/05-Accounts-00001-UTXOs/0-Before-8         	   11942	     93635 ns/op	   27344 B/op	     473 allocs/op
BenchmarkListAccountsByNameAPI/05-Accounts-00001-UTXOs/1-After-8          	   48706	     26620 ns/op	    7682 B/op	     152 allocs/op
BenchmarkListAccountsByNameAPI/10-Accounts-00002-UTXOs/0-Before-8         	    8652	    139057 ns/op	   45927 B/op	     723 allocs/op
BenchmarkListAccountsByNameAPI/10-Accounts-00002-UTXOs/1-After-8          	   28062	     40710 ns/op	   13236 B/op	     222 allocs/op
BenchmarkListAccountsByNameAPI/15-Accounts-00004-UTXOs/0-Before-8         	    5050	    236642 ns/op	   70831 B/op	    1176 allocs/op
BenchmarkListAccountsByNameAPI/15-Accounts-00004-UTXOs/1-After-8          	   16627	     72242 ns/op	   20599 B/op	     356 allocs/op
BenchmarkListAccountsByNameAPI/20-Accounts-00008-UTXOs/0-Before-8         	    3021	    391812 ns/op	  106448 B/op	    2071 allocs/op
BenchmarkListAccountsByNameAPI/20-Accounts-00008-UTXOs/1-After-8          	   10000	    116565 ns/op	   32344 B/op	     624 allocs/op
BenchmarkListAccountsByNameAPI/25-Accounts-00016-UTXOs/0-Before-8         	    1442	    775647 ns/op	  212149 B/op	    3917 allocs/op
BenchmarkListAccountsByNameAPI/25-Accounts-00016-UTXOs/1-After-8          	    4413	    235368 ns/op	   65565 B/op	    1178 allocs/op
BenchmarkListAccountsByNameAPI/30-Accounts-00032-UTXOs/0-Before-8         	     763	   1442807 ns/op	  343417 B/op	    7789 allocs/op
BenchmarkListAccountsByNameAPI/30-Accounts-00032-UTXOs/1-After-8          	    2778	    438640 ns/op	  111965 B/op	    2333 allocs/op
BenchmarkListAccountsByNameAPI/35-Accounts-00064-UTXOs/0-Before-8         	     368	   2882856 ns/op	  680713 B/op	   15650 allocs/op
BenchmarkListAccountsByNameAPI/35-Accounts-00064-UTXOs/1-After-8          	    1562	    866374 ns/op	  226803 B/op	    4672 allocs/op
BenchmarkListAccountsByNameAPI/40-Accounts-00128-UTXOs/0-Before-8         	     188	   6027694 ns/op	 1394728 B/op	   32656 allocs/op
BenchmarkListAccountsByNameAPI/40-Accounts-00128-UTXOs/1-After-8          	     612	   1858016 ns/op	  474215 B/op	    9697 allocs/op
BenchmarkListAccountsByNameAPI/45-Accounts-00256-UTXOs/0-Before-8         	     109	  10907437 ns/op	 2438038 B/op	   55714 allocs/op
BenchmarkListAccountsByNameAPI/45-Accounts-00256-UTXOs/1-After-8          	     416	   2993724 ns/op	  842969 B/op	   16609 allocs/op
BenchmarkListAccountsByNameAPI/50-Accounts-00512-UTXOs/0-Before-8         	     108	  11099415 ns/op	 2712044 B/op	   62684 allocs/op
BenchmarkListAccountsByNameAPI/50-Accounts-00512-UTXOs/1-After-8          	     327	   3412634 ns/op	  955964 B/op	   18658 allocs/op
BenchmarkListAccountsByNameAPI/55-Accounts-01024-UTXOs/0-Before-8         	      96	  12757926 ns/op	 2942922 B/op	   68748 allocs/op
BenchmarkListAccountsByNameAPI/55-Accounts-01024-UTXOs/1-After-8          	     325	   3919696 ns/op	 1068127 B/op	   20463 allocs/op
BenchmarkListAccountsByNameAPI/60-Accounts-02048-UTXOs/0-Before-8         	      85	  13869452 ns/op	 3561010 B/op	   74985 allocs/op
BenchmarkListAccountsByNameAPI/60-Accounts-02048-UTXOs/1-After-8          	     270	   4453334 ns/op	 1263038 B/op	   22297 allocs/op
BenchmarkListAccountsByNameAPI/65-Accounts-04096-UTXOs/0-Before-8         	      76	  14969818 ns/op	 3808219 B/op	   81691 allocs/op
BenchmarkListAccountsByNameAPI/65-Accounts-04096-UTXOs/1-After-8          	     261	   4453857 ns/op	 1392961 B/op	   24283 allocs/op
BenchmarkListAccountsByNameAPI/70-Accounts-08192-UTXOs/0-Before-8         	      69	  16567922 ns/op	 4026711 B/op	   87047 allocs/op
BenchmarkListAccountsByNameAPI/70-Accounts-08192-UTXOs/1-After-8          	     243	   4691718 ns/op	 1482970 B/op	   25914 allocs/op
BenchmarkListAccountsByNameAPI/75-Accounts-16384-UTXOs/0-Before-8         	      68	  17422394 ns/op	 4279690 B/op	   94428 allocs/op
BenchmarkListAccountsByNameAPI/75-Accounts-16384-UTXOs/1-After-8          	     218	   5355809 ns/op	 1290395 B/op	   28091 allocs/op
PASS
ok  	github.com/btcsuite/btcwallet/wallet	204.960s
```

</details>

<details open>
  <summary>Conclusions</summary>
  </br>

- **Execution time reduced by 69-72%** across all test scenarios, with the highest improvement in the 5-account case (93,635 ns to 26,620 ns = 71.6% reduction) and consistent optimization in larger scenarios (76-account case: 19,422,394 ns to 5,355,809 ns = 69.2% reduction)
- **Memory allocations decreased by 65-72%** depending on scenario size, with smaller datasets showing the largest relative improvement (5-account case: 27,344 B to 7,682 B = 71.9% reduction) and larger datasets maintaining strong gains (75-account case: 4,279,690 B to 1,290,395 B = 69.8% reduction)
- **Allocation count reduced by 68-70%** consistently across all test scales, demonstrating that the optimization maintains its effectiveness as data size increases from 1 UTXO (473 to 152 allocations = 67.9% reduction) to 16,384 UTXOs (94,428 to 28,091 allocations = 70.3% reduction)

</details>

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/btcsuite/btcwallet/blob/master/docs/contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcwallet/blob/master/docs/contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcwallet/blob/master/docs/contribution_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcwallet/blob/master/docs/contribution_guidelines.md) for further guidance.
