### PR TITLE
itest: implement `lnd` style itest framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ coverage.out
 *.prof
 *.test
 *cpu.out
+
+# Integration test logs.
+itest/test-logs/
+
+# Backwards compatibility for older log dir.
+itest/.minerlogs/

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,22 @@ itest-db-race:
 	@$(call print, "Running $(IT_DB_LABEL) integration tests (race).")
 	env CGO_ENABLED=1 GORACE="history_size=7 halt_on_errors=1" $(ITEST_DB_RACE)
 
+#? itest: Run integration tests
+#? itest (vars): chain=btcd|bitcoind|neutrino db=kvdb|sqlite|postgres
+#? itest (vars): icase=<regex> (filter itest cases)
+#? itest (vars): timeout=<duration> verbose=1 nocache=1
+#? itest (ex): make itest icase=manager
+#? itest (ex): make itest chain=btcd db=kvdb
+itest:
+	@$(call print, "Running integration tests.")
+	@$(GOTEST) -v ./itest \
+		-tags="itest $(DEV_TAGS) nolog" \
+		$(if $(icase),-test.run="TestBtcWallet/.*/$(icase)",) \
+		$(filter-out -test.run=%,$(TEST_FLAGS)) \
+		-args \
+		-chain="$(if $(chain),$(chain),btcd)" \
+		-db="$(if $(db),$(db),kvdb)"
+
 # =========
 # UTILITIES
 # =========
@@ -279,6 +295,7 @@ sql-lint-check:
 	unit-race \
 	unit-debug \
 	unit-bench \
+	itest \
 	itest-db \
 	itest-db-race \
 	fmt \

--- a/bwtest/chain_backend.go
+++ b/bwtest/chain_backend.go
@@ -1,0 +1,133 @@
+// Package bwtest provides the integration test framework for btcwallet.
+package bwtest
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcd/integration/rpctest"
+	"github.com/btcsuite/btcd/rpcclient"
+	"github.com/stretchr/testify/require"
+)
+
+// ChainBackend defines the interface that all chain backends must implement.
+type ChainBackend interface {
+	// Start launches the chain backend process.
+	Start() error
+
+	// Stop shuts down the chain backend process.
+	Stop() error
+
+	// RPCConfig returns the credentials to connect to this backend.
+	RPCConfig() rpcclient.ConnConfig
+
+	// P2PAddr returns the P2P address of this node.
+	P2PAddr() string
+
+	// ConnectMiner connects this node to the miner.
+	ConnectMiner(minerAddr string) error
+
+	// Name returns the name of the backend ("btcd", "bitcoind", "neutrino").
+	Name() string
+}
+
+// BtcdBackend is a ChainBackend backed by a btcd node (via rpctest).
+type BtcdBackend struct {
+	// harness is the underlying rpctest harness that manages the btcd process.
+	harness *rpctest.Harness
+}
+
+// NewBtcdBackend creates a new BtcdBackend.
+func NewBtcdBackend(t *testing.T) *BtcdBackend {
+	t.Helper()
+
+	btcdBinary, err := GetBtcdBinary()
+	require.NoError(t, err, "unable to find btcd binary")
+
+	// Create a separate harness for the chain backend.
+	// We use the same regression net params.
+	args := []string{
+		"--rejectnonstd",          // Reject non-standard txs in tests.
+		"--txindex",               // Required for some RPC queries.
+		"--nowinservice",          // Avoid Windows service integration.
+		"--nobanning",             // Avoid peer banning in local tests.
+		"--debuglevel=debug",      // Provide detailed logs for debugging.
+		"--trickleinterval=100ms", // Speed up inv relay in regtest.
+		"--nostalldetect",         // Avoid stall detection flakiness.
+	}
+
+	handlers := &rpcclient.NotificationHandlers{}
+	harness, err := rpctest.New(harnessNetParams, handlers, args, btcdBinary)
+	require.NoError(t, err, "unable to create btcd backend harness")
+
+	return &BtcdBackend{
+		harness: harness,
+	}
+}
+
+// Start launches the btcd node.
+func (b *BtcdBackend) Start() error {
+	// SetUp(false, 0) means we don't treat it as a miner
+	// (no mining addrs needed immediately) and don't cache block templates.
+	err := b.harness.SetUp(false, 0)
+	if err != nil {
+		return fmt.Errorf("failed to setup btcd harness: %w", err)
+	}
+
+	return nil
+}
+
+// Stop shuts down the btcd node.
+func (b *BtcdBackend) Stop() error {
+	err := b.harness.TearDown()
+	if err != nil {
+		return fmt.Errorf("failed to teardown btcd harness: %w", err)
+	}
+
+	return nil
+}
+
+// RPCConfig returns the RPC connection config.
+func (b *BtcdBackend) RPCConfig() rpcclient.ConnConfig {
+	return b.harness.RPCConfig()
+}
+
+// P2PAddr returns the P2P address.
+func (b *BtcdBackend) P2PAddr() string {
+	return b.harness.P2PAddress()
+}
+
+// ConnectMiner connects the backend to the miner.
+func (b *BtcdBackend) ConnectMiner(minerAddr string) error {
+	// We use "add" to make it persistent.
+	err := b.harness.Client.AddNode(minerAddr, "add")
+	if err != nil {
+		return fmt.Errorf("failed to add miner node %s: %w", minerAddr,
+			err)
+	}
+
+	return nil
+}
+
+// Name returns "btcd".
+func (b *BtcdBackend) Name() string {
+	return "btcd"
+}
+
+// Ensure BtcdBackend implements ChainBackend.
+var _ ChainBackend = (*BtcdBackend)(nil)
+
+// NewBackend creates a ChainBackend based on the type string.
+// Currently only supports "btcd".
+func NewBackend(t *testing.T, backendType string) ChainBackend {
+	t.Helper()
+
+	switch backendType {
+	case "btcd":
+		return NewBtcdBackend(t)
+	// TODO: Add bitcoind and neutrino support.
+	default:
+		t.Fatalf("unknown backend type: %s", backendType)
+		return nil
+	}
+}

