### PR TITLE
wallet: add store db constructors and safe-casting

### DIFF
--- a/wallet/internal/db/db_connectors_test.go
+++ b/wallet/internal/db/db_connectors_test.go
@@ -1,0 +1,116 @@
+package db
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+const testDriverName = "wallet-test-driver"
+
+var (
+	registerDriverOnce sync.Once
+	testDriver         *mockDriver
+)
+
+// newMockedTestDB returns a *sql.DB backed by a mock driver. It avoids any
+// network or disk usage, so it works well for constructor tests that only
+// need a non nil database handle. It should be used only in very simple
+// scenarios, since it does not implement real behavior and cannot confirm
+// that the issued queries works as expected.
+func newMockedTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	registerDriverOnce.Do(func() {
+		testDriver = &mockDriver{}
+		testDriver.On("Open", mock.Anything).Return(mockConn{}, nil)
+
+		sql.Register(testDriverName, testDriver)
+	})
+
+	db, err := sql.Open(testDriverName, "")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+
+	return db
+}
+
+// TestNewPostgresWalletDB checks that the PostgresWalletDB constructor
+// properly guards against nil *sql.DB inputs and wires up the queries
+// correctly.
+func TestNewPostgresWalletDB(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil db", func(t *testing.T) {
+		t.Parallel()
+
+		db, err := NewPostgresWalletDB(nil)
+		require.ErrorIs(t, err, ErrNilDB)
+		require.Nil(t, db)
+	})
+
+	t.Run("valid db", func(t *testing.T) {
+		t.Parallel()
+
+		sqlDB := newMockedTestDB(t)
+
+		db, err := NewPostgresWalletDB(sqlDB)
+		require.NoError(t, err)
+		require.NotNil(t, db)
+		require.Equal(t, sqlDB, db.db)
+		require.NotNil(t, db.queries)
+	})
+}
+
+// TestNewSQLiteWalletDB checks that the SQLiteWalletDB constructor
+// properly guards against nil *sql.DB inputs and wires up the queries
+// correctly.
+func TestNewSQLiteWalletDB(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil db", func(t *testing.T) {
+		t.Parallel()
+
+		db, err := NewSQLiteWalletDB(nil)
+		require.ErrorIs(t, err, ErrNilDB)
+		require.Nil(t, db)
+	})
+
+	t.Run("valid db", func(t *testing.T) {
+		t.Parallel()
+
+		sqlDB := newMockedTestDB(t)
+
+		db, err := NewSQLiteWalletDB(sqlDB)
+		require.NoError(t, err)
+		require.NotNil(t, db)
+		require.Equal(t, sqlDB, db.db)
+		require.NotNil(t, db.queries)
+	})
+}
+
+// mockDriver implements a bare-bones SQL driver so tests can obtain a *sql.DB
+// without depending on an external database.
+type mockDriver struct {
+	mock.Mock
+}
+
+func (m *mockDriver) Open(name string) (driver.Conn, error) {
+	args := m.Called(name)
+	conn, _ := args.Get(0).(driver.Conn)
+
+	return conn, args.Error(1)
+}
+
+// mockConn is a mock implementation of a database connection. It does not
+// implement any real behavior. Used to be returned by the mockDriver.
+type mockConn struct {
+	mock.Mock
+}

--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -2,9 +2,18 @@ package db
 
 import (
 	"context"
+	"errors"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
+)
+
+var (
+	// ErrNilDB is returned when a nil database connection pointer is
+	// provided to the wallet.
+	ErrNilDB = errors.New(
+		"wallet requires a non-nil database connection",
+	)
 )
 
 // WalletStore defines the methods for wallet-level operations.

--- a/wallet/internal/db/pg.go
+++ b/wallet/internal/db/pg.go
@@ -1,0 +1,26 @@
+package db
+
+import (
+	"database/sql"
+
+	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
+)
+
+// PostgresWalletDB is the PostgreSQL implementation of the
+// WalletStore interface.
+type PostgresWalletDB struct {
+	db      *sql.DB
+	queries *sqlcpg.Queries
+}
+
+// NewPostgresWalletDB creates a new PostgreSQL-based WalletStore.
+func NewPostgresWalletDB(db *sql.DB) (*PostgresWalletDB, error) {
+	if db == nil {
+		return nil, ErrNilDB
+	}
+
+	return &PostgresWalletDB{
+		db:      db,
+		queries: sqlcpg.New(db),
+	}, nil
+}

