### PR TITLE
Add helper methods for `WalletController`

### DIFF
--- a/chain/bitcoind_client.go
+++ b/chain/bitcoind_client.go
@@ -3,6 +3,7 @@ package chain
 import (
 	"container/list"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -11,6 +12,8 @@ import (
 
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/gcs"
+	"github.com/btcsuite/btcd/btcutil/gcs/builder"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
@@ -24,6 +27,10 @@ var (
 	// to receive a notification for a specific item and the bitcoind client
 	// is in the middle of shutting down.
 	ErrBitcoindClientShuttingDown = errors.New("client is shutting down")
+
+	// ErrOnlyBasicFilters is an error returned when a filter type other
+	// than basic is requested.
+	ErrOnlyBasicFilters = errors.New("only basic filters are supported")
 )
 
 // BitcoindClient represents a persistent client connection to a bitcoind server
@@ -110,6 +117,56 @@ var _ Interface = (*BitcoindClient)(nil)
 // BackEnd returns the name of the driver.
 func (c *BitcoindClient) BackEnd() string {
 	return "bitcoind"
+}
+
+// GetCFilter returns a compact filter for the given block hash and filter
+// type.
+//
+// NOTE: This is part of the chain.Interface interface.
+func (c *BitcoindClient) GetCFilter(hash *chainhash.Hash,
+	filterType wire.FilterType) (*gcs.Filter, error) {
+
+	if filterType != wire.GCSFilterRegular {
+		return nil, ErrOnlyBasicFilters
+	}
+
+	// The getblockfilter RPC takes the block hash and the filter type.
+	// Filter type defaults to "basic" if omitted, but we specify it for
+	// clarity.
+	params := []json.RawMessage{
+		json.RawMessage(fmt.Sprintf("%q", hash.String())),
+		json.RawMessage(fmt.Sprintf("%q", "basic")),
+	}
+
+	resp, err := c.chainConn.client.RawRequest("getblockfilter", params)
+	if err != nil {
+		return nil, c.MapRPCErr(err)
+	}
+
+	var res struct {
+		Filter string `json:"filter"`
+		Header string `json:"header"`
+	}
+
+	err = json.Unmarshal(resp, &res)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal filter: %w", err)
+	}
+
+	filterBytes, err := hex.DecodeString(res.Filter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode filter: %w", err)
+	}
+
+	filter, err := gcs.FromNBytes(
+		builder.DefaultP, builder.DefaultM, filterBytes,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create filter from bytes: %w",
+			err)
+	}
+
+	return filter, nil
 }
 
 // GetBestBlock returns the highest block known to bitcoind.

--- a/chain/bitcoind_events_test.go
+++ b/chain/bitcoind_events_test.go
@@ -2,7 +2,6 @@ package chain
 
 import (
 	"fmt"
-	"math/rand"
 	"os/exec"
 	"testing"
 	"time"
@@ -15,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/chain/port"
 	"github.com/stretchr/testify/require"
 )
 