--- a/bwtest/database.go
+++ b/bwtest/database.go
@@ -1,0 +1,53 @@
+package bwtest
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/btcsuite/btcwallet/walletdb"
+	_ "github.com/btcsuite/btcwallet/walletdb/bdb" // Register bdb driver.
+)
+
+var (
+	// ErrUnknownDBBackend is returned when an unknown db backend is requested.
+	ErrUnknownDBBackend = errors.New("unknown db backend")
+)
+
+const (
+	// dbNameKvdb is the identifier used for the kvdb wallet backend.
+	dbNameKvdb = "kvdb"
+
+	// kvdbDriver is the walletdb driver name used for kvdb.
+	kvdbDriver = "bdb"
+
+	// walletDBFilename is the default wallet database filename.
+	walletDBFilename = "wallet.db"
+)
+
+// OpenWalletDB opens a wallet database instance rooted at baseDir.
+//
+// The returned cleanup function should be called to close the database.
+func OpenWalletDB(dbType, baseDir string) (walletdb.DB, func() error, error) {
+	switch dbType {
+	case dbNameKvdb:
+		dbPath := filepath.Join(baseDir, walletDBFilename)
+
+		db, err := walletdb.Create(kvdbDriver, dbPath, true,
+			defaultTestTimeout, false)
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to create bdb instance: %w",
+				err)
+		}
+
+		cleanup := func() error {
+			return db.Close()
+		}
+
+		return db, cleanup, nil
+
+	// TODO: Add sqlite and postgres support.
+	default:
+		return nil, nil, fmt.Errorf("%w: %s", ErrUnknownDBBackend, dbType)
+	}
+}

--- a/bwtest/harness.go
+++ b/bwtest/harness.go
@@ -1,0 +1,240 @@
+package bwtest
+
+import (
+	"runtime/debug"
+	"sync"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcwallet/bwtest/wait"
+	"github.com/btcsuite/btcwallet/chain"
+	"github.com/btcsuite/btcwallet/wallet"
+	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// defaultChainReconnectAttempts is the number of times the chain RPC client
+	// will attempt to reconnect before failing.
+	defaultChainReconnectAttempts = 5
+)
+
+// HarnessTest is the integration test harness.
+type HarnessTest struct {
+	*testing.T
+
+	// miner is the shared mining node used to generate blocks.
+	miner *minerHarness
+
+	// Backend is the chain backend under test.
+	Backend ChainBackend
+
+	// ChainClient is an RPC chain client connected to the active chain backend.
+	//
+	// This client is created for each subtest harness and is intended to be
+	// passed to wallets under test.
+	ChainClient chain.Interface
+
+	// WalletDB is a wallet database instance created for the current subtest.
+	WalletDB walletdb.DB
+
+	// dbType is the configured wallet database backend.
+	dbType string
+
+	// mu protects harness state that can be accessed across the main test and
+	// subtests. This includes the wallet registry and idempotent shutdown.
+	mu sync.Mutex
+
+	// wallets is the set of wallets created by a test case.
+	wallets []*wallet.Wallet
+
+	// stopped prevents stopping shared infrastructure more than once.
+	stopped bool
+}
+
+// SetupHarness creates a new HarnessTest.
+func SetupHarness(t *testing.T, chainBackendType, dbType string) *HarnessTest {
+	t.Helper()
+
+	// 1. Start Miner (always btcd).
+	miner := newMiner(t)
+	miner.SetUp()
+
+	// 2. Start Chain Backend.
+	backend := NewBackend(t, chainBackendType)
+	require.NoError(t, backend.Start(), "failed to start chain backend")
+
+	ht := &HarnessTest{
+		T:       t,
+		miner:   miner,
+		Backend: backend,
+		dbType:  dbType,
+	}
+
+	// Ensure the harness is cleaned up when the test finishes.
+	t.Cleanup(ht.Stop)
+
+	// 3. Connect Backend to Miner.
+	// Backend startup can take a moment, so we retry until it succeeds.
+	err := wait.NoError(func() error {
+		return backend.ConnectMiner(miner.P2PAddress())
+	}, defaultTestTimeout)
+	require.NoError(t, err, "failed to connect backend to miner")
+
+	return ht
+}
+
+// Subtest creates a child harness that shares the miner and chain backend.
+//
+// The returned harness has its own wallet registry and per-test resources.
+// Callers should not call Stop on the returned harness as it would stop shared
+// infrastructure.
+func (h *HarnessTest) Subtest(t *testing.T) *HarnessTest {
+	h.Helper()
+
+	st := &HarnessTest{
+		T:       t,
+		miner:   h.miner,
+		Backend: h.Backend,
+		dbType:  h.dbType,
+	}
+
+	// Use the subtest's testing context for miner assertions.
+	//
+	// The miner is shared across test cases, but we want failures to be
+	// attributed to the active subtest.
+	//
+	// NOTE: The miner is shared across the whole suite and this assignment
+	// mutates that shared state.
+	//
+	// This is safe because the integration test suite runs subtests serially
+	// (no t.Parallel()). Do not enable parallel integration cases unless this
+	// is refactored.
+	st.miner.T = st.T
+
+	st.setUpChainClient()
+	st.setUpWalletDB()
+
+	return st
+}
+
+// RegisterWallet registers a wallet with the harness.
+//
+// Registered wallets are automatically included in harness-level assertions,
+// such as MineBlocks.
+func (h *HarnessTest) RegisterWallet(w *wallet.Wallet) {
+	h.Helper()
+
+	if w == nil {
+		h.Fatalf("cannot register nil wallet")
+	}
+
+	h.mu.Lock()
+	h.wallets = append(h.wallets, w)
+	h.mu.Unlock()
+}
+
+// ActiveWallets returns a snapshot of wallets registered with this harness.
+func (h *HarnessTest) ActiveWallets() []*wallet.Wallet {
+	h.Helper()
+
+	h.mu.Lock()
+	wallets := append([]*wallet.Wallet(nil), h.wallets...)
+	h.mu.Unlock()
+
+	return wallets
+}
+
+// RunTestCase executes a harness test case.
+//
+// Any panic from the test function is converted into a fatal test failure with
+// a stack trace.
+func (h *HarnessTest) RunTestCase(name string,
+	testFunc func(t *HarnessTest)) {
+
+	h.Helper()
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+
+		stack := debug.Stack()
+		h.Fatalf("failed (%s): panic=%v\n%s", name, r, stack)
+	}()
+
+	if testFunc == nil {
+		h.Fatalf("nil test func for %s", name)
+	}
+
+	// Execute the case.
+	testFunc(h)
+}
+
+// NetParams returns the chain parameters used by the harness.
+func (h *HarnessTest) NetParams() *chaincfg.Params {
+	h.Helper()
+
+	return harnessNetParams
+}
+
+// Stop shuts down all resources owned by the harness.
+func (h *HarnessTest) Stop() {
+	h.Helper()
+
+	h.mu.Lock()
+
+	if h.stopped {
+		h.mu.Unlock()
+		return
+	}
+
+	h.stopped = true
+	h.mu.Unlock()
+
+	// Stop the chain backend first to avoid it attempting to reconnect while
+	// the miner is being torn down.
+	require.NoError(h, h.Backend.Stop(), "failed to stop chain backend")
+
+	// Finally, stop the miner.
+	h.miner.Stop()
+}
+
+// setUpChainClient creates and starts an RPC chain client for the active
+// harness backend.
+func (h *HarnessTest) setUpChainClient() {
+	h.Helper()
+
+	backendCfg := h.Backend.RPCConfig()
+	rpcCfg := backendCfg
+
+	chainConfig := &chain.RPCClientConfig{
+		Conn:              &rpcCfg,
+		Chain:             harnessNetParams,
+		ReconnectAttempts: defaultChainReconnectAttempts,
+	}
+	chainClient, err := chain.NewRPCClientWithConfig(chainConfig)
+	require.NoError(h, err, "unable to create chain client")
+
+	err = chainClient.Start(h.Context())
+	require.NoError(h, err, "unable to start chain client")
+	h.Cleanup(chainClient.Stop)
+
+	h.ChainClient = chainClient
+}
+
+// setUpWalletDB opens a wallet database for the configured test backend.
+func (h *HarnessTest) setUpWalletDB() {
+	h.Helper()
+
+	dbDir := h.TempDir()
+	db, cleanup, err := OpenWalletDB(h.dbType, dbDir)
+	require.NoError(h, err, "unable to create wallet db")
+
+	h.Cleanup(func() {
+		require.NoError(h, cleanup(), "failed to close database")
+	})
+
+	h.WalletDB = db
+}

