### PR TITLE
wallet: add SQL tx stores

### DIFF
--- a/wallet/internal/db/block_pg.go
+++ b/wallet/internal/db/block_pg.go
@@ -1,8 +1,10 @@
 package db
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
@@ -42,4 +44,37 @@ func ensureBlockExistsPg(ctx context.Context, qtx *sqlcpg.Queries,
 	}
 
 	return nil
+}
+
+// requireBlockMatchesPg loads the shared block row for the provided height and
+// verifies that its stored metadata matches the supplied block reference.
+func requireBlockMatchesPg(ctx context.Context, qtx *sqlcpg.Queries,
+	block *Block) (int32, error) {
+
+	height, err := uint32ToInt32(block.Height)
+	if err != nil {
+		return 0, fmt.Errorf("convert block height: %w", err)
+	}
+
+	storedBlock, err := qtx.GetBlockByHeight(ctx, height)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, fmt.Errorf("block %d: %w", block.Height,
+				ErrBlockNotFound)
+		}
+
+		return 0, fmt.Errorf("get block by height: %w", err)
+	}
+
+	if !bytes.Equal(storedBlock.HeaderHash, block.Hash[:]) {
+		return 0, fmt.Errorf("block %d header hash: %w", block.Height,
+			ErrBlockMismatch)
+	}
+
+	if storedBlock.BlockTimestamp != block.Timestamp.Unix() {
+		return 0, fmt.Errorf("block %d timestamp: %w", block.Height,
+			ErrBlockMismatch)
+	}
+
+	return height, nil
 }

--- a/wallet/internal/db/block_sqlite.go
+++ b/wallet/internal/db/block_sqlite.go
@@ -1,8 +1,10 @@
 package db
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
@@ -40,4 +42,34 @@ func ensureBlockExistsSqlite(ctx context.Context, qtx *sqlcsqlite.Queries,
 	}
 
 	return nil
+}
+
+// requireBlockMatchesSqlite loads the shared block row for the provided height
+// and verifies that its stored metadata matches the supplied block reference.
+func requireBlockMatchesSqlite(ctx context.Context, qtx *sqlcsqlite.Queries,
+	block *Block) (int64, error) {
+
+	height := int64(block.Height)
+
+	storedBlock, err := qtx.GetBlockByHeight(ctx, height)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, fmt.Errorf("block %d: %w", block.Height,
+				ErrBlockNotFound)
+		}
+
+		return 0, fmt.Errorf("get block by height: %w", err)
+	}
+
+	if !bytes.Equal(storedBlock.HeaderHash, block.Hash[:]) {
+		return 0, fmt.Errorf("block %d header hash: %w", block.Height,
+			ErrBlockMismatch)
+	}
+
+	if storedBlock.BlockTimestamp != block.Timestamp.Unix() {
+		return 0, fmt.Errorf("block %d timestamp: %w", block.Height,
+			ErrBlockMismatch)
+	}
+
+	return height, nil
 }

--- a/wallet/internal/db/itest/pg_test.go
+++ b/wallet/internal/db/itest/pg_test.go
@@ -5,6 +5,7 @@ package itest
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -16,7 +17,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
 	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -231,4 +235,124 @@ func NewTestStore(t *testing.T) *db.PostgresStore {
 	})
 
 	return store
+}
+
+// childSpendingTxIDs returns the direct child transaction IDs recorded for the
+// provided parent transaction hash.
+func childSpendingTxIDs(t *testing.T, store *db.PostgresStore, walletID uint32,
+	txHash chainhash.Hash) []int64 {
+
+	t.Helper()
+
+	meta, err := store.Queries().GetTransactionMetaByHash(
+		t.Context(), sqlcpg.GetTransactionMetaByHashParams{
+			WalletID: int64(walletID),
+			TxHash:   txHash[:],
+		},
+	)
+	require.NoError(t, err)
+
+	childIDs, err := store.Queries().ListSpendingTxIDsByParentTxID(
+		t.Context(), sqlcpg.ListSpendingTxIDsByParentTxIDParams{
+			WalletID: int64(walletID),
+			TxID:     meta.ID,
+		},
+	)
+	require.NoError(t, err)
+
+	ids := make([]int64, 0, len(childIDs))
+	for _, childID := range childIDs {
+		require.True(t, childID.Valid)
+		ids = append(ids, childID.Int64)
+	}
+
+	return ids
+}
+
+// txIDByHash returns the database row ID for the given wallet-scoped
+// transaction hash and reports whether the row exists.
+func txIDByHash(t *testing.T, store *db.PostgresStore, walletID uint32,
+	txHash chainhash.Hash) (int64, bool) {
+
+	t.Helper()
+
+	meta, err := store.Queries().GetTransactionMetaByHash(
+		t.Context(), sqlcpg.GetTransactionMetaByHashParams{
+			WalletID: int64(walletID),
+			TxHash:   txHash[:],
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, false
+		}
+
+		require.NoError(t, err)
+	}
+
+	return meta.ID, true
+}
+
+// rawTxByHash returns the serialized transaction bytes for the given
+// wallet-scoped transaction hash.
+func rawTxByHash(t *testing.T, store *db.PostgresStore, walletID uint32,
+	txHash chainhash.Hash) []byte {
+
+	t.Helper()
+
+	row, err := store.Queries().GetTransactionByHash(
+		t.Context(), sqlcpg.GetTransactionByHashParams{
+			WalletID: int64(walletID),
+			TxHash:   txHash[:],
+		},
+	)
+	require.NoError(t, err)
+
+	return row.RawTx
+}
+
+// setTxStatus rewrites one wallet-scoped transaction row to the provided
+// status using the internal status-update query.
+func setTxStatus(t *testing.T, store *db.PostgresStore, walletID uint32,
+	txHash chainhash.Hash, status db.TxStatus) {
+
+	t.Helper()
+
+	txID, ok := txIDByHash(t, store, walletID, txHash)
+	require.True(t, ok)
+
+	rows, err := store.Queries().UpdateTransactionStatusByIDs(
+		t.Context(), sqlcpg.UpdateTransactionStatusByIDsParams{
+			WalletID: int64(walletID),
+			Status:   int16(status),
+			TxIds:    []int64{txID},
+		},
+	)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rows)
+}
+
+// walletUtxoExists reports whether one wallet-scoped outpoint is currently
+// present in the UTXO set.
+func walletUtxoExists(t *testing.T, store *db.PostgresStore, walletID uint32,
+	outPoint wire.OutPoint) bool {
+
+	t.Helper()
+
+	_, err := store.Queries().GetUtxoIDByOutpoint(
+		t.Context(), sqlcpg.GetUtxoIDByOutpointParams{
+			WalletID:    int64(walletID),
+			TxHash:      outPoint.Hash[:],
+			OutputIndex: int32(outPoint.Index),
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false
+		}
+
+		require.NoError(t, err)
+	}
+
+	return true
 }

--- a/wallet/internal/db/itest/sqlite_test.go
+++ b/wallet/internal/db/itest/sqlite_test.go
@@ -3,10 +3,15 @@
 package itest
 
 import (
+	"database/sql"
+	"errors"
 	"path/filepath"
 	"testing"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,4 +36,124 @@ func NewTestStore(t *testing.T) *db.SqliteStore {
 	})
 
 	return store
+}
+
+// childSpendingTxIDs returns the direct child transaction IDs recorded for the
+// provided parent transaction hash.
+func childSpendingTxIDs(t *testing.T, store *db.SqliteStore, walletID uint32,
+	txHash chainhash.Hash) []int64 {
+
+	t.Helper()
+
+	meta, err := store.Queries().GetTransactionMetaByHash(
+		t.Context(), sqlcsqlite.GetTransactionMetaByHashParams{
+			WalletID: int64(walletID),
+			TxHash:   txHash[:],
+		},
+	)
+	require.NoError(t, err)
+
+	childIDs, err := store.Queries().ListSpendingTxIDsByParentTxID(
+		t.Context(), sqlcsqlite.ListSpendingTxIDsByParentTxIDParams{
+			WalletID: int64(walletID),
+			TxID:     meta.ID,
+		},
+	)
+	require.NoError(t, err)
+
+	ids := make([]int64, 0, len(childIDs))
+	for _, childID := range childIDs {
+		require.True(t, childID.Valid)
+		ids = append(ids, childID.Int64)
+	}
+
+	return ids
+}
+
+// txIDByHash returns the database row ID for the given wallet-scoped
+// transaction hash and reports whether the row exists.
+func txIDByHash(t *testing.T, store *db.SqliteStore, walletID uint32,
+	txHash chainhash.Hash) (int64, bool) {
+
+	t.Helper()
+
+	meta, err := store.Queries().GetTransactionMetaByHash(
+		t.Context(), sqlcsqlite.GetTransactionMetaByHashParams{
+			WalletID: int64(walletID),
+			TxHash:   txHash[:],
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, false
+		}
+
+		require.NoError(t, err)
+	}
+
+	return meta.ID, true
+}
+
+// rawTxByHash returns the serialized transaction bytes for the given
+// wallet-scoped transaction hash.
+func rawTxByHash(t *testing.T, store *db.SqliteStore, walletID uint32,
+	txHash chainhash.Hash) []byte {
+
+	t.Helper()
+
+	row, err := store.Queries().GetTransactionByHash(
+		t.Context(), sqlcsqlite.GetTransactionByHashParams{
+			WalletID: int64(walletID),
+			TxHash:   txHash[:],
+		},
+	)
+	require.NoError(t, err)
+
+	return row.RawTx
+}
+
+// setTxStatus rewrites one wallet-scoped transaction row to the provided
+// status using the internal status-update query.
+func setTxStatus(t *testing.T, store *db.SqliteStore, walletID uint32,
+	txHash chainhash.Hash, status db.TxStatus) {
+
+	t.Helper()
+
+	txID, ok := txIDByHash(t, store, walletID, txHash)
+	require.True(t, ok)
+
+	rows, err := store.Queries().UpdateTransactionStatusByIDs(
+		t.Context(), sqlcsqlite.UpdateTransactionStatusByIDsParams{
+			WalletID: int64(walletID),
+			Status:   int64(status),
+			TxIds:    []int64{txID},
+		},
+	)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rows)
+}
+
+// walletUtxoExists reports whether one wallet-scoped outpoint is currently
+// present in the UTXO set.
+func walletUtxoExists(t *testing.T, store *db.SqliteStore, walletID uint32,
+	outPoint wire.OutPoint) bool {
+
+	t.Helper()
+
+	_, err := store.Queries().GetUtxoIDByOutpoint(
+		t.Context(), sqlcsqlite.GetUtxoIDByOutpointParams{
+			WalletID:    int64(walletID),
+			TxHash:      outPoint.Hash[:],
+			OutputIndex: int64(outPoint.Index),
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false
+		}
+
+		require.NoError(t, err)
+	}
+
+	return true
 }

--- a/wallet/internal/db/itest/tx_utxo_store_test.go
+++ b/wallet/internal/db/itest/tx_utxo_store_test.go
@@ -373,6 +373,307 @@ func TestGetTxNotFound(t *testing.T) {
 	require.ErrorIs(t, err, db.ErrTxNotFound)
 }
 