--- a/wallet/internal/db/safecasting.go
+++ b/wallet/internal/db/safecasting.go
@@ -1,0 +1,88 @@
+package db
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+)
+
+var (
+	// ErrCastingOverflow is returned when a value cannot be safely
+	// cast to the desired type.
+	ErrCastingOverflow = errors.New("casting overflow")
+
+	// ErrInvalidNullInt is returned when an invalid sql.NullInt is
+	// tried to be cast to an integer type.
+	ErrInvalidNullInt = errors.New("invalid NullInt")
+)
+
+// int64ToUint32 safely casts an int64 to an uint32, returning an error
+// if the value is out of range.
+func int64ToUint32(v int64) (uint32, error) {
+	if v < 0 || v > math.MaxUint32 {
+		return 0, fmt.Errorf(
+			"could not cast %d to uint32: %w",
+			v, ErrCastingOverflow,
+		)
+	}
+
+	return uint32(v), nil
+}
+
+// int64ToInt32 safely casts an int64 to an int32, returning an error
+// if the value is out of range.
+func int64ToInt32(v int64) (int32, error) {
+	if v < math.MinInt32 || v > math.MaxInt32 {
+		return 0, fmt.Errorf(
+			"could not cast %d to int32: %w",
+			v, ErrCastingOverflow,
+		)
+	}
+
+	return int32(v), nil
+}
+
+// uint32ToInt32 safely casts an uint32 to an int32, returning an error
+// if the value is out of range.
+func uint32ToInt32(v uint32) (int32, error) {
+	if v > math.MaxInt32 {
+		return 0, fmt.Errorf(
+			"could not cast %d to int32: %w",
+			v, ErrCastingOverflow,
+		)
+	}
+
+	return int32(v), nil
+}
+
+// uint32ToNullInt32 safely casts an uint32 to a sql.NullInt32, returning
+// an error if the value is out of range.
+func uint32ToNullInt32(v uint32) (sql.NullInt32, error) {
+	toInt32, err := uint32ToInt32(v)
+	if err != nil {
+		return sql.NullInt32{}, err
+	}
+
+	return sql.NullInt32{Int32: toInt32, Valid: true}, nil
+}
+
+// nullInt32ToUint32 safely casts a sql.NullInt32 to an uint32, returning
+// an error if the value is out of range or invalid.
+func nullInt32ToUint32(n sql.NullInt32) (uint32, error) {
+	if !n.Valid {
+		return 0, fmt.Errorf(
+			"could not cast invalid NullInt32 to uint32: %w",
+			ErrInvalidNullInt,
+		)
+	}
+
+	if n.Int32 < 0 {
+		return 0, fmt.Errorf(
+			"could not cast %d to uint32: %w",
+			n.Int32, ErrCastingOverflow,
+		)
+	}
+
+	return uint32(n.Int32), nil
+}