--- a/bwtest/harness_assertions.go
+++ b/bwtest/harness_assertions.go
@@ -1,0 +1,44 @@
+package bwtest
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcwallet/bwtest/wait"
+	"github.com/btcsuite/btcwallet/wallet"
+)
+
+var (
+	// ErrWalletNotSynced is returned when a wallet has not reached the chain
+	// tip.
+	ErrWalletNotSynced = errors.New("wallet not synced")
+)
+
+// AssertWalletSynced polls until the wallet reports it is synced to the
+// miner's best known height.
+func (h *HarnessTest) AssertWalletSynced(w *wallet.Wallet) {
+	h.Helper()
+
+	if w == nil {
+		h.Fatalf("nil wallet")
+	}
+
+	err := wait.NoError(func() error {
+		syncedTo := w.SyncedTo()
+
+		_, bestHeight, err := h.miner.Client.GetBestBlock()
+		if err != nil {
+			return fmt.Errorf("get best block: %w", err)
+		}
+
+		if syncedTo.Height != bestHeight {
+			return fmt.Errorf("%w: wallet=%d chain=%d", ErrWalletNotSynced,
+				syncedTo.Height, bestHeight)
+		}
+
+		return nil
+	}, defaultTestTimeout)
+	if err != nil {
+		h.Fatalf("wallet sync timeout: %v", err)
+	}
+}

