### PR TITLE
Use new db methods in wallet syncer

### DIFF
--- a/wallet/syncer.go
+++ b/wallet/syncer.go
@@ -1091,7 +1091,140 @@ func (s *syncer) extractAddrEntries(txOuts []*wire.TxOut) []AddrEntry {
 	return entries
 }
 
-// loadWalletScanData retrieves all necessary data from the database.
+// handleScanReq processes a user-initiated rescan request.
+func (s *syncer) handleScanReq(ctx context.Context,
+	req *scanReq) error {
+
+	// If the wallet is already syncing or rescanning, we can't accept a
+	// full resync request. This prevents conflicting rescan operations.
+	if s.isRecoveryMode() {
+		return fmt.Errorf("%w: wallet is currently %s",
+			ErrStateForbidden, s.syncState())
+	}
+
+	if req.typ == scanTypeTargeted {
+		return s.scanWithTargets(ctx, req)
+	}
+
+	return s.scanWithRewind(ctx, req)
+}
+
+// scanWithRewind rewinds the wallet's sync status to the requested start block.
+func (s *syncer) scanWithRewind(ctx context.Context, req *scanReq) error {
+	current := s.addrStore.SyncedTo()
+
+	if req.startBlock.Height >= current.Height {
+		// Requested start is ahead of or equal to current sync.
+		// Nothing to do (we are already synced past it).
+		return nil
+	}
+
+	log.Infof("Rewinding sync status from %d to %d for rescan",
+		current.Height, req.startBlock.Height)
+
+	// Rewind the database status.
+	err := s.DBPutRewind(ctx, req.startBlock)
+	if err != nil {
+		log.Errorf("Failed to rewind sync status: %v", err)
+
+		return err
+	}
+
+	return nil
+}
+
+// scanWithTargets performs a targeted rescan for specific accounts without
+// rewinding the global sync state.
+func (s *syncer) scanWithTargets(ctx context.Context, req *scanReq) error {
+	scanState, err := s.loadTargetedScanState(ctx, req.targets)
+	if err != nil {
+		return err
+	}
+
+	s.state.Store(uint32(syncStateRescanning))
+	defer s.state.Store(uint32(syncStateSynced))
+
+	startHeight := req.startBlock.Height
+
+	_, bestHeight, err := s.cfg.Chain.GetBestBlock()
+	if err != nil {
+		return fmt.Errorf("get best block: %w", err)
+	}
+
+	log.Infof("Starting targeted rescan from height %d to %d for %d "+
+		"accounts", startHeight, bestHeight, len(req.targets))
+
+	// Loop until caught up.
+	for startHeight < bestHeight {
+		// Cap end height.
+		endHeight := min(
+			startHeight+int32(recoveryBatchSize)-1, bestHeight,
+		)
+
+		// Use fetchAndFilterBlocks directly.
+		results, err := s.fetchAndFilterBlocks(
+			ctx, scanState, startHeight, endHeight,
+		)
+		if err != nil {
+			return err
+		}
+
+		if len(results) == 0 {
+			return fmt.Errorf("%w: fetchAndFilterBlocks returned "+
+				"0 results", ErrScanBatchEmpty)
+		}
+
+		// Process results (update DB).
+		err = s.DBPutTargetedBatch(ctx, results)
+		if err != nil {
+			return err
+		}
+
+		// Advance startHeight.
+		//nolint:gosec // batch size is bounded.
+		startHeight += int32(len(results))
+	}
+
+	log.Infof("Targeted rescan complete")
+
+	return nil
+}
+
+// loadTargetedScanState initializes a recovery state for a targeted rescan of
+// specific accounts.
+func (s *syncer) loadTargetedScanState(ctx context.Context,
+	targets []waddrmgr.AccountScope) (*RecoveryState, error) {
+
+	horizonData, initialAddrs, initialUnspent, err :=
+		s.loadTargetedScanData(ctx, targets)
+	if err != nil {
+		return nil, err
+	}
+
+	state := NewRecoveryState(
+		s.cfg.RecoveryWindow, s.cfg.ChainParams, s.addrStore,
+	)
+
+	err = state.Initialize(horizonData, initialAddrs, initialUnspent)
+	if err != nil {
+		return nil, fmt.Errorf("init scan state: %w", err)
+	}
+
+	return state, nil
+}
+
+// loadTargetedScanData retrieves all necessary data from the database to
+// initialize the recovery state for a targeted rescan.
+func (s *syncer) loadTargetedScanData(ctx context.Context,
+	targets []waddrmgr.AccountScope) ([]*waddrmgr.AccountProperties,
+	[]btcutil.Address, []wtxmgr.Credit, error) {
+
+	return s.DBGetScanData(ctx, targets)
+}
+
+// loadWalletScanData retrieves all necessary data from the database to
+// initialize the recovery state. This includes account horizons, active
+// addresses, and unspent outputs to watch.
 func (s *syncer) loadWalletScanData(ctx context.Context) (
 	[]*waddrmgr.AccountProperties, []btcutil.Address,
 	[]wtxmgr.Credit, error) {

--- a/wallet/syncer.go
+++ b/wallet/syncer.go
@@ -896,7 +896,66 @@ func (s *syncer) dispatchScanStrategy(ctx context.Context,
 	}
 }
 
