### PR TITLE
Add RPC methods for `WalletController`

### DIFF
--- a/chain/bitcoind_client.go
+++ b/chain/bitcoind_client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil/gcs"
 	"github.com/btcsuite/btcd/btcutil/gcs/builder"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/waddrmgr"
@@ -54,6 +55,15 @@ type BitcoindClient struct {
 	// chainConn is the backing client to our rescan client that contains
 	// the RPC and ZMQ connections to a bitcoind node.
 	chainConn *BitcoindConn
+
+	// batchClient is a secondary RPC client dedicated for batch requests.
+	// This client is created specifically for batch operations because the
+	// rpcclient.Client in batch mode is stateful, accumulating requests
+	// until `Send()` is called. Using a dedicated instance avoids race
+	// conditions and ensures isolation from other concurrent RPC calls
+	// made by the main `chainConn.client` or other `BitcoindClient`
+	// instances.
+	batchClient *rpcclient.Client
 
 	// bestBlock keeps track of the tip of the current best chain.
 	bestBlockMtx sync.RWMutex
@@ -602,6 +612,9 @@ func (c *BitcoindClient) Stop() {
 	// Remove this client's reference from the bitcoind connection to
 	// prevent sending notifications to it after it's been stopped.
 	c.chainConn.RemoveClient(c.id)
+
+	c.batchClient.Shutdown()
+	c.batchClient.WaitForShutdown()
 
 	c.notificationQueue.Stop()
 }
@@ -1445,4 +1458,158 @@ func (c *BitcoindClient) updateWatchedFilters(update any) {
 			c.watchedTxs[*txid] = struct{}{}
 		}
 	}
+}
+
+// GetBlockHashes returns a slice of block hashes for the given height range.
+func (c *BitcoindClient) GetBlockHashes(startHeight,
+	endHeight int64) ([]chainhash.Hash, error) {
+
+	if startHeight > endHeight {
+		return nil, fmt.Errorf("%w: start height %d, end height %d",
+			ErrInvalidParam, startHeight, endHeight)
+	}
+
+	client := c.batchClient
+	count := endHeight - startHeight + 1
+	hashes := make([]chainhash.Hash, 0, count)
+	futures := make([]rpcclient.FutureGetBlockHashResult, 0, count)
+
+	for h := startHeight; h <= endHeight; h++ {
+		futures = append(futures, client.GetBlockHashAsync(h))
+	}
+
+	err := client.Send()
+	if err != nil {
+		return nil, fmt.Errorf("batch send: %w", err)
+	}
+
+	for _, f := range futures {
+		hash, err := f.Receive()
+		if err != nil {
+			return nil, fmt.Errorf("receive block hash: %w", err)
+		}
+
+		hashes = append(hashes, *hash)
+	}
+
+	return hashes, nil
+}
+
+// GetCFilters returns a slice of filters for the given block hashes.
+func (c *BitcoindClient) GetCFilters(hashes []chainhash.Hash,
+	filterType wire.FilterType) ([]*gcs.Filter, error) {
+
+	if filterType != wire.GCSFilterRegular {
+		return nil, ErrOnlyBasicFilters
+	}
+
+	client := c.batchClient
+	filters := make([]*gcs.Filter, 0, len(hashes))
+	futures := make([]rpcclient.FutureRawResult, 0, len(hashes))
+
+	for _, hash := range hashes {
+		params := []json.RawMessage{
+			json.RawMessage(fmt.Sprintf("%q", hash.String())),
+			json.RawMessage(fmt.Sprintf("%q", "basic")),
+		}
+		futures = append(futures, client.RawRequestAsync(
+			"getblockfilter", params,
+		))
+	}
+
+	err := client.Send()
+	if err != nil {
+		return nil, fmt.Errorf("batch send: %w", err)
+	}
+
+	for _, f := range futures {
+		resp, err := f.Receive()
+		if err != nil {
+			return nil, fmt.Errorf("receive cfilter: %w", err)
+		}
+
+		var res struct {
+			Filter string `json:"filter"`
+			Header string `json:"header"`
+		}
+
+		err = json.Unmarshal(resp, &res)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshal cfilter: %w", err)
+		}
+
+		filterBytes, err := hex.DecodeString(res.Filter)
+		if err != nil {
+			return nil, fmt.Errorf("decode cfilter: %w", err)
+		}
+
+		filter, err := gcs.FromNBytes(
+			builder.DefaultP, builder.DefaultM, filterBytes,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("parse cfilter: %w", err)
+		}
+
+		filters = append(filters, filter)
+	}
+
+	return filters, nil
+}
+
+// GetBlocks returns a slice of full blocks for the given block hashes.
+func (c *BitcoindClient) GetBlocks(hashes []chainhash.Hash) (
+	[]*wire.MsgBlock, error) {
+
+	client := c.batchClient
+	blocks := make([]*wire.MsgBlock, 0, len(hashes))
+	futures := make([]rpcclient.FutureGetBlockResult, 0, len(hashes))
+
+	for _, hash := range hashes {
+		futures = append(futures, client.GetBlockAsync(&hash))
+	}
+
+	err := client.Send()
+	if err != nil {
+		return nil, fmt.Errorf("batch send: %w", err)
+	}
+
+	for _, f := range futures {
+		block, err := f.Receive()
+		if err != nil {
+			return nil, fmt.Errorf("receive block: %w", err)
+		}
+
+		blocks = append(blocks, block)
+	}
+
+	return blocks, nil
+}
+
+// GetBlockHeaders returns a slice of block headers for the given block hashes.
+func (c *BitcoindClient) GetBlockHeaders(hashes []chainhash.Hash) (
+	[]*wire.BlockHeader, error) {
+
+	client := c.batchClient
+	headers := make([]*wire.BlockHeader, 0, len(hashes))
+	futures := make([]rpcclient.FutureGetBlockHeaderResult, 0, len(hashes))
+
+	for _, hash := range hashes {
+		futures = append(futures, client.GetBlockHeaderAsync(&hash))
+	}
+
+	err := client.Send()
+	if err != nil {
+		return nil, fmt.Errorf("batch send: %w", err)
+	}
+
+	for _, f := range futures {
+		header, err := f.Receive()
+		if err != nil {
+			return nil, fmt.Errorf("receive header: %w", err)
+		}
+
+		headers = append(headers, header)
+	}
+
+	return headers, nil
 }

