### PR TITLE
docs+README: add Single-Passphrase Encryption Model ADR

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,13 @@ disk.  btcwallet uses the
 HD path for all derived addresses, as described by
 [BIP0044](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki).
 
-Due to the sensitive nature of public data in a BIP0032 wallet,
-btcwallet provides the option of encrypting not just private keys, but
-public data as well.  This is intended to thwart privacy risks where a
-wallet file is compromised without exposing all current and future
-addresses (public keys) managed by the wallet. While access to this
-information would not allow an attacker to spend or steal coins, it
-does mean they could track all transactions involving your addresses
-and therefore know your exact balance.  In a future release, public data
-encryption will extend to transactions as well.
+btcwallet encrypts all private key material (private keys, HD seeds)
+at rest using a single passphrase.  Public data such as addresses,
+transactions, and balances is stored in plaintext, consistent with
+Bitcoin Core conventions.  Users who require stronger privacy at rest
+should use full disk encryption (e.g. LUKS).  See
+[ADR 0009](docs/developer/adr/0009-single-passphrase-encryption.md)
+for design rationale.
 
 btcwallet is not an SPV client and requires connecting to a local or
 remote btcd instance for asynchronous blockchain queries and

--- a/docs/developer/adr/0009-single-passphrase-encryption.md
+++ b/docs/developer/adr/0009-single-passphrase-encryption.md
@@ -1,0 +1,75 @@
+# ADR 0009: Single-Passphrase Encryption Model
+
+## 1. Context
+
+`btcwallet` is migrating from a key-value database (kvdb) to a SQL-based
+backend. This transition requires a clean, consistent encryption model that
+works across SQLite and PostgreSQL.
+
+The legacy system used a dual-passphrase hierarchy with separate public and
+private encryption keys. In practice, downstream systems often set the public
+passphrase to a known constant to allow auto-start, which negated the privacy
+benefits while keeping the complexity. This model also diverges from the
+industry standard set by Bitcoin Core and libraries like BDK.
+
+The design notes that guided this change are captured in
+[Single-Passphrase Encryption Design Notes](https://gist.github.com/yyforyongyu/edfeee0f84cf79851735bcc3e740a871).
+
+## 2. Decision
+
+We will adopt a **Single-Passphrase Model** that encrypts **private data only**
+and leaves public data in plaintext.
+
+```mermaid
+flowchart TD
+    A[User Passphrase] --> B[scrypt KDF]
+    B --> C[Master Key]
+    C --> D[Encrypt Private Data]
+    E[Public Data] --> F[(Database)]
+    D --> F
+```
+
+### Key points
+
+1. **One master encryption key** derived from the user passphrase
+2. **Private data encrypted** (private keys, HD seeds, xprivs, scripts)
+3. **Public data plaintext** (addresses, pubkeys, transactions, balances)
+4. **Simplified hierarchy** by removing `CryptoPubKey` and `CryptoScriptKey`
+
+## 3. Consequences
+
+### Pros
+
+* **Simplicity**: Eliminates dual passphrase logic.
+* **Performance**: Read-only operations no longer require decrypting public
+  data, reducing query overhead.
+* **Interoperability**: Aligns with Bitcoin Core and BDK conventions.
+* **UX clarity**: Users only need a single passphrase.
+
+### Cons
+
+* **Privacy at rest**: Transaction history, balances, and public keys are
+  exposed if the database is compromised, consistent with Bitcoin Core tradeoffs.
+  If stronger protection is required, users can rely on full disk encryption such
+  as LUKS.
+* **Migration effort**: Existing wallets must be migrated away from the legacy
+  dual passphrase model. This work will be done along with the SQL backend migration.
+
+## 4. Threat Model and Security Boundaries
+
+This model protects private key material at rest when an attacker can read the
+database but cannot guess the wallet passphrase.
+
+This model does not protect metadata privacy if the database contents are
+exfiltrated. Addresses, balances, and transaction history remain visible by
+design.
+
+Operational mitigations required for this model:
+
+* Full disk encryption for database files.
+* Host hardening (least privilege, patching, endpoint protection).
+* Encrypted backups with independent access controls and key management.
+
+## 5. Status
+
+Accepted.

--- a/docs/developer/adr/README.md
+++ b/docs/developer/adr/README.md
@@ -14,3 +14,4 @@ ADRs serve as a historical log of important design choices, providing context fo
 - [ADR 0006: Wallet Transaction Manager SQL Schema](./0006-wtxmgr-sql-schema.md) - Defines the relational SQL schema for the Wallet Transaction Manager (`wtxmgr`) migration.
 - [ADR 0007: XChaCha20-Poly1305 Encryption](./0007-xchacha20-poly1305-encryption.md) - Replaces XSalsa20-Poly1305 with XChaCha20-Poly1305 for encrypting private key material.
 - [ADR 0008: Integration Test Framework](./0008-integration-test-framework.md) - Defines a modular integration test framework for chain and database backend permutations.
+- [ADR 0009: Single-Passphrase Encryption Model](./0009-single-passphrase-encryption.md) - Adopts a single-passphrase model that encrypts private data only while keeping public wallet metadata in plaintext.


### PR DESCRIPTION
### Summary
- Add ADR 0009 documenting the single-passphrase encryption model, including
  a threat model section covering what it protects (private keys at rest),
  what it does not (metadata privacy on DB exfiltration), and required
  operational mitigations (disk encryption, host hardening, encrypted backups).

- Update root README to reflect the new encryption model, replacing the
  legacy dual-passphrase description that no longer matches the codebase
  direction.