### PR TITLE
btcwallet: add ImportAccountRescan

### DIFF
--- a/waddrmgr/scoped_manager.go
+++ b/waddrmgr/scoped_manager.go
@@ -1241,7 +1241,9 @@ func (s *ScopedKeyManager) extendAddresses(ns walletdb.ReadWriteBucket,
 	// Choose the account key to used based on whether the address manager
 	// is locked.
 	acctKey := acctInfo.acctKeyPub
-	watchOnly := s.rootManager.WatchOnly() || acctInfo.acctKeyPriv != nil
+	watchOnly := s.rootManager.WatchOnly() ||
+		acctInfo.acctKeyPriv != nil ||
+		acctInfo.acctType == accountWatchOnly
 	if !s.rootManager.IsLocked() && !watchOnly {
 		acctKey = acctInfo.acctKeyPriv
 	}

--- a/wallet/import.go
+++ b/wallet/import.go
@@ -224,6 +224,258 @@ func (w *Wallet) ImportAccount(name string, accountPubKey *hdkeychain.ExtendedKe
 	return accountProps, err
 }
 
+// ImportAccountWithRescan imports an account backed by an account extended
+// public key and initiates a background recovery scan to discover historical
+// transactions for addresses derived from the account.
+//
+// The birthdayHeight specifies the block height from which to begin scanning.
+// The recoveryWindow specifies the gap limit for BIP44-style address discovery.
+//
+// The method returns immediately after importing the account. The recovery scan
+// runs in a background goroutine.
+func (w *Wallet) ImportAccountWithRescan(name string,
+	accountPubKey *hdkeychain.ExtendedKey,
+	masterKeyFingerprint uint32, addrType *waddrmgr.AddressType,
+	birthdayHeight int32, recoveryWindow uint32) (
+	*waddrmgr.AccountProperties, error) {
+
+	chainClient, err := w.requireChainClient()
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate birthdayHeight against the chain's best height.
+	_, bestHeight, err := chainClient.GetBestBlock()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get best block: %v", err)
+	}
+	if birthdayHeight > bestHeight {
+		return nil, fmt.Errorf("birthday height %d exceeds best "+
+			"block height %d", birthdayHeight, bestHeight)
+	}
+
+	// Resolve birthdayHeight into a full BlockStamp.
+	birthdayHash, err := chainClient.GetBlockHash(int64(birthdayHeight))
+	if err != nil {
+		return nil, fmt.Errorf("unable to get block hash for "+
+			"height %d: %v", birthdayHeight, err)
+	}
+	birthdayHeader, err := chainClient.GetBlockHeader(birthdayHash)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get block header for "+
+			"hash %v: %v", birthdayHash, err)
+	}
+	birthdayStamp := &waddrmgr.BlockStamp{
+		Hash:      *birthdayHash,
+		Height:    birthdayHeight,
+		Timestamp: birthdayHeader.Timestamp,
+	}
+
+	// Import the account and update birthday if needed.
+	var accountProps *waddrmgr.AccountProperties
+	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+		var err error
+		accountProps, err = w.importAccount(
+			addrmgrNs, name, accountPubKey,
+			masterKeyFingerprint, addrType,
+		)
+		if err != nil {
+			return err
+		}
+
+		// Update the wallet's birthday if the imported account's
+		// birthday is earlier, following ImportPrivateKey's pattern.
+		birthdayBlock, _, err := w.Manager.BirthdayBlock(addrmgrNs)
+		if err != nil {
+			return err
+		}
+		if birthdayStamp.Height >= birthdayBlock.Height {
+			return nil
+		}
+
+		err = w.Manager.SetBirthday(
+			addrmgrNs, birthdayStamp.Timestamp,
+		)
+		if err != nil {
+			return err
+		}
+
+		// Mark as unverified to prompt a sanity check at next
+		// restart.
+		return w.Manager.SetBirthdayBlock(
+			addrmgrNs, *birthdayStamp, false,
+		)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	log.Infof("Imported account %q, starting background recovery "+
+		"from height %d with recovery_window=%d",
+		name, birthdayHeight, recoveryWindow)
+
+	// Launch the background recovery goroutine.
+	go w.recoverImportedAccount(
+		accountProps.KeyScope, accountProps.AccountNumber,
+		birthdayStamp, recoveryWindow,
+	)
+
+	return accountProps, nil
+}
+
+// recoverImportedAccount scans the blockchain from the given birthday block to
+// discover historical transactions for addresses derived from an imported
+// account. This method is designed to run in a background goroutine on an
+// already-synced wallet.
+//
+// After scanning completes, a RescanJob is submitted to catch any blocks mined
+// during the scan and to register discovered addresses and outpoints for
+// ongoing monitoring.
+func (w *Wallet) recoverImportedAccount(scope waddrmgr.KeyScope,
+	account uint32, birthdayStamp *waddrmgr.BlockStamp,
+	recoveryWindow uint32) {
+
+	chainClient, err := w.requireChainClient()
+	if err != nil {
+		log.Errorf("Imported account recovery failed: no chain "+
+			"client: %v", err)
+		return
+	}
+
+	recoveryMgr := NewRecoveryManager(
+		recoveryWindow, recoveryBatchSize, w.chainParams,
+	)
+
+	// Snapshot the best height so we know when to stop.
+	_, bestHeight, err := chainClient.GetBestBlock()
+	if err != nil {
+		log.Errorf("Imported account recovery failed: unable to "+
+			"get best block: %v", err)
+		return
+	}
+
+	// Build a scoped managers map with only the relevant scope.
+	scopedMgr, err := w.Manager.FetchScopedKeyManager(scope)
+	if err != nil {
+		log.Errorf("Imported account recovery failed: unable to "+
+			"fetch scoped key manager: %v", err)
+		return
+	}
+	scopedMgrs := map[waddrmgr.KeyScope]*waddrmgr.ScopedKeyManager{
+		scope: scopedMgr,
+	}
+
+	// Scan blocks from birthdayHeight to bestHeight in batches.
+	var blocks []*waddrmgr.BlockStamp
+	for height := birthdayStamp.Height; height <= bestHeight; height++ {
+		if w.ShuttingDown() {
+			log.Warn("Imported account recovery aborted: " +
+				"wallet shutting down")
+			return
+		}
+
+		hash, err := chainClient.GetBlockHash(int64(height))
+		if err != nil {
+			log.Errorf("Imported account recovery failed at "+
+				"height %d: %v", height, err)
+			return
+		}
+		header, err := chainClient.GetBlockHeader(hash)
+		if err != nil {
+			log.Errorf("Imported account recovery failed "+
+				"getting header at height %d: %v",
+				height, err)
+			return
+		}
+		blocks = append(blocks, &waddrmgr.BlockStamp{
+			Hash:      *hash,
+			Height:    height,
+			Timestamp: header.Timestamp,
+		})
+
+		recoveryMgr.AddToBlockBatch(hash, height, header.Timestamp)
+
+		// Process in batches of recoveryBatchSize or on the last
+		// block.
+		recoveryBatch := recoveryMgr.BlockBatch()
+		if len(recoveryBatch) == recoveryBatchSize || height == bestHeight {
+			err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+				ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+				return w.recoverScopedAddressesForAccount(
+					chainClient, tx, ns,
+					recoveryBatch, recoveryMgr.State(),
+					scopedMgrs, account,
+				)
+			})
+			if err != nil {
+				log.Errorf("Imported account recovery "+
+					"failed during batch scan: %v", err)
+				return
+			}
+
+			if len(recoveryBatch) > 0 {
+				log.Infof("Recovered imported account "+
+					"addresses from blocks %d-%d",
+					recoveryBatch[0].Height,
+					recoveryBatch[len(recoveryBatch)-1].Height)
+			}
+
+			blocks = blocks[:0]
+			recoveryMgr.ResetBlockBatch()
+		}
+	}
+
+	// Collect all discovered addresses and outpoints from recovery state.
+	var allAddrs []btcutil.Address
+	scopeState := recoveryMgr.State().StateForScope(scope)
+	for _, addr := range scopeState.ExternalBranch.Addrs() {
+		allAddrs = append(allAddrs, addr)
+	}
+	for _, addr := range scopeState.InternalBranch.Addrs() {
+		allAddrs = append(allAddrs, addr)
+	}
+
+	watchedOutPoints := recoveryMgr.State().WatchedOutPoints()
+	outpoints := make(map[wire.OutPoint]btcutil.Address, len(watchedOutPoints))
+	for op, addr := range watchedOutPoints {
+		outpoints[op] = addr
+	}
+
+	// Get the block hash for our snapshot height to use as the rescan
+	// start point.
+	bestHash, err := chainClient.GetBlockHash(int64(bestHeight))
+	if err != nil {
+		log.Errorf("Imported account recovery: unable to get block "+
+			"hash for height %d: %v", bestHeight, err)
+		return
+	}
+	bestHeader, err := chainClient.GetBlockHeader(bestHash)
+	if err != nil {
+		log.Errorf("Imported account recovery: unable to get block "+
+			"header for hash %v: %v", bestHash, err)
+		return
+	}
+
+	// Submit a rescan from the snapshot height to catch any blocks mined
+	// during recovery and to register addresses/outpoints for ongoing
+	// monitoring.
+	job := &RescanJob{
+		Addrs:     allAddrs,
+		OutPoints: outpoints,
+		BlockStamp: waddrmgr.BlockStamp{
+			Hash:      *bestHash,
+			Height:    bestHeight,
+			Timestamp: bestHeader.Timestamp,
+		},
+	}
+	_ = w.SubmitRescan(job)
+
+	log.Infof("Imported account recovery complete: discovered %d "+
+		"addresses and %d outpoints, submitted follow-up rescan "+
+		"from height %d", len(allAddrs), len(outpoints), bestHeight)
+}
+
 // ImportAccountWithScope imports an account backed by an account extended
 // public key for a specific key scope which is known in advance.
 // The master key fingerprint denotes the fingerprint of the root key

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1035,6 +1035,214 @@ func internalKeyPath(index uint32) waddrmgr.DerivationPath {
 	}
 }
 
