### PR TITLE
ci: fix claude workflow for fork PRs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,22 +30,26 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Checkout PR branch (handles fork PRs)
+        if: github.event.issue.pull_request || github.event_name == 'pull_request_review_comment' || github.event_name == 'pull_request_review'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            PR_NUMBER=${{ github.event.issue.number }}
+          else
+            PR_NUMBER=${{ github.event.pull_request.number }}
+          fi
+          gh pr checkout "$PR_NUMBER"
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          model: claude-opus-4-6
+          claude_args: '--model claude-opus-4-6'
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
 


### PR DESCRIPTION
The claude-code-action's built-in PR checkout does `git fetch origin <branch>` which fails for fork PRs since the branch only exists on the fork remote. This adds an explicit `gh pr checkout` step before the action runs that handles fork PRs correctly.

Also moves the `model` param from a direct action input (not recognized by the top-level wrapper, only the base-action) to `claude_args` where it's properly forwarded.