--- a/wallet/internal/db/safecasting_test.go
+++ b/wallet/internal/db/safecasting_test.go
@@ -1,0 +1,236 @@
+package db
+
+import (
+	"database/sql"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestInt64ToUint32 checks that an int64 value is converted to uint32 only
+// when it is non-negative and fits within the uint32 range. It should fail
+// loudly for any value outside those bounds.
+func TestInt64ToUint32(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		val     int64
+		want    uint32
+		wantErr bool
+	}{
+		{name: "zero", val: 0, want: 0},
+		{
+			name: "max uint32",
+			val:  int64(math.MaxUint32),
+			want: math.MaxUint32,
+		},
+		{name: "negative", val: -1, wantErr: true},
+		{
+			name:    "too large",
+			val:     int64(math.MaxUint32) + 1,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := int64ToUint32(tc.val)
+			if tc.wantErr {
+				require.ErrorIs(t, err, ErrCastingOverflow)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestInt64ToInt32 checks that an int64 value is converted to int32 only
+// when it fits within the signed 32 bit range. It should fail loudly for
+// any value outside those limits.
+func TestInt64ToInt32(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		val     int64
+		want    int32
+		wantErr bool
+	}{
+		{
+			name: "min int32",
+			val:  int64(math.MinInt32),
+			want: math.MinInt32,
+		},
+		{
+			name: "max int32",
+			val:  int64(math.MaxInt32),
+			want: math.MaxInt32,
+		},
+		{
+			name:    "below min",
+			val:     int64(math.MinInt32) - 1,
+			wantErr: true,
+		},
+		{
+			name:    "above max",
+			val:     int64(math.MaxInt32) + 1,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := int64ToInt32(tc.val)
+			if tc.wantErr {
+				require.ErrorIs(t, err, ErrCastingOverflow)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestUint32ToInt32 checks that an uint32 value is safely converted to int32
+// only when it fits within the signed 32 bit range. It should fail loudly
+// for any value that exceeds those limits.
+func TestUint32ToInt32(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		val     uint32
+		want    int32
+		wantErr bool
+	}{
+		{name: "zero", val: 0, want: 0},
+		{name: "max int32", val: math.MaxInt32, want: math.MaxInt32},
+		{
+			name:    "overflow",
+			val:     uint32(math.MaxInt32) + 1,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := uint32ToInt32(tc.val)
+			if tc.wantErr {
+				require.ErrorIs(t, err, ErrCastingOverflow)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestUint32ToNullInt32 checks that we respect the signed 32 bit limits
+// before converting an uint32 value into sql.NullInt32. It should fail
+// loudly when the value is out of range or when valid is false.
+func TestUint32ToNullInt32(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		val     uint32
+		want    sql.NullInt32
+		wantErr bool
+	}{
+		{
+			name: "zero",
+			val:  0,
+			want: sql.NullInt32{Int32: 0, Valid: true},
+		},
+		{
+			name: "max int32",
+			val:  math.MaxInt32,
+			want: sql.NullInt32{
+				Int32: math.MaxInt32,
+				Valid: true,
+			},
+		},
+		{
+			name:    "overflow",
+			val:     uint32(math.MaxInt32) + 1,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := uint32ToNullInt32(tc.val)
+			if tc.wantErr {
+				require.ErrorIs(t, err, ErrCastingOverflow)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestNullInt32ToUint32 checks that we convert a sql.NullInt32 to uint32
+// only when the value is marked as valid and fits within the uint32 range.
+// It should fail loudly for any out of range or invalid value.
+func TestNullInt32ToUint32(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		val     sql.NullInt32
+		want    uint32
+		wantErr error
+	}{
+		{
+			name: "zero",
+			val:  sql.NullInt32{Int32: 0, Valid: true},
+			want: 0,
+		},
+		{
+			name: "positive",
+			val:  sql.NullInt32{Int32: 42, Valid: true},
+			want: 42,
+		},
+		{
+			name:    "negative overflow",
+			val:     sql.NullInt32{Int32: -1, Valid: true},
+			wantErr: ErrCastingOverflow,
+		},
+		{
+			name:    "invalid null",
+			val:     sql.NullInt32{Valid: false},
+			wantErr: ErrInvalidNullInt,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := nullInt32ToUint32(tc.val)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/wallet/internal/db/sqlite.go
+++ b/wallet/internal/db/sqlite.go
@@ -1,0 +1,25 @@
+package db
+
+import (
+	"database/sql"
+
+	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
+)
+
+// SQLiteWalletDB is the SQLite implementation of the WalletStore interface.
+type SQLiteWalletDB struct {
+	db      *sql.DB
+	queries *sqlcsqlite.Queries
+}
+
+// NewSQLiteWalletDB creates a new SQLite-based WalletStore.
+func NewSQLiteWalletDB(db *sql.DB) (*SQLiteWalletDB, error) {
+	if db == nil {
+		return nil, ErrNilDB
+	}
+
+	return &SQLiteWalletDB{
+		db:      db,
+		queries: sqlcsqlite.New(db),
+	}, nil
+}


### PR DESCRIPTION
## Change Description
  - Add PostgresWalletDB and SQLiteWalletDB structures that will implement the interface methods.
  - Add overflow-safe casting helpers for int64/int32/uint32/sql.NullInt32 plus explicit errors for overflow and invalid nulls.
  
## test
`go test ./wallet/internal/db/...`