### PR TITLE
Prepare upcoming `Controller`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -83,6 +83,11 @@ linters:
       multi-func: true
       multi-if: true
 
+    wrapcheck:
+      ignore-sig-regexps:
+        # Allow returning .Err() from context.Context without wrapping it.
+        - context\.Context.*\.Err\(\)
+
     gomoddirectives:
       replace-local: true
       replace-allow-list:

--- a/chain/bitcoind_client.go
+++ b/chain/bitcoind_client.go
@@ -1229,8 +1229,13 @@ func (c *BitcoindClient) filterBlock(block *wire.MsgBlock, height int32,
 		// transaction.
 		blockDetails.Index = i
 		txDetails := btcutil.NewTx(tx)
+
+		// We disable individual transaction notifications here because
+		// the full set of relevant transactions will be dispatched
+		// atomically via FilteredBlockConnected at the end of block
+		// processing.
 		isRelevant, rec, err := c.filterTx(
-			txDetails, blockDetails, notify,
+			txDetails, blockDetails, false,
 		)
 		if err != nil {
 			log.Warnf("Unable to filter transaction %v: %v",
@@ -1393,8 +1398,9 @@ func (c *BitcoindClient) filterTx(txDetails *btcutil.Tx,
 		c.mempool[*txDetails.Hash()] = struct{}{}
 	}
 
-	c.onRelevantTx(rec, blockDetails)
-
+	if notify {
+		c.onRelevantTx(rec, blockDetails)
+	}
 	return true, rec, nil
 }
 

--- a/wallet/deprecated.go
+++ b/wallet/deprecated.go
@@ -6185,6 +6185,19 @@ type walletDeprecated struct {
 	quit    chan struct{}
 	quitMu  sync.Mutex
 
+	// publicPassphrase is the passphrase used to encrypt and decrypt public
+	// data in the address manager.
+	publicPassphrase []byte
+
+	// db is the underlying key-value database where all wallet data is
+	// persisted.
+	db walletdb.DB
+
+	// recoveryWindow specifies the number of additional keys to derive
+	// beyond the last used one to look for previously used addresses
+	// during a rescan or recovery.
+	recoveryWindow uint32
+
 	chainClient        chain.Interface
 	chainClientLock    sync.Mutex
 	chainClientSynced  bool

--- a/wallet/deprecated.go
+++ b/wallet/deprecated.go
@@ -6310,3 +6310,13 @@ func (w *Wallet) findEligibleOutputs(dbtx walletdb.ReadTx,
 
 	return eligible, nil
 }
+
+// RescanDeprecated begins a rescan for all active addresses and unspent outputs
+// of a wallet.  This is intended to be used to sync a wallet back up to the
+// current best block in the main chain, and is considered an initial sync
+// rescan.
+func (w *Wallet) RescanDeprecated(addrs []btcutil.Address,
+	unspent []wtxmgr.Credit) error {
+
+	return w.rescanWithTarget(addrs, unspent, nil)
+}

--- a/wallet/mock_test.go
+++ b/wallet/mock_test.go
@@ -873,7 +873,7 @@ func (m *mockChain) GetBestBlock() (*chainhash.Hash, int32, error) {
 	args := m.Called()
 	hash, _ := args.Get(0).(*chainhash.Hash)
 
-	return hash, int32(args.Int(1)), args.Error(2)
+	return hash, args.Get(1).(int32), args.Error(2)
 }
 
 // GetBlock implements the chain.Interface interface.
@@ -902,27 +902,29 @@ func (m *mockChain) GetBlockHeader(
 	return header, args.Error(1)
 }
 
-func (m *mockChain) GetBlockHashes(int64, int64) ([]chainhash.Hash, error) {
-	args := m.Called()
+func (m *mockChain) GetBlockHashes(start, end int64) ([]chainhash.Hash, error) {
+	args := m.Called(start, end)
 	return args.Get(0).([]chainhash.Hash), args.Error(1)
 }
 
 func (m *mockChain) GetBlockHeaders(
-	[]chainhash.Hash) ([]*wire.BlockHeader, error) {
+	hashes []chainhash.Hash) ([]*wire.BlockHeader, error) {
 
-	args := m.Called()
+	args := m.Called(hashes)
 	return args.Get(0).([]*wire.BlockHeader), args.Error(1)
 }
 
-func (m *mockChain) GetCFilters([]chainhash.Hash, wire.FilterType) (
-	[]*gcs.Filter, error) {
+func (m *mockChain) GetCFilters(hashes []chainhash.Hash,
+	filterType wire.FilterType) ([]*gcs.Filter, error) {
 
-	args := m.Called()
+	args := m.Called(hashes, filterType)
 	return args.Get(0).([]*gcs.Filter), args.Error(1)
 }
 
-func (m *mockChain) GetBlocks([]chainhash.Hash) ([]*wire.MsgBlock, error) {
-	args := m.Called()
+func (m *mockChain) GetBlocks(
+	hashes []chainhash.Hash) ([]*wire.MsgBlock, error) {
+
+	args := m.Called(hashes)
 	return args.Get(0).([]*wire.MsgBlock), args.Error(1)
 }
 

--- a/wallet/mock_test.go
+++ b/wallet/mock_test.go
@@ -81,6 +81,14 @@ func (m *mockTxStore) InsertConfirmedTx(ns walletdb.ReadWriteBucket,
 	return args.Error(0)
 }
 
+// InsertUnconfirmedTx implements the wtxmgr.TxStore interface.
+func (m *mockTxStore) InsertUnconfirmedTx(ns walletdb.ReadWriteBucket,
+	rec *wtxmgr.TxRecord, credits []wtxmgr.CreditEntry) error {
+
+	args := m.Called(ns, rec, credits)
+	return args.Error(0)
+}
+
 // AddCredit implements the wtxmgr.TxStore interface.
 func (m *mockTxStore) AddCredit(ns walletdb.ReadWriteBucket,
 	rec *wtxmgr.TxRecord, block *wtxmgr.BlockMeta, index uint32,

--- a/wallet/psbt_manager.go
+++ b/wallet/psbt_manager.go
@@ -1716,6 +1716,11 @@ func (w *Wallet) CombinePsbt(_ context.Context, psbts ...*psbt.Packet) (
 	// Iterate through ALL packets (including the first) and merge their
 	// contents into the combined packet.
 	for _, p := range psbts {
+		// Merge Global Unknowns.
+		combined.Unknowns = deduplicateUnknowns(
+			combined.Unknowns, p.Unknowns,
+		)
+
 		// Merge Inputs.
 		for j := range combined.Inputs {
 			err := mergePsbtInputs(
@@ -1787,7 +1792,7 @@ func validatePsbtMerge(psbts []*psbt.Packet) (*psbt.Packet, error) {
 		UnsignedTx: base.UnsignedTx.Copy(),
 		Inputs:     make([]psbt.PInput, nInputs),
 		Outputs:    make([]psbt.POutput, nOutputs),
-		Unknowns:   base.Unknowns,
+		Unknowns:   make([]*psbt.Unknown, 0),
 	}
 
 	return combined, nil
@@ -1844,6 +1849,9 @@ func mergePsbtInputs(dest, src *psbt.PInput) error {
 		return err
 	}
 
+	// Merge Unknowns.
+	dest.Unknowns = deduplicateUnknowns(dest.Unknowns, src.Unknowns)
+
 	return nil
 }
 
@@ -1873,6 +1881,9 @@ func mergePsbtOutputs(dest, src *psbt.POutput) error {
 	if err != nil {
 		return err
 	}
+
+	// Merge Unknowns.
+	dest.Unknowns = deduplicateUnknowns(dest.Unknowns, src.Unknowns)
 
 	return nil
 }
@@ -2286,4 +2297,19 @@ func PsbtPrevOutputFetcher(packet *psbt.Packet) (
 	}
 
 	return fetcher, nil
+}
+
+// deduplicateUnknowns adds new Unknowns from src to dest, avoiding duplicates
+// based on Key.
+func deduplicateUnknowns(dest, src []*psbt.Unknown) []*psbt.Unknown {
+	for _, unknown := range src {
+		if !slices.ContainsFunc(dest, func(dU *psbt.Unknown) bool {
+			return bytes.Equal(dU.Key, unknown.Key)
+		}) {
+
+			dest = append(dest, unknown)
+		}
+	}
+
+	return dest
 }

--- a/wallet/recovery.go
+++ b/wallet/recovery.go
@@ -16,6 +16,8 @@ import (
 
 // RecoveryManager maintains the state required to recover previously used
 // addresses, and coordinates batched processing of the blocks to search.
+//
+// TODO(yy): Deprecated, remove.
 type RecoveryManager struct {
 	// recoveryWindow defines the key-derivation lookahead used when
 	// attempting to recover the set of used addresses.
@@ -40,6 +42,8 @@ type RecoveryManager struct {
 // NewRecoveryManager initializes a new RecoveryManager with a derivation
 // look-ahead of `recoveryWindow` child indexes, and pre-allocates a backing
 // array for `batchSize` blocks to scan at once.
+//
+// TODO(yy): Deprecated, remove.
 func NewRecoveryManager(recoveryWindow, batchSize uint32,
 	chainParams *chaincfg.Params) *RecoveryManager {
 
@@ -56,6 +60,8 @@ func NewRecoveryManager(recoveryWindow, batchSize uint32,
 // have been previously found. This method ensures that the recovery state's
 // horizons properly start from the last found address of a prior recovery
 // attempt.
+//
+// TODO(yy): Deprecated, remove.
 func (rm *RecoveryManager) Resurrect(ns walletdb.ReadBucket,
 	scopedMgrs map[waddrmgr.KeyScope]waddrmgr.AccountStore,
 	credits []wtxmgr.Credit) error {
@@ -145,6 +151,8 @@ func (rm *RecoveryManager) Resurrect(ns walletdb.ReadBucket,
 
 // AddToBlockBatch appends the block information, consisting of hash and height,
 // to the batch of blocks to be searched.
+//
+// TODO(yy): Deprecated, remove.
 func (rm *RecoveryManager) AddToBlockBatch(hash *chainhash.Hash, height int32,
 	timestamp time.Time) {
 
@@ -166,16 +174,22 @@ func (rm *RecoveryManager) AddToBlockBatch(hash *chainhash.Hash, height int32,
 }
 
 // BlockBatch returns a buffer of blocks that have not yet been searched.
+//
+// TODO(yy): Deprecated, remove.
 func (rm *RecoveryManager) BlockBatch() []wtxmgr.BlockMeta {
 	return rm.blockBatch
 }
 
 // ResetBlockBatch resets the internal block buffer to conserve memory.
+//
+// TODO(yy): Deprecated, remove.
 func (rm *RecoveryManager) ResetBlockBatch() {
 	rm.blockBatch = rm.blockBatch[:0]
 }
 
 // State returns the current RecoveryState.
+//
+// TODO(yy): Deprecated, remove.
 func (rm *RecoveryManager) State() *RecoveryState {
 	return rm.state
 }
@@ -201,12 +215,16 @@ type RecoveryState struct {
 	recoveryWindow uint32
 
 	// scopes maintains a map of each requested key scope to its active
-	// RecoveryState.
+	// RecoveryState. Used for legacy compatibility.
+	//
+	// TODO(yy): Deprecated, remove.
 	scopes map[waddrmgr.KeyScope]*ScopeRecoveryState
 
 	// watchedOutPoints contains the set of all outpoints known to the
 	// wallet. This is updated iteratively as new outpoints are found during
 	// a rescan.
+	//
+	// TODO(yy): Deprecated, remove.
 	watchedOutPoints map[wire.OutPoint]btcutil.Address
 }
 
@@ -223,9 +241,11 @@ func NewRecoveryState(recoveryWindow uint32) *RecoveryState {
 	}
 }
 
-// StateForScope returns a ScopeRecoveryState for the provided key scope. If one
-// does not already exist, a new one will be generated with the RecoveryState's
-// recoveryWindow.
+// StateForScope returns the recovery state for the default account of the
+// provided key scope. This exists for backward compatibility with legacy
+// recovery logic which only supports the default account.
+//
+// TODO(yy): Deprecated, remove.
 func (rs *RecoveryState) StateForScope(
 	keyScope waddrmgr.KeyScope) *ScopeRecoveryState {
 
@@ -243,12 +263,16 @@ func (rs *RecoveryState) StateForScope(
 
 // WatchedOutPoints returns the global set of outpoints that are known to belong
 // to the wallet during recovery.
+//
+// TODO(yy): Deprecated, remove.
 func (rs *RecoveryState) WatchedOutPoints() map[wire.OutPoint]btcutil.Address {
 	return rs.watchedOutPoints
 }
 
 // AddWatchedOutPoint updates the recovery state's set of known outpoints that
 // we will monitor for spends during recovery.
+//
+// TODO(yy): Deprecated, remove.
 func (rs *RecoveryState) AddWatchedOutPoint(outPoint *wire.OutPoint,
 	addr btcutil.Address) {
 
@@ -258,6 +282,8 @@ func (rs *RecoveryState) AddWatchedOutPoint(outPoint *wire.OutPoint,
 // ScopeRecoveryState is used to manage the recovery of addresses generated
 // under a particular BIP32 account. Each account tracks both an external and
 // internal branch recovery state, both of which use the same recovery window.
+//
+// TODO(yy): Deprecated, remove.
 type ScopeRecoveryState struct {
 	// ExternalBranch is the recovery state of addresses generated for
 	// external use, i.e. receiving addresses.
@@ -270,6 +296,8 @@ type ScopeRecoveryState struct {
 
 // NewScopeRecoveryState initializes an ScopeRecoveryState with the chosen
 // recovery window.
+//
+// TODO(yy): Deprecated, remove.
 func NewScopeRecoveryState(recoveryWindow uint32) *ScopeRecoveryState {
 	return &ScopeRecoveryState{
 		ExternalBranch: NewBranchRecoveryState(recoveryWindow),

--- a/wallet/recovery_test.go
+++ b/wallet/recovery_test.go
@@ -1,10 +1,10 @@
 package wallet_test
 
 import (
-	"runtime"
 	"testing"
 
 	"github.com/btcsuite/btcwallet/wallet"
+	"github.com/stretchr/testify/require"
 )
 
 // Harness holds the BranchRecoveryState being tested, the recovery window being
@@ -238,9 +238,6 @@ func assertNumInvalid(t *testing.T, i int, have, want uint32) {
 }
 
 func assertHaveWant(t *testing.T, i int, msg string, have, want uint32) {
-	_, _, line, _ := runtime.Caller(2)
-	if want != have {
-		t.Fatalf("[line: %d, step: %d] %s: got %d, want %d",
-			line, i, msg, have, want)
-	}
+	t.Helper()
+	require.Equal(t, want, have, "[step: %d] %s", i, msg)
 }

--- a/wallet/rescan.go
+++ b/wallet/rescan.go
@@ -272,14 +272,6 @@ out:
 	w.wg.Done()
 }
 
-// Rescan begins a rescan for all active addresses and unspent outputs of
-// a wallet.  This is intended to be used to sync a wallet back up to the
-// current best block in the main chain, and is considered an initial sync
-// rescan.
-func (w *Wallet) Rescan(addrs []btcutil.Address, unspent []wtxmgr.Credit) error {
-	return w.rescanWithTarget(addrs, unspent, nil)
-}
-
 // rescanWithTarget performs a rescan starting at the optional startStamp. If
 // none is provided, the rescan will begin from the manager's sync tip.
 func (w *Wallet) rescanWithTarget(addrs []btcutil.Address,

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -184,14 +184,6 @@ type Wallet struct {
 	// these should be phased out as refactoring progresses.
 	*walletDeprecated
 
-	// publicPassphrase is the passphrase used to encrypt and decrypt public
-	// data in the address manager.
-	publicPassphrase []byte
-
-	// db is the underlying key-value database where all wallet data is
-	// persisted.
-	db walletdb.DB
-
 	// addrStore is the address and key manager responsible for hierarchical
 	// deterministic (HD) derivation and storage of cryptographic keys.
 	addrStore waddrmgr.AddrStore
@@ -199,11 +191,6 @@ type Wallet struct {
 	// txStore is the transaction manager responsible for storing and
 	// querying the wallet's transaction history and unspent outputs.
 	txStore wtxmgr.TxStore
-
-	// recoveryWindow specifies the number of additional keys to derive
-	// beyond the last used one to look for previously used addresses
-	// during a rescan or recovery.
-	recoveryWindow uint32
 
 	// NtfnServer handles the delivery of wallet-related events (e.g., new
 	// transactions, block connections) to connected clients.
@@ -477,6 +464,9 @@ func OpenWithRetry(db walletdb.DB, pubPass []byte, cbs *waddrmgr.OpenCallbacks,
 
 	deprecated := &walletDeprecated{
 		lockedOutpoints:     map[wire.OutPoint]struct{}{},
+		publicPassphrase:    pubPass,
+		db:                  db,
+		recoveryWindow:      recoveryWindow,
 		rescanAddJob:        make(chan *RescanJob),
 		rescanBatch:         make(chan *rescanBatch),
 		rescanNotifications: make(chan interface{}),
@@ -495,11 +485,8 @@ func OpenWithRetry(db walletdb.DB, pubPass []byte, cbs *waddrmgr.OpenCallbacks,
 	}
 
 	w := &Wallet{
-		publicPassphrase: pubPass,
-		db:               db,
 		addrStore:        addrMgr,
 		txStore:          txMgr,
-		recoveryWindow:   recoveryWindow,
 		walletDeprecated: deprecated,
 	}
 

--- a/wtxmgr/interface.go
+++ b/wtxmgr/interface.go
@@ -81,6 +81,11 @@ type TxStore interface {
 	InsertConfirmedTx(ns walletdb.ReadWriteBucket, rec *TxRecord,
 		block *BlockMeta, credits []CreditEntry) error
 
+	// InsertUnconfirmedTx records an unmined transaction and its associated
+	// credits in a single operation.
+	InsertUnconfirmedTx(ns walletdb.ReadWriteBucket, rec *TxRecord,
+		credits []CreditEntry) error
+
 	// AddCredit marks a transaction record as containing a transaction
 	// output spendable by wallet. The output is added unspent, and is
 	// marked spent when a new transaction spending the output is inserted


### PR DESCRIPTION
We did a cleanup in #1145, however there are still a few more cleanups needed. In addition, 
- we fixed the case where duplicated tx notifications are sent - we don't need it as we already listen for `case chain.FilteredBlockConnected:`, in which the relevant txns are sent in batch inside the notification already: https://github.com/btcsuite/btcwallet/blob/f358d00bcfc3b77c64252d09ec36b811ed530649/wallet/chainntfns.go#L176-L178
- added dedup logic for PSBT's unknown fields
- fixed the mockChain impl