--- a/bwtest/harness_miner.go
+++ b/bwtest/harness_miner.go
@@ -1,0 +1,505 @@
+package bwtest
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/bwtest/wait"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	// ErrMempoolTxNotFound is returned when a transaction is not found in the
+	// miner's mempool.
+	ErrMempoolTxNotFound = errors.New("transaction not found in mempool")
+
+	// ErrMempoolTxFound is returned when a transaction is found in the miner's
+	// mempool.
+	ErrMempoolTxFound = errors.New("transaction found in mempool")
+
+	// ErrMempoolNumTxnsMismatch is returned when the number of transactions in
+	// the mempool doesn't match the expected value.
+	ErrMempoolNumTxnsMismatch = errors.New("mempool txn count mismatch")
+
+	// ErrBlockMissingTx is returned when a transaction is not found in a block.
+	ErrBlockMissingTx = errors.New("transaction not found in block")
+
+	// ErrBlockUnexpectedTxns is returned when a block contains unexpected
+	// transactions.
+	ErrBlockUnexpectedTxns = errors.New("block contains unexpected txns")
+
+	// ErrOutpointNotFound is returned when an outpoint is not found in the
+	// miner's mempool.
+	ErrOutpointNotFound = errors.New("outpoint not found in mempool")
+
+	// ErrNilBlock is returned when a nil block is provided.
+	ErrNilBlock = errors.New("nil block")
+
+	// ErrMinerNotSynced is returned when a temporary miner is not synced to the
+	// harness miner.
+	ErrMinerNotSynced = errors.New("miner not synced")
+)
+
+const (
+	// coinbaseAndOneTxn is the number of transactions expected in a block that
+	// contains only a coinbase transaction and a single non-coinbase
+	// transaction.
+	coinbaseAndOneTxn = 2
+)
+
+// GenerateBlocks generates the specified number of blocks.
+func (h *HarnessTest) GenerateBlocks(num uint32) []*chainhash.Hash {
+	h.Helper()
+
+	hashes, err := h.miner.Client.Generate(num)
+	require.NoError(h, err, "unable to generate blocks")
+
+	return hashes
+}
+
+// AssertTxInMempool asserts a transaction can be found in the miner's mempool.
+func (h *HarnessTest) AssertTxInMempool(txid chainhash.Hash) *wire.MsgTx {
+	h.Helper()
+
+	var foundTx *wire.MsgTx
+
+	err := wait.NoError(func() error {
+		txids, err := h.getRawMempool()
+		if err != nil {
+			return fmt.Errorf("get raw mempool: %w", err)
+		}
+
+		for _, memTxid := range txids {
+			if memTxid == txid {
+				tx, err := h.miner.Client.GetRawTransaction(&txid)
+				if err != nil {
+					return fmt.Errorf("get raw transaction: %w", err)
+				}
+
+				foundTx = tx.MsgTx()
+
+				return nil
+			}
+		}
+
+		return fmt.Errorf("%w: txid=%s", ErrMempoolTxNotFound, txid)
+	}, defaultTestTimeout)
+	require.NoError(h, err, "timeout waiting for txn in mempool")
+	require.NotNil(h, foundTx, "found tx is nil")
+
+	return foundTx
+}
+
+// AssertTxNotInMempool asserts a transaction cannot be found in the miner's
+// mempool.
+func (h *HarnessTest) AssertTxNotInMempool(txid chainhash.Hash) {
+	h.Helper()
+
+	err := wait.NoError(func() error {
+		txids, err := h.getRawMempool()
+		if err != nil {
+			return fmt.Errorf("get raw mempool: %w", err)
+		}
+
+		for _, memTxid := range txids {
+			if memTxid == txid {
+				return fmt.Errorf("%w: txid=%s", ErrMempoolTxFound,
+					txid)
+			}
+		}
+
+		return nil
+	}, defaultTestTimeout)
+	require.NoError(h, err, "timeout waiting for txn to leave mempool")
+}
+
+// AssertNumTxnsInMempool polls until finding the expected number of
+// transactions in the miner's mempool.
+func (h *HarnessTest) AssertNumTxnsInMempool(n int) []chainhash.Hash {
+	h.Helper()
+
+	if n < 0 {
+		h.Fatalf("invalid mempool size: %d", n)
+	}
+
+	var txids []chainhash.Hash
+
+	err := wait.NoError(func() error {
+		mempoolTxids, err := h.getRawMempool()
+		if err != nil {
+			return fmt.Errorf("get raw mempool: %w", err)
+		}
+
+		if len(mempoolTxids) != n {
+			return fmt.Errorf("%w: want=%d got=%d", ErrMempoolNumTxnsMismatch,
+				n, len(mempoolTxids))
+		}
+
+		txids = mempoolTxids
+
+		return nil
+	}, defaultTestTimeout)
+	require.NoError(h, err, "timeout waiting for mempool size")
+
+	return txids
+}
+
+// AssertOutpointInMempool asserts an outpoint is spent by a transaction in the
+// miner's mempool.
+func (h *HarnessTest) AssertOutpointInMempool(op wire.OutPoint) *wire.MsgTx {
+	h.Helper()
+
+	var foundTx *wire.MsgTx
+
+	err := wait.NoError(func() error {
+		txids, err := h.getRawMempool()
+		if err != nil {
+			return fmt.Errorf("get raw mempool: %w", err)
+		}
+
+		for _, txid := range txids {
+			tx, err := h.miner.Client.GetRawTransaction(&txid)
+			if err != nil {
+				return fmt.Errorf("get raw transaction: %w", err)
+			}
+
+			msgTx := tx.MsgTx()
+			for _, txIn := range msgTx.TxIn {
+				if txIn.PreviousOutPoint == op {
+					foundTx = msgTx
+					return nil
+				}
+			}
+		}
+
+		return fmt.Errorf("%w: outpoint=%v", ErrOutpointNotFound, op)
+	}, defaultTestTimeout)
+	require.NoError(h, err, "timeout waiting for outpoint in mempool")
+	require.NotNil(h, foundTx, "found tx is nil")
+
+	return foundTx
+}
+
+// AssertTxInBlock asserts a transaction can be found in a block.
+func (h *HarnessTest) AssertTxInBlock(block *wire.MsgBlock,
+	txid chainhash.Hash) {
+
+	h.Helper()
+
+	if block == nil {
+		h.Fatalf("nil block")
+	}
+
+	for _, tx := range block.Transactions {
+		if tx == nil {
+			continue
+		}
+
+		if tx.TxHash() == txid {
+			return
+		}
+	}
+
+	h.Fatalf("%v: block=%v", fmt.Errorf("%w: txid=%s", ErrBlockMissingTx,
+		txid), block.BlockHash())
+}
+
+// MineBlocks mines blocks and asserts no transactions are found in the mined
+// blocks.
+//
+// After each block is mined, all registered wallets are required to be synced.
+func (h *HarnessTest) MineBlocks(num int) {
+	h.Helper()
+
+	err := h.MineBlocksNoTxns(num)
+	if err != nil {
+		require.Fail(h, "MineBlocks", err.Error())
+	}
+}
+
+// MineBlocksNoTxns mines blocks and returns an error if any mined block
+// contains non-coinbase transactions.
+func (h *HarnessTest) MineBlocksNoTxns(num int) error {
+	h.Helper()
+
+	blocks := h.generateBlocks(num)
+	for _, b := range blocks {
+		err := h.blockHasNoTxns(b)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// MineEmptyBlocks mines blocks and asserts the mempool remains empty.
+//
+// This differs from MineBlocks in that it explicitly requires the miner's
+// mempool to have no transactions before mining begins.
+func (h *HarnessTest) MineEmptyBlocks(num int) []*wire.MsgBlock {
+	h.Helper()
+
+	// Require the mempool is empty before mining, otherwise these blocks might
+	// confirm pending transactions.
+	h.AssertNumTxnsInMempool(0)
+
+	blocks := h.generateBlocks(num)
+	for _, b := range blocks {
+		err := h.blockHasNoTxns(b)
+		if err != nil {
+			require.Fail(h, "MineEmptyBlocks", err.Error())
+		}
+	}
+
+	return blocks
+}
+
+// MineBlocksAndAssertNumTxns mines blocks and asserts that numTxns
+// transactions are included in the first mined block.
+func (h *HarnessTest) MineBlocksAndAssertNumTxns(num uint32,
+	numTxns int) []*wire.MsgBlock {
+
+	h.Helper()
+
+	if num == 0 {
+		h.Fatalf("invalid block count: %d", num)
+	}
+
+	txids := h.AssertNumTxnsInMempool(numTxns)
+	blocks := h.generateBlocks(int(num))
+
+	for _, txid := range txids {
+		h.AssertTxInBlock(blocks[0], txid)
+		h.AssertTxNotInMempool(txid)
+	}
+
+	return blocks
+}
+
+// MineBlockWithTx mines a single block and asserts it contains the given
+// transaction.
+func (h *HarnessTest) MineBlockWithTx(tx *wire.MsgTx) *wire.MsgBlock {
+	h.Helper()
+
+	if tx == nil {
+		h.Fatalf("nil tx")
+	}
+
+	txid := tx.TxHash()
+	h.AssertTxInMempool(txid)
+
+	// Ensure the mempool only contains our transaction so the mined block
+	// contains only the coinbase and this transaction.
+	mempoolTxids := h.AssertNumTxnsInMempool(1)
+	require.Equal(h, txid, mempoolTxids[0], "unexpected txn in mempool")
+
+	blocks := h.MineBlocksAndAssertNumTxns(1, 1)
+	require.Len(h, blocks, 1, "expected exactly 1 block")
+
+	block := blocks[0]
+	require.NotNil(h, block, "mined block is nil")
+	require.Len(h, block.Transactions, coinbaseAndOneTxn,
+		"expected coinbase and one txn")
+	require.Equal(h, txid, block.Transactions[1].TxHash(),
+		"unexpected txn in mined block")
+
+	return block
+}
+
+// SpawnTempMiner creates a temporary miner that is synced with the current
+// miner.
+//
+// This is useful for reorg tests where an alternative chain needs to be mined
+// in isolation.
+func (h *HarnessTest) SpawnTempMiner() *HarnessTest {
+	h.Helper()
+
+	tempMiner := newMiner(h.T)
+	tempMiner.SetUpNoChain()
+
+	th := &HarnessTest{T: h.T, miner: tempMiner}
+	h.Cleanup(tempMiner.Stop)
+
+	// Connect the miners and wait for the temp miner to sync.
+	h.ConnectToMiner(th)
+
+	_, mainHeight := h.GetBestBlock()
+	err := wait.NoError(func() error {
+		_, tempHeight, err := tempMiner.Client.GetBestBlock()
+		if err != nil {
+			return fmt.Errorf("get best block: %w", err)
+		}
+
+		if tempHeight != mainHeight {
+			return fmt.Errorf("%w: main=%d temp=%d", ErrMinerNotSynced,
+				mainHeight, tempHeight)
+		}
+
+		return nil
+	}, defaultTestTimeout)
+	require.NoError(h, err, "timeout waiting for temp miner to sync")
+
+	// Disconnect the temp miner so it can mine an alternative chain.
+	h.DisconnectFromMiner(th)
+
+	return th
+}
+
+// ConnectToMiner connects the harness miner to tempMiner.
+func (h *HarnessTest) ConnectToMiner(tempMiner *HarnessTest) {
+	h.Helper()
+
+	if tempMiner == nil {
+		h.Fatalf("nil temp miner")
+	}
+
+	if tempMiner.miner == nil {
+		h.Fatalf("nil temp miner harness")
+	}
+
+	err := h.miner.Client.AddNode(tempMiner.miner.P2PAddress(), "add")
+	require.NoError(h, err, "failed to connect to temp miner")
+
+	err = tempMiner.miner.Client.AddNode(h.miner.P2PAddress(), "add")
+	require.NoError(h, err, "failed to connect temp miner")
+}
+
+// DisconnectFromMiner disconnects the harness miner from tempMiner.
+func (h *HarnessTest) DisconnectFromMiner(tempMiner *HarnessTest) {
+	h.Helper()
+
+	if tempMiner == nil {
+		h.Fatalf("nil temp miner")
+	}
+
+	if tempMiner.miner == nil {
+		h.Fatalf("nil temp miner harness")
+	}
+
+	err := h.miner.Client.AddNode(tempMiner.miner.P2PAddress(), "remove")
+	require.NoError(h, err, "failed to disconnect from temp miner")
+
+	err = tempMiner.miner.Client.AddNode(h.miner.P2PAddress(), "remove")
+	require.NoError(h, err, "failed to disconnect temp miner")
+}
+
+// generateBlocks mines num blocks and returns the full blocks.
+//
+// After each block is mined, all registered wallets are required to be synced.
+func (h *HarnessTest) generateBlocks(num int) []*wire.MsgBlock {
+	h.Helper()
+
+	// Mining 0 blocks is a no-op.
+	if num == 0 {
+		return nil
+	}
+
+	if num < 0 {
+		h.Fatalf("invalid block count: %d", num)
+	}
+
+	if num > int(^uint32(0)) {
+		h.Fatalf("too many blocks requested: %d", num)
+	}
+
+	blocks := make([]*wire.MsgBlock, 0, num)
+	for range num {
+		hashes := h.GenerateBlocks(1)
+		require.Len(h, hashes, 1, "expected 1 block hash")
+
+		block, err := h.miner.Client.GetBlock(hashes[0])
+		require.NoError(h, err, "failed to get mined block")
+
+		blocks = append(blocks, block)
+
+		// Ensure all wallets we created in this test have caught up.
+		for _, w := range h.ActiveWallets() {
+			h.AssertWalletSynced(w)
+		}
+	}
+
+	return blocks
+}
+
+// getRawMempool returns the miner's mempool transaction ids.
+func (h *HarnessTest) getRawMempool() ([]chainhash.Hash, error) {
+	h.Helper()
+
+	txids, err := h.miner.Client.GetRawMempool()
+	if err != nil {
+		return nil, fmt.Errorf("get raw mempool: %w", err)
+	}
+
+	result := make([]chainhash.Hash, 0, len(txids))
+	for _, txid := range txids {
+		if txid == nil {
+			continue
+		}
+
+		result = append(result, *txid)
+	}
+
+	return result, nil
+}
+
+// blockHasNoTxns returns an error if block contains non-coinbase transactions.
+func (h *HarnessTest) blockHasNoTxns(block *wire.MsgBlock) error {
+	h.Helper()
+
+	if block == nil {
+		return ErrNilBlock
+	}
+
+	if len(block.Transactions) <= 1 {
+		return nil
+	}
+
+	var desc strings.Builder
+	desc.WriteString(fmt.Sprintf(
+		"block %v has %d txns:\n",
+		block.BlockHash(), len(block.Transactions)-1,
+	))
+
+	for _, tx := range block.Transactions[1:] {
+		if tx == nil {
+			continue
+		}
+
+		desc.WriteString(fmt.Sprintf("%v\n", tx.TxHash()))
+	}
+
+	desc.WriteString(
+		"Consider using `MineBlocksAndAssertNumTxns` if you expect " +
+			"txns, or `MineEmptyBlocks` if you want to keep txns " +
+			"unconfirmed.",
+	)
+
+	return fmt.Errorf("%w: %s", ErrBlockUnexpectedTxns, desc.String())
+}
+
+// SendOutput sends funds from the miner.
+func (h *HarnessTest) SendOutput(output *wire.TxOut,
+	feeRate btcutil.Amount) *chainhash.Hash {
+
+	h.Helper()
+
+	txid, err := h.miner.SendOutputs([]*wire.TxOut{output}, feeRate)
+	require.NoError(h, err, "failed to send output")
+
+	return txid
+}
+
+// GetBestBlock returns the hash and height of the best block.
+func (h *HarnessTest) GetBestBlock() (*chainhash.Hash, int32) {
+	h.Helper()
+
+	hash, height, err := h.miner.Client.GetBestBlock()
+	require.NoError(h, err, "failed to get best block")
+
+	return hash, height
+}

--- a/bwtest/miner.go
+++ b/bwtest/miner.go
@@ -1,0 +1,202 @@
+package bwtest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/integration/rpctest"
+	"github.com/btcsuite/btcd/rpcclient"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// MinerLogFilename is the default log filename for the miner node.
+	MinerLogFilename = "output_btcd_miner.log"
+
+	// MinerLogDir is the default log dir for the miner node.
+	//
+	// Note: When running the integration tests with `go test ./itest`, the
+	// working directory is `itest`, so logs are written under
+	// `itest/test-logs`.
+	MinerLogDir = "test-logs"
+
+	// minerSetupOutputs is the number of outputs to generate during miner
+	// setup.
+	minerSetupOutputs = 50
+
+	// minMatureBlocks is the minimum number of blocks to mine to ensure
+	// coinbase maturity.
+	minMatureBlocks = 100
+
+	// retryMultiplier is the multiplier for connection retries to make tests
+	// more robust.
+	retryMultiplier = 2
+
+	// minerWindowMultiplier is the multiplier for the miner confirmation
+	// window to ensure we mine enough blocks for activation.
+	minerWindowMultiplier = 2
+
+	// minerLogDirPerm is the file mode used when creating the miner log dir.
+	minerLogDirPerm = 0o750
+
+	// maxMinerLogDirAttempts is the maximum number of attempts to create a
+	// unique log directory.
+	maxMinerLogDirAttempts = 1000
+)
+
+var (
+	// harnessNetParams is the network parameters used for the harness.
+	harnessNetParams = &chaincfg.RegressionNetParams
+)
+
+// minerHarness is a wrapper around rpctest.Harness that provides a mining node
+// for integration tests.
+type minerHarness struct {
+	*testing.T
+
+	*rpctest.Harness
+
+	// logPath is the directory path of the miner's logs.
+	logPath string
+
+	// logFilename is the saved log filename of the miner node.
+	logFilename string
+}
+
+// newMiner creates a new minerHarness instance.
+func newMiner(t *testing.T) *minerHarness {
+	t.Helper()
+
+	btcdBinary, err := GetBtcdBinary()
+	require.NoError(t, err, "unable to find btcd binary")
+
+	logDir := createMinerLogDir(t)
+
+	args := []string{
+		"--rejectnonstd",          // Reject non-standard txs in tests.
+		"--txindex",               // Required for some RPC queries.
+		"--nowinservice",          // Avoid Windows service integration.
+		"--nobanning",             // Avoid peer banning in local tests.
+		"--debuglevel=debug",      // Provide detailed logs for debugging.
+		"--logdir=" + logDir,      // Write logs into our per-run dir.
+		"--trickleinterval=100ms", // Speed up inv relay in regtest.
+		"--nostalldetect",         // Avoid stall detection flakiness.
+	}
+
+	// We use an empty handlers struct as we don't need to handle notifications
+	// directly in the miner wrapper for now.
+	handlers := &rpcclient.NotificationHandlers{}
+
+	harness, err := rpctest.New(harnessNetParams, handlers, args, btcdBinary)
+	require.NoError(t, err, "unable to create rpctest harness")
+
+	m := &minerHarness{
+		T:           t,
+		Harness:     harness,
+		logPath:     logDir,
+		logFilename: MinerLogFilename,
+	}
+
+	return m
+}
+
+// createMinerLogDir creates a per-run log directory for the miner.
+//
+// The directory is named using the format log-YYYYMMDD-HHMMSS. If the
+// directory already exists, a numeric suffix is appended.
+func createMinerLogDir(t *testing.T) string {
+	t.Helper()
+
+	// Ensure the log root exists.
+	err := os.MkdirAll(MinerLogDir, minerLogDirPerm)
+	require.NoError(t, err, "unable to create miner log root")
+
+	base := "log-" + time.Now().Format("20060102-150405")
+
+	for i := range maxMinerLogDirAttempts {
+		dir := base
+		if i > 0 {
+			dir = fmt.Sprintf("%s-%d", base, i)
+		}
+
+		fullPath := filepath.Join(MinerLogDir, dir)
+
+		err := os.Mkdir(fullPath, minerLogDirPerm)
+		if err == nil {
+			return fullPath
+		}
+
+		if os.IsExist(err) {
+			continue
+		}
+
+		require.NoError(t, err, "unable to create miner log dir")
+	}
+
+	t.Fatalf(
+		"unable to create miner log dir: too many collisions (%d)",
+		maxMinerLogDirAttempts,
+	)
+
+	return ""
+}
+
+// SetUp starts the miner node and generates initial blocks to activate SegWit.
+func (m *minerHarness) SetUp() {
+	m.Helper()
+
+	// Increase connection retries to make tests more robust.
+	m.MaxConnRetries = rpctest.DefaultMaxConnectionRetries * retryMultiplier
+	m.ConnectionRetryTimeout = rpctest.DefaultConnectionRetryTimeout *
+		retryMultiplier
+
+	require.NoError(
+		m, m.Harness.SetUp(true, minerSetupOutputs),
+		"unable to setup miner",
+	)
+
+	// Mine enough blocks to activate SegWit.
+	// MinerConfirmationWindow is usually 144 for mainnet, but likely smaller
+	// for regtest. For rpctest, standard is often to mine ~200 blocks
+	// total to ensure maturity and activation. Assuming harness params are
+	// standard regtest.
+	numBlocks := max(
+		harnessNetParams.MinerConfirmationWindow*minerWindowMultiplier,
+		minMatureBlocks,
+	)
+
+	_, err := m.Client.Generate(numBlocks)
+	require.NoError(m, err, "unable to generate initial blocks")
+}
+
+// SetUpNoChain starts the miner node without generating a test chain.
+//
+// This is intended for scenarios where the miner will sync to an existing
+// chain (for example, when spawning a temporary miner for reorg tests).
+func (m *minerHarness) SetUpNoChain() {
+	m.Helper()
+
+	// Increase connection retries to make tests more robust.
+	m.MaxConnRetries = rpctest.DefaultMaxConnectionRetries * retryMultiplier
+	m.ConnectionRetryTimeout = rpctest.DefaultConnectionRetryTimeout *
+		retryMultiplier
+
+	// SetUp(true, 0) starts the node, sets up the in-memory wallet, and
+	// registers notifications, but does not mine any blocks.
+	require.NoError(
+		m, m.Harness.SetUp(true, 0),
+		"unable to setup miner",
+	)
+}
+
+// Stop shuts down the miner.
+func (m *minerHarness) Stop() {
+	require.NoError(m, m.TearDown(), "tear down miner failed")
+
+	// Always keep logs for debugging, even for passing tests.
+	m.Logf("Miner logs available at: %s", m.logPath)
+}

--- a/bwtest/timeouts.go
+++ b/bwtest/timeouts.go
@@ -1,0 +1,9 @@
+package bwtest
+
+import "time"
+
+const (
+	// defaultTestTimeout is a shared default timeout for polling and setup
+	// steps in integration tests.
+	defaultTestTimeout = 30 * time.Second
+)

--- a/bwtest/utils.go
+++ b/bwtest/utils.go
@@ -1,0 +1,39 @@
+package bwtest
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+)
+
+// GetBtcdBinary returns the path to the btcd binary.
+// It checks if "btcd" is in the PATH.
+func GetBtcdBinary() (string, error) {
+	// If specific path is needed, we could check env vars here.
+	path, err := exec.LookPath("btcd")
+	if err != nil {
+		return "", fmt.Errorf("failed to find btcd binary: %w", err)
+	}
+
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to get absolute path: %w", err)
+	}
+
+	return path, nil
+}
+
+// GetBitcoindBinary returns the path to the bitcoind binary.
+func GetBitcoindBinary() (string, error) {
+	path, err := exec.LookPath("bitcoind")
+	if err != nil {
+		return "", fmt.Errorf("failed to find bitcoind binary: %w", err)
+	}
+
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to get absolute path: %w", err)
+	}
+
+	return path, nil
+}

