### PR TITLE
wallet: refactor WalletStore interface and add common errors

### DIFF
--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -159,6 +159,10 @@ type WalletInfo struct {
 	// seed or was created as a new wallet.
 	IsImported bool
 
+	// ManagerVersion is the version of the wallet manager that created this
+	// wallet.
+	ManagerVersion int32
+
 	// IsWatchOnly indicates whether the wallet is in watch-only mode,
 	// meaning it does not have private keys and cannot sign transactions.
 	IsWatchOnly bool
@@ -198,6 +202,10 @@ type CreateWalletParams struct {
 	// IsImported should be set to true if the wallet is being created from
 	// an existing seed.
 	IsImported bool
+
+	// ManagerVersion is the version of the wallet manager that created this
+	// wallet.
+	ManagerVersion int32
 
 	// IsWatchOnly indicates whether the wallet is being created in
 	// watch-only mode.

--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -257,24 +257,29 @@ type UpdateWalletParams struct {
 	SyncedTo *Block
 }
 
-// ChangePassphraseParams contains the parameters for changing a wallet's
-// passphrase.
-type ChangePassphraseParams struct {
+// UpdateWalletSecretsParams contains the parameters for updating a wallet's
+// secrets.
+type UpdateWalletSecretsParams struct {
 	// WalletID is the ID of the wallet to update.
 	//
 	// NOTE: uint32 is used to ensure compatibility with standard SQL
 	// databases (signed 64-bit integers).
 	WalletID uint32
 
-	// OldPassphrase is the current passphrase.
-	OldPassphrase []byte
+	// MasterPrivParams are the parameters (e.g. salt, scrypt N/R/P) used
+	// to derive the master private key.
+	MasterPrivParams []byte
 
-	// NewPassphrase is the new passphrase to set.
-	NewPassphrase []byte
+	// EncryptedCryptoPrivKey is the encrypted private crypto key, used to
+	// protect private keys in the database.
+	EncryptedCryptoPrivKey []byte
 
-	// IsPrivate specifies whether to change the private (true) or public
-	// (false) passphrase.
-	IsPrivate bool
+	// EncryptedCryptoScriptKey is the encrypted script crypto key, used to
+	// protect scripts in the database.
+	EncryptedCryptoScriptKey []byte
+
+	// EncryptedMasterHdPrivKey is the encrypted master HD private key.
+	EncryptedMasterHdPrivKey []byte
 }
 
 // --------------------

--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -37,13 +37,9 @@ type WalletStore interface {
 	// encrypted seed as a byte slice or an error if the retrieval fails.
 	GetEncryptedHDSeed(ctx context.Context, walletID uint32) ([]byte, error)
 
-	// ChangePassphrase changes the passphrase for the wallet. It takes the
-	// old and new passphrases as byte slices, and a boolean indicating
-	// whether to change the private passphrase (true) or the public
-	// passphrase (false). It returns an error if the passphrase change
-	// fails (e.g., incorrect old passphrase).
-	ChangePassphrase(ctx context.Context,
-		params ChangePassphraseParams) error
+	// UpdateWalletSecrets updates the secrets for the wallet.
+	UpdateWalletSecrets(ctx context.Context,
+		params UpdateWalletSecretsParams) error
 }
 
 // AccountStore defines the database actions for managing accounts.


### PR DESCRIPTION
## Change Description
  - Add ManagerVersion to wallet metadata and creation params so SQL-backed wallets can track the manager that produced them.
  - Replace ChangePassphrase with UpdateWalletSecrets to update all encrypted wallet secrets in one call (master params, crypto keys, HD master key), since the database does not store the passphrase.

