### PR TITLE
wallet: add P2A and P2PK address types

### DIFF
--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -36,11 +36,18 @@ type KeyScope struct {
 type AddressType uint8
 
 const (
+	// RawPubKey represents a pay-to-pubkey (P2PK) address.
+	RawPubKey AddressType = iota
+
 	// PubKeyHash represents a pay-to-pubkey-hash (P2PKH) address.
-	PubKeyHash AddressType = iota
+	PubKeyHash
 
 	// ScriptHash represents a pay-to-script-hash (P2SH) address.
 	ScriptHash
+
+	// NestedWitnessPubKey represents a P2WKH output nested within a P2SH
+	// address.
+	NestedWitnessPubKey
 
 	// WitnessPubKey represents a pay-to-witness-pubkey-hash (P2WKH)
 	// address.
@@ -50,12 +57,11 @@ const (
 	// address.
 	WitnessScript
 
-	// NestedWitnessPubKey represents a P2WKH output nested within a P2SH
-	// address.
-	NestedWitnessPubKey
-
 	// TaprootPubKey represents a pay-to-taproot (P2TR) address.
 	TaprootPubKey
+
+	// Anchor represents a pay-to-anchor (P2A) address.
+	Anchor
 )
 
 // AddressTypeInfo groups an address type identifier with its readable

--- a/wallet/internal/db/itest/address_types_store_test.go
+++ b/wallet/internal/db/itest/address_types_store_test.go
@@ -18,12 +18,14 @@ func TestListAddressTypes(t *testing.T) {
 	require.NoError(t, err)
 
 	want := []db.AddressTypeInfo{
+		{Type: db.RawPubKey, Description: "P2PK"},
 		{Type: db.PubKeyHash, Description: "P2PKH"},
 		{Type: db.ScriptHash, Description: "P2SH"},
+		{Type: db.NestedWitnessPubKey, Description: "P2SH-P2WPKH"},
 		{Type: db.WitnessPubKey, Description: "P2WPKH"},
 		{Type: db.WitnessScript, Description: "P2WSH"},
-		{Type: db.NestedWitnessPubKey, Description: "P2SH-P2WPKH"},
 		{Type: db.TaprootPubKey, Description: "P2TR"},
+		{Type: db.Anchor, Description: "P2A"},
 	}
 
 	require.Equal(t, want, types)
@@ -41,48 +43,62 @@ func TestGetAddressType(t *testing.T) {
 		{
 			id: 0,
 			wantResult: &db.AddressTypeInfo{
+				Type:        db.RawPubKey,
+				Description: "P2PK",
+			},
+		},
+		{
+			id: 1,
+			wantResult: &db.AddressTypeInfo{
 				Type:        db.PubKeyHash,
 				Description: "P2PKH",
 			},
 		},
 		{
-			id: 1,
+			id: 2,
 			wantResult: &db.AddressTypeInfo{
 				Type:        db.ScriptHash,
 				Description: "P2SH",
 			},
 		},
 		{
-			id: 2,
-			wantResult: &db.AddressTypeInfo{
-				Type:        db.WitnessPubKey,
-				Description: "P2WPKH",
-			},
-		},
-		{
 			id: 3,
-			wantResult: &db.AddressTypeInfo{
-				Type:        db.WitnessScript,
-				Description: "P2WSH",
-			},
-		},
-		{
-			id: 4,
 			wantResult: &db.AddressTypeInfo{
 				Type:        db.NestedWitnessPubKey,
 				Description: "P2SH-P2WPKH",
 			},
 		},
 		{
+			id: 4,
+			wantResult: &db.AddressTypeInfo{
+				Type:        db.WitnessPubKey,
+				Description: "P2WPKH",
+			},
+		},
+		{
 			id: 5,
+			wantResult: &db.AddressTypeInfo{
+				Type:        db.WitnessScript,
+				Description: "P2WSH",
+			},
+		},
+		{
+			id: 6,
 			wantResult: &db.AddressTypeInfo{
 				Type:        db.TaprootPubKey,
 				Description: "P2TR",
 			},
 		},
 		{
+			id: 7,
+			wantResult: &db.AddressTypeInfo{
+				Type:        db.Anchor,
+				Description: "P2A",
+			},
+		},
+		{
 			// Means last valid plus one, so it should be invalid
-			id:      6,
+			id:      8,
 			wantErr: db.ErrAddressTypeNotFound,
 		},
 		{

--- a/wallet/internal/db/migrations/postgres/000003_address_types.up.sql
+++ b/wallet/internal/db/migrations/postgres/000003_address_types.up.sql
@@ -24,9 +24,11 @@ ON address_types (description);
 -- These values are static and represent the Bitcoin address types.
 -- IDs MUST match the iota values in wallet/internal/db/data_types.go.
 INSERT INTO address_types (id, description) VALUES
-(0, 'P2PKH'),          -- Pay-to-PubKey-Hash
-(1, 'P2SH'),           -- Pay-to-Script-Hash
-(2, 'P2WPKH'),         -- Pay-to-Witness-PubKey-Hash
-(3, 'P2WSH'),          -- Pay-to-Witness-Script-Hash
-(4, 'P2SH-P2WPKH'),    -- Nested Witness PubKey
-(5, 'P2TR');           -- Pay-to-Taproot
+(0, 'P2PK'),           -- Pay-to-PubKey
+(1, 'P2PKH'),          -- Pay-to-PubKey-Hash
+(2, 'P2SH'),           -- Pay-to-Script-Hash
+(3, 'P2SH-P2WPKH'),    -- Nested Witness PubKey
+(4, 'P2WPKH'),         -- Pay-to-Witness-PubKey-Hash
+(5, 'P2WSH'),          -- Pay-to-Witness-Script-Hash
+(6, 'P2TR'),           -- Pay-to-Taproot
+(7, 'P2A');            -- Pay-to-Anchor

--- a/wallet/internal/db/migrations/sqlite/000003_address_types.up.sql
+++ b/wallet/internal/db/migrations/sqlite/000003_address_types.up.sql
@@ -24,9 +24,11 @@ ON address_types (description);
 -- These values are static and represent the Bitcoin address types.
 -- IDs MUST match the iota values in wallet/internal/db/data_types.go.
 INSERT INTO address_types (id, description) VALUES
-(0, 'P2PKH'),          -- Pay-to-PubKey-Hash
-(1, 'P2SH'),           -- Pay-to-Script-Hash
-(2, 'P2WPKH'),         -- Pay-to-Witness-PubKey-Hash
-(3, 'P2WSH'),          -- Pay-to-Witness-Script-Hash
-(4, 'P2SH-P2WPKH'),    -- Nested Witness PubKey
-(5, 'P2TR');           -- Pay-to-Taproot
+(0, 'P2PK'),           -- Pay-to-PubKey
+(1, 'P2PKH'),          -- Pay-to-PubKey-Hash
+(2, 'P2SH'),           -- Pay-to-Script-Hash
+(3, 'P2SH-P2WPKH'),    -- Nested Witness PubKey
+(4, 'P2WPKH'),         -- Pay-to-Witness-PubKey-Hash
+(5, 'P2WSH'),          -- Pay-to-Witness-Script-Hash
+(6, 'P2TR'),           -- Pay-to-Taproot
+(7, 'P2A');            -- Pay-to-Anchor


### PR DESCRIPTION
This PR adds two additional address types to avoid future schema migrations. The new types are `P2A` and `P2PK`, as suggested by YY in this review comment https://github.com/btcsuite/btcwallet/pull/1138#pullrequestreview-3587295552.

I intentionally did not include Silent Payment addresses for now. I think this deserves a more careful design later, since the `sp1...` address itself never appears on chain as a standard output. Instead, the sender derives a regular `bc1...` address from the silent payment address during transaction construction, which has different semantics compared to other address types stored today.