+// TestUpdateTxRequiresExistingConfirmedBlock verifies that UpdateTx rejects a
+// state patch whose referenced block height is missing from the shared blocks
+// table.
+//
+// Scenario:
+//   - One stored pending transaction is later patched with a missing block.
+//
+// Setup:
+//   - Create one wallet and insert one pending transaction row.
+//   - Build one block reference without inserting that block row.
+//
+// Action:
+//   - Apply the confirmation patch through UpdateTx.
+//
+// Assertions:
+//   - UpdateTx returns ErrBlockNotFound.
+//   - The transaction remains unconfirmed.
+func TestUpdateTxRequiresExistingConfirmedBlock(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-confirmed-tx-missing-block")
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 5000, PkScript: []byte{0x51}}},
+	)
+	block := db.Block{
+		Hash:      RandomHash(),
+		Height:    240,
+		Timestamp: time.Unix(1710000560, 0),
+	}
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       tx,
+		Received: time.Unix(1710000570, 0),
+		Status:   db.TxStatusPending,
+	})
+	require.NoError(t, err)
+
+	err = store.UpdateTx(t.Context(), db.UpdateTxParams{
+		WalletID: walletID,
+		Txid:     tx.TxHash(),
+		State: &db.UpdateTxState{
+			Block:  &block,
+			Status: db.TxStatusPublished,
+		},
+	})
+	require.ErrorIs(t, err, db.ErrBlockNotFound)
+
+	info, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     tx.TxHash(),
+	})
+	require.NoError(t, err)
+	require.Nil(t, info.Block)
+}
+
+// TestUpdateTxRejectsMismatchedConfirmedBlock verifies that UpdateTx rejects a
+// state patch when the supplied block metadata does not match the stored block
+// row for that height.
+//
+// Scenario:
+//   - One stored pending transaction is later patched with mismatched block
+//     metadata for an existing height.
+//
+// Setup:
+//   - Create one wallet and insert one pending transaction row.
+//   - Insert the real block row for the target height.
+//   - Build a second block reference with the same height but different hash.
+//
+// Action:
+//   - Apply the mismatched confirmation patch through UpdateTx.
+//
+// Assertions:
+//   - UpdateTx returns ErrBlockMismatch.
+//   - The existing transaction row remains unconfirmed and pending.
+func TestUpdateTxRejectsMismatchedConfirmedBlock(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-update-tx-block-mismatch")
+	queries := store.Queries()
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 5000, PkScript: []byte{0x51}}},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       tx,
+		Received: time.Unix(1710000550, 0),
+		Status:   db.TxStatusPending,
+	})
+	require.NoError(t, err)
+
+	block := CreateBlockFixture(t, queries, 240)
+	mismatchBlock := block
+	mismatchBlock.Hash = RandomHash()
+
+	err = store.UpdateTx(t.Context(), db.UpdateTxParams{
+		WalletID: walletID,
+		Txid:     tx.TxHash(),
+		State: &db.UpdateTxState{
+			Block:  &mismatchBlock,
+			Status: db.TxStatusPublished,
+		},
+	})
+	require.ErrorIs(t, err, db.ErrBlockMismatch)
+
+	info, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     tx.TxHash(),
+	})
+	require.NoError(t, err)
+	require.Nil(t, info.Block)
+	require.Equal(t, db.TxStatusPending, info.Status)
+}
+
+// TestUpdateTxUpdatesStoredLabel verifies that UpdateTx can patch the stored
+// user-visible label without mutating chain-state metadata.
+//
+// Scenario:
+//   - One pending wallet transaction already exists with an old label.
+//
+// Setup:
+//   - Create one wallet and insert one pending transaction row with a label.
+//
+// Action:
+//   - Patch only the label through UpdateTx.
+//
+// Assertions:
+//   - The stored label changes.
+//   - The transaction stays pending and unconfirmed.
+func TestUpdateTxUpdatesStoredLabel(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-update-tx-label")
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 5000, PkScript: []byte{0x51}}},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       tx,
+		Received: time.Unix(1710000700, 0),
+		Status:   db.TxStatusPending,
+		Label:    "old-label",
+	})
+	require.NoError(t, err)
+
+	label := "new-label"
+	err = store.UpdateTx(t.Context(), db.UpdateTxParams{
+		WalletID: walletID,
+		Txid:     tx.TxHash(),
+		Label:    &label,
+	})
+	require.NoError(t, err)
+
+	info, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     tx.TxHash(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "new-label", info.Label)
+	require.Equal(t, db.TxStatusPending, info.Status)
+}
+
+// TestUpdateTxConfirmsStoredPendingTx verifies that UpdateTx can attach a
+// confirming block to an already-stored unmined row.
+//
+// Scenario:
+//   - One pending wallet transaction is later observed in a block.
+//
+// Setup:
+//   - Create one wallet and insert one pending transaction row.
+//   - Insert one matching block row.
+//
+// Action:
+//   - Apply a published state patch with that block through UpdateTx.
+//
+// Assertions:
+//   - The transaction now carries the block metadata.
+//   - The status becomes published.
+func TestUpdateTxConfirmsStoredPendingTx(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-update-tx-confirm")
+	queries := store.Queries()
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 6000, PkScript: []byte{0x51}}},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       tx,
+		Received: time.Unix(1710000710, 0),
+		Status:   db.TxStatusPending,
+	})
+	require.NoError(t, err)
+
+	block := CreateBlockFixture(t, queries, 220)
+	err = store.UpdateTx(t.Context(), db.UpdateTxParams{
+		WalletID: walletID,
+		Txid:     tx.TxHash(),
+		State: &db.UpdateTxState{
+			Block:  &block,
+			Status: db.TxStatusPublished,
+		},
+	})
+	require.NoError(t, err)
+
+	info, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     tx.TxHash(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, info.Block)
+	require.Equal(t, block.Height, info.Block.Height)
+	require.Equal(t, block.Hash, info.Block.Hash)
+	require.Equal(t, db.TxStatusPublished, info.Status)
+}
+
+// TestUpdateTxNotFound verifies that UpdateTx returns ErrTxNotFound when the
+// wallet has no matching transaction row.
+//
+// Scenario:
+//   - One wallet has no stored transaction for the requested hash.
+//
+// Setup:
+//   - Create one wallet and one label patch.
+//
+// Action:
+//   - Apply the patch to a random missing tx hash.
+//
+// Assertions:
+//   - UpdateTx returns ErrTxNotFound.
+func TestUpdateTxNotFound(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-update-label-missing")
+
+	label := "new-label"
+	err := store.UpdateTx(t.Context(), db.UpdateTxParams{
+		WalletID: walletID,
+		Txid:     RandomHash(),
+		Label:    &label,
+	})
+	require.ErrorIs(t, err, db.ErrTxNotFound)
+}
+
+// TestUpdateTxRejectsEmptyPatch verifies that UpdateTx rejects a request that
+// does not ask to mutate any transaction field.
+//
+// Scenario:
+//   - One wallet transaction exists, but the caller provides no label or state
+//     mutation.
+//
+// Setup:
+//   - Create one wallet and insert one pending transaction row.
+//
+// Action:
+//   - Call UpdateTx with an empty patch.
+//
+// Assertions:
+//   - UpdateTx returns ErrInvalidParam.
+func TestUpdateTxRejectsEmptyPatch(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-update-empty-patch")
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 6000, PkScript: []byte{0x51}}},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       tx,
+		Received: time.Unix(1710000720, 0),
+		Status:   db.TxStatusPending,
+	})
+	require.NoError(t, err)
+
+	err = store.UpdateTx(t.Context(), db.UpdateTxParams{
+		WalletID: walletID,
+		Txid:     tx.TxHash(),
+	})
+	require.ErrorIs(t, err, db.ErrInvalidParam)
+}
+
 // newCoinbaseTx builds a simple coinbase fixture transaction.
 func newCoinbaseTx(pkScript []byte) *wire.MsgTx {
 	tx := wire.NewMsgTx(2)

--- a/wallet/internal/db/itest/tx_utxo_store_test.go
+++ b/wallet/internal/db/itest/tx_utxo_store_test.go
@@ -301,6 +301,78 @@ func TestCreateTxRejectsDuplicateTx(t *testing.T) {
 	require.True(t, ok)
 }
 
+// TestGetTxReturnsStoredPendingTx verifies that GetTx rebuilds the public
+// transaction view for one stored unmined row.
+//
+// Scenario:
+//   - One pending wallet transaction has already been inserted.
+//
+// Setup:
+//   - Create one wallet and insert one pending transaction row.
+//
+// Action:
+//   - Retrieve the transaction through GetTx.
+//
+// Assertions:
+//   - GetTx returns the stored hash, status, label, and nil block metadata.
+func TestGetTxReturnsStoredPendingTx(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-get-tx")
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 5000, PkScript: []byte{0x51}}},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       tx,
+		Received: time.Unix(1710000600, 0),
+		Status:   db.TxStatusPending,
+		Label:    "pending-note",
+	})
+	require.NoError(t, err)
+
+	info, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     tx.TxHash(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, tx.TxHash(), info.Hash)
+	require.Equal(t, db.TxStatusPending, info.Status)
+	require.Equal(t, "pending-note", info.Label)
+	require.Nil(t, info.Block)
+}
+
+// TestGetTxNotFound verifies that GetTx returns ErrTxNotFound when the wallet
+// has no matching transaction row.
+//
+// Scenario:
+//   - One wallet has no stored transaction for the requested hash.
+//
+// Setup:
+//   - Create one wallet and choose one random transaction hash.
+//
+// Action:
+//   - Query the missing hash through GetTx.
+//
+// Assertions:
+//   - GetTx returns ErrTxNotFound.
+func TestGetTxNotFound(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-get-tx-missing")
+
+	_, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     RandomHash(),
+	})
+	require.ErrorIs(t, err, db.ErrTxNotFound)
+}
+
 // newCoinbaseTx builds a simple coinbase fixture transaction.
 func newCoinbaseTx(pkScript []byte) *wire.MsgTx {
 	tx := wire.NewMsgTx(2)

--- a/wallet/internal/db/itest/tx_utxo_store_test.go
+++ b/wallet/internal/db/itest/tx_utxo_store_test.go
@@ -859,6 +859,139 @@ func TestListTxnsReturnsConfirmedTxsByHeightRange(t *testing.T) {
 	require.Equal(t, uint32(211), infos[0].Block.Height)
 }
 
+// TestDeleteTxRemovesLeafUnminedTx verifies that DeleteTx removes a leaf
+// unmined row and restores any parent spend markers it introduced.
+//
+// Scenario:
+//   - One unmined child transaction is the only spender of one wallet-owned
+//     parent output.
+//
+// Setup:
+//   - Create one wallet-owned parent credit and one unmined child spender.
+//
+// Action:
+//   - Delete the child through DeleteTx.
+//
+// Assertions:
+//   - The child row is removed.
+//   - The parent output becomes spendable again.
+//   - No child spend edges remain.
+func TestDeleteTxRemovesLeafUnminedTx(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-delete-leaf")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+
+	parentTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 5000, PkScript: addr.ScriptPubKey}},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       parentTx,
+		Received: time.Unix(1710001000, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	childTx := newRegularTx(
+		[]wire.OutPoint{{Hash: parentTx.TxHash(), Index: 0}},
+		[]*wire.TxOut{{Value: 4000, PkScript: []byte{0x51}}},
+	)
+
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       childTx,
+		Received: time.Unix(1710001010, 0),
+		Status:   db.TxStatusPending,
+	})
+	require.NoError(t, err)
+
+	err = store.DeleteTx(t.Context(), db.DeleteTxParams{
+		WalletID: walletID,
+		Txid:     childTx.TxHash(),
+	})
+	require.NoError(t, err)
+	require.Empty(t, childSpendingTxIDs(t, store, walletID, parentTx.TxHash()))
+	_, ok := txIDByHash(t, store, walletID, childTx.TxHash())
+	require.False(t, ok)
+	require.True(t, walletUtxoExists(t, store, walletID, wire.OutPoint{
+		Hash: parentTx.TxHash(), Index: 0,
+	}))
+}
+
+// TestDeleteTxRejectsNonLeafTx verifies that DeleteTx refuses to erase an
+// unmined transaction that still has direct child spenders.
+//
+// Scenario:
+//   - One parent transaction still has one direct unmined child spender.
+//
+// Setup:
+//   - Create one wallet-owned parent credit and one child that spends it.
+//
+// Action:
+//   - Attempt to delete the parent through DeleteTx.
+//
+// Assertions:
+//   - DeleteTx returns ErrDeleteRequiresLeaf.
+//   - Both parent and child rows remain stored.
+func TestDeleteTxRejectsNonLeafTx(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-delete-non-leaf")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+
+	parentTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 5000, PkScript: addr.ScriptPubKey}},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       parentTx,
+		Received: time.Unix(1710001100, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	childTx := newRegularTx(
+		[]wire.OutPoint{{Hash: parentTx.TxHash(), Index: 0}},
+		[]*wire.TxOut{{Value: 4000, PkScript: addr.ScriptPubKey}},
+	)
+
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       childTx,
+		Received: time.Unix(1710001110, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	err = store.DeleteTx(t.Context(), db.DeleteTxParams{
+		WalletID: walletID,
+		Txid:     parentTx.TxHash(),
+	})
+	require.ErrorIs(t, err, db.ErrDeleteRequiresLeaf)
+	_, ok := txIDByHash(t, store, walletID, parentTx.TxHash())
+	require.True(t, ok)
+	_, ok = txIDByHash(t, store, walletID, childTx.TxHash())
+	require.True(t, ok)
+}
+
 // newCoinbaseTx builds a simple coinbase fixture transaction.
 func newCoinbaseTx(pkScript []byte) *wire.MsgTx {
 	tx := wire.NewMsgTx(2)

--- a/wallet/internal/db/itest/tx_utxo_store_test.go
+++ b/wallet/internal/db/itest/tx_utxo_store_test.go
@@ -674,6 +674,191 @@ func TestUpdateTxRejectsEmptyPatch(t *testing.T) {
 	require.ErrorIs(t, err, db.ErrInvalidParam)
 }
 
+// TestListTxnsReturnsRowsWithoutBlock verifies that the no-confirming-block
+// query path excludes confirmed rows while still surfacing retained invalid
+// history that no longer has block metadata.
+//
+// Scenario:
+//   - One wallet has confirmed history, active unmined history, and retained
+//     invalid history without blocks.
+//
+// Setup:
+//   - Insert one confirmed transaction, one pending transaction, and one failed
+//     transaction whose block is nil.
+//
+// Action:
+//   - Query ListTxns with UnminedOnly set.
+//
+// Assertions:
+//   - Only unmined rows are returned.
+//   - Both the active pending row and the failed history row are present.
+func TestListTxnsReturnsRowsWithoutBlock(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-list-txns-without-block")
+	queries := store.Queries()
+
+	confirmedBlock := CreateBlockFixture(t, queries, 200)
+	confirmedTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 7000, PkScript: []byte{0x51}}},
+	)
+	unminedTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 8000, PkScript: []byte{0x52}}},
+	)
+	failedTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 8100, PkScript: []byte{0x53}}},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       confirmedTx,
+		Received: time.Unix(1710000800, 0),
+		Status:   db.TxStatusPublished,
+	})
+	require.NoError(t, err)
+	err = store.UpdateTx(t.Context(), db.UpdateTxParams{
+		WalletID: walletID,
+		Txid:     confirmedTx.TxHash(),
+		State: &db.UpdateTxState{
+			Block:  &confirmedBlock,
+			Status: db.TxStatusPublished,
+		},
+	})
+	require.NoError(t, err)
+
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       unminedTx,
+		Received: time.Unix(1710000810, 0),
+		Status:   db.TxStatusPending,
+	})
+	require.NoError(t, err)
+
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       failedTx,
+		Received: time.Unix(1710000815, 0),
+		Status:   db.TxStatusPending,
+	})
+	require.NoError(t, err)
+	setTxStatus(t, store, walletID, failedTx.TxHash(), db.TxStatusFailed)
+
+	infos, err := store.ListTxns(t.Context(), db.ListTxnsQuery{
+		WalletID:    walletID,
+		UnminedOnly: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, infos, 2)
+
+	statusesByHash := make(map[chainhash.Hash]db.TxStatus, len(infos))
+	for _, info := range infos {
+		require.Nil(t, info.Block)
+		statusesByHash[info.Hash] = info.Status
+	}
+
+	require.Equal(t, db.TxStatusPending, statusesByHash[unminedTx.TxHash()])
+	require.Equal(t, db.TxStatusFailed, statusesByHash[failedTx.TxHash()])
+}
+
+// TestListTxnsReturnsConfirmedTxsByHeightRange verifies that the
+// confirmed-range query path excludes unmined rows and respects the height
+// bounds.
+//
+// Scenario:
+//   - One wallet has confirmed transactions at multiple heights plus one
+//     unmined row.
+//
+// Setup:
+//   - Insert two confirmed transactions at different heights and one pending
+//     transaction without a block.
+//
+// Action:
+//   - Query ListTxns for one exact confirmed height range.
+//
+// Assertions:
+//   - Only the matching confirmed transaction is returned.
+//   - The unmined row is excluded.
+func TestListTxnsReturnsConfirmedTxsByHeightRange(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-list-txns-confirmed")
+	queries := store.Queries()
+
+	blockOne := CreateBlockFixture(t, queries, 210)
+	blockTwo := CreateBlockFixture(t, queries, 211)
+
+	txOne := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 9000, PkScript: []byte{0x51}}},
+	)
+	txTwo := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 10000, PkScript: []byte{0x52}}},
+	)
+	unminedTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 11000, PkScript: []byte{0x53}}},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       txOne,
+		Received: time.Unix(1710000900, 0),
+		Status:   db.TxStatusPublished,
+	})
+	require.NoError(t, err)
+	err = store.UpdateTx(t.Context(), db.UpdateTxParams{
+		WalletID: walletID,
+		Txid:     txOne.TxHash(),
+		State: &db.UpdateTxState{
+			Block:  &blockOne,
+			Status: db.TxStatusPublished,
+		},
+	})
+	require.NoError(t, err)
+
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       txTwo,
+		Received: time.Unix(1710000910, 0),
+		Status:   db.TxStatusPublished,
+	})
+	require.NoError(t, err)
+	err = store.UpdateTx(t.Context(), db.UpdateTxParams{
+		WalletID: walletID,
+		Txid:     txTwo.TxHash(),
+		State: &db.UpdateTxState{
+			Block:  &blockTwo,
+			Status: db.TxStatusPublished,
+		},
+	})
+	require.NoError(t, err)
+
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       unminedTx,
+		Received: time.Unix(1710000920, 0),
+		Status:   db.TxStatusPending,
+	})
+	require.NoError(t, err)
+
+	infos, err := store.ListTxns(t.Context(), db.ListTxnsQuery{
+		WalletID:    walletID,
+		StartHeight: 211,
+		EndHeight:   211,
+	})
+	require.NoError(t, err)
+	require.Len(t, infos, 1)
+	require.Equal(t, txTwo.TxHash(), infos[0].Hash)
+	require.NotNil(t, infos[0].Block)
+	require.Equal(t, uint32(211), infos[0].Block.Height)
+}
+
 // newCoinbaseTx builds a simple coinbase fixture transaction.
 func newCoinbaseTx(pkScript []byte) *wire.MsgTx {
 	tx := wire.NewMsgTx(2)

--- a/wallet/internal/db/itest/tx_utxo_store_test.go
+++ b/wallet/internal/db/itest/tx_utxo_store_test.go
@@ -1,0 +1,332 @@
+//go:build itest
+
+package itest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateTxStoresWalletCredit verifies that CreateTx stores the transaction
+// row and the requested wallet-owned output in one atomic write.
+//
+// Scenario:
+//   - One wallet records a new unmined transaction with one wallet-owned
+//     credited output.
+//
+// Setup:
+//   - Create one wallet, one derived account, and one wallet-owned address.
+//   - Build one transaction that pays that address.
+//
+// Action:
+//   - Insert the transaction through CreateTx.
+//
+// Assertions:
+//   - The transaction row exists.
+//   - The credited output exists in the wallet UTXO set.
+func TestCreateTxStoresWalletCredit(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-create-tx-credit")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 5000, PkScript: addr.ScriptPubKey}},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       tx,
+		Received: time.Unix(1710000300, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	_, ok := txIDByHash(t, store, walletID, tx.TxHash())
+	require.True(t, ok)
+	require.True(t, walletUtxoExists(t, store, walletID, wire.OutPoint{
+		Hash: tx.TxHash(), Index: 0,
+	}))
+}
+
+// TestCreateTxStoresConfirmedCoinbase verifies that CreateTx can record one
+// coinbase transaction directly in its confirmed state when the block is
+// already known.
+//
+// Scenario:
+//   - One wallet learns about one coinbase credit together with its confirming
+//     block.
+//
+// Setup:
+//   - Create one wallet, one derived account, one wallet-owned address, and one
+//     matching block fixture.
+//   - Build one coinbase transaction that pays that wallet-owned address.
+//
+// Action:
+//   - Insert the coinbase through CreateTx with the block assignment present.
+//
+// Assertions:
+//   - The transaction row exists.
+//   - The wallet-owned coinbase output exists in the current UTXO set.
+func TestCreateTxStoresConfirmedCoinbase(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-create-confirmed-coinbase")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	block := CreateBlockFixture(t, store.Queries(), 210)
+	coinbaseTx := newCoinbaseTx(addr.ScriptPubKey)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       coinbaseTx,
+		Received: time.Unix(1710000350, 0),
+		Block:    &block,
+		Status:   db.TxStatusPublished,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	_, ok := txIDByHash(t, store, walletID, coinbaseTx.TxHash())
+	require.True(t, ok)
+	require.True(t, walletUtxoExists(t, store, walletID, wire.OutPoint{
+		Hash: coinbaseTx.TxHash(), Index: 0,
+	}))
+}
+
+// TestCreateTxRejectsInvalidParentWalletOutput verifies that CreateTx rejects a
+// child that spends a wallet-owned output whose parent transaction is already
+// invalid.
+//
+// Scenario:
+//   - One wallet output exists, but its parent transaction has already been
+//     marked failed.
+//
+// Setup:
+//   - Create one wallet-owned parent credit.
+//   - Rewrite the parent transaction status to failed.
+//   - Build one child transaction that spends that wallet-owned output.
+//
+// Action:
+//   - Insert the child through CreateTx.
+//
+// Assertions:
+//   - CreateTx returns ErrTxInputInvalidParent.
+//   - No child row or child spend edge is persisted.
+//   - The original parent row remains stored.
+func TestCreateTxRejectsInvalidParentWalletOutput(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-invalid-parent")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	parentTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 50000, PkScript: addr.ScriptPubKey}},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       parentTx,
+		Received: time.Unix(1710000400, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	setTxStatus(t, store, walletID, parentTx.TxHash(), db.TxStatusFailed)
+
+	childTx := newRegularTx(
+		[]wire.OutPoint{{Hash: parentTx.TxHash(), Index: 0}},
+		[]*wire.TxOut{{Value: 49000, PkScript: []byte{0x51}}},
+	)
+
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       childTx,
+		Received: time.Unix(1710000410, 0),
+		Status:   db.TxStatusPending,
+	})
+	require.ErrorIs(t, err, db.ErrTxInputInvalidParent)
+	require.Empty(t, childSpendingTxIDs(t, store, walletID, parentTx.TxHash()))
+	_, ok := txIDByHash(t, store, walletID, childTx.TxHash())
+	require.False(t, ok)
+	_, ok = txIDByHash(t, store, walletID, parentTx.TxHash())
+	require.True(t, ok)
+}
+
+// TestCreateTxRejectsSecondPendingSpend verifies that CreateTx rejects a second
+// pending transaction that spends the same wallet-owned output.
+//
+// Scenario:
+//   - One wallet-owned output already has one pending child spender.
+//
+// Setup:
+//   - Create one wallet-owned parent credit.
+//   - Insert one first child transaction that spends it.
+//   - Build one second child that spends the same outpoint.
+//
+// Action:
+//   - Insert the second child through CreateTx.
+//
+// Assertions:
+//   - CreateTx returns ErrTxInputConflict.
+//   - Only the first child remains recorded as the spender.
+//   - The second child row is not inserted.
+func TestCreateTxRejectsSecondPendingSpend(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-second-spend-conflict")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+
+	parentTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 5000, PkScript: addr.ScriptPubKey}},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       parentTx,
+		Received: time.Unix(1710000500, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	spentOutPoint := wire.OutPoint{Hash: parentTx.TxHash(), Index: 0}
+	firstChild := newRegularTx(
+		[]wire.OutPoint{spentOutPoint},
+		[]*wire.TxOut{{Value: 4000, PkScript: []byte{0x51}}},
+	)
+
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       firstChild,
+		Received: time.Unix(1710000510, 0),
+		Status:   db.TxStatusPending,
+	})
+	require.NoError(t, err)
+
+	secondChild := newRegularTx(
+		[]wire.OutPoint{spentOutPoint},
+		[]*wire.TxOut{{Value: 3000, PkScript: []byte{0x52}}},
+	)
+
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       secondChild,
+		Received: time.Unix(1710000520, 0),
+		Status:   db.TxStatusPending,
+	})
+	require.ErrorIs(t, err, db.ErrTxInputConflict)
+
+	childIDs := childSpendingTxIDs(t, store, walletID, parentTx.TxHash())
+	require.Len(t, childIDs, 1)
+
+	_, ok := txIDByHash(t, store, walletID, firstChild.TxHash())
+	require.True(t, ok)
+	_, ok = txIDByHash(t, store, walletID, secondChild.TxHash())
+	require.False(t, ok)
+}
+
+// TestCreateTxRejectsDuplicateTx verifies that CreateTx inserts one wallet-
+// scoped transaction row only once.
+//
+// Scenario:
+//   - One wallet transaction hash is already present in the store.
+//
+// Setup:
+//   - Create one wallet and insert one pending transaction row.
+//
+// Action:
+//   - Attempt to insert the same transaction hash again.
+//
+// Assertions:
+//   - CreateTx returns ErrTxAlreadyExists.
+//   - The original row remains stored once.
+func TestCreateTxRejectsDuplicateTx(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-create-tx-duplicate")
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 5000, PkScript: []byte{0x51}}},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       tx,
+		Received: time.Unix(1710000580, 0),
+		Status:   db.TxStatusPending,
+	})
+	require.NoError(t, err)
+
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       tx,
+		Received: time.Unix(1710000590, 0),
+		Status:   db.TxStatusPending,
+	})
+	require.ErrorIs(t, err, db.ErrTxAlreadyExists)
+
+	_, ok := txIDByHash(t, store, walletID, tx.TxHash())
+	require.True(t, ok)
+}
+
+// newCoinbaseTx builds a simple coinbase fixture transaction.
+func newCoinbaseTx(pkScript []byte) *wire.MsgTx {
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{Index: ^uint32(0)}})
+	tx.AddTxOut(&wire.TxOut{Value: 5000, PkScript: pkScript})
+
+	return tx
+}
+
+// newRegularTx builds a simple fixture transaction with the provided inputs and
+// outputs.
+func newRegularTx(inputs []wire.OutPoint, outputs []*wire.TxOut) *wire.MsgTx {
+	tx := wire.NewMsgTx(2)
+
+	for _, prevOut := range inputs {
+		tx.AddTxIn(&wire.TxIn{PreviousOutPoint: prevOut})
+	}
+
+	for _, txOut := range outputs {
+		tx.AddTxOut(txOut)
+	}
+
+	return tx
+}
+
+// randomOutPoint returns one fixture outpoint backed by a random hash.
+func randomOutPoint() wire.OutPoint {
+	return wire.OutPoint{Hash: RandomHash(), Index: 0}
+}

--- a/wallet/internal/db/itest/tx_utxo_store_test.go
+++ b/wallet/internal/db/itest/tx_utxo_store_test.go
@@ -992,6 +992,170 @@ func TestDeleteTxRejectsNonLeafTx(t *testing.T) {
 	require.True(t, ok)
 }
 