@@ -460,10 +460,13 @@ func setupBitcoind(t *testing.T, minerAddr string,
 	// Start a bitcoind instance and connect it to miner1.
 	tempBitcoindDir := t.TempDir()
 
-	zmqBlockHost := "ipc:///" + tempBitcoindDir + "/blocks.socket"
-	zmqTxHost := "ipc:///" + tempBitcoindDir + "/tx.socket"
+	zmqBlockPort := port.NextAvailablePort()
+	zmqTxPort := port.NextAvailablePort()
 
-	rpcPort := rand.Int()%(65536-1024) + 1024
+	zmqBlockHost := fmt.Sprintf("tcp://127.0.0.1:%d", zmqBlockPort)
+	zmqTxHost := fmt.Sprintf("tcp://127.0.0.1:%d", zmqTxPort)
+
+	rpcPort := port.NextAvailablePort()
 	bitcoind := exec.Command(
 		"bitcoind",
 		"-datadir="+tempBitcoindDir,

--- a/chain/btcd.go
+++ b/chain/btcd.go
@@ -282,6 +282,28 @@ func (c *RPCClient) Rescan(startHash *chainhash.Hash, addrs []btcutil.Address,
 	return c.Client.Rescan(startHash, addrs, flatOutpoints) // nolint:staticcheck
 }
 
+// GetCFilter returns a compact filter for the given block hash and filter
+// type. It wraps the underlying rpcclient method and converts the result to a
+// *gcs.Filter.
+func (c *RPCClient) GetCFilter(hash *chainhash.Hash,
+	filterType wire.FilterType) (*gcs.Filter, error) {
+
+	rawFilter, err := c.Client.GetCFilter(hash, filterType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get filter: %w", err)
+	}
+
+	filter, err := gcs.FromNBytes(
+		builder.DefaultP, builder.DefaultM, rawFilter.Data,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create filter from bytes: %w",
+			err)
+	}
+
+	return filter, nil
+}
+
 // WaitForShutdown blocks until both the client has finished disconnecting
 // and all handlers have exited.
 func (c *RPCClient) WaitForShutdown() {
@@ -332,7 +354,9 @@ func (c *RPCClient) FilterBlocks(
 	// the filter returns a positive match, the full block is then requested
 	// and scanned for addresses using the block filterer.
 	for i, blk := range req.Blocks {
-		rawFilter, err := c.GetCFilter(&blk.Hash, wire.GCSFilterRegular)
+		rawFilter, err := c.Client.GetCFilter(
+			&blk.Hash, wire.GCSFilterRegular,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/chain/interface.go
+++ b/chain/interface.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/gcs"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/wire"
@@ -40,6 +41,8 @@ type Interface interface {
 	GetBlockHash(int64) (*chainhash.Hash, error)
 	GetBlockHeader(*chainhash.Hash) (*wire.BlockHeader, error)
 	IsCurrent() bool
+	GetCFilter(hash *chainhash.Hash,
+		filterType wire.FilterType) (*gcs.Filter, error)
 	FilterBlocks(*FilterBlocksRequest) (*FilterBlocksResponse, error)
 	BlockStamp() (*waddrmgr.BlockStamp, error)
 	SendRawTransaction(*wire.MsgTx, bool) (*chainhash.Hash, error)

--- a/chain/jitter_test.go
+++ b/chain/jitter_test.go
@@ -91,8 +91,8 @@ func TestJitterTicker(t *testing.T) {
 		// Tick duration should be between 80ms and 120ms.
 		require.True(t, diff >= 80*time.Millisecond, "diff: %v", diff)
 
-		// We give 1ms more to account for the time it takes to run the
+		// We give 5ms more to account for the time it takes to run the
 		// code.
-		require.True(t, diff < 121*time.Millisecond, "diff: %v", diff)
+		require.Less(t, diff, 125*time.Millisecond, "diff: %v", diff)
 	}
 }

--- a/chain/neutrino.go
+++ b/chain/neutrino.go
@@ -215,6 +215,22 @@ func (s *NeutrinoClient) IsCurrent() bool {
 	return s.CS.IsCurrent()
 }
 
+// GetCFilter returns a compact filter for the given block hash and filter
+// type.
+//
+// NOTE: This is part of the chain.Interface interface.
+func (s *NeutrinoClient) GetCFilter(blockHash *chainhash.Hash,
+	filterType wire.FilterType) (*gcs.Filter, error) {
+
+	filter, err := s.CS.GetCFilter(*blockHash, filterType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get filter from "+
+			"neutrino: %w", err)
+	}
+
+	return filter, nil
+}
+
 // SendRawTransaction replicates the RPC client's SendRawTransaction command.
 func (s *NeutrinoClient) SendRawTransaction(tx *wire.MsgTx, allowHighFees bool) (
 	*chainhash.Hash, error) {

--- a/chain/port/port.go
+++ b/chain/port/port.go
@@ -1,0 +1,149 @@
+package port
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+)
+
+const (
+	// defaultTimeout is the default timeout that is used for the wait
+	// package.
+	defaultTimeout = 30 * time.Second
+
+	// ListenerFormat is the format string that is used to generate local
+	// listener addresses.
+	ListenerFormat = "127.0.0.1:%d"
+
+	// defaultNodePort is the start of the range for listening ports of
+	// harness nodes. Ports are monotonically increasing starting from this
+	// number and are determined by the results of NextAvailablePort().
+	defaultNodePort int = 10000
+
+	// uniquePortFile is the name of the file that is used to store the
+	// last port that was used by a node. This is used to make sure that
+	// the same port is not used by multiple nodes at the same time. The
+	// file is located in the temp directory of a system.
+	uniquePortFile = "rpctest-port"
+)
+
+var (
+	// portFileMutex is a mutex that is used to make sure that the port file
+	// is not accessed by multiple goroutines of the same process at the
+	// same time. This is used in conjunction with the lock file to make
+	// sure that the port file is not accessed by multiple processes at the
+	// same time either. So the lock file is to guard between processes and
+	// the mutex is to guard between goroutines of the same process.
+	portFileMutex sync.Mutex
+)
+
+// NextAvailablePort returns the first port that is available for listening by a
+// new node, using a lock file to make sure concurrent access for parallel tasks
+// on the same system don't re-use the same port.
+func NextAvailablePort() int {
+	portFileMutex.Lock()
+	defer portFileMutex.Unlock()
+
+	lockFile := filepath.Join(os.TempDir(), uniquePortFile+".lock")
+	timeout := time.After(defaultTimeout)
+
+	var (
+		lockFileHandle *os.File
+		err            error
+	)
+	for {
+		// Attempt to acquire the lock file. If it already exists, wait
+		// for a bit and retry.
+		lockFileHandle, err = os.OpenFile(
+			lockFile, os.O_CREATE|os.O_EXCL, 0600,
+		)
+		if err == nil {
+			// Lock acquired.
+			break
+		}
+
+		// Wait for a bit and retry.
+		select {
+		case <-timeout:
+			panic("timeout waiting for lock file")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	// Release the lock file when we're done.
+	defer func() {
+		// Always close file first, Windows won't allow us to remove it
+		// otherwise.
+		_ = lockFileHandle.Close()
+
+		err := os.Remove(lockFile)
+		if err != nil {
+			panic(fmt.Errorf("couldn't remove lock file: %w", err))
+		}
+	}()
+
+	portFile := filepath.Join(os.TempDir(), uniquePortFile)
+
+	port, err := os.ReadFile(portFile)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			panic(fmt.Errorf("error reading port file: %w", err))
+		}
+
+		port = []byte(strconv.Itoa(defaultNodePort))
+	}
+
+	lastPort, err := strconv.Atoi(string(port))
+	if err != nil {
+		panic(fmt.Errorf("error parsing port: %w", err))
+	}
+
+	// We take the next one.
+	lastPort++
+	for lastPort < 65535 {
+		// If there are no errors while attempting to listen on this
+		// port, close the socket and return it as available. While it
+		// could be the case that some other process picks up this port
+		// between the time the socket is closed, and it's reopened in
+		// the harness node, in practice in CI servers this seems much
+		// less likely than simply some other process already being
+		// bound at the start of the tests.
+		addr := fmt.Sprintf(ListenerFormat, lastPort)
+
+		l, err := net.Listen("tcp4", addr)
+		if err == nil {
+			err := l.Close()
+			if err == nil {
+				err := os.WriteFile(
+					portFile,
+					[]byte(strconv.Itoa(lastPort)), 0600,
+				)
+				if err != nil {
+					panic(fmt.Errorf("error updating "+
+						"port file: %w", err))
+				}
+
+				return lastPort
+			}
+		}
+
+		lastPort++
+
+		// Start from the beginning if we reached the end of the port
+		// range. We need to do this because the lock file now is
+		// persistent across runs on the same machine during the same
+		// boot/uptime cycle. So in order to make this work on
+		// developer's machines, we need to reset the port to the
+		// default value when we reach the end of the range.
+		if lastPort == 65535 {
+			lastPort = defaultNodePort
+		}
+	}
+
+	// No ports available? Must be a mistake.
+	panic("no ports available for listening")
+}

--- a/waddrmgr/scoped_manager_test.go
+++ b/waddrmgr/scoped_manager_test.go
@@ -1,0 +1,303 @@
+package waddrmgr
+
+import (
+	"math"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/hdkeychain"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeriveAddrs verifies that DeriveAddrs correctly derives addresses using
+// in-memory state, producing the same results as database-backed derivation.
+func TestDeriveAddrs(t *testing.T) {
+	t.Parallel()
+
+	// Initialize a new address manager with a clean database for testing.
+	teardown, db, mgr := setupManager(t)
+	t.Cleanup(teardown)
+
+	// Unlock the manager to allow full functionality, although DeriveAddrs
+	// works without unlocking (tested separately). We unlock here to
+	// ensure DeriveFromKeyPath (the baseline) has access to private keys
+	// if needed by its internal logic.
+	err := walletdb.View(db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+		return mgr.Unlock(ns, privPassphrase)
+	})
+	require.NoError(t, err)
+
+	// Fetch the default BIP0044 scoped manager.
+	scope := KeyScopeBIP0044
+	acctStore, err := mgr.FetchScopedKeyManager(scope)
+	require.NoError(t, err)
+
+	// Cast to the concrete type to access the method under test.
+	scopedMgr, ok := acctStore.(*ScopedKeyManager)
+	require.True(t, ok, "expected *ScopedKeyManager")
+
+	account := uint32(DefaultAccountNum)
+
+	// Pre-load account into cache (required for DeriveAddrs).
+	err = walletdb.View(db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+		_, err := scopedMgr.AccountProperties(ns, account)
+
+		return err
+	})
+	require.NoError(t, err)
+
+	// NOTE: We define it here instead of using anonymous struct as this
+	// struct is needed for the `assertDBCorrectness`.
+	type testCase struct {
+		name       string
+		branch     uint32
+		startIndex uint32
+		count      uint32
+	}
+
+	// We define a set of test cases covering different branches
+	// (internal/external) and index ranges to ensure robust derivation. We
+	// also test large batches to verify performance and correctness at
+	// scale.
+	tests := []testCase{
+		{
+			name:       "External Branch, Index 0-4",
+			branch:     ExternalBranch,
+			startIndex: 0,
+			count:      5,
+		},
+		{
+			name:       "Internal Branch, Index 10-14",
+			branch:     InternalBranch,
+			startIndex: 10,
+			count:      5,
+		},
+		{
+			name:       "Large Batch",
+			branch:     ExternalBranch,
+			startIndex: 100,
+			count:      50,
+		},
+		{
+			name:       "Single Address",
+			branch:     ExternalBranch,
+			startIndex: 1000,
+			count:      1,
+		},
+		{
+			name:       "Zero Addresses",
+			branch:     ExternalBranch,
+			startIndex: 0,
+			count:      0,
+		},
+	}
+
+	accountNum := hdkeychain.HardenedKeyStart + account
+
+	// assertDBCorrectness is a helper closure that verifies the results
+	// returned by DeriveAddrs against the baseline DeriveFromKeyPath
+	// method. This ensures that the in-memory derivation logic produces
+	// identical addresses and scripts as the database-backed logic.
+	assertDBCorrectness := func(t *testing.T, tc testCase,
+		addrs []btcutil.Address) {
+
+		t.Helper()
+
+		err = walletdb.View(db, func(tx walletdb.ReadTx) error {
+			ns := tx.ReadBucket(waddrmgrNamespaceKey)
+
+			for i := range tc.count {
+				index := tc.startIndex + i
+
+				// Construct the derivation path for the
+				// baseline check.
+				path := DerivationPath{
+					InternalAccount: account,
+					Account:         accountNum,
+					Branch:          tc.branch,
+					Index:           index,
+				}
+
+				// Derive using the standard DB-backed method.
+				managedAddr, err := scopedMgr.DeriveFromKeyPath(
+					ns, path,
+				)
+				require.NoError(t, err)
+
+				// Compare the resulting address string.
+				expectedAddr := managedAddr.Address()
+				require.Equal(t, expectedAddr.String(),
+					addrs[i].String(), "Address mismatch "+
+						"at index %d", index)
+
+				// Compare the resulting script.
+				require.Equal(t, expectedAddr.ScriptAddress(),
+					addrs[i].ScriptAddress())
+			}
+
+			return nil
+		})
+		require.NoError(t, err)
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Call the new in-memory derivation method. This
+			// should return the derived addresses and scripts
+			// without further DB access.
+			addrs, scripts, err := scopedMgr.DeriveAddrs(
+				account, tc.branch, tc.startIndex, tc.count,
+			)
+			require.NoError(t, err)
+			require.Len(t, addrs, int(tc.count))
+			require.Len(t, scripts, int(tc.count))
+
+			// Verify the results against the established,
+			// database-backed DeriveFromKeyPath method to ensure
+			// correctness.
+			assertDBCorrectness(t, tc, addrs)
+		})
+	}
+}
+
+// TestDeriveAddrsLocked verifies that DeriveAddrs works even when the wallet
+// is locked (using extended public keys).
+func TestDeriveAddrsLocked(t *testing.T) {
+	t.Parallel()
+
+	// Initialize the manager. By default, it is locked.
+	teardown, db, mgr := setupManager(t)
+	t.Cleanup(teardown)
+
+	// Confirm the manager is indeed locked.
+	require.True(t, mgr.IsLocked())
+
+	scope := KeyScopeBIP0044
+	acctStore, err := mgr.FetchScopedKeyManager(scope)
+	require.NoError(t, err)
+
+	scopedMgr, ok := acctStore.(*ScopedKeyManager)
+	require.True(t, ok)
+
+	// Pre-load the account into the cache using a read-only transaction.
+	// AccountProperties only needs public keys, so it works while locked.
+	err = walletdb.View(db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+		_, err := scopedMgr.AccountProperties(ns, DefaultAccountNum)
+
+		return err
+	})
+	require.NoError(t, err)
+
+	// Attempt to derive addresses while locked. This should succeed
+	// because it uses the cached extended public keys.
+	addrs, _, err := scopedMgr.DeriveAddrs(
+		DefaultAccountNum, ExternalBranch, 0, 5,
+	)
+
+	// Verify success and result count.
+	require.NoError(t, err, "DeriveAddrs should succeed when locked")
+	require.Len(t, addrs, 5)
+}
+
+// TestDeriveAddrsOverflow verifies that DeriveAddrs returns an error when the
+// requested range of child indexes overflows uint32.
+func TestDeriveAddrsOverflow(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Setup the environment with a zero-valued ScopedKeyManager,
+	// as the overflow check is performed before any other logic or state
+	// access.
+	var s ScopedKeyManager
+
+	// Act: Execute the function under test with a range that triggers a
+	// uint32 overflow (startIndex + count > math.MaxUint32).
+	startIndex := uint32(math.MaxUint32 - 5)
+	count := uint32(10)
+	_, _, err := s.DeriveAddrs(0, 0, startIndex, count)
+
+	// Assert: Verify that the expected overflow error is returned.
+	require.Error(t, err)
+	require.True(t, IsError(err, ErrTooManyAddresses))
+	require.Contains(t, err.Error(), "child index overflow")
+}
+
+// TestDeriveAddr verifies that DeriveAddr correctly derives a single address
+// using in-memory state.
+func TestDeriveAddr(t *testing.T) {
+	t.Parallel()
+
+	// Initialize manager.
+	teardown, db, mgr := setupManager(t)
+	t.Cleanup(teardown)
+
+	// Unlock manager to allow full functionality.
+	err := walletdb.View(db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+		return mgr.Unlock(ns, privPassphrase)
+	})
+	require.NoError(t, err)
+
+	// Fetch scoped manager.
+	scope := KeyScopeBIP0044
+	acctStore, err := mgr.FetchScopedKeyManager(scope)
+	require.NoError(t, err)
+
+	scopedMgr, ok := acctStore.(*ScopedKeyManager)
+	require.True(t, ok)
+
+	account := uint32(DefaultAccountNum)
+
+	// Pre-load account into cache.
+	err = walletdb.View(db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+		_, err := scopedMgr.AccountProperties(ns, account)
+
+		return err
+	})
+	require.NoError(t, err)
+
+	// Define test parameters.
+	branch := ExternalBranch
+	index := uint32(0)
+
+	// Call DeriveAddr (In-Memory).
+	addr, script, err := scopedMgr.DeriveAddr(account, branch, index)
+	require.NoError(t, err)
+
+	// Verify against Baseline (DeriveFromKeyPath via DB).
+	err = walletdb.View(db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+
+		path := DerivationPath{
+			InternalAccount: account,
+			Account:         hdkeychain.HardenedKeyStart + account,
+			Branch:          branch,
+			Index:           index,
+		}
+
+		managedAddr, err := scopedMgr.DeriveFromKeyPath(ns, path)
+		require.NoError(t, err)
+
+		// Compare address string and script hash.
+		require.Equal(t, managedAddr.Address().String(),
+			addr.String())
+		require.Equal(t, managedAddr.Address().ScriptAddress(),
+			addr.ScriptAddress())
+
+		// Verify returned script matches expected P2PKH script.
+		expectedScript, _ := txscript.PayToAddrScript(
+			managedAddr.Address(),
+		)
+		require.Equal(t, expectedScript, script)
+
+		return nil
+	})
+	require.NoError(t, err)
+}