--- a/bwtest/wait/wait.go
+++ b/bwtest/wait/wait.go
@@ -1,0 +1,58 @@
+// Package wait provides polling helpers for integration tests.
+package wait
+
+import (
+	"errors"
+	"time"
+)
+
+var (
+	// ErrNoResponse is returned when f does not return within the timeout.
+	ErrNoResponse = errors.New("method did not return within the timeout")
+)
+
+// PollInterval is the default polling interval used by NoError.
+const PollInterval = 200 * time.Millisecond
+
+// NoError polls f until it returns nil or the timeout is reached.
+//
+// If the timeout is reached, the last error returned by f is returned.
+func NoError(f func() error, timeout time.Duration) error {
+	// f is expected to be cheap and non-blocking. This helper is intended for
+	// polling state (e.g. "is the node ready?") rather than performing a long
+	// operation.
+	//
+	// NOTE: NoError does not interrupt f. If f blocks, NoError may block longer
+	// than the provided timeout.
+
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+
+	ticker := time.NewTicker(PollInterval)
+	defer ticker.Stop()
+
+	// Call f() immediately to avoid the initial ticker delay.
+	lastErr := f()
+	if lastErr == nil {
+		return nil
+	}
+
+	for {
+		select {
+		case <-deadline.C:
+			if lastErr == nil {
+				return ErrNoResponse
+			}
+
+			return lastErr
+
+		case <-ticker.C:
+			err := f()
+			if err == nil {
+				return nil
+			}
+
+			lastErr = err
+		}
+	}
+}

