### PR TITLE
[4/8][AccountManager]: benchmark `NewAccount` API against deprecated `NextAccount` API

### DIFF
--- a/wallet/benchmark_helpers_test.go
+++ b/wallet/benchmark_helpers_test.go
@@ -33,6 +33,11 @@ func exponentialGrowth(i int) int {
 	return 1 << i
 }
 
+// constantGrowth scales the parameter value to a constant value.
+func constantGrowth(i int) int {
+	return 5
+}
+
 // benchmarkDataSize represents different test data sizes for stress testing.
 type benchmarkDataSize struct {
 	// numAccounts is the number of accounts to create.


### PR DESCRIPTION
## Change Description

In this PR, we benchmark the new `NewAccount` API against the deprecated `NextAccount` API to make sure there are no regressions in terms of performance. That deprecation API process happening in upstream PR https://github.com/btcsuite/btcwallet/pull/1050.

Towards https://github.com/btcsuite/btcwallet/issues/1066.
Towards https://github.com/btcsuite/btcwallet/issues/1067.
Towards #1015.
Prev https://github.com/btcsuite/btcwallet/pull/1070.
Next https://github.com/btcsuite/btcwallet/pull/1072.

## Benchmarking Report

<div align="center">
  <table>
    <tr>
      <td align="center">
<img width="1058" height="500" alt="NewAccountAPI - Allocations_op" src="https://github.com/user-attachments/assets/a4f6a2b2-2c81-43bb-9a02-0818696e131b" />
        <br>
        <sub><b>Allocations per Operation</b></sub>
      </td>
      <td align="center">
<img width="1058" height="500" alt="NewAccountAPI - Execution Time (ns_op)" src="https://github.com/user-attachments/assets/dacab279-fc1e-4779-953c-597402558cea" />
        <br>
        <sub><b>Execution Time (ns/op)</b></sub>
      </td>
      <td align="center">
<img width="1058" height="500" alt="NewAccountAPI - Memory Usage (B_op)" src="https://github.com/user-attachments/assets/c376b3c5-de2f-45ea-8004-940fc4852a3c" />
        <br>
        <sub><b>Memory Usage (B/op)</b></sub>
      </td>
    </tr>
  </table>
</div>

<details closed>
  <summary>Benchmarks in Raw Format</summary>
  </br>
 
```bash
Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkNewAccountAPI$ github.com/btcsuite/btcwallet/wallet

goos: linux
goarch: amd64
pkg: github.com/btcsuite/btcwallet/wallet
cpu: Intel Xeon Processor (Skylake, IBRS, no TSX)
BenchmarkNewAccountAPI/05-Accounts/0-Before-8         	     230	   4769440 ns/op	   84495 B/op	     739 allocs/op
BenchmarkNewAccountAPI/05-Accounts/1-After-8          	     267	   4619531 ns/op	   85325 B/op	     739 allocs/op
BenchmarkNewAccountAPI/10-Accounts/0-Before-8         	     240	   4632297 ns/op	   85746 B/op	     744 allocs/op
BenchmarkNewAccountAPI/10-Accounts/1-After-8          	     248	   4788386 ns/op	   85736 B/op	     740 allocs/op
BenchmarkNewAccountAPI/15-Accounts/0-Before-8         	     276	   4473191 ns/op	   86108 B/op	     743 allocs/op
BenchmarkNewAccountAPI/15-Accounts/1-After-8          	     247	   4730149 ns/op	   85917 B/op	     740 allocs/op
BenchmarkNewAccountAPI/20-Accounts/0-Before-8         	     241	   4742668 ns/op	   86318 B/op	     744 allocs/op
BenchmarkNewAccountAPI/20-Accounts/1-After-8          	     258	   4534317 ns/op	   86002 B/op	     742 allocs/op
BenchmarkNewAccountAPI/25-Accounts/0-Before-8         	     243	   4835494 ns/op	   86239 B/op	     743 allocs/op
BenchmarkNewAccountAPI/25-Accounts/1-After-8          	     256	   4649063 ns/op	   86088 B/op	     742 allocs/op
BenchmarkNewAccountAPI/30-Accounts/0-Before-8         	     261	   4697026 ns/op	   86190 B/op	     744 allocs/op
BenchmarkNewAccountAPI/30-Accounts/1-After-8          	     268	   4595639 ns/op	   86587 B/op	     745 allocs/op
BenchmarkNewAccountAPI/35-Accounts/0-Before-8         	     253	   4529846 ns/op	   86398 B/op	     745 allocs/op
BenchmarkNewAccountAPI/35-Accounts/1-After-8          	     248	   4597467 ns/op	   86166 B/op	     742 allocs/op
BenchmarkNewAccountAPI/40-Accounts/0-Before-8         	     267	   4526510 ns/op	   86279 B/op	     745 allocs/op
BenchmarkNewAccountAPI/40-Accounts/1-After-8          	     247	   4817130 ns/op	   86316 B/op	     744 allocs/op
BenchmarkNewAccountAPI/45-Accounts/0-Before-8         	     237	   4902451 ns/op	   88282 B/op	     746 allocs/op
BenchmarkNewAccountAPI/45-Accounts/1-After-8          	     273	   4548468 ns/op	   87858 B/op	     741 allocs/op
BenchmarkNewAccountAPI/50-Accounts/0-Before-8         	     267	   4339536 ns/op	   88061 B/op	     745 allocs/op
BenchmarkNewAccountAPI/50-Accounts/1-After-8          	     237	   4540937 ns/op	   88647 B/op	     749 allocs/op
BenchmarkNewAccountAPI/55-Accounts/0-Before-8         	     268	   4453365 ns/op	   87897 B/op	     749 allocs/op
BenchmarkNewAccountAPI/55-Accounts/1-After-8          	     247	   4496924 ns/op	   88171 B/op	     748 allocs/op
PASS
ok  	github.com/btcsuite/btcwallet/wallet	149.327s
```

</details>

<details open>
  <summary>Conclusions</summary>
  </br>

- **Execution time showed minimal and inconsistent changes**, ranging from a 7.2% improvement (45-account case: 4,902,451 ns to 4,548,468 ns) to a 6.4% degradation (40-account case: 4,526,510 ns to 4,817,130 ns), with most scenarios showing negligible differences within ±5
- **Memory allocations remained essentially unchanged**, with variations typically under 1% in either direction (e.g., 5-account case: 84,495 B to 85,325 B = +1.0%; 45-account case: 88,282 B to 87,858 B = -0.5%), indicating no meaningful optimization impact on memory usage
- **Allocation count showed no significant improvement**, with changes ranging from -0.7% to +0.5% across all scenarios (e.g., 15-account case: 743 to 740 allocations = -0.4%; 50-account case: 745 to 749 allocations = +0.5%), demonstrating that this optimization had minimal effect on the NewAccountAPI operation's allocation efficiency

</details>

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/btcsuite/btcwallet/blob/master/docs/contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcwallet/blob/master/docs/contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcwallet/blob/master/docs/contribution_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcwallet/blob/master/docs/contribution_guidelines.md) for further guidance.
