### PR TITLE
build: standardize tab-width to 4 in linter config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# Top-most EditorConfig file.
+root = true
+
+# Unix-style newlines with a newline ending every file.
+[*.md]
+end_of_line = lf
+insert_final_newline = true
+max_line_length = 80
+
+# 4 space indentation for Golang code.
+[*.go]
+indent_style = tab
+indent_size = 4
+max_line_length = 80

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -74,7 +74,7 @@ linters:
       line-length: 80
       # Tab width in spaces.
       # Default: 1
-      tab-width: 8
+      tab-width: 4
 
     whitespace:
       multi-func: true


### PR DESCRIPTION
## Summary

- Update `.golangci.yml` to use `tab-width: 4` in the lll section, fixing false positives in line length calculations
- Add `.editorconfig` aligned with LND to ensure consistent formatting across editors

Fixes #1150

## Test plan

- [x] Verify `.golangci.yml` change: `tab-width: 8` -> `tab-width: 4`
- [x] Verify `.editorconfig` is created with proper Go settings (4-space tabs)
- [ ] Run `golangci-lint run` to verify no new issues introduced

Generated with [Claude Code](https://claude.ai/code)