--- a/docs/developer/adr/0008-integration-test-framework.md
+++ b/docs/developer/adr/0008-integration-test-framework.md
@@ -1,0 +1,121 @@
+# ADR 0008: Integration Test Framework
+
+## 1. Context
+
+The `btcwallet` project requires a robust integration testing framework to verify the correctness of its core `wallet` package against various configurations. The current testing landscape is insufficient for verifying the complex matrix of supported backends and modes.
+
+There is a requirement to support:
+1.  **Multiple Chain Backends**: `btcd` (native), `bitcoind` (external process), and `neutrino` (SPV).
+2.  **Multiple Database Backends**: `kvdb` (bbolt/etcd), `sqlite`, and `postgres`.
+3.  **Public API Testing**: Verifying the public methods of the `wallet` package (e.g., `Create`, `Load`, `Start`, `Stop`).
+
+We need a standardized, reusable approach to write integration tests that can run across all these permutations without duplicating setup logic.
+
+## 2. Decision
+
+We will implement a modular integration test framework modeled after `lnd`'s `lntest`, adapted for library-mode testing.
+
+### 2.1. Library-Mode Testing
+Tests will run `btcwallet` in **Library Mode** (in-process).
+- **Why**: Faster execution, easier debugging, and direct internal state assertion.
+- **How**: The test harness instantiates `wallet.Manager` directly.
+
+### 2.2. Architecture & Components
+
+The framework is split into `bwtest` (framework) and `itest` (test cases).
+
+#### Component Interaction
+
+```mermaid
+graph TD
+    subgraph "Test Execution (itest)"
+        Test["Test Function (t.Run)"]
+        Harness["HarnessTest (Instance)"]
+    end
+
+    subgraph "Infrastructure (bwtest)"
+        Miner["Miner (btcd)"]
+        ChainNode["Chain Node Process"]
+        DB["Database Backend"]
+    end
+
+    subgraph "Application Under Test"
+        CB["ChainBackend (Interface Wrapper)"]
+        W["Wallet (In-Memory)"]
+    end
+
+    Test -->|Creates & Owns| Harness
+    Harness -->|Starts| Miner
+    Harness -->|Starts| ChainNode
+    Harness -->|Initializes| DB
+    Harness -->|Configures| CB
+    Harness -->|Creates| W
+
+    ChainNode -->|"P2P Sync"| Miner
+    CB -->|"RPC / P2P"| ChainNode
+    W -->|"Uses (chain.Interface)"| CB
+    W -->|"Stores Data"| DB
+```
+
+*   **`Miner`**: A dedicated `btcd` instance responsible for generating blocks. It acts as the source of truth for the blockchain state.
+*   **`Chain Node`**: The software providing chain data (`btcd`, `bitcoind`).
+    *   For `btcd` tests: A separate `btcd` process is started as the Chain Node and connects to the Miner.
+    *   For `bitcoind` tests: A separate `bitcoind` process connects (P2P) to the Miner to sync.
+    *   For `neutrino` tests: There is no separate "Chain Node" process; Neutrino connects directly to the Miner.
+*   **`ChainBackend`**: The interface wrapper (`rpcclient` or `neutrino.ChainService`) used by the Wallet to communicate with the Chain Node.
+*   **`Database Backend`**: The storage layer (`kvdb`, `postgres`, `sqlite`).
+*   **`HarnessTest`**: The specific test instance. It manages unique ports, temp directories, and process lifecycles.
+
+### 2.3. Package Structure
+
+- **`bwtest/`**:
+    - `harness.go`: `HarnessTest` orchestrator. Manages `t.Cleanup` for resource teardown.
+    - `chain_backend.go`: Logic to start/stop `btcd`/`bitcoind` processes and configure `neutrino`.
+    - `miner.go`: `Miner` implementation (controls the primary `btcd` instance).
+    - `database.go`: Helpers to setup/teardown DBs (create temp bolt files, init SQL schemas).
+- **`itest/`**:
+    - `main_test.go`: Flag parsing (`-chain`, `-db`) and global test runner.
+    - `manager_test.go`: Test cases for `wallet.Manager`.
+
+### 2.4. Configuration & Isolation
+
+Configuration is handled via `go test` flags.
+
+```bash
+# Default (btcd + kvdb)
+make itest
+
+# Explicit configuration
+make itest chain=bitcoind db=postgres
+
+# Run specific test case
+make itest case=TestNewWallet
+```
+
+*   **Sequential Execution**: Tests run sequentially to avoid resource exhaustion and port conflicts, given the heavy overhead of spinning up multiple full nodes per test.
+*   **Neutrino Support**: The `Miner` (btcd) will be configured with `--cfilters` to serve compact block filters, allowing Neutrino clients to connect directly to it for SPV synchronization.
+
+## 3. Implementation Plan
+
+1.  **Scaffold Framework (`bwtest`)**:
+    - Implement `Miner` (wraps `rpctest`).
+    - Implement `ChainBackend` logic (start bitcoind/btcd process, setup neutrino).
+    - Implement `Database` setup (init postgres schema, temp sqlite files).
+    - Implement `HarnessTest` to orchestrate the dependency graph:
+      `Miner -> ChainNode -> ChainBackend -> DB -> Wallet`.
+2.  **Scaffold Tests (`itest`)**:
+    - Create `manager_test.go` as a proof-of-concept.
+3.  **CI Integration**:
+    - Update `Makefile` with `itest` targets mapping flags correctly.
+
+## 4. Consequences
+
+### Pros
+- **Consistency**: Clear separation between Network, Infrastructure, and Application.
+- **Isolation**: Per-test harnesses prevent state leaks.
+- **Coverage**: capable of validating the entire support matrix.
+
+### Cons
+- **Resource Intensity**: Running a separate `bitcoind`/`btcd` process per test is CPU/RAM intensive.
+- **Complexity**: Dynamic port allocation and process lifecycle management are error-prone.
+- **Execution Time**: Tests will take longer to run due to sequential execution and process startup costs.