--- a/chain/bitcoind_events_test.go
+++ b/chain/bitcoind_events_test.go
@@ -83,6 +83,15 @@ func runBitcoindEventsTests(t *testing.T, rpcPolling bool) {
 			name:   "GetCFilter",
 			testFn: testBitcoindClientGetCFilter,
 		},
+		{
+			name: "Batch RPCs",
+			testFn: func(t *testing.T, h *rpctest.Harness,
+				bc *BitcoindClient) {
+
+				t.Helper()
+				testInterfaceBatchMethods(t, h, bc)
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/chain/bitcoind_events_test.go
+++ b/chain/bitcoind_events_test.go
@@ -553,7 +553,8 @@ func setupBitcoind(t *testing.T, minerAddr string,
 	})
 
 	// Create a bitcoind client.
-	btcClient := chainConn.NewBitcoindClient()
+	btcClient, err := chainConn.NewBitcoindClient()
+	require.NoError(t, err)
 	require.NoError(t, btcClient.Start())
 
 	t.Cleanup(func() {

--- a/chain/btcd.go
+++ b/chain/btcd.go
@@ -38,6 +38,8 @@ type RPCClient struct {
 	wg      sync.WaitGroup
 	started bool
 	quitMtx sync.Mutex
+
+	batchClient *rpcclient.Client
 }
 
 // A compile-time check to ensure that RPCClient satisfies the chain.Interface
@@ -90,7 +92,25 @@ func NewRPCClient(chainParams *chaincfg.Params, connect, user, pass string, cert
 	if err != nil {
 		return nil, err
 	}
+
+	batchConfig := *client.connConfig
+
+	// The batch client is exclusively used for batch RPC calls, which
+	// require HTTP POST mode. Therefore, we explicitly set HTTPPostMode to
+	// true and clear the Endpoint field to ensure the batch client is
+	// correctly configured, regardless of the main client's WebSocket (ws)
+	// or HTTP POST configuration.
+	batchConfig.HTTPPostMode = true
+	batchConfig.Endpoint = ""
+
+	batchClient, err := rpcclient.NewBatch(&batchConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create batch client: %w", err)
+	}
+
+	client.batchClient = batchClient
 	client.Client = rpcClient
+
 	return client, nil
 }
 
@@ -193,7 +213,24 @@ func NewRPCClientWithConfig(cfg *RPCClientConfig) (*RPCClient, error) {
 		return nil, err
 	}
 
+	batchConfig := *cfg.Conn
+
+	// The batch client is exclusively used for batch RPC calls, which
+	// require HTTP POST mode. Therefore, we explicitly set HTTPPostMode to
+	// true and clear the Endpoint field to ensure the batch client is
+	// correctly configured, regardless of the main client's WebSocket (ws)
+	// or HTTP POST configuration.
+	batchConfig.HTTPPostMode = true
+	batchConfig.Endpoint = ""
+
+	batchClient, err := rpcclient.NewBatch(&batchConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create batch client: %w", err)
+	}
+
+	client.batchClient = batchClient
 	client.Client = rpcClient
+
 	return client, nil
 }
 
@@ -243,6 +280,8 @@ func (c *RPCClient) Stop() {
 		close(c.quit)
 		c.Client.Shutdown()
 		c.Client.WaitForShutdown()
+		c.batchClient.Shutdown()
+		c.batchClient.WaitForShutdown()
 
 		if !c.started {
 			close(c.dequeueNotification)
@@ -662,4 +701,134 @@ func (c *RPCClient) SendRawTransaction(tx *wire.MsgTx,
 	}
 
 	return txid, nil
+}
+
+// GetBlockHashes returns a slice of block hashes for the given height range.
+func (c *RPCClient) GetBlockHashes(startHeight,
+	endHeight int64) ([]chainhash.Hash, error) {
+
+	if startHeight > endHeight {
+		return nil, fmt.Errorf("%w: start height %d, end height %d",
+			ErrInvalidParam, startHeight, endHeight)
+	}
+
+	count := endHeight - startHeight + 1
+	hashes := make([]chainhash.Hash, 0, count)
+	futures := make([]rpcclient.FutureGetBlockHashResult, 0, count)
+
+	for h := startHeight; h <= endHeight; h++ {
+		futures = append(futures, c.batchClient.GetBlockHashAsync(h))
+	}
+
+	err := c.batchClient.Send()
+	if err != nil {
+		return nil, fmt.Errorf("batch send: %w", err)
+	}
+
+	for _, f := range futures {
+		hash, err := f.Receive()
+		if err != nil {
+			return nil, fmt.Errorf("receive block hash: %w", err)
+		}
+
+		hashes = append(hashes, *hash)
+	}
+
+	return hashes, nil
+}
+
+// GetCFilters returns a slice of filters for the given block hashes.
+func (c *RPCClient) GetCFilters(hashes []chainhash.Hash,
+	filterType wire.FilterType) ([]*gcs.Filter, error) {
+
+	filters := make([]*gcs.Filter, 0, len(hashes))
+	futures := make([]rpcclient.FutureGetCFilterResult, 0, len(hashes))
+
+	for _, hash := range hashes {
+		futures = append(
+			futures,
+			c.batchClient.GetCFilterAsync(&hash, filterType),
+		)
+	}
+
+	err := c.batchClient.Send()
+	if err != nil {
+		return nil, fmt.Errorf("batch send: %w", err)
+	}
+
+	for _, f := range futures {
+		msgFilter, err := f.Receive()
+		if err != nil {
+			return nil, fmt.Errorf("receive cfilter: %w", err)
+		}
+
+		filter, err := gcs.FromNBytes(
+			builder.DefaultP, builder.DefaultM, msgFilter.Data,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("parse cfilter: %w", err)
+		}
+
+		filters = append(filters, filter)
+	}
+
+	return filters, nil
+}
+
+// GetBlocks returns a slice of full blocks for the given block hashes.
+func (c *RPCClient) GetBlocks(hashes []chainhash.Hash) (
+	[]*wire.MsgBlock, error) {
+
+	blocks := make([]*wire.MsgBlock, 0, len(hashes))
+	futures := make([]rpcclient.FutureGetBlockResult, 0, len(hashes))
+
+	for _, hash := range hashes {
+		futures = append(futures, c.batchClient.GetBlockAsync(&hash))
+	}
+
+	err := c.batchClient.Send()
+	if err != nil {
+		return nil, fmt.Errorf("batch send: %w", err)
+	}
+
+	for _, f := range futures {
+		block, err := f.Receive()
+		if err != nil {
+			return nil, fmt.Errorf("receive block: %w", err)
+		}
+
+		blocks = append(blocks, block)
+	}
+
+	return blocks, nil
+}
+
+// GetBlockHeaders returns a slice of block headers for the given block hashes.
+func (c *RPCClient) GetBlockHeaders(hashes []chainhash.Hash) (
+	[]*wire.BlockHeader, error) {
+
+	headers := make([]*wire.BlockHeader, 0, len(hashes))
+	futures := make([]rpcclient.FutureGetBlockHeaderResult, 0, len(hashes))
+
+	for _, hash := range hashes {
+		futures = append(
+			futures, c.batchClient.GetBlockHeaderAsync(&hash),
+		)
+	}
+
+	err := c.batchClient.Send()
+	if err != nil {
+		return nil, fmt.Errorf("batch send: %w", err)
+	}
+
+	for _, f := range futures {
+		header, err := f.Receive()
+		if err != nil {
+			return nil, fmt.Errorf("receive header: %w", err)
+		}
+
+		headers = append(headers, header)
+	}
+
+	return headers, nil
 }

--- a/chain/btcd_test.go
+++ b/chain/btcd_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/integration/rpctest"
 	"github.com/btcsuite/btcd/rpcclient"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/stretchr/testify/require"
 )
 
@@ -105,4 +106,91 @@ func TestValidateConfig(t *testing.T) {
 	// When a nil config is provided, it should return an error.
 	_, err := NewRPCClientWithConfig(nil)
 	rt.ErrorContains(err, "missing rpc config")
+}
+
+// testInterfaceBatchMethods verifies the batch fetching methods implementation
+// for a given chain.Interface client.
+func testInterfaceBatchMethods(t *testing.T, miner *rpctest.Harness,
+	client Interface) {
+
+	t.Helper()
+
+	require := require.New(t)
+
+	// Generate blocks to have a chain to query.
+	const numBlocks = 5
+
+	_, err := miner.Client.Generate(numBlocks)
+	require.NoError(err)
+
+	// Test GetBlockHashes.
+	// Query from height 1 to 3.
+	startHeight := int64(1)
+	endHeight := int64(3)
+	hashes, err := client.GetBlockHashes(startHeight, endHeight)
+	require.NoError(err, "GetBlockHashes failed")
+	require.Len(hashes, 3)
+
+	// Verify hashes match miner.
+	for i, hash := range hashes {
+		minerHash, err := miner.Client.GetBlockHash(int64(i) + 1)
+		require.NoError(err)
+		require.Equal(*minerHash, hash)
+	}
+
+	// Test GetBlocks.
+	blocks, err := client.GetBlocks(hashes)
+	require.NoError(err, "GetBlocks failed")
+	require.Len(blocks, 3)
+
+	for i, block := range blocks {
+		require.Equal(hashes[i], block.BlockHash())
+	}
+
+	// Test GetBlockHeaders.
+	headers, err := client.GetBlockHeaders(hashes)
+	require.NoError(err, "GetBlockHeaders failed")
+	require.Len(headers, 3)
+
+	for i, header := range headers {
+		require.Equal(hashes[i], header.BlockHash())
+	}
+
+	// Test GetCFilters.
+	// Note: bitcoind needs -blockfilterindex=1 for this to work, which is
+	// set in setupBitcoind.
+	// We use Eventually because filter indexing is asynchronous.
+	require.Eventually(func() bool {
+		filters, err := client.GetCFilters(
+			hashes, wire.GCSFilterRegular,
+		)
+		if err != nil {
+			return false
+		}
+
+		if len(filters) != 3 {
+			return false
+		}
+		// Verify filters are not empty/nil.
+		for _, f := range filters {
+			if f == nil || f.N() == 0 {
+				return false
+			}
+		}
+
+		return true
+	}, defaultTestTimeout, 100*time.Millisecond,
+		"GetCFilters failed or timed out")
+}
+
+// TestRPCClientBatchMethods verifies the RPCClient's batch fetching methods
+// implementation against a live btcd node.
+func TestRPCClientBatchMethods(t *testing.T) {
+	t.Parallel()
+
+	// Set up a miner (btcd node) and client.
+	miner, client := setupBtcd(t)
+
+	// Run batch method tests.
+	testInterfaceBatchMethods(t, miner, client)
 }

--- a/chain/btcd_test.go
+++ b/chain/btcd_test.go
@@ -1,12 +1,62 @@
 package chain
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/integration/rpctest"
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/stretchr/testify/require"
 )
+
+// setupBtcd starts up a btcd node with cfilters enabled and returns a client
+// wrapper of this connection.
+func setupBtcd(t *testing.T) (*rpctest.Harness, *RPCClient) {
+	t.Helper()
+
+	trickle := fmt.Sprintf("--trickleinterval=%v", 10*time.Millisecond)
+	args := []string{trickle}
+
+	miner, err := rpctest.New(
+		&chaincfg.RegressionNetParams, nil, args, "",
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, miner.SetUp(true, 1))
+
+	t.Cleanup(func() {
+		require.NoError(t, miner.TearDown())
+	})
+
+	rpcConf := miner.RPCConfig()
+	client, err := NewRPCClientWithConfig(&RPCClientConfig{
+		ReconnectAttempts: 1,
+		Chain:             &chaincfg.RegressionNetParams,
+		Conn: &rpcclient.ConnConfig{
+			Host:                 rpcConf.Host,
+			User:                 rpcConf.User,
+			Pass:                 rpcConf.Pass,
+			Certificates:         rpcConf.Certificates,
+			DisableTLS:           false,
+			DisableAutoReconnect: false,
+			DisableConnectOnNew:  true,
+			HTTPPostMode:         false,
+			Endpoint:             "ws",
+		},
+	})
+	require.NoError(t, err)
+
+	err = client.Start()
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		client.Stop()
+	})
+
+	return miner, client
+}
 
 // TestValidateConfig checks the `validate` method on the RPCClientConfig
 // behaves as expected.