--- a/wallet/chain_mock_test.go
+++ b/wallet/chain_mock_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/gcs"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/chain"
@@ -109,6 +110,12 @@ func (m *mockChainClient) GetMempool() (map[chainhash.Hash]*wire.MsgTx, error) {
 
 func (m *mockChainClient) IsCurrent() bool {
 	return false
+}
+
+func (m *mockChainClient) GetCFilter(hash *chainhash.Hash,
+	filterType wire.FilterType) (*gcs.Filter, error) {
+
+	return nil, ErrNotImplemented
 }
 
 func (m *mockChainClient) FilterBlocks(*chain.FilterBlocksRequest) (

--- a/wallet/mock_test.go
+++ b/wallet/mock_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/gcs"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -854,6 +855,18 @@ func (m *mockChain) GetBlockHeader(
 func (m *mockChain) IsCurrent() bool {
 	args := m.Called()
 	return args.Bool(0)
+}
+
+// GetCFilter implements the chain.Interface interface.
+func (m *mockChain) GetCFilter(hash *chainhash.Hash,
+	filterType wire.FilterType) (*gcs.Filter, error) {
+
+	args := m.Called(hash, filterType)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*gcs.Filter), args.Error(1)
 }
 
 // FilterBlocks implements the chain.Interface interface.


### PR DESCRIPTION
In this PR,
- added `DeriveAddr` and `DeriveAddrs` for in-memory derivation
- exposed exsiting `GetCFilter` on `chain.Interface`, which will be used for fast querying
- copied `port.go` from `lnd` into `chain/port` to fix port collision in unit tests