### PR TITLE
Separate DB operations from rescan logic

### DIFF
--- a/wallet/common_test.go
+++ b/wallet/common_test.go
@@ -1,0 +1,104 @@
+package wallet
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcwallet/walletdb"
+	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	errDBMock = errors.New("db error")
+	errMock   = errors.New("mock error")
+)
+
+// setupTestDB creates a temporary database for testing.
+func setupTestDB(t *testing.T) (walletdb.DB, func()) {
+	t.Helper()
+
+	f, err := os.CreateTemp(t.TempDir(), "wallet-test-*.db")
+	require.NoError(t, err)
+
+	dbPath := f.Name()
+	require.NoError(t, f.Close())
+	require.NoError(t, os.Remove(dbPath))
+
+	db, err := walletdb.Create("bdb", dbPath, true, time.Second*10, false)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		_ = db.Close()
+		_ = os.Remove(dbPath)
+	}
+
+	// Create buckets.
+	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		_, err := tx.CreateTopLevelBucket(waddrmgrNamespaceKey)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.CreateTopLevelBucket(wtxmgrNamespaceKey)
+
+		return err
+	})
+	require.NoError(t, err)
+
+	return db, cleanup
+}
+
+// mockWalletDeps holds the mocked dependencies for the Wallet.
+type mockWalletDeps struct {
+	addrStore *mockAddrStore
+	txStore   *mockTxStore
+	syncer    *mockChainSyncer
+	chain     *mockChain
+}
+
+// createTestWalletWithMocks creates a Wallet instance with mocked
+// dependencies. It returns the wallet and the struct holding the mocks for
+// assertion.
+func createTestWalletWithMocks(t *testing.T) (*Wallet, *mockWalletDeps) {
+	t.Helper()
+
+	db, cleanup := setupTestDB(t)
+	t.Cleanup(cleanup)
+
+	mockAddrStore := &mockAddrStore{}
+	mockTxStore := &mockTxStore{}
+	mockSyncer := &mockChainSyncer{}
+	mockChain := &mockChain{}
+
+	w := &Wallet{
+		addrStore: mockAddrStore,
+		txStore:   mockTxStore,
+		sync:      mockSyncer,
+		state:     newWalletState(mockSyncer),
+		cfg: Config{
+			DB:          db,
+			Chain:       mockChain,
+			ChainParams: &chaincfg.MainNetParams,
+		},
+	}
+
+	deps := &mockWalletDeps{
+		addrStore: mockAddrStore,
+		txStore:   mockTxStore,
+		syncer:    mockSyncer,
+		chain:     mockChain,
+	}
+
+	t.Cleanup(func() {
+		mockAddrStore.AssertExpectations(t)
+		mockTxStore.AssertExpectations(t)
+		mockSyncer.AssertExpectations(t)
+		mockChain.AssertExpectations(t)
+	})
+
+	return w, deps
+}