--- a/chain/interface.go
+++ b/chain/interface.go
@@ -53,6 +53,32 @@ type Interface interface {
 	BackEnd() string
 	TestMempoolAccept([]*wire.MsgTx, float64) ([]*btcjson.TestMempoolAcceptResult, error)
 	MapRPCErr(err error) error
+
+	// Batching methods for optimized scanning.
+	//
+	// GetBlockHashes returns a slice of block hashes for the given height
+	// range (inclusive).
+	//
+	// NOTE: This is a batching method, designed for optimized scanning.
+	GetBlockHashes(startHeight, endHeight int64) ([]chainhash.Hash, error)
+
+	// GetCFilters returns a slice of compact filters for the given block
+	// hashes and filter type.
+	//
+	// NOTE: This is a batching method, designed for optimized scanning.
+	GetCFilters(hashes []chainhash.Hash,
+		filterType wire.FilterType) ([]*gcs.Filter, error)
+
+	// GetBlocks returns a slice of full blocks for the given block hashes.
+	//
+	// NOTE: This is a batching method, designed for optimized scanning.
+	GetBlocks(hashes []chainhash.Hash) ([]*wire.MsgBlock, error)
+
+	// GetBlockHeaders returns a slice of block headers for the given block
+	// hashes.
+	//
+	// NOTE: This is a batching method, designed for optimized scanning.
+	GetBlockHeaders(hashes []chainhash.Hash) ([]*wire.BlockHeader, error)
 }
 
 // Notification types.  These are defined here and processed from from reading