--- a/docs/developer/adr/README.md
+++ b/docs/developer/adr/README.md
@@ -7,3 +7,4 @@ ADRs serve as a historical log of important design choices, providing context fo
 ## Existing ADRs
 
 *   [ADR 0001: Multi-Wallet Architecture](./0001-multi-wallet-architecture.md)
+*   [ADR 0008: Integration Test Framework](./0008-integration-test-framework.md)

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -1,0 +1,22 @@
+//go:build itest
+
+package itest
+
+import "github.com/btcsuite/btcwallet/bwtest"
+
+// testCase defines a single integration test case.
+type testCase struct {
+	// Name is the human-readable name of the test case.
+	Name string
+
+	// TestFunc executes the test case.
+	TestFunc func(t *bwtest.HarnessTest)
+}
+
+// allTestCases is the full set of integration test cases.
+var allTestCases = []*testCase{
+	{
+		Name:     "manager create wallet",
+		TestFunc: testCreateWallet,
+	},
+}

--- a/itest/main_test.go
+++ b/itest/main_test.go
@@ -1,0 +1,84 @@
+//go:build itest
+
+package itest
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcwallet/bwtest"
+)
+
+var (
+	// chainBackend defines the blockchain backend to be used for the
+	// integration tests.
+	// Options: "btcd" (default), "bitcoind", "neutrino".
+	chainBackend = flag.String(
+		"chain", "btcd",
+		"chain backend to use (btcd, bitcoind, neutrino)",
+	)
+
+	// dbBackend defines the database backend to be used for the wallet
+	// storage.
+	// Options: "kvdb" (default), "sqlite", "postgres".
+	//
+	// This flag allows verifying that the wallet functions correctly across all
+	// supported database drivers.
+	dbBackend = flag.String(
+		"db", "kvdb",
+		"database backend to use (kvdb, sqlite, postgres)",
+	)
+)
+
+// TestBtcWallet runs the btcwallet integration test suite.
+func TestBtcWallet(t *testing.T) {
+	if len(allTestCases) == 0 {
+		t.Skip("no integration test cases registered")
+	}
+
+	harness := bwtest.SetupHarness(t, *chainBackend, *dbBackend)
+
+	for _, tc := range allTestCases {
+		if tc == nil {
+			continue
+		}
+
+		validateTestCaseName(t, tc.Name)
+
+		name := fmt.Sprintf("%s/%s", *chainBackend, tc.Name)
+
+		success := t.Run(name, func(st *testing.T) {
+			ht := harness.Subtest(st)
+			ht.RunTestCase(tc.Name, tc.TestFunc)
+		})
+		if !success {
+			t.Logf("failure time: %v", time.Now().Format(
+				"2006-01-02 15:04:05.000",
+			))
+			break
+		}
+	}
+}
+
+// validateTestCaseName enforces a consistent naming convention for integration
+// test cases.
+//
+// Names must be in the format "component action" (space separated), and must
+// not include underscores.
+func validateTestCaseName(t *testing.T, name string) {
+	t.Helper()
+
+	if strings.Contains(name, "_") {
+		t.Fatalf("invalid test case name %q: underscores are not allowed",
+			name)
+	}
+
+	words := strings.Fields(name)
+	if len(words) < 2 {
+		t.Fatalf("invalid test case name %q: want 'component action'",
+			name)
+	}
+}

