### PR TITLE
Automating CLI versioning

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -6,55 +6,37 @@ package build
 
 import (
 	"bytes"
-	"fmt"
+	"runtime/debug"
 	"strings"
 )
 
 // semanticAlphabet
 const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
 
-// These constants define the application version and follow the semantic
-// versioning 2.0.0 spec (http://semver.org/).
-const (
-	appMajor uint = 0
-	appMinor uint = 15
-	appPatch uint = 1
-
-	// appPreRelease MUST only contain characters from semanticAlphabet
-	// per the semantic versioning spec.
-	appPreRelease = "alpha"
-)
-
-// appBuild is defined as a variable so it can be overridden during the build
-// process with '-ldflags "-X main.appBuild foo' if needed.  It MUST only
-// contain characters from semanticAlphabet per the semantic versioning spec.
-var appBuild string
+// appVersion is defined as a variable so it can be overridden during the build
+// process if needed. It MUST only contain characters from semanticAlphabet per
+// the semantic versioning spec.
+//
+// Example:
+// go build -ldflags "-X github.com/btcsuite/btcwallet/build.appVersion=v1.0.0" ./...
+var appVersion string
 
 // Version returns the application version as a properly formed string per the
 // semantic versioning 2.0.0 spec (http://semver.org/).
+//
+// May panic if the version is poorly configured on build.
 func Version() string {
-	// Start with the major, minor, and path versions.
-	version := fmt.Sprintf("%d.%d.%d", appMajor, appMinor, appPatch)
-
-	// Append pre-release version if there is one.  The hyphen called for
-	// by the semantic versioning spec is automatically appended and should
-	// not be contained in the pre-release string.  The pre-release version
-	// is not appended if it contains invalid characters.
-	preRelease := normalizeVerString(appPreRelease)
-	if preRelease != "" {
-		version = fmt.Sprintf("%s-%s", version, preRelease)
+	// If set the module version must overridden.
+	if appVersion != "" {
+		return normalizeVerString(appVersion)
 	}
 
-	// Append build metadata if there is any.  The plus called for
-	// by the semantic versioning spec is automatically appended and should
-	// not be contained in the build metadata string.  The build metadata
-	// string is not appended if it contains invalid characters.
-	build := normalizeVerString(appBuild)
-	if build != "" {
-		version = fmt.Sprintf("%s+%s", version, build)
+	info, ok := debug.ReadBuildInfo()
+	if ok {
+		return info.Main.Version
 	}
 
-	return version
+	panic("Application version is not set")
 }
 
 // normalizeVerString returns the passed string stripped of all characters which


### PR DESCRIPTION
## Change Description
Addressing #790. Added [runtime/debug](https://pkg.go.dev/runtime/debug) package for automatic versioning. It uses the last git tag to get the current version. Variable `appVersion` can be used to set the version manually.

I'm not really happy with panic so let me please know what it can be replaced with.

## Steps to Test
1. Build the CLI when checked out on a tag
2. Build the CLI when checked out past a tag
3. Build the CLI with the flag `-ldflags "-X github.com/btcsuite/btcwallet/build.appVersion=<custom_version>"`

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#ideal-git-commit-structure).
- [x] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md) for further guidance.