+// TestDeleteTxRemovesParentWithFailedChild verifies that DeleteTx only treats
+// still-active unmined children as leaf blockers.
+//
+// Scenario:
+//   - One parent transaction still has one direct child row, but that child has
+//     already been marked failed.
+//
+// Setup:
+//   - Create one wallet-owned parent credit and one child that spends it.
+//   - Mark the child failed to simulate an already-invalid branch.
+//
+// Action:
+//   - Delete the parent through DeleteTx.
+//
+// Assertions:
+//   - DeleteTx succeeds because the failed child is no longer part of the
+//     active unmined graph.
+//   - The parent row is removed.
+func TestDeleteTxRemovesParentWithFailedChild(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-delete-parent-failed-child")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+
+	parentTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 5000, PkScript: addr.ScriptPubKey}},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       parentTx,
+		Received: time.Unix(1710001115, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	childTx := newRegularTx(
+		[]wire.OutPoint{{Hash: parentTx.TxHash(), Index: 0}},
+		[]*wire.TxOut{{Value: 4000, PkScript: addr.ScriptPubKey}},
+	)
+
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       childTx,
+		Received: time.Unix(1710001120, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+	setTxStatus(t, store, walletID, childTx.TxHash(), db.TxStatusFailed)
+
+	err = store.DeleteTx(t.Context(), db.DeleteTxParams{
+		WalletID: walletID,
+		Txid:     parentTx.TxHash(),
+	})
+	require.NoError(t, err)
+
+	_, ok := txIDByHash(t, store, walletID, parentTx.TxHash())
+	require.False(t, ok)
+}
+
+// TestRollbackToBlockFailsCoinbaseDescendants verifies that RollbackToBlock
+// marks every unmined descendant of a disconnected coinbase root as failed and
+// clears the recorded spend edges they had claimed.
+//
+// Scenario:
+//   - One confirmed coinbase credit has one unmined child spender and one
+//     unmined grandchild spender beneath it.
+//
+// Setup:
+//   - Create one wallet-owned coinbase output and confirm it in one block.
+//   - Insert one child transaction that spends that output and creates one new
+//     wallet-owned credit.
+//   - Insert one grandchild that spends the child's wallet-owned output.
+//
+// Action:
+//   - Roll back the block that confirmed the coinbase root.
+//
+// Assertions:
+//   - Both unmined descendants become failed.
+//   - The spend edges from the coinbase root and child are cleared.
+func TestRollbackToBlockFailsCoinbaseDescendants(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-rollback-coinbase-descendants")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+	queries := store.Queries()
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	coinbaseTx := newCoinbaseTx(addr.ScriptPubKey)
+
+	block := CreateBlockFixture(t, queries, 300)
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       coinbaseTx,
+		Received: time.Unix(1710001200, 0),
+		Block:    &block,
+		Status:   db.TxStatusPublished,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	childTx := newRegularTx(
+		[]wire.OutPoint{{Hash: coinbaseTx.TxHash(), Index: 0}},
+		[]*wire.TxOut{{Value: 4000, PkScript: addr.ScriptPubKey}},
+	)
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       childTx,
+		Received: time.Unix(1710001210, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	grandchildTx := newRegularTx(
+		[]wire.OutPoint{{Hash: childTx.TxHash(), Index: 0}},
+		[]*wire.TxOut{{Value: 3000, PkScript: []byte{0x51}}},
+	)
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       grandchildTx,
+		Received: time.Unix(1710001220, 0),
+		Status:   db.TxStatusPending,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, childSpendingTxIDs(t, store, walletID, coinbaseTx.TxHash()),
+		1)
+	require.Len(t, childSpendingTxIDs(t, store, walletID, childTx.TxHash()), 1)
+
+	err = store.RollbackToBlock(t.Context(), block.Height)
+	require.NoError(t, err)
+
+	childInfo, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     childTx.TxHash(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, db.TxStatusFailed, childInfo.Status)
+	require.Nil(t, childInfo.Block)
+
+	grandchildInfo, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     grandchildTx.TxHash(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, db.TxStatusFailed, grandchildInfo.Status)
+	require.Nil(t, grandchildInfo.Block)
+
+	require.Empty(t, childSpendingTxIDs(t, store, walletID, coinbaseTx.TxHash()))
+	require.Empty(t, childSpendingTxIDs(t, store, walletID, childTx.TxHash()))
+}
+
 // newCoinbaseTx builds a simple coinbase fixture transaction.
 func newCoinbaseTx(pkScript []byte) *wire.MsgTx {
 	tx := wire.NewMsgTx(2)

--- a/wallet/internal/db/postgres_txstore_createtx.go
+++ b/wallet/internal/db/postgres_txstore_createtx.go
@@ -1,0 +1,311 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
+)
+
+// CreateTx atomically records a wallet-scoped transaction row, its
+// wallet-owned credits, and any spend edges created by its inputs.
+//
+// The full write runs inside ExecuteTx so the transaction row, created UTXOs,
+// and spent-parent markers are either committed together or not at all.
+// Received timestamps are normalized to UTC before insert. CreateTx is
+// insert-only and returns ErrTxAlreadyExists if the wallet already stores the
+// tx hash.
+func (s *PostgresStore) CreateTx(ctx context.Context,
+	params CreateTxParams) error {
+
+	req, err := newCreateTxRequest(params)
+	if err != nil {
+		return err
+	}
+
+	return s.ExecuteTx(ctx, func(qtx *sqlcpg.Queries) error {
+		return createTxWithOps(ctx, req, &pgCreateTxOps{qtx: qtx})
+	})
+}
+
+// pgCreateTxOps adapts postgres sqlc queries to the shared CreateTx flow.
+type pgCreateTxOps struct {
+	qtx *sqlcpg.Queries
+
+	blockHeight sql.NullInt32
+}
+
+var _ createTxOps = (*pgCreateTxOps)(nil)
+
+// hasExisting reports whether the wallet already stores the requested tx hash.
+func (o *pgCreateTxOps) hasExisting(ctx context.Context,
+	req createTxRequest) (bool, error) {
+
+	_, err := o.qtx.GetTransactionMetaByHash(
+		ctx,
+		sqlcpg.GetTransactionMetaByHashParams{
+			WalletID: int64(req.params.WalletID),
+			TxHash:   req.txHash[:],
+		},
+	)
+	if err == nil {
+		return true, nil
+	}
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+
+	return false, fmt.Errorf("get tx metadata: %w", err)
+}
+
+// prepareBlock validates the optional confirming block and caches the postgres
+// block-height value that the later insert query will store.
+func (o *pgCreateTxOps) prepareBlock(ctx context.Context,
+	req createTxRequest) error {
+
+	o.blockHeight = sql.NullInt32{}
+
+	if req.params.Block == nil {
+		return nil
+	}
+
+	height, err := requireBlockMatchesPg(ctx, o.qtx, req.params.Block)
+	if err != nil {
+		return err
+	}
+
+	o.blockHeight = sql.NullInt32{Int32: height, Valid: true}
+
+	return nil
+}
+
+// insert stores one new postgres transaction row for CreateTx.
+func (o *pgCreateTxOps) insert(ctx context.Context,
+	req createTxRequest) (int64, error) {
+
+	txID, err := o.qtx.InsertTransaction(ctx, sqlcpg.InsertTransactionParams{
+		WalletID:     int64(req.params.WalletID),
+		TxHash:       req.txHash[:],
+		RawTx:        req.rawTx,
+		BlockHeight:  o.blockHeight,
+		TxStatus:     int16(req.params.Status),
+		ReceivedTime: req.received,
+		IsCoinbase:   req.isCoinbase,
+		TxLabel:      req.params.Label,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("insert tx row: %w", err)
+	}
+
+	return txID, nil
+}
+
+// insertCredits stores any wallet-owned outputs created by the transaction.
+func (o *pgCreateTxOps) insertCredits(ctx context.Context,
+	req createTxRequest, txID int64) error {
+
+	return insertCreditsPg(ctx, o.qtx, req.params, txID)
+}
+
+// markInputsSpent records wallet-owned inputs spent by the transaction.
+func (o *pgCreateTxOps) markInputsSpent(ctx context.Context,
+	req createTxRequest, txID int64) error {
+
+	return markInputsSpentPg(ctx, o.qtx, req.params, txID)
+}
+
+// insertCreditsPg inserts one wallet-owned UTXO row for each credited output of
+// the transaction being stored.
+func insertCreditsPg(ctx context.Context, qtx *sqlcpg.Queries,
+	params CreateTxParams, txID int64) error {
+
+	for index := range params.Credits {
+		creditExists, err := creditExistsPg(
+			ctx, qtx, params.WalletID, params.Tx.TxHash(), index,
+		)
+		if err != nil {
+			return err
+		}
+
+		if creditExists {
+			continue
+		}
+
+		pkScript := params.Tx.TxOut[index].PkScript
+
+		addrRow, err := qtx.GetAddressByScriptPubKey(
+			ctx, sqlcpg.GetAddressByScriptPubKeyParams{
+				ScriptPubKey: pkScript,
+				WalletID:     int64(params.WalletID),
+			},
+		)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("credit output %d: %w", index,
+					ErrAddressNotFound)
+			}
+
+			return fmt.Errorf("resolve credit address %d: %w", index, err)
+		}
+
+		outputIndex, err := uint32ToInt32(index)
+		if err != nil {
+			return fmt.Errorf("convert credit index %d: %w", index, err)
+		}
+
+		_, err = qtx.InsertUtxo(ctx, sqlcpg.InsertUtxoParams{
+			WalletID:    int64(params.WalletID),
+			TxID:        txID,
+			OutputIndex: outputIndex,
+			Amount:      params.Tx.TxOut[index].Value,
+			AddressID:   addrRow.ID,
+		})
+		if err != nil {
+			return fmt.Errorf("insert credit output %d: %w", index, err)
+		}
+	}
+
+	return nil
+}
+
+// creditExistsPg reports whether the wallet already has a UTXO row for the
+// given credited output, even if that output is now spent by a child tx.
+func creditExistsPg(ctx context.Context, qtx *sqlcpg.Queries,
+	walletID uint32, txHash chainhash.Hash, outputIndex uint32) (bool, error) {
+
+	convertedIndex, err := uint32ToInt32(outputIndex)
+	if err != nil {
+		return false, fmt.Errorf("convert credit index %d: %w", outputIndex,
+			err)
+	}
+
+	_, err = qtx.GetUtxoSpendByOutpoint(
+		ctx, sqlcpg.GetUtxoSpendByOutpointParams{
+			WalletID:    int64(walletID),
+			TxHash:      txHash[:],
+			OutputIndex: convertedIndex,
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("lookup credit output %d: %w", outputIndex,
+			err)
+	}
+
+	return true, nil
+}
+
+// markInputsSpentPg attaches wallet-owned outpoints spent by the stored
+// transaction to its row ID and input indexes.
+//
+// If another wallet transaction already owns the spend edge for a
+// wallet-controlled input, the create path fails with ErrTxInputConflict
+// instead of silently storing a second spender. Inputs that reference a
+// wallet-owned output whose parent transaction is already invalid fail with
+// ErrTxInputInvalidParent.
+func markInputsSpentPg(ctx context.Context, qtx *sqlcpg.Queries,
+	params CreateTxParams, txID int64) error {
+
+	if blockchain.IsCoinBaseTx(params.Tx) {
+		return nil
+	}
+
+	for inputIndex, txIn := range params.Tx.TxIn {
+		outputIndex, err := uint32ToInt32(txIn.PreviousOutPoint.Index)
+		if err != nil {
+			return fmt.Errorf("convert input outpoint index %d: %w", inputIndex,
+				err)
+		}
+
+		spentInputIndex, err := int64ToInt32(int64(inputIndex))
+		if err != nil {
+			return fmt.Errorf("convert input index %d: %w", inputIndex, err)
+		}
+
+		rowsAffected, err := qtx.MarkUtxoSpent(ctx, sqlcpg.MarkUtxoSpentParams{
+			WalletID:        int64(params.WalletID),
+			TxHash:          txIn.PreviousOutPoint.Hash[:],
+			OutputIndex:     outputIndex,
+			SpentByTxID:     sql.NullInt64{Int64: txID, Valid: true},
+			SpentInputIndex: sql.NullInt32{Int32: spentInputIndex, Valid: true},
+		})
+		if err != nil {
+			return fmt.Errorf("mark spent input %d: %w", inputIndex, err)
+		}
+
+		if rowsAffected == 0 {
+			err = ensureSpendConflictPg(
+				ctx, qtx, params.WalletID, txIn.PreviousOutPoint.Hash,
+				outputIndex, txID,
+			)
+			if err != nil {
+				return fmt.Errorf("mark spent input %d: %w", inputIndex, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// ensureSpendConflictPg reports ErrTxInputConflict when the referenced outpoint
+// is wallet-owned, still eligible for spending, and already attached to another
+// transaction. If the wallet owns the parent output but that parent is already
+// invalid, the helper returns ErrTxInputInvalidParent instead.
+func ensureSpendConflictPg(ctx context.Context, qtx *sqlcpg.Queries,
+	walletID uint32, txHash chainhash.Hash, outputIndex int32,
+	txID int64) error {
+
+	spendByTxID, err := qtx.GetUtxoSpendByOutpoint(
+		ctx, sqlcpg.GetUtxoSpendByOutpointParams{
+			WalletID:    int64(walletID),
+			TxHash:      txHash[:],
+			OutputIndex: outputIndex,
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ensureWalletParentValidPg(
+				ctx, qtx, walletID, txHash, outputIndex,
+			)
+		}
+
+		return fmt.Errorf("check spend conflict: %w", err)
+	}
+
+	if spendByTxID.Valid && spendByTxID.Int64 != txID {
+		return ErrTxInputConflict
+	}
+
+	return nil
+}
+
+// ensureWalletParentValidPg reports ErrTxInputInvalidParent when the wallet
+// owns the referenced outpoint but its parent transaction is already invalid.
+func ensureWalletParentValidPg(ctx context.Context, qtx *sqlcpg.Queries,
+	walletID uint32, txHash chainhash.Hash, outputIndex int32) error {
+
+	hasInvalid, err := qtx.HasInvalidWalletUtxoByOutpoint(
+		ctx, sqlcpg.HasInvalidWalletUtxoByOutpointParams{
+			WalletID:    int64(walletID),
+			TxHash:      txHash[:],
+			OutputIndex: outputIndex,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("check invalid wallet parent: %w", err)
+	}
+
+	if hasInvalid {
+		return ErrTxInputInvalidParent
+	}
+
+	return nil
+}

--- a/wallet/internal/db/postgres_txstore_deletetx.go
+++ b/wallet/internal/db/postgres_txstore_deletetx.go
@@ -1,0 +1,184 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
+)
+
+// DeleteTx atomically removes one unmined transaction and restores any wallet
+// UTXO rows that it had spent.
+//
+// DeleteTx is limited to unmined pending/published rows; confirmed rows and
+// terminal invalid-history rows remain part of the wallet timeline. The
+// transaction must also be a leaf among the wallet's unmined transactions so
+// the delete cannot detach child spenders from their parent history.
+func (s *PostgresStore) DeleteTx(ctx context.Context,
+	params DeleteTxParams) error {
+
+	return s.ExecuteTx(ctx, func(qtx *sqlcpg.Queries) error {
+		return deleteTxWithOps(ctx, params, pgDeleteTxOps{qtx: qtx})
+	})
+}
+
+// pgDeleteTxOps adapts postgres sqlc queries to the shared DeleteTx flow.
+type pgDeleteTxOps struct {
+	qtx *sqlcpg.Queries
+}
+
+var _ deleteTxOps = (*pgDeleteTxOps)(nil)
+
+// loadDeleteTarget loads and validates the unmined transaction row DeleteTx is
+// allowed to remove.
+func (o pgDeleteTxOps) loadDeleteTarget(ctx context.Context, walletID uint32,
+	txHash chainhash.Hash) (int64, error) {
+
+	meta, err := getDeleteTxMetaPg(ctx, o.qtx, walletID, txHash)
+	if err != nil {
+		return 0, err
+	}
+
+	return meta.ID, nil
+}
+
+// ensureLeaf rejects DeleteTx when the target still has direct unmined child
+// spenders.
+func (o pgDeleteTxOps) ensureLeaf(ctx context.Context, walletID uint32,
+	txHash chainhash.Hash, txID int64) error {
+
+	return ensureDeleteLeafPg(ctx, o.qtx, walletID, txHash, txID)
+}
+
+// clearSpentUtxos restores any wallet-owned parent outputs the transaction had
+// marked spent.
+func (o pgDeleteTxOps) clearSpentUtxos(ctx context.Context, walletID uint32,
+	txID int64) error {
+
+	_, err := o.qtx.ClearUtxosSpentByTxID(
+		ctx,
+		sqlcpg.ClearUtxosSpentByTxIDParams{
+			WalletID:    int64(walletID),
+			SpentByTxID: sql.NullInt64{Int64: txID, Valid: true},
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("clear spent utxo rows: %w", err)
+	}
+
+	return nil
+}
+
+// deleteCreatedUtxos removes any wallet-owned outputs created by the
+// transaction being deleted.
+func (o pgDeleteTxOps) deleteCreatedUtxos(ctx context.Context,
+	walletID uint32, txID int64) error {
+
+	_, err := o.qtx.DeleteUtxosByTxID(
+		ctx,
+		sqlcpg.DeleteUtxosByTxIDParams{
+			WalletID: int64(walletID),
+			TxID:     txID,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("delete created utxo rows: %w", err)
+	}
+
+	return nil
+}
+
+// deleteUnminedTransaction removes the target unmined row after its dependent
+// wallet state has been cleaned up.
+func (o pgDeleteTxOps) deleteUnminedTransaction(ctx context.Context,
+	walletID uint32, txHash chainhash.Hash) (int64, error) {
+
+	rows, err := o.qtx.DeleteUnminedTransactionByHash(
+		ctx,
+		sqlcpg.DeleteUnminedTransactionByHashParams{
+			WalletID: int64(walletID),
+			TxHash:   txHash[:],
+		},
+	)
+	if err != nil {
+		return 0, fmt.Errorf("delete unmined tx row: %w", err)
+	}
+
+	return rows, nil
+}
+
+// ensureDeleteLeafPg rejects DeleteTx requests for transactions that still have
+// direct unmined child spenders, including children that spend non-credit
+// parent outputs.
+func ensureDeleteLeafPg(ctx context.Context, qtx *sqlcpg.Queries,
+	walletID uint32, txHash chainhash.Hash, txID int64) error {
+
+	rows, err := qtx.ListUnminedTransactions(ctx, int64(walletID))
+	if err != nil {
+		return fmt.Errorf("list unmined txns: %w", err)
+	}
+
+	candidates, err := buildUnminedTxRecords(rows,
+		func(row sqlcpg.ListUnminedTransactionsRow) (int64, []byte, []byte) {
+			return row.ID, row.TxHash, row.RawTx
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	filtered := candidates[:0]
+	for _, candidate := range candidates {
+		if candidate.id == txID {
+			continue
+		}
+
+		filtered = append(filtered, candidate)
+	}
+
+	if len(collectDirectChildTxIDs(txHash, filtered)) > 0 {
+		return fmt.Errorf("delete tx %s: %w", txHash,
+			ErrDeleteRequiresLeaf)
+	}
+
+	return nil
+}
+
+// getDeleteTxMetaPg loads the transaction metadata DeleteTx needs and enforces
+// the unmined precondition up front.
+func getDeleteTxMetaPg(ctx context.Context, qtx *sqlcpg.Queries,
+	walletID uint32, txHash chainhash.Hash) (
+	sqlcpg.GetTransactionMetaByHashRow, error) {
+
+	meta, err := qtx.GetTransactionMetaByHash(
+		ctx, sqlcpg.GetTransactionMetaByHashParams{
+			WalletID: int64(walletID),
+			TxHash:   txHash[:],
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return sqlcpg.GetTransactionMetaByHashRow{},
+				fmt.Errorf("tx %s: %w", txHash, ErrTxNotFound)
+		}
+
+		return sqlcpg.GetTransactionMetaByHashRow{},
+			fmt.Errorf("get tx metadata: %w", err)
+	}
+
+	status, err := parseTxStatus(int64(meta.TxStatus))
+	if err != nil {
+		return sqlcpg.GetTransactionMetaByHashRow{}, err
+	}
+
+	if meta.BlockHeight.Valid || !isUnminedStatus(status) {
+		return sqlcpg.GetTransactionMetaByHashRow{},
+			fmt.Errorf("delete tx %s: %w", txHash,
+				ErrDeleteRequiresUnmined)
+	}
+
+	return meta, nil
+}

--- a/wallet/internal/db/postgres_txstore_gettx.go
+++ b/wallet/internal/db/postgres_txstore_gettx.go
@@ -1,0 +1,61 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
+)
+
+// GetTx retrieves one wallet-scoped transaction snapshot by hash.
+//
+// The returned TxInfo is rebuilt from normalized SQL columns; missing rows map
+// to ErrTxNotFound for the requested wallet/hash pair.
+func (s *PostgresStore) GetTx(ctx context.Context,
+	query GetTxQuery) (*TxInfo, error) {
+
+	row, err := s.queries.GetTransactionByHash(
+		ctx, sqlcpg.GetTransactionByHashParams{
+			WalletID: int64(query.WalletID),
+			TxHash:   query.Txid[:],
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("tx %s: %w", query.Txid, ErrTxNotFound)
+		}
+
+		return nil, fmt.Errorf("get tx: %w", err)
+	}
+
+	return txInfoFromPgRow(
+		row.TxHash, row.RawTx, row.ReceivedTime, row.BlockHeight,
+		row.BlockHash, row.BlockTimestamp, int64(row.TxStatus), row.TxLabel,
+	)
+}
+
+// txInfoFromPgRow converts one normalized postgres query row into the public
+// TxInfo shape.
+func txInfoFromPgRow(hash []byte, rawTx []byte, received time.Time,
+	blockHeight sql.NullInt32, blockHash []byte, blockTimestamp sql.NullInt64,
+	status int64, label string) (*TxInfo, error) {
+
+	var (
+		block *Block
+		err   error
+	)
+
+	// Unmined rows legitimately have no block metadata, so only build the Block
+	// shape when the row still carries a valid height.
+	if blockHeight.Valid {
+		block, err = buildPgBlock(blockHeight, blockHash, blockTimestamp)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return buildTxInfo(hash, rawTx, received, block, status, label)
+}

--- a/wallet/internal/db/postgres_txstore_listtxns.go
+++ b/wallet/internal/db/postgres_txstore_listtxns.go
@@ -1,0 +1,104 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
+)
+
+// ListTxns lists wallet-scoped transactions using either the confirmed-range
+// or unmined-only read path.
+//
+// The no-confirming-block path returns every row without a confirming block,
+// including retained invalid history such as orphaned or failed transactions,
+// while the confirmed path is bounded by the requested height range.
+func (s *PostgresStore) ListTxns(ctx context.Context,
+	query ListTxnsQuery) ([]TxInfo, error) {
+
+	if query.UnminedOnly {
+		return s.listTxnsWithoutBlockPg(ctx, query.WalletID)
+	}
+
+	return s.listConfirmedTxnsPg(ctx, query)
+}
+
+// listTxnsWithoutBlockPg loads every transaction row that currently has no
+// confirming block. This includes the active unmined set together with any
+// retained invalid history that rollback or invalidation flows left without a
+// confirming block.
+func (s *PostgresStore) listTxnsWithoutBlockPg(ctx context.Context,
+	walletID uint32) ([]TxInfo, error) {
+
+	rows, err := s.queries.ListTransactionsWithoutBlock(ctx, int64(walletID))
+	if err != nil {
+		return nil, fmt.Errorf("list txns without block: %w", err)
+	}
+
+	infos := make([]TxInfo, len(rows))
+	for i, row := range rows {
+		info, err := txInfoFromPgRow(
+			row.TxHash, row.RawTx, row.ReceivedTime, row.BlockHeight,
+			row.BlockHash, row.BlockTimestamp, int64(row.TxStatus), row.TxLabel,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		infos[i] = *info
+	}
+
+	return infos, nil
+}
+
+// listConfirmedTxnsPg loads the confirmed height-range view used by ListTxns
+// when callers query mined history.
+func (s *PostgresStore) listConfirmedTxnsPg(ctx context.Context,
+	query ListTxnsQuery) ([]TxInfo, error) {
+
+	startHeight, err := uint32ToInt32(query.StartHeight)
+	if err != nil {
+		return nil, fmt.Errorf("convert start height: %w", err)
+	}
+
+	endHeight, err := uint32ToInt32(query.EndHeight)
+	if err != nil {
+		return nil, fmt.Errorf("convert end height: %w", err)
+	}
+
+	rows, err := s.queries.ListTransactionsByHeightRange(
+		ctx, sqlcpg.ListTransactionsByHeightRangeParams{
+			WalletID:    int64(query.WalletID),
+			StartHeight: startHeight,
+			EndHeight:   endHeight,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list txns by height: %w", err)
+	}
+
+	infos := make([]TxInfo, len(rows))
+	for i, row := range rows {
+		block, err := buildPgBlock(
+			row.BlockHeight,
+			row.BlockHash,
+			sql.NullInt64{Int64: row.BlockTimestamp, Valid: true},
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		info, err := buildTxInfo(
+			row.TxHash, row.RawTx, row.ReceivedTime, block,
+			int64(row.TxStatus), row.TxLabel,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		infos[i] = *info
+	}
+
+	return infos, nil
+}

--- a/wallet/internal/db/postgres_txstore_rollback.go
+++ b/wallet/internal/db/postgres_txstore_rollback.go
@@ -1,0 +1,191 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
+)
+
+// RollbackToBlock atomically removes every block at or above the provided
+// height and rewrites wallet sync-state references so the block delete can
+// succeed.
+func (s *PostgresStore) RollbackToBlock(ctx context.Context,
+	height uint32) error {
+
+	return s.ExecuteTx(ctx, func(qtx *sqlcpg.Queries) error {
+		return rollbackToBlockWithOps(ctx, height,
+			pgRollbackToBlockOps{qtx: qtx})
+	})
+}
+
+// pgRollbackToBlockOps adapts postgres sqlc queries to the shared rollback
+// sequence.
+type pgRollbackToBlockOps struct {
+	qtx *sqlcpg.Queries
+}
+
+var _ rollbackToBlockOps = (*pgRollbackToBlockOps)(nil)
+
+// listRollbackRootHashes loads the coinbase roots that a rollback disconnects
+// and groups them by wallet.
+func (o pgRollbackToBlockOps) listRollbackRootHashes(ctx context.Context,
+	height uint32) (map[uint32]map[chainhash.Hash]struct{}, error) {
+
+	rollbackHeight, err := uint32ToInt32(height)
+	if err != nil {
+		return nil, fmt.Errorf("convert rollback height: %w", err)
+	}
+
+	rows, err := o.qtx.ListRollbackCoinbaseRoots(ctx, rollbackHeight)
+	if err != nil {
+		return nil, fmt.Errorf("query rollback coinbase roots: %w", err)
+	}
+
+	return groupRollbackCoinbaseRootsPg(rows)
+}
+
+// rewindWalletSyncStateHeights clamps wallet sync-state references below the
+// rollback boundary before the block rows are deleted.
+func (o pgRollbackToBlockOps) rewindWalletSyncStateHeights(
+	ctx context.Context, height uint32) error {
+
+	// PostgreSQL stores block heights as INTEGER today, so rollback still needs
+	// a checked cast into the current int32-backed schema. On networks with
+	// Bitcoin's 10-minute target spacing, MaxInt32 would not be reached until
+	// around year 42839. Regtest can exceed that sooner because blocks are
+	// mined on demand.
+	//
+	// TODO(yy): Fix it when we are in year 42000, which will give us 800 years
+	// before it's reached.
+	rollbackHeight, err := uint32ToInt32(height)
+	if err != nil {
+		return fmt.Errorf("convert rollback height: %w", err)
+	}
+
+	newHeight := sql.NullInt32{}
+	if height > 0 {
+		newHeight, err = uint32ToNullInt32(height - 1)
+		if err != nil {
+			return fmt.Errorf("convert new height: %w", err)
+		}
+	}
+
+	_, err = o.qtx.RewindWalletSyncStateHeightsForRollback(
+		ctx, sqlcpg.RewindWalletSyncStateHeightsForRollbackParams{
+			RollbackHeight: rollbackHeight,
+			NewHeight:      newHeight,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("rewind wallet sync state heights query: %w", err)
+	}
+
+	return nil
+}
+
+// deleteBlocksAtOrAboveHeight removes the shared block rows after sync-state
+// references have been rewound.
+func (o pgRollbackToBlockOps) deleteBlocksAtOrAboveHeight(
+	ctx context.Context, height uint32) error {
+
+	rollbackHeight, err := uint32ToInt32(height)
+	if err != nil {
+		return fmt.Errorf("convert rollback height: %w", err)
+	}
+
+	_, err = o.qtx.DeleteBlocksAtOrAboveHeight(ctx, rollbackHeight)
+	if err != nil {
+		return fmt.Errorf("delete blocks at or above height query: %w", err)
+	}
+
+	return nil
+}
+
+// listUnminedTxRecords loads and decodes every unmined transaction row for the
+// wallet so the shared helper can inspect raw inputs for descendant edges.
+func (o pgRollbackToBlockOps) listUnminedTxRecords(
+	ctx context.Context, walletID int64) ([]unminedTxRecord, error) {
+
+	rows, err := o.qtx.ListUnminedTransactions(ctx, walletID)
+	if err != nil {
+		return nil, fmt.Errorf("list unmined txns: %w", err)
+	}
+
+	return buildUnminedTxRecords(rows,
+		func(row sqlcpg.ListUnminedTransactionsRow) (int64, []byte, []byte) {
+			return row.ID, row.TxHash, row.RawTx
+		},
+	)
+}
+
+// clearDescendantSpends removes any wallet-owned spend edges claimed by one
+// invalid descendant transaction before its status is rewritten.
+func (o pgRollbackToBlockOps) clearDescendantSpends(
+	ctx context.Context, walletID int64, descendantID int64) error {
+
+	_, err := o.qtx.ClearUtxosSpentByTxID(
+		ctx, sqlcpg.ClearUtxosSpentByTxIDParams{
+			WalletID: walletID,
+			SpentByTxID: sql.NullInt64{
+				Int64: descendantID,
+				Valid: true,
+			},
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("clear descendant spends: %w", err)
+	}
+
+	return nil
+}
+
+// markDescendantsFailed batch-marks the collected rollback descendants as
+// failed once every dependent spend edge has been cleared.
+func (o pgRollbackToBlockOps) markDescendantsFailed(
+	ctx context.Context, walletID int64, descendantIDs []int64) error {
+
+	_, err := o.qtx.UpdateTransactionStatusByIDs(
+		ctx, sqlcpg.UpdateTransactionStatusByIDsParams{
+			WalletID: walletID,
+			Status:   int16(TxStatusFailed),
+			TxIds:    descendantIDs,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("mark descendants failed: %w", err)
+	}
+
+	return nil
+}
+
+// groupRollbackCoinbaseRootsPg groups rollback-affected coinbase hashes by
+// wallet so descendant invalidation can reuse wallet-scoped unmined queries.
+func groupRollbackCoinbaseRootsPg(rows []sqlcpg.ListRollbackCoinbaseRootsRow) (
+	map[uint32]map[chainhash.Hash]struct{}, error) {
+
+	rootHashesByWallet := make(
+		map[uint32]map[chainhash.Hash]struct{}, len(rows),
+	)
+	for _, row := range rows {
+		walletID, err := int64ToUint32(row.WalletID)
+		if err != nil {
+			return nil, fmt.Errorf("rollback coinbase wallet id: %w", err)
+		}
+
+		txHash, err := chainhash.NewHash(row.TxHash)
+		if err != nil {
+			return nil, fmt.Errorf("rollback coinbase hash: %w", err)
+		}
+
+		if _, ok := rootHashesByWallet[walletID]; !ok {
+			rootHashesByWallet[walletID] = make(map[chainhash.Hash]struct{})
+		}
+
+		rootHashesByWallet[walletID][*txHash] = struct{}{}
+	}
+
+	return rootHashesByWallet, nil
+}

--- a/wallet/internal/db/postgres_txstore_updatetx.go
+++ b/wallet/internal/db/postgres_txstore_updatetx.go
@@ -1,0 +1,134 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
+)
+
+// UpdateTx patches the mutable metadata for one wallet-scoped transaction.
+//
+// UpdateTx may edit the user-visible label, the block/status view, or both in
+// one SQL transaction. Immutable transaction facts such as raw_tx, credits, and
+// spent-input edges stay owned by CreateTx and the internal rollback/delete
+// flows.
+func (s *PostgresStore) UpdateTx(ctx context.Context,
+	params UpdateTxParams) error {
+
+	return s.ExecuteTx(ctx, func(qtx *sqlcpg.Queries) error {
+		return updateTxWithOps(ctx, params, &pgUpdateTxOps{qtx: qtx})
+	})
+}
+
+// pgUpdateTxOps adapts postgres sqlc queries to the shared UpdateTx flow.
+type pgUpdateTxOps struct {
+	// qtx is the transaction-scoped postgres query set used by UpdateTx.
+	qtx *sqlcpg.Queries
+
+	// blockHeight caches the validated postgres block-height wrapper prepared
+	// for the later state update query.
+	blockHeight sql.NullInt32
+
+	// status caches the postgres status code prepared for the later state
+	// update query.
+	status int16
+}
+
+var _ updateTxOps = (*pgUpdateTxOps)(nil)
+
+// loadIsCoinbase loads the existing row metadata UpdateTx needs before it can
+// validate one patch.
+func (o *pgUpdateTxOps) loadIsCoinbase(ctx context.Context, walletID uint32,
+	txHash chainhash.Hash) (bool, error) {
+
+	meta, err := o.qtx.GetTransactionMetaByHash(
+		ctx,
+		sqlcpg.GetTransactionMetaByHashParams{
+			WalletID: int64(walletID),
+			TxHash:   txHash[:],
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, fmt.Errorf("tx %s: %w", txHash, ErrTxNotFound)
+		}
+
+		return false, fmt.Errorf("get tx metadata: %w", err)
+	}
+
+	return meta.IsCoinbase, nil
+}
+
+// prepareState validates any referenced confirming block and captures the
+// postgres-specific state params for the later row update.
+func (o *pgUpdateTxOps) prepareState(ctx context.Context,
+	state UpdateTxState) error {
+
+	blockHeight := sql.NullInt32{}
+
+	if state.Block != nil {
+		height, err := requireBlockMatchesPg(ctx, o.qtx, state.Block)
+		if err != nil {
+			return fmt.Errorf("require confirming block: %w", err)
+		}
+
+		blockHeight = sql.NullInt32{Int32: height, Valid: true}
+	}
+
+	o.blockHeight = blockHeight
+	o.status = int16(state.Status)
+
+	return nil
+}
+
+// updateState writes one block/status patch after prepareState has validated
+// any referenced block metadata.
+func (o *pgUpdateTxOps) updateState(ctx context.Context, walletID uint32,
+	txHash chainhash.Hash, _ UpdateTxState) error {
+
+	rows, err := o.qtx.UpdateTransactionStateByHash(
+		ctx,
+		sqlcpg.UpdateTransactionStateByHashParams{
+			BlockHeight: o.blockHeight,
+			Status:      o.status,
+			WalletID:    int64(walletID),
+			TxHash:      txHash[:],
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("update tx state query: %w", err)
+	}
+
+	if rows == 0 {
+		return fmt.Errorf("tx %s: %w", txHash, ErrTxNotFound)
+	}
+
+	return nil
+}
+
+// updateLabel writes one user-visible label change.
+func (o *pgUpdateTxOps) updateLabel(ctx context.Context, walletID uint32,
+	txHash chainhash.Hash, label string) error {
+
+	rows, err := o.qtx.UpdateTransactionLabelByHash(
+		ctx,
+		sqlcpg.UpdateTransactionLabelByHashParams{
+			Label:    label,
+			WalletID: int64(walletID),
+			TxHash:   txHash[:],
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("update tx label query: %w", err)
+	}
+
+	if rows == 0 {
+		return fmt.Errorf("tx %s: %w", txHash, ErrTxNotFound)
+	}
+
+	return nil
+}

--- a/wallet/internal/db/sqlite_txstore_createtx.go
+++ b/wallet/internal/db/sqlite_txstore_createtx.go
@@ -1,0 +1,299 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
+)
+
+// CreateTx atomically records a wallet-scoped transaction row, its wallet-owned
+// credits, and any spend edges created by its inputs.
+//
+// The full write runs inside ExecuteTx so the transaction row, created UTXOs,
+// and spent-parent markers are either committed together or not at all.
+// Received timestamps are normalized to UTC before insert. CreateTx is
+// insert-only and returns ErrTxAlreadyExists if the wallet already stores the
+// tx hash.
+func (s *SqliteStore) CreateTx(ctx context.Context,
+	params CreateTxParams) error {
+
+	req, err := newCreateTxRequest(params)
+	if err != nil {
+		return err
+	}
+
+	return s.ExecuteTx(ctx, func(qtx *sqlcsqlite.Queries) error {
+		return createTxWithOps(ctx, req, &sqliteCreateTxOps{qtx: qtx})
+	})
+}
+
+// sqliteCreateTxOps adapts sqlite sqlc queries to the shared CreateTx flow.
+type sqliteCreateTxOps struct {
+	qtx *sqlcsqlite.Queries
+
+	blockHeight sql.NullInt64
+}
+
+var _ createTxOps = (*sqliteCreateTxOps)(nil)
+
+// hasExisting reports whether the wallet already stores the requested tx hash.
+func (o *sqliteCreateTxOps) hasExisting(ctx context.Context,
+	req createTxRequest) (bool, error) {
+
+	_, err := o.qtx.GetTransactionMetaByHash(
+		ctx,
+		sqlcsqlite.GetTransactionMetaByHashParams{
+			WalletID: int64(req.params.WalletID),
+			TxHash:   req.txHash[:],
+		},
+	)
+
+	// Exit early if there is no error.
+	if err == nil {
+		return true, nil
+	}
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+
+	return false, fmt.Errorf("get tx metadata: %w", err)
+}
+
+// prepareBlock validates the optional confirming block and caches the sqlite
+// block-height value that the later insert query will store.
+func (o *sqliteCreateTxOps) prepareBlock(ctx context.Context,
+	req createTxRequest) error {
+
+	o.blockHeight = sql.NullInt64{}
+
+	if req.params.Block == nil {
+		return nil
+	}
+
+	height, err := requireBlockMatchesSqlite(ctx, o.qtx, req.params.Block)
+	if err != nil {
+		return err
+	}
+
+	o.blockHeight = sql.NullInt64{Int64: height, Valid: true}
+
+	return nil
+}
+
+// insert stores one new sqlite transaction row for CreateTx.
+func (o *sqliteCreateTxOps) insert(ctx context.Context,
+	req createTxRequest) (int64, error) {
+
+	txID, err := o.qtx.InsertTransaction(
+		ctx,
+		sqlcsqlite.InsertTransactionParams{
+			WalletID:     int64(req.params.WalletID),
+			TxHash:       req.txHash[:],
+			RawTx:        req.rawTx,
+			BlockHeight:  o.blockHeight,
+			TxStatus:     int64(req.params.Status),
+			ReceivedTime: req.received,
+			IsCoinbase:   req.isCoinbase,
+			TxLabel:      req.params.Label,
+		},
+	)
+	if err != nil {
+		return 0, fmt.Errorf("insert tx row: %w", err)
+	}
+
+	return txID, nil
+}
+
+// insertCredits stores any wallet-owned outputs created by the transaction.
+func (o *sqliteCreateTxOps) insertCredits(ctx context.Context,
+	req createTxRequest, txID int64) error {
+
+	return insertCreditsSqlite(ctx, o.qtx, req.params, txID)
+}
+
+// markInputsSpent records wallet-owned inputs spent by the transaction.
+func (o *sqliteCreateTxOps) markInputsSpent(ctx context.Context,
+	req createTxRequest, txID int64) error {
+
+	return markInputsSpentSqlite(ctx, o.qtx, req.params, txID)
+}
+
+// insertCreditsSqlite inserts one wallet-owned UTXO row for each credited
+// output of the transaction being stored.
+func insertCreditsSqlite(ctx context.Context, qtx *sqlcsqlite.Queries,
+	params CreateTxParams, txID int64) error {
+
+	for index := range params.Credits {
+		creditExists, err := creditExistsSqlite(
+			ctx, qtx, params.WalletID, params.Tx.TxHash(), index,
+		)
+		if err != nil {
+			return err
+		}
+
+		if creditExists {
+			continue
+		}
+
+		pkScript := params.Tx.TxOut[index].PkScript
+
+		addrRow, err := qtx.GetAddressByScriptPubKey(
+			ctx, sqlcsqlite.GetAddressByScriptPubKeyParams{
+				ScriptPubKey: pkScript,
+				WalletID:     int64(params.WalletID),
+			},
+		)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("credit output %d: %w", index,
+					ErrAddressNotFound)
+			}
+
+			return fmt.Errorf("resolve credit address %d: %w", index, err)
+		}
+
+		_, err = qtx.InsertUtxo(ctx, sqlcsqlite.InsertUtxoParams{
+			WalletID:    int64(params.WalletID),
+			TxID:        txID,
+			OutputIndex: int64(index),
+			Amount:      params.Tx.TxOut[index].Value,
+			AddressID:   addrRow.ID,
+		})
+		if err != nil {
+			return fmt.Errorf("insert credit output %d: %w", index, err)
+		}
+	}
+
+	return nil
+}
+
+// creditExistsSqlite reports whether the wallet already has a UTXO row for the
+// given credited output, even if that output is now spent by a child tx.
+func creditExistsSqlite(ctx context.Context, qtx *sqlcsqlite.Queries,
+	walletID uint32, txHash chainhash.Hash, outputIndex uint32) (bool, error) {
+
+	_, err := qtx.GetUtxoSpendByOutpoint(
+		ctx, sqlcsqlite.GetUtxoSpendByOutpointParams{
+			WalletID:    int64(walletID),
+			TxHash:      txHash[:],
+			OutputIndex: int64(outputIndex),
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("lookup credit output %d: %w", outputIndex,
+			err)
+	}
+
+	return true, nil
+}
+
+// markInputsSpentSqlite attaches wallet-owned outpoints spent by the stored
+// transaction to its row ID and input indexes.
+//
+// If another wallet transaction already owns the spend edge for a
+// wallet-controlled input, the create path fails with ErrTxInputConflict
+// instead of silently storing a second spender. Inputs that reference a
+// wallet-owned output whose parent transaction is already invalid fail with
+// ErrTxInputInvalidParent.
+func markInputsSpentSqlite(ctx context.Context, qtx *sqlcsqlite.Queries,
+	params CreateTxParams, txID int64) error {
+
+	if blockchain.IsCoinBaseTx(params.Tx) {
+		return nil
+	}
+
+	for inputIndex, txIn := range params.Tx.TxIn {
+		spentInputIndex := sql.NullInt64{Int64: int64(inputIndex), Valid: true}
+
+		rowsAffected, err := qtx.MarkUtxoSpent(ctx,
+			sqlcsqlite.MarkUtxoSpentParams{
+				WalletID:        int64(params.WalletID),
+				TxHash:          txIn.PreviousOutPoint.Hash[:],
+				OutputIndex:     int64(txIn.PreviousOutPoint.Index),
+				SpentByTxID:     sql.NullInt64{Int64: txID, Valid: true},
+				SpentInputIndex: spentInputIndex,
+			})
+		if err != nil {
+			return fmt.Errorf("mark spent input %d: %w", inputIndex, err)
+		}
+
+		if rowsAffected == 0 {
+			err = ensureSpendConflictSqlite(
+				ctx, qtx, params.WalletID, txIn.PreviousOutPoint.Hash,
+				int64(txIn.PreviousOutPoint.Index), txID,
+			)
+			if err != nil {
+				return fmt.Errorf("mark spent input %d: %w", inputIndex, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// ensureSpendConflictSqlite reports ErrTxInputConflict when the referenced
+// outpoint is wallet-owned, still eligible for spending, and already attached
+// to another transaction. If the wallet owns the parent output but that parent
+// is already invalid, the helper returns ErrTxInputInvalidParent instead.
+func ensureSpendConflictSqlite(ctx context.Context,
+	qtx *sqlcsqlite.Queries, walletID uint32, txHash chainhash.Hash,
+	outputIndex int64, txID int64) error {
+
+	spendByTxID, err := qtx.GetUtxoSpendByOutpoint(
+		ctx, sqlcsqlite.GetUtxoSpendByOutpointParams{
+			WalletID:    int64(walletID),
+			TxHash:      txHash[:],
+			OutputIndex: outputIndex,
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ensureWalletParentValidSqlite(
+				ctx, qtx, walletID, txHash, outputIndex,
+			)
+		}
+
+		return fmt.Errorf("check spend conflict: %w", err)
+	}
+
+	if spendByTxID.Valid && spendByTxID.Int64 != txID {
+		return ErrTxInputConflict
+	}
+
+	return nil
+}
+
+// ensureWalletParentValidSqlite reports ErrTxInputInvalidParent when the
+// wallet owns the referenced outpoint but its parent transaction is already
+// invalid.
+func ensureWalletParentValidSqlite(ctx context.Context,
+	qtx *sqlcsqlite.Queries, walletID uint32, txHash chainhash.Hash,
+	outputIndex int64) error {
+
+	hasInvalid, err := qtx.HasInvalidWalletUtxoByOutpoint(
+		ctx, sqlcsqlite.HasInvalidWalletUtxoByOutpointParams{
+			WalletID:    int64(walletID),
+			TxHash:      txHash[:],
+			OutputIndex: outputIndex,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("check invalid wallet parent: %w", err)
+	}
+
+	if hasInvalid {
+		return ErrTxInputInvalidParent
+	}
+
+	return nil
+}

--- a/wallet/internal/db/sqlite_txstore_deletetx.go
+++ b/wallet/internal/db/sqlite_txstore_deletetx.go
@@ -1,0 +1,187 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
+)
+
+// DeleteTx atomically removes one unmined transaction and restores any wallet
+// UTXO rows that it had spent.
+//
+// DeleteTx is limited to unmined pending/published rows; confirmed rows and
+// terminal invalid-history rows remain part of the wallet timeline. The
+// transaction must also be a leaf among the wallet's unmined transactions so
+// the delete cannot detach child spenders from their parent history.
+func (s *SqliteStore) DeleteTx(ctx context.Context,
+	params DeleteTxParams) error {
+
+	return s.ExecuteTx(ctx, func(qtx *sqlcsqlite.Queries) error {
+		return deleteTxWithOps(ctx, params, sqliteDeleteTxOps{qtx: qtx})
+	})
+}
+
+// sqliteDeleteTxOps adapts sqlite sqlc queries to the shared DeleteTx flow.
+type sqliteDeleteTxOps struct {
+	qtx *sqlcsqlite.Queries
+}
+
+var _ deleteTxOps = (*sqliteDeleteTxOps)(nil)
+
+// loadDeleteTarget loads and validates the unmined transaction row DeleteTx is
+// allowed to remove.
+func (o sqliteDeleteTxOps) loadDeleteTarget(ctx context.Context,
+	walletID uint32, txHash chainhash.Hash) (int64, error) {
+
+	meta, err := getDeleteTxMetaSqlite(ctx, o.qtx, walletID, txHash)
+	if err != nil {
+		return 0, err
+	}
+
+	return meta.ID, nil
+}
+
+// ensureLeaf rejects DeleteTx when the target still has direct unmined child
+// spenders.
+func (o sqliteDeleteTxOps) ensureLeaf(ctx context.Context, walletID uint32,
+	txHash chainhash.Hash, txID int64) error {
+
+	return ensureDeleteLeafSqlite(ctx, o.qtx, walletID, txHash, txID)
+}
+
+// clearSpentUtxos restores any wallet-owned parent outputs the transaction had
+// marked spent.
+func (o sqliteDeleteTxOps) clearSpentUtxos(ctx context.Context,
+	walletID uint32, txID int64) error {
+
+	_, err := o.qtx.ClearUtxosSpentByTxID(
+		ctx,
+		sqlcsqlite.ClearUtxosSpentByTxIDParams{
+			WalletID:    int64(walletID),
+			SpentByTxID: sql.NullInt64{Int64: txID, Valid: true},
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("clear spent utxo rows: %w", err)
+	}
+
+	return nil
+}
+
+// deleteCreatedUtxos removes any wallet-owned outputs created by the
+// transaction being deleted.
+func (o sqliteDeleteTxOps) deleteCreatedUtxos(ctx context.Context,
+	walletID uint32, txID int64) error {
+
+	_, err := o.qtx.DeleteUtxosByTxID(
+		ctx,
+		sqlcsqlite.DeleteUtxosByTxIDParams{
+			WalletID: int64(walletID),
+			TxID:     txID,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("delete created utxo rows: %w", err)
+	}
+
+	return nil
+}
+
+// deleteUnminedTransaction removes the target unmined row after its dependent
+// wallet state has been cleaned up.
+func (o sqliteDeleteTxOps) deleteUnminedTransaction(ctx context.Context,
+	walletID uint32, txHash chainhash.Hash) (int64, error) {
+
+	rows, err := o.qtx.DeleteUnminedTransactionByHash(
+		ctx,
+		sqlcsqlite.DeleteUnminedTransactionByHashParams{
+			WalletID: int64(walletID),
+			TxHash:   txHash[:],
+		},
+	)
+	if err != nil {
+		return 0, fmt.Errorf("delete unmined tx row: %w", err)
+	}
+
+	return rows, nil
+}
+
+// ensureDeleteLeafSqlite rejects DeleteTx requests for transactions that still
+// have direct unmined child spenders, including children that spend non-credit
+// parent outputs.
+func ensureDeleteLeafSqlite(ctx context.Context, qtx *sqlcsqlite.Queries,
+	walletID uint32, txHash chainhash.Hash, txID int64) error {
+
+	rows, err := qtx.ListUnminedTransactions(ctx, int64(walletID))
+	if err != nil {
+		return fmt.Errorf("list unmined txns: %w", err)
+	}
+
+	candidates, err := buildUnminedTxRecords(
+		rows,
+		func(row sqlcsqlite.ListUnminedTransactionsRow) (int64,
+			[]byte, []byte) {
+
+			return row.ID, row.TxHash, row.RawTx
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	filtered := candidates[:0]
+	for _, candidate := range candidates {
+		if candidate.id == txID {
+			continue
+		}
+
+		filtered = append(filtered, candidate)
+	}
+
+	if len(collectDirectChildTxIDs(txHash, filtered)) > 0 {
+		return fmt.Errorf("delete tx %s: %w", txHash,
+			ErrDeleteRequiresLeaf)
+	}
+
+	return nil
+}
+
+// getDeleteTxMetaSqlite loads the transaction metadata DeleteTx needs and
+// enforces the unmined precondition up front.
+func getDeleteTxMetaSqlite(ctx context.Context, qtx *sqlcsqlite.Queries,
+	walletID uint32, txHash chainhash.Hash) (
+	sqlcsqlite.GetTransactionMetaByHashRow, error) {
+
+	meta, err := qtx.GetTransactionMetaByHash(
+		ctx, sqlcsqlite.GetTransactionMetaByHashParams{
+			WalletID: int64(walletID),
+			TxHash:   txHash[:],
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return sqlcsqlite.GetTransactionMetaByHashRow{},
+				fmt.Errorf("tx %s: %w", txHash, ErrTxNotFound)
+		}
+
+		return sqlcsqlite.GetTransactionMetaByHashRow{},
+			fmt.Errorf("get tx metadata: %w", err)
+	}
+
+	status, err := parseTxStatus(meta.TxStatus)
+	if err != nil {
+		return sqlcsqlite.GetTransactionMetaByHashRow{}, err
+	}
+
+	if meta.BlockHeight.Valid || !isUnminedStatus(status) {
+		return sqlcsqlite.GetTransactionMetaByHashRow{},
+			fmt.Errorf("delete tx %s: %w", txHash,
+				ErrDeleteRequiresUnmined)
+	}
+
+	return meta, nil
+}

--- a/wallet/internal/db/sqlite_txstore_gettx.go
+++ b/wallet/internal/db/sqlite_txstore_gettx.go
@@ -1,0 +1,61 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
+)
+
+// GetTx retrieves one wallet-scoped transaction snapshot by hash.
+//
+// The returned TxInfo is rebuilt from normalized SQL columns; missing rows map
+// to ErrTxNotFound for the requested wallet/hash pair.
+func (s *SqliteStore) GetTx(ctx context.Context,
+	query GetTxQuery) (*TxInfo, error) {
+
+	row, err := s.queries.GetTransactionByHash(
+		ctx, sqlcsqlite.GetTransactionByHashParams{
+			WalletID: int64(query.WalletID),
+			TxHash:   query.Txid[:],
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("tx %s: %w", query.Txid, ErrTxNotFound)
+		}
+
+		return nil, fmt.Errorf("get tx: %w", err)
+	}
+
+	return txInfoFromSqliteRow(
+		row.TxHash, row.RawTx, row.ReceivedTime, row.BlockHeight,
+		row.BlockHash, row.BlockTimestamp, row.TxStatus, row.TxLabel,
+	)
+}
+
+// txInfoFromSqliteRow converts one normalized sqlite query row into the public
+// TxInfo shape.
+func txInfoFromSqliteRow(hash []byte, rawTx []byte, received time.Time,
+	blockHeight sql.NullInt64, blockHash []byte, blockTimestamp sql.NullInt64,
+	status int64, label string) (*TxInfo, error) {
+
+	var (
+		block *Block
+		err   error
+	)
+
+	// Unmined rows legitimately have no block metadata, so only build the Block
+	// shape when the row still carries a valid height.
+	if blockHeight.Valid {
+		block, err = buildSqliteBlock(blockHeight, blockHash, blockTimestamp)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return buildTxInfo(hash, rawTx, received, block, status, label)
+}

--- a/wallet/internal/db/sqlite_txstore_listtxns.go
+++ b/wallet/internal/db/sqlite_txstore_listtxns.go
@@ -1,0 +1,94 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
+)
+
+// ListTxns lists wallet-scoped transactions using either the confirmed-range
+// or unmined-only read path.
+//
+// The no-confirming-block path returns every row without a confirming block,
+// including retained invalid history such as orphaned or failed transactions,
+// while the confirmed path is bounded by the requested height range.
+func (s *SqliteStore) ListTxns(ctx context.Context,
+	query ListTxnsQuery) ([]TxInfo, error) {
+
+	if query.UnminedOnly {
+		return s.listTxnsWithoutBlockSqlite(ctx, query.WalletID)
+	}
+
+	return s.listConfirmedTxnsSqlite(ctx, query)
+}
+
+// listTxnsWithoutBlockSqlite loads every transaction row that currently has no
+// confirming block. This includes the active unmined set together with any
+// retained invalid history that rollback or invalidation flows left without a
+// confirming block.
+func (s *SqliteStore) listTxnsWithoutBlockSqlite(ctx context.Context,
+	walletID uint32) ([]TxInfo, error) {
+
+	rows, err := s.queries.ListTransactionsWithoutBlock(ctx, int64(walletID))
+	if err != nil {
+		return nil, fmt.Errorf("list txns without block: %w", err)
+	}
+
+	infos := make([]TxInfo, len(rows))
+	for i, row := range rows {
+		info, err := txInfoFromSqliteRow(
+			row.TxHash, row.RawTx, row.ReceivedTime, row.BlockHeight,
+			row.BlockHash, row.BlockTimestamp, row.TxStatus, row.TxLabel,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		infos[i] = *info
+	}
+
+	return infos, nil
+}
+
+// listConfirmedTxnsSqlite loads the confirmed height-range view used by
+// ListTxns when callers query mined history.
+func (s *SqliteStore) listConfirmedTxnsSqlite(ctx context.Context,
+	query ListTxnsQuery) ([]TxInfo, error) {
+
+	rows, err := s.queries.ListTransactionsByHeightRange(
+		ctx, sqlcsqlite.ListTransactionsByHeightRangeParams{
+			WalletID:    int64(query.WalletID),
+			StartHeight: int64(query.StartHeight),
+			EndHeight:   int64(query.EndHeight),
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list txns by height: %w", err)
+	}
+
+	infos := make([]TxInfo, len(rows))
+	for i, row := range rows {
+		block, err := buildSqliteBlock(
+			row.BlockHeight,
+			row.BlockHash,
+			sql.NullInt64{Int64: row.BlockTimestamp, Valid: true},
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		info, err := buildTxInfo(
+			row.TxHash, row.RawTx, row.ReceivedTime, block, row.TxStatus,
+			row.TxLabel,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		infos[i] = *info
+	}
+
+	return infos, nil
+}

--- a/wallet/internal/db/sqlite_txstore_rollback.go
+++ b/wallet/internal/db/sqlite_txstore_rollback.go
@@ -1,0 +1,168 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
+)
+
+// RollbackToBlock atomically removes every block at or above the provided
+// height and rewrites wallet sync-state references so the block delete can
+// succeed.
+func (s *SqliteStore) RollbackToBlock(ctx context.Context,
+	height uint32) error {
+
+	return s.ExecuteTx(ctx, func(qtx *sqlcsqlite.Queries) error {
+		return rollbackToBlockWithOps(ctx, height,
+			sqliteRollbackToBlockOps{qtx: qtx})
+	})
+}
+
+// sqliteRollbackToBlockOps adapts sqlite sqlc queries to the shared rollback
+// sequence.
+type sqliteRollbackToBlockOps struct {
+	qtx *sqlcsqlite.Queries
+}
+
+var _ rollbackToBlockOps = (*sqliteRollbackToBlockOps)(nil)
+
+// listRollbackRootHashes loads the coinbase roots that a rollback disconnects
+// and groups them by wallet.
+func (o sqliteRollbackToBlockOps) listRollbackRootHashes(ctx context.Context,
+	height uint32) (map[uint32]map[chainhash.Hash]struct{}, error) {
+
+	rows, err := o.qtx.ListRollbackCoinbaseRoots(ctx, int64(height))
+	if err != nil {
+		return nil, fmt.Errorf("query rollback coinbase roots: %w", err)
+	}
+
+	return groupRollbackCoinbaseRootsSqlite(rows)
+}
+
+// rewindWalletSyncStateHeights clamps wallet sync-state references below the
+// rollback boundary before the block rows are deleted.
+func (o sqliteRollbackToBlockOps) rewindWalletSyncStateHeights(
+	ctx context.Context, height uint32) error {
+
+	newHeight := sql.NullInt64{}
+	if height > 0 {
+		newHeight = sql.NullInt64{Int64: int64(height - 1), Valid: true}
+	}
+
+	_, err := o.qtx.RewindWalletSyncStateHeightsForRollback(
+		ctx, sqlcsqlite.RewindWalletSyncStateHeightsForRollbackParams{
+			RollbackHeight: int64(height),
+			NewHeight:      newHeight,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("rewind wallet sync state heights query: %w", err)
+	}
+
+	return nil
+}
+
+// deleteBlocksAtOrAboveHeight removes the shared block rows after sync-state
+// references have been rewound.
+func (o sqliteRollbackToBlockOps) deleteBlocksAtOrAboveHeight(
+	ctx context.Context, height uint32) error {
+
+	_, err := o.qtx.DeleteBlocksAtOrAboveHeight(ctx, int64(height))
+	if err != nil {
+		return fmt.Errorf("delete blocks at or above height query: %w", err)
+	}
+
+	return nil
+}
+
+// listUnminedTxRecords loads and decodes every unmined transaction row for the
+// wallet so the shared helper can inspect raw inputs for descendant edges.
+func (o sqliteRollbackToBlockOps) listUnminedTxRecords(
+	ctx context.Context, walletID int64) ([]unminedTxRecord, error) {
+
+	rows, err := o.qtx.ListUnminedTransactions(ctx, walletID)
+	if err != nil {
+		return nil, fmt.Errorf("list unmined txns: %w", err)
+	}
+
+	return buildUnminedTxRecords(rows,
+		func(row sqlcsqlite.ListUnminedTransactionsRow) (
+			int64, []byte, []byte) {
+
+			return row.ID, row.TxHash, row.RawTx
+		},
+	)
+}
+
+// clearDescendantSpends removes any wallet-owned spend edges claimed by one
+// invalid descendant transaction before its status is rewritten.
+func (o sqliteRollbackToBlockOps) clearDescendantSpends(
+	ctx context.Context, walletID int64, descendantID int64) error {
+
+	_, err := o.qtx.ClearUtxosSpentByTxID(
+		ctx, sqlcsqlite.ClearUtxosSpentByTxIDParams{
+			WalletID: walletID,
+			SpentByTxID: sql.NullInt64{
+				Int64: descendantID,
+				Valid: true,
+			},
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("clear descendant spends: %w", err)
+	}
+
+	return nil
+}
+
+// markDescendantsFailed batch-marks the collected rollback descendants as
+// failed once every dependent spend edge has been cleared.
+func (o sqliteRollbackToBlockOps) markDescendantsFailed(
+	ctx context.Context, walletID int64, descendantIDs []int64) error {
+
+	_, err := o.qtx.UpdateTransactionStatusByIDs(
+		ctx, sqlcsqlite.UpdateTransactionStatusByIDsParams{
+			WalletID: walletID,
+			Status:   int64(TxStatusFailed),
+			TxIds:    descendantIDs,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("mark descendants failed: %w", err)
+	}
+
+	return nil
+}
+
+// groupRollbackCoinbaseRootsSqlite groups rollback-affected coinbase hashes by
+// wallet so descendant invalidation can reuse wallet-scoped unmined queries.
+func groupRollbackCoinbaseRootsSqlite(
+	rows []sqlcsqlite.ListRollbackCoinbaseRootsRow) (
+	map[uint32]map[chainhash.Hash]struct{}, error) {
+
+	rootHashesByWallet := make(
+		map[uint32]map[chainhash.Hash]struct{}, len(rows),
+	)
+	for _, row := range rows {
+		walletID, err := int64ToUint32(row.WalletID)
+		if err != nil {
+			return nil, fmt.Errorf("rollback coinbase wallet id: %w", err)
+		}
+
+		txHash, err := chainhash.NewHash(row.TxHash)
+		if err != nil {
+			return nil, fmt.Errorf("rollback coinbase hash: %w", err)
+		}
+
+		if _, ok := rootHashesByWallet[walletID]; !ok {
+			rootHashesByWallet[walletID] = make(map[chainhash.Hash]struct{})
+		}
+
+		rootHashesByWallet[walletID][*txHash] = struct{}{}
+	}
+
+	return rootHashesByWallet, nil
+}

--- a/wallet/internal/db/sqlite_txstore_updatetx.go
+++ b/wallet/internal/db/sqlite_txstore_updatetx.go
@@ -1,0 +1,134 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
+)
+
+// UpdateTx patches the mutable metadata for one wallet-scoped transaction.
+//
+// UpdateTx may edit the user-visible label, the block/status view, or both in
+// one SQL transaction. Immutable transaction facts such as raw_tx, credits, and
+// spent-input edges stay owned by CreateTx and the internal rollback/delete
+// flows.
+func (s *SqliteStore) UpdateTx(ctx context.Context,
+	params UpdateTxParams) error {
+
+	return s.ExecuteTx(ctx, func(qtx *sqlcsqlite.Queries) error {
+		return updateTxWithOps(ctx, params, &sqliteUpdateTxOps{qtx: qtx})
+	})
+}
+
+// sqliteUpdateTxOps adapts sqlite sqlc queries to the shared UpdateTx flow.
+type sqliteUpdateTxOps struct {
+	// qtx is the transaction-scoped sqlite query set used by UpdateTx.
+	qtx *sqlcsqlite.Queries
+
+	// blockHeight caches the validated sqlite block-height wrapper prepared for
+	// the later state update query.
+	blockHeight sql.NullInt64
+
+	// status caches the sqlite status code prepared for the later state update
+	// query.
+	status int64
+}
+
+var _ updateTxOps = (*sqliteUpdateTxOps)(nil)
+
+// loadIsCoinbase loads the existing row metadata UpdateTx needs before it can
+// validate one patch.
+func (o *sqliteUpdateTxOps) loadIsCoinbase(ctx context.Context,
+	walletID uint32, txHash chainhash.Hash) (bool, error) {
+
+	meta, err := o.qtx.GetTransactionMetaByHash(
+		ctx,
+		sqlcsqlite.GetTransactionMetaByHashParams{
+			WalletID: int64(walletID),
+			TxHash:   txHash[:],
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, fmt.Errorf("tx %s: %w", txHash, ErrTxNotFound)
+		}
+
+		return false, fmt.Errorf("get tx metadata: %w", err)
+	}
+
+	return meta.IsCoinbase, nil
+}
+
+// prepareState validates any referenced confirming block and captures the
+// sqlite-specific state params for the later row update.
+func (o *sqliteUpdateTxOps) prepareState(ctx context.Context,
+	state UpdateTxState) error {
+
+	blockHeight := sql.NullInt64{}
+
+	if state.Block != nil {
+		height, err := requireBlockMatchesSqlite(ctx, o.qtx, state.Block)
+		if err != nil {
+			return fmt.Errorf("require confirming block: %w", err)
+		}
+
+		blockHeight = sql.NullInt64{Int64: height, Valid: true}
+	}
+
+	o.blockHeight = blockHeight
+	o.status = int64(state.Status)
+
+	return nil
+}
+
+// updateLabel writes one user-visible label change.
+func (o *sqliteUpdateTxOps) updateLabel(ctx context.Context, walletID uint32,
+	txHash chainhash.Hash, label string) error {
+
+	rows, err := o.qtx.UpdateTransactionLabelByHash(
+		ctx,
+		sqlcsqlite.UpdateTransactionLabelByHashParams{
+			Label:    label,
+			WalletID: int64(walletID),
+			TxHash:   txHash[:],
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("update tx label query: %w", err)
+	}
+
+	if rows == 0 {
+		return fmt.Errorf("tx %s: %w", txHash, ErrTxNotFound)
+	}
+
+	return nil
+}
+
+// updateState writes one block/status patch after prepareState has validated
+// any referenced block metadata.
+func (o *sqliteUpdateTxOps) updateState(ctx context.Context, walletID uint32,
+	txHash chainhash.Hash, _ UpdateTxState) error {
+
+	rows, err := o.qtx.UpdateTransactionStateByHash(
+		ctx,
+		sqlcsqlite.UpdateTransactionStateByHashParams{
+			BlockHeight: o.blockHeight,
+			Status:      o.status,
+			WalletID:    int64(walletID),
+			TxHash:      txHash[:],
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("update tx state query: %w", err)
+	}
+
+	if rows == 0 {
+		return fmt.Errorf("tx %s: %w", txHash, ErrTxNotFound)
+	}
+
+	return nil
+}

--- a/wallet/internal/db/tx_store_common.go
+++ b/wallet/internal/db/tx_store_common.go
@@ -2,10 +2,12 @@ package db
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"time"
 
+	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 )
@@ -17,6 +19,14 @@ var (
 	// ErrInvalidStatus is returned when a transaction status is unknown or not
 	// allowed for the requested operation.
 	ErrInvalidStatus = errors.New("invalid transaction status")
+
+	// ErrIndexOutOfRange is returned when a referenced transaction input or
+	// output index does not exist.
+	ErrIndexOutOfRange = errors.New("index out of range")
+
+	// ErrDuplicateInputOutPoint is returned when CreateTx receives the same
+	// previous outpoint more than once.
+	ErrDuplicateInputOutPoint = errors.New("duplicate input outpoint")
 )
 
 // serializeMsgTx serializes a wire.MsgTx so it can be stored in the
@@ -96,4 +106,226 @@ func buildTxInfo(hash []byte, rawTx []byte, received time.Time, block *Block,
 		Status:       txStatus,
 		Label:        label,
 	}, nil
+}
+
+// validateCreateTxParams enforces the CreateTx invariants shared by both SQL
+// backends after serializeMsgTx has already verified that params.Tx is non-nil.
+func validateCreateTxParams(params CreateTxParams) error {
+	isCoinbase := blockchain.IsCoinBaseTx(params.Tx)
+
+	err := validateCreateTxStatus(
+		params.Status, params.Block != nil, isCoinbase,
+	)
+	if err != nil {
+		return err
+	}
+
+	maxIndex := uint64(len(params.Tx.TxOut))
+
+	for index := range params.Credits {
+		if uint64(index) >= maxIndex {
+			return fmt.Errorf("%w: credit index %d is out of range: %w",
+				ErrInvalidParam, index, ErrIndexOutOfRange)
+		}
+	}
+
+	// Coinbase transactions only enter wallet history once a block already
+	// anchors them, so CreateTx requires the caller to provide that block up
+	// front instead of storing a fake unmined intermediate row first.
+	if isCoinbase {
+		return nil
+	}
+
+	seenInputs := make(map[wire.OutPoint]struct{}, len(params.Tx.TxIn))
+	for inputIndex, txIn := range params.Tx.TxIn {
+		// One transaction cannot spend the same previous outpoint twice.
+		// Rejecting duplicate inputs here keeps the later wallet-spend walk
+		// simple and avoids writing contradictory spend metadata.
+		if _, ok := seenInputs[txIn.PreviousOutPoint]; ok {
+			return fmt.Errorf("%w: input %d duplicates a previous outpoint: %w",
+				ErrInvalidParam, inputIndex, ErrDuplicateInputOutPoint)
+		}
+
+		seenInputs[txIn.PreviousOutPoint] = struct{}{}
+	}
+
+	return nil
+}
+
+// validateCreateTxStatus checks the status/block combinations that CreateTx may
+// store directly.
+func validateCreateTxStatus(status TxStatus, hasBlock bool,
+	isCoinbase bool) error {
+
+	_, err := parseTxStatus(int64(status))
+	if err != nil {
+		return fmt.Errorf("%w: status %d is not supported: %w",
+			ErrInvalidParam, status, ErrInvalidStatus)
+	}
+
+	// Orphaned rows only arise later when rollback disconnects a confirmed
+	// coinbase transaction. CreateTx records the initial observed facts, so it
+	// never inserts orphaned history directly.
+	if status == TxStatusOrphaned {
+		return fmt.Errorf("%w: CreateTx cannot insert orphaned txns: %w",
+			ErrInvalidParam, ErrInvalidStatus)
+	}
+
+	if !hasBlock {
+		// Coinbase transactions cannot exist without a confirming block from
+		// the store's point of view, so callers must supply that block up
+		// front.
+		if isCoinbase {
+			return fmt.Errorf("%w: coinbase txns require a block: %w",
+				ErrInvalidParam, ErrInvalidStatus)
+		}
+
+		// Unmined non-coinbase inserts still represent current unmined wallet
+		// history, so CreateTx only accepts the two active unmined statuses
+		// there.
+		if status != TxStatusPending && status != TxStatusPublished {
+			return fmt.Errorf("%w: CreateTx requires pending or published: %w",
+				ErrInvalidParam, ErrInvalidStatus)
+		}
+
+		return nil
+	}
+
+	// A non-nil block means the caller already knows the transaction is mined.
+	// Mined rows must be published immediately to satisfy the transaction-state
+	// invariants enforced by the schema.
+	if status != TxStatusPublished {
+		return fmt.Errorf("%w: confirmed txns must be published: %w",
+			ErrInvalidParam, ErrInvalidStatus)
+	}
+
+	return nil
+}
+
+// createTxRequest captures the backend-independent CreateTx inputs after the
+// shared validation and normalization step has already succeeded.
+type createTxRequest struct {
+	// params keeps the original public request available for backend helpers
+	// that still need the caller-supplied CreateTx metadata.
+	params CreateTxParams
+
+	// rawTx stores the serialized transaction bytes once so both backends reuse
+	// the same payload throughout the write.
+	rawTx []byte
+
+	// txHash avoids recomputing the transaction hash across the shared flow and
+	// backend adapters.
+	txHash chainhash.Hash
+
+	// received is normalized to UTC before any backend insert logic runs.
+	received time.Time
+
+	// isCoinbase caches the consensus coinbase check for backend insert params.
+	isCoinbase bool
+}
+
+// newCreateTxRequest performs the backend-independent CreateTx preparation
+// shared by both SQL stores before they open a write transaction.
+func newCreateTxRequest(params CreateTxParams) (createTxRequest, error) {
+	rawTx, err := serializeMsgTx(params.Tx)
+	if err != nil {
+		return createTxRequest{}, err
+	}
+
+	err = validateCreateTxParams(params)
+	if err != nil {
+		return createTxRequest{}, err
+	}
+
+	return createTxRequest{
+		params:     params,
+		rawTx:      rawTx,
+		txHash:     params.Tx.TxHash(),
+		received:   params.Received.UTC(),
+		isCoinbase: blockchain.IsCoinBaseTx(params.Tx),
+	}, nil
+}
+
+// createTxOps is the small semantic adapter CreateTx needs from one SQL
+// backend.
+//
+// The shared CreateTx algorithm is intentionally linear:
+//   - load any existing wallet-scoped row for the same tx hash first
+//   - if the same tx is being reconfirmed, update that existing row instead of
+//     inserting a duplicate
+//   - validate and cache any confirming block metadata before later writes use
+//     it
+//   - when the incoming tx is confirmed, discover and invalidate any direct
+//     conflict roots before the new row claims their wallet-owned inputs
+//   - insert the base transaction row exactly once when no existing row can be
+//     reused
+//   - insert every wallet-owned credited output as a UTXO
+//   - attach any wallet-owned spent inputs to that final transaction row
+//
+// Each backend implements those steps with its own sqlc-generated query types
+// while createTxWithOps keeps the high-level sequencing in one place.
+// That sequencing matters because confirmation, conflict invalidation, credit
+// creation, and spent-input claims must either all observe the same tx row or
+// all roll back together.
+type createTxOps interface {
+	// hasExisting reports whether CreateTx would collide with an existing
+	// wallet-scoped transaction row for the same hash.
+	hasExisting(ctx context.Context, req createTxRequest) (bool, error)
+
+	// prepareBlock validates and caches any optional confirming block metadata
+	// the later insert step needs.
+	prepareBlock(ctx context.Context, req createTxRequest) error
+
+	// insert writes the base transaction row and returns its new primary key.
+	insert(ctx context.Context, req createTxRequest) (int64, error)
+
+	// insertCredits records every wallet-owned output that the caller
+	// marked as a credit for this transaction.
+	insertCredits(ctx context.Context, req createTxRequest, txID int64) error
+
+	// markInputsSpent attaches wallet-owned parent outpoints to this
+	// transaction row and rejects conflicts or invalid wallet parents.
+	markInputsSpent(ctx context.Context, req createTxRequest, txID int64) error
+}
+
+// createTxWithOps runs the backend-independent CreateTx orchestration once the
+// caller has opened a backend-specific SQL transaction.
+//
+// The helper inserts the base transaction row before it records credits or
+// spent inputs so every later step can point at one stable row ID. If any later
+// step fails, ExecuteTx rolls the whole write back.
+func createTxWithOps(ctx context.Context, req createTxRequest,
+	ops createTxOps) error {
+
+	exists, err := ops.hasExisting(ctx, req)
+	if err != nil {
+		return fmt.Errorf("prepare create tx: check existing tx: %w", err)
+	}
+
+	if exists {
+		return fmt.Errorf("prepare create tx: tx %s: %w", req.txHash,
+			ErrTxAlreadyExists)
+	}
+
+	err = ops.prepareBlock(ctx, req)
+	if err != nil {
+		return fmt.Errorf("prepare create block assignment: %w", err)
+	}
+
+	txID, err := ops.insert(ctx, req)
+	if err != nil {
+		return fmt.Errorf("insert tx: %w", err)
+	}
+
+	err = ops.insertCredits(ctx, req, txID)
+	if err != nil {
+		return fmt.Errorf("create tx credits: %w", err)
+	}
+
+	err = ops.markInputsSpent(ctx, req, txID)
+	if err != nil {
+		return fmt.Errorf("create tx spends: %w", err)
+	}
+
+	return nil
 }

--- a/wallet/internal/db/tx_store_common.go
+++ b/wallet/internal/db/tx_store_common.go
@@ -562,6 +562,50 @@ type unminedTxRecord struct {
 // the shared `(id, tx_hash, raw_tx)` shape used by the invalidation walk.
 type extractUnminedTxFn[Row any] func(Row) (int64, []byte, []byte)
 
+// rollbackToBlockOps adapts one SQL backend to the full RollbackToBlock
+// sequence, including sync-state rewinds, block deletion, and descendant
+// invalidation.
+//
+// The shared rollback algorithm is intentionally ordered:
+//   - collect rollback root hashes before block rows are removed
+//   - rewind sync-state heights that still point at the removed blocks
+//   - delete the shared block rows at or above the rollback height
+//   - mark the disconnected coinbase roots orphaned once their confirming
+//     blocks have been removed
+//   - walk the disconnected roots and invalidate dependent descendants
+//
+// The adapter methods map directly to those stages so the shared helper can own
+// the rollback sequencing while the backends keep only query details.
+type rollbackToBlockOps interface {
+	// listRollbackRootHashes returns the coinbase roots disconnected by the
+	// rollback, grouped by wallet for the later descendant walk.
+	listRollbackRootHashes(ctx context.Context,
+		height uint32) (map[uint32]map[chainhash.Hash]struct{}, error)
+
+	// rewindWalletSyncStateHeights clamps wallet sync-state references
+	// below the rollback boundary before block rows are removed.
+	rewindWalletSyncStateHeights(ctx context.Context, height uint32) error
+
+	// deleteBlocksAtOrAboveHeight removes the shared block rows at or above the
+	// rollback boundary after sync-state references have been rewound.
+	deleteBlocksAtOrAboveHeight(ctx context.Context, height uint32) error
+
+	// listUnminedTxRecords loads the wallet's current unmined transaction
+	// rows in the normalized shape the descendant walk expects.
+	listUnminedTxRecords(ctx context.Context,
+		walletID int64) ([]unminedTxRecord, error)
+
+	// clearDescendantSpends removes any wallet-owned spend edges claimed by one
+	// invalid descendant before its status is rewritten.
+	clearDescendantSpends(ctx context.Context, walletID int64,
+		descendantID int64) error
+
+	// markDescendantsFailed batch-marks the discovered descendants as
+	// failed once every dependent spend edge has been cleared.
+	markDescendantsFailed(ctx context.Context, walletID int64,
+		descendantIDs []int64) error
+}
+
 // newUnminedTxRecord decodes one normalized unmined transaction row into the
 // shared dependency-walk shape.
 func newUnminedTxRecord(id int64, hash []byte,
@@ -617,6 +661,116 @@ func collectDirectChildTxIDs(parentHash chainhash.Hash,
 	}
 
 	return childIDs
+}
+
+// collectDescendantTxIDs returns every unmined transaction that depends on any
+// of the provided root hashes, including indirect descendants discovered
+// through newly invalidated child hashes.
+func collectDescendantTxIDs(rootHashes map[chainhash.Hash]struct{},
+	candidates []unminedTxRecord) []int64 {
+
+	invalidHashes := make(map[chainhash.Hash]struct{}, len(rootHashes))
+	for hash := range rootHashes {
+		invalidHashes[hash] = struct{}{}
+	}
+
+	invalidIDs := make(map[int64]struct{}, len(candidates))
+	for changed := true; changed; {
+		changed = false
+
+		for _, candidate := range candidates {
+			if _, ok := invalidIDs[candidate.id]; ok {
+				continue
+			}
+
+			if !txSpendsAnyParent(candidate.tx, invalidHashes) {
+				continue
+			}
+
+			invalidIDs[candidate.id] = struct{}{}
+			invalidHashes[candidate.hash] = struct{}{}
+			changed = true
+		}
+	}
+
+	descendantIDs := make([]int64, 0, len(invalidIDs))
+	for _, candidate := range candidates {
+		if _, ok := invalidIDs[candidate.id]; ok {
+			descendantIDs = append(descendantIDs, candidate.id)
+		}
+	}
+
+	return descendantIDs
+}
+
+// invalidateRollbackDescendants clears spend edges and marks failed every
+// unmined descendant discovered from the provided wallet-scoped rollback roots.
+func invalidateRollbackDescendants(ctx context.Context,
+	rootHashesByWallet map[uint32]map[chainhash.Hash]struct{},
+	ops rollbackToBlockOps) error {
+
+	for walletID, rootHashes := range rootHashesByWallet {
+		walletID64 := int64(walletID)
+
+		candidates, err := ops.listUnminedTxRecords(ctx, walletID64)
+		if err != nil {
+			return fmt.Errorf("list unmined rollback descendants for "+
+				"wallet %d: %w", walletID, err)
+		}
+
+		descendantIDs := collectDescendantTxIDs(rootHashes, candidates)
+		if len(descendantIDs) == 0 {
+			continue
+		}
+
+		for _, descendantID := range descendantIDs {
+			err = ops.clearDescendantSpends(ctx, walletID64, descendantID)
+			if err != nil {
+				return fmt.Errorf("clear rollback descendant spends for "+
+					"wallet %d: %w", walletID, err)
+			}
+		}
+
+		err = ops.markDescendantsFailed(ctx, walletID64, descendantIDs)
+		if err != nil {
+			return fmt.Errorf("mark rollback descendants failed for "+
+				"wallet %d: %w", walletID, err)
+		}
+	}
+
+	return nil
+}
+
+// rollbackToBlockWithOps runs the shared RollbackToBlock sequence inside one
+// backend-specific SQL transaction.
+//
+// The helper rewinds sync-state heights before deleting blocks, then clears and
+// fails any now-invalid unmined descendants rooted in disconnected coinbase
+// history so rollback cannot leave dangling references behind.
+func rollbackToBlockWithOps(ctx context.Context, height uint32,
+	ops rollbackToBlockOps) error {
+
+	rootHashesByWallet, err := ops.listRollbackRootHashes(ctx, height)
+	if err != nil {
+		return fmt.Errorf("list rollback coinbase roots: %w", err)
+	}
+
+	err = ops.rewindWalletSyncStateHeights(ctx, height)
+	if err != nil {
+		return fmt.Errorf("rewind wallet sync state heights: %w", err)
+	}
+
+	err = ops.deleteBlocksAtOrAboveHeight(ctx, height)
+	if err != nil {
+		return fmt.Errorf("delete blocks at or above height: %w", err)
+	}
+
+	err = invalidateRollbackDescendants(ctx, rootHashesByWallet, ops)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // txSpendsAnyParent reports whether the transaction spends any hash in the

--- a/wallet/internal/db/tx_store_common.go
+++ b/wallet/internal/db/tx_store_common.go
@@ -27,6 +27,16 @@ var (
 	// ErrDuplicateInputOutPoint is returned when CreateTx receives the same
 	// previous outpoint more than once.
 	ErrDuplicateInputOutPoint = errors.New("duplicate input outpoint")
+
+	// ErrDeleteRequiresUnmined indicates that DeleteTx only accepts unmined
+	// transactions.
+	ErrDeleteRequiresUnmined = errors.New(
+		"delete requires an unmined transaction",
+	)
+
+	// ErrDeleteRequiresLeaf indicates that DeleteTx only accepts unmined
+	// transactions with no child spenders.
+	ErrDeleteRequiresLeaf = errors.New("delete requires a leaf transaction")
 )
 
 // serializeMsgTx serializes a wire.MsgTx so it can be stored in the
@@ -459,4 +469,181 @@ func updateTxWithOps(ctx context.Context, params UpdateTxParams,
 	}
 
 	return nil
+}
+
+// deleteTxOps is the minimal backend adapter the shared DeleteTx workflow
+// needs.
+//
+// The shared delete sequence is:
+//   - load and validate the target unmined row
+//   - reject deletes that would orphan direct child spenders
+//   - restore any wallet-owned parents the tx had marked spent
+//   - delete wallet-owned outputs created by the tx itself
+//   - delete the transaction row last
+//
+// DeleteTx is the ordinary leaf-cleanup path, not the invalidation path. The
+// shared helper therefore proves the leaf invariant first and only then unwinds
+// the wallet-owned state that points at the target row.
+type deleteTxOps interface {
+	// loadDeleteTarget returns the row ID of the unmined transaction
+	// DeleteTx is allowed to remove.
+	loadDeleteTarget(ctx context.Context, walletID uint32,
+		txHash chainhash.Hash) (int64, error)
+
+	// ensureLeaf rejects DeleteTx when the target still has direct
+	// unmined child spenders.
+	ensureLeaf(ctx context.Context, walletID uint32, txHash chainhash.Hash,
+		txID int64) error
+
+	// clearSpentUtxos restores any wallet-owned parent outputs the
+	// transaction had marked spent.
+	clearSpentUtxos(ctx context.Context, walletID uint32, txID int64) error
+
+	// deleteCreatedUtxos removes any wallet-owned outputs created by the
+	// transaction being deleted.
+	deleteCreatedUtxos(ctx context.Context, walletID uint32, txID int64) error
+
+	// deleteUnminedTransaction removes the target row after its dependent
+	// wallet state has been cleaned up.
+	deleteUnminedTransaction(ctx context.Context, walletID uint32,
+		txHash chainhash.Hash) (int64, error)
+}
+
+// deleteTxWithOps runs the shared DeleteTx sequence inside a backend-specific
+// SQL transaction.
+//
+// The helper restores wallet-owned parent state before deleting created wallet
+// outputs and only removes the transaction row last, so a failed delete cannot
+// leave partial wallet bookkeeping behind.
+func deleteTxWithOps(ctx context.Context, params DeleteTxParams,
+	ops deleteTxOps) error {
+
+	txID, err := ops.loadDeleteTarget(ctx, params.WalletID, params.Txid)
+	if err != nil {
+		return fmt.Errorf("load delete tx target: %w", err)
+	}
+
+	err = ops.ensureLeaf(ctx, params.WalletID, params.Txid, txID)
+	if err != nil {
+		return fmt.Errorf("check delete tx leaf: %w", err)
+	}
+
+	err = ops.clearSpentUtxos(ctx, params.WalletID, txID)
+	if err != nil {
+		return fmt.Errorf("clear spent utxos: %w", err)
+	}
+
+	err = ops.deleteCreatedUtxos(ctx, params.WalletID, txID)
+	if err != nil {
+		return fmt.Errorf("delete created utxos: %w", err)
+	}
+
+	rows, err := ops.deleteUnminedTransaction(ctx, params.WalletID, params.Txid)
+	if err != nil {
+		return fmt.Errorf("delete unmined tx: %w", err)
+	}
+
+	if rows == 0 {
+		return fmt.Errorf("tx %s: %w", params.Txid, ErrTxNotFound)
+	}
+
+	return nil
+}
+
+// unminedTxRecord is the decoded view of one unmined transaction row used by
+// shared descendant checks.
+type unminedTxRecord struct {
+	id   int64
+	hash chainhash.Hash
+	tx   *wire.MsgTx
+}
+
+// extractUnminedTxFn projects one backend-specific unmined transaction row into
+// the shared `(id, tx_hash, raw_tx)` shape used by the invalidation walk.
+type extractUnminedTxFn[Row any] func(Row) (int64, []byte, []byte)
+
+// newUnminedTxRecord decodes one normalized unmined transaction row into the
+// shared dependency-walk shape.
+func newUnminedTxRecord(id int64, hash []byte,
+	rawTx []byte) (unminedTxRecord, error) {
+
+	txHash, err := chainhash.NewHash(hash)
+	if err != nil {
+		return unminedTxRecord{}, fmt.Errorf("tx hash: %w", err)
+	}
+
+	tx, err := deserializeMsgTx(rawTx)
+	if err != nil {
+		return unminedTxRecord{}, err
+	}
+
+	return unminedTxRecord{id: id, hash: *txHash, tx: tx}, nil
+}
+
+// buildUnminedTxRecords decodes backend-specific unmined transaction rows into
+// the shared dependency-walk shape.
+func buildUnminedTxRecords[T any](rows []T,
+	extract extractUnminedTxFn[T]) ([]unminedTxRecord, error) {
+
+	records := make([]unminedTxRecord, 0, len(rows))
+	for _, row := range rows {
+		id, hash, rawTx := extract(row)
+
+		record, err := newUnminedTxRecord(id, hash, rawTx)
+		if err != nil {
+			return nil, fmt.Errorf("decode unmined tx %d: %w", id, err)
+		}
+
+		records = append(records, record)
+	}
+
+	return records, nil
+}
+
+// collectDirectChildTxIDs returns the IDs of unmined transactions that directly
+// spend any output created by the provided parent hash.
+func collectDirectChildTxIDs(parentHash chainhash.Hash,
+	candidates []unminedTxRecord) []int64 {
+
+	parentHashes := map[chainhash.Hash]struct{}{
+		parentHash: {},
+	}
+
+	childIDs := make([]int64, 0, len(candidates))
+	for _, candidate := range candidates {
+		if txSpendsAnyParent(candidate.tx, parentHashes) {
+			childIDs = append(childIDs, candidate.id)
+		}
+	}
+
+	return childIDs
+}
+
+// txSpendsAnyParent reports whether the transaction spends any hash in the
+// provided parent set.
+func txSpendsAnyParent(tx *wire.MsgTx,
+	parentHashes map[chainhash.Hash]struct{}) bool {
+
+	for _, txIn := range tx.TxIn {
+		if _, ok := parentHashes[txIn.PreviousOutPoint.Hash]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isUnminedStatus reports whether a status still represents an unmined
+// transaction that DeleteTx may erase.
+func isUnminedStatus(status TxStatus) bool {
+	switch status {
+	case TxStatusPending, TxStatusPublished:
+		return true
+
+	case TxStatusReplaced, TxStatusFailed, TxStatusOrphaned:
+		return false
+
+	default:
+		return false
+	}
 }

--- a/wallet/internal/db/tx_store_common.go
+++ b/wallet/internal/db/tx_store_common.go
@@ -1,0 +1,99 @@
+package db
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+)
+
+var (
+	// ErrInvalidParam is returned when a TxStore method receives invalid input.
+	ErrInvalidParam = errors.New("invalid param")
+
+	// ErrInvalidStatus is returned when a transaction status is unknown or not
+	// allowed for the requested operation.
+	ErrInvalidStatus = errors.New("invalid transaction status")
+)
+
+// serializeMsgTx serializes a wire.MsgTx so it can be stored in the
+// transactions table.
+func serializeMsgTx(tx *wire.MsgTx) ([]byte, error) {
+	if tx == nil {
+		return nil, fmt.Errorf("%w: tx is required", ErrInvalidParam)
+	}
+
+	var buf bytes.Buffer
+
+	err := tx.Serialize(&buf)
+	if err != nil {
+		return nil, fmt.Errorf("serialize tx: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// deserializeMsgTx deserializes a stored transaction payload back into a
+// wire.MsgTx.
+func deserializeMsgTx(rawTx []byte) (*wire.MsgTx, error) {
+	var tx wire.MsgTx
+
+	err := tx.Deserialize(bytes.NewReader(rawTx))
+	if err != nil {
+		return nil, fmt.Errorf("deserialize tx: %w", err)
+	}
+
+	return &tx, nil
+}
+
+// parseTxStatus converts a stored numeric status code into the strongly typed
+// TxStatus enum used by the public db API.
+func parseTxStatus(status int64) (TxStatus, error) {
+	txStatus, err := int64ToUint8(status)
+	if err != nil {
+		return TxStatus(0), fmt.Errorf("status %d: %w", status,
+			ErrInvalidStatus)
+	}
+
+	switch TxStatus(txStatus) {
+	case TxStatusPending,
+		TxStatusPublished,
+		TxStatusReplaced,
+		TxStatusFailed,
+		TxStatusOrphaned:
+
+		return TxStatus(txStatus), nil
+
+	default:
+		return TxStatus(0), fmt.Errorf("status %d: %w", status,
+			ErrInvalidStatus)
+	}
+}
+
+// buildTxInfo converts normalized transaction fields into the public TxInfo
+// shape returned by the db interfaces.
+func buildTxInfo(hash []byte, rawTx []byte, received time.Time, block *Block,
+	status int64, label string) (*TxInfo, error) {
+
+	txHash, err := chainhash.NewHash(hash)
+	if err != nil {
+		return nil, fmt.Errorf("tx hash: %w", err)
+	}
+
+	txStatus, err := parseTxStatus(status)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TxInfo{
+		Hash:         *txHash,
+		SerializedTx: rawTx,
+		Received:     received.UTC(),
+		Block:        block,
+		Status:       txStatus,
+		Label:        label,
+	}, nil
+}

--- a/wallet/internal/db/tx_store_common.go
+++ b/wallet/internal/db/tx_store_common.go
@@ -329,3 +329,134 @@ func createTxWithOps(ctx context.Context, req createTxRequest,
 
 	return nil
 }
+
+// validateUpdateTxParams checks that UpdateTx received at least one mutable
+// field and that any requested state transition satisfies the transaction table
+// invariants.
+func validateUpdateTxParams(params UpdateTxParams, isCoinbase bool) error {
+	if params.Label == nil && params.State == nil {
+		return fmt.Errorf("%w: UpdateTx requires at least one field",
+			ErrInvalidParam)
+	}
+
+	if params.State != nil {
+		return validateUpdateTxState(*params.State, isCoinbase)
+	}
+
+	return nil
+}
+
+// validateUpdateTxState checks the block/status combinations UpdateTx may store
+// on an existing row.
+func validateUpdateTxState(state UpdateTxState, isCoinbase bool) error {
+	_, err := parseTxStatus(int64(state.Status))
+	if err != nil {
+		return fmt.Errorf("%w: status %d is not supported: %w",
+			ErrInvalidParam, state.Status, ErrInvalidStatus)
+	}
+
+	// Only disconnected coinbase rows become orphaned. Ordinary
+	// transactions use the replaced/failed states instead, so UpdateTx
+	// must reject orphaned transitions for non-coinbase history.
+	if !isCoinbase && state.Status == TxStatusOrphaned {
+		return fmt.Errorf("%w: non-coinbase txns cannot be orphaned: %w",
+			ErrInvalidParam, ErrInvalidStatus)
+	}
+
+	// Any row with a confirming block represents mined history, and mined
+	// wallet history is always published from the wallet's point of view.
+	if state.Block != nil && state.Status != TxStatusPublished {
+		return fmt.Errorf("%w: confirmed txns must be published: %w",
+			ErrInvalidParam, ErrInvalidStatus)
+	}
+
+	// A unmined coinbase row only appears after rollback disconnects its block,
+	// at which point the row must be marked orphaned rather than treated as an
+	// active unmined transaction.
+	if isCoinbase && state.Block == nil && state.Status != TxStatusOrphaned {
+		return fmt.Errorf("%w: unmined coinbase txns must be orphaned: %w",
+			ErrInvalidParam, ErrInvalidStatus)
+	}
+
+	return nil
+}
+
+// updateTxOps is the minimal backend adapter the shared UpdateTx workflow
+// needs.
+//
+// The shared UpdateTx algorithm is intentionally ordered:
+//   - load the target row metadata first
+//   - validate the requested label/state patch against that metadata
+//   - prepare any backend-specific block/status params next
+//   - apply the label patch if requested
+//   - apply the state patch last
+//
+// Keeping that sequence documented here matters because UpdateTx is
+// deliberately row-local. The backend adapters only supply query wiring. The
+// shared helper owns the mutation ordering and the invariants that keep
+// block/status patches from accidentally turning into graph-level
+// reconciliation.
+type updateTxOps interface {
+	// loadIsCoinbase returns whether the existing row is coinbase history
+	// so the shared validation can enforce orphaning rules correctly.
+	loadIsCoinbase(ctx context.Context, walletID uint32,
+		txHash chainhash.Hash) (bool, error)
+
+	// prepareState validates and caches any backend-specific block/status
+	// params needed for the later row update.
+	prepareState(ctx context.Context, state UpdateTxState) error
+
+	// updateLabel applies one user-visible label patch.
+	updateLabel(ctx context.Context, walletID uint32, txHash chainhash.Hash,
+		label string) error
+
+	// updateState applies one block/status patch after prepareState succeeds.
+	updateState(ctx context.Context, walletID uint32, txHash chainhash.Hash,
+		state UpdateTxState) error
+}
+
+// updateTxWithOps runs the shared UpdateTx patch workflow inside one backend-
+// specific SQL transaction.
+//
+// The helper validates the existing row first, prepares any requested state
+// patch next, and then applies the label patch and state patch in that order.
+// That keeps block validation and row mutation inside one transaction while
+// still allowing callers to update either field independently.
+func updateTxWithOps(ctx context.Context, params UpdateTxParams,
+	ops updateTxOps) error {
+
+	isCoinbase, err := ops.loadIsCoinbase(
+		ctx, params.WalletID, params.Txid,
+	)
+	if err != nil {
+		return fmt.Errorf("load update tx target: %w", err)
+	}
+
+	err = validateUpdateTxParams(params, isCoinbase)
+	if err != nil {
+		return err
+	}
+
+	if params.State != nil {
+		err = ops.prepareState(ctx, *params.State)
+		if err != nil {
+			return fmt.Errorf("prepare tx state update: %w", err)
+		}
+	}
+
+	if params.Label != nil {
+		err = ops.updateLabel(ctx, params.WalletID, params.Txid, *params.Label)
+		if err != nil {
+			return fmt.Errorf("update tx label: %w", err)
+		}
+	}
+
+	if params.State != nil {
+		err = ops.updateState(ctx, params.WalletID, params.Txid, *params.State)
+		if err != nil {
+			return fmt.Errorf("update tx state: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/wallet/internal/db/tx_store_common_test.go
+++ b/wallet/internal/db/tx_store_common_test.go
@@ -1,0 +1,139 @@
+package db
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSerializeDeserializeMsgTx verifies that the common serialization helpers
+// preserve transaction bytes across a round trip.
+func TestSerializeDeserializeMsgTx(t *testing.T) {
+	t.Parallel()
+
+	tx := testRegularMsgTx()
+
+	rawTx, err := serializeMsgTx(tx)
+	require.NoError(t, err)
+
+	decoded, err := deserializeMsgTx(rawTx)
+	require.NoError(t, err)
+
+	var got bytes.Buffer
+
+	err = decoded.Serialize(&got)
+	require.NoError(t, err)
+
+	require.Equal(t, rawTx, got.Bytes())
+}
+
+// TestSerializeMsgTxNil verifies that serializeMsgTx rejects a missing
+// transaction pointer with the public invalid-param error.
+func TestSerializeMsgTxNil(t *testing.T) {
+	t.Parallel()
+
+	_, err := serializeMsgTx(nil)
+	require.ErrorIs(t, err, ErrInvalidParam)
+}
+
+// TestParseTxStatus verifies that stored numeric values map back to the public
+// TxStatus enum and that unknown values fail loudly.
+func TestParseTxStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		status  int64
+		want    TxStatus
+		wantErr error
+	}{
+		{name: "pending", status: 0, want: TxStatusPending},
+		{name: "published", status: 1, want: TxStatusPublished},
+		{name: "replaced", status: 2, want: TxStatusReplaced},
+		{name: "failed", status: 3, want: TxStatusFailed},
+		{name: "orphaned", status: 4, want: TxStatusOrphaned},
+		{name: "invalid", status: 9, wantErr: ErrInvalidStatus},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseTxStatus(tc.status)
+			require.ErrorIs(t, err, tc.wantErr)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestBuildTxInfo verifies the shared row-to-domain conversion used by both
+// SQL backends when returning a valid TxInfo value.
+func TestBuildTxInfo(t *testing.T) {
+	t.Parallel()
+
+	tx := testRegularMsgTx()
+	hash := tx.TxHash()
+	rawTx, err := serializeMsgTx(tx)
+	require.NoError(t, err)
+
+	blockHash := chainhash.Hash{1, 2, 3}
+	block := &Block{
+		Hash:      blockHash,
+		Height:    77,
+		Timestamp: time.Unix(500, 0),
+	}
+
+	info, err := buildTxInfo(
+		hash[:], rawTx, time.Unix(600, 0).In(time.FixedZone("X", 3600)),
+		block, int64(TxStatusPublished), "note",
+	)
+	require.NoError(t, err)
+	require.Equal(t, hash, info.Hash)
+	require.Equal(t, rawTx, info.SerializedTx)
+	require.Equal(t, TxStatusPublished, info.Status)
+	require.Equal(t, "note", info.Label)
+	require.Equal(t, time.UTC, info.Received.Location())
+	require.Equal(t, block, info.Block)
+}
+
+// TestBuildTxInfoInvalidHash verifies that buildTxInfo rejects malformed hash
+// bytes.
+func TestBuildTxInfoInvalidHash(t *testing.T) {
+	t.Parallel()
+
+	tx := testRegularMsgTx()
+	rawTx, err := serializeMsgTx(tx)
+	require.NoError(t, err)
+
+	_, err = buildTxInfo([]byte{1, 2, 3}, rawTx, time.Now(), nil,
+		int64(TxStatusPending), "")
+	require.Error(t, err)
+}
+
+// TestBuildTxInfoInvalidStatus verifies that buildTxInfo rejects unknown status
+// codes.
+func TestBuildTxInfoInvalidStatus(t *testing.T) {
+	t.Parallel()
+
+	tx := testRegularMsgTx()
+	hash := tx.TxHash()
+	rawTx, err := serializeMsgTx(tx)
+	require.NoError(t, err)
+
+	_, err = buildTxInfo(hash[:], rawTx, time.Now(), nil, 9, "")
+	require.ErrorIs(t, err, ErrInvalidStatus)
+}
+
+// testRegularMsgTx builds a minimal non-coinbase transaction fixture for the
+// shared TxStore helper tests.
+func testRegularMsgTx() *wire.MsgTx {
+	tx := wire.NewMsgTx(wire.TxVersion)
+	tx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{1}}})
+	tx.AddTxOut(&wire.TxOut{Value: 1, PkScript: []byte{0x51}})
+
+	return tx
+}

--- a/wallet/internal/db/tx_store_common_test.go
+++ b/wallet/internal/db/tx_store_common_test.go
@@ -2,9 +2,11 @@ package db
 
 import (
 	"bytes"
+	"context"
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/stretchr/testify/require"
@@ -15,8 +17,10 @@ import (
 func TestSerializeDeserializeMsgTx(t *testing.T) {
 	t.Parallel()
 
+	// Arrange: Build one regular transaction fixture.
 	tx := testRegularMsgTx()
 
+	// Act: Serialize it and deserialize the result.
 	rawTx, err := serializeMsgTx(tx)
 	require.NoError(t, err)
 
@@ -28,6 +32,7 @@ func TestSerializeDeserializeMsgTx(t *testing.T) {
 	err = decoded.Serialize(&got)
 	require.NoError(t, err)
 
+	// Assert: The decoded transaction serializes back to the same bytes.
 	require.Equal(t, rawTx, got.Bytes())
 }
 
@@ -42,6 +47,9 @@ func TestSerializeMsgTxNil(t *testing.T) {
 
 // TestParseTxStatus verifies that stored numeric values map back to the public
 // TxStatus enum and that unknown values fail loudly.
+//
+// The table keeps the setup identical for every case so the loop only varies
+// the input status code and the expected result.
 func TestParseTxStatus(t *testing.T) {
 	t.Parallel()
 
@@ -75,6 +83,7 @@ func TestParseTxStatus(t *testing.T) {
 func TestBuildTxInfo(t *testing.T) {
 	t.Parallel()
 
+	// Arrange: Build one serialized transaction and one block fixture.
 	tx := testRegularMsgTx()
 	hash := tx.TxHash()
 	rawTx, err := serializeMsgTx(tx)
@@ -87,11 +96,14 @@ func TestBuildTxInfo(t *testing.T) {
 		Timestamp: time.Unix(500, 0),
 	}
 
+	// Act: Convert the normalized row fields into TxInfo.
 	info, err := buildTxInfo(
 		hash[:], rawTx, time.Unix(600, 0).In(time.FixedZone("X", 3600)),
 		block, int64(TxStatusPublished), "note",
 	)
 	require.NoError(t, err)
+
+	// Assert: The resulting TxInfo preserves the expected public fields.
 	require.Equal(t, hash, info.Hash)
 	require.Equal(t, rawTx, info.SerializedTx)
 	require.Equal(t, TxStatusPublished, info.Status)
@@ -128,12 +140,325 @@ func TestBuildTxInfoInvalidStatus(t *testing.T) {
 	require.ErrorIs(t, err, ErrInvalidStatus)
 }
 
+// TestValidateCreateTxParams verifies the shared CreateTx invariants that both
+// SQL backends rely on before opening a write transaction.
+//
+// The cases vary only the CreateTx input data so the table-driven structure
+// stays clear and does not need conditional setup inside the loop.
+func TestValidateCreateTxParams(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		params       CreateTxParams
+		wantErr      error
+		wantParamErr error
+	}{
+		{
+			name: "coinbase must be published",
+			params: CreateTxParams{
+				Tx:     testCoinbaseMsgTx(),
+				Block:  testBlock(100),
+				Status: TxStatusPending,
+			},
+			wantErr:      ErrInvalidStatus,
+			wantParamErr: ErrInvalidParam,
+		},
+		{
+			name: "coinbase requires block",
+			params: CreateTxParams{
+				Tx:     testCoinbaseMsgTx(),
+				Status: TxStatusPublished,
+			},
+			wantErr:      ErrInvalidStatus,
+			wantParamErr: ErrInvalidParam,
+		},
+		{
+			name: "orphaned status rejected on create",
+			params: CreateTxParams{
+				Tx:     testRegularMsgTx(),
+				Status: TxStatusOrphaned,
+			},
+			wantErr:      ErrInvalidStatus,
+			wantParamErr: ErrInvalidParam,
+		},
+		{
+			name: "failed status rejected on create",
+			params: CreateTxParams{
+				Tx:     testRegularMsgTx(),
+				Status: TxStatusFailed,
+			},
+			wantErr:      ErrInvalidStatus,
+			wantParamErr: ErrInvalidParam,
+		},
+		{
+			name: "replaced status rejected on create",
+			params: CreateTxParams{
+				Tx:     testRegularMsgTx(),
+				Status: TxStatusReplaced,
+			},
+			wantErr:      ErrInvalidStatus,
+			wantParamErr: ErrInvalidParam,
+		},
+		{
+			name: "credit index out of range",
+			params: CreateTxParams{
+				Tx:      testRegularMsgTx(),
+				Credits: map[uint32]btcutil.Address{2: nil},
+				Status:  TxStatusPending,
+			},
+			wantErr:      ErrIndexOutOfRange,
+			wantParamErr: ErrInvalidParam,
+		},
+		{
+			name: "duplicate input outpoint",
+			params: CreateTxParams{
+				Tx: &wire.MsgTx{
+					Version: wire.TxVersion,
+					TxIn: []*wire.TxIn{{
+						PreviousOutPoint: wire.OutPoint{
+							Hash:  chainhash.Hash{1},
+							Index: 0,
+						},
+					}, {
+						PreviousOutPoint: wire.OutPoint{
+							Hash:  chainhash.Hash{1},
+							Index: 0,
+						},
+					}},
+					TxOut: []*wire.TxOut{{Value: 1, PkScript: []byte{0x51}}},
+				},
+				Status: TxStatusPending,
+			},
+			wantErr:      ErrDuplicateInputOutPoint,
+			wantParamErr: ErrInvalidParam,
+		},
+		{
+			name: "confirmed create must be published",
+			params: CreateTxParams{
+				Tx:     testRegularMsgTx(),
+				Block:  testBlock(101),
+				Status: TxStatusPending,
+			},
+			wantErr:      ErrInvalidStatus,
+			wantParamErr: ErrInvalidParam,
+		},
+		{
+			name: "valid pending unmined transaction",
+			params: CreateTxParams{
+				Tx:      testRegularMsgTx(),
+				Status:  TxStatusPending,
+				Credits: map[uint32]btcutil.Address{0: nil},
+			},
+		},
+		{
+			name: "valid published confirmed transaction",
+			params: CreateTxParams{
+				Tx:      testRegularMsgTx(),
+				Block:   testBlock(102),
+				Status:  TxStatusPublished,
+				Credits: map[uint32]btcutil.Address{0: nil},
+			},
+		},
+		{
+			name: "valid published coinbase facts",
+			params: CreateTxParams{
+				Tx:      testCoinbaseMsgTx(),
+				Block:   testBlock(103),
+				Status:  TxStatusPublished,
+				Credits: map[uint32]btcutil.Address{0: nil},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateCreateTxParams(tc.params)
+			require.ErrorIs(t, err, tc.wantErr)
+			require.ErrorIs(t, err, tc.wantParamErr)
+		})
+	}
+}
+
+// TestNewCreateTxRequest verifies that the shared CreateTx preparation step
+// normalizes the request before either backend opens a write transaction.
+func TestNewCreateTxRequest(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Build one valid request with a non-UTC received timestamp.
+	params := CreateTxParams{
+		WalletID: 7,
+		Tx:       testRegularMsgTx(),
+		Received: time.Unix(123, 0).In(time.FixedZone("X", 3600)),
+		Block:    testBlock(77),
+		Status:   TxStatusPublished,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+		Label:    "note",
+	}
+
+	// Act: Normalize it through newCreateTxRequest.
+	req, err := newCreateTxRequest(params)
+	require.NoError(t, err)
+
+	wantRawTx, err := serializeMsgTx(params.Tx)
+	require.NoError(t, err)
+
+	// Assert: The prepared request caches the normalized transaction facts.
+	require.Equal(t, params, req.params)
+	require.Equal(t, params.Tx.TxHash(), req.txHash)
+	require.Equal(t, wantRawTx, req.rawTx)
+	require.Equal(t, time.UTC, req.received.Location())
+	require.False(t, req.isCoinbase)
+}
+
+// TestCreateTxWithOpsInsert verifies that the shared CreateTx orchestration
+// performs the full insert path in order for one fresh transaction row.
+func TestCreateTxWithOpsInsert(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Build one prepared CreateTx request and one stub adapter.
+	req := testCreateTxRequest(t)
+	ops := &stubCreateTxOps{insertTxID: 11}
+
+	// Act: Run createTxWithOps.
+	err := createTxWithOps(context.Background(), req, ops)
+	require.NoError(t, err)
+
+	// Assert: The shared flow executes the expected write sequence.
+	require.Equal(t,
+		[]string{"exists", "prepare-block", "insert", "credits", "inputs"},
+		ops.calls,
+	)
+	require.Equal(t, int64(11), ops.creditsTxID)
+	require.Equal(t, int64(11), ops.inputsTxID)
+	require.Equal(t, req.txHash, ops.insertReq.txHash)
+}
+
+// TestCreateTxWithOpsDuplicate verifies that the shared CreateTx helper maps an
+// existing wallet-scoped tx hash to ErrTxAlreadyExists.
+func TestCreateTxWithOpsDuplicate(t *testing.T) {
+	t.Parallel()
+
+	req := testCreateTxRequest(t)
+	ops := &stubCreateTxOps{hasExistingResult: true}
+
+	err := createTxWithOps(context.Background(), req, ops)
+	require.ErrorIs(t, err, ErrTxAlreadyExists)
+	require.Equal(t, []string{"exists"}, ops.calls)
+}
+
+// testBlock builds a simple block fixture for CreateTx validation tests.
+func testBlock(height uint32) *Block {
+	return &Block{
+		Hash:      chainhash.Hash{byte(height)},
+		Height:    height,
+		Timestamp: time.Unix(int64(height), 0),
+	}
+}
+
 // testRegularMsgTx builds a minimal non-coinbase transaction fixture for the
 // shared TxStore helper tests.
 func testRegularMsgTx() *wire.MsgTx {
 	tx := wire.NewMsgTx(wire.TxVersion)
-	tx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{1}}})
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{1}},
+	})
 	tx.AddTxOut(&wire.TxOut{Value: 1, PkScript: []byte{0x51}})
 
 	return tx
+}
+
+// testCoinbaseMsgTx builds a minimal coinbase transaction fixture.
+func testCoinbaseMsgTx() *wire.MsgTx {
+	tx := wire.NewMsgTx(wire.TxVersion)
+	tx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{Index: ^uint32(0)}})
+	tx.AddTxOut(&wire.TxOut{Value: 1, PkScript: []byte{0x51}})
+
+	return tx
+}
+
+// stubCreateTxOps records how the shared CreateTx helper drives one backend
+// adapter while letting each test control the returned transaction IDs.
+type stubCreateTxOps struct {
+	hasExistingResult bool
+	insertTxID        int64
+
+	calls       []string
+	insertReq   createTxRequest
+	creditsTxID int64
+	inputsTxID  int64
+}
+
+var _ createTxOps = (*stubCreateTxOps)(nil)
+
+// hasExisting records that the shared flow checked whether the tx hash already
+// exists and returns the test-controlled result.
+func (s *stubCreateTxOps) hasExisting(_ context.Context,
+	_ createTxRequest) (bool, error) {
+
+	s.calls = append(s.calls, "exists")
+
+	return s.hasExistingResult, nil
+}
+
+// prepareBlock records that the shared flow validated any optional block
+// assignment before insert.
+func (s *stubCreateTxOps) prepareBlock(_ context.Context,
+	_ createTxRequest) error {
+
+	s.calls = append(s.calls, "prepare-block")
+
+	return nil
+}
+
+// insert records the request that the shared flow would store as a fresh
+// transaction row.
+func (s *stubCreateTxOps) insert(_ context.Context,
+	req createTxRequest) (int64, error) {
+
+	s.calls = append(s.calls, "insert")
+	s.insertReq = req
+
+	return s.insertTxID, nil
+}
+
+// insertCredits records the transaction ID the shared flow used when
+// reconciling wallet-owned outputs.
+func (s *stubCreateTxOps) insertCredits(_ context.Context,
+	_ createTxRequest, txID int64) error {
+
+	s.calls = append(s.calls, "credits")
+	s.creditsTxID = txID
+
+	return nil
+}
+
+// markInputsSpent records the transaction ID the shared flow used when
+// attaching wallet-owned spent inputs.
+func (s *stubCreateTxOps) markInputsSpent(_ context.Context,
+	_ createTxRequest, txID int64) error {
+
+	s.calls = append(s.calls, "inputs")
+	s.inputsTxID = txID
+
+	return nil
+}
+
+// testCreateTxRequest builds one valid normalized CreateTx request for the
+// shared CreateTx orchestration tests.
+func testCreateTxRequest(t *testing.T) createTxRequest {
+	t.Helper()
+
+	req, err := newCreateTxRequest(CreateTxParams{
+		WalletID: 5,
+		Tx:       testRegularMsgTx(),
+		Received: time.Unix(456, 0),
+		Status:   TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	return req
 }

--- a/wallet/internal/db/tx_store_common_test.go
+++ b/wallet/internal/db/tx_store_common_test.go
@@ -462,3 +462,102 @@ func testCreateTxRequest(t *testing.T) createTxRequest {
 
 	return req
 }
+
+// TestUpdateTxWithOpsLabelAndState verifies that the shared UpdateTx workflow
+// can apply both a label patch and a state patch in one atomic sequence.
+func TestUpdateTxWithOpsLabelAndState(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Build one request with both a label patch and a state patch.
+	label := "note"
+	params := UpdateTxParams{
+		WalletID: 5,
+		Txid:     chainhash.Hash{1},
+		Label:    &label,
+		State: &UpdateTxState{
+			Status: TxStatusPublished,
+		},
+	}
+	ops := &stubUpdateTxOps{isCoinbase: false}
+
+	// Act: Run updateTxWithOps against a stub backend adapter.
+	err := updateTxWithOps(context.Background(), params, ops)
+	require.NoError(t, err)
+
+	// Assert: The shared flow loads, prepares, and applies both patches.
+	require.Equal(t,
+		[]string{"load", "prepare-state", "label", "state"},
+		ops.calls,
+	)
+	require.Equal(t, label, ops.updatedLabel)
+	require.Equal(t, TxStatusPublished, ops.updatedState.Status)
+}
+
+// TestUpdateTxWithOpsEmptyPatch verifies that the shared UpdateTx helper
+// rejects requests that do not ask to mutate any field.
+func TestUpdateTxWithOpsEmptyPatch(t *testing.T) {
+	t.Parallel()
+
+	params := UpdateTxParams{
+		WalletID: 5,
+		Txid:     chainhash.Hash{1},
+	}
+	ops := &stubUpdateTxOps{isCoinbase: false}
+
+	err := updateTxWithOps(context.Background(), params, ops)
+	require.ErrorIs(t, err, ErrInvalidParam)
+	require.Equal(t, []string{"load"}, ops.calls)
+}
+
+// stubUpdateTxOps records how the shared UpdateTx helper drives one backend
+// adapter while letting tests control the loaded metadata.
+type stubUpdateTxOps struct {
+	isCoinbase   bool
+	calls        []string
+	updatedLabel string
+	updatedState UpdateTxState
+}
+
+var _ updateTxOps = (*stubUpdateTxOps)(nil)
+
+// loadIsCoinbase records that the shared flow loaded the existing transaction
+// row metadata.
+func (s *stubUpdateTxOps) loadIsCoinbase(_ context.Context, _ uint32,
+	_ chainhash.Hash) (bool, error) {
+
+	s.calls = append(s.calls, "load")
+
+	return s.isCoinbase, nil
+}
+
+// prepareState records that the shared flow validated and prepared one state
+// patch before applying it.
+func (s *stubUpdateTxOps) prepareState(_ context.Context,
+	_ UpdateTxState) error {
+
+	s.calls = append(s.calls, "prepare-state")
+
+	return nil
+}
+
+// updateLabel records the label value the shared flow asked the backend to
+// write.
+func (s *stubUpdateTxOps) updateLabel(_ context.Context, _ uint32,
+	_ chainhash.Hash, label string) error {
+
+	s.calls = append(s.calls, "label")
+	s.updatedLabel = label
+
+	return nil
+}
+
+// updateState records the state patch the shared flow asked the backend to
+// write.
+func (s *stubUpdateTxOps) updateState(_ context.Context, _ uint32,
+	_ chainhash.Hash, state UpdateTxState) error {
+
+	s.calls = append(s.calls, "state")
+	s.updatedState = state
+
+	return nil
+}


### PR DESCRIPTION
This PR builds on #1197
and adds the SQL-backed `TxStore` implementations for postgres
and sqlite, along with the shared helpers and tests needed to exercise the new
store read/write paths.

Already reviewed [here](https://github.com/yyforyongyu/btcwallet/pull/31).