--- a/itest/manager_test.go
+++ b/itest/manager_test.go
@@ -1,0 +1,53 @@
+//go:build itest
+
+package itest
+
+import (
+	"context"
+	"time"
+
+	"github.com/btcsuite/btcwallet/bwtest"
+	"github.com/btcsuite/btcwallet/wallet"
+	"github.com/stretchr/testify/require"
+)
+
+// testCreateWallet verifies a wallet can be created, started, and synced.
+func testCreateWallet(h *bwtest.HarnessTest) {
+	h.Helper()
+
+	// Create a wallet using the Manager API.
+	cfg := wallet.Config{
+		DB:                      h.WalletDB,
+		Chain:                   h.ChainClient,
+		ChainParams:             h.NetParams(),
+		RecoveryWindow:          20,
+		WalletSyncRetryInterval: 500 * time.Millisecond,
+		Name:                    "testwallet",
+		PubPassphrase:           []byte("public"),
+	}
+
+	manager := wallet.NewManager()
+	params := wallet.CreateWalletParams{
+		Mode:              wallet.ModeGenSeed,
+		PubPassphrase:     []byte("public"),
+		PrivatePassphrase: []byte("private"),
+		Birthday:          time.Now().Add(-1 * time.Hour),
+	}
+
+	w, err := manager.Create(cfg, params)
+	require.NoError(h, err, "failed to create wallet")
+
+	err = w.Start(h.Context())
+	require.NoError(h, err, "failed to start wallet")
+	h.Cleanup(func() {
+		// We use a background context here because h.Context() might be
+		// cancelled already.
+		require.NoError(h, w.Stop(context.Background()), "failed to stop wallet")
+	})
+
+	// Register the wallet so harness helpers can assert global invariants.
+	h.RegisterWallet(w)
+
+	// Mine a few blocks and require the wallet catches up.
+	h.MineBlocks(5)
+}


### PR DESCRIPTION
We now start the framework, mostly just mimicking the `lnd`'s `itest` and `lntest` pkg.

In addition we also fix the git worktree, using a similar approach from [here](https://github.com/lightningnetwork/lnd/pull/10547).