### PR TITLE
kvdb: start implementing `Store` interface

### DIFF
--- a/wallet/benchmark_helpers_test.go
+++ b/wallet/benchmark_helpers_test.go
@@ -310,6 +310,8 @@ func setupBenchmarkWallet(tb testing.TB,
 		w.sync = newSyncer(w.cfg, w.addrStore, w.txStore, w)
 	}
 
+	require.NotNil(tb, w.store)
+
 	// Initialize controller channels and timer.
 	if w.requestChan == nil {
 		w.requestChan = make(chan any)

--- a/wallet/common_test.go
+++ b/wallet/common_test.go
@@ -94,6 +94,7 @@ func setupTestDB(t *testing.T) (walletdb.DB, func()) {
 // mockWalletDeps holds the mocked dependencies for the Wallet.
 type mockWalletDeps struct {
 	addrStore      *mockAddrStore
+	store          *mockStore
 	txStore        *mockTxStore
 	syncer         *mockChainSyncer
 	chain          *mockChain
@@ -113,6 +114,7 @@ func createTestWalletWithMocks(t *testing.T) (*Wallet, *mockWalletDeps) {
 	t.Cleanup(cleanup)
 
 	mockAddrStore := &mockAddrStore{}
+	mockStore := &mockStore{}
 	mockTxStore := &mockTxStore{}
 	mockSyncer := &mockChainSyncer{}
 	mockChain := &mockChain{}
@@ -125,6 +127,7 @@ func createTestWalletWithMocks(t *testing.T) (*Wallet, *mockWalletDeps) {
 
 	w := &Wallet{
 		addrStore:   mockAddrStore,
+		store:       mockStore,
 		txStore:     mockTxStore,
 		sync:        mockSyncer,
 		state:       newWalletState(mockSyncer),
@@ -147,6 +150,7 @@ func createTestWalletWithMocks(t *testing.T) (*Wallet, *mockWalletDeps) {
 
 	deps := &mockWalletDeps{
 		addrStore:      mockAddrStore,
+		store:          mockStore,
 		txStore:        mockTxStore,
 		syncer:         mockSyncer,
 		chain:          mockChain,
@@ -158,6 +162,7 @@ func createTestWalletWithMocks(t *testing.T) (*Wallet, *mockWalletDeps) {
 
 	t.Cleanup(func() {
 		mockAddrStore.AssertExpectations(t)
+		mockStore.AssertExpectations(t)
 		mockTxStore.AssertExpectations(t)
 		mockSyncer.AssertExpectations(t)
 		mockChain.AssertExpectations(t)

--- a/wallet/deprecated.go
+++ b/wallet/deprecated.go
@@ -27,6 +27,7 @@ import (
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/btcsuite/btcwallet/internal/prompt"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	kvdb "github.com/btcsuite/btcwallet/wallet/internal/db/kvdb"
 	"github.com/btcsuite/btcwallet/wallet/txauthor"
 	"github.com/btcsuite/btcwallet/wallet/txrules"
 	"github.com/btcsuite/btcwallet/walletdb"
@@ -6714,6 +6715,7 @@ func OpenWithRetry(db walletdb.DB, pubPass []byte, cbs *waddrmgr.OpenCallbacks,
 
 	w := &Wallet{
 		addrStore:        addrMgr,
+		store:            kvdb.NewStore(db, txMgr),
 		txStore:          txMgr,
 		walletDeprecated: deprecated,
 	}

--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -58,6 +58,28 @@ var (
 	ErrMaxAccountNumberReached = errors.New("max account number reached")
 )
 
+// Store defines the set of database operations used by the wallet.
+//
+// NOTE: Ideally each wallet component/manager should depend on a small,
+// purpose-built interface (for example, the UtxoManager should only depend on
+// UTXOStore). However, the wallet is still a monolithic struct and its managers
+// are currently only separated by files, all implemented as methods on Wallet.
+// Until we break the wallet into independent components, we use this monolithic
+// Store abstraction as a transitional step.
+//
+// For this PR, Store only includes UTXOStore. Over time it is expected to grow
+// to include WalletStore, AccountStore, AddressStore, and TxStore as those
+// callers migrate to the new internal db interfaces.
+//
+// TODO(yy): Break down wallet managers into independent components.
+//
+// TODO(yy): Remove the linter ignore once Store grows beyond UTXOStore.
+//
+//nolint:iface // Transitional alias until Store grows beyond UTXOStore.
+type Store interface {
+	UTXOStore
+}
+
 // WalletStore defines the methods for wallet-level operations.
 type WalletStore interface {
 	// CreateWallet creates a new wallet in the database with the provided
@@ -227,6 +249,8 @@ type TxStore interface {
 }
 
 // UTXOStore defines the database actions for managing the UTXO set.
+//
+//nolint:iface // Store is a transitional wrapper over UTXOStore.
 type UTXOStore interface {
 	// GetUtxo retrieves a single unspent transaction output (UTXO) by its
 	// outpoint. It returns a UtxoInfo struct containing the UTXO's details

--- a/wallet/internal/db/kvdb/driver.go
+++ b/wallet/internal/db/kvdb/driver.go
@@ -1,0 +1,28 @@
+package kvdb
+
+import (
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+)
+
+// Store is the kvdb (walletdb) implementation of the db.Store interface.
+//
+// NOTE: This is a partial implementation that will be expanded as the wallet
+// UTXO manager migrates to the new db interfaces.
+type Store struct {
+	db      walletdb.DB
+	txStore wtxmgr.TxStore
+}
+
+// A compile-time assertion to ensure that Store implements the db.Store
+// interface.
+var _ db.Store = (*Store)(nil)
+
+// NewStore creates a new kvdb-backed UTXO store.
+func NewStore(dbConn walletdb.DB, txStore wtxmgr.TxStore) *Store {
+	return &Store{
+		db:      dbConn,
+		txStore: txStore,
+	}
+}

--- a/wallet/internal/db/kvdb/utils_test.go
+++ b/wallet/internal/db/kvdb/utils_test.go
@@ -1,0 +1,65 @@
+package kvdb
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcwallet/walletdb"
+	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+	"github.com/stretchr/testify/require"
+)
+
+const defaultDBTimeout = 10 * time.Second
+
+// newTestDB creates a temporary bdb walletdb for kvdb store tests.
+//
+// It returns the opened database and a cleanup function that must be called
+// after the test completes.
+func newTestDB(t *testing.T) (walletdb.DB, func()) {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "wallet.db")
+
+	dbConn, err := walletdb.Create(
+		"bdb", dbPath, true, defaultDBTimeout, false,
+	)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		_ = dbConn.Close()
+	}
+
+	return dbConn, cleanup
+}
+
+// newTxStore initializes and opens a wtxmgr store in the test database.
+//
+// NOTE: The kvdb Store under test expects the walletdb top-level bucket key
+// `wtxmgrNamespaceKey` to exist and contain a valid wtxmgr store.
+func newTxStore(t *testing.T, dbConn walletdb.DB) *wtxmgr.Store {
+	t.Helper()
+
+	var txStore *wtxmgr.Store
+
+	err := walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns, err := tx.CreateTopLevelBucket(wtxmgrNamespaceKey)
+		if err != nil {
+			return err
+		}
+
+		err = wtxmgr.Create(ns)
+		if err != nil {
+			return err
+		}
+
+		txStore, err = wtxmgr.Open(ns, &chaincfg.RegressionNetParams)
+
+		return err
+	})
+	require.NoError(t, err)
+
+	return txStore
+}

--- a/wallet/internal/db/kvdb/utxo.go
+++ b/wallet/internal/db/kvdb/utxo.go
@@ -1,0 +1,106 @@
+// Package kvdb provides a walletdb (kvdb) backed implementation of the
+// wallet/internal/db UTXO store interface.
+package kvdb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+)
+
+var (
+	// errNotImplemented is returned for unimplemented kvdb store methods.
+	errNotImplemented = errors.New("not implemented")
+
+	// errMissingTxmgrNamespace is returned when the `wtxmgr` namespace bucket
+	// cannot be found in a walletdb transaction.
+	errMissingTxmgrNamespace = errors.New("missing wtxmgr namespace")
+
+	// wtxmgrNamespaceKey is the walletdb top-level bucket key used by the
+	// transaction manager.
+	//
+	// NOTE: This must match the namespace used by the wallet package.
+	wtxmgrNamespaceKey = []byte("wtxmgr")
+)
+
+func notImplemented(_ context.Context, method string) error {
+	return fmt.Errorf("kvdb.Store.%s: %w", method, errNotImplemented)
+}
+
+// GetUtxo is not yet implemented for kvdb.
+func (s *Store) GetUtxo(ctx context.Context,
+	_ db.GetUtxoQuery) (*db.UtxoInfo, error) {
+
+	return nil, notImplemented(ctx, "GetUtxo")
+}
+
+// ListUTXOs is not yet implemented for kvdb.
+func (s *Store) ListUTXOs(ctx context.Context,
+	_ db.ListUtxosQuery) ([]db.UtxoInfo, error) {
+
+	return nil, notImplemented(ctx, "ListUTXOs")
+}
+
+// LeaseOutput is not yet implemented for kvdb.
+func (s *Store) LeaseOutput(ctx context.Context,
+	_ db.LeaseOutputParams) (*db.LeasedOutput, error) {
+
+	return nil, notImplemented(ctx, "LeaseOutput")
+}
+
+// ReleaseOutput releases a previously leased output.
+//
+// How it works:
+// The method executes a single walletdb update transaction that deletes the
+// lock record associated with the specified outpoint.
+//
+// Database Actions:
+//   - Performs exactly one write transaction (walletdb.Update).
+//   - Writes to the `wtxmgr` namespace.
+//
+// NOTE: The legacy kvdb backend only supports a single wallet instance, so the
+// WalletID field is ignored.
+func (s *Store) ReleaseOutput(_ context.Context,
+	params db.ReleaseOutputParams) error {
+
+	lockID := wtxmgr.LockID(params.ID)
+	op := params.OutPoint
+
+	err := walletdb.Update(s.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+		if ns == nil {
+			return errMissingTxmgrNamespace
+		}
+
+		err := s.txStore.UnlockOutput(ns, lockID, op)
+		if err != nil {
+			return fmt.Errorf("unlock output: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("kvdb.Store.ReleaseOutput: %w", err)
+	}
+
+	return nil
+}
+
+// ListLeasedOutputs is not yet implemented for kvdb.
+func (s *Store) ListLeasedOutputs(ctx context.Context,
+	_ uint32) ([]db.LeasedOutput, error) {
+
+	return nil, notImplemented(ctx, "ListLeasedOutputs")
+}
+
+// Balance is not yet implemented for kvdb.
+func (s *Store) Balance(ctx context.Context,
+	_ db.BalanceParams) (btcutil.Amount, error) {
+
+	return 0, notImplemented(ctx, "Balance")
+}

--- a/wallet/internal/db/kvdb/utxo_test.go
+++ b/wallet/internal/db/kvdb/utxo_test.go
@@ -1,0 +1,114 @@
+package kvdb
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReleaseOutputSuccess verifies that kvdb.Store.ReleaseOutput removes an
+// existing output lease from the underlying wtxmgr store.
+func TestReleaseOutputSuccess(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore)
+
+	lockID := wtxmgr.LockID{1}
+	op := wire.OutPoint{Hash: [32]byte{1}, Index: 0}
+
+	// Arrange: Create a lease so there is something to release.
+	err := walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+		require.NotNil(t, ns)
+
+		// Create a mock transaction to satisfy the "known output" check in
+		// wtxmgr.
+		txMsg := &wire.MsgTx{
+			Version: 1,
+			TxOut: []*wire.TxOut{{
+				Value:    1000,
+				PkScript: []byte{0x00}, // OP_0
+			}},
+		}
+
+		rec, err := wtxmgr.NewTxRecordFromMsgTx(txMsg, time.Now())
+		if err != nil {
+			return fmt.Errorf("create tx record: %w", err)
+		}
+
+		// Insert the transaction as mined.
+		block := &wtxmgr.BlockMeta{
+			Block: wtxmgr.Block{Height: 1},
+			Time:  time.Now(),
+		}
+
+		err = txStore.InsertTx(ns, rec, block)
+		if err != nil {
+			return fmt.Errorf("insert tx: %w", err)
+		}
+
+		// Add the output as a credit so wtxmgr knows about it.
+		err = txStore.AddCredit(ns, rec, block, 0, false)
+		if err != nil {
+			return fmt.Errorf("add credit: %w", err)
+		}
+
+		// Use the inserted transaction's hash for the outpoint.
+		op.Hash = rec.Hash
+
+		_, err = txStore.LockOutput(ns, lockID, op, time.Hour)
+
+		return err
+	})
+	require.NoError(t, err)
+
+	// Act: Release the lease through the kvdb store implementation.
+	err = store.ReleaseOutput(t.Context(), db.ReleaseOutputParams{
+		WalletID: 1,
+		ID:       [32]byte(lockID),
+		OutPoint: op,
+	})
+	require.NoError(t, err)
+
+	// Assert: The lock set is now empty.
+	err = walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(wtxmgrNamespaceKey)
+		require.NotNil(t, ns)
+
+		locked, err := txStore.ListLockedOutputs(ns)
+		require.NoError(t, err)
+		require.Empty(t, locked)
+
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// TestReleaseOutputMissingNamespace verifies a helpful error is returned when
+// the `wtxmgr` namespace bucket is not present.
+func TestReleaseOutputMissingNamespace(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	store := NewStore(dbConn, nil)
+
+	err := store.ReleaseOutput(t.Context(), db.ReleaseOutputParams{
+		WalletID: 0,
+		ID:       [32]byte{1},
+		OutPoint: wire.OutPoint{Hash: [32]byte{1}, Index: 0},
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, errMissingTxmgrNamespace)
+}

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	kvdb "github.com/btcsuite/btcwallet/wallet/internal/db/kvdb"
 )
 
 var (
@@ -294,6 +295,7 @@ func (m *Manager) Load(cfg Config) (*Wallet, error) {
 	w := &Wallet{
 		cfg:         cfg,
 		addrStore:   addrMgr,
+		store:       kvdb.NewStore(cfg.DB, txMgr),
 		txStore:     txMgr,
 		requestChan: make(chan any),
 		lifetimeCtx: lifetimeCtx,

--- a/wallet/mock_test.go
+++ b/wallet/mock_test.go
@@ -2,9 +2,8 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-// This file contains a mock implementation of the wtxmgr.TxStore interface.
-// It is used in various tests to isolate wallet logic from the underlying
-// database.
+// This file contains mock implementations of wallet dependencies used in
+// tests to isolate wallet logic from underlying storage backends.
 
 package wallet
 
@@ -22,6 +21,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	db "github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/lightninglabs/neutrino"
@@ -29,6 +29,88 @@ import (
 	"github.com/lightninglabs/neutrino/headerfs"
 	"github.com/stretchr/testify/mock"
 )
+
+// mockStore is a mock implementation of the db.Store interface.
+//
+// It is used to unit test wallet UTXO manager public methods without
+// exercising a real database backend.
+type mockStore struct {
+	mock.Mock
+}
+
+// A compile-time assertion to ensure that mockStore implements the db.Store
+// interface.
+var _ db.Store = (*mockStore)(nil)
+
+// GetUtxo implements the db.UTXOStore interface.
+func (m *mockStore) GetUtxo(ctx context.Context,
+	query db.GetUtxoQuery) (*db.UtxoInfo, error) {
+
+	args := m.Called(ctx, query)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*db.UtxoInfo), args.Error(1)
+}
+
+// ListUTXOs implements the db.UTXOStore interface.
+func (m *mockStore) ListUTXOs(ctx context.Context,
+	query db.ListUtxosQuery) ([]db.UtxoInfo, error) {
+
+	args := m.Called(ctx, query)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).([]db.UtxoInfo), args.Error(1)
+}
+
+// LeaseOutput implements the db.UTXOStore interface.
+func (m *mockStore) LeaseOutput(ctx context.Context,
+	params db.LeaseOutputParams) (*db.LeasedOutput, error) {
+
+	args := m.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*db.LeasedOutput), args.Error(1)
+}
+
+// ReleaseOutput implements the db.UTXOStore interface.
+func (m *mockStore) ReleaseOutput(ctx context.Context,
+	params db.ReleaseOutputParams) error {
+
+	args := m.Called(ctx, params)
+	return args.Error(0)
+}
+
+// ListLeasedOutputs implements the db.UTXOStore interface.
+func (m *mockStore) ListLeasedOutputs(ctx context.Context,
+	walletID uint32) ([]db.LeasedOutput, error) {
+
+	args := m.Called(ctx, walletID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).([]db.LeasedOutput), args.Error(1)
+}
+
+// Balance implements the db.UTXOStore interface.
+func (m *mockStore) Balance(ctx context.Context,
+	params db.BalanceParams) (btcutil.Amount, error) {
+
+	args := m.Called(ctx, params)
+
+	amount, ok := args.Get(0).(btcutil.Amount)
+	if !ok {
+		return 0, args.Error(1)
+	}
+
+	return amount, args.Error(1)
+}
 
 // mockTxStore is a mock implementation of the wtxmgr.TxStore interface.
 type mockTxStore struct {

--- a/wallet/utxo_manager_test.go
+++ b/wallet/utxo_manager_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	db "github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -319,10 +320,12 @@ func TestReleaseOutput(t *testing.T) {
 		Index: 0,
 	}
 
-	// Mock the UnlockOutput method to return nil.
-	mocks.txStore.On("UnlockOutput",
-		mock.Anything, mock.Anything, utxo,
-	).Return(nil)
+	// Mock the UTXOStore ReleaseOutput method to return nil.
+	mocks.store.On("ReleaseOutput", mock.Anything, db.ReleaseOutputParams{
+		WalletID: 0,
+		ID:       [32]byte{1},
+		OutPoint: utxo,
+	}).Return(nil)
 
 	// Now, try to release the output.
 	leaseID := wtxmgr.LockID{1}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -24,6 +24,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	db "github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 )
@@ -339,6 +340,11 @@ type Wallet struct {
 	// txStore is the transaction manager responsible for storing and
 	// querying the wallet's transaction history and unspent outputs.
 	txStore wtxmgr.TxStore
+
+	// store provides access to database operations used by wallet managers.
+	//
+	// TODO(yy): Migrate UTXO-related callers behind db.UTXOStore.
+	store db.Store
 
 	// NtfnServer handles the delivery of wallet-related events (e.g., new
 	// transactions, block connections) to connected clients.


### PR DESCRIPTION
We build the skeleton to refactor the existing kvdb to meet the new `Store` interface.

As a starting point we add a simple method from the utxo store.

This has been review [here](https://github.com/yyforyongyu/btcwallet/pull/18) already.