### PR TITLE
fix: correct function name in TestMempoolAccept comment

### DIFF
--- a/chain/bitcoind_client.go
+++ b/chain/bitcoind_client.go
@@ -246,7 +246,7 @@ func (c *BitcoindClient) MapRPCErr(rpcErr error) error {
 	return fmt.Errorf("%w: %v", ErrUndefined, rpcErr)
 }
 
-// TestMempoolAcceptCmd returns result of mempool acceptance tests indicating
+// TestMempoolAccept returns result of mempool acceptance tests indicating
 // if raw transaction(s) would be accepted by mempool.
 //
 // NOTE: This is part of the chain.Interface interface.

--- a/chain/neutrino.go
+++ b/chain/neutrino.go
@@ -228,7 +228,7 @@ func (s *NeutrinoClient) SendRawTransaction(tx *wire.MsgTx, allowHighFees bool) 
 	return &hash, nil
 }
 
-// TestMempoolAcceptCmd returns result of mempool acceptance tests indicating
+// TestMempoolAccept returns result of mempool acceptance tests indicating
 // if raw transaction(s) would be accepted by mempool.
 //
 // NOTE: This is part of the chain.Interface interface.

--- a/wallet/mock.go
+++ b/wallet/mock.go
@@ -92,7 +92,7 @@ func (m *mockChainClient) BackEnd() string {
 	return "mock"
 }
 
-// TestMempoolAcceptCmd returns result of mempool acceptance tests indicating
+// TestMempoolAccept returns result of mempool acceptance tests indicating
 // if raw transaction(s) would be accepted by mempool.
 //
 // NOTE: This is part of the chain.Interface interface.


### PR DESCRIPTION
## Change Description
Fixed comment referencing `TestMempoolAcceptCmd` to match the actual function name `TestMempoolAccept`.
## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#ideal-git-commit-structure).
- [ ] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md) for further guidance.