+// accountExternalKeyPath returns the relative external derivation path
+// /account/0/index for the given account.
+func accountExternalKeyPath(account, index uint32) waddrmgr.DerivationPath {
+	return waddrmgr.DerivationPath{
+		InternalAccount: account,
+		Account:         account,
+		Branch:          waddrmgr.ExternalBranch,
+		Index:           index,
+	}
+}
+
+// accountInternalKeyPath returns the relative internal derivation path
+// /account/1/index for the given account.
+func accountInternalKeyPath(account, index uint32) waddrmgr.DerivationPath {
+	return waddrmgr.DerivationPath{
+		InternalAccount: account,
+		Account:         account,
+		Branch:          waddrmgr.InternalBranch,
+		Index:           index,
+	}
+}
+
+// expandScopeHorizonsForAccount is like expandScopeHorizons but derives
+// addresses from the specified account rather than the default account.
+func expandScopeHorizonsForAccount(ns walletdb.ReadBucket,
+	scopedMgr *waddrmgr.ScopedKeyManager,
+	scopeState *ScopeRecoveryState, account uint32) error {
+
+	exHorizon, exWindow := scopeState.ExternalBranch.ExtendHorizon()
+	count, childIndex := uint32(0), exHorizon
+	for count < exWindow {
+		keyPath := accountExternalKeyPath(account, childIndex)
+		addr, err := scopedMgr.DeriveFromKeyPath(ns, keyPath)
+		switch {
+		case err == hdkeychain.ErrInvalidChild:
+			scopeState.ExternalBranch.MarkInvalidChild(childIndex)
+			childIndex++
+			continue
+		case err != nil:
+			return err
+		}
+		scopeState.ExternalBranch.AddAddr(childIndex, addr.Address())
+		childIndex++
+		count++
+	}
+
+	inHorizon, inWindow := scopeState.InternalBranch.ExtendHorizon()
+	count, childIndex = 0, inHorizon
+	for count < inWindow {
+		keyPath := accountInternalKeyPath(account, childIndex)
+		addr, err := scopedMgr.DeriveFromKeyPath(ns, keyPath)
+		switch {
+		case err == hdkeychain.ErrInvalidChild:
+			scopeState.InternalBranch.MarkInvalidChild(childIndex)
+			childIndex++
+			continue
+		case err != nil:
+			return err
+		}
+		scopeState.InternalBranch.AddAddr(childIndex, addr.Address())
+		childIndex++
+		count++
+	}
+
+	return nil
+}
+
+// extendFoundAddressesForAccount is like extendFoundAddresses but extends
+// addresses for the specified account rather than the default account.
+func extendFoundAddressesForAccount(ns walletdb.ReadWriteBucket,
+	filterResp *chain.FilterBlocksResponse,
+	scopedMgrs map[waddrmgr.KeyScope]*waddrmgr.ScopedKeyManager,
+	recoveryState *RecoveryState, account uint32) error {
+
+	for scope, indexes := range filterResp.FoundExternalAddrs {
+		scopeState := recoveryState.StateForScope(scope)
+		for index := range indexes {
+			scopeState.ExternalBranch.ReportFound(index)
+		}
+
+		scopedMgr := scopedMgrs[scope]
+		exNextUnfound := scopeState.ExternalBranch.NextUnfound()
+		exLastFound := exNextUnfound
+		if exLastFound > 0 {
+			exLastFound--
+		}
+		err := scopedMgr.ExtendExternalAddresses(
+			ns, account, exLastFound,
+		)
+		if err != nil {
+			return err
+		}
+		for index := range indexes {
+			addr := scopeState.ExternalBranch.GetAddr(index)
+			err := scopedMgr.MarkUsed(ns, addr)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	for scope, indexes := range filterResp.FoundInternalAddrs {
+		scopeState := recoveryState.StateForScope(scope)
+		for index := range indexes {
+			scopeState.InternalBranch.ReportFound(index)
+		}
+
+		scopedMgr := scopedMgrs[scope]
+		inNextUnfound := scopeState.InternalBranch.NextUnfound()
+		inLastFound := inNextUnfound
+		if inLastFound > 0 {
+			inLastFound--
+		}
+		err := scopedMgr.ExtendInternalAddresses(
+			ns, account, inLastFound,
+		)
+		if err != nil {
+			return err
+		}
+		for index := range indexes {
+			addr := scopeState.InternalBranch.GetAddr(index)
+			err := scopedMgr.MarkUsed(ns, addr)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// recoverScopedAddressesForAccount is like recoverScopedAddresses but recovers
+// addresses for a specific imported account.
+func (w *Wallet) recoverScopedAddressesForAccount(
+	chainClient chain.Interface,
+	tx walletdb.ReadWriteTx,
+	ns walletdb.ReadWriteBucket,
+	batch []wtxmgr.BlockMeta,
+	recoveryState *RecoveryState,
+	scopedMgrs map[waddrmgr.KeyScope]*waddrmgr.ScopedKeyManager,
+	account uint32) error {
+
+	if len(batch) == 0 {
+		return nil
+	}
+
+	log.Infof("Scanning %d blocks for imported account addresses",
+		len(batch))
+
+expandHorizons:
+	for scope, scopedMgr := range scopedMgrs {
+		scopeState := recoveryState.StateForScope(scope)
+		err := expandScopeHorizonsForAccount(
+			ns, scopedMgr, scopeState, account,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	filterReq := newFilterBlocksRequest(batch, scopedMgrs, recoveryState)
+
+	filterResp, err := chainClient.FilterBlocks(filterReq)
+	if err != nil {
+		return err
+	}
+
+	if filterResp == nil {
+		return nil
+	}
+
+	block := batch[filterResp.BatchIndex]
+	logFilterBlocksResp(block, filterResp)
+
+	err = extendFoundAddressesForAccount(
+		ns, filterResp, scopedMgrs, recoveryState, account,
+	)
+	if err != nil {
+		return err
+	}
+
+	for outPoint, addr := range filterResp.FoundOutPoints {
+		outPoint := outPoint
+		recoveryState.AddWatchedOutPoint(&outPoint, addr)
+	}
+
+	for _, txn := range filterResp.RelevantTxns {
+		txRecord, err := wtxmgr.NewTxRecordFromMsgTx(
+			txn, filterResp.BlockMeta.Time,
+		)
+		if err != nil {
+			return err
+		}
+
+		err = w.addRelevantTx(tx, txRecord, &filterResp.BlockMeta)
+		if err != nil {
+			return err
+		}
+	}
+
+	batch = batch[filterResp.BatchIndex+1:]
+	if len(batch) > 0 {
+		goto expandHorizons
+	}
+
+	return nil
+}
+
 // newFilterBlocksRequest constructs FilterBlocksRequests using our current
 // block range, scoped managers, and recovery state.
 func newFilterBlocksRequest(batch []wtxmgr.BlockMeta,


### PR DESCRIPTION
## Change Description
Adds account-aware recovery code to support rescanning historical transactions for imported watch-only accounts. Used by LND WalletKit's `ImportAccount`.                                             

Currently, ImportAccount creates a watch-only account from an extended public key but cannot detect transactions that occurred before the import. The existing recovery system (used for seed restore) performs gap-limit-based address discovery via FilterBlocks, but is hardcoded to DefaultAccountNum. This PR makes the recovery system account-parameterized so it can be used for any account, and adds ImportAccountWithRescan which imports an account and launches a background recovery scan from a caller-specified birthday height.

This is backend-agnostic — it uses chain.Interface.FilterBlocks() which is implemented by all backends (neutrino, btcd, bitcoind).

A companion PR to lnd will wire these new methods into the ImportAccount RPC by adding birthday_height and recovery_window request fields, allowing users to trigger a historical rescan when importing an account.

Example usage:
```bash
$ lncli wallet accounts import --address_type=p2wkh --recovery_window=250 --birthday_height=500000 zpub...
```

## Steps to Test
1. Set up a regtest environment with btcd or bitcoind.
2. Create wallet A, derive addresses from a BIP-84 account, fund them with transactions at various block heights.
3. Export the account's extended public key (zpub).
4. Create wallet B with a separate seed.
5. Call ImportAccountWithRescan on wallet B with the zpub and a birthdayHeight at or before the first funded block.
6. Verify that wallet B discovers the historical transactions and the correct balance is reflected.
7. Verify that spending one of the discovered UTXOs from wallet A is detected by wallet B (outpoint spend monitoring).
8. Test with birthdayHeight set after the funded blocks — verify those transactions are not discovered (as expected).
9. Test gap limit behavior: fund address at index 0 and index 100, import with recoveryWindow=50 (should miss index 100) vs recoveryWindow=150 (should find both).

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#ideal-git-commit-structure).
- [x] Any new logging statements use an appropriate subsystem and logging level.