--- a/chain/mocks_test.go
+++ b/chain/mocks_test.go
@@ -66,96 +66,115 @@ func (m *mockRescanner) WaitForShutdown() {
 // mockChainService is a mock implementation of a chain service for use in
 // tests.  Only the Start, GetBlockHeader and BestBlock methods are implemented.
 type mockChainService struct {
+	mock.Mock
 }
 
 func (m *mockChainService) Start() error {
-	return nil
+	args := m.Called()
+	return args.Error(0)
 }
 
 func (m *mockChainService) BestBlock() (*headerfs.BlockStamp, error) {
-	return testBestBlock, nil
+	args := m.Called()
+	return args.Get(0).(*headerfs.BlockStamp), args.Error(1)
 }
 
 func (m *mockChainService) GetBlockHeader(
-	*chainhash.Hash) (*wire.BlockHeader, error) {
+	hash *chainhash.Hash) (*wire.BlockHeader, error) {
 
-	return &wire.BlockHeader{}, nil
+	args := m.Called(hash)
+	return args.Get(0).(*wire.BlockHeader), args.Error(1)
 }
 
-func (m *mockChainService) GetBlock(chainhash.Hash,
-	...neutrino.QueryOption) (*btcutil.Block, error) {
+func (m *mockChainService) GetBlock(
+	hash chainhash.Hash,
+	options ...neutrino.QueryOption) (*btcutil.Block, error) {
 
-	return nil, errNotImplemented
+	args := m.Called(hash, options)
+	return args.Get(0).(*btcutil.Block), args.Error(1)
 }
 
-func (m *mockChainService) GetBlockHeight(*chainhash.Hash) (int32, error) {
-	return 0, errNotImplemented
+func (m *mockChainService) GetBlockHeight(hash *chainhash.Hash) (int32, error) {
+	args := m.Called(hash)
+	return args.Get(0).(int32), args.Error(1)
 }
 
-func (m *mockChainService) GetBlockHash(int64) (*chainhash.Hash, error) {
-	return nil, errNotImplemented
+func (m *mockChainService) GetBlockHash(height int64) (*chainhash.Hash, error) {
+	args := m.Called(height)
+	return args.Get(0).(*chainhash.Hash), args.Error(1)
 }
 
 func (m *mockChainService) IsCurrent() bool {
-	return false
+	args := m.Called()
+	return args.Bool(0)
 }
 
-func (m *mockChainService) SendTransaction(*wire.MsgTx) error {
-	return errNotImplemented
+func (m *mockChainService) SendTransaction(tx *wire.MsgTx) error {
+	args := m.Called(tx)
+	return args.Error(0)
 }
 
-func (m *mockChainService) GetCFilter(chainhash.Hash,
-	wire.FilterType, ...neutrino.QueryOption) (*gcs.Filter, error) {
+func (m *mockChainService) GetCFilter(
+	hash chainhash.Hash, filterType wire.FilterType,
+	options ...neutrino.QueryOption) (*gcs.Filter, error) {
 
-	return nil, errNotImplemented
+	args := m.Called(hash, filterType, options)
+	return args.Get(0).(*gcs.Filter), args.Error(1)
 }
 
 func (m *mockChainService) GetUtxo(
-	_ ...neutrino.RescanOption) (*neutrino.SpendReport, error) {
+	opts ...neutrino.RescanOption) (*neutrino.SpendReport, error) {
 
-	return nil, errNotImplemented
+	args := m.Called(opts)
+	return args.Get(0).(*neutrino.SpendReport), args.Error(1)
 }
 
-func (m *mockChainService) BanPeer(string, banman.Reason) error {
-	return errNotImplemented
+func (m *mockChainService) BanPeer(addr string, reason banman.Reason) error {
+	args := m.Called(addr, reason)
+	return args.Error(0)
 }
 
 func (m *mockChainService) IsBanned(addr string) bool {
-	panic(errNotImplemented)
+	args := m.Called(addr)
+	return args.Bool(0)
 }
 
-func (m *mockChainService) AddPeer(*neutrino.ServerPeer) {
-	panic(errNotImplemented)
+func (m *mockChainService) AddPeer(peer *neutrino.ServerPeer) {
+	m.Called(peer)
 }
 
-func (m *mockChainService) AddBytesSent(uint64) {
-	panic(errNotImplemented)
+func (m *mockChainService) AddBytesSent(bytes uint64) {
+	m.Called(bytes)
 }
 
-func (m *mockChainService) AddBytesReceived(uint64) {
-	panic(errNotImplemented)
+func (m *mockChainService) AddBytesReceived(bytes uint64) {
+	m.Called(bytes)
 }
 
 func (m *mockChainService) NetTotals() (uint64, uint64) {
-	panic(errNotImplemented)
+	args := m.Called()
+	return args.Get(0).(uint64), args.Get(1).(uint64)
 }
 
-func (m *mockChainService) UpdatePeerHeights(*chainhash.Hash,
-	int32, *neutrino.ServerPeer,
-) {
-	panic(errNotImplemented)
+func (m *mockChainService) UpdatePeerHeights(hash *chainhash.Hash,
+	height int32, peer *neutrino.ServerPeer) {
+
+	m.Called(hash, height, peer)
 }
 
 func (m *mockChainService) ChainParams() chaincfg.Params {
-	panic(errNotImplemented)
+	args := m.Called()
+	return args.Get(0).(chaincfg.Params)
 }
 
 func (m *mockChainService) Stop() error {
-	panic(errNotImplemented)
+	args := m.Called()
+	return args.Error(0)
 }
 
-func (m *mockChainService) PeerByAddr(string) *neutrino.ServerPeer {
-	panic(errNotImplemented)
+func (m *mockChainService) PeerByAddr(addr string) *neutrino.ServerPeer {
+	args := m.Called(addr)
+	return args.Get(0).(*neutrino.ServerPeer)
 }
 
 // mockRPCClient mocks the rpcClient interface.

--- a/chain/neutrino.go
+++ b/chain/neutrino.go
@@ -579,6 +579,85 @@ func (s *NeutrinoClient) SetStartTime(startTime time.Time) {
 	s.startTime = startTime
 }
 
+// GetBlockHashes returns a slice of block hashes for the given height range.
+func (s *NeutrinoClient) GetBlockHashes(startHeight, endHeight int64) (
+	[]chainhash.Hash, error) {
+
+	if startHeight > endHeight {
+		return nil, fmt.Errorf("%w: start height %d, end height %d",
+			ErrInvalidParam, startHeight, endHeight)
+	}
+
+	count := endHeight - startHeight + 1
+
+	hashes := make([]chainhash.Hash, 0, count)
+
+	for h := startHeight; h <= endHeight; h++ {
+		hash, err := s.CS.GetBlockHash(h)
+		if err != nil {
+			return nil, fmt.Errorf("get block hash: %w", err)
+		}
+
+		hashes = append(hashes, *hash)
+	}
+
+	return hashes, nil
+}
+
+// GetCFilters returns a slice of filters for the given block hashes.
+func (s *NeutrinoClient) GetCFilters(hashes []chainhash.Hash,
+	filterType wire.FilterType) ([]*gcs.Filter, error) {
+
+	filters := make([]*gcs.Filter, 0, len(hashes))
+
+	for _, hash := range hashes {
+		filter, err := s.CS.GetCFilter(hash, filterType)
+		if err != nil {
+			return nil, fmt.Errorf("get cfilter: %w", err)
+		}
+
+		filters = append(filters, filter)
+	}
+
+	return filters, nil
+}
+
+// GetBlocks returns a slice of full blocks for the given block hashes.
+func (s *NeutrinoClient) GetBlocks(hashes []chainhash.Hash) (
+	[]*wire.MsgBlock, error) {
+
+	blocks := make([]*wire.MsgBlock, 0, len(hashes))
+
+	for _, hash := range hashes {
+		block, err := s.CS.GetBlock(hash)
+		if err != nil {
+			return nil, fmt.Errorf("get block: %w", err)
+		}
+
+		blocks = append(blocks, block.MsgBlock())
+	}
+
+	return blocks, nil
+}
+
+// GetBlockHeaders returns a slice of block headers for the given block hashes.
+func (s *NeutrinoClient) GetBlockHeaders(hashes []chainhash.Hash) (
+	[]*wire.BlockHeader, error) {
+
+	headers := make([]*wire.BlockHeader, 0, len(hashes))
+
+	for _, hash := range hashes {
+		header, err := s.CS.GetBlockHeader(&hash)
+		if err != nil {
+			return nil, fmt.Errorf("get block header: %w", err)
+		}
+
+		headers = append(headers, header)
+	}
+
+	return headers, nil
+}
+
 // onFilteredBlockConnected sends appropriate notifications to the notification
 // channel.
 func (s *NeutrinoClient) onFilteredBlockConnected(height int32,

--- a/waddrmgr/interface.go
+++ b/waddrmgr/interface.go
@@ -228,6 +228,11 @@ type AccountStore interface {
 	ExtendInternalAddresses(ns walletdb.ReadWriteBucket, account uint32,
 		count uint32) error
 
+	// ExtendAddresses ensures that all valid keys through lastIndex are
+	// derived and stored in the wallet for the specified branch.
+	ExtendAddresses(ns walletdb.ReadWriteBucket, account uint32,
+		lastIndex uint32, branch uint32) error
+
 	// MarkUsed updates the used flag for the provided address.
 	MarkUsed(ns walletdb.ReadWriteBucket, address btcutil.Address) error
 
@@ -305,4 +310,13 @@ type AccountStore interface {
 	// ImportScript imports a script.
 	ImportScript(ns walletdb.ReadWriteBucket, script []byte,
 		bs *BlockStamp) (ManagedScriptAddress, error)
+
+	// ActiveAccounts returns the account numbers of all accounts currently
+	// loaded in memory.
+	ActiveAccounts() []uint32
+
+	// DeriveAddr derives a single address for the given account, branch,
+	// and index.
+	DeriveAddr(account uint32, branch uint32, index uint32) (
+		btcutil.Address, []byte, error)
 }

--- a/waddrmgr/scoped_manager_test.go
+++ b/waddrmgr/scoped_manager_test.go
@@ -107,7 +107,7 @@ func TestDeriveAddrs(t *testing.T) {
 
 		t.Helper()
 
-		err = walletdb.View(db, func(tx walletdb.ReadTx) error {
+		err := walletdb.View(db, func(tx walletdb.ReadTx) error {
 			ns := tx.ReadBucket(waddrmgrNamespaceKey)
 
 			for i := range tc.count {

--- a/wallet/chain_mock_test.go
+++ b/wallet/chain_mock_test.go
@@ -89,6 +89,30 @@ func (m *mockChainClient) GetBlockHeader(*chainhash.Hash) (*wire.BlockHeader,
 	return m.getBlockHeader, nil
 }
 
+func (m *mockChainClient) GetBlockHashes(int64,
+	int64) ([]chainhash.Hash, error) {
+
+	return nil, ErrNotImplemented
+}
+
+func (m *mockChainClient) GetBlockHeaders(
+	[]chainhash.Hash) ([]*wire.BlockHeader, error) {
+
+	return nil, ErrNotImplemented
+}
+
+func (m *mockChainClient) GetCFilters([]chainhash.Hash, wire.FilterType) (
+	[]*gcs.Filter, error) {
+
+	return nil, ErrNotImplemented
+}
+
+func (m *mockChainClient) GetBlocks(
+	[]chainhash.Hash) ([]*wire.MsgBlock, error) {
+
+	return nil, ErrNotImplemented
+}
+
 func (m *mockChainClient) GetMempool() (map[chainhash.Hash]*wire.MsgTx, error) {
 	// Acquire read lock non-exclusively. It allows concurrent readers and
 	// blocks writers.

--- a/wallet/mock_test.go
+++ b/wallet/mock_test.go
@@ -851,6 +851,30 @@ func (m *mockChain) GetBlockHeader(
 	return header, args.Error(1)
 }
 
+func (m *mockChain) GetBlockHashes(int64, int64) ([]chainhash.Hash, error) {
+	args := m.Called()
+	return args.Get(0).([]chainhash.Hash), args.Error(1)
+}
+
+func (m *mockChain) GetBlockHeaders(
+	[]chainhash.Hash) ([]*wire.BlockHeader, error) {
+
+	args := m.Called()
+	return args.Get(0).([]*wire.BlockHeader), args.Error(1)
+}
+
+func (m *mockChain) GetCFilters([]chainhash.Hash, wire.FilterType) (
+	[]*gcs.Filter, error) {
+
+	args := m.Called()
+	return args.Get(0).([]*gcs.Filter), args.Error(1)
+}
+
+func (m *mockChain) GetBlocks([]chainhash.Hash) ([]*wire.MsgBlock, error) {
+	args := m.Called()
+	return args.Get(0).([]*wire.MsgBlock), args.Error(1)
+}
+
 // IsCurrent implements the chain.Interface interface.
 func (m *mockChain) IsCurrent() bool {
 	args := m.Called()

--- a/wallet/mock_test.go
+++ b/wallet/mock_test.go
@@ -71,6 +71,15 @@ func (m *mockTxStore) InsertTxCheckIfExists(ns walletdb.ReadWriteBucket,
 	return args.Bool(0), args.Error(1)
 }
 
+// InsertConfirmedTx implements the wtxmgr.TxStore interface.
+func (m *mockTxStore) InsertConfirmedTx(ns walletdb.ReadWriteBucket,
+	rec *wtxmgr.TxRecord, block *wtxmgr.BlockMeta,
+	credits []wtxmgr.CreditEntry) error {
+
+	args := m.Called(ns, rec, block, credits)
+	return args.Error(0)
+}
+
 // AddCredit implements the wtxmgr.TxStore interface.
 func (m *mockTxStore) AddCredit(ns walletdb.ReadWriteBucket,
 	rec *wtxmgr.TxRecord, block *wtxmgr.BlockMeta, index uint32,

--- a/wallet/mock_test.go
+++ b/wallet/mock_test.go
@@ -671,6 +671,39 @@ func (m *mockAccountStore) ImportPrivateKey(ns walletdb.ReadWriteBucket,
 	return args.Get(0).(waddrmgr.ManagedPubKeyAddress), args.Error(1)
 }
 
+// ActiveAccounts implements the waddrmgr.AccountStore interface.
+func (m *mockAccountStore) ActiveAccounts() []uint32 {
+	args := m.Called()
+	return args.Get(0).([]uint32)
+}
+
+// ExtendAddresses implements the waddrmgr.AccountStore interface.
+func (m *mockAccountStore) ExtendAddresses(ns walletdb.ReadWriteBucket,
+	account uint32, lastIndex uint32, branch uint32) error {
+
+	args := m.Called(ns, account, lastIndex, branch)
+	return args.Error(0)
+}
+
+// DeriveAddr implements the waddrmgr.AccountStore interface.
+func (m *mockAccountStore) DeriveAddr(account, branch, index uint32) (
+	btcutil.Address, []byte, error) {
+
+	args := m.Called(account, branch, index)
+
+	var addr btcutil.Address
+	if args.Get(0) != nil {
+		addr = args.Get(0).(btcutil.Address)
+	}
+
+	var script []byte
+	if args.Get(1) != nil {
+		script = args.Get(1).([]byte)
+	}
+
+	return addr, script, args.Error(2)
+}
+
 // AddrAccount implements the waddrmgr.AccountStore interface.
 func (m *mockAccountStore) AddrAccount(ns walletdb.ReadBucket,
 	address btcutil.Address) (uint32, error) {

--- a/wallet/psbt_manager_test.go
+++ b/wallet/psbt_manager_test.go
@@ -1357,11 +1357,11 @@ func TestPopulatePsbtPacketErrors(t *testing.T) {
 		},
 		ChangeIndex: 0, // Output 0 is change
 	}
-	packet := &psbt.Packet{}
 
 	t.Run("DecorateInputs fails", func(t *testing.T) {
 		t.Parallel()
 		w, mocks := testWalletWithMocks(t)
+		packet := &psbt.Packet{}
 
 		// Mock TxDetails failure (DecorateInputs ->
 		// fetchAndValidateUtxo)
@@ -1377,6 +1377,7 @@ func TestPopulatePsbtPacketErrors(t *testing.T) {
 	t.Run("addChangeOutputInfo fails", func(t *testing.T) {
 		t.Parallel()
 		w, mocks := testWalletWithMocks(t)
+		packet := &psbt.Packet{}
 
 		// Mock TxDetails success (DecorateInputs)
 		txDetails := &wtxmgr.TxDetails{

--- a/wtxmgr/interface.go
+++ b/wtxmgr/interface.go
@@ -76,6 +76,11 @@ type TxStore interface {
 	InsertTxCheckIfExists(ns walletdb.ReadWriteBucket, rec *TxRecord,
 		block *BlockMeta) (bool, error)
 
+	// InsertConfirmedTx records a mined transaction and its associated
+	// credits in a single operation.
+	InsertConfirmedTx(ns walletdb.ReadWriteBucket, rec *TxRecord,
+		block *BlockMeta, credits []CreditEntry) error
+
 	// AddCredit marks a transaction record as containing a transaction
 	// output spendable by wallet. The output is added unspent, and is
 	// marked spent when a new transaction spending the output is inserted


### PR DESCRIPTION
This PR prepares the next `WalletController` PR, it,
- adds batch RPC methods to be used, the underlying methods are already built, we just need to expose them on the interface.
- adds several methods on `wtxmgr` and `waddrmgr` which are to be used in the next PR.