### PR TITLE
chore(ci): upgrade checkout to v6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: git checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: git checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -118,7 +118,7 @@ jobs:
           docker rm $CONTAINER_ID
 
       - name: git checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Clean up runner space
         uses: ./.github/actions/cleanup-space


### PR DESCRIPTION
Updates CI to use `actions/checkout@v6` for improved performance and security.

https://github.com/actions/checkout/releases/tag/v6.0.0