-// scanBatch fetches and processes a batch of blocks from the chain backend.
+// advanceChainSync checks if the wallet is behind the chain tip and processes
+// a batch of blocks if necessary. It returns (syncFinished, error) where
+// syncFinished is true if the wallet is caught up to the best known tip, and
+// false if a sync operation was performed (or attempted) indicating that the
+// caller should continue polling.
+func (s *syncer) advanceChainSync(ctx context.Context) (bool, error) {
+	// Check the chain tip.
+	_, bestHeight, err := s.cfg.Chain.GetBestBlock()
+	if err != nil {
+		// An error getting best block height means we couldn't
+		// determine sync status. We are NOT finished, and an error
+		// occurred. Caller should retry.
+		return false, fmt.Errorf("unable to get best block height: %w",
+			err)
+	}
+
+	// Determine our current sync state.
+	syncedTo := s.addrStore.SyncedTo()
+
+	// If the wallet is caught up to the best known tip, log this and
+	// return.
+	if syncedTo.Height >= bestHeight {
+		s.state.Store(uint32(syncStateSynced))
+		log.Infof("Wallet is synced to chain tip: height=%d",
+			syncedTo.Height)
+
+		return true, nil
+	}
+
+	// Calculate the gap.
+	gap := bestHeight - syncedTo.Height
+
+	// If the gap is large (> 6 blocks), we treat it as a major event
+	// requiring Syncing state protection. Smaller gaps are handled
+	// silently to avoid disrupting user operations like CreateTx.
+	isLargeGap := gap > syncStateSwitchThreshold
+
+	if isLargeGap {
+		s.state.Store(uint32(syncStateSyncing))
+	}
+
+	// Wallet is behind, log the sync range and attempt to scan a batch.
+	log.Infof("Wallet is in syncing mode: from height %d to %d (gap=%d)",
+		syncedTo.Height+1, bestHeight, gap)
+
+	err = s.scanBatch(ctx, syncedTo, bestHeight)
+	if err != nil {
+		// Scan failed. Sync operation was attempted but not finished
+		// due to error.
+		return false, fmt.Errorf("failed to process batch: %w", err)
+	}
+
+	// Scan successful, but wallet might still be behind. Synchronization
+	// is NOT finished. Caller should continue looping to process the next
+	// batch.
+	return false, nil
+}
+
+// scanBatch fetches and processes a batch of blocks from the chain backend. It
+// handles fetching, CFilter matching, and DB updates.
 func (s *syncer) scanBatch(ctx context.Context, syncedTo waddrmgr.BlockStamp,
 	bestHeight int32) error {
 

--- a/wallet/syncer.go
+++ b/wallet/syncer.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/chain"
@@ -351,4 +352,97 @@ func (s *syncer) requestScan(ctx context.Context, req *scanReq) error {
 	case <-ctx.Done():
 		return fmt.Errorf("context done: %w", ctx.Err())
 	}
+}
+
+// scanBatchHeadersOnly performs a lightweight scan by only fetching block
+// headers. This is used when the wallet has no addresses or outpoints to
+// watch, allowing it to fast-forward its sync state.
+func (s *syncer) scanBatchHeadersOnly(_ context.Context,
+	startHeight, endHeight int32) ([]scanResult, error) {
+
+	// Batch 1: Fetch Block Hashes.
+	hashes, err := s.cfg.Chain.GetBlockHashes(
+		int64(startHeight), int64(endHeight),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("batch get block hashes: %w", err)
+	}
+
+	// Batch 2: Fetch Block Headers (for timestamps).
+	headers, err := s.cfg.Chain.GetBlockHeaders(hashes)
+	if err != nil {
+		return nil, fmt.Errorf("batch get block headers: %w", err)
+	}
+
+	results := make([]scanResult, 0, len(hashes))
+	for i := range hashes {
+		hash := hashes[i]
+		header := headers[i]
+
+		//nolint:gosec // i is bounded by batch size (2000), so
+		// addition to startHeight won't overflow int32.
+		height := startHeight + int32(i)
+
+		meta := &wtxmgr.BlockMeta{
+			Block: wtxmgr.Block{Hash: hash, Height: height},
+			Time:  header.Timestamp,
+		}
+
+		results = append(results, scanResult{
+			meta: meta,
+			// We provide an empty BlockProcessResult to avoid nil
+			// pointer dereferences when accessing embedded fields
+			// (like RelevantTxs) in commitSyncBatch. This
+			// effectively acts as a "no-op" result.
+			BlockProcessResult: &BlockProcessResult{},
+		})
+	}
+
+	return results, nil
+}
+
+// loadFullScanState initializes a fresh recovery state for a new batch scan.
+// It loads active data, syncs horizons from DB, and prepares the initial
+// lookahead window.
+func (s *syncer) loadFullScanState(
+	ctx context.Context) (*RecoveryState, error) {
+
+	horizonData, initialAddrs, initialUnspent, err := s.loadWalletScanData(
+		ctx,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Initialize a fresh recovery state for this batch to ensure no stale
+	// state leaks between batches.
+	scanState := NewRecoveryState(
+		s.cfg.RecoveryWindow, s.cfg.ChainParams, s.addrStore,
+	)
+
+	// Initialize Batch State (History + Lookahead)
+	err = scanState.Initialize(horizonData, initialAddrs, initialUnspent)
+	if err != nil {
+		return nil, fmt.Errorf("init scan state: %w", err)
+	}
+
+	return scanState, nil
+}
+
+// loadWalletScanData retrieves all necessary data from the database.
+func (s *syncer) loadWalletScanData(ctx context.Context) (
+	[]*waddrmgr.AccountProperties, []btcutil.Address,
+	[]wtxmgr.Credit, error) {
+
+	var targets []waddrmgr.AccountScope
+	for _, scopedMgr := range s.addrStore.ActiveScopedKeyManagers() {
+		for _, accNum := range scopedMgr.ActiveAccounts() {
+			targets = append(targets, waddrmgr.AccountScope{
+				Scope:   scopedMgr.Scope(),
+				Account: accNum,
+			})
+		}
+	}
+
+	return s.DBGetScanData(ctx, targets)
 }

--- a/wallet/syncer.go
+++ b/wallet/syncer.go
@@ -1,4 +1,3 @@
-//nolint:unused,revive // TODO(yy): remove it once implemented
 package wallet
 
 import (
@@ -470,7 +469,7 @@ func (s *syncer) requestScan(ctx context.Context, req *scanReq) error {
 		return nil
 
 	case <-ctx.Done():
-		return fmt.Errorf("context done: %w", ctx.Err())
+		return ctx.Err()
 	}
 }
 

--- a/wallet/syncer_test.go
+++ b/wallet/syncer_test.go
@@ -62,8 +62,8 @@ func TestSyncerRequestScan(t *testing.T) {
 		},
 	}
 
