### PR TITLE
multi: add coveralls for database integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,24 +152,26 @@ jobs:
         run: make ${{ matrix.unit_type }}
 
       - name: Send coverage
-        uses: shogo82148/actions-goveralls@v1
+        uses: coverallsapp/github-action@v2
         if: matrix.unit_type == 'unit-cover'
         continue-on-error: true
         with:
-          path-to-profile: coverage.txt
+          file: coverage.txt
+          flag-name: unit
+          format: golang
           parallel: true
 
   ########################
   # run integration tests (SQLite + Postgres)
   ########################
   itest-db:
-    name: integration tests (${{ matrix.db }}, ${{ matrix.target }})
+    name: integration tests (${{ matrix.db }}, ${{ matrix.race && 'race' || 'cover' }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         db: [sqlite, postgres]
-        target: [itest-db, itest-db-race]
+        race: [false, true]
     steps:
       - name: git checkout
         uses: actions/checkout@v5
@@ -193,5 +195,35 @@ jobs:
         with:
           go-version: '${{ env.GO_VERSION }}'
 
-      - name: run ${{ matrix.db }} ${{ matrix.target }}
-        run: make ${{ matrix.target }} db=${{ matrix.db }} verbose=1
+      - name: run ${{ matrix.db }} itest-db (coverage)
+        if: ${{ !matrix.race }}
+        run: make itest-db db=${{ matrix.db }} cover=1 verbose=1
+
+      - name: run ${{ matrix.db }} itest-db-race
+        if: matrix.race
+        run: make itest-db-race db=${{ matrix.db }} verbose=1
+
+      - name: Upload coverage to Coveralls
+        uses: coverallsapp/github-action@v2
+        if: ${{ !matrix.race }}
+        continue-on-error: true
+        with:
+          file: coverage-itest-${{ matrix.db }}.txt
+          flag-name: itest-db-${{ matrix.db }}
+          format: golang
+          parallel: true
+
+  ########################
+  # Complete parallel coverage uploads
+  ########################
+  finish:
+    name: Finish coverage upload
+    if: ${{ !cancelled() }}
+    needs: [unit-test, itest-db]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Finish parallel Coveralls upload
+        uses: coverallsapp/github-action@v2
+        continue-on-error: true
+        with:
+          parallel-finished: true

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ btcwallet
 vendor
 .idea
 coverage.txt
+coverage-itest-postgres.txt
+coverage-itest-sqlite.txt
 *.swp
 .vscode
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,10 @@ itest-db:
 	fi
 	@$(call print, "Running $(IT_DB_LABEL) integration tests.")
 	$(ITEST_DB)
+	@if [ -n "$(ITEST_DB_COVERPROFILE)" ]; then \
+		echo  "Filtering coverage report."; \
+		./scripts/filter_coverage.sh $(IT_DB_TYPE); \
+	fi
 
 #? itest-db-race: Run integration tests for wallet database with race detector
 itest-db-race:

--- a/config/testing_flags.mk
+++ b/config/testing_flags.mk
@@ -7,9 +7,17 @@ IT_TAGS ?=
 ifeq ($(db),postgres)
 IT_TAGS += test_db_postgres
 IT_DB_LABEL := PostgreSQL
+IT_DB_TYPE := postgres
 else
 IT_TAGS :=
 IT_DB_LABEL := SQLite
+IT_DB_TYPE := sqlite
+endif
+
+# Enable integration test coverage
+ifeq ($(cover),1)
+ITEST_DB_COVERPROFILE = coverage-itest-$(IT_DB_TYPE).txt
+ITEST_DB_COVERAGE = -coverprofile=$(ITEST_DB_COVERPROFILE) -coverpkg=$(PKG)/wallet/internal/db/... -covermode=atomic
 endif
 
 GOCC ?= go
@@ -91,5 +99,5 @@ endif
 
 UNIT_COVER := $(GOTEST) $(COVER_FLAGS) -tags="$(DEV_TAGS) $(LOG_TAGS)" $(TEST_FLAGS) $(COVER_PKG)
 
-ITEST_DB := $(GOTEST) -tags="itest $(DEV_TAGS) $(LOG_TAGS) $(IT_TAGS)" $(TEST_FLAGS) $(PKG)/wallet/internal/db/itest
+ITEST_DB := $(GOTEST) $(ITEST_DB_COVERAGE) -tags="itest $(DEV_TAGS) $(LOG_TAGS) $(IT_TAGS)" $(TEST_FLAGS) $(PKG)/wallet/internal/db/itest
 ITEST_DB_RACE := $(GOTEST) -race -tags="itest $(DEV_TAGS) $(LOG_TAGS) $(IT_TAGS)" $(TEST_FLAGS) $(PKG)/wallet/internal/db/itest

--- a/scripts/filter_coverage.sh
+++ b/scripts/filter_coverage.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Filter coverage files to exclude opposite backend implementations
+# Usage: filter_coverage.sh <db_type>
+# Where db_type is 'sqlite' or 'postgres'
+
+set -e
+
+DB_TYPE="$1"
+if [ "$DB_TYPE" != "sqlite" ] && [ "$DB_TYPE" != "postgres" ]; then
+	echo "Usage: $0 <sqlite|postgres>"
+	exit 1
+fi
+
+COVERAGE_FILE="coverage-itest-${DB_TYPE}.txt"
+if [ ! -f "$COVERAGE_FILE" ]; then
+	echo "Coverage file $COVERAGE_FILE not found"
+	exit 1
+fi
+
+# Create filtered version
+FILTERED_FILE="${COVERAGE_FILE}.filtered"
+
+# Keep the mode line, filter out opposite backend files
+head -1 "$COVERAGE_FILE" >"$FILTERED_FILE"
+
+if [ "$DB_TYPE" = "sqlite" ]; then
+	# For sqlite: exclude postgres files
+	tail -n +2 "$COVERAGE_FILE" | grep -Ev 'pg|postgres'	>>"$FILTERED_FILE"
+else
+	# For postgres: exclude sqlite files
+	tail -n +2 "$COVERAGE_FILE" | grep -Ev 'sqlite' >>"$FILTERED_FILE"
+fi
+
+# Replace original with filtered
+mv "$FILTERED_FILE" "$COVERAGE_FILE"
+
+# Output the filtered coverage percentage
+go tool cover -func="$COVERAGE_FILE" |
+	awk '/^total:/ { print "Filtered test coverage for '"$DB_TYPE"': " $3 }'


### PR DESCRIPTION
This PR adds commands to generate coverage reports for database integration tests and uploads the results to Coveralls.