### PR TITLE
unit+wallet: add missing units and base units

### DIFF
--- a/pkg/btcunit/rates.go
+++ b/pkg/btcunit/rates.go
@@ -285,6 +285,15 @@ func CalcSatPerKVByte(fee btcutil.Amount, kvb KVByte) SatPerKVByte {
 	return SatPerKVByte{newBaseFeeRate(numerator, denominator)}
 }
 
+// Val returns the fee rate in sat/kvb.
+//
+// NOTE: This method is provided for backward compatibility with legacy APIs
+// that expect a raw integer fee rate. New code should use the btcunit types
+// directly.
+func (s SatPerKVByte) Val() btcutil.Amount {
+	return s.FeeForKVByte(NewKVByte(1))
+}
+
 // String returns a human-readable string of the fee rate.
 func (s SatPerKVByte) String() string {
 	// Calculate the fee rate in sat/kvb from the canonical sat/kwu.
@@ -352,6 +361,15 @@ func CalcSatPerKWeight(fee btcutil.Amount, kwu KWeightUnit) SatPerKWeight {
 	denominator := kwu.wu
 
 	return SatPerKWeight{newBaseFeeRate(numerator, denominator)}
+}
+
+// Val returns the fee rate in sat/kw.
+//
+// NOTE: This method is provided for backward compatibility with legacy APIs
+// that expect a raw integer fee rate. New code should use the btcunit types
+// directly.
+func (s SatPerKWeight) Val() btcutil.Amount {
+	return s.FeeForKWeight(NewKWeightUnit(1))
 }
 
 // String returns a human-readable string of the fee rate.

--- a/pkg/btcunit/rates.go
+++ b/pkg/btcunit/rates.go
@@ -41,16 +41,16 @@ func NewSatPerVByte(fee btcutil.Amount, vb VByte) SatPerVByte {
 	}
 }
 