--- a/wallet/db_ops.go
+++ b/wallet/db_ops.go
@@ -1,0 +1,737 @@
+// Package wallet provides the implementation of a Bitcoin wallet.
+//
+// TODO(yy): This file will be removed once the Store implementation is
+// finished.
+package wallet
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+)
+
+// DBGetBirthdayBlock retrieves the current birthday block from the database.
+//
+// TODO(yy): Refactor this in the `Store` implementation - we can call
+// `GetWallet` to get the birthday info.
+func (w *Wallet) DBGetBirthdayBlock(_ context.Context) (waddrmgr.BlockStamp,
+	bool, error) {
+
+	var (
+		birthdayBlock waddrmgr.BlockStamp
+		verified      bool
+	)
+
+	err := walletdb.View(w.cfg.DB, func(tx walletdb.ReadTx) error {
+		var err error
+
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+
+		birthdayBlock, verified, err = w.addrStore.BirthdayBlock(ns)
+		if err != nil {
+			return fmt.Errorf("get birthday block: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return waddrmgr.BlockStamp{}, false, fmt.Errorf("view: %w", err)
+	}
+
+	return birthdayBlock, verified, nil
+}
+
+// DBPutBirthdayBlock updates the wallet's birthday block in the database
+// and marks it as verified.
+//
+// TODO(yy): Refactor this in the `Store` implementation - we can call
+// `UpdateWallet` to set the birthday info.
+func (w *Wallet) DBPutBirthdayBlock(_ context.Context,
+	block waddrmgr.BlockStamp) error {
+
+	err := walletdb.Update(w.cfg.DB, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+		err := w.addrStore.SetBirthdayBlock(ns, block, true)
+		if err != nil {
+			return fmt.Errorf("set birthday block: %w", err)
+		}
+
+		return w.addrStore.SetSyncedTo(ns, &block)
+	})
+	if err != nil {
+		return fmt.Errorf("update: %w", err)
+	}
+
+	return nil
+}
+
+// DBDeleteExpiredLockedOutputs removes any expired output locks from the
+// transaction store.
+//
+// TODO(yy): Refactor this in the `Store` implementation - we can call
+// `UpdateUTXOs` instead.
+func (w *Wallet) DBDeleteExpiredLockedOutputs(_ context.Context) error {
+	err := walletdb.Update(w.cfg.DB, func(tx walletdb.ReadWriteTx) error {
+		txmgrNs := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+		return w.txStore.DeleteExpiredLockedOutputs(txmgrNs)
+	})
+	if err != nil {
+		return fmt.Errorf("cleanup expired locks: %w", err)
+	}
+
+	return nil
+}
+
+// DBUnlock attempts to unlock the wallet's address manager with the provided
+// passphrase.
+//
+// TODO(yy): Refactor this in the `Store` implementation - the only db
+// operation needed is to load the account info and derive the private keys.
+func (w *Wallet) DBUnlock(_ context.Context, passphrase []byte) error {
+	err := walletdb.View(w.cfg.DB, func(tx walletdb.ReadTx) error {
+		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+		return w.addrStore.Unlock(addrmgrNs, passphrase)
+	})
+	if err != nil {
+		return fmt.Errorf("view: %w", err)
+	}
+
+	return nil
+}
+
+// DBPutPassphrase updates the wallet's public or private passphrases.
+//
+// TODO(yy): Refactor this in the `Store` implementation - we can call
+// `UpdateWallet` instead.
+func (w *Wallet) DBPutPassphrase(_ context.Context,
+	req ChangePassphraseRequest) error {
+
+	err := walletdb.Update(w.cfg.DB, func(tx walletdb.ReadWriteTx) error {
+		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+		if req.ChangePublic {
+			err := w.addrStore.ChangePassphrase(
+				addrmgrNs, req.PublicOld, req.PublicNew,
+				false, &waddrmgr.DefaultScryptOptions,
+			)
+			if err != nil {
+				return fmt.Errorf("change public passphrase: "+
+					"%w", err)
+			}
+		}
+
+		if req.ChangePrivate {
+			err := w.addrStore.ChangePassphrase(
+				addrmgrNs, req.PrivateOld,
+				req.PrivateNew, true,
+				&waddrmgr.DefaultScryptOptions,
+			)
+			if err != nil {
+				return fmt.Errorf("change private passphrase: "+
+					"%w", err)
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("update: %w", err)
+	}
+
+	return nil
+}
+
+// DBGetAllAccounts ensures all account properties are loaded into the address
+// manager's cache.
+//
+// TODO(yy): Refactor this in the `Store` implementation - we can call
+// `ListAccounts` instead, without the balance info.
+func (w *Wallet) DBGetAllAccounts(_ context.Context) error {
+	scopes := w.addrStore.ActiveScopedKeyManagers()
+
+	err := walletdb.View(w.cfg.DB, func(tx walletdb.ReadTx) error {
+		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+		for _, scopedMgr := range scopes {
+			lastAccount, err := scopedMgr.LastAccount(addrmgrNs)
+			if err != nil {
+				if waddrmgr.IsError(
+					err, waddrmgr.ErrAccountNotFound,
+				) {
+
+					continue
+				}
+
+				return fmt.Errorf("last account: %w", err)
+			}
+
+			for i := uint32(0); i <= lastAccount; i++ {
+				_, err := scopedMgr.AccountProperties(
+					addrmgrNs, i,
+				)
+				if err != nil {
+					return fmt.Errorf("account: %w", err)
+				}
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("load all accounts: %w", err)
+	}
+
+	return nil
+}
+
+// DBGetUnminedTxns retrieves all transactions currently held in the
+// wallet's unmined (mempool) store.
+//
+// TODO(yy): Refactor this in the `Store` implementation - we can call
+// `ListTxns` instead.
+func (s *syncer) DBGetUnminedTxns(_ context.Context) ([]*wire.MsgTx, error) {
+	var txs []*wire.MsgTx
+
+	err := walletdb.View(
+		s.cfg.DB, func(tx walletdb.ReadTx) error {
+			txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
+
+			var err error
+
+			txs, err = s.txStore.UnminedTxs(txmgrNs)
+			if err != nil {
+				return fmt.Errorf("unmined txs: %w",
+					err)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("view: %w", err)
+	}
+
+	return txs, nil
+}
+
+// DBPutBlocks atomically processes a filtered block connected notification
+// by inserting relevant transactions and updating the sync tip.
+//
+// NOTE: This method is used for notifications (not scans). It performs an
+// extra step to resolve address scopes (via putRelevantTxns) before
+// committing, as notification data does not include scope information.
+//
+// TODO(yy): Refactor this in the `Store` implementation - we can call
+// `UpdateWallet` instead.
+func (s *syncer) DBPutBlocks(ctx context.Context,
+	matches TxEntries, block *wtxmgr.BlockMeta) error {
+
+	err := walletdb.Update(s.cfg.DB, func(tx walletdb.ReadWriteTx) error {
+		if len(matches) > 0 {
+			err := s.putRelevantTxns(
+				ctx, tx, matches, block,
+			)
+			if err != nil {
+				return err
+			}
+		}
+
+		return s.putSyncTip(ctx, tx, *block)
+	})
+	if err != nil {
+		return fmt.Errorf("process filtered block: %w", err)
+	}
+
+	return nil
+}
+
+// DBPutTxns parses a batch of relevant transactions, identifies their
+// relevant outputs, and commits them to the database.
+//
+// NOTE: This method is used for notifications (not scans). It performs an
+// extra step to resolve address scopes (via putRelevantTxns) before
+// committing, as notification data does not include scope information.
+//
+// TODO(yy): Refactor this in the `Store` implementation - we can call
+// `UpdateUTXOs` instead.
+func (s *syncer) DBPutTxns(ctx context.Context, matches TxEntries,
+	block *wtxmgr.BlockMeta) error {
+
+	err := walletdb.Update(s.cfg.DB, func(tx walletdb.ReadWriteTx) error {
+		return s.putRelevantTxns(ctx, tx, matches, block)
+	})
+	if err != nil {
+		return fmt.Errorf("process txns: %w", err)
+	}
+
+	return nil
+}
+
+// DBGetScanData retrieves all necessary data from the database to initialize
+// the recovery state. This includes account horizons, active addresses, and
+// unspent outputs to watch.
+//
+// TODO(yy): Refactor this in the `Store` implementation - we can call
+// `ListUTXOx+ListAddress` instead, or build a dedicated sql query.
+func (s *syncer) DBGetScanData(_ context.Context,
+	targets []waddrmgr.AccountScope) ([]*waddrmgr.AccountProperties,
+	[]btcutil.Address, []wtxmgr.Credit, error) {
+
+	var (
+		horizonData    []*waddrmgr.AccountProperties
+		initialAddrs   []btcutil.Address
+		initialUnspent []wtxmgr.Credit
+	)
+
+	// Perform all database reads in a single read-only transaction.
+	//
+	// TODO(yy): Refactor to build a single SQL query for these data
+	// fetches instead of multiple smaller operations within the
+	// transaction.
+	//
+	// NOTE: RecoveryState initialization and mutation are intentionally
+	// kept outside this transaction to strictly separate database I/O from
+	// in-memory state management.
+	err := walletdb.View(s.cfg.DB, func(dbtx walletdb.ReadTx) error {
+		addrmgrNs := dbtx.ReadBucket(waddrmgrNamespaceKey)
+		txmgrNs := dbtx.ReadBucket(wtxmgrNamespaceKey)
+
+		// 1. Collect Horizons.
+		for _, target := range targets {
+			scopedMgr, err := s.addrStore.FetchScopedKeyManager(
+				target.Scope,
+			)
+			if err != nil {
+				return fmt.Errorf("fetch scoped manager: %w",
+					err)
+			}
+
+			props, err := scopedMgr.AccountProperties(
+				addrmgrNs, target.Account,
+			)
+			if err != nil {
+				return fmt.Errorf("account properties: %w", err)
+			}
+
+			horizonData = append(horizonData, props)
+		}
+
+		// 2. Load Active Addresses.
+		err := s.addrStore.ForEachRelevantActiveAddress(
+			addrmgrNs, func(addr btcutil.Address) error {
+				initialAddrs = append(initialAddrs, addr)
+				return nil
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("for each relevant address: %w", err)
+		}
+
+		// 3. Load UTXOs.
+		initialUnspent, err = s.txStore.OutputsToWatch(txmgrNs)
+		if err != nil {
+			return fmt.Errorf("outputs to watch: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("load recovery state: %w", err)
+	}
+
+	return horizonData, initialAddrs, initialUnspent, nil
+}
+
+// DBGetSyncedBlocks retrieves a batch of block hashes from the wallet's
+// database for the range [startHeight, endHeight].
+//
+// TODO(yy): Refactor this in the `Store` implementation - we can call
+// `ListSyncedBlocks` instead on `WalletStore`?
+func (s *syncer) DBGetSyncedBlocks(_ context.Context, startHeight,
+	endHeight int32) ([]*chainhash.Hash, error) {
+
+	var localHashes []*chainhash.Hash
+
+	err := walletdb.View(s.cfg.DB, func(tx walletdb.ReadTx) error {
+		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+
+		count := endHeight - startHeight + 1
+		localHashes = make([]*chainhash.Hash, 0, count)
+
+		// We fetch from startHeight to endHeight to match the order
+		// we'll get from the chain backend (ascending).
+		for h := startHeight; h <= endHeight; h++ {
+			hash, err := s.addrStore.BlockHash(addrmgrNs, h)
+			if err != nil {
+				return fmt.Errorf("get block hash %d: %w",
+					h, err)
+			}
+
+			localHashes = append(localHashes, hash)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("fetch synced block hashes: %w", err)
+	}
+
+	return localHashes, nil
+}
+
+// DBPutRewind rewinds the wallet state to the specified fork point.
+//
+// TODO(yy): Refactor this in the `Store` implementation - we need to define a
+// new method and build customized query for this.
+func (s *syncer) DBPutRewind(_ context.Context,
+	bs waddrmgr.BlockStamp) error {
+
+	err := walletdb.Update(s.cfg.DB, func(tx walletdb.ReadWriteTx) error {
+		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+		txmgrNs := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+
+		err := s.addrStore.SetSyncedTo(addrmgrNs, &bs)
+		if err != nil {
+			return fmt.Errorf("set synced to: %w", err)
+		}
+
+		return s.txStore.Rollback(txmgrNs, bs.Height+1)
+	})
+	if err != nil {
+		return fmt.Errorf("rollback wallet: %w", err)
+	}
+
+	return nil
+}
+
+// DBPutSyncBatch updates the database with the results of a batch scan. It
+// handles persisting address horizons, transactions, and connecting blocks.
+//
+// TODO(yy): Refactor this in the `Store` implementation - we need a dedicated
+// query for this on `WalletStore`?
+func (s *syncer) DBPutSyncBatch(ctx context.Context,
+	results []scanResult) error {
+
+	// TODO(yy): build a single SQL query for this.
+	err := walletdb.Update(s.cfg.DB, func(dbtx walletdb.ReadWriteTx) error {
+		addrmgrNs := dbtx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+		// 1. Update Address State (Horizons).
+		err := s.putAddrHorizons(ctx, addrmgrNs, results)
+		if err != nil {
+			return err
+		}
+
+		// 2. Update UTXO State (Transactions).
+		err = s.putScanTxns(ctx, dbtx, results)
+		if err != nil {
+			return err
+		}
+
+		// 3. Connect Blocks.
+		// We must process blocks in order and connect each one to
+		// ensure the address manager's block index remains contiguous.
+		//
+		// TODO(yy): This is inefficient as it performs a DB
+		// write/check for each block. Implement a batch write method
+		// in waddrmgr (or wait for SQL migration) to validate and
+		// insert the entire chain segment at once.
+		for _, res := range results {
+			err = s.putSyncTip(ctx, dbtx, *res.meta)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("process scan batch: %w", err)
+	}
+
+	return nil
+}
+
+// DBPutTargetedBatch updates the database with the results of a targeted
+// rescan. It persists address horizons and transactions but does NOT connect
+// blocks or update the wallet's synced tip.
+//
+// TODO(yy): Refactor this in the `Store` implementation - we need a dedicated
+// query for this on `WalletStore`?
+func (s *syncer) DBPutTargetedBatch(ctx context.Context,
+	results []scanResult) error {
+
+	err := walletdb.Update(s.cfg.DB, func(dbtx walletdb.ReadWriteTx) error {
+		addrmgrNs := dbtx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+		// 1. Update Address State (Horizons).
+		err := s.putAddrHorizons(ctx, addrmgrNs, results)
+		if err != nil {
+			return err
+		}
+
+		// 2. Update UTXO State (Transactions).
+		err = s.putScanTxns(ctx, dbtx, results)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("process rescan batch: %w", err)
+	}
+
+	return nil
+}
+
+// DBPutSyncTip handles a chain server notification by marking a wallet
+// that's currently in-sync with the chain server as being synced up to the
+// passed block.
+//
+// TODO(yy): Refactor this in the `Store` implementation - we can call
+// `UpdateWallet` instead.
+func (s *syncer) DBPutSyncTip(ctx context.Context,
+	b wtxmgr.BlockMeta) error {
+
+	err := walletdb.Update(s.cfg.DB, func(tx walletdb.ReadWriteTx) error {
+		return s.putSyncTip(ctx, tx, b)
+	})
+	if err != nil {
+		return fmt.Errorf("commit sync tip: %w", err)
+	}
+
+	return nil
+}
+
+// putRelevantTxns identifies the branch scopes for a batch of relevant
+// transactions received from notifications (not scans), resolves them, and
+// commits them to the database.
+func (s *syncer) putRelevantTxns(ctx context.Context,
+	dbtx walletdb.ReadWriteTx, matches TxEntries,
+	block *wtxmgr.BlockMeta) error {
+
+	// 1. Resolution: Resolve scopes and finalize entries.
+	err := s.resolveTxMatches(ctx, dbtx, matches)
+	if err != nil {
+		return err
+	}
+
+	// 2. Commit: Insert each transaction with its resolved credits.
+	return s.putTxns(ctx, dbtx, matches, block)
+}
+
+// resolveTxMatches identifies the branch scopes for a batch of pre-extracted
+// transactions and address entries, filtering out invalid ones.
+func (s *syncer) resolveTxMatches(ctx context.Context,
+	dbtx walletdb.ReadTx, matches TxEntries) error {
+
+	// 1. Resolution: Resolve scopes for all unique addresses.
+	scopeMap, err := s.filterBranchScopes(ctx, dbtx, matches)
+	if err != nil {
+		return err
+	}
+
+	// 2. Construction: Finalize entries by applying resolved scopes.
+	for i := range matches {
+		match := &matches[i]
+
+		valid := make([]AddrEntry, 0, len(match.Entries))
+		for _, entry := range match.Entries {
+			scope, ok := scopeMap[entry.Address.String()]
+			if !ok {
+				continue
+			}
+
+			entry.Credit.Change = scope.Branch ==
+				waddrmgr.InternalBranch
+
+			valid = append(valid, entry)
+		}
+
+		match.Entries = valid
+	}
+
+	return nil
+}
+
+// putSyncTip handles a chain server notification by marking a wallet that's
+// currently in-sync with the chain server as being synced up to the passed
+// block.
+func (s *syncer) putSyncTip(_ context.Context,
+	dbtx walletdb.ReadWriteTx, b wtxmgr.BlockMeta) error {
+
+	addrmgrNs := dbtx.ReadWriteBucket(waddrmgrNamespaceKey)
+	bs := waddrmgr.BlockStamp{
+		Height:    b.Height,
+		Hash:      b.Hash,
+		Timestamp: b.Time,
+	}
+
+	err := s.addrStore.SetSyncedTo(addrmgrNs, &bs)
+	if err != nil {
+		return fmt.Errorf("failed to set synced to: %w", err)
+	}
+
+	return nil
+}
+
+// filterBranchScopes retrieves the branch scope for a given set of address
+// entries. It returns a map where the key is the address string and the value
+// is the corresponding branch scope.
+func (s *syncer) filterBranchScopes(_ context.Context, dbtx walletdb.ReadTx,
+	matches TxEntries) (map[string]waddrmgr.BranchScope, error) {
+
+	ns := dbtx.ReadBucket(waddrmgrNamespaceKey)
+
+	// Deduplicate addresses from the input entries to minimize expensive
+	// database lookups for transactions with multiple outputs to the same
+	// address.
+	uniqueAddrs := make(map[string]btcutil.Address)
+	for _, match := range matches {
+		for _, entry := range match.Entries {
+			uniqueAddrs[entry.Address.String()] = entry.Address
+		}
+	}
+
+	// Resolve the branch scope (Scope, Account, Branch) for each unique
+	// address. Addresses not found in the manager are skipped.
+	scopes := make(map[string]waddrmgr.BranchScope, len(uniqueAddrs))
+	for addrStr, addr := range uniqueAddrs {
+		ma, err := s.addrStore.Address(ns, addr)
+		if err != nil {
+			if waddrmgr.IsError(err, waddrmgr.ErrAddressNotFound) {
+				continue
+			}
+
+			return nil, fmt.Errorf("get address info: %w", err)
+		}
+
+		scopedManager, account, err := s.addrStore.AddrAccount(ns, addr)
+		if err != nil {
+			return nil, fmt.Errorf("get addr account: %w", err)
+		}
+
+		branch := waddrmgr.ExternalBranch
+		if ma.Internal() {
+			branch = waddrmgr.InternalBranch
+		}
+
+		scopes[addrStr] = waddrmgr.BranchScope{
+			Scope:   scopedManager.Scope(),
+			Account: account,
+			Branch:  branch,
+		}
+	}
+
+	return scopes, nil
+}
+
+// putAddrHorizons aggregates found address horizons from the scan
+// results and updates the address manager state (extends horizons) in the
+// database.
+func (s *syncer) putAddrHorizons(_ context.Context,
+	ns walletdb.ReadWriteBucket, results []scanResult) error {
+
+	// Aggregate Horizon Expansion.
+	batchHorizons := make(map[waddrmgr.BranchScope]uint32)
+	for _, res := range results {
+		for bs, idx := range res.FoundHorizons {
+			if current, ok := batchHorizons[bs]; !ok ||
+				idx > current {
+
+				batchHorizons[bs] = idx
+			}
+		}
+	}
+
+	if len(batchHorizons) == 0 {
+		return nil
+	}
+	// Update the database.
+	for bs, maxFoundIndex := range batchHorizons {
+		scopedMgr, err := s.addrStore.FetchScopedKeyManager(bs.Scope)
+		if err != nil {
+			return fmt.Errorf("fetch scoped manager: %w", err)
+		}
+
+		err = scopedMgr.ExtendAddresses(
+			ns, bs.Account, maxFoundIndex, bs.Branch,
+		)
+		if err != nil {
+			return fmt.Errorf("extend addresses: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// putScanTxns processes relevant transactions found during the scan
+// and inserts them into the transaction store (and address manager for usage).
+func (s *syncer) putScanTxns(ctx context.Context,
+	dbtx walletdb.ReadWriteTx, results []scanResult) error {
+
+	for _, result := range results {
+		matches := result.RelevantOutputs
+
+		// The RelevantTxs in scanResult are *btcutil.Tx. We need to
+		// ensure the TxEntries have the correct *wtxmgr.TxRecord.
+		for i := range matches {
+			matches[i].Rec.Received = result.meta.Time
+		}
+
+		err := s.putTxns(ctx, dbtx, matches, result.meta)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// putTxns inserts relevant transactions and their credits into the wallet
+// using pre-matched output data.
+func (s *syncer) putTxns(_ context.Context, dbtx walletdb.ReadWriteTx,
+	matches TxEntries, block *wtxmgr.BlockMeta) error {
+
+	txmgrNs := dbtx.ReadWriteBucket(wtxmgrNamespaceKey)
+	addrmgrNs := dbtx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+	for _, match := range matches {
+		rec := match.Rec
+		entries := match.Entries
+
+		credits := make([]wtxmgr.CreditEntry, 0, len(entries))
+		for _, entry := range entries {
+			credits = append(credits, entry.Credit)
+
+			err := s.addrStore.MarkUsed(addrmgrNs, entry.Address)
+			if err != nil {
+				return fmt.Errorf("mark used: %w", err)
+			}
+		}
+
+		var err error
+		if block != nil {
+			err = s.txStore.InsertConfirmedTx(
+				txmgrNs, rec, block, credits,
+			)
+		} else {
+			err = s.txStore.InsertUnconfirmedTx(
+				txmgrNs, rec, credits,
+			)
+		}
+
+		if err != nil {
+			return fmt.Errorf("insert tx: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/wallet/db_ops_test.go
+++ b/wallet/db_ops_test.go
@@ -1,0 +1,612 @@
+package wallet
+
+import (
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/walletdb"
+	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDBBirthdayBlock verifies that the wallet can successfully persist and
+// retrieve its birthday block information.
+func TestDBBirthdayBlock(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a test wallet with mocked underlying stores.
+	w, mocks := createTestWalletWithMocks(t)
+
+	block := waddrmgr.BlockStamp{
+		Height:    100,
+		Hash:      chainhash.Hash{0x01},
+		Timestamp: time.Unix(1000, 0),
+	}
+
+	// 1. Test DBPutBirthdayBlock.
+	//
+	// Arrange: Setup the expected mock calls for updating the birthday
+	// block and the sync tip in the address manager.
+	mocks.addrStore.On(
+		"SetBirthdayBlock", mock.Anything, block, true,
+	).Return(nil).Once()
+	mocks.addrStore.On(
+		"SetSyncedTo", mock.Anything, &block,
+	).Return(nil).Once()
+
+	// Act: Persist the birthday block to the database.
+	err := w.DBPutBirthdayBlock(t.Context(), block)
+
+	// Assert: Ensure the update completed without error.
+	require.NoError(t, err)
+
+	// 2. Test DBGetBirthdayBlock.
+	//
+	// Arrange: Setup the expected mock call for retrieving the birthday
+	// block from the address manager.
+	mocks.addrStore.On(
+		"BirthdayBlock", mock.Anything,
+	).Return(block, true, nil).Once()
+
+	// Act: Retrieve the persisted birthday block from the database.
+	retBlock, verified, err := w.DBGetBirthdayBlock(t.Context())
+
+	// Assert: Verify the retrieved block data and verification status
+	// matches what was persisted.
+	require.NoError(t, err)
+	require.True(t, verified)
+	require.Equal(t, block, retBlock)
+}
+
+// TestDBUnlock verifies that the wallet can successfully unlock its address
+// manager using the provided passphrase.
+func TestDBUnlock(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a test wallet and setup the expected mock call for
+	// unlocking the address manager.
+	w, mocks := createTestWalletWithMocks(t)
+	pass := []byte("password")
+
+	mocks.addrStore.On("Unlock", mock.Anything, pass).Return(nil).Once()
+
+	// Act: Attempt to unlock the wallet with the passphrase.
+	err := w.DBUnlock(t.Context(), pass)
+
+	// Assert: Verify that the unlock operation succeeded.
+	require.NoError(t, err)
+}
+
+// TestDBDeleteExpiredLockedOutputs verifies that the wallet successfully
+// invokes the transaction store to remove any expired output locks.
+func TestDBDeleteExpiredLockedOutputs(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a test wallet and setup the expected mock call for
+	// deleting expired locked outputs.
+	w, mocks := createTestWalletWithMocks(t)
+
+	mocks.txStore.On(
+		"DeleteExpiredLockedOutputs", mock.Anything,
+	).Return(nil).Once()
+
+	// Act: Trigger the cleanup of expired locked outputs in the database.
+	err := w.DBDeleteExpiredLockedOutputs(t.Context())
+
+	// Assert: Verify that the cleanup operation finished without error.
+	require.NoError(t, err)
+}
+
+// TestDBPutPassphrase verifies that the wallet can successfully update both
+// its public and private passphrases in the address manager.
+func TestDBPutPassphrase(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a test wallet and a request to change both
+	// passphrases.
+	w, mocks := createTestWalletWithMocks(t)
+
+	req := ChangePassphraseRequest{
+		ChangePublic:  true,
+		PublicOld:     []byte("old"),
+		PublicNew:     []byte("new"),
+		ChangePrivate: true,
+		PrivateOld:    []byte("old_priv"),
+		PrivateNew:    []byte("new_priv"),
+	}
+
+	// Setup mock calls for both passphrase changes.
+	mocks.addrStore.On(
+		"ChangePassphrase", mock.Anything, []byte("old"), []byte("new"),
+		false, mock.Anything,
+	).Return(nil).Once()
+
+	mocks.addrStore.On(
+		"ChangePassphrase", mock.Anything, req.PrivateOld,
+		req.PrivateNew, true,
+		mock.MatchedBy(func(opts *waddrmgr.ScryptOptions) bool {
+			return opts.N == 16 && opts.R == 8 && opts.P == 1
+		}),
+	).Return(nil).Once()
+
+	// Act: Commit the passphrase changes to the database.
+	err := w.DBPutPassphrase(t.Context(), req)
+
+	// Assert: Verify that both passphrases were updated successfully.
+	require.NoError(t, err)
+}
+
+// TestDBPutPassphrase_Error verifies that DBPutPassphrase correctly handles
+// and returns errors encountered during the passphrase update process.
+func TestDBPutPassphrase_Error(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a test wallet and setup a mock call that simulates
+	// a database error during a private passphrase change.
+	w, mocks := createTestWalletWithMocks(t)
+
+	req := ChangePassphraseRequest{
+		ChangePrivate: true,
+	}
+
+	mocks.addrStore.On(
+		"ChangePassphrase", mock.Anything, mock.Anything,
+		mock.Anything, true, mock.Anything,
+	).Return(errDBMock).Once()
+
+	// Act: Attempt to change the passphrase, expecting a failure.
+	err := w.DBPutPassphrase(t.Context(), req)
+
+	// Assert: Verify that the expected database error is returned.
+	require.ErrorContains(t, err, "db error")
+}
+
+// TestDBPutBlocks_Error verifies that DBPutBlocks correctly handles errors
+// that occur during the transaction matching resolution phase.
+func TestDBPutBlocks_Error(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a syncer with mocked stores and setup a scenario
+	// where address lookup fails during transaction resolution.
+	w, mocks := createTestWalletWithMocks(t)
+	s := newSyncer(w.cfg, w.addrStore, w.txStore, nil)
+
+	addr, _ := btcutil.NewAddressPubKeyHash(
+		make([]byte, 20), &chaincfg.MainNetParams,
+	)
+	matches := TxEntries{{Entries: []AddrEntry{{Address: addr}}}}
+
+	mocks.addrStore.On("Address", mock.Anything, addr).Return(
+		nil, errDBMock,
+	).Once()
+
+	// Act: Attempt to process a block with relevant transactions.
+	err := s.DBPutBlocks(t.Context(), matches, nil)
+
+	// Assert: Verify that the address lookup error is correctly
+	// propagated.
+	require.ErrorContains(t, err, "db error")
+}
+
+// TestDBPutSyncBatch_Error verifies that DBPutSyncBatch correctly propagates
+// errors encountered when fetching scoped key managers for horizon updates.
+func TestDBPutSyncBatch_Error(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a syncer and a scan result that requires updating an
+	// address manager's horizon.
+	w, mocks := createTestWalletWithMocks(t)
+	s := newSyncer(w.cfg, w.addrStore, w.txStore, nil)
+
+	res := scanResult{
+		meta: &wtxmgr.BlockMeta{
+			Block: wtxmgr.Block{Height: 100},
+		},
+		BlockProcessResult: &BlockProcessResult{
+			FoundHorizons: map[waddrmgr.BranchScope]uint32{
+				{
+					Scope: waddrmgr.KeyScopeBIP0084,
+				}: 5,
+			},
+		},
+	}
+
+	// Simulate a failure when fetching the scoped key manager.
+	mocks.addrStore.On(
+		"FetchScopedKeyManager", waddrmgr.KeyScopeBIP0084,
+	).Return(nil, errMock).Once()
+
+	// Act: Attempt to commit a batch of scan results to the database.
+	err := s.DBPutSyncBatch(t.Context(), []scanResult{res})
+
+	// Assert: Verify that the expected error is returned.
+	require.ErrorIs(t, err, errMock)
+}
+
+// TestDBPutBlocks verifies the full lifecycle of DBPutBlocks, including
+// resolving transaction scopes, marking addresses as used, inserting confirmed
+// transactions, and updating the sync tip.
+func TestDBPutBlocks(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a syncer and setup test data for a confirmed
+	// transaction.
+	w, mocks := createTestWalletWithMocks(t)
+	s := newSyncer(w.cfg, w.addrStore, w.txStore, nil)
+
+	tx := wire.NewMsgTx(1)
+	rec, _ := wtxmgr.NewTxRecordFromMsgTx(tx, time.Now())
+	addr, _ := btcutil.NewAddressPubKeyHash(
+		make([]byte, 20), &chaincfg.MainNetParams,
+	)
+
+	matches := TxEntries{{
+		Rec: rec,
+		Entries: []AddrEntry{{
+			Address: addr,
+		}},
+	}}
+
+	block := &wtxmgr.BlockMeta{
+		Block: wtxmgr.Block{Height: 100},
+	}
+
+	// 1. Transaction Resolution.
+	//
+	// Setup mocks to resolve the address scope for the transaction output.
+	mockAddr := &mockManagedPubKeyAddr{}
+	mockAddr.On("Internal").Return(false).Once()
+	mocks.addrStore.On("Address", mock.Anything, addr).Return(
+		mockAddr, nil,
+	).Once()
+
+	scopedMgr := &mockAccountStore{}
+	scopedMgr.On("Scope").Return(waddrmgr.KeyScopeBIP0084).Once()
+	mocks.addrStore.On("AddrAccount", mock.Anything, addr).Return(
+		scopedMgr, uint32(0), nil,
+	).Once()
+
+	// 2. Transaction Insertion.
+	//
+	// Expect the address to be marked as used and the transaction to be
+	// inserted as confirmed.
+	mocks.addrStore.On("MarkUsed", mock.Anything, addr).Return(nil).Once()
+	mocks.txStore.On("InsertConfirmedTx", mock.Anything, rec, block,
+		mock.Anything,
+	).Return(nil).Once()
+
+	// 3. Sync Tip Update.
+	//
+	// Expect the wallet's sync tip to be updated to the new block.
+	mocks.addrStore.On("SetSyncedTo", mock.Anything, mock.Anything).Return(
+		nil,
+	).Once()
+
+	// Act: Process the block and its relevant transactions.
+	err := s.DBPutBlocks(t.Context(), matches, block)
+
+	// Assert: Verify that all operations completed successfully.
+	require.NoError(t, err)
+}
+
+// TestDBPutTxns verifies that DBPutTxns can successfully resolve and persist
+// unconfirmed transactions in the wallet's transaction store.
+func TestDBPutTxns(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a syncer and setup test data for an unconfirmed
+	// transaction.
+	w, mocks := createTestWalletWithMocks(t)
+	s := newSyncer(w.cfg, w.addrStore, w.txStore, nil)
+
+	tx := wire.NewMsgTx(1)
+	rec, _ := wtxmgr.NewTxRecordFromMsgTx(tx, time.Now())
+	addr, _ := btcutil.NewAddressPubKeyHash(
+		make([]byte, 20), &chaincfg.MainNetParams,
+	)
+
+	matches := TxEntries{{
+		Rec: rec,
+		Entries: []AddrEntry{{
+			Address: addr,
+		}},
+	}}
+
+	// Setup mock calls to resolve the address scope and persist the
+	// unconfirmed transaction.
+	mockAddr := &mockManagedPubKeyAddr{}
+	mockAddr.On("Internal").Return(false).Once()
+	mocks.addrStore.On("Address", mock.Anything, addr).Return(
+		mockAddr, nil,
+	).Once()
+
+	scopedMgr := &mockAccountStore{}
+	scopedMgr.On("Scope").Return(waddrmgr.KeyScopeBIP0084).Once()
+	mocks.addrStore.On("AddrAccount", mock.Anything, addr).Return(
+		scopedMgr, uint32(0), nil,
+	).Once()
+
+	mocks.addrStore.On("MarkUsed", mock.Anything, addr).Return(nil).Once()
+	mocks.txStore.On("InsertUnconfirmedTx", mock.Anything, rec,
+		mock.Anything,
+	).Return(nil).Once()
+
+	// Act: Attempt to persist the unconfirmed transaction.
+	err := s.DBPutTxns(t.Context(), matches, nil)
+
+	// Assert: Verify that the transaction was persisted successfully.
+	require.NoError(t, err)
+}
+
+// TestPutAddrHorizons verifies that address horizons are correctly extended
+// in the database based on scan results.
+func TestPutAddrHorizons(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a syncer and setup a scan result that indicates a
+	// horizon expansion is needed for a specific BIP84 account.
+	w, mocks := createTestWalletWithMocks(t)
+	s := newSyncer(w.cfg, w.addrStore, w.txStore, nil)
+
+	bs := waddrmgr.BranchScope{
+		Scope:   waddrmgr.KeyScopeBIP0084,
+		Account: 0,
+		Branch:  waddrmgr.ExternalBranch,
+	}
+
+	res := []scanResult{{
+		BlockProcessResult: &BlockProcessResult{
+			FoundHorizons: map[waddrmgr.BranchScope]uint32{
+				bs: 10,
+			},
+		},
+	}}
+
+	// Setup mock calls for fetching the manager and extending the
+	// addresses.
+	scopedMgr := &mockAccountStore{}
+	mocks.addrStore.On("FetchScopedKeyManager", bs.Scope).Return(
+		scopedMgr, nil,
+	).Once()
+
+	scopedMgr.On("ExtendAddresses", mock.Anything, bs.Account, uint32(10),
+		bs.Branch,
+	).Return(nil).Once()
+
+	// Act: Trigger the horizon expansion within a database transaction.
+	err := walletdb.Update(w.cfg.DB, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+		return s.putAddrHorizons(t.Context(), ns, res)
+	})
+
+	// Assert: Verify that the horizons were extended without error.
+	require.NoError(t, err)
+}
+
+// TestDBGetScanData verifies that the wallet can successfully retrieve all
+// necessary state (horizons, active addresses, and UTXOs) to initialize a
+// chain rescan.
+func TestDBGetScanData(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a syncer and setup mock expectations for all data
+	// required during rescan initialization.
+	w, mocks := createTestWalletWithMocks(t)
+	s := newSyncer(w.cfg, w.addrStore, w.txStore, nil)
+
+	targets := []waddrmgr.AccountScope{{
+		Scope:   waddrmgr.KeyScopeBIP0084,
+		Account: 0,
+	}}
+
+	// 1. Horizons lookup.
+	scopedMgr := &mockAccountStore{}
+	mocks.addrStore.On("FetchScopedKeyManager",
+		waddrmgr.KeyScopeBIP0084,
+	).Return(scopedMgr, nil).Once()
+
+	props := &waddrmgr.AccountProperties{AccountNumber: 0}
+	scopedMgr.On("AccountProperties", mock.Anything, uint32(0)).Return(
+		props, nil,
+	).Once()
+
+	// 2. Active addresses lookup.
+	mocks.addrStore.On("ForEachRelevantActiveAddress", mock.Anything,
+		mock.Anything,
+	).Return(nil).Once()
+
+	// 3. UTXO lookup.
+	mocks.txStore.On("OutputsToWatch", mock.Anything).Return(
+		[]wtxmgr.Credit(nil), nil,
+	).Once()
+
+	// Act: Retrieve the initial scan data from the database.
+	horizonData, initialAddrs, initialUnspent, err := s.DBGetScanData(
+		t.Context(), targets,
+	)
+
+	// Assert: Verify that the retrieved data matches our expectations and
+	// that no error occurred.
+	require.NoError(t, err)
+	require.Len(t, horizonData, 1)
+	require.Equal(t, props, horizonData[0])
+	require.Empty(t, initialAddrs)
+	require.Empty(t, initialUnspent)
+}
+
+// TestDBGetSyncedBlocks verifies that the wallet can successfully retrieve a
+// range of block hashes from its internal index.
+func TestDBGetSyncedBlocks(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a syncer and setup a mock expectation for fetching a
+	// block hash from the address manager.
+	w, mocks := createTestWalletWithMocks(t)
+	s := newSyncer(w.cfg, w.addrStore, w.txStore, nil)
+
+	hash := chainhash.Hash{0x01}
+	mocks.addrStore.On("BlockHash", mock.Anything, int32(100)).Return(
+		&hash, nil,
+	).Once()
+
+	// Act: Fetch the block hashes for the requested range.
+	hashes, err := s.DBGetSyncedBlocks(t.Context(), 100, 100)
+
+	// Assert: Verify that the retrieved hash is correct.
+	require.NoError(t, err)
+	require.Len(t, hashes, 1)
+	require.Equal(t, &hash, hashes[0])
+}
+
+// TestDBPutRewind verifies that the wallet can successfully rewind its
+// synchronized state and transaction history to a specific point.
+func TestDBPutRewind(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a syncer and setup mock expectations for updating
+	// the sync tip and rolling back the transaction store.
+	w, mocks := createTestWalletWithMocks(t)
+	s := newSyncer(w.cfg, w.addrStore, w.txStore, nil)
+
+	bs := waddrmgr.BlockStamp{Height: 100, Hash: chainhash.Hash{0x01}}
+
+	mocks.addrStore.On("SetSyncedTo", mock.Anything, &bs).Return(nil).Once()
+	mocks.txStore.On("Rollback",
+		mock.Anything, int32(101),
+	).Return(nil).Once()
+
+	// Act: Rewind the wallet state to the specified block height.
+	err := s.DBPutRewind(t.Context(), bs)
+
+	// Assert: Verify that the rewind operation succeeded.
+	require.NoError(t, err)
+}
+
+// TestDBPutBirthdayBlock_Error verifies that DBPutBirthdayBlock correctly
+// handles and returns database errors during persistence.
+func TestDBPutBirthdayBlock_Error(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a test wallet and setup a mock call that simulates a
+	// failure when setting the birthday block.
+	w, mocks := createTestWalletWithMocks(t)
+
+	bs := waddrmgr.BlockStamp{Height: 100}
+
+	mocks.addrStore.On("SetBirthdayBlock", mock.Anything, bs, true).Return(
+		errDBMock,
+	).Once()
+
+	// Act: Attempt to persist the birthday block, expecting a failure.
+	err := w.DBPutBirthdayBlock(t.Context(), bs)
+
+	// Assert: Verify that the database error is correctly propagated.
+	require.ErrorContains(t, err, "db error")
+}
+
+// TestDBGetAllAccounts_Error verifies that DBGetAllAccounts correctly
+// handles and returns database errors encountered while iterating over
+// accounts.
+func TestDBGetAllAccounts_Error(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a test wallet and setup a mock call that simulates a
+	// failure while querying for the last account index.
+	w, mocks := createTestWalletWithMocks(t)
+	scopedMgr := &mockAccountStore{}
+
+	mocks.addrStore.On("ActiveScopedKeyManagers").Return(
+		[]waddrmgr.AccountStore{scopedMgr},
+	).Once()
+
+	scopedMgr.On("LastAccount", mock.Anything).Return(
+		uint32(0), errDBMock,
+	).Once()
+
+	// Act: Attempt to load all account properties.
+	err := w.DBGetAllAccounts(t.Context())
+
+	// Assert: Verify that the expected error is returned.
+	require.ErrorContains(t, err, "db error")
+}
+
+// TestDBGetScanData_MultipleTargets verifies that DBGetScanData correctly
+// aggregates horizon data when multiple account scopes are requested.
+func TestDBGetScanData_MultipleTargets(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a syncer and setup test data for multiple accounts
+	// across different scopes.
+	w, mocks := createTestWalletWithMocks(t)
+	s := newSyncer(w.cfg, w.addrStore, w.txStore, nil)
+
+	targets := []waddrmgr.AccountScope{
+		{Scope: waddrmgr.KeyScopeBIP0084, Account: 0},
+		{Scope: waddrmgr.KeyScopeBIP0049Plus, Account: 1},
+	}
+
+	// Setup mock calls to handle property retrieval for both targets.
+	scopedMgr := &mockAccountStore{}
+	mocks.addrStore.On("FetchScopedKeyManager", mock.Anything).Return(
+		scopedMgr, nil,
+	).Twice()
+
+	scopedMgr.On("AccountProperties", mock.Anything, mock.Anything).Return(
+		&waddrmgr.AccountProperties{}, nil,
+	).Twice()
+
+	mocks.addrStore.On("ForEachRelevantActiveAddress", mock.Anything,
+		mock.Anything,
+	).Return(nil).Once()
+
+	mocks.txStore.On("OutputsToWatch", mock.Anything).Return(
+		[]wtxmgr.Credit(nil), nil,
+	).Once()
+
+	// Act: Retrieve initial scan data for all requested targets.
+	horizons, _, _, err := s.DBGetScanData(t.Context(), targets)
+
+	// Assert: Verify that data for both targets was successfully
+	// collected.
+	require.NoError(t, err)
+	require.Len(t, horizons, 2)
+}
+
+// TestDBGetScanData_Error verifies that DBGetScanData correctly handles
+// and returns database errors during horizon lookup, ensuring no stale
+// data is returned.
+func TestDBGetScanData_Error(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a syncer and setup a mock expectation for a failure
+	// while fetching a scoped key manager.
+	w, mocks := createTestWalletWithMocks(t)
+	s := newSyncer(w.cfg, w.addrStore, w.txStore, nil)
+
+	targets := []waddrmgr.AccountScope{{
+		Scope:   waddrmgr.KeyScopeBIP0084,
+		Account: 0,
+	}}
+
+	mocks.addrStore.On("FetchScopedKeyManager",
+		waddrmgr.KeyScopeBIP0084,
+	).Return(nil, errDBMock).Once()
+
+	// Act: Attempt to retrieve scan data, which is expected to fail.
+	horizons, addrs, unspent, err := s.DBGetScanData(t.Context(), targets)
+
+	// Assert: Verify that the database error is returned and all returned
+	// data slices are nil.
+	require.ErrorContains(t, err, "db error")
+	require.Nil(t, horizons)
+	require.Nil(t, addrs)
+	require.Nil(t, unspent)
+}

--- a/wallet/import_test.go
+++ b/wallet/import_test.go
@@ -71,7 +71,6 @@ type testCase struct {
 }
 
 var (
-	//nolint:lll
 	testCases = []*testCase{{
 		name: "bip44 with nested witness address type",
 		masterPriv: "tprv8ZgxMBicQKsPeWwrFuNjEGTTDSY4mRLwd2KDJAPGa1AY" +

--- a/wallet/mock_test.go
+++ b/wallet/mock_test.go
@@ -1275,3 +1275,38 @@ func (m *mockTxPublisher) Broadcast(ctx context.Context, tx *wire.MsgTx,
 	args := m.Called(ctx, tx, label)
 	return args.Error(0)
 }
+
+// mockAddress is a mock implementation of the btcutil.Address interface.
+// It embeds mock.Mock to allow for flexible stubbing of its methods,
+// enabling granular control over address behavior in tests.
+type mockAddress struct {
+	mock.Mock
+}
+
+// EncodeAddress mocks the EncodeAddress method.
+// It returns a predefined string based on mock expectations.
+func (m *mockAddress) EncodeAddress() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+// ScriptAddress mocks the ScriptAddress method.
+// It returns a predefined byte slice based on mock expectations.
+func (m *mockAddress) ScriptAddress() []byte {
+	args := m.Called()
+	return args.Get(0).([]byte)
+}
+
+// IsForNet mocks the IsForNet method.
+// It returns a predefined boolean based on mock expectations.
+func (m *mockAddress) IsForNet(params *chaincfg.Params) bool {
+	args := m.Called(params)
+	return args.Bool(0)
+}
+
+// String mocks the String method.
+// It returns a predefined string based on mock expectations.
+func (m *mockAddress) String() string {
+	args := m.Called()
+	return args.String(0)
+}

--- a/wallet/psbt_manager_test.go
+++ b/wallet/psbt_manager_test.go
@@ -2498,7 +2498,6 @@ func TestAddTaprootSigToPInput(t *testing.T) {
 				LeafHashes:  [][]byte{leafHash},
 			},
 			// Assert: Expect TaprootScriptSpendSig to be appended.
-			//nolint:lll
 			expectedPInput: &psbt.PInput{
 				SighashType: txscript.SigHashDefault,
 				TaprootScriptSpendSig: []*psbt.TaprootScriptSpendSig{{

--- a/wallet/recovery.go
+++ b/wallet/recovery.go
@@ -390,6 +390,376 @@ type AddrEntry struct {
 	addrScope waddrmgr.AddrScope
 }
 
+// Initialize prepares the recovery state for a new batch scan by syncing
+// horizons, populating history/UTXOs, and expanding the lookahead window.
+//
+// TODO(yy): Once RecoveryManager is removed, privatize this method and call
+// it directly from NewRecoveryState to simplify the initialization flow.
+func (rs *RecoveryState) Initialize(accounts []*waddrmgr.AccountProperties,
+	initialAddrs []btcutil.Address, initialUnspent []wtxmgr.Credit) error {
+
+	rs.outpoints = make(map[wire.OutPoint][]byte)
+	rs.addrFilters = make(map[string]AddrEntry)
+
+	// 1. Sync Horizons & Derive Lookahead.
+	//
+	// We iterate over all accounts loaded from the database (horizonData)
+	// to sync the recovery horizons. This loop will also populate the
+	// rs.branchStates map with all active branches. For each branch, it
+	// will derive addresses up to the recovery window size and add them to
+	// rs.addrFilters.
+	for _, props := range accounts {
+		err := rs.initAccountState(props)
+		if err != nil {
+			return err
+		}
+	}
+
+	// 2. Populate the filter with "History" - addresses that are already
+	// active/used in the wallet database. We monitor these to detect any
+	// new payments to existing keys.
+	for _, addr := range initialAddrs {
+		addrStr := addr.EncodeAddress()
+
+		entry := AddrEntry{
+			Address:     addr,
+			IsLookahead: false,
+		}
+		rs.addrFilters[addrStr] = entry
+	}
+
+	// 3. Populate the set of unspent outputs (UTXOs) to watch. We monitor
+	// these outpoints to detect when they are spent by a transaction in a
+	// block.
+	for _, u := range initialUnspent {
+		rs.outpoints[u.OutPoint] = u.PkScript
+	}
+
+	return nil
+}
+
+// BuildCFilterData constructs the list of scripts (addresses + outpoints) used
+// for CFilter matching. This is an expensive operation (script derivation) and
+// should only be called when filters are actually used.
+func (rs *RecoveryState) BuildCFilterData() ([][]byte, error) {
+	// Calculate size: addrFilters (Addrs) + outpoints (UTXOs).
+	size := len(rs.addrFilters) + len(rs.outpoints)
+	watchList := make([][]byte, 0, size)
+
+	for _, entry := range rs.addrFilters {
+		script, err := txscript.PayToAddrScript(entry.Address)
+		if err != nil {
+			return nil, fmt.Errorf("failed to gen script for %s: "+
+				"%w", entry.Address, err)
+		}
+
+		watchList = append(watchList, script)
+	}
+
+	for _, script := range rs.outpoints {
+		watchList = append(watchList, script)
+	}
+
+	return watchList, nil
+}
+
+// TxEntry pairs a transaction record with its extracted address entries.
+type TxEntry struct {
+	Rec     *wtxmgr.TxRecord
+	Entries []AddrEntry
+}
+
+// TxEntries is a list of matched transaction entries, preserving the order of
+// transactions.
+type TxEntries []TxEntry
+
+// BlockProcessResult contains the results of processing a block for recovery.
+type BlockProcessResult struct {
+	// RelevantTxs is a slice of transactions within the block that are
+	// relevant to the wallet (i.e., they spend one of our watched
+	// outpoints or send funds to one of our addresses).
+	RelevantTxs []*btcutil.Tx
+
+	// FoundHorizons maps the BranchScope to the highest child index found
+	// in this block. This is used for persistent horizon expansion.
+	FoundHorizons map[waddrmgr.BranchScope]uint32
+
+	// RelevantOutputs holds the details of transaction outputs that
+	// matched the wallet's filters. This allows efficient access to
+	// derivation information without re-parsing scripts or re-fetching
+	// addresses.
+	RelevantOutputs TxEntries
+
+	// Expanded indicates whether any new addresses were derived and added
+	// to the address filters as a result of processing this block (i.e., a
+	// lookahead horizon expansion was triggered).
+	Expanded bool
+}
+
+// ProcessBlock filters a block for relevant transactions and expands the
+// recovery horizons if new addresses are found. It handles the "Filter ->
+// Expand -> Retry" loop internally and returns the relevant transactions,
+// found horizons (for state update), relevant matches (for efficient
+// ingestion), and a boolean indicating if any expansion occurred.
+func (rs *RecoveryState) ProcessBlock(block *wire.MsgBlock) (
+	*BlockProcessResult, error) {
+
+	var (
+		expanded        bool
+		relevantTxs     []*btcutil.Tx
+		foundScopes     map[waddrmgr.AddrScope]struct{}
+		relevantOutputs TxEntries
+		foundHorizons   map[waddrmgr.BranchScope]uint32
+	)
+
+	for {
+		relevantTxs, foundScopes, relevantOutputs = rs.filterBlock(
+			block,
+		)
+
+		foundHorizons = rs.reportFound(foundScopes)
+		if len(foundHorizons) == 0 {
+			break
+		}
+
+		expandedNow, err := rs.expandHorizons()
+		if err != nil {
+			return nil, fmt.Errorf("expand horizons: %w", err)
+		}
+
+		if !expandedNow {
+			break
+		}
+
+		expanded = true
+	}
+
+	return &BlockProcessResult{
+		RelevantTxs:     relevantTxs,
+		FoundHorizons:   foundHorizons,
+		RelevantOutputs: relevantOutputs,
+		Expanded:        expanded,
+	}, nil
+}
+
+// initAccountState initializes the recovery state for a specific account by
+// setting up branch recovery states for both external and internal branches.
+// It iterates through the known address counts (from the provided account
+// properties) to sync the horizons and populate the address filters with
+// derived addresses up to the recovery window.
+func (rs *RecoveryState) initAccountState(
+	props *waddrmgr.AccountProperties) error {
+
+	initBranch := func(branch uint32, lastKnownIndex uint32) error {
+		bs := waddrmgr.BranchScope{
+			Scope:   props.KeyScope,
+			Account: props.AccountNumber,
+			Branch:  branch,
+		}
+
+		branchState, err := rs.GetBranchState(bs)
+		if err != nil {
+			return err
+		}
+
+		entries, err := branchState.buildAddrFilters(bs, lastKnownIndex)
+		if err != nil {
+			return err
+		}
+
+		for _, entry := range entries {
+			rs.addrFilters[entry.Address.EncodeAddress()] = entry
+		}
+
+		return nil
+	}
+
+	err := initBranch(waddrmgr.ExternalBranch, props.ExternalKeyCount)
+	if err != nil {
+		return fmt.Errorf("derive external addrs for %s/%d': %w",
+			props.KeyScope, props.AccountNumber, err)
+	}
+
+	err = initBranch(waddrmgr.InternalBranch, props.InternalKeyCount)
+	if err != nil {
+		return fmt.Errorf("derive internal addrs for %s/%d': %w",
+			props.KeyScope, props.AccountNumber, err)
+	}
+
+	return nil
+}
+
+// reportFound updates the recovery state with any addresses found in the
+// current block. It returns the set of found horizons (max index per branch).
+func (rs *RecoveryState) reportFound(
+	found map[waddrmgr.AddrScope]struct{}) map[waddrmgr.BranchScope]uint32 {
+
+	foundHorizons := make(map[waddrmgr.BranchScope]uint32)
+
+	// Group by branch and find max index.
+	for addrScope := range found {
+		bs := addrScope.BranchScope
+
+		idx := addrScope.Index
+		if currentMax, ok := foundHorizons[bs]; !ok ||
+			idx > currentMax {
+
+			foundHorizons[bs] = idx
+		}
+	}
+
+	// Update memory state.
+	for bs, maxIdx := range foundHorizons {
+		state, err := rs.GetBranchState(bs)
+		if err != nil {
+			// This should theoretically not happen if the found
+			// map was populated correctly from filters that
+			// correspond to valid branch states. Log this as an
+			// error for debugging.
+			log.Errorf("Failed to get branch state for %v: %v", bs,
+				err)
+
+			continue
+		}
+
+		state.ReportFound(maxIdx)
+	}
+
+	return foundHorizons
+}
+
+// filterBlock checks a block for any transactions relevant to the wallet.
+// It returns the relevant transactions and the set of found addresses (by
+// branch scope and index).
+//
+// NOTE: This method mutates the recovery state's outpoints in-place by
+// removing spent inputs and adding new relevant outputs. This handles
+// intra-block chains correctly.
+func (rs *RecoveryState) filterBlock(block *wire.MsgBlock) ([]*btcutil.Tx,
+	map[waddrmgr.AddrScope]struct{}, TxEntries) {
+
+	var relevant []*btcutil.Tx
+
+	foundScopes := make(map[waddrmgr.AddrScope]struct{})
+
+	var relevantOutputs TxEntries
+	for _, tx := range block.Transactions {
+		isRelevant, entries := rs.filterTx(tx, foundScopes)
+		if isRelevant {
+			relevant = append(relevant, btcutil.NewTx(tx))
+
+			// We create a temporary record here. The timestamp
+			// will be updated during commitment.
+			rec, _ := wtxmgr.NewTxRecordFromMsgTx(
+				tx, time.Time{},
+			)
+
+			relevantOutputs = append(relevantOutputs, TxEntry{
+				Rec:     rec,
+				Entries: entries,
+			})
+		}
+	}
+
+	return relevant, foundScopes, relevantOutputs
+}
+
+// filterTx checks a single transaction for relevance and returns any matching
+// address entries.
+func (rs *RecoveryState) filterTx(tx *wire.MsgTx,
+	foundScopes map[waddrmgr.AddrScope]struct{}) (bool, []AddrEntry) {
+
+	var (
+		isRelevant bool
+		entries    []AddrEntry
+	)
+
+	// Check if the transaction spends any of our watched outpoints. If so,
+	// it's relevant (a debit).
+	for _, txIn := range tx.TxIn {
+		if _, ok := rs.outpoints[txIn.PreviousOutPoint]; ok {
+			isRelevant = true
+
+			delete(rs.outpoints, txIn.PreviousOutPoint)
+		}
+	}
+
+	// Check if the transaction pays to any of our watched addresses. If
+	// so, it's relevant (a credit).
+	for i, txOut := range tx.TxOut {
+		_, addrs, _, err := txscript.ExtractPkScriptAddrs(
+			txOut.PkScript, rs.chainParams,
+		)
+		if err != nil {
+			log.Debugf("Could not extract addresses from script "+
+				"%x: %v", txOut.PkScript, err)
+
+			continue
+		}
+
+		for _, a := range addrs {
+			entry, ok := rs.addrFilters[a.EncodeAddress()]
+			if !ok {
+				continue
+			}
+
+			isRelevant = true
+
+			if entry.IsLookahead {
+				foundScopes[entry.addrScope] = struct{}{}
+			}
+
+			//nolint:gosec // Output index fits in uint32.
+			idx := uint32(i)
+
+			// Create result entry with Credit populated.
+			entry.Credit.Index = idx
+			entries = append(entries, entry)
+
+			// Add new output to map immediately to catch
+			// intra-block spends.
+			op := wire.OutPoint{Hash: tx.TxHash(), Index: idx}
+			rs.outpoints[op] = txOut.PkScript
+		}
+	}
+
+	return isRelevant, entries
+}
+
+// expandHorizons ensures that the recovery state's lookahead horizon is
+// sufficient by deriving new addresses if needed, and then updates the
+// internal batch artifacts (addrFilters) with the lookahead addresses.
+func (rs *RecoveryState) expandHorizons() (bool, error) {
+	// We iterate over all active branch states and ensure their lookahead
+	// windows are sufficiently expanded.
+	//
+	// NOTE: rs.branchStates contains the set of all active branches
+	// determined at initialization. This set remains static for the
+	// duration of the batch scan, even as the internal state of each
+	// branch (horizon) evolves.
+	var expanded bool
+	for bs, branchState := range rs.branchStates {
+		// Passing 0 for lastKnownIndex means we don't want to update
+		// the found status based on historical data, just ensure the
+		// lookahead is sufficient based on the current state.
+		newEntries, err := branchState.buildAddrFilters(bs, 0)
+		if err != nil {
+			return false, err
+		}
+
+		if len(newEntries) > 0 {
+			expanded = true
+
+			for _, entry := range newEntries {
+				rs.addrFilters[entry.Address.EncodeAddress()] =
+					entry
+			}
+		}
+	}
+
+	return expanded, nil
+}
+
 // ScopeRecoveryState is used to manage the recovery of addresses generated
 // under a particular BIP32 account. Each account tracks both an external and
 // internal branch recovery state, both of which use the same recovery window.

--- a/wallet/recovery.go
+++ b/wallet/recovery.go
@@ -1,6 +1,8 @@
 package wallet
 
 import (
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
@@ -279,6 +281,25 @@ func (rs *RecoveryState) AddWatchedOutPoint(outPoint *wire.OutPoint,
 	rs.watchedOutPoints[*outPoint] = addr
 }
 
+// AddrEntry holds the derivation info for an address to support
+// reverse lookups during filtering.
+type AddrEntry struct {
+	// Address is the cached address for script generation.
+	Address btcutil.Address
+
+	// Credit records the transaction credit metadata (index, change)
+	// when this address matches a transaction output.
+	Credit wtxmgr.CreditEntry
+
+	// IsLookahead indicates whether this address is part of the current
+	// lookahead window. If true, finding this address *in the block*
+	// triggers horizon expansion.
+	IsLookahead bool
+
+	// addrScope identifies the specific address derivation path.
+	addrScope waddrmgr.AddrScope
+}
+
 // ScopeRecoveryState is used to manage the recovery of addresses generated
 // under a particular BIP32 account. Each account tracks both an external and
 // internal branch recovery state, both of which use the same recovery window.
@@ -300,8 +321,8 @@ type ScopeRecoveryState struct {
 // TODO(yy): Deprecated, remove.
 func NewScopeRecoveryState(recoveryWindow uint32) *ScopeRecoveryState {
 	return &ScopeRecoveryState{
-		ExternalBranch: NewBranchRecoveryState(recoveryWindow),
-		InternalBranch: NewBranchRecoveryState(recoveryWindow),
+		ExternalBranch: NewBranchRecoveryState(recoveryWindow, nil),
+		InternalBranch: NewBranchRecoveryState(recoveryWindow, nil),
 	}
 }
 
@@ -335,15 +356,22 @@ type BranchRecoveryState struct {
 	// invalidChildren records the set of child indexes that derive to
 	// invalid keys.
 	invalidChildren map[uint32]struct{}
+
+	// manager is the scoped key manager used to derive addresses for this
+	// branch.
+	manager waddrmgr.AccountStore
 }
 
 // NewBranchRecoveryState creates a new BranchRecoveryState that can be used to
 // track either the external or internal branch of an account's derivation path.
-func NewBranchRecoveryState(recoveryWindow uint32) *BranchRecoveryState {
+func NewBranchRecoveryState(recoveryWindow uint32,
+	manager waddrmgr.AccountStore) *BranchRecoveryState {
+
 	return &BranchRecoveryState{
 		recoveryWindow:  recoveryWindow,
 		addresses:       make(map[uint32]btcutil.Address),
 		invalidChildren: make(map[uint32]struct{}),
+		manager:         manager,
 	}
 }
 
@@ -435,4 +463,75 @@ func (brs *BranchRecoveryState) NumInvalidInHorizon() uint32 {
 	}
 
 	return nInvalid
+}
+
+// buildAddrFilters is a helper method that maintains the address lookahead
+// window for this branch. It performs two main tasks:
+//  1. Syncs the branch state to the provided `lastKnownIndex` (if non-zero),
+//     ensuring the state reflects what is known from disk or previous scans.
+//  2. Extends the lookahead window if necessary, deriving new addresses and
+//     creating filter entries for them.
+//
+// The returned entries are used to populate the batch-wide address filter.
+func (brs *BranchRecoveryState) buildAddrFilters(bs waddrmgr.BranchScope,
+	lastKnownIndex uint32) ([]AddrEntry, error) {
+
+	// 1. Sync State.
+	// If a last known index is provided (e.g., from DB during
+	// initialization), we update our state to reflect that we've found
+	// addresses up to this point.
+	if lastKnownIndex > 0 {
+		brs.ReportFound(lastKnownIndex - 1)
+	}
+
+	// 2. Compute Extension.
+	// Determine the current horizon and how many new addresses are needed
+	// to maintain the required lookahead window (recoveryWindow) beyond
+	// the last found address.
+	curHorizon, windowToDerive := brs.ExtendHorizon()
+	count, childIndex := uint32(0), curHorizon
+
+	var newEntries []AddrEntry
+
+	// 3. Derive & Cache.
+	// Iterate to derive the required number of new addresses.
+	for count < windowToDerive {
+		addr, _, err := brs.manager.DeriveAddr(
+			bs.Account, bs.Branch, childIndex,
+		)
+		if err != nil {
+			// Handle invalid children (rare in HD, but possible).
+			// We skip the invalid index, mark it, and continue to
+			// ensure we still generate the full window of *valid*
+			// addresses.
+			if errors.Is(err, hdkeychain.ErrInvalidChild) {
+				brs.MarkInvalidChild(childIndex)
+				childIndex++
+
+				continue
+			}
+
+			return nil, fmt.Errorf("derive addr: %w", err)
+		}
+
+		// Cache the valid address in the branch state for future
+		// lookups.
+		brs.AddAddr(childIndex, addr)
+
+		// Create a filter entry for the new address. This entry
+		// contains the metadata (Scope, Account, Branch, Index) needed
+		// to map a future hit back to this specific derivation path.
+		as := waddrmgr.AddrScope{BranchScope: bs, Index: childIndex}
+		entry := AddrEntry{
+			Address:     addr,
+			addrScope:   as,
+			IsLookahead: true,
+		}
+		newEntries = append(newEntries, entry)
+
+		childIndex++
+		count++
+	}
+
+	return newEntries, nil
 }

--- a/wallet/recovery_test.go
+++ b/wallet/recovery_test.go
@@ -1,9 +1,10 @@
-package wallet_test
+package wallet
 
 import (
 	"testing"
+	"time"
 
-	"github.com/btcsuite/btcwallet/wallet"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/stretchr/testify/require"
 )
 
@@ -12,7 +13,7 @@ import (
 // and next unfound values.
 type Harness struct {
 	t              *testing.T
-	brs            *wallet.BranchRecoveryState
+	brs            *BranchRecoveryState
 	recoveryWindow uint32
 	expHorizon     uint32
 	expNextUnfound uint32
@@ -209,7 +210,7 @@ func TestBranchRecoveryState(t *testing.T) {
 		// Expected horizon: 30.
 	}
 
-	brs := wallet.NewBranchRecoveryState(recoveryWindow)
+	brs := NewBranchRecoveryState(recoveryWindow, nil)
 	harness := &Harness{
 		t:              t,
 		brs:            brs,
@@ -240,4 +241,89 @@ func assertNumInvalid(t *testing.T, i int, have, want uint32) {
 func assertHaveWant(t *testing.T, i int, msg string, have, want uint32) {
 	t.Helper()
 	require.Equal(t, want, have, "[step: %d] %s", i, msg)
+}
+
+// TestRecoveryManagerBatch verifies that the RecoveryManager correctly tracks
+// and resets its internal batch of processed blocks.
+func TestRecoveryManagerBatch(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a new recovery manager with a recovery window of 10
+	// and a lookahead distance of 5.
+	rm := NewRecoveryManager(10, 5, &chainParams)
+
+	// Act: Add a block to the current batch.
+	hash := chainhash.Hash{0x01}
+	rm.AddToBlockBatch(&hash, 100, time.Now())
+
+	// Assert: Verify that the block was correctly added to the batch.
+	batch := rm.BlockBatch()
+	require.Len(t, batch, 1)
+	require.Equal(t, int32(100), batch[0].Height)
+
+	// Act: Clear the current batch.
+	rm.ResetBlockBatch()
+
+	// Assert: Verify that the batch is now empty.
+	require.Empty(t, rm.BlockBatch())
+}
+
+// TestBranchRecoveryStateHorizon verifies horizon expansion logic.
+func TestBranchRecoveryStateHorizon(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Window 10.
+	brs := NewBranchRecoveryState(10, nil)
+
+	// Act: Initial horizon extend.
+	// Horizon is 0. NextUnfound is 0. MinValid = 0 + 10 = 10.
+	// Delta = 10 - 0 = 10.
+	// Returns current horizon (start index) and delta.
+	horizon, delta := brs.ExtendHorizon()
+	require.Equal(t, uint32(0), horizon)
+	require.Equal(t, uint32(10), delta)
+
+	// Act: Report found at 5.
+	brs.ReportFound(5)
+
+	// NextUnfound becomes 6.
+	require.Equal(t, uint32(6), brs.NextUnfound())
+
+	// Act: Extend again.
+	// MinValid = 6 + 10 = 16.
+	// Current Horizon = 10.
+	// Delta = 16 - 10 = 6.
+	horizon, delta = brs.ExtendHorizon()
+	require.Equal(t, uint32(10), horizon)
+	require.Equal(t, uint32(6), delta)
+}
+
+// TestBranchRecoveryStateInvalidChild verifies handling of invalid keys.
+func TestBranchRecoveryStateInvalidChild(t *testing.T) {
+	t.Parallel()
+
+	brs := NewBranchRecoveryState(5, nil)
+	// Initial: Horizon 5.
+	brs.ExtendHorizon()
+
+	// Act: Mark index 2 as invalid.
+	brs.MarkInvalidChild(2)
+
+	// Assert: Horizon incremented to 6.
+	require.Equal(t, uint32(1), brs.NumInvalidInHorizon())
+
+	// Act: Extend.
+	// NextUnfound = 0. Window = 5. Invalid = 1.
+	// MinValid = 0 + 5 + 1 = 6.
+	// Current Horizon = 6.
+	// Delta = 0.
+	horizon, delta := brs.ExtendHorizon()
+	require.Equal(t, uint32(6), horizon)
+	require.Equal(t, uint32(0), delta)
+
+	// Act: Found 3.
+	brs.ReportFound(3)
+
+	// Invalid child 2 is < 3, so it should be pruned.
+	require.Equal(t, uint32(0), brs.NumInvalidInHorizon())
 }

--- a/wallet/recovery_test.go
+++ b/wallet/recovery_test.go
@@ -1,10 +1,18 @@
 package wallet
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/stretchr/testify/require"
 )
 
@@ -326,4 +334,748 @@ func TestBranchRecoveryStateInvalidChild(t *testing.T) {
 
 	// Invalid child 2 is < 3, so it should be pruned.
 	require.Equal(t, uint32(0), brs.NumInvalidInHorizon())
+}
+
+// TestGetBranchState verifies the GetBranchState method of RecoveryState.
+// It ensures that the method correctly fetches and caches BranchRecoveryState
+// instances based on the provided BranchScope, optimizing for subsequent
+// lookups by returning the cached state instead of re-creating it.
+func TestGetBranchState(t *testing.T) {
+	t.Parallel()
+
+	addrMgr := &mockAddrStore{}
+	defer addrMgr.AssertExpectations(t)
+
+	scope := waddrmgr.KeyScope{
+		Purpose: waddrmgr.KeyScopeBIP0084.Purpose,
+		Coin:    waddrmgr.KeyScopeBIP0084.Coin,
+	}
+	bs := waddrmgr.BranchScope{
+		Scope:   scope,
+		Account: 0,
+		Branch:  0,
+	}
+
+	// Expect FetchScopedKeyManager to be called only once for a given
+	// scope.
+	addrMgr.On("FetchScopedKeyManager", scope).Return(
+		&mockAccountStore{}, nil,
+	).Once()
+
+	rs := NewRecoveryState(10, &chainParams, addrMgr)
+
+	// First call should fetch the manager and create a new state.
+	state1, err := rs.GetBranchState(bs)
+	require.NoError(t, err)
+	require.NotNil(t, state1)
+
+	// Second call with the same scope should return the cached state.
+	state2, err := rs.GetBranchState(bs)
+	require.NoError(t, err)
+	require.Equal(t, state1, state2)
+}
+
+// TestInitialize verifies the public Initialize method of RecoveryState.
+// It ensures the method correctly sets up transient address filters and
+// outpoints based on account properties and mock address derivations.
+// This includes verifying that the lookahead horizons are properly synced
+// and that the address filters are populated with the expected number of
+// derived addresses for both external and internal branches.
+func TestInitialize(t *testing.T) {
+	t.Parallel()
+
+	addrMgr := &mockAddrStore{}
+	defer addrMgr.AssertExpectations(t)
+
+	accountStore := &mockAccountStore{}
+	defer accountStore.AssertExpectations(t)
+
+	scope := waddrmgr.KeyScope{Purpose: 84, Coin: 0}
+
+	props := &waddrmgr.AccountProperties{
+		KeyScope:         scope,
+		AccountNumber:    0,
+		ExternalKeyCount: 5, // 5 found addresses
+		InternalKeyCount: 3, // 3 found addresses
+	}
+
+	// FetchScopedKeyManager is called twice (once for external, once for
+	// internal branch)
+	addrMgr.On("FetchScopedKeyManager", scope).Return(
+		accountStore, nil,
+	).Times(2)
+
+	// Helper to mock DeriveAddr calls for a given branch and
+	// range of indices.
+	mockDerive := func(branch, count uint32) {
+		for i := range count {
+			id := int(branch)*1000 + int(i)
+			addr := &mockAddress{}
+			addrStr := fmt.Sprintf("addr-%d", id)
+			script := fmt.Appendf(nil, "script-%d", id)
+
+			// Configure mockAddress expectations.
+			addr.On("EncodeAddress").Return(addrStr)
+			addr.On("ScriptAddress").Return(script)
+
+			accountStore.On(
+				"DeriveAddr", uint32(0), branch, i,
+			).Return(addr, script, nil).Once()
+		}
+	}
+
+	// External branch: 5 found, recovery window 10. Total 15 derivations
+	// (0-14).
+	mockDerive(0, 15)
+
+	// Internal branch: 3 found, recovery window 10. Total 13 derivations
+	// (0-12).
+	mockDerive(1, 13)
+
+	rs := NewRecoveryState(10, &chainParams, addrMgr)
+
+	err := rs.Initialize([]*waddrmgr.AccountProperties{props}, nil, nil)
+	require.NoError(t, err)
+
+	// Verify that the address filters are populated with the expected
+	// number of addresses.
+	require.Len(t, rs.addrFilters, 15+13)
+	require.Equal(t, 15+13, rs.WatchListSize())
+}
+
+// TestProcessBlock verifies the core private filterTx and expandHorizons
+// methods through the public ProcessBlock entry point. It simulates a
+// block containing transactions that trigger address discovery and horizon
+// expansion. This test ensures the method correctly identifies relevant
+// transactions, updates outpoints, and manages the lookahead window by
+// repeatedly filtering the block and expanding horizons until convergence,
+// correctly handling intra-block chains and lookahead expansions.
+func TestProcessBlock(t *testing.T) {
+	t.Parallel()
+
+	addrMgr := &mockAddrStore{}
+	defer addrMgr.AssertExpectations(t)
+
+	accountStore := &mockAccountStore{}
+	defer accountStore.AssertExpectations(t)
+
+	scope := waddrmgr.KeyScope{Purpose: 84, Coin: 0}
+	props := &waddrmgr.AccountProperties{
+		KeyScope:      scope,
+		AccountNumber: 0,
+
+		// Start fresh for easier expansion testing.
+		ExternalKeyCount: 0,
+		InternalKeyCount: 0,
+	}
+
+	addrMgr.On("FetchScopedKeyManager", scope).Return(
+		accountStore, nil,
+	).Maybe() // Called by GetBranchState within Initialize/ProcessBlock
+
+	// Store generated addresses to construct block data.
+	addrs := make(map[int]btcutil.Address)
+
+	// Helper to mock DeriveAddr and store the generated address.
+	setupDerive := func(branch, idx uint32) {
+		id := int(branch)*1000 + int(idx)
+
+		// Create a valid P2PKH address for deterministic scripts.
+		hash := make([]byte, 20)
+		hash[0] = byte(id >> 8)
+		hash[1] = byte(id)
+		addr, _ := btcutil.NewAddressPubKeyHash(
+			hash, &chainParams,
+		)
+		addrs[id] = addr
+
+		// Set up mock expectation for DeriveAddr.
+		script, _ := txscript.PayToAddrScript(addr)
+		accountStore.On(
+			"DeriveAddr", uint32(0), branch, idx,
+		).Return(addr, script, nil).Maybe()
+	}
+
+	// 1. Initialize RecoveryState (derives initial lookahead 0-9 for both
+	//    branches).
+	for i := range uint32(10) {
+		setupDerive(0, i) // External addresses
+		setupDerive(1, i) // Internal addresses
+	}
+
+	rs := NewRecoveryState(10, &chainParams, addrMgr)
+	err := rs.Initialize([]*waddrmgr.AccountProperties{props}, nil, nil)
+	require.NoError(t, err)
+
+	// 2. Setup expectations for subsequent horizon expansions:
+	//
+	// Finding address at index 5 (External) should make next unfound 6.
+	// Horizon expands to 6 + window (10) = 16. New addresses derived from
+	// 10 to 15.
+	for i := uint32(10); i < 16; i++ {
+		setupDerive(0, i)
+	}
+
+	// Finding address at index 12 (External) should make next unfound 13.
+	// Horizon expands to 13 + window (10) = 23. New addresses derived from
+	// 16 to 22.
+	for i := uint32(16); i < 23; i++ {
+		setupDerive(0, i)
+	}
+
+	// 3. Construct a mock block with transactions.
+	block := wire.NewMsgBlock(wire.NewBlockHeader(
+		0, &chainhash.Hash{}, &chainhash.Hash{}, 0, 0,
+	))
+
+	// Tx1: Pays to Addr 5 (External Branch) - an address within initial
+	// lookahead.
+	addr5 := addrs[5] // Corresponds to id 5 (branch 0, index 5)
+	script5, _ := txscript.PayToAddrScript(addr5)
+	tx1 := wire.NewMsgTx(2)
+	tx1.AddTxOut(wire.NewTxOut(1000, script5))
+	_ = block.AddTransaction(tx1)
+
+	// Tx2: Pays to Addr 12 (External Branch) - an address initially
+	// outside the lookahead, but becomes visible after the first
+	// expansion.
+	addr12 := addrs[12] // Corresponds to id 12 (branch 0, index 12)
+	script12, _ := txscript.PayToAddrScript(addr12)
+	tx2 := wire.NewMsgTx(2)
+	tx2.AddTxOut(wire.NewTxOut(2000, script12))
+	_ = block.AddTransaction(tx2)
+
+	// 4. Process the block and verify results.
+	res, err := rs.ProcessBlock(block)
+	require.NoError(t, err)
+
+	// Expect expansion occurred due to finding index 12.
+	require.True(t, res.Expanded)
+
+	// Expect both transactions to be identified as relevant.
+	require.Len(t, res.RelevantTxs, 2)
+
+	// Verify the maximum index found for Branch 0 (External) is 12.
+	bs := waddrmgr.BranchScope{Scope: scope, Account: 0, Branch: 0}
+	require.Contains(t, res.FoundHorizons, bs)
+	require.Equal(t, uint32(12), res.FoundHorizons[bs])
+}
+
+// TestBuildCFilterData verifies the BuildCFilterData method of RecoveryState.
+// It ensures that the method correctly aggregates all relevant scripts from
+// both the transient address filters and the watched outpoints into a single
+// list, which is then used for CFilter construction. This tests the data
+// aggregation logic, independent of address derivation or block processing.
+func TestBuildCFilterData(t *testing.T) {
+	t.Parallel()
+
+	addrMgr := &mockAddrStore{}
+	defer addrMgr.AssertExpectations(t)
+
+	rs := NewRecoveryState(10, &chainParams, addrMgr)
+
+	// Initially, the recovery state should be empty.
+	require.True(t, rs.Empty())
+
+	// Manually initialize maps as Initialize is not called for this test.
+	rs.addrFilters = make(map[string]AddrEntry)
+	rs.outpoints = make(map[wire.OutPoint][]byte)
+
+	// Add a sample address filter entry.
+	addr1, _ := btcutil.DecodeAddress(
+		"mrCDrCybB6J1vRfbwM5hemdJz73FwDBC8r", &chainParams,
+	)
+	rs.addrFilters[addr1.EncodeAddress()] = AddrEntry{
+		Address: addr1,
+	}
+
+	// Add a sample watched outpoint.
+	op := wire.OutPoint{Hash: chainhash.Hash{1}, Index: 0}
+	pkScript := []byte{0x00, 0x14, 0x01, 0x02} // Dummy P2WPKH script
+	rs.outpoints[op] = pkScript
+
+	// Verify WatchListSize reflects the manually added entries.
+	require.Equal(t, 2, rs.WatchListSize())
+
+	// Build the CFilter data.
+	data, err := rs.BuildCFilterData()
+	require.NoError(t, err)
+
+	// Construct the expected script for addr1.
+	script1, _ := txscript.PayToAddrScript(addr1)
+
+	// Verify the returned data contains both scripts.
+	require.Len(t, data, 2)
+	require.Contains(t, data, script1)
+	require.Contains(t, data, pkScript)
+}
+
+// TestInitAccountState verifies the private initAccountState method.
+// It focuses on ensuring that when an account's properties are processed,
+// the method correctly initializes branch recovery states for both external
+// and internal branches. This involves verifying that the address manager's
+// FetchScopedKeyManager is called appropriately and that the recovery
+// state's addrFilters are populated with the initial set of derived
+// addresses based on the configured recovery window.
+func TestInitAccountState(t *testing.T) {
+	t.Parallel()
+
+	addrMgr := &mockAddrStore{}
+	defer addrMgr.AssertExpectations(t)
+
+	accountStore := &mockAccountStore{}
+	defer accountStore.AssertExpectations(t)
+
+	scope := waddrmgr.KeyScope{Purpose: 84, Coin: 0}
+	props := &waddrmgr.AccountProperties{
+		KeyScope:         scope,
+		AccountNumber:    0,
+		ExternalKeyCount: 0,
+		InternalKeyCount: 0,
+	}
+
+	// RecoveryWindow 2.
+	rs := NewRecoveryState(2, &chainParams, addrMgr)
+	rs.addrFilters = make(map[string]AddrEntry)
+
+	// FetchScopedKeyManager is called twice (once for external, once for
+	// internal branch).
+	addrMgr.On("FetchScopedKeyManager", scope).Return(
+		accountStore, nil,
+	).Times(2)
+
+	// Helper to mock DeriveAddr calls for a given branch and range of
+	// indices.
+	mockDerive := func(branch uint32) {
+		for i := range uint32(2) {
+			id := int(branch)*1000 + int(i)
+			addr := &mockAddress{}
+			addrStr := fmt.Sprintf("b%d-%d", branch, i)
+			script := fmt.Appendf(nil, "script-%d", id)
+
+			// Configure mockAddress expectations.
+			addr.On("EncodeAddress").Return(addrStr)
+			addr.On("ScriptAddress").Return(script)
+
+			accountStore.On(
+				"DeriveAddr", uint32(0), branch, i,
+			).Return(addr, script, nil).Once()
+		}
+	}
+
+	mockDerive(0) // External
+	mockDerive(1) // Internal
+
+	err := rs.initAccountState(props)
+	require.NoError(t, err)
+	require.Len(t, rs.addrFilters, 4)
+}
+
+// TestExpandHorizons verifies the private expandHorizons method.
+// It ensures that the lookahead horizon is correctly expanded when new
+// addresses are reported as found. This test specifically checks that new
+// addresses are derived (via the mocked AccountStore) to maintain the recovery
+// window, and that these newly derived addresses are subsequently added to the
+// RecoveryState's transient addrFilters.
+func TestExpandHorizons(t *testing.T) {
+	t.Parallel()
+
+	store := &mockAccountStore{}
+	defer store.AssertExpectations(t)
+
+	rs := NewRecoveryState(2, nil, nil)
+	rs.addrFilters = make(map[string]AddrEntry)
+
+	// Setup a branch state manually.
+	bs := waddrmgr.BranchScope{Branch: 0}
+	brs := NewBranchRecoveryState(2, store)
+	rs.branchStates[bs] = brs
+
+	// Simulate finding index 0, which requires derivation of 0, 1, 2
+	// because NextUnfound becomes 1, MinHorizon = 1+2=3.
+	brs.ReportFound(0)
+
+	// Expect derivation of 0, 1, 2.
+	for i := range uint32(3) {
+		addr := &mockAddress{}
+		addrStr := fmt.Sprintf("addr-%d", i)
+		script := fmt.Appendf(nil, "script-%d", i)
+
+		addr.On("EncodeAddress").Return(addrStr)
+		addr.On("ScriptAddress").Return(script)
+
+		store.On("DeriveAddr", uint32(0), uint32(0), i).Return(
+			addr, script, nil,
+		).Once()
+	}
+
+	expanded, err := rs.expandHorizons()
+	require.NoError(t, err)
+	require.True(t, expanded)
+	require.Len(t, rs.addrFilters, 3)
+}
+
+// TestReportFound verifies the private reportFound method.
+// It ensures that the method correctly processes a map of found AddrScopes,
+// identifying the maximum index found for each BranchScope. It then verifies
+// that the corresponding BranchRecoveryState's internal `nextUnfound` value is
+// updated appropriately based on these findings, triggering potential future
+// horizon expansions.
+func TestReportFound(t *testing.T) {
+	t.Parallel()
+
+	rs := NewRecoveryState(10, nil, nil)
+	bs := waddrmgr.BranchScope{Branch: 0}
+	brs := NewBranchRecoveryState(10, nil)
+	rs.branchStates[bs] = brs
+
+	// Simulate finding index 5 on this branch.
+	found := map[waddrmgr.AddrScope]struct{}{
+		{BranchScope: bs, Index: 5}: {},
+	}
+
+	horizons := rs.reportFound(found)
+
+	require.Contains(t, horizons, bs)
+	require.Equal(t, uint32(5), horizons[bs])
+	require.Equal(t, uint32(6), brs.NextUnfound())
+}
+
+// TestFilterTx verifies the private filterTx method.
+// It simulates a single transaction and checks its relevance against the
+// RecoveryState's configured address filters and watched outpoints. This test
+// ensures that the method correctly identifies credits (payments to our
+// addresses) and debits (spends from our outpoints), updates the transient
+// outpoints map (removing spent inputs, adding new relevant outputs), and
+// populates the foundScopes and relevantOutputs maps for subsequent
+// processing.
+func TestFilterTx(t *testing.T) {
+	t.Parallel()
+
+	rs := NewRecoveryState(10, &chainParams, nil)
+	rs.addrFilters = make(map[string]AddrEntry)
+	rs.outpoints = make(map[wire.OutPoint][]byte)
+
+	// 1. Setup Watched Address.
+	// Use real address for Script parsing interaction with txscript.
+	addr, _ := btcutil.DecodeAddress(
+		"mrCDrCybB6J1vRfbwM5hemdJz73FwDBC8r", &chainParams,
+	)
+
+	rs.addrFilters[addr.EncodeAddress()] = AddrEntry{
+		Address: addr,
+		addrScope: waddrmgr.AddrScope{
+			BranchScope: waddrmgr.BranchScope{Branch: 0},
+			Index:       10,
+		},
+		IsLookahead: true,
+	}
+
+	// 2. Setup Watched Outpoint.
+	opHash := chainhash.Hash{0x01}
+	op := wire.OutPoint{Hash: opHash, Index: 0}
+	rs.outpoints[op] = []byte{0x00} // Dummy script
+
+	// 3. Construct Tx.
+	// Input spending 'op'.
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(wire.NewTxIn(&op, nil, nil))
+
+	// Output paying to 'addr'.
+	pkScript, _ := txscript.PayToAddrScript(addr)
+	tx.AddTxOut(wire.NewTxOut(1000, pkScript))
+
+	// 4. Filter.
+	foundScopes := make(map[waddrmgr.AddrScope]struct{})
+	isRelevant, entries := rs.filterTx(tx, foundScopes)
+	require.True(t, isRelevant)
+
+	// Verify Outpoint spent (removed).
+	_, ok := rs.outpoints[op]
+	require.False(t, ok, "outpoint should be removed")
+
+	// Verify Output matched.
+	txHash := tx.TxHash()
+
+	require.Len(t, entries, 1)
+
+	// Verify Scope found.
+	expectedScope := waddrmgr.AddrScope{
+		BranchScope: waddrmgr.BranchScope{Branch: 0},
+		Index:       10,
+	}
+	require.Contains(t, foundScopes, expectedScope)
+
+	// Verify new outpoint added.
+	newOp := wire.OutPoint{Hash: txHash, Index: 0}
+	_, ok = rs.outpoints[newOp]
+	require.True(t, ok, "new outpoint should be watched")
+}
+
+// TestRecoveryStateWatchedOutPoints verifies the management of persistent
+// watched outpoints through AddWatchedOutPoint and WatchedOutPoints.
+func TestRecoveryStateWatchedOutPoints(t *testing.T) {
+	t.Parallel()
+
+	rs := NewRecoveryState(10, nil, nil)
+
+	// Initially, no watched outpoints.
+	require.Empty(t, rs.WatchedOutPoints())
+
+	op1 := wire.OutPoint{Hash: chainhash.Hash{1}, Index: 0}
+	addr1 := &mockAddress{}
+	op2 := wire.OutPoint{Hash: chainhash.Hash{2}, Index: 1}
+	addr2 := &mockAddress{}
+
+	rs.AddWatchedOutPoint(&op1, addr1)
+	rs.AddWatchedOutPoint(&op2, addr2)
+
+	watched := rs.WatchedOutPoints()
+	require.Len(t, watched, 2)
+	require.Equal(t, addr1, watched[op1])
+	require.Equal(t, addr2, watched[op2])
+}
+
+// TestRecoveryStateStringAndEmpty verifies the String and Empty methods of
+// RecoveryState. It ensures that the String method produces a non-empty
+// summary and that the Empty method accurately reflects the presence or
+// absence of filters and outpoints.
+func TestRecoveryStateStringAndEmpty(t *testing.T) {
+	t.Parallel()
+
+	rs := NewRecoveryState(10, nil, nil)
+
+	// Initially, state should be empty.
+	require.True(t, rs.Empty())
+	require.Contains(t, rs.String(), "RecoveryState(addrs=0, outpoints=0)")
+
+	// Add an address filter entry.
+	rs.addrFilters = make(map[string]AddrEntry)
+	rs.addrFilters["a"] = AddrEntry{}
+
+	require.False(t, rs.Empty())
+	require.Contains(t, rs.String(), "RecoveryState(addrs=1, outpoints=0)")
+
+	// Add an outpoint.
+	rs.outpoints = make(map[wire.OutPoint][]byte)
+	op := wire.OutPoint{Hash: chainhash.Hash{1}, Index: 0}
+	rs.outpoints[op] = []byte{}
+
+	require.False(t, rs.Empty())
+	require.Contains(t, rs.String(), "RecoveryState(addrs=1, outpoints=1)")
+}
+
+// Define a static error for testing FetchScopedKeyManager failure.
+var errFetch = errors.New("fetch error")
+
+// TestExpandHorizonsWithInvalidChild verifies that expandHorizons correctly
+// handles hdkeychain.ErrInvalidChild by skipping the invalid index and
+// continuing derivation until the window is full.
+func TestExpandHorizonsWithInvalidChild(t *testing.T) {
+	t.Parallel()
+
+	store := &mockAccountStore{}
+	defer store.AssertExpectations(t)
+
+	rs := NewRecoveryState(2, nil, nil)
+	rs.addrFilters = make(map[string]AddrEntry)
+
+	// Setup a branch state manually.
+	bs := waddrmgr.BranchScope{Branch: 0}
+	brs := NewBranchRecoveryState(2, store)
+	rs.branchStates[bs] = brs
+
+	// Simulate finding index 0. This triggers expansion.
+	brs.ReportFound(0)
+
+	// Expect derivation of 0 -> Success
+	addr0 := &mockAddress{}
+	addr0.On("EncodeAddress").Return("addr-0")
+	addr0.On("ScriptAddress").Return([]byte("script-0"))
+	store.On("DeriveAddr", uint32(0), uint32(0), uint32(0)).Return(
+		addr0, []byte("script-0"), nil,
+	).Once()
+
+	// Expect derivation of 1 -> ErrInvalidChild
+	store.On("DeriveAddr", uint32(0), uint32(0), uint32(1)).Return(
+		nil, nil, hdkeychain.ErrInvalidChild,
+	).Once()
+
+	// Expect derivation of 2 -> Success
+	addr2 := &mockAddress{}
+	addr2.On("EncodeAddress").Return("addr-2")
+	addr2.On("ScriptAddress").Return([]byte("script-2"))
+	store.On("DeriveAddr", uint32(0), uint32(0), uint32(2)).Return(
+		addr2, []byte("script-2"), nil,
+	).Once()
+
+	// Expect derivation of 3 -> Success (to fill window)
+	addr3 := &mockAddress{}
+	addr3.On("EncodeAddress").Return("addr-3")
+	addr3.On("ScriptAddress").Return([]byte("script-3"))
+	store.On("DeriveAddr", uint32(0), uint32(0), uint32(3)).Return(
+		addr3, []byte("script-3"), nil,
+	).Once()
+
+	expanded, err := rs.expandHorizons()
+	require.NoError(t, err)
+	require.True(t, expanded)
+
+	// Verify filters contain 0, 2, 3 (3 valid addresses).
+	require.Len(t, rs.addrFilters, 3)
+	require.Contains(t, rs.addrFilters, "addr-0")
+	require.Contains(t, rs.addrFilters, "addr-2")
+	require.Contains(t, rs.addrFilters, "addr-3")
+	require.NotContains(t, rs.addrFilters, "addr-1")
+}
+
+// TestInitializeError verifies that Initialize propagates errors from
+// initAccountState (e.g. FetchScopedKeyManager failures).
+func TestInitializeError(t *testing.T) {
+	t.Parallel()
+
+	addrMgr := &mockAddrStore{}
+	defer addrMgr.AssertExpectations(t)
+
+	rs := NewRecoveryState(10, nil, addrMgr)
+	scope := waddrmgr.KeyScope{Purpose: 84, Coin: 0}
+	props := &waddrmgr.AccountProperties{KeyScope: scope}
+
+	// Mock failure.
+	addrMgr.On("FetchScopedKeyManager", scope).Return(nil, errFetch).Once()
+
+	err := rs.Initialize([]*waddrmgr.AccountProperties{props}, nil, nil)
+	require.ErrorIs(t, err, errFetch)
+}
+
+// TestInitAccountStateDeriveError verifies that initAccountState propagates
+// errors from DeriveAddr.
+func TestInitAccountStateDeriveError(t *testing.T) {
+	t.Parallel()
+
+	addrMgr := &mockAddrStore{}
+	accountStore := &mockAccountStore{}
+
+	defer addrMgr.AssertExpectations(t)
+	defer accountStore.AssertExpectations(t)
+
+	rs := NewRecoveryState(10, nil, addrMgr)
+	rs.addrFilters = make(map[string]AddrEntry)
+	scope := waddrmgr.KeyScope{Purpose: 84, Coin: 0}
+	props := &waddrmgr.AccountProperties{KeyScope: scope}
+
+	// First call succeeds (External).
+	addrMgr.On("FetchScopedKeyManager", scope).Return(
+		accountStore, nil,
+	).Once()
+
+	// Derive fails immediately.
+	accountStore.On(
+		"DeriveAddr", uint32(0), uint32(0), uint32(0),
+	).Return(nil, nil, errFetch).Once()
+
+	err := rs.initAccountState(props)
+	require.ErrorIs(t, err, errFetch)
+}
+
+// TestExpandHorizonsError verifies that expandHorizons propagates errors from
+// DeriveAddr when attempting to extend the lookahead window.
+func TestExpandHorizonsError(t *testing.T) {
+	t.Parallel()
+
+	accountStore := &mockAccountStore{}
+	defer accountStore.AssertExpectations(t)
+
+	rs := NewRecoveryState(2, nil, nil)
+	rs.addrFilters = make(map[string]AddrEntry)
+	bs := waddrmgr.BranchScope{Branch: 0}
+	brs := NewBranchRecoveryState(2, accountStore)
+	rs.branchStates[bs] = brs
+
+	// Trigger expansion requirement.
+	brs.ReportFound(0)
+
+	// Mock DeriveAddr error.
+	accountStore.On(
+		"DeriveAddr", uint32(0), uint32(0), uint32(0),
+	).Return(nil, nil, errFetch).Once()
+
+	_, err := rs.expandHorizons()
+	require.ErrorIs(t, err, errFetch)
+}
+
+// TestInitializeWithState verifies Initialize with existing state.
+func TestInitializeWithState(t *testing.T) {
+	t.Parallel()
+
+	addrMgr := &mockAddrStore{}
+	defer addrMgr.AssertExpectations(t)
+
+	rs := NewRecoveryState(10, nil, addrMgr)
+
+	// Mock address and outpoint.
+	addr := &mockAddress{}
+	addr.On("EncodeAddress").Return("addr1")
+
+	outpoint := wtxmgr.Credit{
+		OutPoint: wire.OutPoint{Hash: chainhash.Hash{1}, Index: 0},
+		PkScript: []byte{1},
+	}
+
+	err := rs.Initialize(
+		nil, []btcutil.Address{addr}, []wtxmgr.Credit{outpoint},
+	)
+	require.NoError(t, err)
+	require.Len(t, rs.addrFilters, 1)
+	require.Len(t, rs.outpoints, 1)
+}
+
+// TestProcessBlockError verifies that ProcessBlock propagates errors from
+// expandHorizons.
+func TestProcessBlockError(t *testing.T) {
+	t.Parallel()
+
+	store := &mockAccountStore{}
+	defer store.AssertExpectations(t)
+
+	rs := NewRecoveryState(10, &chainParams, nil)
+	rs.addrFilters = make(map[string]AddrEntry)
+	rs.outpoints = make(map[wire.OutPoint][]byte)
+
+	// Setup branch.
+	bs := waddrmgr.BranchScope{Branch: 0}
+	brs := NewBranchRecoveryState(10, store)
+	rs.branchStates[bs] = brs
+
+	// Add filter entry that triggers expansion (using real address for
+	// txscript compatibility).
+	realAddr, _ := btcutil.NewAddressPubKeyHash(
+		make([]byte, 20), &chainParams,
+	)
+	rs.addrFilters[realAddr.EncodeAddress()] = AddrEntry{
+		Address: realAddr,
+		addrScope: waddrmgr.AddrScope{
+			BranchScope: bs, Index: 0,
+		},
+		IsLookahead: true,
+	}
+
+	// Block with tx paying to realAddr.
+	block := wire.NewMsgBlock(&wire.BlockHeader{})
+	tx := wire.NewMsgTx(2)
+	txOut := wire.NewTxOut(1000, nil)
+
+	var err error
+
+	txOut.PkScript, err = txscript.PayToAddrScript(realAddr)
+	require.NoError(t, err)
+	tx.AddTxOut(txOut)
+	_ = block.AddTransaction(tx)
+
+	// Mock failure.
+	store.On("DeriveAddr", uint32(0), uint32(0), uint32(0)).Return(
+		nil, nil, errFetch).Once()
+
+	_, err = rs.ProcessBlock(block)
+	require.ErrorIs(t, err, errFetch)
 }

--- a/wallet/syncer.go
+++ b/wallet/syncer.go
@@ -80,6 +80,16 @@ type scanReq struct {
 	targets []waddrmgr.AccountScope
 }
 
+// scanResult holds the result of processing a single block during a batch
+// scan.
+type scanResult struct {
+	// BlockProcessResult embeds the results of filtering the block.
+	*BlockProcessResult
+
+	// meta contains block metadata (hash, height, time).
+	meta *wtxmgr.BlockMeta
+}
+
 // chainSyncer is a private interface that abstracts the chain synchronization
 // logic, allowing it to be mocked for testing the wallet and controller.
 type chainSyncer interface {

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -280,8 +280,6 @@ func locateBirthdayBlock(chainClient chainConn,
 // Wallet is a structure containing all the components for a complete wallet.
 // It manages the cryptographic keys, transaction history, and synchronization
 // with the blockchain.
-//
-//nolint:unused // TODO(yy): remove it once implemented
 type Wallet struct {
 	// walletDeprecated embeds the legacy state and channels. Access to
 	// these should be phased out as refactoring progresses.


### PR DESCRIPTION
We now introduce a few preliminary methods to help us separate the DB logic from business logic, and expand the `RecoveryState` to handle the ephemeral state to further isolate the DB operations.