-	// Act: Submit request.
-	err := s.requestScan(context.Background(), req)
+	// Act: Submit the rewind request to the syncer.
+	err := s.requestScan(t.Context(), req)
 
 	// Assert: Ensure the request is accepted without error and is
 	// correctly placed in the scan request channel.
@@ -91,9 +91,10 @@ func TestSyncerRequestScanBlocked(t *testing.T) {
 	// Fill the buffer (size 1).
 	s.scanReqChan <- &scanReq{}
 
-	// Act: Submit another request with a canceled context.
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // Cancel immediately.
+	// Act: Attempt to submit another request with a context that is
+	// already canceled.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
 
 	err := s.requestScan(ctx, &scanReq{})
 
@@ -124,8 +125,9 @@ func TestSyncerRun(t *testing.T) {
 	mockAddrStore.On("SyncedTo").Return(waddrmgr.BlockStamp{}).Maybe()
 	mockChain.On("NotifyBlocks").Return(nil).Maybe()
 
-	// Act: Run with canceled context to stop loop immediately.
-	ctx, cancel := context.WithCancel(context.Background())
+	// Act: Execute the syncer's run loop with a context that is canceled
+	// immediately to stop the loop.
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
 	// Assert: The run loop should exit without error.


### PR DESCRIPTION
We now apply the new db methods in the core syncing logic.

This PR has been reviewed [here](https://github.com/yyforyongyu/btcwallet/pull/10) already.