### PR TITLE
wallet: add real db constructors out of itest

### DIFF
--- a/wallet/internal/db/accounts_pg.go
+++ b/wallet/internal/db/accounts_pg.go
@@ -8,25 +8,25 @@ import (
 	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
 )
 
-// Ensure PostgresWalletDB satisfies the AccountStore interface.
-var _ AccountStore = (*PostgresWalletDB)(nil)
+// Ensure PostgresStore satisfies the AccountStore interface.
+var _ AccountStore = (*PostgresStore)(nil)
 
 // GetAccount retrieves information about a specific account, identified by its
 // name or account number within a given key scope.
-func (w *PostgresWalletDB) GetAccount(ctx context.Context,
+func (s *PostgresStore) GetAccount(ctx context.Context,
 	query GetAccountQuery) (*AccountInfo, error) {
 
-	getQueries := pgAccountGetQueries{q: w.queries}
+	getQueries := pgAccountGetQueries{q: s.queries}
 
 	return getAccountByQuery(ctx, query, getQueries.byNumber, getQueries.byName)
 }
 
 // ListAccounts returns a slice of AccountInfo for all accounts, optionally
 // filtered by name or key scope.
-func (w *PostgresWalletDB) ListAccounts(ctx context.Context,
+func (s *PostgresStore) ListAccounts(ctx context.Context,
 	query ListAccountsQuery) ([]AccountInfo, error) {
 
-	listQueries := pgAccountListQueries{q: w.queries}
+	listQueries := pgAccountListQueries{q: s.queries}
 
 	return listAccountsByQuery(
 		ctx, query, listQueries.byScope, listQueries.byName, listQueries.all,
@@ -35,10 +35,10 @@ func (w *PostgresWalletDB) ListAccounts(ctx context.Context,
 
 // RenameAccount changes the name of an account. The account can be identified
 // by its old name or its account number.
-func (w *PostgresWalletDB) RenameAccount(ctx context.Context,
+func (s *PostgresStore) RenameAccount(ctx context.Context,
 	params RenameAccountParams) error {
 
-	renameQueries := pgAccountRenameQueries{q: w.queries}
+	renameQueries := pgAccountRenameQueries{q: s.queries}
 
 	return renameAccountByQuery(
 		ctx, params, renameQueries.byNumber, renameQueries.byName,
@@ -48,7 +48,7 @@ func (w *PostgresWalletDB) RenameAccount(ctx context.Context,
 // CreateDerivedAccount creates a new derived account with the given name and
 // scope. If the key scope does not exist, it is created with NULL encrypted
 // keys using the address schema provided by the caller.
-func (w *PostgresWalletDB) CreateDerivedAccount(ctx context.Context,
+func (s *PostgresStore) CreateDerivedAccount(ctx context.Context,
 	params CreateDerivedAccountParams) (*AccountInfo, error) {
 
 	paramsErr := params.validate()
@@ -58,7 +58,7 @@ func (w *PostgresWalletDB) CreateDerivedAccount(ctx context.Context,
 
 	var info *AccountInfo
 
-	err := w.ExecuteTx(ctx, func(qtx *sqlcpg.Queries) error {
+	err := s.ExecuteTx(ctx, func(qtx *sqlcpg.Queries) error {
 		scopeID, err := pgEnsureKeyScope(
 			ctx, qtx, params.WalletID, params.Scope,
 		)
@@ -117,12 +117,12 @@ func (w *PostgresWalletDB) CreateDerivedAccount(ctx context.Context,
 // public key. If the key scope does not exist, it is created with NULL
 // encrypted keys using the address schema provided by the caller. Imported
 // accounts have NULL account_number since they don't follow BIP44 derivation.
-func (w *PostgresWalletDB) CreateImportedAccount(ctx context.Context,
+func (s *PostgresStore) CreateImportedAccount(ctx context.Context,
 	params CreateImportedAccountParams) (*AccountProperties, error) {
 
 	var props *AccountProperties
 
-	err := w.ExecuteTx(ctx, func(qtx *sqlcpg.Queries) error {
+	err := s.ExecuteTx(ctx, func(qtx *sqlcpg.Queries) error {
 		var err error
 
 		props, err = createImportedAccount(

--- a/wallet/internal/db/accounts_sqlite.go
+++ b/wallet/internal/db/accounts_sqlite.go
@@ -8,25 +8,25 @@ import (
 	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
 )
 
-// Ensure SQLiteWalletDB satisfies the AccountStore interface.
-var _ AccountStore = (*SQLiteWalletDB)(nil)
+// Ensure SqliteStore satisfies the AccountStore interface.
+var _ AccountStore = (*SqliteStore)(nil)
 
 // GetAccount retrieves information about a specific account, identified by its
 // name or account number within a given key scope.
-func (w *SQLiteWalletDB) GetAccount(ctx context.Context,
+func (s *SqliteStore) GetAccount(ctx context.Context,
 	query GetAccountQuery) (*AccountInfo, error) {
 
-	getQueries := sqliteAccountGetQueries{q: w.queries}
+	getQueries := sqliteAccountGetQueries{q: s.queries}
 
 	return getAccountByQuery(ctx, query, getQueries.byNumber, getQueries.byName)
 }
 
 // ListAccounts returns a slice of AccountInfo for all accounts, optionally
 // filtered by name or key scope.
-func (w *SQLiteWalletDB) ListAccounts(ctx context.Context,
+func (s *SqliteStore) ListAccounts(ctx context.Context,
 	query ListAccountsQuery) ([]AccountInfo, error) {
 
-	listQueries := sqliteAccountListQueries{q: w.queries}
+	listQueries := sqliteAccountListQueries{q: s.queries}
 
 	return listAccountsByQuery(
 		ctx, query, listQueries.byScope, listQueries.byName, listQueries.all,
@@ -35,10 +35,10 @@ func (w *SQLiteWalletDB) ListAccounts(ctx context.Context,
 
 // RenameAccount changes the name of an account. The account can be identified
 // by its old name or its account number.
-func (w *SQLiteWalletDB) RenameAccount(ctx context.Context,
+func (s *SqliteStore) RenameAccount(ctx context.Context,
 	params RenameAccountParams) error {
 
-	renameQueries := sqliteAccountRenameQueries{q: w.queries}
+	renameQueries := sqliteAccountRenameQueries{q: s.queries}
 
 	return renameAccountByQuery(
 		ctx, params, renameQueries.byNumber, renameQueries.byName,
@@ -48,7 +48,7 @@ func (w *SQLiteWalletDB) RenameAccount(ctx context.Context,
 // CreateDerivedAccount creates a new derived account with the given name and
 // scope. If the key scope does not exist, it is created with NULL encrypted
 // keys using the address schema provided by the caller.
-func (w *SQLiteWalletDB) CreateDerivedAccount(ctx context.Context,
+func (s *SqliteStore) CreateDerivedAccount(ctx context.Context,
 	params CreateDerivedAccountParams) (*AccountInfo, error) {
 
 	paramsErr := params.validate()
@@ -58,7 +58,7 @@ func (w *SQLiteWalletDB) CreateDerivedAccount(ctx context.Context,
 
 	var info *AccountInfo
 
-	err := w.ExecuteTx(ctx, func(qtx *sqlcsqlite.Queries) error {
+	err := s.ExecuteTx(ctx, func(qtx *sqlcsqlite.Queries) error {
 		scopeID, err := sqliteEnsureKeyScope(
 			ctx, qtx, params.WalletID, params.Scope,
 		)
@@ -137,12 +137,12 @@ func sqliteEnsureKeyScope(ctx context.Context, qtx *sqlcsqlite.Queries,
 // public key. If the key scope does not exist, it is created with NULL
 // encrypted keys using the address schema provided by the caller. Imported
 // accounts have NULL account_number since they don't follow BIP44 derivation.
-func (w *SQLiteWalletDB) CreateImportedAccount(ctx context.Context,
+func (s *SqliteStore) CreateImportedAccount(ctx context.Context,
 	params CreateImportedAccountParams) (*AccountProperties, error) {
 
 	var props *AccountProperties
 
-	err := w.ExecuteTx(ctx, func(qtx *sqlcsqlite.Queries) error {
+	err := s.ExecuteTx(ctx, func(qtx *sqlcsqlite.Queries) error {
 		var err error
 
 		props, err = createImportedAccount(

--- a/wallet/internal/db/address_types_pg.go
+++ b/wallet/internal/db/address_types_pg.go
@@ -22,21 +22,21 @@ func pgAddressTypeRowToInfo(row sqlcpg.AddressType) (AddressTypeInfo, error) {
 
 // ListAddressTypes returns all supported address types along with their
 // readable descriptions, wrapped in AddressTypeInfo values.
-func (w *PostgresWalletDB) ListAddressTypes(ctx context.Context) (
+func (s *PostgresStore) ListAddressTypes(ctx context.Context) (
 	[]AddressTypeInfo, error) {
 
 	return listAddressTypes(
-		ctx, w.queries.ListAddressTypes, pgAddressTypeRowToInfo,
+		ctx, s.queries.ListAddressTypes, pgAddressTypeRowToInfo,
 	)
 }
 
 // GetAddressType returns the AddressTypeInfo associated with the given address
 // type identifier. An error is returned if the type is unknown.
-func (w *PostgresWalletDB) GetAddressType(ctx context.Context,
+func (s *PostgresStore) GetAddressType(ctx context.Context,
 	id AddressType) (AddressTypeInfo, error) {
 
 	return getAddressTypeByID(
-		ctx, w.queries.GetAddressTypeByID, int16(id), id,
+		ctx, s.queries.GetAddressTypeByID, int16(id), id,
 		pgAddressTypeRowToInfo,
 	)
 }

--- a/wallet/internal/db/address_types_sqlite.go
+++ b/wallet/internal/db/address_types_sqlite.go
@@ -24,21 +24,21 @@ func sqliteAddressTypeRowToInfo(row sqlcsqlite.AddressType) (AddressTypeInfo,
 
 // ListAddressTypes returns all supported address types along with their
 // readable descriptions, wrapped in AddressTypeInfo values.
-func (w *SQLiteWalletDB) ListAddressTypes(ctx context.Context) (
+func (s *SqliteStore) ListAddressTypes(ctx context.Context) (
 	[]AddressTypeInfo, error) {
 
 	return listAddressTypes(
-		ctx, w.queries.ListAddressTypes, sqliteAddressTypeRowToInfo,
+		ctx, s.queries.ListAddressTypes, sqliteAddressTypeRowToInfo,
 	)
 }
 
 // GetAddressType returns the AddressTypeInfo associated with the given address
 // type identifier. An error is returned if the type is unknown.
-func (w *SQLiteWalletDB) GetAddressType(ctx context.Context,
+func (s *SqliteStore) GetAddressType(ctx context.Context,
 	id AddressType) (AddressTypeInfo, error) {
 
 	return getAddressTypeByID(
-		ctx, w.queries.GetAddressTypeByID, int64(id), id,
+		ctx, s.queries.GetAddressTypeByID, int64(id), id,
 		sqliteAddressTypeRowToInfo,
 	)
 }

--- a/wallet/internal/db/addresses_pg.go
+++ b/wallet/internal/db/addresses_pg.go
@@ -11,14 +11,14 @@ import (
 
 // GetAddress retrieves information about a specific address, identified by
 // its script pubkey.
-func (w *PostgresWalletDB) GetAddress(ctx context.Context,
+func (s *PostgresStore) GetAddress(ctx context.Context,
 	query GetAddressQuery) (*AddressInfo, error) {
 
 	getByScript := func(ctx context.Context, q GetAddressQuery) (*AddressInfo,
 		error) {
 
 		return getAddress(
-			ctx, w.queries.GetAddressByScriptPubKey,
+			ctx, s.queries.GetAddressByScriptPubKey,
 			sqlcpg.GetAddressByScriptPubKeyParams{
 				ScriptPubKey: q.ScriptPubKey,
 				WalletID:     int64(q.WalletID),
@@ -31,11 +31,11 @@ func (w *PostgresWalletDB) GetAddress(ctx context.Context,
 
 // ListAddresses returns a slice of AddressInfo for all addresses in a given
 // account.
-func (w *PostgresWalletDB) ListAddresses(ctx context.Context,
+func (s *PostgresStore) ListAddresses(ctx context.Context,
 	query ListAddressesQuery) ([]AddressInfo, error) {
 
 	return listAddresses(
-		ctx, w.queries.ListAddressesByAccount,
+		ctx, s.queries.ListAddressesByAccount,
 		sqlcpg.ListAddressesByAccountParams{
 			WalletID:    int64(query.WalletID),
 			Purpose:     int64(query.Scope.Purpose),
@@ -46,17 +46,17 @@ func (w *PostgresWalletDB) ListAddresses(ctx context.Context,
 }
 
 // GetAddressSecret retrieves the encrypted secret information for an address.
-func (w *PostgresWalletDB) GetAddressSecret(ctx context.Context,
+func (s *PostgresStore) GetAddressSecret(ctx context.Context,
 	addressID uint32) (*AddressSecret, error) {
 
 	return getAddressSecret(
-		ctx, w.queries.GetAddressSecret, addressID, pgAddressSecretRowToSecret,
+		ctx, s.queries.GetAddressSecret, addressID, pgAddressSecretRowToSecret,
 	)
 }
 
 // NewDerivedAddress creates a new address for a given account and key
 // scope.
-func (w *PostgresWalletDB) NewDerivedAddress(ctx context.Context,
+func (s *PostgresStore) NewDerivedAddress(ctx context.Context,
 	params NewDerivedAddressParams,
 	deriveFn AddressDerivationFunc) (*AddressInfo, error) {
 
@@ -65,7 +65,7 @@ func (w *PostgresWalletDB) NewDerivedAddress(ctx context.Context,
 		sqlcpg.GetAccountByWalletScopeAndNameRow,
 		accountLookupKey,
 		sqlcpg.CreateDerivedAddressRow]{
-		getAccount:    pgGetAccountFromKey(w.queries),
+		getAccount:    pgGetAccountFromKey(s.queries),
 		accountParams: accountKeyFromParams,
 		getAccountID:  newDerivedAddressGetAccountIDPg,
 		getExtIndex:   newDerivedAddressGetExtIndexPg,
@@ -75,11 +75,11 @@ func (w *PostgresWalletDB) NewDerivedAddress(ctx context.Context,
 		rowCreatedAt:  newDerivedAddressRowCreatedAtPg,
 	}
 
-	return newDerivedAddressWithTx(ctx, params, w.ExecuteTx, adapters, deriveFn)
+	return newDerivedAddressWithTx(ctx, params, s.ExecuteTx, adapters, deriveFn)
 }
 
 // NewImportedAddress imports a new address, script, or private key.
-func (w *PostgresWalletDB) NewImportedAddress(ctx context.Context,
+func (s *PostgresStore) NewImportedAddress(ctx context.Context,
 	params NewImportedAddressParams) (*AddressInfo, error) {
 
 	adapters := importedAddressAdapters[
@@ -89,7 +89,7 @@ func (w *PostgresWalletDB) NewImportedAddress(ctx context.Context,
 		sqlcpg.CreateImportedAddressParams,
 		sqlcpg.CreateImportedAddressRow,
 		sqlcpg.InsertAddressSecretParams]{
-		getAccount:    pgGetAccountFromKey(w.queries),
+		getAccount:    pgGetAccountFromKey(s.queries),
 		accountParams: accountKeyFromImportedParams,
 		getAccountID:  newImportedAddressGetAccountIDPg,
 		createAddr:    pgCreateImportedAddress,
@@ -100,7 +100,7 @@ func (w *PostgresWalletDB) NewImportedAddress(ctx context.Context,
 		rowCreatedAt:  importedAddressRowCreatedAtPg,
 	}
 
-	return newImportedAddressWithTx(ctx, params, w.ExecuteTx, adapters)
+	return newImportedAddressWithTx(ctx, params, s.ExecuteTx, adapters)
 }
 
 // pgGetAccountFromKey returns a helper to look up accounts by key.

--- a/wallet/internal/db/addresses_sqlite.go
+++ b/wallet/internal/db/addresses_sqlite.go
@@ -10,14 +10,14 @@ import (
 
 // GetAddress retrieves information about a specific address, identified by
 // its script pubkey.
-func (w *SQLiteWalletDB) GetAddress(ctx context.Context,
+func (s *SqliteStore) GetAddress(ctx context.Context,
 	query GetAddressQuery) (*AddressInfo, error) {
 
 	getByScript := func(ctx context.Context, q GetAddressQuery) (*AddressInfo,
 		error) {
 
 		return getAddress(
-			ctx, w.queries.GetAddressByScriptPubKey,
+			ctx, s.queries.GetAddressByScriptPubKey,
 			sqlcsqlite.GetAddressByScriptPubKeyParams{
 				WalletID:     int64(q.WalletID),
 				ScriptPubKey: q.ScriptPubKey,
@@ -30,11 +30,11 @@ func (w *SQLiteWalletDB) GetAddress(ctx context.Context,
 
 // ListAddresses returns a slice of AddressInfo for all addresses in a given
 // account.
-func (w *SQLiteWalletDB) ListAddresses(ctx context.Context,
+func (s *SqliteStore) ListAddresses(ctx context.Context,
 	query ListAddressesQuery) ([]AddressInfo, error) {
 
 	return listAddresses(
-		ctx, w.queries.ListAddressesByAccount,
+		ctx, s.queries.ListAddressesByAccount,
 		sqlcsqlite.ListAddressesByAccountParams{
 			WalletID:    int64(query.WalletID),
 			Purpose:     int64(query.Scope.Purpose),
@@ -45,18 +45,18 @@ func (w *SQLiteWalletDB) ListAddresses(ctx context.Context,
 }
 
 // GetAddressSecret retrieves the encrypted secret information for an address.
-func (w *SQLiteWalletDB) GetAddressSecret(ctx context.Context,
+func (s *SqliteStore) GetAddressSecret(ctx context.Context,
 	addressID uint32) (*AddressSecret, error) {
 
 	return getAddressSecret(
-		ctx, w.queries.GetAddressSecret, addressID,
+		ctx, s.queries.GetAddressSecret, addressID,
 		sqliteAddressSecretRowToSecret,
 	)
 }
 
 // NewDerivedAddress creates a new address for a given account and key
 // scope.
-func (w *SQLiteWalletDB) NewDerivedAddress(ctx context.Context,
+func (s *SqliteStore) NewDerivedAddress(ctx context.Context,
 	params NewDerivedAddressParams,
 	deriveFn AddressDerivationFunc) (*AddressInfo, error) {
 
@@ -65,7 +65,7 @@ func (w *SQLiteWalletDB) NewDerivedAddress(ctx context.Context,
 		sqlcsqlite.GetAccountByWalletScopeAndNameRow,
 		accountLookupKey,
 		sqlcsqlite.CreateDerivedAddressRow]{
-		getAccount:    sqliteGetAccountFromKey(w.queries),
+		getAccount:    sqliteGetAccountFromKey(s.queries),
 		accountParams: accountKeyFromParams,
 		getAccountID:  newDerivedAddressGetAccountIDSQLite,
 		getExtIndex:   newDerivedAddressGetExtIndexSQLite,
@@ -75,11 +75,11 @@ func (w *SQLiteWalletDB) NewDerivedAddress(ctx context.Context,
 		rowCreatedAt:  newDerivedAddressRowCreatedAtSQLite,
 	}
 
-	return newDerivedAddressWithTx(ctx, params, w.ExecuteTx, adapters, deriveFn)
+	return newDerivedAddressWithTx(ctx, params, s.ExecuteTx, adapters, deriveFn)
 }
 
 // NewImportedAddress imports a new address, script, or private key.
-func (w *SQLiteWalletDB) NewImportedAddress(ctx context.Context,
+func (s *SqliteStore) NewImportedAddress(ctx context.Context,
 	params NewImportedAddressParams) (*AddressInfo, error) {
 
 	adapters := importedAddressAdapters[
@@ -89,7 +89,7 @@ func (w *SQLiteWalletDB) NewImportedAddress(ctx context.Context,
 		sqlcsqlite.CreateImportedAddressParams,
 		sqlcsqlite.CreateImportedAddressRow,
 		sqlcsqlite.InsertAddressSecretParams]{
-		getAccount:    sqliteGetAccountFromKey(w.queries),
+		getAccount:    sqliteGetAccountFromKey(s.queries),
 		accountParams: accountKeyFromImportedParams,
 		getAccountID:  newImportedAddressGetAccountIDSQLite,
 		createAddr:    sqliteCreateImportedAddress,
@@ -100,7 +100,7 @@ func (w *SQLiteWalletDB) NewImportedAddress(ctx context.Context,
 		rowCreatedAt:  importedAddressRowCreatedAtSQLite,
 	}
 
-	return newImportedAddressWithTx(ctx, params, w.ExecuteTx, adapters)
+	return newImportedAddressWithTx(ctx, params, s.ExecuteTx, adapters)
 }
 
 // sqliteGetAccountFromKey returns a helper to look up accounts by key.

--- a/wallet/internal/db/config.go
+++ b/wallet/internal/db/config.go
@@ -1,0 +1,90 @@
+package db
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+const (
+	// DefaultMaxConnections is the default maximum number of permitted
+	// connections (both active and idle) to the database. We want to limit
+	// this so it isn't unlimited. The same value is used for the maximum
+	// number of idle connections, which can improve performance by avoiding
+	// the overhead of establishing a new connection for each query.
+	DefaultMaxConnections = 25
+
+	// DefaultConnIdleLifetime is the default amount of time a connection
+	// can be idle before being closed.
+	DefaultConnIdleLifetime = 5 * time.Minute
+
+	// DefaultConnectionTimeout is the default timeout for establishing
+	// a new database connection.
+	DefaultConnectionTimeout = 5 * time.Second
+)
+
+var (
+	// ErrEmptyDBPath is returned when an empty database path is provided.
+	ErrEmptyDBPath = errors.New("database path cannot be empty")
+
+	// ErrNegativeMaxConns is returned when MaxConnections is negative.
+	ErrNegativeMaxConns = errors.New("max connections must be non-negative")
+
+	// ErrEmptyDSN is returned when the DSN string is empty.
+	ErrEmptyDSN = errors.New("DSN is required")
+)
+
+// SqliteConfig holds the configuration for the SQLite database.
+type SqliteConfig struct {
+	// DBPath is the filesystem path to the SQLite database file.
+	DBPath string
+
+	// MaxConnections is the maximum number of open connections to the
+	// database. Set to zero to use DefaultMaxConnections.
+	MaxConnections int
+}
+
+// Validate checks that the SqliteConfig values are valid.
+func (c *SqliteConfig) Validate() error {
+	if c.DBPath == "" {
+		return ErrEmptyDBPath
+	}
+
+	if c.MaxConnections < 0 {
+		return ErrNegativeMaxConns
+	}
+
+	return nil
+}
+
+// PostgresConfig holds the configuration for the PostgreSQL database.
+type PostgresConfig struct {
+	// Dsn is the database connection string.
+	Dsn string
+
+	// MaxConnections is the maximum number of open connections to the
+	// database. Set to zero to use DefaultMaxConnections.
+	MaxConnections int
+}
+
+// Validate checks that the PostgresConfig values are valid.
+func (c *PostgresConfig) Validate() error {
+	if c.Dsn == "" {
+		return ErrEmptyDSN
+	}
+
+	// Parse the DSN using pgx to ensure it's a valid PostgreSQL
+	// connection string.
+	_, err := pgx.ParseConfig(c.Dsn)
+	if err != nil {
+		return fmt.Errorf("invalid DSN: %w", err)
+	}
+
+	if c.MaxConnections < 0 {
+		return ErrNegativeMaxConns
+	}
+
+	return nil
+}

--- a/wallet/internal/db/config_test.go
+++ b/wallet/internal/db/config_test.go
@@ -1,0 +1,162 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSqliteConfigValidateSuccess tests valid SqliteConfig scenarios.
+func TestSqliteConfigValidateSuccess(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		config SqliteConfig
+	}{
+		{
+			name: "valid config with zero max connections",
+			config: SqliteConfig{
+				DBPath:         "/tmp/test.db",
+				MaxConnections: 0,
+			},
+		},
+		{
+			name: "valid config with positive max connections",
+			config: SqliteConfig{
+				DBPath:         "/tmp/test.db",
+				MaxConnections: 10,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.config.Validate()
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestSqliteConfigValidateErrors tests SqliteConfig validation errors.
+func TestSqliteConfigValidateErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		config      SqliteConfig
+		expectedErr error
+	}{
+		{
+			name: "empty DB path",
+			config: SqliteConfig{
+				DBPath:         "",
+				MaxConnections: 0,
+			},
+			expectedErr: ErrEmptyDBPath,
+		},
+		{
+			name: "negative max connections",
+			config: SqliteConfig{
+				DBPath:         "/tmp/test.db",
+				MaxConnections: -1,
+			},
+			expectedErr: ErrNegativeMaxConns,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.config.Validate()
+			require.ErrorIs(t, err, tc.expectedErr)
+		})
+	}
+}
+
+// TestPostgresConfigValidateSuccess tests valid PostgresConfig scenarios.
+func TestPostgresConfigValidateSuccess(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		config PostgresConfig
+	}{
+		{
+			name: "valid config with all fields set",
+			config: PostgresConfig{
+				Dsn:            "postgres://user:pass@localhost/db",
+				MaxConnections: 25,
+			},
+		},
+		{
+			name: "valid config with zero max connections",
+			config: PostgresConfig{
+				Dsn:            "postgres://localhost/db",
+				MaxConnections: 0,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.config.Validate()
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestPostgresConfigValidateErrors tests PostgresConfig validation errors.
+func TestPostgresConfigValidateErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		config         PostgresConfig
+		expectedErr    error
+		expectAnyError bool
+	}{
+		{
+			name: "empty DSN",
+			config: PostgresConfig{
+				Dsn:            "",
+				MaxConnections: 10,
+			},
+			expectedErr: ErrEmptyDSN,
+		},
+		{
+			name: "invalid DSN format",
+			config: PostgresConfig{
+				Dsn:            "://invalid",
+				MaxConnections: 10,
+			},
+			expectAnyError: true,
+		},
+		{
+			name: "negative max connections",
+			config: PostgresConfig{
+				Dsn:            "postgres://localhost/db",
+				MaxConnections: -5,
+			},
+			expectedErr: ErrNegativeMaxConns,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.config.Validate()
+			if tc.expectAnyError {
+				require.Error(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.expectedErr)
+			}
+		})
+	}
+}

--- a/wallet/internal/db/db_connectors_test.go
+++ b/wallet/internal/db/db_connectors_test.go
@@ -42,16 +42,16 @@ func newMockedTestDB(t *testing.T) *sql.DB {
 	return db
 }
 
-// TestNewPostgresWalletDB checks that the PostgresWalletDB constructor
+// TestNewPostgresStore checks that the PostgresStore constructor
 // properly guards against nil *sql.DB inputs and wires up the queries
 // correctly.
-func TestNewPostgresWalletDB(t *testing.T) {
+func TestNewPostgresStore(t *testing.T) {
 	t.Parallel()
 
 	t.Run("nil db", func(t *testing.T) {
 		t.Parallel()
 
-		db, err := NewPostgresWalletDB(nil)
+		db, err := NewPostgresStore(nil)
 		require.ErrorIs(t, err, ErrNilDB)
 		require.Nil(t, db)
 	})
@@ -61,7 +61,7 @@ func TestNewPostgresWalletDB(t *testing.T) {
 
 		sqlDB := newMockedTestDB(t)
 
-		db, err := NewPostgresWalletDB(sqlDB)
+		db, err := NewPostgresStore(sqlDB)
 		require.NoError(t, err)
 		require.NotNil(t, db)
 		require.Equal(t, sqlDB, db.db)
@@ -69,16 +69,16 @@ func TestNewPostgresWalletDB(t *testing.T) {
 	})
 }
 
-// TestNewSQLiteWalletDB checks that the SQLiteWalletDB constructor
+// TestNewSqliteStore checks that the SqliteStore constructor
 // properly guards against nil *sql.DB inputs and wires up the queries
 // correctly.
-func TestNewSQLiteWalletDB(t *testing.T) {
+func TestNewSqliteStore(t *testing.T) {
 	t.Parallel()
 
 	t.Run("nil db", func(t *testing.T) {
 		t.Parallel()
 
-		db, err := NewSQLiteWalletDB(nil)
+		db, err := NewSqliteStore(nil)
 		require.ErrorIs(t, err, ErrNilDB)
 		require.Nil(t, db)
 	})
@@ -88,7 +88,7 @@ func TestNewSQLiteWalletDB(t *testing.T) {
 
 		sqlDB := newMockedTestDB(t)
 
-		db, err := NewSQLiteWalletDB(sqlDB)
+		db, err := NewSqliteStore(sqlDB)
 		require.NoError(t, err)
 		require.NotNil(t, db)
 		require.Equal(t, sqlDB, db.db)

--- a/wallet/internal/db/db_connectors_test.go
+++ b/wallet/internal/db/db_connectors_test.go
@@ -1,116 +1,113 @@
 package db
 
 import (
-	"database/sql"
-	"database/sql/driver"
-	"sync"
+	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
-const testDriverName = "wallet-test-driver"
+func TestNewPostgresStoreValidateConfig(t *testing.T) {
+	t.Parallel()
 
-var (
-	registerDriverOnce sync.Once
-	testDriver         *mockDriver
-)
+	tests := []struct {
+		name    string
+		cfg     PostgresConfig
+		wantErr error
+	}{
+		{
+			name: "empty DSN",
+			cfg: PostgresConfig{
+				Dsn: "",
+			},
+			wantErr: ErrEmptyDSN,
+		},
+		{
+			name: "negative max connections",
+			cfg: PostgresConfig{
+				Dsn:            "postgres://test",
+				MaxConnections: -1,
+			},
+			wantErr: ErrNegativeMaxConns,
+		},
+	}
 
-// newMockedTestDB returns a *sql.DB backed by a mock driver. It avoids any
-// network or disk usage, so it works well for constructor tests that only
-// need a non nil database handle. It should be used only in very simple
-// scenarios, since it does not implement real behavior and cannot confirm
-// that the issued queries works as expected.
-func newMockedTestDB(t *testing.T) *sql.DB {
-	t.Helper()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	registerDriverOnce.Do(func() {
-		testDriver = &mockDriver{}
-		testDriver.On("Open", mock.Anything).Return(mockConn{}, nil)
+			store, err := NewPostgresStore(t.Context(), tc.cfg)
+			require.ErrorIs(t, err, tc.wantErr)
+			require.Nil(t, store)
+		})
+	}
+}
 
-		sql.Register(testDriverName, testDriver)
-	})
+func TestNewPostgresStoreConnectionFailure(t *testing.T) {
+	t.Parallel()
 
-	db, err := sql.Open(testDriverName, "")
+	// Valid config, but hits a connection failure.
+	cfg := PostgresConfig{
+		Dsn: "postgres://localhost:1/testdb",
+	}
+
+	store, err := NewPostgresStore(t.Context(), cfg)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "ping database")
+	require.NotErrorIs(t, err, ErrEmptyDSN)
+	require.NotErrorIs(t, err, ErrNegativeMaxConns)
+
+	// We are asserting nil here because it's not an integration test, so we
+	// are not able to create a postgres database and connect to it.
+	require.Nil(t, store)
+}
+
+func TestNewSqliteStoreValidateConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     SqliteConfig
+		wantErr error
+	}{
+		{
+			name: "empty DB path",
+			cfg: SqliteConfig{
+				DBPath: "",
+			},
+			wantErr: ErrEmptyDBPath,
+		},
+		{
+			name: "negative max connections",
+			cfg: SqliteConfig{
+				DBPath:         "/tmp/test.db",
+				MaxConnections: -1,
+			},
+			wantErr: ErrNegativeMaxConns,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store, err := NewSqliteStore(t.Context(), tc.cfg)
+			require.ErrorIs(t, err, tc.wantErr)
+			require.Nil(t, store)
+		})
+	}
+}
+
+func TestNewSqliteStoreSuccess(t *testing.T) {
+	t.Parallel()
+
+	cfg := SqliteConfig{
+		DBPath: filepath.Join(t.TempDir(), "wallet.db"),
+	}
+
+	store, err := NewSqliteStore(t.Context(), cfg)
 	require.NoError(t, err)
+	require.NotNil(t, store)
 
-	t.Cleanup(func() {
-		_ = db.Close()
-	})
-
-	return db
-}
-
-// TestNewPostgresStore checks that the PostgresStore constructor
-// properly guards against nil *sql.DB inputs and wires up the queries
-// correctly.
-func TestNewPostgresStore(t *testing.T) {
-	t.Parallel()
-
-	t.Run("nil db", func(t *testing.T) {
-		t.Parallel()
-
-		db, err := NewPostgresStore(nil)
-		require.ErrorIs(t, err, ErrNilDB)
-		require.Nil(t, db)
-	})
-
-	t.Run("valid db", func(t *testing.T) {
-		t.Parallel()
-
-		sqlDB := newMockedTestDB(t)
-
-		db, err := NewPostgresStore(sqlDB)
-		require.NoError(t, err)
-		require.NotNil(t, db)
-		require.Equal(t, sqlDB, db.db)
-		require.NotNil(t, db.queries)
-	})
-}
-
-// TestNewSqliteStore checks that the SqliteStore constructor
-// properly guards against nil *sql.DB inputs and wires up the queries
-// correctly.
-func TestNewSqliteStore(t *testing.T) {
-	t.Parallel()
-
-	t.Run("nil db", func(t *testing.T) {
-		t.Parallel()
-
-		db, err := NewSqliteStore(nil)
-		require.ErrorIs(t, err, ErrNilDB)
-		require.Nil(t, db)
-	})
-
-	t.Run("valid db", func(t *testing.T) {
-		t.Parallel()
-
-		sqlDB := newMockedTestDB(t)
-
-		db, err := NewSqliteStore(sqlDB)
-		require.NoError(t, err)
-		require.NotNil(t, db)
-		require.Equal(t, sqlDB, db.db)
-		require.NotNil(t, db.queries)
-	})
-}
-
-// mockDriver implements a bare-bones SQL driver so tests can obtain a *sql.DB
-// without depending on an external database.
-type mockDriver struct {
-	mock.Mock
-}
-
-func (m *mockDriver) Open(name string) (driver.Conn, error) {
-	args := m.Called(name)
-	conn, _ := args.Get(0).(driver.Conn)
-
-	return conn, args.Error(1)
-}
-
-// mockConn is a mock implementation of a database connection. It does not
-// implement any real behavior. Used to be returned by the mockDriver.
-type mockConn struct {
-	mock.Mock
+	require.NoError(t, store.Close())
 }

--- a/wallet/internal/db/db_itest.go
+++ b/wallet/internal/db/db_itest.go
@@ -1,0 +1,15 @@
+//go:build itest
+
+package db
+
+import "database/sql"
+
+// DB returns the underlying *sql.DB connection for integration testing.
+func (s *SqliteStore) DB() *sql.DB {
+	return s.db
+}
+
+// DB returns the underlying *sql.DB connection for integration testing.
+func (s *PostgresStore) DB() *sql.DB {
+	return s.db
+}

--- a/wallet/internal/db/db_itest.go
+++ b/wallet/internal/db/db_itest.go
@@ -2,14 +2,29 @@
 
 package db
 
-import "database/sql"
+import (
+	"database/sql"
+
+	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
+	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
+)
 
 // DB returns the underlying *sql.DB connection for integration testing.
 func (s *SqliteStore) DB() *sql.DB {
 	return s.db
 }
 
+// Queries returns the underlying sqlc queries for integration testing.
+func (s *SqliteStore) Queries() *sqlcsqlite.Queries {
+	return s.queries
+}
+
 // DB returns the underlying *sql.DB connection for integration testing.
 func (s *PostgresStore) DB() *sql.DB {
 	return s.db
+}
+
+// Queries returns the underlying sqlc queries for integration testing.
+func (s *PostgresStore) Queries() *sqlcpg.Queries {
+	return s.queries
 }

--- a/wallet/internal/db/itest/account_store_test.go
+++ b/wallet/internal/db/itest/account_store_test.go
@@ -21,7 +21,7 @@ import (
 // across all standard key scopes between multiple wallets.
 func TestCreateAccounts(t *testing.T) {
 	t.Parallel()
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	// Create 3 wallets to ensure wallet_id scoping works.
 	for i := range 3 {
@@ -51,7 +51,7 @@ func TestCreateAccounts(t *testing.T) {
 func TestCreateDerivedAccountErrors(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	walletID := newWallet(t, store, "wallet-create-derived-account-errors")
 
@@ -96,7 +96,7 @@ func TestCreateDerivedAccountErrors(t *testing.T) {
 func TestCreateDerivedAccountDuplicateName(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	walletID := newWallet(t, store, "duplicate-name-wallet")
 
@@ -120,7 +120,7 @@ func TestCreateDerivedAccountDuplicateName(t *testing.T) {
 func TestCreateDerivedAccountSameNameDifferentScopes(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	walletID := newWallet(t, store, "multi-scope-wallet")
 
@@ -151,7 +151,7 @@ func TestCreateDerivedAccountSameNameDifferentScopes(t *testing.T) {
 func TestCreateDerivedAccountSequentialNumbers(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	walletID := newWallet(t, store, "sequential-wallet")
 
@@ -177,7 +177,7 @@ func TestCreateDerivedAccountSequentialNumbers(t *testing.T) {
 func TestCreateDerivedAccountConcurrent(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	walletID := newWallet(t, store, "concurrent-wallet")
 
@@ -222,7 +222,7 @@ func TestCreateDerivedAccountConcurrent(t *testing.T) {
 func TestCreateImportedAccountErrors(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	walletID := newWallet(t, store, "wallet-create-imported-account-errors")
 
@@ -279,7 +279,7 @@ func TestCreateImportedAccountErrors(t *testing.T) {
 func TestCreateImportedAccountDuplicateName(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	walletID := newWallet(t, store, "imported-duplicate-name-wallet")
 
@@ -306,7 +306,7 @@ func TestCreateImportedAccountDuplicateName(t *testing.T) {
 func TestGetAccount(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	walletID := newWallet(t, store, "wallet-get-account")
 
@@ -345,7 +345,7 @@ func TestGetAccount(t *testing.T) {
 func TestGetAccountNotFound(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	walletID := newWallet(t, store, "wallet-get-account-not-found")
 
@@ -380,7 +380,7 @@ func TestListAccounts(t *testing.T) {
 	// Ensure that has at least 3 accounts to be tested.
 	require.GreaterOrEqual(t, len(AllAccountCases), 3)
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	walletID := newWallet(t, store, "wallet-list-accounts")
 
@@ -454,7 +454,7 @@ func TestListAccounts(t *testing.T) {
 func TestListAccountsOrdering(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	walletID := newWallet(t, store, "wallet-list-ordering")
 
@@ -493,7 +493,7 @@ func TestListAccountsOrdering(t *testing.T) {
 func TestAccountCreatedAtTimestamp(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	walletID := newWallet(t, store, "wallet-created-at")
 
@@ -534,7 +534,7 @@ func TestAccountCreatedAtTimestamp(t *testing.T) {
 func TestRenameAccount(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	walletID := newWallet(t, store, "wallet-rename-account")
 
@@ -595,7 +595,7 @@ func TestRenameAccount(t *testing.T) {
 func TestRenameAccountErrors(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	walletID := newWallet(t, store, "wallet-rename-account-errors")
 
@@ -667,11 +667,10 @@ func TestRenameAccountErrors(t *testing.T) {
 func TestCreateDerivedAccountMaxAccountNumber(t *testing.T) {
 	t.Parallel()
 
-	store, queries := NewTestStore(t)
+	store := NewTestStore(t)
 	walletID := newWallet(t, store, "wallet-max-account")
 	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "account-0")
-	scopeID := GetKeyScopeID(t, queries, walletID, db.KeyScopeBIP0084)
-	CreateAccountWithNumber(t, queries, scopeID, math.MaxUint32-1, "account-near-max")
+	setupMaxAccountNumberTest(t, store, walletID)
 
 	// This should succeed with account_number = MaxUint32.
 	info, err := store.CreateDerivedAccount(

--- a/wallet/internal/db/itest/address_store_test.go
+++ b/wallet/internal/db/itest/address_store_test.go
@@ -88,7 +88,8 @@ func getAccountByName(t *testing.T, store db.AccountStore, walletID uint32,
 func TestNewImportedAddress(t *testing.T) {
 	t.Parallel()
 
-	store, queries := NewTestStore(t)
+	store := NewTestStore(t)
+	queries := store.Queries()
 	walletID := newWallet(t, store, "wallet-imported-addresses")
 
 	createImportedAccount(t, store, walletID, db.KeyScopeBIP0044, "imported")
@@ -231,7 +232,8 @@ func TestNewImportedAddress(t *testing.T) {
 func TestNewImportedAddressWithEncryptedScript(t *testing.T) {
 	t.Parallel()
 
-	store, queries := NewTestStore(t)
+	store := NewTestStore(t)
+	queries := store.Queries()
 	walletID := newWallet(t, store, "wallet-encrypted-script")
 	createImportedAccount(t, store, walletID, db.KeyScopeBIP0044, "imported")
 	createImportedAccount(t, store, walletID, db.KeyScopeBIP0049Plus, "imported")
@@ -339,7 +341,8 @@ func TestNewImportedAddressWithEncryptedScript(t *testing.T) {
 func TestImportedAddressCounterInsertDelete(t *testing.T) {
 	t.Parallel()
 
-	store, _, dbConn := NewTestStoreWithDB(t)
+	store := NewTestStore(t)
+	dbConn := store.DB()
 	walletID := newWallet(t, store, "wallet-imported-counter")
 	createImportedAccount(t, store, walletID, db.KeyScopeBIP0084, "imported")
 
@@ -386,7 +389,8 @@ func TestImportedAddressCounterInsertDelete(t *testing.T) {
 func TestImportedAddressCounterConcurrentInsert(t *testing.T) {
 	t.Parallel()
 
-	store, _, dbConn := NewTestStoreWithDB(t)
+	store := NewTestStore(t)
+	dbConn := store.DB()
 	walletID := newWallet(t, store, "wallet-imported-counter-concurrent")
 	createImportedAccount(t, store, walletID, db.KeyScopeBIP0084, "imported")
 
@@ -468,7 +472,7 @@ func TestImportedAddressCounterConcurrentInsert(t *testing.T) {
 func TestNewImportedAddressDuplicate(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 	walletID := newWallet(t, store, "wallet-duplicate-import")
 	createImportedAccount(t, store, walletID, db.KeyScopeBIP0084, "imported")
 
@@ -501,7 +505,7 @@ func TestNewImportedAddressDuplicate(t *testing.T) {
 func TestGetAddressSecret(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 	walletID := newWallet(t, store, "wallet-secrets")
 	createImportedAccount(t, store, walletID, db.KeyScopeBIP0044, "imported")
 
@@ -568,7 +572,7 @@ func TestGetAddressSecret(t *testing.T) {
 func TestGetAddress(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 	walletID := newWallet(t, store, "wallet-get-address")
 
 	tests := []struct {
@@ -654,7 +658,7 @@ func TestGetAddress(t *testing.T) {
 func TestListAddresses(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 	walletID := newWallet(t, store, "wallet-list-addresses")
 
 	tests := []struct {
@@ -772,7 +776,7 @@ func TestListAddresses(t *testing.T) {
 func TestNewDerivedAddress(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 	walletID := newWallet(t, store, "wallet-derived")
 
 	// Create account in BIP44 scope.
@@ -824,7 +828,7 @@ func TestNewDerivedAddress(t *testing.T) {
 func TestNewImportedAddress_NonExistentImportedAccount(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 	walletID := newWallet(t, store, "test-wallet")
 
 	// Attempt to import address when "imported" account doesn't exist.
@@ -851,7 +855,7 @@ func TestNewImportedAddress_NonExistentImportedAccount(t *testing.T) {
 func TestGetAddressSecret_DerivedAddress(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 	walletID := newWallet(t, store, "test-wallet")
 	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "test-account")
 
@@ -879,7 +883,7 @@ func TestGetAddressSecret_DerivedAddress(t *testing.T) {
 func TestNewDerivedAddressSequentialIndexes(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 	walletID := newWallet(t, store, "wallet-sequential-indexes")
 
 	// Create derived account for the test.
@@ -901,7 +905,7 @@ func TestNewDerivedAddressSequentialIndexes(t *testing.T) {
 func TestListAddressesOrdering(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 	walletID := newWallet(t, store, "wallet-list-ordering")
 
 	createDerivedAccount(
@@ -962,7 +966,7 @@ func TestListAddressesOrdering(t *testing.T) {
 func TestNewDerivedAddressErrors(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 	walletID := newWallet(t, store, "wallet-new-derived-address-errors")
 
 	tests := []struct {
@@ -1021,7 +1025,7 @@ func TestNewDerivedAddressErrors(t *testing.T) {
 func TestNewDerivedAddressConcurrent(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 	walletID := newWallet(t, store, "concurrent-wallet")
 
 	accountName := "concurrent-account"
@@ -1075,7 +1079,7 @@ func TestNewDerivedAddressConcurrent(t *testing.T) {
 func TestNewDerivedAddressBranchIsolation(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 	walletID := newWallet(t, store, "wallet-branch-isolation")
 
 	// Create derived account for the test.
@@ -1119,7 +1123,7 @@ func TestNewDerivedAddressBranchIsolation(t *testing.T) {
 func TestNewDerivedAddressAccountKeyCounts(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 	walletID := newWallet(t, store, "wallet-account-key-counts")
 
 	accountName := "counted-account"
@@ -1145,7 +1149,7 @@ func TestNewDerivedAddressAccountKeyCounts(t *testing.T) {
 func TestNewDerivedAddressBranchCounters(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 	walletID := newWallet(t, store, "wallet-branch-counters")
 
 	accountName := "branch-counter-account"
@@ -1178,7 +1182,9 @@ func TestNewDerivedAddressBranchCounters(t *testing.T) {
 func TestNewDerivedAddressMaxIndex(t *testing.T) {
 	t.Parallel()
 
-	store, queries, dbConn := NewTestStoreWithDB(t)
+	store := NewTestStore(t)
+	queries := store.Queries()
+	dbConn := store.DB()
 	walletID := newWallet(t, store, "wallet-max-index")
 	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "max-acct")
 
@@ -1216,7 +1222,9 @@ func TestNewDerivedAddressMaxIndex(t *testing.T) {
 func TestNewDerivedAddressMaxIndexInternal(t *testing.T) {
 	t.Parallel()
 
-	store, queries, dbConn := NewTestStoreWithDB(t)
+	store := NewTestStore(t)
+	queries := store.Queries()
+	dbConn := store.DB()
 	walletID := newWallet(t, store, "wallet-max-index-internal")
 	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "max-acct")
 

--- a/wallet/internal/db/itest/address_types_store_test.go
+++ b/wallet/internal/db/itest/address_types_store_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestListAddressTypes(t *testing.T) {
 	t.Parallel()
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	types, err := store.ListAddressTypes(t.Context())
 	require.NoError(t, err)
@@ -33,7 +33,7 @@ func TestListAddressTypes(t *testing.T) {
 
 func TestGetAddressType(t *testing.T) {
 	t.Parallel()
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	tests := []struct {
 		id         db.AddressType

--- a/wallet/internal/db/itest/fixtures_pg_test.go
+++ b/wallet/internal/db/itest/fixtures_pg_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
@@ -181,4 +182,18 @@ func deleteAddress(ctx context.Context, dbConn *sql.DB,
 	}
 
 	return nil
+}
+
+func setupMaxAccountNumberTest(t *testing.T, store db.AccountStore,
+	walletID uint32) {
+
+	t.Helper()
+
+	require.IsType(t, &db.PostgresStore{}, store)
+
+	pgStore := store.(*db.PostgresStore)
+	queries := pgStore.Queries()
+	scopeID := GetKeyScopeID(t, queries, walletID, db.KeyScopeBIP0084)
+	CreateAccountWithNumber(t, queries, scopeID, math.MaxUint32-1,
+		"account-near-max")
 }

--- a/wallet/internal/db/itest/fixtures_sqlite_test.go
+++ b/wallet/internal/db/itest/fixtures_sqlite_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
@@ -181,4 +182,18 @@ func deleteAddress(ctx context.Context, dbConn *sql.DB,
 	}
 
 	return nil
+}
+
+func setupMaxAccountNumberTest(t *testing.T, store db.AccountStore,
+	walletID uint32) {
+
+	t.Helper()
+
+	require.IsType(t, &db.SqliteStore{}, store)
+
+	sqliteStore := store.(*db.SqliteStore)
+	queries := sqliteStore.Queries()
+	scopeID := GetKeyScopeID(t, queries, walletID, db.KeyScopeBIP0084)
+	CreateAccountWithNumber(t, queries, scopeID, math.MaxUint32-1,
+		"account-near-max")
 }

--- a/wallet/internal/db/itest/pg_test.go
+++ b/wallet/internal/db/itest/pg_test.go
@@ -190,14 +190,14 @@ func NewPostgresDB(t *testing.T) *sql.DB {
 
 // NewTestStoreWithDB creates a PostgreSQL wallet store and also returns the
 // raw sql.DB for fixture-level direct SQL setup.
-func NewTestStoreWithDB(t *testing.T) (*db.PostgresWalletDB, *sqlcpg.Queries,
+func NewTestStoreWithDB(t *testing.T) (*db.PostgresStore, *sqlcpg.Queries,
 	*sql.DB) {
 
 	t.Helper()
 
 	dbConn := NewPostgresDB(t)
 
-	store, err := db.NewPostgresWalletDB(dbConn)
+	store, err := db.NewPostgresStore(dbConn)
 	require.NoError(t, err, "failed to create wallet store")
 
 	queries := sqlcpg.New(dbConn)
@@ -206,7 +206,7 @@ func NewTestStoreWithDB(t *testing.T) (*db.PostgresWalletDB, *sqlcpg.Queries,
 }
 
 // NewTestStore creates a PostgreSQL wallet store and returns it with queries.
-func NewTestStore(t *testing.T) (*db.PostgresWalletDB, *sqlcpg.Queries) {
+func NewTestStore(t *testing.T) (*db.PostgresStore, *sqlcpg.Queries) {
 	t.Helper()
 
 	store, queries, _ := NewTestStoreWithDB(t)

--- a/wallet/internal/db/itest/pg_test.go
+++ b/wallet/internal/db/itest/pg_test.go
@@ -133,7 +133,7 @@ func sanitizedPgDBName(t *testing.T) string {
 
 // NewPostgresDB creates a new PostgreSQL database connection with migrations
 // applied. Each test gets its own database for isolation.
-func NewPostgresDB(t *testing.T) *sql.DB {
+func NewPostgresDB(t *testing.T) *db.PostgresStore {
 	t.Helper()
 	ctx := t.Context()
 
@@ -170,22 +170,19 @@ func NewPostgresDB(t *testing.T) *sql.DB {
 	// Build the connection string for the test database.
 	testConnStr := strings.Replace(connStr, "/postgres?", "/"+dbName+"?", 1)
 
-	// TODO(gustavostingelin): replace with the real PostgreSQL database
-	// connection constructor when available.
-	dbConn, err := sql.Open("pgx", testConnStr)
-	require.NoError(t, err, "failed to open test database connection")
-	require.NotNil(t, dbConn, "test database connection is nil")
+	cfg := db.PostgresConfig{
+		Dsn:            testConnStr,
+		MaxConnections: 0,
+	}
 
-	// Close the connection to avoid leaking an idle connection during tests.
-	// The container is reused across all tests, so we explicitly clean this up.
+	store, err := db.NewPostgresStore(t.Context(), cfg)
+	require.NoError(t, err, "failed to create postgres store")
+
 	t.Cleanup(func() {
-		_ = dbConn.Close()
+		_ = store.Close()
 	})
 
-	err = db.ApplyPostgresMigrations(dbConn)
-	require.NoError(t, err, "failed to apply migrations")
-
-	return dbConn
+	return store
 }
 
 // NewTestStoreWithDB creates a PostgreSQL wallet store and also returns the
@@ -195,11 +192,8 @@ func NewTestStoreWithDB(t *testing.T) (*db.PostgresStore, *sqlcpg.Queries,
 
 	t.Helper()
 
-	dbConn := NewPostgresDB(t)
-
-	store, err := db.NewPostgresStore(dbConn)
-	require.NoError(t, err, "failed to create wallet store")
-
+	store := NewPostgresDB(t)
+	dbConn := store.DB()
 	queries := sqlcpg.New(dbConn)
 
 	return store, queries, dbConn

--- a/wallet/internal/db/itest/pg_test.go
+++ b/wallet/internal/db/itest/pg_test.go
@@ -14,8 +14,6 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
-	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
@@ -131,9 +129,9 @@ func sanitizedPgDBName(t *testing.T) string {
 	return dbName
 }
 
-// NewPostgresDB creates a new PostgreSQL database connection with migrations
+// NewTestStore creates a new PostgreSQL database connection with migrations
 // applied. Each test gets its own database for isolation.
-func NewPostgresDB(t *testing.T) *db.PostgresStore {
+func NewTestStore(t *testing.T) *db.PostgresStore {
 	t.Helper()
 	ctx := t.Context()
 
@@ -183,27 +181,4 @@ func NewPostgresDB(t *testing.T) *db.PostgresStore {
 	})
 
 	return store
-}
-
-// NewTestStoreWithDB creates a PostgreSQL wallet store and also returns the
-// raw sql.DB for fixture-level direct SQL setup.
-func NewTestStoreWithDB(t *testing.T) (*db.PostgresStore, *sqlcpg.Queries,
-	*sql.DB) {
-
-	t.Helper()
-
-	store := NewPostgresDB(t)
-	dbConn := store.DB()
-	queries := sqlcpg.New(dbConn)
-
-	return store, queries, dbConn
-}
-
-// NewTestStore creates a PostgreSQL wallet store and returns it with queries.
-func NewTestStore(t *testing.T) (*db.PostgresStore, *sqlcpg.Queries) {
-	t.Helper()
-
-	store, queries, _ := NewTestStoreWithDB(t)
-
-	return store, queries
 }

--- a/wallet/internal/db/itest/sqlite_test.go
+++ b/wallet/internal/db/itest/sqlite_test.go
@@ -15,39 +15,25 @@ import (
 
 // NewSQLiteDB creates a new SQLite database for testing with migrations
 // applied. Each test gets its own temporary database file.
-func NewSQLiteDB(t *testing.T) *sql.DB {
+func NewSQLiteDB(t *testing.T) *db.SqliteStore {
 	t.Helper()
 
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test.db")
 
-	// Enable foreign keys (required for proper constraint enforcement).
-	dsn := dbPath + "?_pragma=foreign_keys=on"
+	cfg := db.SqliteConfig{
+		DBPath:         dbPath,
+		MaxConnections: 0,
+	}
 
-	// Enable WAL mode for better concurrency. WAL allows multiple readers and
-	// reduces lock contention for concurrent writers.
-	dsn = dsn + "&_pragma=journal_mode=WAL"
-
-	// Enable immediate transaction locking to avoid races.
-	dsn = dsn + "&_txlock=immediate"
-
-	// Set busy timeout to 5 seconds. This makes SQLite retry acquiring locks
-	// instead of immediately returning SQLITE_BUSY errors.
-	dsn = dsn + "&_pragma=busy_timeout=5000"
-
-	// TODO(gustavostingelin): replace with the real SQLite database
-	// connection constructor when available.
-	dbConn, err := sql.Open("sqlite", dsn)
-	require.NoError(t, err, "failed to open sqlite database")
-
-	err = db.ApplySQLiteMigrations(dbConn)
-	require.NoError(t, err, "failed to apply migrations")
+	store, err := db.NewSqliteStore(t.Context(), cfg)
+	require.NoError(t, err, "failed to create sqlite store")
 
 	t.Cleanup(func() {
-		_ = dbConn.Close()
+		_ = store.Close()
 	})
 
-	return dbConn
+	return store
 }
 
 // NewTestStoreWithDB creates a SQLite wallet store and also returns the raw
@@ -57,11 +43,8 @@ func NewTestStoreWithDB(t *testing.T) (*db.SqliteStore, *sqlcsqlite.Queries,
 
 	t.Helper()
 
-	dbConn := NewSQLiteDB(t)
-
-	store, err := db.NewSqliteStore(dbConn)
-	require.NoError(t, err, "failed to create wallet store")
-
+	store := NewSQLiteDB(t)
+	dbConn := store.DB()
 	queries := sqlcsqlite.New(dbConn)
 
 	return store, queries, dbConn

--- a/wallet/internal/db/itest/sqlite_test.go
+++ b/wallet/internal/db/itest/sqlite_test.go
@@ -3,19 +3,16 @@
 package itest
 
 import (
-	"database/sql"
 	"path/filepath"
 	"testing"
 
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
 	"github.com/stretchr/testify/require"
-	_ "modernc.org/sqlite"
 )
 
-// NewSQLiteDB creates a new SQLite database for testing with migrations
+// NewTestStore creates a new SQLite database for testing with migrations
 // applied. Each test gets its own temporary database file.
-func NewSQLiteDB(t *testing.T) *db.SqliteStore {
+func NewTestStore(t *testing.T) *db.SqliteStore {
 	t.Helper()
 
 	tmpDir := t.TempDir()
@@ -34,27 +31,4 @@ func NewSQLiteDB(t *testing.T) *db.SqliteStore {
 	})
 
 	return store
-}
-
-// NewTestStoreWithDB creates a SQLite wallet store and also returns the raw
-// sql.DB for fixture-level direct SQL setup.
-func NewTestStoreWithDB(t *testing.T) (*db.SqliteStore, *sqlcsqlite.Queries,
-	*sql.DB) {
-
-	t.Helper()
-
-	store := NewSQLiteDB(t)
-	dbConn := store.DB()
-	queries := sqlcsqlite.New(dbConn)
-
-	return store, queries, dbConn
-}
-
-// NewTestStore creates the SQLite wallet store and returns it with queries.
-func NewTestStore(t *testing.T) (*db.SqliteStore, *sqlcsqlite.Queries) {
-	t.Helper()
-
-	store, queries, _ := NewTestStoreWithDB(t)
-
-	return store, queries
 }

--- a/wallet/internal/db/itest/sqlite_test.go
+++ b/wallet/internal/db/itest/sqlite_test.go
@@ -52,14 +52,14 @@ func NewSQLiteDB(t *testing.T) *sql.DB {
 
 // NewTestStoreWithDB creates a SQLite wallet store and also returns the raw
 // sql.DB for fixture-level direct SQL setup.
-func NewTestStoreWithDB(t *testing.T) (*db.SQLiteWalletDB, *sqlcsqlite.Queries,
+func NewTestStoreWithDB(t *testing.T) (*db.SqliteStore, *sqlcsqlite.Queries,
 	*sql.DB) {
 
 	t.Helper()
 
 	dbConn := NewSQLiteDB(t)
 
-	store, err := db.NewSQLiteWalletDB(dbConn)
+	store, err := db.NewSqliteStore(dbConn)
 	require.NoError(t, err, "failed to create wallet store")
 
 	queries := sqlcsqlite.New(dbConn)
@@ -68,7 +68,7 @@ func NewTestStoreWithDB(t *testing.T) (*db.SQLiteWalletDB, *sqlcsqlite.Queries,
 }
 
 // NewTestStore creates the SQLite wallet store and returns it with queries.
-func NewTestStore(t *testing.T) (*db.SQLiteWalletDB, *sqlcsqlite.Queries) {
+func NewTestStore(t *testing.T) (*db.SqliteStore, *sqlcsqlite.Queries) {
 	t.Helper()
 
 	store, queries, _ := NewTestStoreWithDB(t)

--- a/wallet/internal/db/itest/store_test.go
+++ b/wallet/internal/db/itest/store_test.go
@@ -1,0 +1,24 @@
+//go:build itest
+
+package itest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTestStore(t *testing.T) {
+	t.Parallel()
+
+	// This test store exercises the underlying database connector in a test
+	// environment, so we can verify that the store is created successfully with
+	// a valid database connection and later properly closed. Will test all
+	// backends (SQLite, PostgreSQL) based in the build tags.
+	store := NewTestStore(t)
+
+	require.NotNil(t, store)
+	require.NotNil(t, store.DB())
+	require.NotNil(t, store.Queries())
+	require.NoError(t, store.Close())
+}

--- a/wallet/internal/db/itest/wallet_store_test.go
+++ b/wallet/internal/db/itest/wallet_store_test.go
@@ -15,7 +15,7 @@ import (
 func TestCreateWallet(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 	params := CreateWalletParamsFixture("test-wallet")
 	info, err := store.CreateWallet(t.Context(), params)
 	require.NoError(t, err)
@@ -37,7 +37,7 @@ func TestCreateWallet(t *testing.T) {
 func TestCreateWallet_WithBirthday(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	params := CreateWalletParamsFixture("birthday-wallet")
 	birthday := time.Now().UTC().Add(-30 * 24 * time.Hour)
@@ -56,7 +56,7 @@ func TestCreateWallet_WithBirthday(t *testing.T) {
 func TestCreateWallet_DuplicateName(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 	params := CreateWalletParamsFixture("duplicate-wallet")
 
 	_, err := store.CreateWallet(t.Context(), params)
@@ -100,7 +100,7 @@ func TestCreateWallet_Variants(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			store, _ := NewTestStore(t)
+			store := NewTestStore(t)
 			params := tc.params(tc.name)
 
 			info, err := store.CreateWallet(t.Context(), params)
@@ -116,7 +116,7 @@ func TestCreateWallet_Variants(t *testing.T) {
 func TestGetWallet(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	params := CreateWalletParamsFixture("get-test-wallet")
 	created, err := store.CreateWallet(t.Context(), params)
@@ -138,7 +138,7 @@ func TestGetWallet(t *testing.T) {
 func TestGetWallet_NotFound(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	_, err := store.GetWallet(t.Context(), "non-existent-wallet")
 	require.Error(t, err)
@@ -149,7 +149,7 @@ func TestGetWallet_NotFound(t *testing.T) {
 func TestListWallets(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	// Initially empty.
 	wallets, err := store.ListWallets(t.Context())
@@ -181,7 +181,8 @@ func TestListWallets(t *testing.T) {
 func TestUpdateWallet_SyncedTo(t *testing.T) {
 	t.Parallel()
 
-	store, queries := NewTestStore(t)
+	store := NewTestStore(t)
+	queries := store.Queries()
 
 	params := CreateWalletParamsFixture("update-sync-wallet")
 	created, err := store.CreateWallet(t.Context(), params)
@@ -215,7 +216,8 @@ func TestUpdateWallet_SyncedTo(t *testing.T) {
 func TestUpdateWallet_BirthdayBlock(t *testing.T) {
 	t.Parallel()
 
-	store, queries := NewTestStore(t)
+	store := NewTestStore(t)
+	queries := store.Queries()
 
 	params := CreateWalletParamsFixture("update-birthday-wallet")
 	created, err := store.CreateWallet(t.Context(), params)
@@ -255,7 +257,7 @@ func TestUpdateWallet_BirthdayBlock(t *testing.T) {
 func TestUpdateWallet_Birthday(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	params := CreateWalletParamsFixture("birthday-timestamp-wallet")
 	created, err := store.CreateWallet(t.Context(), params)
@@ -288,7 +290,7 @@ func TestUpdateWallet_Birthday(t *testing.T) {
 func TestUpdateWallet_NotFound(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	updateParams := db.UpdateWalletParams{
 		WalletID: 99999, // Non-existent ID.
@@ -303,7 +305,7 @@ func TestUpdateWallet_NotFound(t *testing.T) {
 func TestGetEncryptedHDSeed(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	params := CreateWalletParamsFixture("seed-wallet")
 	expectedSeed := params.EncryptedMasterPrivKey
@@ -321,7 +323,7 @@ func TestGetEncryptedHDSeed(t *testing.T) {
 func TestGetEncryptedHDSeed_WatchOnly(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	params := CreateWatchOnlyWalletParams("watch-only-seed")
 	created, err := store.CreateWallet(t.Context(), params)
@@ -337,7 +339,7 @@ func TestGetEncryptedHDSeed_WatchOnly(t *testing.T) {
 func TestUpdateWalletSecrets(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	params := CreateWalletParamsFixture("secrets-wallet")
 	created, err := store.CreateWallet(t.Context(), params)
@@ -364,7 +366,7 @@ func TestUpdateWalletSecrets(t *testing.T) {
 func TestUpdateWallet_AutoBlockInsertion(t *testing.T) {
 	t.Parallel()
 
-	store, _ := NewTestStore(t)
+	store := NewTestStore(t)
 
 	params := CreateWalletParamsFixture("auto-block-wallet")
 	created, err := store.CreateWallet(t.Context(), params)

--- a/wallet/internal/db/pg.go
+++ b/wallet/internal/db/pg.go
@@ -3,8 +3,10 @@ package db
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
+	_ "github.com/jackc/pgx/v5/stdlib" // Import pgx driver for postgres database/sql support.
 )
 
 // PostgresStore is the PostgreSQL implementation of the
@@ -14,27 +16,73 @@ type PostgresStore struct {
 	queries *sqlcpg.Queries
 }
 
-// NewPostgresStore creates a new PostgreSQL-based WalletStore.
-func NewPostgresStore(db *sql.DB) (*PostgresStore, error) {
-	if db == nil {
-		return nil, ErrNilDB
+// NewPostgresStore creates a new PostgreSQL-based WalletStore. It handles
+// the full connection setup including config validation, connection opening,
+// health checks, connection pool configuration, and migration application.
+func NewPostgresStore(ctx context.Context, cfg PostgresConfig) (*PostgresStore,
+	error) {
+
+	err := cfg.Validate()
+	if err != nil {
+		return nil, fmt.Errorf("invalid config: %w", err)
+	}
+
+	db, err := sql.Open("pgx", cfg.Dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open database: %w", err)
+	}
+
+	connCtx, cancel := context.WithTimeout(ctx, DefaultConnectionTimeout)
+	defer cancel()
+
+	err = db.PingContext(connCtx)
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("ping database: %w", err)
+	}
+
+	maxConns := DefaultMaxConnections
+	if cfg.MaxConnections > 0 {
+		maxConns = cfg.MaxConnections
+	}
+
+	db.SetMaxOpenConns(maxConns)
+	db.SetMaxIdleConns(maxConns)
+	db.SetConnMaxIdleTime(DefaultConnIdleLifetime)
+
+	queries := sqlcpg.New(db)
+
+	err = ApplyPostgresMigrations(db)
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("apply migrations: %w", err)
 	}
 
 	return &PostgresStore{
 		db:      db,
-		queries: sqlcpg.New(db),
+		queries: queries,
 	}, nil
+}
+
+// Close closes the database connection.
+func (s *PostgresStore) Close() error {
+	err := s.db.Close()
+	if err != nil {
+		return fmt.Errorf("close database: %w", err)
+	}
+
+	return nil
 }
 
 // ExecuteTx executes a function within a database transaction. The function
 // receives a transactional query executor and should perform all database
 // operations using it. The transaction will be automatically committed on
 // success or rolled back on error.
-func (w *PostgresStore) ExecuteTx(ctx context.Context,
+func (s *PostgresStore) ExecuteTx(ctx context.Context,
 	fn func(*sqlcpg.Queries) error) error {
 
-	return execInTx(ctx, w.db, func(tx *sql.Tx) error {
-		qtx := w.queries.WithTx(tx)
+	return execInTx(ctx, s.db, func(tx *sql.Tx) error {
+		qtx := s.queries.WithTx(tx)
 		return fn(qtx)
 	})
 }

--- a/wallet/internal/db/pg.go
+++ b/wallet/internal/db/pg.go
@@ -7,20 +7,20 @@ import (
 	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
 )
 
-// PostgresWalletDB is the PostgreSQL implementation of the
+// PostgresStore is the PostgreSQL implementation of the
 // WalletStore interface.
-type PostgresWalletDB struct {
+type PostgresStore struct {
 	db      *sql.DB
 	queries *sqlcpg.Queries
 }
 
-// NewPostgresWalletDB creates a new PostgreSQL-based WalletStore.
-func NewPostgresWalletDB(db *sql.DB) (*PostgresWalletDB, error) {
+// NewPostgresStore creates a new PostgreSQL-based WalletStore.
+func NewPostgresStore(db *sql.DB) (*PostgresStore, error) {
 	if db == nil {
 		return nil, ErrNilDB
 	}
 
-	return &PostgresWalletDB{
+	return &PostgresStore{
 		db:      db,
 		queries: sqlcpg.New(db),
 	}, nil
@@ -30,7 +30,7 @@ func NewPostgresWalletDB(db *sql.DB) (*PostgresWalletDB, error) {
 // receives a transactional query executor and should perform all database
 // operations using it. The transaction will be automatically committed on
 // success or rolled back on error.
-func (w *PostgresWalletDB) ExecuteTx(ctx context.Context,
+func (w *PostgresStore) ExecuteTx(ctx context.Context,
 	fn func(*sqlcpg.Queries) error) error {
 
 	return execInTx(ctx, w.db, func(tx *sql.Tx) error {

--- a/wallet/internal/db/sqlite.go
+++ b/wallet/internal/db/sqlite.go
@@ -7,19 +7,19 @@ import (
 	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
 )
 
-// SQLiteWalletDB is the SQLite implementation of the WalletStore interface.
-type SQLiteWalletDB struct {
+// SqliteStore is the SQLite implementation of the WalletStore interface.
+type SqliteStore struct {
 	db      *sql.DB
 	queries *sqlcsqlite.Queries
 }
 
-// NewSQLiteWalletDB creates a new SQLite-based WalletStore.
-func NewSQLiteWalletDB(db *sql.DB) (*SQLiteWalletDB, error) {
+// NewSqliteStore creates a new SQLite-based WalletStore.
+func NewSqliteStore(db *sql.DB) (*SqliteStore, error) {
 	if db == nil {
 		return nil, ErrNilDB
 	}
 
-	return &SQLiteWalletDB{
+	return &SqliteStore{
 		db:      db,
 		queries: sqlcsqlite.New(db),
 	}, nil
@@ -29,7 +29,7 @@ func NewSQLiteWalletDB(db *sql.DB) (*SQLiteWalletDB, error) {
 // receives a transactional query executor and should perform all database
 // operations using it. The transaction will be automatically committed on
 // success or rolled back on error.
-func (w *SQLiteWalletDB) ExecuteTx(ctx context.Context,
+func (w *SqliteStore) ExecuteTx(ctx context.Context,
 	fn func(*sqlcsqlite.Queries) error) error {
 
 	return execInTx(ctx, w.db, func(tx *sql.Tx) error {

--- a/wallet/internal/db/sqlite.go
+++ b/wallet/internal/db/sqlite.go
@@ -3,8 +3,10 @@ package db
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
+	_ "modernc.org/sqlite" // Import sqlite driver for sqlite database/sql support.
 )
 
 // SqliteStore is the SQLite implementation of the WalletStore interface.
@@ -13,27 +15,79 @@ type SqliteStore struct {
 	queries *sqlcsqlite.Queries
 }
 
-// NewSqliteStore creates a new SQLite-based WalletStore.
-func NewSqliteStore(db *sql.DB) (*SqliteStore, error) {
-	if db == nil {
-		return nil, ErrNilDB
+// NewSqliteStore creates a new SQLite-based WalletStore. It handles the full
+// connection setup including DSN construction with pragmas, connection
+// opening, health checks, connection pool configuration, and migration
+// application.
+func NewSqliteStore(ctx context.Context, cfg SqliteConfig) (*SqliteStore,
+	error) {
+
+	err := cfg.Validate()
+	if err != nil {
+		return nil, fmt.Errorf("invalid config: %w", err)
+	}
+
+	dsn := cfg.DBPath + "?_pragma=foreign_keys=on"
+	dsn += "&_pragma=journal_mode=WAL"
+	dsn += "&_txlock=immediate"
+	dsn += "&_pragma=busy_timeout=5000"
+
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("open database: %w", err)
+	}
+
+	connCtx, cancel := context.WithTimeout(ctx, DefaultConnectionTimeout)
+	defer cancel()
+
+	err = db.PingContext(connCtx)
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("ping database: %w", err)
+	}
+
+	maxConns := DefaultMaxConnections
+	if cfg.MaxConnections > 0 {
+		maxConns = cfg.MaxConnections
+	}
+
+	db.SetMaxOpenConns(maxConns)
+	db.SetMaxIdleConns(maxConns)
+	db.SetConnMaxIdleTime(DefaultConnIdleLifetime)
+
+	queries := sqlcsqlite.New(db)
+
+	err = ApplySQLiteMigrations(db)
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("apply migrations: %w", err)
 	}
 
 	return &SqliteStore{
 		db:      db,
-		queries: sqlcsqlite.New(db),
+		queries: queries,
 	}, nil
+}
+
+// Close closes the database connection.
+func (s *SqliteStore) Close() error {
+	err := s.db.Close()
+	if err != nil {
+		return fmt.Errorf("close database: %w", err)
+	}
+
+	return nil
 }
 
 // ExecuteTx executes a function within a database transaction. The function
 // receives a transactional query executor and should perform all database
 // operations using it. The transaction will be automatically committed on
 // success or rolled back on error.
-func (w *SqliteStore) ExecuteTx(ctx context.Context,
+func (s *SqliteStore) ExecuteTx(ctx context.Context,
 	fn func(*sqlcsqlite.Queries) error) error {
 
-	return execInTx(ctx, w.db, func(tx *sql.Tx) error {
-		qtx := w.queries.WithTx(tx)
+	return execInTx(ctx, s.db, func(tx *sql.Tx) error {
+		qtx := s.queries.WithTx(tx)
 		return fn(qtx)
 	})
 }

--- a/wallet/internal/db/tx.go
+++ b/wallet/internal/db/tx.go
@@ -10,7 +10,7 @@ import (
 // the transaction lifecycle: begin, commit, and rollback on error.
 //
 // This is a helper function used by the public ExecuteTx methods on
-// PostgresWalletDB and SQLiteWalletDB. It guarantees that the transaction
+// PostgresStore and SqliteStore. It guarantees that the transaction
 // will be either committed (on success) or rolled back (on error or panic).
 func execInTx(ctx context.Context, db *sql.DB, fn func(*sql.Tx) error) error {
 	tx, err := db.BeginTx(ctx, nil)

--- a/wallet/internal/db/wallet_pg.go
+++ b/wallet/internal/db/wallet_pg.go
@@ -9,18 +9,18 @@ import (
 	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
 )
 
-// Ensure PostgresWalletDB satisfies the WalletStore interface.
-var _ WalletStore = (*PostgresWalletDB)(nil)
+// Ensure PostgresStore satisfies the WalletStore interface.
+var _ WalletStore = (*PostgresStore)(nil)
 
 // CreateWallet creates a new wallet in the database with the provided
 // parameters. It returns the created wallet info or an error if the
 // creation fails.
-func (w *PostgresWalletDB) CreateWallet(ctx context.Context,
+func (s *PostgresStore) CreateWallet(ctx context.Context,
 	params CreateWalletParams) (*WalletInfo, error) {
 
 	var info *WalletInfo
 
-	err := w.ExecuteTx(ctx, func(qtx *sqlcpg.Queries) error {
+	err := s.ExecuteTx(ctx, func(qtx *sqlcpg.Queries) error {
 		walletParams := sqlcpg.CreateWalletParams{
 			WalletName:              params.Name,
 			IsImported:              params.IsImported,
@@ -111,10 +111,10 @@ func (w *PostgresWalletDB) CreateWallet(ctx context.Context,
 // GetWallet retrieves information about a wallet given its name. It
 // returns a WalletInfo struct containing the wallet's properties or an
 // error if the wallet is not found.
-func (w *PostgresWalletDB) GetWallet(ctx context.Context,
+func (s *PostgresStore) GetWallet(ctx context.Context,
 	name string) (*WalletInfo, error) {
 
-	row, err := w.queries.GetWalletByName(ctx, name)
+	row, err := s.queries.GetWalletByName(ctx, name)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, fmt.Errorf("wallet %q: %w", name,
@@ -143,10 +143,10 @@ func (w *PostgresWalletDB) GetWallet(ctx context.Context,
 // ListWallets returns a slice of WalletInfo for all wallets stored in
 // the database. It returns an empty slice if no wallets are found, or
 // an error if the retrieval fails.
-func (w *PostgresWalletDB) ListWallets(ctx context.Context) ([]WalletInfo,
+func (s *PostgresStore) ListWallets(ctx context.Context) ([]WalletInfo,
 	error) {
 
-	rows, err := w.queries.ListWallets(ctx)
+	rows, err := s.queries.ListWallets(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list wallets: %w", err)
 	}
@@ -181,10 +181,10 @@ func (w *PostgresWalletDB) ListWallets(ctx context.Context) ([]WalletInfo,
 // birthday, birthday block, or sync state. The specific fields to
 // update are provided in the UpdateWalletParams struct. It returns an
 // error if the update fails.
-func (w *PostgresWalletDB) UpdateWallet(ctx context.Context,
+func (s *PostgresStore) UpdateWallet(ctx context.Context,
 	params UpdateWalletParams) error {
 
-	return w.ExecuteTx(ctx, func(qtx *sqlcpg.Queries) error {
+	return s.ExecuteTx(ctx, func(qtx *sqlcpg.Queries) error {
 		// Insert blocks if needed.
 		if params.SyncedTo != nil {
 			err := ensureBlockExistsPg(ctx, qtx, params.SyncedTo)
@@ -227,10 +227,10 @@ func (w *PostgresWalletDB) UpdateWallet(ctx context.Context,
 // Deterministic (HD) seed of the wallet. This seed is sensitive
 // information and is returned in its encrypted form. It returns the
 // encrypted seed as a byte slice or an error if the retrieval fails.
-func (w *PostgresWalletDB) GetEncryptedHDSeed(ctx context.Context,
+func (s *PostgresStore) GetEncryptedHDSeed(ctx context.Context,
 	walletID uint32) ([]byte, error) {
 
-	secrets, err := w.queries.GetWalletSecrets(ctx, int64(walletID))
+	secrets, err := s.queries.GetWalletSecrets(ctx, int64(walletID))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, fmt.Errorf("secrets for wallet %d: %w",
@@ -250,7 +250,7 @@ func (w *PostgresWalletDB) GetEncryptedHDSeed(ctx context.Context,
 }
 
 // UpdateWalletSecrets updates the secrets for the wallet.
-func (w *PostgresWalletDB) UpdateWalletSecrets(ctx context.Context,
+func (s *PostgresStore) UpdateWalletSecrets(ctx context.Context,
 	params UpdateWalletSecretsParams) error {
 
 	secretsParams := sqlcpg.UpdateWalletSecretsParams{
@@ -261,7 +261,7 @@ func (w *PostgresWalletDB) UpdateWalletSecrets(ctx context.Context,
 		WalletID:                 int64(params.WalletID),
 	}
 
-	rowsAffected, err := w.queries.UpdateWalletSecrets(ctx, secretsParams)
+	rowsAffected, err := s.queries.UpdateWalletSecrets(ctx, secretsParams)
 	if err != nil {
 		return fmt.Errorf("update wallet secrets: %w", err)
 	}

--- a/wallet/internal/db/wallet_sqlite.go
+++ b/wallet/internal/db/wallet_sqlite.go
@@ -9,18 +9,18 @@ import (
 	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
 )
 
-// Ensure SQLiteWalletDB satisfies the WalletStore interface.
-var _ WalletStore = (*SQLiteWalletDB)(nil)
+// Ensure SqliteStore satisfies the WalletStore interface.
+var _ WalletStore = (*SqliteStore)(nil)
 
 // CreateWallet creates a new wallet in the database with the provided
 // parameters. It returns the created wallet info or an error if the
 // creation fails.
-func (w *SQLiteWalletDB) CreateWallet(ctx context.Context,
+func (s *SqliteStore) CreateWallet(ctx context.Context,
 	params CreateWalletParams) (*WalletInfo, error) {
 
 	var info *WalletInfo
 
-	err := w.ExecuteTx(ctx, func(qtx *sqlcsqlite.Queries) error {
+	err := s.ExecuteTx(ctx, func(qtx *sqlcsqlite.Queries) error {
 		walletParams := sqlcsqlite.CreateWalletParams{
 			WalletName:              params.Name,
 			IsImported:              params.IsImported,
@@ -111,10 +111,10 @@ func (w *SQLiteWalletDB) CreateWallet(ctx context.Context,
 // GetWallet retrieves information about a wallet given its name. It
 // returns a WalletInfo struct containing the wallet's properties or an
 // error if the wallet is not found.
-func (w *SQLiteWalletDB) GetWallet(ctx context.Context,
+func (s *SqliteStore) GetWallet(ctx context.Context,
 	name string) (*WalletInfo, error) {
 
-	row, err := w.queries.GetWalletByName(ctx, name)
+	row, err := s.queries.GetWalletByName(ctx, name)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, fmt.Errorf("wallet %q: %w", name,
@@ -143,10 +143,10 @@ func (w *SQLiteWalletDB) GetWallet(ctx context.Context,
 // ListWallets returns a slice of WalletInfo for all wallets stored in
 // the database. It returns an empty slice if no wallets are found, or
 // an error if the retrieval fails.
-func (w *SQLiteWalletDB) ListWallets(ctx context.Context) ([]WalletInfo,
+func (s *SqliteStore) ListWallets(ctx context.Context) ([]WalletInfo,
 	error) {
 
-	rows, err := w.queries.ListWallets(ctx)
+	rows, err := s.queries.ListWallets(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list wallets: %w", err)
 	}
@@ -181,10 +181,10 @@ func (w *SQLiteWalletDB) ListWallets(ctx context.Context) ([]WalletInfo,
 // birthday, birthday block, or sync state. The specific fields to
 // update are provided in the UpdateWalletParams struct. It returns an
 // error if the update fails.
-func (w *SQLiteWalletDB) UpdateWallet(ctx context.Context,
+func (s *SqliteStore) UpdateWallet(ctx context.Context,
 	params UpdateWalletParams) error {
 
-	return w.ExecuteTx(ctx, func(qtx *sqlcsqlite.Queries) error {
+	return s.ExecuteTx(ctx, func(qtx *sqlcsqlite.Queries) error {
 		// Insert blocks if needed.
 		if params.SyncedTo != nil {
 			err := ensureBlockExistsSqlite(
@@ -226,10 +226,10 @@ func (w *SQLiteWalletDB) UpdateWallet(ctx context.Context,
 // Deterministic (HD) seed of the wallet. This seed is sensitive
 // information and is returned in its encrypted form. It returns the
 // encrypted seed as a byte slice or an error if the retrieval fails.
-func (w *SQLiteWalletDB) GetEncryptedHDSeed(ctx context.Context,
+func (s *SqliteStore) GetEncryptedHDSeed(ctx context.Context,
 	walletID uint32) ([]byte, error) {
 
-	secrets, err := w.queries.GetWalletSecrets(ctx, int64(walletID))
+	secrets, err := s.queries.GetWalletSecrets(ctx, int64(walletID))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, fmt.Errorf("secrets for wallet %d: %w",
@@ -249,7 +249,7 @@ func (w *SQLiteWalletDB) GetEncryptedHDSeed(ctx context.Context,
 }
 
 // UpdateWalletSecrets updates the secrets for the wallet.
-func (w *SQLiteWalletDB) UpdateWalletSecrets(ctx context.Context,
+func (s *SqliteStore) UpdateWalletSecrets(ctx context.Context,
 	params UpdateWalletSecretsParams) error {
 
 	secretsParams := sqlcsqlite.UpdateWalletSecretsParams{
@@ -260,7 +260,7 @@ func (w *SQLiteWalletDB) UpdateWalletSecrets(ctx context.Context,
 		WalletID:                 int64(params.WalletID),
 	}
 
-	rowsAffected, err := w.queries.UpdateWalletSecrets(ctx, secretsParams)
+	rowsAffected, err := s.queries.UpdateWalletSecrets(ctx, secretsParams)
 	if err != nil {
 		return fmt.Errorf("update wallet secrets: %w", err)
 	}


### PR DESCRIPTION
Adds real database constructors outside the itest package so integration tests exercise the same constructor code paths used in production, including connection setup and pool configuration.