-// FeePerKWeight converts the current fee rate from sat/vb to sat/kw.
-func (s SatPerVByte) FeePerKWeight() SatPerKWeight {
+// ToSatPerKWeight converts the current fee rate from sat/vb to sat/kw.
+func (s SatPerVByte) ToSatPerKWeight() SatPerKWeight {
 	vbToKwRate := big.NewRat(SatsPerKilo, blockchain.WitnessScaleFactor)
 	kwRate := new(big.Rat).Mul(s.Rat, vbToKwRate)
 
 	return SatPerKWeight{kwRate}
 }
 
-// FeePerKVByte converts the current fee rate from sat/vb to sat/kvb.
-func (s SatPerVByte) FeePerKVByte() SatPerKVByte {
+// ToSatPerKVByte converts the current fee rate from sat/vb to sat/kvb.
+func (s SatPerVByte) ToSatPerKVByte() SatPerKVByte {
 	vbToKvbRate := big.NewRat(SatsPerKilo, 1)
 	kvbRate := new(big.Rat).Mul(s.Rat, vbToKvbRate)
 
@@ -157,16 +157,16 @@ func (s SatPerKVByte) FeeForWeight(wu WeightUnit) btcutil.Amount {
 	return s.FeeForVSize(wu.ToVB())
 }
 
-// FeePerKWeight converts the current fee rate from sat/kb to sat/kw.
-func (s SatPerKVByte) FeePerKWeight() SatPerKWeight {
+// ToSatPerKWeight converts the current fee rate from sat/kb to sat/kw.
+func (s SatPerKVByte) ToSatPerKWeight() SatPerKWeight {
 	kvbToKwRate := big.NewRat(1, blockchain.WitnessScaleFactor)
 	kwRate := new(big.Rat).Mul(s.Rat, kvbToKwRate)
 
 	return SatPerKWeight{kwRate}
 }
 
-// FeePerVByte converts the current fee rate from sat/kvb to sat/vb.
-func (s SatPerKVByte) FeePerVByte() SatPerVByte {
+// ToSatPerVByte converts the current fee rate from sat/kvb to sat/vb.
+func (s SatPerKVByte) ToSatPerVByte() SatPerVByte {
 	kvbToVbRate := new(big.Rat).Quo(
 		s.Rat, new(big.Rat).SetInt64(SatsPerKilo),
 	)
@@ -264,7 +264,7 @@ func (s SatPerKWeight) FeeForWeightRoundUp(
 // FeeForVByte calculates the fee resulting from this fee rate and the given
 // size in vbytes (vb).
 func (s SatPerKWeight) FeeForVByte(vb VByte) btcutil.Amount {
-	return s.FeePerKVByte().FeeForVSize(vb)
+	return s.ToSatPerKVByte().FeeForVSize(vb)
 }
 
 // FeeForKVByte calculates the fee resulting from this fee rate and the given
@@ -273,16 +273,16 @@ func (s SatPerKWeight) FeeForKVByte(kvb KVByte) btcutil.Amount {
 	return s.FeeForVByte(kvb.ToVB())
 }
 
-// FeePerKVByte converts the current fee rate from sat/kw to sat/kb.
-func (s SatPerKWeight) FeePerKVByte() SatPerKVByte {
+// ToSatPerKVByte converts the current fee rate from sat/kw to sat/kb.
+func (s SatPerKWeight) ToSatPerKVByte() SatPerKVByte {
 	kwToKvbRate := big.NewRat(blockchain.WitnessScaleFactor, 1)
 	kwRate := new(big.Rat).Mul(s.Rat, kwToKvbRate)
 
 	return SatPerKVByte{kwRate}
 }
 
-// FeePerVByte converts the current fee rate from sat/kw to sat/vb.
-func (s SatPerKWeight) FeePerVByte() SatPerVByte {
+// ToSatPerVByte converts the current fee rate from sat/kw to sat/vb.
+func (s SatPerKWeight) ToSatPerVByte() SatPerVByte {
 	kwToVbRate := big.NewRat(blockchain.WitnessScaleFactor, SatsPerKilo)
 	vbRate := new(big.Rat).Mul(s.Rat, kwToVbRate)
 

--- a/pkg/btcunit/rates.go
+++ b/pkg/btcunit/rates.go
@@ -51,11 +51,10 @@ type baseFeeRate struct {
 }
 
 // newBaseFeeRate creates a new baseFeeRate with the given numerator and
-// denominator. It handles the zero denominator case by returning a zero fee
-// rate.
+// denominator. It panics if the denominator is zero.
 func newBaseFeeRate(numerator btcutil.Amount, denominator uint64) baseFeeRate {
 	if denominator == 0 {
-		return baseFeeRate{satsPerKWU: big.NewRat(0, 1)}
+		panic("fee rate calculation: denominator cannot be zero")
 	}
 
 	return baseFeeRate{satsPerKWU: big.NewRat(

--- a/pkg/btcunit/rates_test.go
+++ b/pkg/btcunit/rates_test.go
@@ -343,22 +343,24 @@ func TestSafeUint64ToInt64Overflow(t *testing.T) {
 	t.Parallel()
 
 	fee := btcutil.Amount(1)
-	overflowVByte := NewVByte(math.MaxInt64 + 1)
 
 	// Test NewSatPerVByte with an overflowing vbyte value.
 	// The denominator should be capped at math.MaxInt64.
+	// We manually construct the VByte to ensure wu > MaxInt64 without
+	// overflowing the constructor's internal multiplication.
+	overflowVByte := VByte{baseUnit{wu: math.MaxInt64 + 1}}
 	rateVB := NewSatPerVByte(fee, overflowVByte)
 	expectedDenom := big.NewInt(math.MaxInt64)
 	require.Zero(t, expectedDenom.Cmp(rateVB.Denom()))
 
 	// Test NewSatPerKVByte with an overflowing kvb value.
 	// The denominator should be capped at math.MaxInt64.
-	overflowKVByte := NewKVByte(math.MaxInt64 + 1)
+	overflowKVByte := KVByte{baseUnit{wu: math.MaxInt64 + 1}}
 	rateKVB := NewSatPerKVByte(fee, overflowKVByte)
 	require.Zero(t, expectedDenom.Cmp(rateKVB.Denom()))
 
 	// Test NewSatPerKWeight with an overflowing weight unit value.
-	overflowWU := NewWeightUnit(math.MaxInt64 + 1)
+	overflowWU := WeightUnit{baseUnit{wu: math.MaxInt64 + 1}}
 	rateKW := NewSatPerKWeight(fee, overflowWU)
 	require.Zero(t, expectedDenom.Cmp(rateKW.Denom()))
 }

--- a/pkg/btcunit/rates_test.go
+++ b/pkg/btcunit/rates_test.go
@@ -64,10 +64,10 @@ func TestFeeRateConversions(t *testing.T) {
 			case SatPerVByte:
 				require.True(t, tc.expectedVB.Equal(r))
 				require.True(t, tc.expectedKVB.Equal(
-					r.FeePerKVByte()),
+					r.ToSatPerKVByte()),
 				)
 				require.True(t, tc.expectedKW.Equal(
-					r.FeePerKWeight()),
+					r.ToSatPerKWeight()),
 				)
 
 				// The expected sats is the floor of the fee
@@ -80,11 +80,11 @@ func TestFeeRateConversions(t *testing.T) {
 
 			case SatPerKVByte:
 				require.True(t, tc.expectedVB.Equal(
-					r.FeePerKWeight().FeePerVByte()),
+					r.ToSatPerKWeight().ToSatPerVByte()),
 				)
 				require.True(t, tc.expectedKVB.Equal(r))
 				require.True(t, tc.expectedKW.Equal(
-					r.FeePerKWeight()),
+					r.ToSatPerKWeight()),
 				)
 				floor := new(big.Int).Div(r.Num(), r.Denom())
 				require.Equal(
@@ -94,10 +94,10 @@ func TestFeeRateConversions(t *testing.T) {
 
 			case SatPerKWeight:
 				require.True(t, tc.expectedVB.Equal(
-					r.FeePerVByte()),
+					r.ToSatPerVByte()),
 				)
 				require.True(t, tc.expectedKVB.Equal(
-					r.FeePerKVByte()),
+					r.ToSatPerKVByte()),
 				)
 				require.True(t, tc.expectedKW.Equal(r))
 				floor := new(big.Int).Div(r.Num(), r.Denom())
@@ -110,8 +110,9 @@ func TestFeeRateConversions(t *testing.T) {
 	}
 }
 
-// TestFeeRateComparisons tests the comparison methods of the fee rate types.
-func TestFeeRateComparisons(t *testing.T) {
+// TestFeeRateComparisonsVB tests the comparison methods of the SatPerVByte
+// type.
+func TestFeeRateComparisonsVB(t *testing.T) {
 	t.Parallel()
 
 	// Create a set of fee rates to compare.
@@ -149,7 +150,7 @@ func TestFeeRateComparisons(t *testing.T) {
 func TestFeeForWeightRoundUp(t *testing.T) {
 	t.Parallel()
 
-	feeRate := SatPerVByte{big.NewRat(1, 1)}.FeePerKWeight()
+	feeRate := SatPerVByte{big.NewRat(1, 1)}.ToSatPerKWeight()
 	txWeight := NewWeightUnit(674) // 674 weight units is 168.5 vb.
 
 	require.EqualValues(t, 168, feeRate.FeeForWeight(txWeight))
@@ -294,8 +295,8 @@ func TestFeeForSize(t *testing.T) {
 	require.Equal(t, btcutil.Amount(250),
 		r3.FeeForWeight(NewWeightUnit(1000)))
 
-	// Test FeePerVByte with SatPerKVByte.
-	require.True(t, r3.Equal(r1.FeePerVByte()))
+	// Test ToSatPerVByte with SatPerKVByte.
+	require.True(t, r3.Equal(r1.ToSatPerVByte()))
 
 	// Test FeeForKVByte with SatPerKVByte.
 	require.Equal(t, btcutil.Amount(1000), r1.FeeForKVByte(NewKVByte(1)))

--- a/pkg/btcunit/rates_test.go
+++ b/pkg/btcunit/rates_test.go
@@ -25,51 +25,47 @@ func TestFeeRateConversions(t *testing.T) {
 	}{
 		{
 			name:         "1 sat/vb",
-			rate:         NewSatPerVByte(1, NewVByte(1)),
-			expectedVB:   NewSatPerVByte(1, NewVByte(1)),
-			expectedKVB:  NewSatPerKVByte(1000, NewKVByte(1)),
-			expectedKW:   NewSatPerKWeight(250, NewKWeightUnit(1)),
-			expectedW:    NewSatPerWeight(1, NewWeightUnit(4)),
+			rate:         NewSatPerVByte(1),
+			expectedVB:   NewSatPerVByte(1),
+			expectedKVB:  NewSatPerKVByte(1000),
+			expectedKW:   NewSatPerKWeight(250),
+			expectedW:    CalcSatPerWeight(1, NewWeightUnit(4)),
 			expectedSats: 250,
 		},
 		{
 			name:         "1000 sat/kvb",
-			rate:         NewSatPerKVByte(1000, NewKVByte(1)),
-			expectedVB:   NewSatPerVByte(1, NewVByte(1)),
-			expectedKVB:  NewSatPerKVByte(1000, NewKVByte(1)),
-			expectedKW:   NewSatPerKWeight(250, NewKWeightUnit(1)),
-			expectedW:    NewSatPerWeight(1, NewWeightUnit(4)),
+			rate:         NewSatPerKVByte(1000),
+			expectedVB:   NewSatPerVByte(1),
+			expectedKVB:  NewSatPerKVByte(1000),
+			expectedKW:   NewSatPerKWeight(250),
+			expectedW:    CalcSatPerWeight(1, NewWeightUnit(4)),
 			expectedSats: 250,
 		},
 		{
 			name:         "250 sat/kw",
-			rate:         NewSatPerKWeight(250, NewKWeightUnit(1)),
-			expectedVB:   NewSatPerVByte(1, NewVByte(1)),
-			expectedKVB:  NewSatPerKVByte(1000, NewKVByte(1)),
-			expectedKW:   NewSatPerKWeight(250, NewKWeightUnit(1)),
-			expectedW:    NewSatPerWeight(1, NewWeightUnit(4)),
+			rate:         NewSatPerKWeight(250),
+			expectedVB:   NewSatPerVByte(1),
+			expectedKVB:  NewSatPerKVByte(1000),
+			expectedKW:   NewSatPerKWeight(250),
+			expectedW:    CalcSatPerWeight(1, NewWeightUnit(4)),
 			expectedSats: 250,
 		},
 		{
 			name:         "0.25 sat/wu",
-			rate:         NewSatPerWeight(1, NewWeightUnit(4)),
-			expectedVB:   NewSatPerVByte(1, NewVByte(1)),
-			expectedKVB:  NewSatPerKVByte(1000, NewKVByte(1)),
-			expectedKW:   NewSatPerKWeight(250, NewKWeightUnit(1)),
-			expectedW:    NewSatPerWeight(1, NewWeightUnit(4)),
+			rate:         CalcSatPerWeight(1, NewWeightUnit(4)),
+			expectedVB:   NewSatPerVByte(1),
+			expectedKVB:  NewSatPerKVByte(1000),
+			expectedKW:   NewSatPerKWeight(250),
+			expectedW:    CalcSatPerWeight(1, NewWeightUnit(4)),
 			expectedSats: 250,
 		},
 		{
-			name:        "0.11 sat/vb",
-			rate:        NewSatPerVByte(11, NewVByte(100)),
-			expectedVB:  NewSatPerVByte(11, NewVByte(100)),
-			expectedKVB: NewSatPerKVByte(110, NewKVByte(1)),
-			expectedKW: NewSatPerKWeight(
-				27500, NewKWeightUnit(1000),
-			),
-			expectedW: NewSatPerWeight(
-				11, NewWeightUnit(400),
-			),
+			name:         "0.11 sat/vb",
+			rate:         CalcSatPerVByte(11, NewVByte(100)),
+			expectedVB:   CalcSatPerVByte(11, NewVByte(100)),
+			expectedKVB:  NewSatPerKVByte(110),
+			expectedKW:   CalcSatPerKWeight(55, NewKWeightUnit(2)),
+			expectedW:    CalcSatPerWeight(11, NewWeightUnit(400)),
 			expectedSats: 27,
 		},
 	}
@@ -191,9 +187,9 @@ func TestFeeRateComparisonsVB(t *testing.T) {
 	t.Parallel()
 
 	// Create a set of fee rates to compare.
-	r1 := NewSatPerVByte(1, NewVByte(1))
-	r2 := NewSatPerVByte(2, NewVByte(1))
-	r3 := NewSatPerVByte(1, NewVByte(1))
+	r1 := NewSatPerVByte(1)
+	r2 := NewSatPerVByte(2)
+	r3 := NewSatPerVByte(1)
 
 	// Test Equal.
 	require.True(t, r1.Equal(r3))
@@ -225,51 +221,51 @@ func TestFeeRateComparisonsVB(t *testing.T) {
 func TestFeeForWeightRoundUp(t *testing.T) {
 	t.Parallel()
 
-	feeRate := NewSatPerVByte(1, NewVByte(1)).ToSatPerKWeight()
+	feeRate := NewSatPerVByte(1).ToSatPerKWeight()
 	txWeight := NewWeightUnit(674) // 674 weight units is 168.5 vb.
 
 	require.EqualValues(t, 168, feeRate.FeeForWeight(txWeight))
 	require.EqualValues(t, 169, feeRate.FeeForWeightRoundUp(txWeight))
 }
 
-// TestNewFeeRateConstructors checks that the New* fee rate constructors work
-// as expected.
+// TestNewFeeRateConstructors checks that the New* and Calc* fee rate
+// constructors work as expected.
 func TestNewFeeRateConstructors(t *testing.T) {
 	t.Parallel()
 
-	// Test NewSatPerKWeight.
+	// Test CalcSatPerKWeight.
 	fee := btcutil.Amount(1000)
 	wu := NewWeightUnit(1000)
-	expectedRate := NewSatPerKWeight(1000, NewKWeightUnit(1))
+	expectedRate := NewSatPerKWeight(1000)
 	require.Zero(
 		t, expectedRate.satsPerKWU.Cmp(
-			NewSatPerKWeight(fee, wu.ToKWU()).satsPerKWU,
+			CalcSatPerKWeight(fee, wu.ToKWU()).satsPerKWU,
 		),
 	)
 
-	// Test NewSatPerWeight.
-	expectedRateW := NewSatPerWeight(1000, NewWeightUnit(1))
+	// Test CalcSatPerWeight.
+	expectedRateW := NewSatPerWeight(1000)
 	require.Zero(
 		t, expectedRateW.satsPerKWU.Cmp(
-			NewSatPerWeight(fee, NewWeightUnit(1)).satsPerKWU,
+			CalcSatPerWeight(fee, NewWeightUnit(1)).satsPerKWU,
 		),
 	)
 
-	// Test NewSatPerVByte.
+	// Test CalcSatPerVByte.
 	vb := NewVByte(250)
-	expectedRateVB := NewSatPerVByte(4, NewVByte(1))
+	expectedRateVB := NewSatPerVByte(4)
 	require.Zero(
 		t, expectedRateVB.satsPerKWU.Cmp(
-			NewSatPerVByte(fee, vb).satsPerKWU,
+			CalcSatPerVByte(fee, vb).satsPerKWU,
 		),
 	)
 
-	// Test NewSatPerKVByte.
+	// Test CalcSatPerKVByte.
 	kvb := NewKVByte(1)
-	expectedRateKVB := NewSatPerKVByte(1000, NewKVByte(1))
+	expectedRateKVB := NewSatPerKVByte(1000)
 	require.Zero(
 		t, expectedRateKVB.satsPerKWU.Cmp(
-			NewSatPerKVByte(fee, kvb).satsPerKWU,
+			CalcSatPerKVByte(fee, kvb).satsPerKWU,
 		),
 	)
 }
@@ -279,10 +275,10 @@ func TestStringer(t *testing.T) {
 	t.Parallel()
 
 	// Create a set of fee rates to test.
-	r1 := NewSatPerVByte(1, NewVByte(1))
-	r2 := NewSatPerKVByte(1000, NewKVByte(1))
-	r3 := NewSatPerKWeight(250, NewKWeightUnit(1))
-	r4 := NewSatPerWeight(1, NewWeightUnit(4)) // 1 sat / 4 wu = 0.25 sat/wu
+	r1 := NewSatPerVByte(1)
+	r2 := NewSatPerKVByte(1000)
+	r3 := NewSatPerKWeight(250)
+	r4 := CalcSatPerWeight(1, NewWeightUnit(4)) // 0.25 sat/wu
 
 	// Test String.
 	require.Equal(t, "1.000 sat/vb", r1.String())
@@ -297,9 +293,9 @@ func TestFeeRateComparisonsKVB(t *testing.T) {
 	t.Parallel()
 
 	// Create a set of fee rates to compare.
-	r1 := NewSatPerKVByte(1, NewKVByte(1))
-	r2 := NewSatPerKVByte(2, NewKVByte(1))
-	r3 := NewSatPerKVByte(1, NewKVByte(1))
+	r1 := NewSatPerKVByte(1)
+	r2 := NewSatPerKVByte(2)
+	r3 := NewSatPerKVByte(1)
 
 	// Test Equal.
 	require.True(t, r1.Equal(r3))
@@ -332,9 +328,9 @@ func TestFeeRateComparisonsKW(t *testing.T) {
 	t.Parallel()
 
 	// Create a set of fee rates to compare.
-	r1 := NewSatPerKWeight(1, NewKWeightUnit(1))
-	r2 := NewSatPerKWeight(2, NewKWeightUnit(1))
-	r3 := NewSatPerKWeight(1, NewKWeightUnit(1))
+	r1 := NewSatPerKWeight(1)
+	r2 := NewSatPerKWeight(2)
+	r3 := NewSatPerKWeight(1)
 
 	// Test Equal.
 	require.True(t, r1.Equal(r3))
@@ -367,9 +363,9 @@ func TestFeeRateComparisonsW(t *testing.T) {
 	t.Parallel()
 
 	// Create a set of fee rates to compare.
-	r1 := NewSatPerWeight(1, NewWeightUnit(1))
-	r2 := NewSatPerWeight(2, NewWeightUnit(1))
-	r3 := NewSatPerWeight(1, NewWeightUnit(1))
+	r1 := NewSatPerWeight(1)
+	r2 := NewSatPerWeight(2)
+	r3 := NewSatPerWeight(1)
 
 	// Test Equal.
 	require.True(t, r1.Equal(r3))
@@ -402,22 +398,17 @@ func TestFeeForSize(t *testing.T) {
 
 	// Create a set of fee rates to test.
 	// r1: 1000 sat/kvb = 1000 sat / 1000 vbyte = 1 sat/vbyte.
-	// Since 1 vbyte = 4 weight units, this is 1 sat / 4 wu = 0.25 sat/wu.
-	// In canonical units: 0.25 * 1000 = 250 sat/kwu.
-	r1 := NewSatPerKVByte(1000, NewKVByte(1))
+	r1 := NewSatPerKVByte(1000)
 
 	// r2: 250 sat/kwu. This matches r1.
-	r2 := NewSatPerKWeight(250, NewKWeightUnit(1))
+	r2 := NewSatPerKWeight(250)
 
 	// r3: 1 sat/vbyte.
-	// 1 sat / 4 wu = 0.25 sat/wu = 250 sat/kwu.
-	// All three rates are equivalent.
-	r3 := NewSatPerVByte(1, NewVByte(1))
+	r3 := NewSatPerVByte(1)
 
 	// r4: 0.25 sat/wu.
 	// 0.25 sat/wu * 1000 = 250 sat/kwu.
-	// All four rates are equivalent.
-	r4 := NewSatPerWeight(1, NewWeightUnit(4))
+	r4 := CalcSatPerWeight(1, NewWeightUnit(4))
 
 	// Test FeeForVByte with r1 (1000 sat/kvb).
 	// Size: 250 vbytes.
@@ -496,56 +487,48 @@ func TestFeeForSize(t *testing.T) {
 func TestNewFeeRateConstructorsZero(t *testing.T) {
 	t.Parallel()
 
-	// Test NewSatPerKWeight with zero weight.
+	// Test CalcSatPerKWeight with zero weight.
 	fee := btcutil.Amount(1000)
 	kwu := NewKWeightUnit(0)
-	expectedRate := NewSatPerKWeight(0, NewKWeightUnit(1))
+	expectedRate := NewSatPerKWeight(0)
 	require.Zero(
 		t, expectedRate.satsPerKWU.Cmp(
-			NewSatPerKWeight(fee, kwu).satsPerKWU,
+			CalcSatPerKWeight(fee, kwu).satsPerKWU,
 		),
 	)
 
-	// Test NewSatPerVByte with zero vbytes.
+	// Test CalcSatPerVByte with zero vbytes.
 	vb := NewVByte(0)
-	expectedRateVB := NewSatPerVByte(0, NewVByte(1))
+	expectedRateVB := NewSatPerVByte(0)
 	require.Zero(
 		t, expectedRateVB.satsPerKWU.Cmp(
-			NewSatPerVByte(fee, vb).satsPerKWU,
+			CalcSatPerVByte(fee, vb).satsPerKWU,
 		),
 	)
 
-	// Test NewSatPerKVByte with zero kvbytes.
+	// Test CalcSatPerKVByte with zero kvbytes.
 	kvb := NewKVByte(0)
-	expectedRateKVB := NewSatPerKVByte(0, NewKVByte(1))
+	expectedRateKVB := NewSatPerKVByte(0)
 	require.Zero(
 		t, expectedRateKVB.satsPerKWU.Cmp(
-			NewSatPerKVByte(fee, kvb).satsPerKWU,
+			CalcSatPerKVByte(fee, kvb).satsPerKWU,
 		),
 	)
 
-	// Test NewSatPerWeight with zero weight units.
+	// Test CalcSatPerWeight with zero weight units.
 	wu := NewWeightUnit(0)
-	expectedRateW := NewSatPerWeight(0, NewWeightUnit(1))
+	expectedRateW := NewSatPerWeight(0)
 	require.Zero(
 		t, expectedRateW.satsPerKWU.Cmp(
-			NewSatPerWeight(fee, wu).satsPerKWU,
+			CalcSatPerWeight(fee, wu).satsPerKWU,
 		),
 	)
 
 	// Test zero constants.
-	require.True(t, ZeroSatPerVByte.Equal(
-		NewSatPerVByte(0, NewVByte(1)),
-	))
-	require.True(t, ZeroSatPerKVByte.Equal(
-		NewSatPerKVByte(0, NewKVByte(1)),
-	))
-	require.True(t, ZeroSatPerKWeight.Equal(
-		NewSatPerKWeight(0, NewKWeightUnit(1)),
-	))
-	require.True(t, ZeroSatPerWeight.Equal(
-		NewSatPerWeight(0, NewWeightUnit(1)),
-	))
+	require.True(t, ZeroSatPerVByte.Equal(NewSatPerVByte(0)))
+	require.True(t, ZeroSatPerKVByte.Equal(NewSatPerKVByte(0)))
+	require.True(t, ZeroSatPerKWeight.Equal(NewSatPerKWeight(0)))
+	require.True(t, ZeroSatPerWeight.Equal(NewSatPerWeight(0)))
 
 	require.Equal(t, "0.000 sat/vb", ZeroSatPerVByte.String())
 	require.Equal(t, "0.000 sat/kvb", ZeroSatPerKVByte.String())
@@ -560,29 +543,30 @@ func TestSafeUint64ToInt64Overflow(t *testing.T) {
 
 	fee := btcutil.Amount(1)
 
-	// Test NewSatPerVByte with an overflowing vbyte value.
+	// Test CalcSatPerVByte with an overflowing vbyte value.
 	// The denominator should be capped at math.MaxInt64.
 	// We manually construct the VByte to ensure wu > MaxInt64 without
 	// overflowing the constructor's internal multiplication.
 	overflowVByte := VByte{baseUnit{wu: math.MaxInt64 + 1}}
 	expectedDenom := big.NewInt(math.MaxInt64)
 
-	rateVB := NewSatPerVByte(fee, overflowVByte)
+	rateVB := CalcSatPerVByte(fee, overflowVByte)
 	require.Zero(t, expectedDenom.Cmp(rateVB.satsPerKWU.Denom()))
 
-	// Test NewSatPerKVByte with an overflowing kvb value.
+	// Test CalcSatPerKVByte with an overflowing kvb value.
 	// The denominator should be capped at math.MaxInt64.
 	overflowKVByte := KVByte{baseUnit{wu: math.MaxInt64 + 1}}
-	rateKVB := NewSatPerKVByte(fee, overflowKVByte)
+	rateKVB := CalcSatPerKVByte(fee, overflowKVByte)
 	require.Zero(t, expectedDenom.Cmp(rateKVB.satsPerKWU.Denom()))
 
-	// Test NewSatPerKWeight with an overflowing weight unit value.
+	// Test CalcSatPerKWeight with an overflowing weight unit value.
 	overflowWU := KWeightUnit{baseUnit{wu: math.MaxInt64 + 1}}
-	rateKW := NewSatPerKWeight(fee, overflowWU)
+	rateKW := CalcSatPerKWeight(fee, overflowWU)
 	require.Zero(t, expectedDenom.Cmp(rateKW.satsPerKWU.Denom()))
 
-	// Test NewSatPerWeight with an overflowing weight unit value.
+	// Test CalcSatPerWeight with an overflowing weight unit value.
 	overflowWeight := WeightUnit{baseUnit{wu: math.MaxInt64 + 1}}
-	rateW := NewSatPerWeight(fee, overflowWeight)
+	rateW := CalcSatPerWeight(fee, overflowWeight)
 	require.Zero(t, expectedDenom.Cmp(rateW.satsPerKWU.Denom()))
 }
+

--- a/pkg/btcunit/rates_test.go
+++ b/pkg/btcunit/rates_test.go
@@ -487,44 +487,33 @@ func TestFeeForSize(t *testing.T) {
 func TestNewFeeRateConstructorsZero(t *testing.T) {
 	t.Parallel()
 
-	// Test CalcSatPerKWeight with zero weight.
+	// Test CalcSatPerKWeight with zero weight should panic.
 	fee := btcutil.Amount(1000)
-	kwu := NewKWeightUnit(0)
-	expectedRate := NewSatPerKWeight(0)
-	require.Zero(
-		t, expectedRate.satsPerKWU.Cmp(
-			CalcSatPerKWeight(fee, kwu).satsPerKWU,
-		),
-	)
+	require.Panics(t, func() {
+		kwu := NewKWeightUnit(0)
+		_ = CalcSatPerKWeight(fee, kwu)
+	})
 
-	// Test CalcSatPerVByte with zero vbytes.
-	vb := NewVByte(0)
-	expectedRateVB := NewSatPerVByte(0)
-	require.Zero(
-		t, expectedRateVB.satsPerKWU.Cmp(
-			CalcSatPerVByte(fee, vb).satsPerKWU,
-		),
-	)
+	// Test CalcSatPerVByte with zero vbytes should panic.
+	require.Panics(t, func() {
+		vb := NewVByte(0)
+		_ = CalcSatPerVByte(fee, vb)
+	})
 
-	// Test CalcSatPerKVByte with zero kvbytes.
-	kvb := NewKVByte(0)
-	expectedRateKVB := NewSatPerKVByte(0)
-	require.Zero(
-		t, expectedRateKVB.satsPerKWU.Cmp(
-			CalcSatPerKVByte(fee, kvb).satsPerKWU,
-		),
-	)
+	// Test CalcSatPerKVByte with zero kvbytes should panic.
+	require.Panics(t, func() {
+		kvb := NewKVByte(0)
+		_ = CalcSatPerKVByte(fee, kvb)
+	})
 
-	// Test CalcSatPerWeight with zero weight units.
-	wu := NewWeightUnit(0)
-	expectedRateW := NewSatPerWeight(0)
-	require.Zero(
-		t, expectedRateW.satsPerKWU.Cmp(
-			CalcSatPerWeight(fee, wu).satsPerKWU,
-		),
-	)
+	// Test CalcSatPerWeight with zero weight units should panic.
+	require.Panics(t, func() {
+		wu := NewWeightUnit(0)
+		_ = CalcSatPerWeight(fee, wu)
+	})
 
 	// Test zero constants.
+	// NewSatPerVByte(0) -> Rate 0 sats / 1 vb. Valid.
 	require.True(t, ZeroSatPerVByte.Equal(NewSatPerVByte(0)))
 	require.True(t, ZeroSatPerKVByte.Equal(NewSatPerKVByte(0)))
 	require.True(t, ZeroSatPerKWeight.Equal(NewSatPerKWeight(0)))

--- a/pkg/btcunit/txsize.go
+++ b/pkg/btcunit/txsize.go
@@ -2,10 +2,35 @@ package btcunit
 
 import (
 	"fmt"
-	"math"
 
 	"github.com/btcsuite/btcd/blockchain"
 )
+
+// baseUnit stores the canonical representation of a transaction size, which is
+// weight units (wu). All other size units are derived from this.
+type baseUnit struct {
+	wu uint64
+}
+
+// ToWU converts the unit to a WeightUnit.
+func (b baseUnit) ToWU() WeightUnit {
+	return WeightUnit{b}
+}
+
+// ToVB converts the unit to a VByte.
+func (b baseUnit) ToVB() VByte {
+	return VByte{b}
+}
+
+// ToKVB converts the unit to a KVByte.
+func (b baseUnit) ToKVB() KVByte {
+	return KVByte{b}
+}
+
+// ToKWU converts the unit to a KWeightUnit.
+func (b baseUnit) ToKWU() KWeightUnit {
+	return KWeightUnit{b}
+}
 
 // WeightUnit defines a unit to express the transaction size. One weight unit
 // is 1/4_000_000 of the max block size. The tx weight is calculated using
@@ -15,86 +40,73 @@ import (
 //   - Total tx size is the transaction size in bytes serialized according
 //     #BIP144.
 type WeightUnit struct {
-	val uint64
+	// The internal size is recorded in weight units.
+	baseUnit
 }
 
-// NewWeightUnit creates a new WeightUnit from a uint64.
+// NewWeightUnit creates a new WeightUnit from a uint64 value.
 func NewWeightUnit(val uint64) WeightUnit {
-	return WeightUnit{val: val}
-}
-
-// ToVB converts a value expressed in weight units to virtual bytes.
-func (wu WeightUnit) ToVB() VByte {
-	// According to BIP141: Virtual transaction size is defined as
-	// Transaction weight / 4 (rounded up to the next integer).
-	vbytes := math.Ceil(float64(wu.val) / blockchain.WitnessScaleFactor)
-	return VByte{val: uint64(vbytes)}
+	return WeightUnit{baseUnit{wu: val}}
 }
 
 // String returns the string representation of the weight unit.
-func (wu WeightUnit) String() string {
-	return fmt.Sprintf("%d wu", wu.val)
+func (w WeightUnit) String() string {
+	return fmt.Sprintf("%d wu", w.wu)
 }
 
 // VByte defines a unit to express the transaction size. One virtual byte is
 // 1/4th of a weight unit. The tx virtual bytes is calculated using `TxWeight /
 // 4`.
 type VByte struct {
-	val uint64
+	// The internal size is recorded in weight units.
+	baseUnit
 }
 
-// NewVByte creates a new VByte from a uint64.
+// NewVByte creates a new VByte from a uint64 value.
 func NewVByte(val uint64) VByte {
-	return VByte{val: val}
-}
-
-// ToWU converts a value expressed in virtual bytes to weight units.
-func (vb VByte) ToWU() WeightUnit {
-	return WeightUnit{val: vb.val * blockchain.WitnessScaleFactor}
+	return VByte{baseUnit{wu: val * blockchain.WitnessScaleFactor}}
 }
 
 // String returns the string representation of the virtual byte.
-func (vb VByte) String() string {
-	return fmt.Sprintf("%d vb", vb.val)
+func (v VByte) String() string {
+	vbytes := (v.wu + blockchain.WitnessScaleFactor - 1) /
+		blockchain.WitnessScaleFactor
+
+	return fmt.Sprintf("%d vb", vbytes)
 }
 
 // KVByte defines a unit to express the transaction size in kilo-virtual-bytes.
 type KVByte struct {
-	val uint64
+	// The internal size is recorded in weight units.
+	baseUnit
 }
 
 // NewKVByte creates a new KVByte from a uint64.
 func NewKVByte(val uint64) KVByte {
-	return KVByte{val: val}
-}
-
-// ToVB converts a value expressed in kilo-virtual-bytes to virtual bytes.
-func (kvb KVByte) ToVB() VByte {
-	return VByte{val: kvb.val * 1000}
+	return KVByte{baseUnit{wu: val * kilo * blockchain.WitnessScaleFactor}}
 }
 
 // String returns the string representation of the kilo-virtual-byte.
-func (kvb KVByte) String() string {
-	return fmt.Sprintf("%d kvb", kvb.val)
+func (k KVByte) String() string {
+	vbytes := (k.wu + blockchain.WitnessScaleFactor - 1) /
+		blockchain.WitnessScaleFactor
+
+	return fmt.Sprintf("%d kvb", vbytes/kilo)
 }
 
 // KWeightUnit defines a unit to express the transaction size in
 // kilo-weight-units.
 type KWeightUnit struct {
-	val uint64
+	// The internal size is recorded in weight units.
+	baseUnit
 }
 
 // NewKWeightUnit creates a new KWeightUnit from a uint64.
 func NewKWeightUnit(val uint64) KWeightUnit {
-	return KWeightUnit{val: val}
-}
-
-// ToWU converts a value expressed in kilo-weight-units to weight units.
-func (kwu KWeightUnit) ToWU() WeightUnit {
-	return WeightUnit{val: kwu.val * 1000}
+	return KWeightUnit{baseUnit{wu: val * kilo}}
 }
 
 // String returns the string representation of the kilo-weight-unit.
-func (kwu KWeightUnit) String() string {
-	return fmt.Sprintf("%d kwu", kwu.val)
+func (k KWeightUnit) String() string {
+	return fmt.Sprintf("%d kwu", k.wu/kilo)
 }

--- a/pkg/btcunit/txsize.go
+++ b/pkg/btcunit/txsize.go
@@ -57,3 +57,44 @@ func (vb VByte) ToWU() WeightUnit {
 func (vb VByte) String() string {
 	return fmt.Sprintf("%d vb", vb.val)
 }
+
+// KVByte defines a unit to express the transaction size in kilo-virtual-bytes.
+type KVByte struct {
+	val uint64
+}
+
+// NewKVByte creates a new KVByte from a uint64.
+func NewKVByte(val uint64) KVByte {
+	return KVByte{val: val}
+}
+
+// ToVB converts a value expressed in kilo-virtual-bytes to virtual bytes.
+func (kvb KVByte) ToVB() VByte {
+	return VByte{val: kvb.val * 1000}
+}
+
+// String returns the string representation of the kilo-virtual-byte.
+func (kvb KVByte) String() string {
+	return fmt.Sprintf("%d kvb", kvb.val)
+}
+
+// KWeightUnit defines a unit to express the transaction size in
+// kilo-weight-units.
+type KWeightUnit struct {
+	val uint64
+}
+
+// NewKWeightUnit creates a new KWeightUnit from a uint64.
+func NewKWeightUnit(val uint64) KWeightUnit {
+	return KWeightUnit{val: val}
+}
+
+// ToWU converts a value expressed in kilo-weight-units to weight units.
+func (kwu KWeightUnit) ToWU() WeightUnit {
+	return WeightUnit{val: kwu.val * 1000}
+}
+
+// String returns the string representation of the kilo-weight-unit.
+func (kwu KWeightUnit) String() string {
+	return fmt.Sprintf("%d kwu", kwu.val)
+}

--- a/pkg/btcunit/txsize_test.go
+++ b/pkg/btcunit/txsize_test.go
@@ -19,6 +19,18 @@ func TestTxSizeConversion(t *testing.T) {
 
 	// 250 vb should be equal to 1000 wu.
 	require.Equal(t, wu, NewVByte(250).ToWU())
+
+	// Create a test kvbyte of 1 kvb.
+	kvb := NewKVByte(1)
+
+	// 1 kvb should be equal to 1000 vb.
+	require.Equal(t, NewVByte(1000), kvb.ToVB())
+
+	// Create a test kweightunit of 1 kwu.
+	kwu := NewKWeightUnit(1)
+
+	// 1 kwu should be equal to 1000 wu.
+	require.Equal(t, NewWeightUnit(1000), kwu.ToWU())
 }
 
 // TestTxSizeStringer tests the stringer methods of the tx size types.
@@ -28,8 +40,12 @@ func TestTxSizeStringer(t *testing.T) {
 	// Create a test weight of 1000 wu.
 	wu := NewWeightUnit(1000)
 	vb := NewVByte(250)
+	kvb := NewKVByte(1)
+	kwu := NewKWeightUnit(1)
 
 	// Test String.
 	require.Equal(t, "1000 wu", wu.String())
 	require.Equal(t, "250 vb", vb.String())
+	require.Equal(t, "1 kvb", kvb.String())
+	require.Equal(t, "1 kwu", kwu.String())
 }

--- a/pkg/btcunit/txsize_test.go
+++ b/pkg/btcunit/txsize_test.go
@@ -6,31 +6,109 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestBaseUnitConversions checks that the conversion methods of baseUnit are
+// correct.
+func TestBaseUnitConversions(t *testing.T) {
+	t.Parallel()
+
+	// Test data: 1000 weight units.
+	base := baseUnit{wu: 1000}
+
+	// Test ToWU: 1000 wu.
+	wu := base.ToWU()
+	require.Equal(t, uint64(1000), wu.wu)
+
+	// Test ToVByte: 1000 wu (250 vb).
+	vb := base.ToVB()
+	require.Equal(t, uint64(1000), vb.wu)
+
+	// Test ToKVByte: 1000 wu (0.25 kvb).
+	kvb := base.ToKVB()
+	require.Equal(t, uint64(1000), kvb.wu)
+
+	// Test ToKWeightUnit: 1000 wu (1 kwu).
+	kwu := base.ToKWU()
+	require.Equal(t, uint64(1000), kwu.wu)
+}
+
 // TestTxSizeConversion checks that the conversion between weight units and
 // virtual bytes is correct.
 func TestTxSizeConversion(t *testing.T) {
 	t.Parallel()
 
-	// Create a test weight of 1000 wu.
-	wu := NewWeightUnit(1000)
-
-	// 1000 wu should be equal to 250 vb.
-	require.Equal(t, NewVByte(250), wu.ToVB())
-
-	// 250 vb should be equal to 1000 wu.
-	require.Equal(t, wu, NewVByte(250).ToWU())
-
-	// Create a test kvbyte of 1 kvb.
+	// We'll use 4000 weight units (wu) as our base for testing. This is
+	// equivalent to 1000 virtual bytes (vb), 1 kilo-virtual-byte (kvb),
+	// and 4 kilo-weight-units (kwu).
+	//
+	// Initialize the same size in different units.
+	wu := NewWeightUnit(4000)
+	vb := NewVByte(1000)
 	kvb := NewKVByte(1)
+	kwu := NewKWeightUnit(4)
 
-	// 1 kvb should be equal to 1000 vb.
-	require.Equal(t, NewVByte(1000), kvb.ToVB())
+	// Check that the internal 'wu' values are consistent across different
+	// unit types representing the same size.
+	require.Equal(t, uint64(4000), wu.wu)
+	require.Equal(t, uint64(4000), vb.wu)
+	require.Equal(t, uint64(4000), kvb.wu)
+	require.Equal(t, uint64(4000), kwu.wu)
 
-	// Create a test kweightunit of 1 kwu.
-	kwu := NewKWeightUnit(1)
+	// Test conversions from WeightUnit. After conversion, the underlying
+	// weight units (wu) should remain 4000.
+	require.Equal(t, uint64(4000), wu.ToWU().wu)
+	require.Equal(t, uint64(4000), wu.ToVB().wu)
+	require.Equal(t, uint64(4000), wu.ToKVB().wu)
+	require.Equal(t, uint64(4000), wu.ToKWU().wu)
+	require.Equal(t, "4000 wu", wu.String())
 
-	// 1 kwu should be equal to 1000 wu.
-	require.Equal(t, NewWeightUnit(1000), kwu.ToWU())
+	// Test conversions from VByte. After conversion, the underlying weight
+	// units (wu) should remain 4000.
+	require.Equal(t, uint64(4000), vb.ToWU().wu)
+	require.Equal(t, uint64(4000), vb.ToVB().wu)
+	require.Equal(t, uint64(4000), vb.ToKVB().wu)
+	require.Equal(t, uint64(4000), vb.ToKWU().wu)
+	require.Equal(t, "1000 vb", vb.String())
+
+	// Test conversions from KVByte. After conversion, the underlying
+	// weight units (wu) should remain 4000.
+	require.Equal(t, uint64(4000), kvb.ToWU().wu)
+	require.Equal(t, uint64(4000), kvb.ToVB().wu)
+	require.Equal(t, uint64(4000), kvb.ToKVB().wu)
+	require.Equal(t, uint64(4000), kvb.ToKWU().wu)
+	require.Equal(t, "1 kvb", kvb.String())
+
+	// Test conversions from KWeightUnit. After conversion, the underlying
+	// weight units (wu) should remain 4000.
+	require.Equal(t, uint64(4000), kwu.ToWU().wu)
+	require.Equal(t, uint64(4000), kwu.ToVB().wu)
+	require.Equal(t, uint64(4000), kwu.ToKVB().wu)
+	require.Equal(t, uint64(4000), kwu.ToKWU().wu)
+	require.Equal(t, "4 kwu", kwu.String())
+}
+
+// TestTxSizePrecision checks that precision is preserved when converting
+// between units for values that are not perfectly divisible by the witness
+// scale factor.
+func TestTxSizePrecision(t *testing.T) {
+	t.Parallel()
+
+	// Use a weight unit value that is not divisible by 4
+	// (WitnessScaleFactor).
+	// 3999 % 4 = 3.
+	wu := NewWeightUnit(3999)
+
+	// Convert to VByte. This should wrap the same underlying wu value.
+	vb := wu.ToVB()
+	require.Equal(t, uint64(3999), vb.wu)
+
+	// Convert back to WeightUnit. Should still be 3999.
+	wu2 := vb.ToWU()
+	require.Equal(t, uint64(3999), wu2.wu)
+
+	// The string representation should still perform the rounding for
+	// display.
+	// ceil(3999 / 4) = 1000.
+	require.Equal(t, "1000 vb", vb.String())
 }
 
 // TestTxSizeStringer tests the stringer methods of the tx size types.

--- a/wallet/tx_creator_test.go
+++ b/wallet/tx_creator_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/pkg/btcunit"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/txrules"
 	"github.com/btcsuite/btcwallet/walletdb"
@@ -47,6 +48,7 @@ func TestValidateTxIntent(t *testing.T) {
 		AccountName: validAccountName,
 		KeyScope:    waddrmgr.KeyScopeBIP0086,
 	}
+	defaultFeeRate := btcunit.NewSatPerKVByte(1000)
 
 	// Define the test cases, each representing a different scenario for
 	// validating a TxIntent.
@@ -65,7 +67,7 @@ func TestValidateTxIntent(t *testing.T) {
 				ChangeSource: &ScopedAccount{
 					AccountName: defaultAccountName,
 				},
-				FeeRate: 1000,
+				FeeRate: defaultFeeRate,
 			},
 			expectedErr: nil,
 		},
@@ -80,7 +82,7 @@ func TestValidateTxIntent(t *testing.T) {
 				ChangeSource: &ScopedAccount{
 					AccountName: defaultAccountName,
 				},
-				FeeRate: 1000,
+				FeeRate: defaultFeeRate,
 			},
 			expectedErr: nil,
 		},
@@ -98,7 +100,7 @@ func TestValidateTxIntent(t *testing.T) {
 				ChangeSource: &ScopedAccount{
 					AccountName: defaultAccountName,
 				},
-				FeeRate: 1000,
+				FeeRate: defaultFeeRate,
 			},
 			expectedErr: nil,
 		},
@@ -110,7 +112,7 @@ func TestValidateTxIntent(t *testing.T) {
 				ChangeSource: &ScopedAccount{
 					AccountName: defaultAccountName,
 				},
-				FeeRate: 1000,
+				FeeRate: defaultFeeRate,
 			},
 			expectedErr: nil,
 		},
@@ -122,7 +124,7 @@ func TestValidateTxIntent(t *testing.T) {
 				ChangeSource: &ScopedAccount{
 					AccountName: defaultAccountName,
 				},
-				FeeRate: 1000,
+				FeeRate: defaultFeeRate,
 			},
 			expectedErr: ErrMissingInputs,
 		},
@@ -136,7 +138,7 @@ func TestValidateTxIntent(t *testing.T) {
 				ChangeSource: &ScopedAccount{
 					AccountName: defaultAccountName,
 				},
-				FeeRate: 1000,
+				FeeRate: defaultFeeRate,
 			},
 			expectedErr: ErrNoTxOutputs,
 		},
@@ -150,7 +152,7 @@ func TestValidateTxIntent(t *testing.T) {
 				ChangeSource: &ScopedAccount{
 					AccountName: defaultAccountName,
 				},
-				FeeRate: 1000,
+				FeeRate: defaultFeeRate,
 			},
 			expectedErr: txrules.ErrOutputIsDust,
 		},
@@ -164,7 +166,7 @@ func TestValidateTxIntent(t *testing.T) {
 				ChangeSource: &ScopedAccount{
 					AccountName: defaultAccountName,
 				},
-				FeeRate: 1000,
+				FeeRate: defaultFeeRate,
 			},
 			expectedErr: ErrManualInputsEmpty,
 		},
@@ -180,7 +182,7 @@ func TestValidateTxIntent(t *testing.T) {
 				ChangeSource: &ScopedAccount{
 					AccountName: defaultAccountName,
 				},
-				FeeRate: 1000,
+				FeeRate: defaultFeeRate,
 			},
 			expectedErr: ErrDuplicatedUtxo,
 		},
@@ -194,7 +196,7 @@ func TestValidateTxIntent(t *testing.T) {
 				ChangeSource: &ScopedAccount{
 					AccountName: defaultAccountName,
 				},
-				FeeRate: 1000,
+				FeeRate: defaultFeeRate,
 			},
 			expectedErr: ErrMissingAccountName,
 		},
@@ -210,7 +212,7 @@ func TestValidateTxIntent(t *testing.T) {
 				ChangeSource: &ScopedAccount{
 					AccountName: defaultAccountName,
 				},
-				FeeRate: 1000,
+				FeeRate: defaultFeeRate,
 			},
 			expectedErr: ErrManualInputsEmpty,
 		},
@@ -228,7 +230,7 @@ func TestValidateTxIntent(t *testing.T) {
 				ChangeSource: &ScopedAccount{
 					AccountName: defaultAccountName,
 				},
-				FeeRate: 1000,
+				FeeRate: defaultFeeRate,
 			},
 			expectedErr: ErrDuplicatedUtxo,
 		},
@@ -242,7 +244,7 @@ func TestValidateTxIntent(t *testing.T) {
 				ChangeSource: &ScopedAccount{
 					AccountName: defaultAccountName,
 				},
-				FeeRate: 1000,
+				FeeRate: defaultFeeRate,
 			},
 			expectedErr: ErrUnsupportedCoinSource,
 		},
@@ -254,7 +256,7 @@ func TestValidateTxIntent(t *testing.T) {
 				ChangeSource: &ScopedAccount{
 					AccountName: defaultAccountName,
 				},
-				FeeRate: 1000,
+				FeeRate: defaultFeeRate,
 			},
 			expectedErr: nil,
 		},
@@ -269,7 +271,7 @@ func TestValidateTxIntent(t *testing.T) {
 					AccountName: "",
 					KeyScope:    waddrmgr.KeyScopeBIP0086,
 				},
-				FeeRate: 1000,
+				FeeRate: defaultFeeRate,
 			},
 			expectedErr: ErrMissingAccountName,
 		},
@@ -284,7 +286,7 @@ func TestValidateTxIntent(t *testing.T) {
 					AccountName: defaultAccountName,
 					KeyScope:    waddrmgr.KeyScopeBIP0086,
 				},
-				FeeRate: 0,
+				FeeRate: btcunit.ZeroSatPerKVByte,
 			},
 			expectedErr: ErrMissingFeeRate,
 		},
@@ -299,7 +301,7 @@ func TestValidateTxIntent(t *testing.T) {
 					AccountName: defaultAccountName,
 					KeyScope:    waddrmgr.KeyScopeBIP0086,
 				},
-				FeeRate: DefaultMaxFeeRate + 1,
+				FeeRate: btcunit.NewSatPerKVByte(2_000_000),
 			},
 			expectedErr: ErrFeeRateTooLarge,
 		},
@@ -777,7 +779,7 @@ func TestCreatePolicyInputSource(t *testing.T) {
 	t.Parallel()
 
 	dbtx := &mockReadTx{}
-	feeRate := SatPerKVByte(1000)
+	feeRate := btcunit.NewSatPerKVByte(1000)
 
 	utxo1 := wtxmgr.Credit{
 		OutPoint: wire.OutPoint{Hash: [32]byte{1}, Index: 0},
@@ -910,7 +912,10 @@ func TestCreateInputSource(t *testing.T) {
 	unsupported := &unsupportedInputs{}
 
 	intentManual := &TxIntent{Inputs: manualInputs}
-	intentPolicy := &TxIntent{Inputs: policyInputs, FeeRate: 1000}
+	intentPolicy := &TxIntent{
+		Inputs:  policyInputs,
+		FeeRate: btcunit.NewSatPerKVByte(1000),
+	}
 	intentUnsupported := &TxIntent{Inputs: unsupported}
 
 	testCases := []struct {
@@ -1020,7 +1025,7 @@ func TestCreateTransactionSuccessManualInputs(t *testing.T) {
 			AccountName: defaultAccountName,
 			KeyScope:    waddrmgr.KeyScopeBIP0086,
 		},
-		FeeRate: 1000,
+		FeeRate: btcunit.NewSatPerKVByte(1000),
 	}
 
 	accountStore := &mockAccountStore{}
@@ -1110,7 +1115,7 @@ func TestCreateTransactionSuccessNilChangeSourceManualInputs(t *testing.T) {
 			UTXOs: []wire.OutPoint{validUTXO},
 		},
 		ChangeSource: nil,
-		FeeRate:      1000,
+		FeeRate:      btcunit.NewSatPerKVByte(1000),
 	}
 
 	accountStore := &mockAccountStore{}
@@ -1205,7 +1210,7 @@ func TestCreateTransactionSuccessNilChangeSourcePolicyInputs(t *testing.T) {
 			},
 		},
 		ChangeSource: nil,
-		FeeRate:      1000,
+		FeeRate:      btcunit.NewSatPerKVByte(1000),
 	}
 
 	accountStore := &mockAccountStore{}
@@ -1327,7 +1332,7 @@ func TestCreateTransactionAccountNotFound(t *testing.T) {
 			AccountName: "unknown",
 			KeyScope:    waddrmgr.KeyScopeBIP0086,
 		},
-		FeeRate: 1000,
+		FeeRate: btcunit.NewSatPerKVByte(1000),
 	}
 
 	accountStore := &mockAccountStore{}

--- a/wallet/tx_creator_test.go
+++ b/wallet/tx_creator_test.go
@@ -23,6 +23,9 @@ var (
 
 	// errDB is used to simulate database operation failures within tests.
 	errDB = errors.New("db error")
+
+	// defaultAccountName is the name of the default account.
+	defaultAccountName = "default"
 )
 
 // TestValidateTxIntent ensures that the validateTxIntent function returns
@@ -605,7 +608,7 @@ func TestGetEligibleUTXOs(t *testing.T) {
 	utxo := wire.OutPoint{}
 	credit := &wtxmgr.Credit{}
 	scopedAccount := &ScopedAccount{
-		AccountName: "default",
+		AccountName: defaultAccountName,
 		KeyScope:    waddrmgr.KeyScopeBIP0086,
 	}
 
@@ -1014,7 +1017,7 @@ func TestCreateTransactionSuccessManualInputs(t *testing.T) {
 			UTXOs: []wire.OutPoint{validUTXO},
 		},
 		ChangeSource: &ScopedAccount{
-			AccountName: "default",
+			AccountName: defaultAccountName,
 			KeyScope:    waddrmgr.KeyScopeBIP0086,
 		},
 		FeeRate: 1000,

--- a/wallet/tx_reader.go
+++ b/wallet/tx_reader.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"math/big"
 	"time"
 
 	"github.com/btcsuite/btcd/blockchain"
@@ -283,7 +282,7 @@ func (w *Wallet) buildBasicTxDetail(txDetails *wtxmgr.TxDetails) *TxDetail {
 		Label:        txDetails.Label,
 		ReceivedTime: txDetails.Received,
 		Weight:       safeInt64ToWeightUnit(txWeight),
-		FeeRate:      btcunit.SatPerVByte{Rat: big.NewRat(0, 1)},
+		FeeRate:      btcunit.ZeroSatPerVByte,
 	}
 }
 

--- a/wallet/tx_reader.go
+++ b/wallet/tx_reader.go
@@ -339,7 +339,7 @@ func (w *Wallet) calculateValueAndFee(details *TxDetail,
 	}
 
 	details.Fee = totalInput - totalOutput
-	details.FeeRate = btcunit.NewSatPerVByte(
+	details.FeeRate = btcunit.CalcSatPerVByte(
 		details.Fee, details.Weight.ToVB(),
 	)
 }

--- a/wallet/tx_reader_test.go
+++ b/wallet/tx_reader_test.go
@@ -280,7 +280,7 @@ func createUnminedTxDetail(t *testing.T) (*wtxmgr.TxDetails, *TxDetail) {
 		Label:         testLabel,
 		Value:         totalCredits - debitAmt,
 		Fee:           fee,
-		FeeRate:       btcunit.NewSatPerVByte(fee, weight.ToVB()),
+		FeeRate:       btcunit.CalcSatPerVByte(fee, weight.ToVB()),
 		Confirmations: 0,
 		Weight:        weight,
 		ReceivedTime:  txTime,

--- a/wallet/tx_reader_test.go
+++ b/wallet/tx_reader_test.go
@@ -5,7 +5,6 @@
 package wallet
 
 import (
-	"math/big"
 	"testing"
 	"time"
 
@@ -30,9 +29,7 @@ func TestBuildTxDetail(t *testing.T) {
 	unminedNoFeeDetails, unminedNoFeeTxDetail := createUnminedTxDetail(t)
 	unminedNoFeeDetails.Debits = nil
 	unminedNoFeeTxDetail.Fee = 0
-	unminedNoFeeTxDetail.FeeRate = btcunit.SatPerVByte{
-		Rat: big.NewRat(0, 1),
-	}
+	unminedNoFeeTxDetail.FeeRate = btcunit.ZeroSatPerVByte
 	unminedNoFeeTxDetail.Value = unminedNoFeeDetails.Credits[0].Amount +
 		unminedNoFeeDetails.Credits[1].Amount
 	unminedNoFeeTxDetail.PrevOuts[0].IsOurs = false


### PR DESCRIPTION
Introduced from #1091, I realized we are missing a few units in this package. In this PR,
- add missing `KVByte` and `KWeightUnit` and `SatPerWeight` units
- unify all calculations - we will always use `weight` as the base size and `sat/kw` as the base fee rate
- rename methods for clarity
- use the new fee rate unit in `TxIntent`