### PR TITLE
wallet: implement store pagination

### DIFF
--- a/wallet/internal/db/addresses_common.go
+++ b/wallet/internal/db/addresses_common.go
@@ -359,36 +359,14 @@ func getAddress[T any, Args any](ctx context.Context,
 	return nil, ErrAddressNotFound
 }
 
-// listAddresses is a generic helper that retrieves addresses using the provided
-// lister function and converts the results to AddressInfo structs.
-func listAddresses[T any, Args any](ctx context.Context,
-	lister func(context.Context, Args) ([]T, error), args Args,
-	toInfo func(T) (*AddressInfo, error)) ([]AddressInfo, error) {
+// nextListAddressesQuery returns a query with its pagination cursor advanced to
+// the provided value.
+func nextListAddressesQuery(q ListAddressesQuery,
+	cursor uint32) ListAddressesQuery {
 
-	rows, err := lister(ctx, args)
-	if err != nil {
-		return nil, fmt.Errorf("list addresses: %w", err)
-	}
+	q.Page = q.Page.WithAfter(cursor)
 
-	return addressInfosFromRows(rows, toInfo)
-}
-
-// addressInfosFromRows converts a slice of row types to AddressInfo structs
-// using the provided converter function.
-func addressInfosFromRows[T any](rows []T,
-	toInfo func(T) (*AddressInfo, error)) ([]AddressInfo, error) {
-
-	infos := make([]AddressInfo, len(rows))
-	for i, row := range rows {
-		info, err := toInfo(row)
-		if err != nil {
-			return nil, err
-		}
-
-		infos[i] = *info
-	}
-
-	return infos, nil
+	return q
 }
 
 // derivedAddressAdapters groups the functions needed to create a

--- a/wallet/internal/db/addresses_pg.go
+++ b/wallet/internal/db/addresses_pg.go
@@ -9,6 +9,8 @@ import (
 	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
 )
 
+var _ AddressStore = (*PostgresStore)(nil)
+
 // GetAddress retrieves information about a specific address, identified by
 // its script pubkey.
 func (s *PostgresStore) GetAddress(ctx context.Context,

--- a/wallet/internal/db/addresses_pg.go
+++ b/wallet/internal/db/addresses_pg.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"iter"
 	"time"
 
+	"github.com/btcsuite/btcwallet/wallet/internal/db/page"
 	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
 )
 
@@ -31,19 +33,31 @@ func (s *PostgresStore) GetAddress(ctx context.Context,
 	return getAddressByQuery(ctx, query, getByScript)
 }
 
-// ListAddresses returns a slice of AddressInfo for all addresses in a given
-// account.
+// ListAddresses returns a page of addresses matching the given query.
 func (s *PostgresStore) ListAddresses(ctx context.Context,
-	query ListAddressesQuery) ([]AddressInfo, error) {
+	query ListAddressesQuery) (page.Result[AddressInfo, uint32], error) {
 
-	return listAddresses(
-		ctx, s.queries.ListAddressesByAccount,
-		sqlcpg.ListAddressesByAccountParams{
-			WalletID:    int64(query.WalletID),
-			Purpose:     int64(query.Scope.Purpose),
-			CoinType:    int64(query.Scope.Coin),
-			AccountName: query.AccountName,
-		}, pgAddressRowToInfo,
+	items, err := pgListAddressesByAccount(ctx, s.queries, query)
+	if err != nil {
+		return page.Result[AddressInfo, uint32]{}, err
+	}
+
+	result := page.BuildResult(
+		query.Page, items,
+		func(item AddressInfo) uint32 {
+			return item.ID
+		},
+	)
+
+	return result, nil
+}
+
+// IterAddresses returns an iterator over paginated address results.
+func (s *PostgresStore) IterAddresses(ctx context.Context,
+	query ListAddressesQuery) iter.Seq2[AddressInfo, error] {
+
+	return page.Iter(
+		ctx, query, s.ListAddresses, nextListAddressesQuery,
 	)
 }
 
@@ -299,4 +313,54 @@ func pgAddressRowToInfo[T pgAddressInfoRow](row T) (*AddressInfo, error) {
 	}
 
 	return info, nil
+}
+
+// pgListAddressesByAccount lists addresses filtered by wallet ID, key scope,
+// and account name, with pagination support.
+func pgListAddressesByAccount(ctx context.Context, q *sqlcpg.Queries,
+	query ListAddressesQuery) ([]AddressInfo, error) {
+
+	rows, err := q.ListAddressesByAccount(
+		ctx, pgBuildAddressPageParams(query),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list addresses by account: %w", err)
+	}
+
+	items := make([]AddressInfo, len(rows))
+	for i, row := range rows {
+		item, err := pgAddressRowToInfo(row)
+		if err != nil {
+			return nil,
+				fmt.Errorf("list addresses by account: map address row: %w",
+					err)
+		}
+
+		items[i] = *item
+	}
+
+	return items, nil
+}
+
+// pgBuildAddressPageParams translates a ListAddresses query to
+// ListAddressesByAccount parameters, handling pagination cursors.
+func pgBuildAddressPageParams(
+	q ListAddressesQuery) sqlcpg.ListAddressesByAccountParams {
+
+	params := sqlcpg.ListAddressesByAccountParams{
+		WalletID:    int64(q.WalletID),
+		Purpose:     int64(q.Scope.Purpose),
+		CoinType:    int64(q.Scope.Coin),
+		AccountName: q.AccountName,
+		PageLimit:   int64(q.Page.QueryLimit()),
+	}
+
+	if cursor, ok := q.Page.After(); ok {
+		params.CursorID = sql.NullInt64{
+			Int64: int64(cursor),
+			Valid: true,
+		}
+	}
+
+	return params
 }

--- a/wallet/internal/db/addresses_sqlite.go
+++ b/wallet/internal/db/addresses_sqlite.go
@@ -3,8 +3,11 @@ package db
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"iter"
 	"time"
 
+	"github.com/btcsuite/btcwallet/wallet/internal/db/page"
 	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
 )
 
@@ -30,19 +33,31 @@ func (s *SqliteStore) GetAddress(ctx context.Context,
 	return getAddressByQuery(ctx, query, getByScript)
 }
 
-// ListAddresses returns a slice of AddressInfo for all addresses in a given
-// account.
+// ListAddresses returns a page of addresses matching the given query.
 func (s *SqliteStore) ListAddresses(ctx context.Context,
-	query ListAddressesQuery) ([]AddressInfo, error) {
+	query ListAddressesQuery) (page.Result[AddressInfo, uint32], error) {
 
-	return listAddresses(
-		ctx, s.queries.ListAddressesByAccount,
-		sqlcsqlite.ListAddressesByAccountParams{
-			WalletID:    int64(query.WalletID),
-			Purpose:     int64(query.Scope.Purpose),
-			CoinType:    int64(query.Scope.Coin),
-			AccountName: query.AccountName,
-		}, sqliteAddressRowToInfo,
+	items, err := sqliteListAddressesByAccount(ctx, s.queries, query)
+	if err != nil {
+		return page.Result[AddressInfo, uint32]{}, err
+	}
+
+	result := page.BuildResult(
+		query.Page, items,
+		func(item AddressInfo) uint32 {
+			return item.ID
+		},
+	)
+
+	return result, nil
+}
+
+// IterAddresses returns an iterator over paginated address results.
+func (s *SqliteStore) IterAddresses(ctx context.Context,
+	query ListAddressesQuery) iter.Seq2[AddressInfo, error] {
+
+	return page.Iter(
+		ctx, query, s.ListAddresses, nextListAddressesQuery,
 	)
 }
 
@@ -292,4 +307,51 @@ func sqliteAddressRowToInfo[T sqliteAddressInfoRow](row T) (*AddressInfo,
 	}
 
 	return info, nil
+}
+
+// sqliteListAddressesByAccount lists addresses filtered by wallet ID, key
+// scope, and account name, with pagination support.
+func sqliteListAddressesByAccount(ctx context.Context, q *sqlcsqlite.Queries,
+	query ListAddressesQuery) ([]AddressInfo, error) {
+
+	rows, err := q.ListAddressesByAccount(
+		ctx, sqliteBuildAddressPageParams(query),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list addresses by account: %w", err)
+	}
+
+	items := make([]AddressInfo, len(rows))
+	for i, row := range rows {
+		item, err := sqliteAddressRowToInfo(row)
+		if err != nil {
+			return nil,
+				fmt.Errorf("list addresses by account: map address row: %w",
+					err)
+		}
+
+		items[i] = *item
+	}
+
+	return items, nil
+}
+
+// sqliteBuildAddressPageParams translates a ListAddresses query to
+// ListAddressesByAccount parameters, handling pagination cursors.
+func sqliteBuildAddressPageParams(
+	q ListAddressesQuery) sqlcsqlite.ListAddressesByAccountParams {
+
+	params := sqlcsqlite.ListAddressesByAccountParams{
+		WalletID:    int64(q.WalletID),
+		Purpose:     int64(q.Scope.Purpose),
+		CoinType:    int64(q.Scope.Coin),
+		AccountName: q.AccountName,
+		PageLimit:   int64(q.Page.QueryLimit()),
+	}
+
+	if cursor, ok := q.Page.After(); ok {
+		params.CursorID = int64(cursor)
+	}
+
+	return params
 }

--- a/wallet/internal/db/addresses_sqlite.go
+++ b/wallet/internal/db/addresses_sqlite.go
@@ -8,6 +8,8 @@ import (
 	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
 )
 
+var _ AddressStore = (*SqliteStore)(nil)
+
 // GetAddress retrieves information about a specific address, identified by
 // its script pubkey.
 func (s *SqliteStore) GetAddress(ctx context.Context,

--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -240,6 +240,12 @@ type Block struct {
 	Timestamp time.Time
 }
 
+// ListWalletsQuery contains the parameters for listing wallets.
+type ListWalletsQuery struct {
+	// Page holds the pagination parameters for this query.
+	Page page.Request[uint32]
+}
+
 // CreateWalletParams contains the parameters required to create a new wallet.
 type CreateWalletParams struct {
 	// Name is the name of the new wallet.

--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/wallet/internal/db/page"
 )
 
 const (
@@ -710,6 +711,9 @@ type ListAddressesQuery struct {
 
 	// Scope is the key scope of the account.
 	Scope KeyScope
+
+	// Page holds the pagination parameters for this query.
+	Page page.Request[uint32]
 }
 
 // --------------------

--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -3,6 +3,9 @@ package db
 import (
 	"context"
 	"errors"
+	"iter"
+
+	"github.com/btcsuite/btcwallet/wallet/internal/db/page"
 )
 
 var (
@@ -235,10 +238,15 @@ type AddressStore interface {
 	// an error if the address is not found.
 	GetAddress(ctx context.Context, query GetAddressQuery) (*AddressInfo, error)
 
-	// ListAddresses returns a slice of AddressInfo for all addresses in a
-	// given account. It returns an empty slice if no addresses are found.
-	ListAddresses(ctx context.Context, query ListAddressesQuery) ([]AddressInfo,
-		error)
+	// ListAddresses returns one page of addresses for the given query,
+	// including a next-cursor for the following page.
+	ListAddresses(ctx context.Context, query ListAddressesQuery) (
+		page.Result[AddressInfo, uint32], error)
+
+	// IterAddresses returns an iterator that fetches pages transparently and
+	// yields addresses one by one until exhaustion or error.
+	IterAddresses(ctx context.Context,
+		query ListAddressesQuery) iter.Seq2[AddressInfo, error]
 
 	// GetAddressSecret retrieves the encrypted secret material for a given
 	// address. Returns the AddressSecret containing encrypted private key

--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -142,10 +142,15 @@ type WalletStore interface {
 	// error if the wallet is not found.
 	GetWallet(ctx context.Context, name string) (*WalletInfo, error)
 
-	// ListWallets returns a slice of WalletInfo for all wallets stored in
-	// the database. It returns an empty slice if no wallets are found, or
-	// an error if the retrieval fails.
-	ListWallets(ctx context.Context) ([]WalletInfo, error)
+	// ListWallets returns one page of wallets for the given query, including a
+	// next-cursor for the following page.
+	ListWallets(ctx context.Context, query ListWalletsQuery) (
+		page.Result[WalletInfo, uint32], error)
+
+	// IterWallets returns an iterator that fetches pages transparently and
+	// yields wallets one by one until exhaustion or error.
+	IterWallets(ctx context.Context,
+		query ListWalletsQuery) iter.Seq2[WalletInfo, error]
 
 	// UpdateWallet updates various properties of a wallet, such as its
 	// birthday, birthday block, or sync state. The specific fields to

--- a/wallet/internal/db/itest/address_store_test.go
+++ b/wallet/internal/db/itest/address_store_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/db/page"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,9 +36,9 @@ func mockDeriveFunc() db.AddressDerivationFunc {
 	}
 }
 
+// newDerivedAddress creates and returns a derived address for testing.
 func newDerivedAddress(t *testing.T, store db.AddressStore, walletID uint32,
 	scope db.KeyScope, accountName string, change bool) *db.AddressInfo {
-
 	t.Helper()
 
 	info, err := store.NewDerivedAddress(
@@ -53,10 +54,11 @@ func newDerivedAddress(t *testing.T, store db.AddressStore, walletID uint32,
 	return info
 }
 
+// createDerivedAddresses creates and returns a slice of derived addresses for
+// testing.
 func createDerivedAddresses(t *testing.T, store db.AddressStore,
 	walletID uint32, scope db.KeyScope, accountName string, change bool,
 	count int) []db.AddressInfo {
-
 	t.Helper()
 
 	addresses := make([]db.AddressInfo, 0, count)
@@ -70,9 +72,9 @@ func createDerivedAddresses(t *testing.T, store db.AddressStore,
 	return addresses
 }
 
+// getAccountByName retrieves an account by wallet, scope, and name for testing.
 func getAccountByName(t *testing.T, store db.AccountStore, walletID uint32,
 	scope db.KeyScope, accountName string) *db.AccountInfo {
-
 	t.Helper()
 
 	account, err := store.GetAccount(
@@ -81,6 +83,45 @@ func getAccountByName(t *testing.T, store db.AccountStore, walletID uint32,
 	require.NoError(t, err)
 
 	return account
+}
+
+// collectAddressPages collects paginated address results by iterating
+// through all pages from ListAddresses, using cursor pagination until
+// Next is nil.
+func collectAddressPages(t *testing.T, store db.AddressStore,
+	query db.ListAddressesQuery) []page.Result[db.AddressInfo, uint32] {
+	t.Helper()
+
+	pages := make([]page.Result[db.AddressInfo, uint32], 0)
+	for {
+		pageResult, err := store.ListAddresses(t.Context(), query)
+		require.NoError(t, err)
+		pages = append(pages, pageResult)
+
+		if pageResult.Next == nil {
+			return pages
+		}
+
+		query.Page = query.Page.WithAfter(*pageResult.Next)
+	}
+}
+
+// flattenAddressPages flattens paginated address results into a single
+// slice containing all addresses from all pages.
+func flattenAddressPages(
+	pages []page.Result[db.AddressInfo, uint32]) []db.AddressInfo {
+
+	count := 0
+	for i := range pages {
+		count += len(pages[i].Items)
+	}
+
+	addresses := make([]db.AddressInfo, 0, count)
+	for i := range pages {
+		addresses = append(addresses, pages[i].Items...)
+	}
+
+	return addresses
 }
 
 // TestNewImportedAddress verifies that NewImportedAddress correctly imports
@@ -236,7 +277,9 @@ func TestNewImportedAddressWithEncryptedScript(t *testing.T) {
 	queries := store.Queries()
 	walletID := newWallet(t, store, "wallet-encrypted-script")
 	createImportedAccount(t, store, walletID, db.KeyScopeBIP0044, "imported")
-	createImportedAccount(t, store, walletID, db.KeyScopeBIP0049Plus, "imported")
+	createImportedAccount(
+		t, store, walletID, db.KeyScopeBIP0049Plus, "imported",
+	)
 
 	redeemScript := RandomBytes(32)
 	witnessScript := RandomBytes(48)
@@ -661,9 +704,9 @@ func TestGetAddress(t *testing.T) {
 	}
 }
 
-// TestListAddresses verifies that ListAddresses correctly returns all
-// addresses for an account in a specified scope, filters by scope
-// appropriately, and handles empty results without error.
+// TestListAddresses verifies that ListAddresses correctly returns addresses
+// with page-contract behavior, filters by scope appropriately, and handles
+// empty results without error.
 func TestListAddresses(t *testing.T) {
 	t.Parallel()
 
@@ -780,7 +823,7 @@ func TestListAddresses(t *testing.T) {
 			walletID := newWallet(t, store, tc.name+"-wallet")
 
 			query := tc.setupFunc(t, store, store, walletID)
-			addrs, err := store.ListAddresses(t.Context(), query)
+			pageResult, err := store.ListAddresses(t.Context(), query)
 
 			if tc.wantErr != nil {
 				require.ErrorIs(t, err, tc.wantErr)
@@ -788,6 +831,7 @@ func TestListAddresses(t *testing.T) {
 			}
 
 			require.NoError(t, err)
+			addrs := pageResult.Items
 			require.Len(t, addrs, tc.wantCount)
 
 			if tc.validate != nil {
@@ -946,7 +990,7 @@ func TestListAddressesOrdering(t *testing.T) {
 		t, store, walletID, db.KeyScopeBIP0084, "ordering-account", true, 3,
 	)
 
-	addresses, err := store.ListAddresses(
+	pageResult, err := store.ListAddresses(
 		t.Context(),
 		db.ListAddressesQuery{
 			WalletID:    walletID,
@@ -956,6 +1000,7 @@ func TestListAddressesOrdering(t *testing.T) {
 	)
 
 	require.NoError(t, err)
+	addresses := pageResult.Items
 	require.Len(t, addresses, 6)
 
 	// Separate addresses by branch for verification.
@@ -984,6 +1029,410 @@ func TestListAddressesOrdering(t *testing.T) {
 			t, changeAddrs[i-1].Index <= changeAddrs[i].Index,
 			"change addresses not in order",
 		)
+	}
+}
+
+// TestListAddressesPagination verifies that ListAddresses paginates correctly
+// and sets Next without requiring an extra round-trip.
+func TestListAddressesPagination(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-list-addresses-strong-mode")
+	scope := db.KeyScopeBIP0084
+
+	createDerivedAccount(t, store, walletID, scope, "account-a")
+	createDerivedAccount(t, store, walletID, scope, "account-b")
+
+	accountA := createDerivedAddresses(
+		t, store, walletID, scope, "account-a", false, 5,
+	)
+	createDerivedAddresses(t, store, walletID, scope, "account-b", false, 2)
+
+	query := db.ListAddressesQuery{
+		WalletID:    walletID,
+		Scope:       scope,
+		AccountName: "account-a",
+		Page:        page.Request[uint32]{}.WithLimit(2),
+	}
+
+	page1, err := store.ListAddresses(t.Context(), query)
+	require.NoError(t, err)
+	require.Len(t, page1.Items, 2)
+	require.Equal(t, accountA[:2], page1.Items)
+	require.NotNil(t, page1.Next)
+
+	query.Page = query.Page.WithAfter(*page1.Next)
+	page2, err := store.ListAddresses(t.Context(), query)
+	require.NoError(t, err)
+	require.Len(t, page2.Items, 2)
+	require.Equal(t, accountA[2:4], page2.Items)
+	require.NotNil(t, page2.Next)
+
+	query.Page = query.Page.WithAfter(*page2.Next)
+	page3, err := store.ListAddresses(t.Context(), query)
+	require.NoError(t, err)
+	require.Len(t, page3.Items, 1)
+	require.Equal(t, accountA[4:], page3.Items)
+	require.Nil(t, page3.Next)
+
+	query.Page = query.Page.WithAfter(page3.Items[len(page3.Items)-1].ID)
+	page4, err := store.ListAddresses(t.Context(), query)
+	require.NoError(t, err)
+	require.Empty(t, page4.Items)
+	require.Nil(t, page4.Next)
+
+	paged := append([]db.AddressInfo{}, page1.Items...)
+	paged = append(paged, page2.Items...)
+	paged = append(paged, page3.Items...)
+	require.Equal(t, accountA, paged)
+	for i, addr := range paged {
+		require.Equal(t, uint32(i), addr.Index)
+		require.Equal(t, uint32(0), addr.Branch)
+	}
+}
+
+// TestListAddressesExactBoundary verifies that pagination correctly handles
+// the exact boundary case where total results equal page-size multiples.
+func TestListAddressesExactBoundary(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "boundary-wallet")
+	scope := db.KeyScopeBIP0084
+	accountName := "boundary-account"
+
+	createDerivedAccount(t, store, walletID, scope, accountName)
+	expected := createDerivedAddresses(
+		t, store, walletID, scope, accountName, false, 4,
+	)
+
+	query := db.ListAddressesQuery{
+		WalletID:    walletID,
+		Scope:       scope,
+		AccountName: accountName,
+		Page:        page.Request[uint32]{}.WithLimit(2),
+	}
+
+	page1, err := store.ListAddresses(t.Context(), query)
+	require.NoError(t, err)
+	require.Equal(t, expected[:2], page1.Items)
+	require.NotNil(t, page1.Next)
+	require.Equal(t, page1.Items[1].ID, *page1.Next)
+
+	query.Page = query.Page.WithAfter(*page1.Next)
+	page2, err := store.ListAddresses(t.Context(), query)
+	require.NoError(t, err)
+	require.Equal(t, expected[2:], page2.Items)
+	require.Nil(t, page2.Next)
+	require.Greater(t, page2.Items[0].ID, *page1.Next)
+
+	query.Page = query.Page.WithAfter(page2.Items[len(page2.Items)-1].ID)
+	page3, err := store.ListAddresses(t.Context(), query)
+	require.NoError(t, err)
+	require.Empty(t, page3.Items)
+	require.Nil(t, page3.Next)
+}
+
+// TestListAddressesPagedEmptyResult verifies that paginated ListAddresses
+// returns an empty result with no cursor for an account with no addresses.
+func TestListAddressesPagedEmptyResult(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-list-addresses-empty")
+	scope := db.KeyScopeBIP0084
+	pageSize := uint(2)
+
+	createDerivedAccount(t, store, walletID, scope, "empty-account")
+
+	pageResult, err := store.ListAddresses(t.Context(), db.ListAddressesQuery{
+		WalletID:    walletID,
+		Scope:       scope,
+		AccountName: "empty-account",
+		Page:        page.Request[uint32]{}.WithLimit(uint32(pageSize)),
+	})
+	require.NoError(t, err)
+	require.Empty(t, pageResult.Items)
+	require.Nil(t, pageResult.Next)
+}
+
+// TestListAddressesDeterministicPagination verifies stable ID-ordered address
+// pagination and next-cursor behavior.
+func TestListAddressesDeterministicPagination(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-address-deterministic")
+	scope := db.KeyScopeBIP0084
+	accountName := "deterministic-account"
+	createDerivedAccount(t, store, walletID, scope, accountName)
+	expected := createDerivedAddresses(
+		t, store, walletID, scope, accountName, false, 5,
+	)
+
+	pages := collectAddressPages(t, store, db.ListAddressesQuery{
+		WalletID:    walletID,
+		Scope:       scope,
+		AccountName: accountName,
+		Page:        page.Request[uint32]{}.WithLimit(2),
+	})
+	require.Len(t, pages, 3)
+	require.Len(t, pages[0].Items, 2)
+	require.Len(t, pages[1].Items, 2)
+	require.Len(t, pages[2].Items, 1)
+	require.NotNil(t, pages[0].Next)
+	require.NotNil(t, pages[1].Next)
+	require.Nil(t, pages[2].Next)
+
+	addresses := flattenAddressPages(pages)
+	require.Equal(t, expected, addresses)
+
+	seenIDs := make(map[uint32]struct{}, len(addresses))
+	for i := range pages {
+		for j, addr := range pages[i].Items {
+			_, duplicate := seenIDs[addr.ID]
+			require.False(t, duplicate)
+			seenIDs[addr.ID] = struct{}{}
+
+			// Skip the first item on the first page; there's no prior cursor
+			// to compare against.
+			if i == 0 && j == 0 {
+				continue
+			}
+
+			// First item on a later page: verify it sorts strictly after the
+			// previous page's cursor to ensure no gaps or duplicates at page
+			// boundaries.
+			if j == 0 {
+				require.Greater(t, addr.ID, *pages[i-1].Next)
+				continue
+			}
+
+			// Items within the same page: verify strict ordering to ensure
+			// the page contents are sorted.
+			require.Greater(t, addr.ID, pages[i].Items[j-1].ID)
+		}
+	}
+
+	for i := range addresses {
+		if i == 0 {
+			continue
+		}
+
+		require.Less(t, addresses[i-1].ID, addresses[i].ID)
+	}
+}
+
+// TestListAddressesAccountIsolation verifies that ListAddresses returns only
+// addresses for the requested account, excluding addresses from other accounts.
+func TestListAddressesAccountIsolation(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-address-account-isolation")
+	scope := db.KeyScopeBIP0084
+
+	createDerivedAccount(t, store, walletID, scope, "account-a")
+	createDerivedAccount(t, store, walletID, scope, "account-b")
+
+	expected := createDerivedAddresses(
+		t, store, walletID, scope, "account-a", false, 5,
+	)
+	otherAccount := createDerivedAddresses(
+		t, store, walletID, scope, "account-b", false, 3,
+	)
+
+	pages := collectAddressPages(t, store, db.ListAddressesQuery{
+		WalletID:    walletID,
+		Scope:       scope,
+		AccountName: "account-a",
+		Page:        page.Request[uint32]{}.WithLimit(2),
+	})
+	addresses := flattenAddressPages(pages)
+
+	require.Len(t, addresses, len(expected))
+	require.Equal(t, expected, addresses)
+	accountAID := expected[0].AccountID
+	accountBID := otherAccount[0].AccountID
+	for _, addr := range addresses {
+		require.Equal(t, accountAID, addr.AccountID)
+		require.NotEqual(t, accountBID, addr.AccountID)
+	}
+}
+
+// TestListAddressesInsertAfterCursor verifies inserts after page N are
+// returned on page N+1 when pagination uses increasing ID cursors.
+func TestListAddressesInsertAfterCursor(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-address-boundary-insert")
+	scope := db.KeyScopeBIP0084
+	accountName := "boundary-account"
+	createDerivedAccount(t, store, walletID, scope, accountName)
+	createDerivedAddresses(t, store, walletID, scope, accountName, false, 3)
+
+	query := db.ListAddressesQuery{
+		WalletID:    walletID,
+		Scope:       scope,
+		AccountName: accountName,
+		Page: page.Request[uint32]{}.
+			WithLimit(2),
+	}
+	page1, err := store.ListAddresses(t.Context(), query)
+	require.NoError(t, err)
+	require.Len(t, page1.Items, 2)
+	require.NotNil(t, page1.Next)
+
+	// Pagination is by increasing address ID (id > cursor).
+	// An address created after page 1 should therefore appear on page 2.
+	inserted := newDerivedAddress(
+		t, store, walletID, scope, accountName, false,
+	)
+
+	query.Page = query.Page.WithAfter(*page1.Next)
+	page2, err := store.ListAddresses(t.Context(), query)
+	require.NoError(t, err)
+	require.Len(t, page2.Items, 2)
+	require.Equal(t, uint32(2), page2.Items[0].Index)
+	require.Equal(t, inserted.ID, page2.Items[1].ID)
+	require.Equal(t, uint32(3), page2.Items[1].Index)
+	require.Nil(t, page2.Next)
+}
+
+// TestListAddressesCursorEdges verifies stale and zero-value cursors produce
+// deterministic page results.
+func TestListAddressesCursorEdges(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-address-cursor-edges")
+	scope := db.KeyScopeBIP0084
+	accountName := "cursor-account"
+	createDerivedAccount(t, store, walletID, scope, accountName)
+	createDerivedAddresses(t, store, walletID, scope, accountName, false, 3)
+
+	stalePage, err := store.ListAddresses(t.Context(), db.ListAddressesQuery{
+		WalletID:    walletID,
+		Scope:       scope,
+		AccountName: accountName,
+		Page: page.Request[uint32]{}.
+			WithLimit(2).
+			WithAfter(math.MaxUint32),
+	})
+	require.NoError(t, err)
+	require.Empty(t, stalePage.Items)
+	require.Nil(t, stalePage.Next)
+
+	zeroPage, err := store.ListAddresses(t.Context(), db.ListAddressesQuery{
+		WalletID:    walletID,
+		Scope:       scope,
+		AccountName: accountName,
+		Page: page.Request[uint32]{}.
+			WithLimit(2).
+			WithAfter(0),
+	})
+	require.NoError(t, err)
+	require.Len(t, zeroPage.Items, 2)
+	require.Equal(t, uint32(0), zeroPage.Items[0].Index)
+	require.Equal(t, uint32(1), zeroPage.Items[1].Index)
+	require.NotNil(t, zeroPage.Next)
+}
+
+// TestIterAddresses verifies that IterAddresses yields the same addresses in
+// the same order as manual cursor-based pagination.
+func TestIterAddresses(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-iter-addresses")
+	scope := db.KeyScopeBIP0084
+	pageSize := uint(2)
+
+	createDerivedAccount(t, store, walletID, scope, "iter-account")
+	expected := createDerivedAddresses(
+		t, store, walletID, scope, "iter-account", false, 5,
+	)
+
+	query := db.ListAddressesQuery{
+		WalletID:    walletID,
+		Scope:       scope,
+		AccountName: "iter-account",
+		Page:        page.Request[uint32]{}.WithLimit(uint32(pageSize)),
+	}
+
+	iterAddrs := make([]db.AddressInfo, 0, len(expected))
+	for addr, err := range store.IterAddresses(t.Context(), query) {
+		require.NoError(t, err)
+		iterAddrs = append(iterAddrs, addr)
+	}
+
+	paged := flattenAddressPages(collectAddressPages(t, store, query))
+	require.Equal(t, expected, paged)
+	require.Equal(t, expected, iterAddrs)
+	require.Equal(t, paged, iterAddrs)
+}
+
+// TestIterAddressesPaginated verifies that IterAddresses produces the same
+// results as manual pagination and correctly signals end-of-list.
+func TestIterAddressesPaginated(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-iter-addresses-early")
+	scope := db.KeyScopeBIP0084
+
+	createDerivedAccount(t, store, walletID, scope, "iter-account")
+	createDerivedAddresses(
+		t, store, walletID, scope, "iter-account", false, 4,
+	)
+
+	query := db.ListAddressesQuery{
+		WalletID:    walletID,
+		Scope:       scope,
+		AccountName: "iter-account",
+		Page: page.Request[uint32]{}.
+			WithLimit(2),
+	}
+
+	pages := collectAddressPages(t, store, query)
+	require.Len(t, pages, 2)
+	require.NotNil(t, pages[0].Next)
+	require.Nil(t, pages[1].Next)
+
+	expected := flattenAddressPages(pages)
+
+	iterAddrs := make([]db.AddressInfo, 0, len(expected))
+	for addr, err := range store.IterAddresses(t.Context(), query) {
+		require.NoError(t, err)
+		iterAddrs = append(iterAddrs, addr)
+	}
+
+	require.Equal(t, expected, iterAddrs)
+}
+
+// TestIterAddressesEmpty verifies that IterAddresses correctly handles
+// empty accounts without error and yields no addresses.
+func TestIterAddressesEmpty(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-iter-addresses-empty")
+	scope := db.KeyScopeBIP0084
+
+	createDerivedAccount(t, store, walletID, scope, "empty-account")
+
+	query := db.ListAddressesQuery{
+		WalletID:    walletID,
+		Scope:       scope,
+		AccountName: "empty-account",
+		Page:        page.Request[uint32]{}.WithLimit(10),
+	}
+
+	for addr, err := range store.IterAddresses(t.Context(), query) {
+		require.NoError(t, err)
+		require.Failf(t, "unexpected address", "address=%v", addr)
 	}
 }
 

--- a/wallet/internal/db/itest/wallet_store_test.go
+++ b/wallet/internal/db/itest/wallet_store_test.go
@@ -3,10 +3,12 @@
 package itest
 
 import (
+	"math"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/db/page"
 	"github.com/stretchr/testify/require"
 )
 
@@ -145,16 +147,22 @@ func TestGetWallet_NotFound(t *testing.T) {
 	require.ErrorIs(t, err, db.ErrWalletNotFound)
 }
 
-// TestListWallets verifies that ListWallets returns all wallets.
+// TestListWallets verifies that ListWallets correctly returns wallets and
+// handles empty results without error.
 func TestListWallets(t *testing.T) {
 	t.Parallel()
 
 	store := NewTestStore(t)
 
 	// Initially empty.
-	wallets, err := store.ListWallets(t.Context())
+	query := db.ListWalletsQuery{
+		Page: page.Request[uint32]{}.WithLimit(10),
+	}
+
+	pageResult, err := store.ListWallets(t.Context(), query)
 	require.NoError(t, err)
-	require.Empty(t, wallets)
+	require.Empty(t, pageResult.Items)
+	require.Nil(t, pageResult.Next)
 
 	// Create three wallets.
 	names := []string{"wallet-1", "wallet-2", "wallet-3"}
@@ -164,16 +172,447 @@ func TestListWallets(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	wallets, err = store.ListWallets(t.Context())
+	pageResult, err = store.ListWallets(t.Context(), query)
 	require.NoError(t, err)
-	require.Len(t, wallets, 3)
+	require.Len(t, pageResult.Items, 3)
 
 	// Verify all names are present.
-	walletsName := make([]string, len(wallets))
-	for i, w := range wallets {
+	walletsName := make([]string, len(pageResult.Items))
+	for i, w := range pageResult.Items {
 		walletsName[i] = w.Name
 	}
 	require.ElementsMatch(t, names, walletsName)
+}
+
+// TestListWalletsPagination verifies that ListWallets paginates correctly and
+// sets Next without requiring an extra round-trip.
+func TestListWalletsPagination(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+
+	names := []string{"wallet-1", "wallet-2", "wallet-3", "wallet-4"}
+	for _, name := range names {
+		params := CreateWalletParamsFixture(name)
+		_, err := store.CreateWallet(t.Context(), params)
+		require.NoError(t, err)
+	}
+
+	query := db.ListWalletsQuery{
+		Page: page.Request[uint32]{}.WithLimit(2),
+	}
+
+	page1, err := store.ListWallets(t.Context(), query)
+	require.NoError(t, err)
+	require.Len(t, page1.Items, 2)
+	require.NotNil(t, page1.Next)
+	require.Equal(t, page1.Items[1].ID, *page1.Next)
+
+	query.Page = query.Page.WithAfter(*page1.Next)
+	page2, err := store.ListWallets(t.Context(), query)
+	require.NoError(t, err)
+	require.Len(t, page2.Items, 2)
+	require.Nil(t, page2.Next)
+
+	query.Page = query.Page.WithAfter(page2.Items[len(page2.Items)-1].ID)
+	page3, err := store.ListWallets(t.Context(), query)
+	require.NoError(t, err)
+	require.Empty(t, page3.Items)
+	require.Nil(t, page3.Next)
+
+	paged := append([]db.WalletInfo{}, page1.Items...)
+	paged = append(paged, page2.Items...)
+	require.Len(t, paged, len(names))
+
+	pagedNames := make([]string, len(paged))
+	for i, wallet := range paged {
+		pagedNames[i] = wallet.Name
+	}
+	require.Equal(t, names, pagedNames)
+}
+
+// TestListWalletsExactBoundary verifies that pagination correctly handles the
+// exact boundary case where total results equal page-size multiples.
+func TestListWalletsExactBoundary(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	names := []string{"wallet-1", "wallet-2", "wallet-3", "wallet-4"}
+	for _, name := range names {
+		_, err := store.CreateWallet(
+			t.Context(), CreateWalletParamsFixture(name),
+		)
+		require.NoError(t, err)
+	}
+
+	query := db.ListWalletsQuery{
+		Page: page.Request[uint32]{}.WithLimit(2),
+	}
+
+	page1, err := store.ListWallets(t.Context(), query)
+	require.NoError(t, err)
+	require.Len(t, page1.Items, 2)
+	require.Equal(t, names[0], page1.Items[0].Name)
+	require.Equal(t, names[1], page1.Items[1].Name)
+	require.NotNil(t, page1.Next)
+	require.Equal(t, page1.Items[1].ID, *page1.Next)
+
+	query.Page = query.Page.WithAfter(*page1.Next)
+	page2, err := store.ListWallets(t.Context(), query)
+	require.NoError(t, err)
+	require.Len(t, page2.Items, 2)
+	require.Equal(t, names[2], page2.Items[0].Name)
+	require.Equal(t, names[3], page2.Items[1].Name)
+	require.Nil(t, page2.Next)
+	require.Greater(t, page2.Items[0].ID, *page1.Next)
+
+	query.Page = query.Page.WithAfter(page2.Items[len(page2.Items)-1].ID)
+	page3, err := store.ListWallets(t.Context(), query)
+	require.NoError(t, err)
+	require.Empty(t, page3.Items)
+	require.Nil(t, page3.Next)
+}
+
+// TestIterWallets verifies that IterWallets exhaustively retrieves all wallets
+// and yields the same results in the same order as manual cursor-based
+// pagination.
+func TestIterWallets(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+
+	names := []string{"wallet-1", "wallet-2", "wallet-3", "wallet-4"}
+	for _, name := range names {
+		params := CreateWalletParamsFixture(name)
+		_, err := store.CreateWallet(t.Context(), params)
+		require.NoError(t, err)
+	}
+
+	query := db.ListWalletsQuery{
+		Page: page.Request[uint32]{}.WithLimit(2),
+	}
+	expected := flattenWalletPages(collectWalletPages(t, store, query))
+
+	iterWallets := make([]db.WalletInfo, 0, len(expected))
+	for wallet, err := range store.IterWallets(t.Context(), query) {
+		require.NoError(t, err)
+		iterWallets = append(iterWallets, wallet)
+	}
+
+	require.Equal(t, expected, iterWallets)
+}
+
+// TestIterWalletsPaginated verifies that IterWallets produces the same
+// results as manual pagination and correctly signals end-of-list.
+func TestIterWalletsPaginated(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+
+	names := []string{"wallet-1", "wallet-2", "wallet-3", "wallet-4"}
+	for _, name := range names {
+		params := CreateWalletParamsFixture(name)
+		_, err := store.CreateWallet(t.Context(), params)
+		require.NoError(t, err)
+	}
+
+	query := db.ListWalletsQuery{
+		Page: page.Request[uint32]{}.WithLimit(2),
+	}
+
+	pages := collectWalletPages(t, store, query)
+	require.Len(t, pages, 2)
+	require.NotNil(t, pages[0].Next)
+	require.Nil(t, pages[1].Next)
+
+	expected := flattenWalletPages(pages)
+
+	iterWallets := make([]db.WalletInfo, 0, len(expected))
+	for wallet, err := range store.IterWallets(t.Context(), query) {
+		require.NoError(t, err)
+		iterWallets = append(iterWallets, wallet)
+	}
+
+	require.Equal(t, expected, iterWallets)
+}
+
+// TestListWalletsPagedFromCursor verifies that ListWallets can resume
+// pagination from a specific cursor position, returning only wallets after
+// that cursor.
+func TestListWalletsPagedFromCursor(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+
+	names := []string{"wallet-1", "wallet-2", "wallet-3", "wallet-4"}
+	created := make([]*db.WalletInfo, 0, len(names))
+	for _, name := range names {
+		params := CreateWalletParamsFixture(name)
+		wallet, err := store.CreateWallet(t.Context(), params)
+		require.NoError(t, err)
+		created = append(created, wallet)
+	}
+
+	query := db.ListWalletsQuery{
+		Page: page.Request[uint32]{}.WithLimit(2).WithAfter(created[1].ID),
+	}
+
+	pageResult, err := store.ListWallets(t.Context(), query)
+	require.NoError(t, err)
+	require.Len(t, pageResult.Items, 2)
+	require.Equal(t, names[2], pageResult.Items[0].Name)
+	require.Equal(t, names[3], pageResult.Items[1].Name)
+	require.Nil(t, pageResult.Next)
+
+	query.Page = query.Page.WithAfter(created[3].ID)
+	pageResult, err = store.ListWallets(t.Context(), query)
+	require.NoError(t, err)
+	require.Empty(t, pageResult.Items)
+	require.Nil(t, pageResult.Next)
+}
+
+// TestListWalletsPagedWithSyncMetadata verifies that paginated wallet
+// listings include sync metadata such as synced-to block and birthday block.
+func TestListWalletsPagedWithSyncMetadata(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	queries := store.Queries()
+
+	birthday1 := time.Now().UTC().Add(-48 * time.Hour)
+	birthday2 := time.Now().UTC().Add(-24 * time.Hour)
+
+	params1 := CreateWalletParamsFixture("wallet-sync-1")
+	params1.Birthday = birthday1
+	wallet1, err := store.CreateWallet(t.Context(), params1)
+	require.NoError(t, err)
+
+	params2 := CreateWalletParamsFixture("wallet-sync-2")
+	params2.Birthday = birthday2
+	wallet2, err := store.CreateWallet(t.Context(), params2)
+	require.NoError(t, err)
+
+	block1 := CreateBlockFixture(t, queries, 100)
+	block2 := CreateBlockFixture(t, queries, 101)
+
+	err = store.UpdateWallet(t.Context(), db.UpdateWalletParams{
+		WalletID:      wallet1.ID,
+		SyncedTo:      &block2,
+		BirthdayBlock: &block1,
+	})
+	require.NoError(t, err)
+
+	err = store.UpdateWallet(t.Context(), db.UpdateWalletParams{
+		WalletID:      wallet2.ID,
+		SyncedTo:      &block2,
+		BirthdayBlock: &block1,
+	})
+	require.NoError(t, err)
+
+	query := db.ListWalletsQuery{
+		Page: page.Request[uint32]{}.WithLimit(1),
+	}
+
+	page1, err := store.ListWallets(t.Context(), query)
+	require.NoError(t, err)
+	require.Len(t, page1.Items, 1)
+	require.NotNil(t, page1.Items[0].SyncedTo)
+	require.NotNil(t, page1.Items[0].BirthdayBlock)
+	require.False(t, page1.Items[0].Birthday.IsZero())
+	require.NotNil(t, page1.Next)
+
+	query.Page = query.Page.WithAfter(*page1.Next)
+	page2, err := store.ListWallets(t.Context(), query)
+	require.NoError(t, err)
+	require.Len(t, page2.Items, 1)
+	require.NotNil(t, page2.Items[0].SyncedTo)
+	require.NotNil(t, page2.Items[0].BirthdayBlock)
+	require.False(t, page2.Items[0].Birthday.IsZero())
+	require.Nil(t, page2.Next)
+}
+
+// TestListWalletsDeterministicPagination verifies stable page ordering and
+// next-cursor behavior for multi-page wallet listings.
+func TestListWalletsDeterministicPagination(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	names := []string{
+		"wallet-page-1",
+		"wallet-page-2",
+		"wallet-page-3",
+		"wallet-page-4",
+		"wallet-page-5",
+	}
+
+	for _, name := range names {
+		_, err := store.CreateWallet(
+			t.Context(), CreateWalletParamsFixture(name),
+		)
+		require.NoError(t, err)
+	}
+
+	pages := collectWalletPages(t, store, db.ListWalletsQuery{
+		Page: page.Request[uint32]{}.WithLimit(2),
+	})
+	require.Len(t, pages, 3)
+	require.Len(t, pages[0].Items, 2)
+	require.Len(t, pages[1].Items, 2)
+	require.Len(t, pages[2].Items, 1)
+	require.NotNil(t, pages[0].Next)
+	require.NotNil(t, pages[1].Next)
+	require.Nil(t, pages[2].Next)
+
+	wallets := flattenWalletPages(pages)
+	require.Len(t, wallets, len(names))
+
+	collectedNames := make([]string, len(wallets))
+	for i, wallet := range wallets {
+		if i > 0 {
+			require.Less(t, wallets[i-1].ID, wallet.ID)
+		}
+
+		collectedNames[i] = wallet.Name
+	}
+
+	require.Equal(t, names, collectedNames)
+	require.Equal(t, wallets[1].ID, *pages[0].Next)
+	require.Equal(t, wallets[3].ID, *pages[1].Next)
+
+	seenIDs := make(map[uint32]struct{}, len(wallets))
+	for i := range pages {
+		for j, wallet := range pages[i].Items {
+			_, duplicate := seenIDs[wallet.ID]
+			require.False(t, duplicate)
+			seenIDs[wallet.ID] = struct{}{}
+
+			// Skip the first item on the first page; there's no prior cursor
+			// to compare against.
+			if i == 0 && j == 0 {
+				continue
+			}
+
+			// First item on a later page: verify it sorts strictly after the
+			// previous page's cursor to ensure no gaps or duplicates at page
+			// boundaries.
+			if j == 0 {
+				require.Greater(t, wallet.ID, *pages[i-1].Next)
+				continue
+			}
+
+			// Items within the same page: verify strict ordering to ensure
+			// the page contents are sorted.
+			require.Greater(t, wallet.ID, pages[i].Items[j-1].ID)
+		}
+	}
+}
+
+// TestListWalletsInsertAfterCursor verifies inserts after page N are returned
+// on page N+1 when pagination uses increasing ID cursors.
+func TestListWalletsInsertAfterCursor(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	for _, name := range []string{"wallet-a", "wallet-b", "wallet-c"} {
+		_, err := store.CreateWallet(
+			t.Context(), CreateWalletParamsFixture(name),
+		)
+		require.NoError(t, err)
+	}
+
+	query := db.ListWalletsQuery{
+		Page: page.Request[uint32]{}.WithLimit(2),
+	}
+	page1, err := store.ListWallets(t.Context(), query)
+	require.NoError(t, err)
+	require.Len(t, page1.Items, 2)
+	require.NotNil(t, page1.Next)
+
+	// Pagination is by increasing wallet ID (id > cursor).
+	// A wallet created after page 1 should therefore appear on page 2.
+	inserted, err := store.CreateWallet(
+		t.Context(), CreateWalletParamsFixture("wallet-d"),
+	)
+	require.NoError(t, err)
+
+	query.Page = query.Page.WithAfter(*page1.Next)
+	page2, err := store.ListWallets(t.Context(), query)
+	require.NoError(t, err)
+	require.Len(t, page2.Items, 2)
+	require.Equal(t, "wallet-c", page2.Items[0].Name)
+	require.Equal(t, inserted.ID, page2.Items[1].ID)
+	require.Equal(t, "wallet-d", page2.Items[1].Name)
+	require.Nil(t, page2.Next)
+}
+
+// TestListWalletsCursorEdges verifies stale and zero-value cursors produce
+// deterministic page results.
+func TestListWalletsCursorEdges(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	names := []string{"wallet-1", "wallet-2", "wallet-3"}
+	for _, name := range names {
+		_, err := store.CreateWallet(
+			t.Context(), CreateWalletParamsFixture(name),
+		)
+		require.NoError(t, err)
+	}
+
+	stalePage, err := store.ListWallets(t.Context(), db.ListWalletsQuery{
+		Page: page.Request[uint32]{}.WithLimit(2).WithAfter(math.MaxUint32),
+	})
+	require.NoError(t, err)
+	require.Empty(t, stalePage.Items)
+	require.Nil(t, stalePage.Next)
+
+	zeroPage, err := store.ListWallets(t.Context(), db.ListWalletsQuery{
+		Page: page.Request[uint32]{}.WithLimit(2).WithAfter(0),
+	})
+	require.NoError(t, err)
+	require.Len(t, zeroPage.Items, 2)
+	require.Equal(t, names[0], zeroPage.Items[0].Name)
+	require.Equal(t, names[1], zeroPage.Items[1].Name)
+	require.NotNil(t, zeroPage.Next)
+}
+
+// collectWalletPages collects paginated wallet results by iterating
+// through all pages from ListWallets, using cursor pagination until
+// Next is nil.
+func collectWalletPages(t *testing.T, store db.WalletStore,
+	query db.ListWalletsQuery) []page.Result[db.WalletInfo, uint32] {
+	t.Helper()
+
+	pages := make([]page.Result[db.WalletInfo, uint32], 0)
+	for {
+		pageResult, err := store.ListWallets(t.Context(), query)
+		require.NoError(t, err)
+		pages = append(pages, pageResult)
+
+		if pageResult.Next == nil {
+			return pages
+		}
+
+		query.Page = query.Page.WithAfter(*pageResult.Next)
+	}
+}
+
+// flattenWalletPages flattens paginated wallet results into a single
+// slice containing all wallets from all pages.
+func flattenWalletPages(
+	pages []page.Result[db.WalletInfo, uint32]) []db.WalletInfo {
+
+	count := 0
+	for i := range pages {
+		count += len(pages[i].Items)
+	}
+
+	wallets := make([]db.WalletInfo, 0, count)
+	for i := range pages {
+		wallets = append(wallets, pages[i].Items...)
+	}
+
+	return wallets
 }
 
 // TestUpdateWallet_SyncedTo checks that updating the wallet's synced-to block

--- a/wallet/internal/db/migrations/postgres/000006_addresses.down.sql
+++ b/wallet/internal/db/migrations/postgres/000006_addresses.down.sql
@@ -1,4 +1,5 @@
 -- Rollback note: Idempotent by design (using "IF EXISTS").
 -- Must succeed even if tables are already dropped or database is in unexpected state.
+DROP INDEX IF EXISTS idx_addresses_account_id;
 DROP TABLE IF EXISTS address_secrets;
 DROP TABLE IF EXISTS addresses;

--- a/wallet/internal/db/migrations/postgres/000006_addresses.up.sql
+++ b/wallet/internal/db/migrations/postgres/000006_addresses.up.sql
@@ -76,6 +76,10 @@ ON addresses (account_id, script_pub_key);
 -- Used by GetAddressByScriptPubKey.
 CREATE INDEX idx_addresses_script_pub_key ON addresses (script_pub_key);
 
+-- Index on (account_id, id) for efficient pagination of addresses by account.
+-- Used by ListAddressesByAccount for cursor-based pagination.
+CREATE INDEX idx_addresses_account_id ON addresses (account_id, id);
+
 -- Address Secrets table stores sensitive encrypted material needed to spend
 -- from an address. This table has a one-to-one relationship with addresses.
 -- Watch-only addresses may have no row in this table.

--- a/wallet/internal/db/migrations/sqlite/000006_addresses.down.sql
+++ b/wallet/internal/db/migrations/sqlite/000006_addresses.down.sql
@@ -1,4 +1,5 @@
 -- Rollback note: Idempotent by design (using "IF EXISTS").
 -- Must succeed even if tables are already dropped or database is in unexpected state.
+DROP INDEX IF EXISTS idx_addresses_account_id;
 DROP TABLE IF EXISTS address_secrets;
 DROP TABLE IF EXISTS addresses;

--- a/wallet/internal/db/migrations/sqlite/000006_addresses.up.sql
+++ b/wallet/internal/db/migrations/sqlite/000006_addresses.up.sql
@@ -74,6 +74,10 @@ ON addresses (account_id, script_pub_key);
 -- Used by GetAddressByScriptPubKey.
 CREATE INDEX idx_addresses_script_pub_key ON addresses (script_pub_key);
 
+-- Index on (account_id, id) for efficient pagination of addresses by account.
+-- Used by ListAddressesByAccount for cursor-based pagination.
+CREATE INDEX idx_addresses_account_id ON addresses (account_id, id);
+
 -- Address Secrets table stores sensitive encrypted material needed to spend
 -- from an address. This table has a one-to-one relationship with addresses.
 -- Watch-only addresses may have no row in this table.

--- a/wallet/internal/db/page/doc.go
+++ b/wallet/internal/db/page/doc.go
@@ -1,0 +1,31 @@
+// Package page provides after-based pagination primitives for SQL-backed
+// stores.
+//
+// # Core types
+//
+// A [Request] carries the parameters for a single page fetch: page limit,
+// and an optional after that identifies where the previous page ended.
+// The zero value requests the first page at [DefaultLimit].
+//
+// A [Result] carries the items returned by one fetch together with
+// [Result.Next]. Pass *Next back to [Request.WithAfter] to advance to the
+// next page.
+//
+// Queries fetch normalizedLimit+1 rows internally and return at most
+// normalizedLimit items. If the extra row exists, [Result.Next] is non-nil.
+// If it does not, [Result.Next] is nil and the current page is the last page.
+//
+// # Iterating
+//
+// [Iter] wraps a fetch function in a standard [iter.Seq2] that pages
+// transparently until the list is exhausted or the caller breaks early.
+// It propagates fetch errors and respects context cancellation through
+// the fetchPage callback.
+//
+// # Store integration
+//
+// Stores typically translate [Request.After] into an optional backend
+// query parameter, fetch [Request.QueryLimit] rows with a single ordered
+// SQL query, map the raw rows to domain items, and then call
+// [BuildResult] to derive [Result.Next].
+package page

--- a/wallet/internal/db/page/iter.go
+++ b/wallet/internal/db/page/iter.go
@@ -1,0 +1,55 @@
+package page
+
+import (
+	"context"
+	"iter"
+)
+
+// Iter iterates through paginated results by repeatedly fetching pages and
+// yielding items until exhaustion, caller break, error, or cancellation.
+//
+// Errors are yielded as the second value in the iterator pair. Callers must
+// check the error on every iteration before using the yielded item.
+func Iter[Query, Item, Cursor any](ctx context.Context, query Query,
+	fetch func(context.Context, Query) (Result[Item, Cursor], error),
+	withAfter func(Query, Cursor) Query) iter.Seq2[Item, error] {
+
+	return func(yield func(Item, error) bool) {
+		var zero Item
+
+		for {
+			err := ctx.Err()
+			if err != nil {
+				yield(zero, err)
+
+				return
+			}
+
+			result, err := fetch(ctx, query)
+			if err != nil {
+				yield(zero, err)
+
+				return
+			}
+
+			for _, item := range result.Items {
+				err = ctx.Err()
+				if err != nil {
+					yield(zero, err)
+
+					return
+				}
+
+				if !yield(item, nil) {
+					return
+				}
+			}
+
+			if result.Next == nil {
+				return
+			}
+
+			query = withAfter(query, *result.Next)
+		}
+	}
+}

--- a/wallet/internal/db/page/iter_test.go
+++ b/wallet/internal/db/page/iter_test.go
@@ -1,0 +1,487 @@
+package page
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// errTest is a sentinel error used across page package tests to
+// verify error propagation through pagination helpers.
+var errTest = errors.New("test error")
+
+// intPtr returns a pointer to the given int value. It is used in tests to
+// construct Result literals that require a *int after.
+func intPtr(v int) *int {
+	return &v
+}
+
+// TestIterTraversal tests the traversal of items using the page iterator.
+func TestIterTraversal(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		pages          [][]int
+		wantItems      []int
+		wantFetchCalls int
+		wantQueries    []int
+		wantCursors    []int
+	}{
+		{
+			name:           "empty result",
+			pages:          [][]int{{}},
+			wantItems:      nil,
+			wantFetchCalls: 1,
+			wantQueries:    nil,
+			wantCursors:    nil,
+		},
+		{
+			name:           "single non-empty page",
+			pages:          [][]int{{1, 2}},
+			wantItems:      []int{1, 2},
+			wantFetchCalls: 1,
+			wantQueries:    nil,
+			wantCursors:    nil,
+		},
+		{
+			name:           "multi page traversal",
+			pages:          [][]int{{1, 2}, {3, 4}, {5}},
+			wantItems:      []int{1, 2, 3, 4, 5},
+			wantFetchCalls: 3,
+			wantQueries:    []int{0, 1},
+			wantCursors:    []int{2, 4},
+		},
+		{
+			name:           "exact multiple of page limit",
+			pages:          [][]int{{1, 2}, {3, 4}},
+			wantItems:      []int{1, 2, 3, 4},
+			wantFetchCalls: 2,
+			wantQueries:    []int{0},
+			wantCursors:    []int{2},
+		},
+		{
+			name:           "limit one traversal",
+			pages:          [][]int{{1}, {2}, {3}},
+			wantItems:      []int{1, 2, 3},
+			wantFetchCalls: 3,
+			wantQueries:    []int{0, 1},
+			wantCursors:    []int{1, 2},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				fetchCalls  int
+				nextQueries []int
+				nextCursors []int
+				gotItems    []int
+			)
+
+			fetchPage := func(_ context.Context, query int) (Result[int, int],
+				error) {
+
+				require.Less(t, fetchCalls, len(tc.pages))
+				require.Equal(t, fetchCalls, query)
+
+				items := tc.pages[fetchCalls]
+				hasMore := fetchCalls < len(tc.pages)-1
+				fetchCalls++
+
+				result := Result[int, int]{
+					Items: items,
+				}
+				if hasMore && len(items) > 0 {
+					last := items[len(items)-1]
+					result.Next = &last
+				}
+
+				return result, nil
+			}
+
+			setCursor := func(query int, cursor int) int {
+				nextQueries = append(nextQueries, query)
+				nextCursors = append(nextCursors, cursor)
+
+				return query + 1
+			}
+
+			for item, err := range Iter(
+				t.Context(), 0, fetchPage, setCursor,
+			) {
+				require.NoError(t, err)
+
+				gotItems = append(gotItems, item)
+			}
+
+			require.Equal(t, tc.wantItems, gotItems)
+			require.Equal(t, tc.wantFetchCalls, fetchCalls)
+			require.Equal(t, tc.wantQueries, nextQueries)
+			require.Equal(t, tc.wantCursors, nextCursors)
+		})
+	}
+}
+
+// TestIterFetchErrorOnFirstCall verifies that Iter yields the error immediately
+// when fetchPage fails on the very first call, before any items are produced.
+func TestIterFetchErrorOnFirstCall(t *testing.T) {
+	t.Parallel()
+
+	gotItems := make([]int, 0)
+
+	var iterErr error
+
+	fetchPage := func(_ context.Context, _ int) (Result[int, int], error) {
+		return Result[int, int]{}, errTest
+	}
+
+	setCursor := func(_ int, _ int) int {
+		return 0
+	}
+
+	for item, err := range Iter(
+		t.Context(), 0, fetchPage, setCursor,
+	) {
+		if err != nil {
+			iterErr = err
+			break
+		}
+
+		gotItems = append(gotItems, item)
+	}
+
+	require.ErrorIs(t, iterErr, errTest)
+	require.Empty(t, gotItems)
+}
+
+// TestIterFetchErrorAfterTwoPages verifies that Iter yields all items from
+// successful pages before propagating an error from a later fetchPage call.
+func TestIterFetchErrorAfterTwoPages(t *testing.T) {
+	t.Parallel()
+
+	var (
+		fetchCalls  int
+		nextCursors []int
+		iterErr     error
+	)
+
+	gotItems := make([]int, 0)
+
+	fetchPage := func(
+		_ context.Context, _ int,
+	) (Result[int, int], error) {
+
+		fetchCalls++
+		switch fetchCalls {
+		case 1:
+			return Result[int, int]{
+				Items: []int{1, 2},
+				Next:  intPtr(2),
+			}, nil
+		case 2:
+			return Result[int, int]{
+				Items: []int{3, 4},
+				Next:  intPtr(4),
+			}, nil
+		default:
+			return Result[int, int]{}, errTest
+		}
+	}
+
+	setCursor := func(query int, cursor int) int {
+		nextCursors = append(nextCursors, cursor)
+		return query + 1
+	}
+
+	for item, err := range Iter(
+		t.Context(), 0, fetchPage, setCursor,
+	) {
+		if err != nil {
+			iterErr = err
+			break
+		}
+
+		gotItems = append(gotItems, item)
+	}
+
+	require.ErrorIs(t, iterErr, errTest)
+	require.Equal(t, []int{1, 2, 3, 4}, gotItems)
+	require.Equal(t, 3, fetchCalls)
+	require.Equal(t, []int{2, 4}, nextCursors)
+}
+
+// TestIterContextCancellation tests cancellation behavior for page iteration.
+func TestIterContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name             string
+		pages            [][]int
+		cancelBefore     bool
+		cancelAfterItems int
+		wantItems        []int
+		wantFetchCalls   int
+	}{
+		{
+			name:           "cancelled before first fetch",
+			pages:          [][]int{{1, 2}},
+			cancelBefore:   true,
+			wantItems:      nil,
+			wantFetchCalls: 0,
+		},
+		{
+			name:             "cancelled between pages",
+			pages:            [][]int{{1, 2}, {3, 4}},
+			cancelAfterItems: 2,
+			wantItems:        []int{1, 2},
+			wantFetchCalls:   1,
+		},
+		{
+			name: "cancel mid-page stops before next yield",
+			pages: [][]int{
+				{1, 2, 3},
+				{4, 5},
+			},
+			cancelAfterItems: 1,
+			wantItems:        []int{1},
+			wantFetchCalls:   1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				fetchCalls int
+				gotItems   []int
+				iterErr    error
+			)
+
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+
+			if tc.cancelBefore {
+				cancel()
+			}
+
+			fetchPage := func(ctx context.Context, _ int) (Result[int, int],
+				error) {
+
+				err := ctx.Err()
+				if err != nil {
+					fetchCalls++
+
+					return Result[int, int]{}, err
+				}
+
+				require.Less(t, fetchCalls, len(tc.pages))
+
+				items := tc.pages[fetchCalls]
+				fetchCalls++
+
+				result := Result[int, int]{
+					Items: items,
+				}
+				if len(items) > 0 {
+					last := items[len(items)-1]
+					result.Next = &last
+				}
+
+				return result, nil
+			}
+
+			setCursor := func(query int, _ int) int {
+				return query + 1
+			}
+
+			for item, err := range Iter(
+				ctx, 0, fetchPage, setCursor,
+			) {
+				if err != nil {
+					iterErr = err
+					break
+				}
+
+				gotItems = append(gotItems, item)
+				if tc.cancelAfterItems > 0 &&
+					len(gotItems) == tc.cancelAfterItems {
+
+					cancel()
+				}
+			}
+
+			require.ErrorIs(t, iterErr, context.Canceled)
+			require.Equal(t, tc.wantItems, gotItems)
+			require.Equal(t, tc.wantFetchCalls, fetchCalls)
+		})
+	}
+}
+
+// TestIterConsumerBreaks tests the page iterator when the consumer breaks out
+// of the loop.
+func TestIterConsumerBreaks(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		pages          [][]int
+		stopAfter      int
+		wantItems      []int
+		wantFetchCalls int
+		wantNextCalls  int
+	}{
+		{
+			name:           "mid page",
+			pages:          [][]int{{1, 2, 3}, {4, 5}},
+			stopAfter:      2,
+			wantItems:      []int{1, 2},
+			wantFetchCalls: 1,
+			wantNextCalls:  0,
+		},
+		{
+			// The consumer stops after consuming all items in the first page.
+			// setCursor is never called because the break happens before the
+			// iterator advances to the next page.
+			name:           "at page boundary",
+			pages:          [][]int{{1, 2}, {3, 4}},
+			stopAfter:      2,
+			wantItems:      []int{1, 2},
+			wantFetchCalls: 1,
+			wantNextCalls:  0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				fetchCalls int
+				nextCalls  int
+				gotItems   []int
+			)
+
+			fetchPage := func(_ context.Context, _ int) (Result[int, int],
+				error) {
+
+				require.Less(t, fetchCalls, len(tc.pages))
+
+				items := tc.pages[fetchCalls]
+				hasMore := fetchCalls < len(tc.pages)-1
+				fetchCalls++
+
+				result := Result[int, int]{
+					Items: items,
+				}
+				if hasMore && len(items) > 0 {
+					last := items[len(items)-1]
+					result.Next = &last
+				}
+
+				return result, nil
+			}
+
+			setCursor := func(query int, cursor int) int {
+				nextCalls++
+
+				return query + cursor
+			}
+
+			for item, err := range Iter(
+				t.Context(), 0, fetchPage, setCursor,
+			) {
+				require.NoError(t, err)
+
+				gotItems = append(gotItems, item)
+				if len(gotItems) == tc.stopAfter {
+					break
+				}
+			}
+
+			require.Equal(t, tc.wantItems, gotItems)
+			require.Equal(t, tc.wantFetchCalls, fetchCalls)
+			require.Equal(t, tc.wantNextCalls, nextCalls)
+		})
+	}
+}
+
+// TestIterNextNilTermination verifies Iter stops when Next becomes nil,
+// without requiring an extra empty-page fetch.
+func TestIterNextNilTermination(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		pages          []Result[int, int]
+		wantItems      []int
+		wantFetchCalls int
+		wantNextCalls  int
+	}{
+		{
+			name: "stops on last non-empty page",
+			pages: []Result[int, int]{
+				{Items: []int{1, 2}},
+			},
+			wantItems:      []int{1, 2},
+			wantFetchCalls: 1,
+			wantNextCalls:  0,
+		},
+		{
+			name: "multi-page, stops mid",
+			pages: []Result[int, int]{
+				{Items: []int{1, 2}, Next: intPtr(2)},
+				{Items: []int{3}},
+			},
+			wantItems:      []int{1, 2, 3},
+			wantFetchCalls: 2,
+			wantNextCalls:  1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				fetchCalls int
+				nextCalls  int
+				gotItems   []int
+			)
+
+			fetchPage := func(_ context.Context, _ int) (Result[int, int],
+				error) {
+
+				require.Less(t, fetchCalls, len(tc.pages))
+
+				result := tc.pages[fetchCalls]
+				fetchCalls++
+
+				return result, nil
+			}
+
+			setCursor := func(query int, _ int) int {
+				nextCalls++
+
+				return query + 1
+			}
+
+			for item, err := range Iter(
+				t.Context(), 0, fetchPage, setCursor,
+			) {
+				require.NoError(t, err)
+
+				gotItems = append(gotItems, item)
+			}
+
+			require.Equal(t, tc.wantItems, gotItems)
+			require.Equal(t, tc.wantFetchCalls, fetchCalls)
+			require.Equal(t, tc.wantNextCalls, nextCalls)
+		})
+	}
+}

--- a/wallet/internal/db/page/request.go
+++ b/wallet/internal/db/page/request.go
@@ -1,0 +1,119 @@
+package page
+
+const (
+	// DefaultLimit is the default number of items that can be returned to a
+	// page.
+	DefaultLimit = 100
+
+	// MaxLimit is the maximum number of items that can be returned to a page.
+	// Store implementations may fetch MaxLimit+1 rows internally to detect
+	// whether another page exists.
+	MaxLimit = 1000
+)
+
+// Request holds the parameters for a paginated list query. The zero value is
+// valid and requests the first page at DefaultLimit. All With* methods
+// return a modified shallow copy of the request.
+//
+// Fields are unexported so that callers must use the With* methods and
+// accessor functions. This design preserves the normalization of limit (zero
+// maps to DefaultLimit via normalizedLimit()) and ensures consistency across
+// all page operations.
+type Request[Cursor any] struct {
+	// limit is the maximum number of items to return per page.
+	limit uint32
+
+	// after is the pagination cursor that marks where the next page
+	// starts after. Nil means the first page.
+	after *Cursor
+}
+
+// QueryLimit returns the number of rows the SQL query should fetch. Queries
+// fetch normalizedLimit+1 rows, so BuildResult can use the extra row as a
+// lookahead signal to determine whether another page exists.
+func (r Request[Cursor]) QueryLimit() uint32 {
+	return r.normalizedLimit() + 1
+}
+
+// WithLimit returns a copy of the request with the limit replaced. The limit is
+// not validated here; normalization (zero -> DefaultLimit, over MaxLimit ->
+// MaxLimit) happens in normalizedLimit() and QueryLimit(). A caller passing
+// 0 or a large value will not see an error, the value will just be normalized
+// later.
+func (r Request[Cursor]) WithLimit(limit uint32) Request[Cursor] {
+	r.limit = limit
+
+	return r
+}
+
+// After returns the pagination after from the previous page.
+// A false ok return value means the first page is being requested.
+func (r Request[Cursor]) After() (Cursor, bool) {
+	if r.after == nil {
+		var zero Cursor
+
+		return zero, false
+	}
+
+	return *r.after, true
+}
+
+// WithAfter returns a copy of the request with the after replaced.
+// Calling this on a zero-value Request produces a request for the second page
+// (the page after this after). It takes the after by value to avoid
+// the caller retaining a pointer into the Request.
+func (r Request[Cursor]) WithAfter(after Cursor) Request[Cursor] {
+	r.after = &after
+
+	return r
+}
+
+// BuildResult assembles a page.Result from a slice of items already fetched by
+// the caller. It uses r.normalizedLimit to determine whether the query fetched
+// an extra lookahead row. The toCursor function is called on the last item of
+// the possibly trimmed slice.
+//
+// An empty slice always returns an empty result.
+//
+// If len(items) is greater than normalizedLimit, it trims to normalizedLimit
+// and sets Next to the after of the last item in the trimmed slice.
+// Otherwise, Next is nil.
+func BuildResult[Cursor, Item any](r Request[Cursor], items []Item,
+	nextOf func(Item) Cursor) Result[Item, Cursor] {
+
+	if len(items) == 0 {
+		return Result[Item, Cursor]{Items: items}
+	}
+
+	limit := r.normalizedLimit()
+	if len(items) <= int(limit) {
+		return Result[Item, Cursor]{
+			Items: items,
+		}
+	}
+
+	items = items[:int(limit)]
+	last := items[len(items)-1]
+	cursor := nextOf(last)
+
+	return Result[Item, Cursor]{
+		Items: items,
+		Next:  &cursor,
+	}
+}
+
+// normalizedLimit returns the normalized requested page limit for this request.
+// A limit of zero returns DefaultLimit. A limit greater than MaxLimit is
+// clamped to MaxLimit.
+func (r Request[Cursor]) normalizedLimit() uint32 {
+	switch {
+	case r.limit == 0:
+		return DefaultLimit
+
+	case r.limit > MaxLimit:
+		return MaxLimit
+
+	default:
+		return r.limit
+	}
+}

--- a/wallet/internal/db/page/request_test.go
+++ b/wallet/internal/db/page/request_test.go
@@ -1,0 +1,243 @@
+package page
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRequestSize verifies that normalizedLimit normalizes the raw limit field.
+func TestRequestSize(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		size     uint32
+		wantSize uint32
+	}{
+		{
+			name:     "zero defaults to DefaultLimit",
+			size:     0,
+			wantSize: DefaultLimit,
+		},
+		{
+			name:     "minimum in range",
+			size:     1,
+			wantSize: 1,
+		},
+		{
+			name:     "exactly MaxLimit passes through",
+			size:     MaxLimit,
+			wantSize: MaxLimit,
+		},
+		{
+			name:     "over MaxLimit clamped to MaxLimit",
+			size:     uint32(MaxLimit) + 1,
+			wantSize: MaxLimit,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			request := Request[uint32]{}.WithLimit(tc.size)
+			require.Equal(t, tc.wantSize, request.normalizedLimit())
+		})
+	}
+}
+
+// TestQueryLimit verifies that QueryLimit returns normalizedLimit+1,
+// including at MaxLimit.
+func TestQueryLimit(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uses limit plus one", func(t *testing.T) {
+		t.Parallel()
+
+		r := Request[uint32]{}.WithLimit(25)
+		require.Equal(t, r.normalizedLimit()+1, r.QueryLimit())
+	})
+
+	t.Run("at max page limit", func(t *testing.T) {
+		t.Parallel()
+
+		r := Request[uint32]{}.WithLimit(MaxLimit)
+		require.Equal(t, uint32(MaxLimit)+1, r.QueryLimit())
+	})
+}
+
+// TestRequestChaining verifies that chaining With* calls produces the
+// expected limit and after on the resulting Request.
+func TestRequestChaining(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		request       Request[uint32]
+		wantSize      uint32
+		wantCursor    uint32
+		wantHasCursor bool
+	}{
+		{
+			name:          "after nil by default",
+			request:       Request[uint32]{},
+			wantSize:      DefaultLimit,
+			wantHasCursor: false,
+		},
+		{
+			name:          "after set without limit",
+			request:       Request[uint32]{}.WithAfter(42),
+			wantSize:      DefaultLimit,
+			wantCursor:    42,
+			wantHasCursor: true,
+		},
+		{
+			name:          "limit and after set together",
+			request:       Request[uint32]{}.WithLimit(50).WithAfter(99),
+			wantSize:      50,
+			wantCursor:    99,
+			wantHasCursor: true,
+		},
+		{
+			name:          "after overwrites previous after",
+			request:       Request[uint32]{}.WithAfter(1).WithAfter(2),
+			wantSize:      DefaultLimit,
+			wantCursor:    2,
+			wantHasCursor: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.wantSize, tc.request.normalizedLimit())
+
+			if !tc.wantHasCursor {
+				_, ok := tc.request.After()
+				require.False(t, ok)
+
+				return
+			}
+
+			after, ok := tc.request.After()
+			require.True(t, ok)
+			require.Equal(t, tc.wantCursor, after)
+		})
+	}
+}
+
+// TestRequestWithSizeImmutability verifies that WithLimit returns a new
+// Request and does not modify the original.
+func TestRequestWithSizeImmutability(t *testing.T) {
+	t.Parallel()
+
+	original := Request[uint32]{}.WithLimit(10).WithAfter(7)
+	updated := original.WithLimit(20)
+
+	require.Equal(t, uint32(10), original.normalizedLimit())
+	originalAfter, ok := original.After()
+	require.True(t, ok)
+	require.Equal(t, uint32(7), originalAfter)
+
+	require.Equal(t, uint32(20), updated.normalizedLimit())
+	updatedAfter, ok := updated.After()
+	require.True(t, ok)
+	require.Equal(t, uint32(7), updatedAfter)
+}
+
+// TestRequestWithCursorImmutability verifies that WithAfter returns a new
+// Request and does not modify the original.
+func TestRequestWithCursorImmutability(t *testing.T) {
+	t.Parallel()
+
+	original := Request[uint32]{}.WithLimit(10).WithAfter(7)
+	updated := original.WithAfter(9)
+
+	require.Equal(t, uint32(10), original.normalizedLimit())
+	originalAfter, ok := original.After()
+	require.True(t, ok)
+	require.Equal(t, uint32(7), originalAfter)
+
+	require.Equal(t, uint32(10), updated.normalizedLimit())
+	updatedAfter, ok := updated.After()
+	require.True(t, ok)
+	require.Equal(t, uint32(9), updatedAfter)
+}
+
+// TestRequestAfterReturnsCursorCopy verifies that mutating the local cursor
+// variable returned by After does not mutate the request's internal cursor.
+func TestRequestAfterReturnsCursorCopy(t *testing.T) {
+	t.Parallel()
+
+	request := Request[uint32]{}.WithAfter(7)
+	after, ok := request.After()
+
+	require.True(t, ok)
+	require.Equal(t, uint32(7), after)
+
+	after = 9
+	require.Equal(t, uint32(9), after)
+
+	originalAfter, ok := request.After()
+	require.True(t, ok)
+	require.Equal(t, uint32(7), originalAfter)
+}
+
+// TestBuildResult verifies BuildResult assembles the correct Result using the
+// lookahead row trimming and Next logic.
+func TestBuildResult(t *testing.T) {
+	t.Parallel()
+
+	toCursor := func(item int) int { return item }
+
+	testCases := []struct {
+		name      string
+		items     []int
+		size      uint32
+		wantItems []int
+		wantNext  *int
+	}{
+		{
+			name:      "empty slice returns empty result",
+			items:     []int{},
+			size:      100,
+			wantItems: []int{},
+			wantNext:  nil,
+		},
+		{
+			name:      "len less than limit leaves Next nil",
+			items:     []int{1, 2},
+			size:      5,
+			wantItems: []int{1, 2},
+			wantNext:  nil,
+		},
+		{
+			name:      "len equal to limit leaves Next nil",
+			items:     []int{1, 2},
+			size:      2,
+			wantItems: []int{1, 2},
+			wantNext:  nil,
+		},
+		{
+			name:      "len greater than limit trims and sets Next",
+			items:     []int{1, 2, 3},
+			size:      2,
+			wantItems: []int{1, 2},
+			wantNext:  func() *int { v := 2; return &v }(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := Request[int]{}.WithLimit(tc.size)
+			result := BuildResult(req, tc.items, toCursor)
+
+			require.Equal(t, tc.wantItems, result.Items)
+			require.Equal(t, tc.wantNext, result.Next)
+		})
+	}
+}

--- a/wallet/internal/db/page/result.go
+++ b/wallet/internal/db/page/result.go
@@ -1,0 +1,12 @@
+package page
+
+// Result holds one page of items returned by a paginated list query.
+type Result[T any, C any] struct {
+	// Items contain the results for this page. It may be empty on the last
+	// page.
+	Items []T
+
+	// Next is the after to use for fetching the next page. It is nil when
+	// no more pages exist.
+	Next *C
+}

--- a/wallet/internal/db/queries/postgres/addresses.sql
+++ b/wallet/internal/db/queries/postgres/addresses.sql
@@ -71,9 +71,10 @@ INSERT INTO addresses (
 RETURNING id, created_at;
 
 -- name: ListAddressesByAccount :many
--- Lists all addresses for a given account identified by wallet_id, key scope
--- (purpose/coin_type), and account name. Returns all address columns for
--- filtering and processing by the application.
+-- Lists addresses for an account identified by wallet_id, key scope
+-- (purpose/coin_type), and account name, ordered by address ID.
+-- When cursor_id is provided, only rows strictly after that address ID are
+-- returned. Returns up to page_limit rows.
 SELECT
     a.id,
     a.account_id,
@@ -91,6 +92,17 @@ INNER JOIN accounts AS acc ON a.account_id = acc.id
 INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
 LEFT JOIN address_secrets AS s ON a.id = s.address_id
 WHERE
-    ks.wallet_id = $1 AND ks.purpose = $2 AND ks.coin_type = $3
-    AND acc.account_name = $4
-ORDER BY a.id;
+    ks.wallet_id = sqlc.arg('wallet_id')
+    AND ks.purpose = sqlc.arg('purpose')
+    AND ks.coin_type = sqlc.arg('coin_type')
+    AND acc.account_name = sqlc.arg('account_name')
+    -- sqlc.arg()/sqlc.narg() calls are bind parameters, not column
+    -- references; the RF02 suppression below silences a false-positive
+    -- from sqlfluff, which cannot distinguish sqlc pseudo-functions
+    -- from column names in a multi-table JOIN context.
+    AND (
+        sqlc.narg('cursor_id')::BIGINT IS NULL -- noqa: RF02
+        OR a.id > sqlc.narg('cursor_id')::BIGINT -- noqa: RF02
+    )
+ORDER BY a.id
+LIMIT sqlc.arg('page_limit')::BIGINT;

--- a/wallet/internal/db/queries/postgres/wallets.sql
+++ b/wallet/internal/db/queries/postgres/wallets.sql
@@ -62,6 +62,9 @@ LEFT JOIN blocks AS b_birthday ON s.birthday_height = b_birthday.block_height
 WHERE w.wallet_name = $1;
 
 -- name: ListWallets :many
+-- Lists wallets using cursor-based pagination. If cursor_id is NULL, starts
+-- from the beginning; otherwise returns wallets with id > cursor_id. Returns up
+-- to page_limit rows.
 SELECT
     w.id,
     w.wallet_name,
@@ -80,7 +83,12 @@ FROM wallets AS w
 LEFT JOIN wallet_sync_states AS s ON w.id = s.wallet_id
 LEFT JOIN blocks AS b_synced ON s.synced_height = b_synced.block_height
 LEFT JOIN blocks AS b_birthday ON s.birthday_height = b_birthday.block_height
-ORDER BY w.id;
+WHERE (
+    sqlc.narg('cursor_id')::BIGINT IS NULL
+    OR w.id > sqlc.narg('cursor_id')::BIGINT
+)
+ORDER BY w.id
+LIMIT sqlc.arg('page_limit')::BIGINT;
 
 -- name: GetWalletByID :one
 SELECT

--- a/wallet/internal/db/queries/sqlite/addresses.sql
+++ b/wallet/internal/db/queries/sqlite/addresses.sql
@@ -71,9 +71,10 @@ INSERT INTO addresses (
 RETURNING id, created_at;
 
 -- name: ListAddressesByAccount :many
--- Lists all addresses for a given account identified by wallet_id, key scope
--- (purpose/coin_type), and account name. Returns all address columns for
--- filtering and processing by the application.
+-- Lists addresses for an account identified by wallet_id, key scope
+-- (purpose/coin_type), and account name, ordered by address ID.
+-- When cursor_id is provided, only rows strictly after that address ID are
+-- returned. Returns up to page_limit rows.
 SELECT
     a.id,
     a.account_id,
@@ -91,6 +92,17 @@ INNER JOIN accounts AS acc ON a.account_id = acc.id
 INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
 LEFT JOIN address_secrets AS s ON a.id = s.address_id
 WHERE
-    ks.wallet_id = ? AND ks.purpose = ? AND ks.coin_type = ?
-    AND acc.account_name = ?
-ORDER BY a.id;
+    ks.wallet_id = sqlc.arg('wallet_id')
+    AND ks.purpose = sqlc.arg('purpose')
+    AND ks.coin_type = sqlc.arg('coin_type')
+    AND acc.account_name = sqlc.arg('account_name')
+    -- sqlc.arg()/sqlc.narg() calls are bind parameters, not column
+    -- references; the RF02 suppression below silences a false-positive
+    -- from sqlfluff, which cannot distinguish sqlc pseudo-functions
+    -- from column names in a multi-table JOIN context.
+    AND (
+        sqlc.narg('cursor_id') IS NULL -- noqa: RF02
+        OR a.id > sqlc.narg('cursor_id') -- noqa: RF02
+    )
+ORDER BY a.id
+LIMIT sqlc.arg('page_limit');

--- a/wallet/internal/db/queries/sqlite/wallets.sql
+++ b/wallet/internal/db/queries/sqlite/wallets.sql
@@ -62,6 +62,9 @@ LEFT JOIN blocks AS b_birthday ON s.birthday_height = b_birthday.block_height
 WHERE w.wallet_name = ?;
 
 -- name: ListWallets :many
+-- Lists wallets using cursor-based pagination. If cursor_id is NULL, starts
+-- from the beginning; otherwise returns wallets with id > cursor_id. Returns up
+-- to page_limit rows.
 SELECT
     w.id,
     w.wallet_name,
@@ -80,7 +83,12 @@ FROM wallets AS w
 LEFT JOIN wallet_sync_states AS s ON w.id = s.wallet_id
 LEFT JOIN blocks AS b_synced ON s.synced_height = b_synced.block_height
 LEFT JOIN blocks AS b_birthday ON s.birthday_height = b_birthday.block_height
-ORDER BY w.id;
+WHERE (
+    sqlc.narg('cursor_id') IS NULL
+    OR w.id > sqlc.narg('cursor_id')
+)
+ORDER BY w.id
+LIMIT sqlc.arg('page_limit');
 
 -- name: GetWalletByID :one
 SELECT

--- a/wallet/internal/db/sqlc/postgres/addresses.sql.go
+++ b/wallet/internal/db/sqlc/postgres/addresses.sql.go
@@ -220,9 +220,20 @@ INNER JOIN accounts AS acc ON a.account_id = acc.id
 INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
 LEFT JOIN address_secrets AS s ON a.id = s.address_id
 WHERE
-    ks.wallet_id = $1 AND ks.purpose = $2 AND ks.coin_type = $3
+    ks.wallet_id = $1
+    AND ks.purpose = $2
+    AND ks.coin_type = $3
     AND acc.account_name = $4
+    -- sqlc.arg()/sqlc.narg() calls are bind parameters, not column
+    -- references; the RF02 suppression below silences a false-positive
+    -- from sqlfluff, which cannot distinguish sqlc pseudo-functions
+    -- from column names in a multi-table JOIN context.
+    AND (
+        $5::BIGINT IS NULL -- noqa: RF02
+        OR a.id > $5::BIGINT -- noqa: RF02
+    )
 ORDER BY a.id
+LIMIT $6::BIGINT
 `
 
 type ListAddressesByAccountParams struct {
@@ -230,6 +241,8 @@ type ListAddressesByAccountParams struct {
 	Purpose     int64
 	CoinType    int64
 	AccountName string
+	CursorID    sql.NullInt64
+	PageLimit   int64
 }
 
 type ListAddressesByAccountRow struct {
@@ -246,15 +259,18 @@ type ListAddressesByAccountRow struct {
 	HasScript     bool
 }
 
-// Lists all addresses for a given account identified by wallet_id, key scope
-// (purpose/coin_type), and account name. Returns all address columns for
-// filtering and processing by the application.
+// Lists addresses for an account identified by wallet_id, key scope
+// (purpose/coin_type), and account name, ordered by address ID.
+// When cursor_id is provided, only rows strictly after that address ID are
+// returned. Returns up to page_limit rows.
 func (q *Queries) ListAddressesByAccount(ctx context.Context, arg ListAddressesByAccountParams) ([]ListAddressesByAccountRow, error) {
 	rows, err := q.query(ctx, q.listAddressesByAccountStmt, ListAddressesByAccount,
 		arg.WalletID,
 		arg.Purpose,
 		arg.CoinType,
 		arg.AccountName,
+		arg.CursorID,
+		arg.PageLimit,
 	)
 	if err != nil {
 		return nil, err

--- a/wallet/internal/db/sqlc/postgres/querier.go
+++ b/wallet/internal/db/sqlc/postgres/querier.go
@@ -328,9 +328,10 @@ type Querier interface {
 	ListActiveUtxoLeases(ctx context.Context, arg ListActiveUtxoLeasesParams) ([]ListActiveUtxoLeasesRow, error)
 	// Returns all address types ordered by ID.
 	ListAddressTypes(ctx context.Context) ([]AddressType, error)
-	// Lists all addresses for a given account identified by wallet_id, key scope
-	// (purpose/coin_type), and account name. Returns all address columns for
-	// filtering and processing by the application.
+	// Lists addresses for an account identified by wallet_id, key scope
+	// (purpose/coin_type), and account name, ordered by address ID.
+	// When cursor_id is provided, only rows strictly after that address ID are
+	// returned. Returns up to page_limit rows.
 	ListAddressesByAccount(ctx context.Context, arg ListAddressesByAccountParams) ([]ListAddressesByAccountRow, error)
 	// Lists all key scopes for a wallet, ordered by ID.
 	ListKeyScopesByWallet(ctx context.Context, walletID int64) ([]KeyScope, error)

--- a/wallet/internal/db/sqlc/postgres/querier.go
+++ b/wallet/internal/db/sqlc/postgres/querier.go
@@ -457,7 +457,10 @@ type Querier interface {
 	// - Treats min/max confirmations as optional filters so callers can
 	//   distinguish "not set" from an explicit zero-conf request.
 	ListUtxos(ctx context.Context, arg ListUtxosParams) ([]ListUtxosRow, error)
-	ListWallets(ctx context.Context) ([]ListWalletsRow, error)
+	// Lists wallets using cursor-based pagination. If cursor_id is NULL, starts
+	// from the beginning; otherwise returns wallets with id > cursor_id. Returns up
+	// to page_limit rows.
+	ListWallets(ctx context.Context, arg ListWalletsParams) ([]ListWalletsRow, error)
 	// Acquires a transaction-level advisory lock to serialize account creation within a scope.
 	// The lock is automatically released upon transaction commit or rollback.
 	// This MUST be called immediately before 'CreateDerivedAccount' within the same transaction.

--- a/wallet/internal/db/sqlc/postgres/wallets.sql.go
+++ b/wallet/internal/db/sqlc/postgres/wallets.sql.go
@@ -271,8 +271,18 @@ FROM wallets AS w
 LEFT JOIN wallet_sync_states AS s ON w.id = s.wallet_id
 LEFT JOIN blocks AS b_synced ON s.synced_height = b_synced.block_height
 LEFT JOIN blocks AS b_birthday ON s.birthday_height = b_birthday.block_height
+WHERE (
+    $1::BIGINT IS NULL
+    OR w.id > $1::BIGINT
+)
 ORDER BY w.id
+LIMIT $2::BIGINT
 `
+
+type ListWalletsParams struct {
+	CursorID  sql.NullInt64
+	PageLimit int64
+}
 
 type ListWalletsRow struct {
 	ID                     int64
@@ -290,8 +300,11 @@ type ListWalletsRow struct {
 	BirthdayBlockTimestamp sql.NullInt64
 }
 
-func (q *Queries) ListWallets(ctx context.Context) ([]ListWalletsRow, error) {
-	rows, err := q.query(ctx, q.listWalletsStmt, ListWallets)
+// Lists wallets using cursor-based pagination. If cursor_id is NULL, starts
+// from the beginning; otherwise returns wallets with id > cursor_id. Returns up
+// to page_limit rows.
+func (q *Queries) ListWallets(ctx context.Context, arg ListWalletsParams) ([]ListWalletsRow, error) {
+	rows, err := q.query(ctx, q.listWalletsStmt, ListWallets, arg.CursorID, arg.PageLimit)
 	if err != nil {
 		return nil, err
 	}

--- a/wallet/internal/db/sqlc/sqlite/addresses.sql.go
+++ b/wallet/internal/db/sqlc/sqlite/addresses.sql.go
@@ -220,9 +220,20 @@ INNER JOIN accounts AS acc ON a.account_id = acc.id
 INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
 LEFT JOIN address_secrets AS s ON a.id = s.address_id
 WHERE
-    ks.wallet_id = ? AND ks.purpose = ? AND ks.coin_type = ?
-    AND acc.account_name = ?
+    ks.wallet_id = ?1
+    AND ks.purpose = ?2
+    AND ks.coin_type = ?3
+    AND acc.account_name = ?4
+    -- sqlc.arg()/sqlc.narg() calls are bind parameters, not column
+    -- references; the RF02 suppression below silences a false-positive
+    -- from sqlfluff, which cannot distinguish sqlc pseudo-functions
+    -- from column names in a multi-table JOIN context.
+    AND (
+        ?5 IS NULL -- noqa: RF02
+        OR a.id > ?5 -- noqa: RF02
+    )
 ORDER BY a.id
+LIMIT ?6
 `
 
 type ListAddressesByAccountParams struct {
@@ -230,6 +241,8 @@ type ListAddressesByAccountParams struct {
 	Purpose     int64
 	CoinType    int64
 	AccountName string
+	CursorID    interface{}
+	PageLimit   int64
 }
 
 type ListAddressesByAccountRow struct {
@@ -246,15 +259,18 @@ type ListAddressesByAccountRow struct {
 	HasScript     bool
 }
 
-// Lists all addresses for a given account identified by wallet_id, key scope
-// (purpose/coin_type), and account name. Returns all address columns for
-// filtering and processing by the application.
+// Lists addresses for an account identified by wallet_id, key scope
+// (purpose/coin_type), and account name, ordered by address ID.
+// When cursor_id is provided, only rows strictly after that address ID are
+// returned. Returns up to page_limit rows.
 func (q *Queries) ListAddressesByAccount(ctx context.Context, arg ListAddressesByAccountParams) ([]ListAddressesByAccountRow, error) {
 	rows, err := q.query(ctx, q.listAddressesByAccountStmt, ListAddressesByAccount,
 		arg.WalletID,
 		arg.Purpose,
 		arg.CoinType,
 		arg.AccountName,
+		arg.CursorID,
+		arg.PageLimit,
 	)
 	if err != nil {
 		return nil, err

--- a/wallet/internal/db/sqlc/sqlite/querier.go
+++ b/wallet/internal/db/sqlc/sqlite/querier.go
@@ -453,7 +453,10 @@ type Querier interface {
 	// - Treats min/max confirmations as optional filters so callers can
 	//   distinguish "not set" from an explicit zero-conf request.
 	ListUtxos(ctx context.Context, arg ListUtxosParams) ([]ListUtxosRow, error)
-	ListWallets(ctx context.Context) ([]ListWalletsRow, error)
+	// Lists wallets using cursor-based pagination. If cursor_id is NULL, starts
+	// from the beginning; otherwise returns wallets with id > cursor_id. Returns up
+	// to page_limit rows.
+	ListWallets(ctx context.Context, arg ListWalletsParams) ([]ListWalletsRow, error)
 	// Marks a wallet-owned UTXO as spent by a transaction.
 	//
 	// How:

--- a/wallet/internal/db/sqlc/sqlite/querier.go
+++ b/wallet/internal/db/sqlc/sqlite/querier.go
@@ -324,9 +324,10 @@ type Querier interface {
 	ListActiveUtxoLeases(ctx context.Context, arg ListActiveUtxoLeasesParams) ([]ListActiveUtxoLeasesRow, error)
 	// Returns all address types ordered by ID.
 	ListAddressTypes(ctx context.Context) ([]AddressType, error)
-	// Lists all addresses for a given account identified by wallet_id, key scope
-	// (purpose/coin_type), and account name. Returns all address columns for
-	// filtering and processing by the application.
+	// Lists addresses for an account identified by wallet_id, key scope
+	// (purpose/coin_type), and account name, ordered by address ID.
+	// When cursor_id is provided, only rows strictly after that address ID are
+	// returned. Returns up to page_limit rows.
 	ListAddressesByAccount(ctx context.Context, arg ListAddressesByAccountParams) ([]ListAddressesByAccountRow, error)
 	// Lists all key scopes for a wallet, ordered by ID.
 	ListKeyScopesByWallet(ctx context.Context, walletID int64) ([]KeyScope, error)

--- a/wallet/internal/db/sqlc/sqlite/wallets.sql.go
+++ b/wallet/internal/db/sqlc/sqlite/wallets.sql.go
@@ -271,8 +271,18 @@ FROM wallets AS w
 LEFT JOIN wallet_sync_states AS s ON w.id = s.wallet_id
 LEFT JOIN blocks AS b_synced ON s.synced_height = b_synced.block_height
 LEFT JOIN blocks AS b_birthday ON s.birthday_height = b_birthday.block_height
+WHERE (
+    ?1 IS NULL
+    OR w.id > ?1
+)
 ORDER BY w.id
+LIMIT ?2
 `
+
+type ListWalletsParams struct {
+	CursorID  interface{}
+	PageLimit int64
+}
 
 type ListWalletsRow struct {
 	ID                     int64
@@ -290,8 +300,11 @@ type ListWalletsRow struct {
 	BirthdayBlockTimestamp sql.NullInt64
 }
 
-func (q *Queries) ListWallets(ctx context.Context) ([]ListWalletsRow, error) {
-	rows, err := q.query(ctx, q.listWalletsStmt, ListWallets)
+// Lists wallets using cursor-based pagination. If cursor_id is NULL, starts
+// from the beginning; otherwise returns wallets with id > cursor_id. Returns up
+// to page_limit rows.
+func (q *Queries) ListWallets(ctx context.Context, arg ListWalletsParams) ([]ListWalletsRow, error) {
+	rows, err := q.query(ctx, q.listWalletsStmt, ListWallets, arg.CursorID, arg.PageLimit)
 	if err != nil {
 		return nil, err
 	}

--- a/wallet/internal/db/wallet_pg.go
+++ b/wallet/internal/db/wallet_pg.go
@@ -5,7 +5,9 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"iter"
 
+	"github.com/btcsuite/btcwallet/wallet/internal/db/page"
 	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
 )
 
@@ -140,41 +142,44 @@ func (s *PostgresStore) GetWallet(ctx context.Context,
 	})
 }
 
-// ListWallets returns a slice of WalletInfo for all wallets stored in
-// the database. It returns an empty slice if no wallets are found, or
-// an error if the retrieval fails.
-func (s *PostgresStore) ListWallets(ctx context.Context) ([]WalletInfo,
-	error) {
+// ListWallets returns a page of wallets matching the given query.
+func (s *PostgresStore) ListWallets(ctx context.Context,
+	query ListWalletsQuery) (page.Result[WalletInfo, uint32], error) {
 
-	rows, err := s.queries.ListWallets(ctx)
+	rows, err := s.queries.ListWallets(ctx, pgListWalletsParams(query.Page))
 	if err != nil {
-		return nil, fmt.Errorf("list wallets: %w", err)
+		return page.Result[WalletInfo, uint32]{},
+			fmt.Errorf("list wallets page: %w", err)
 	}
 
-	wallets := make([]WalletInfo, len(rows))
+	items := make([]WalletInfo, len(rows))
 	for i, row := range rows {
-		info, err := buildPgWalletInfo(pgWalletRowParams{
-			id:                     row.ID,
-			name:                   row.WalletName,
-			isImported:             row.IsImported,
-			managerVersion:         row.ManagerVersion,
-			isWatchOnly:            row.IsWatchOnly,
-			syncedHeight:           row.SyncedHeight,
-			syncedBlockHash:        row.SyncedBlockHash,
-			syncedBlockTimestamp:   row.SyncedBlockTimestamp,
-			birthdayHeight:         row.BirthdayHeight,
-			birthdayTimestamp:      row.BirthdayTimestamp,
-			birthdayBlockHash:      row.BirthdayBlockHash,
-			birthdayBlockTimestamp: row.BirthdayBlockTimestamp,
-		})
-		if err != nil {
-			return nil, err
+		item, errMap := pgListWalletRowToInfo(row)
+		if errMap != nil {
+			return page.Result[WalletInfo, uint32]{},
+				fmt.Errorf("list wallets page: map row: %w", errMap)
 		}
 
-		wallets[i] = *info
+		items[i] = *item
 	}
 
-	return wallets, nil
+	result := page.BuildResult(
+		query.Page, items,
+		func(item WalletInfo) uint32 {
+			return item.ID
+		},
+	)
+
+	return result, nil
+}
+
+// IterWallets returns an iterator over paginated wallet results.
+func (s *PostgresStore) IterWallets(ctx context.Context,
+	query ListWalletsQuery) iter.Seq2[WalletInfo, error] {
+
+	return page.Iter(
+		ctx, query, s.ListWallets, nextListWalletsQuery,
+	)
 }
 
 // UpdateWallet updates various properties of a wallet, such as its
@@ -289,6 +294,44 @@ type pgWalletRowParams struct {
 	birthdayTimestamp      sql.NullTime
 	birthdayBlockHash      []byte
 	birthdayBlockTimestamp sql.NullInt64
+}
+
+// pgListWalletRowToInfo converts a ListWallets result row to a WalletInfo
+// struct for pagination.
+func pgListWalletRowToInfo(row sqlcpg.ListWalletsRow) (*WalletInfo, error) {
+	return buildPgWalletInfo(pgWalletRowParams{
+		id:                     row.ID,
+		name:                   row.WalletName,
+		isImported:             row.IsImported,
+		managerVersion:         row.ManagerVersion,
+		isWatchOnly:            row.IsWatchOnly,
+		syncedHeight:           row.SyncedHeight,
+		syncedBlockHash:        row.SyncedBlockHash,
+		syncedBlockTimestamp:   row.SyncedBlockTimestamp,
+		birthdayHeight:         row.BirthdayHeight,
+		birthdayTimestamp:      row.BirthdayTimestamp,
+		birthdayBlockHash:      row.BirthdayBlockHash,
+		birthdayBlockTimestamp: row.BirthdayBlockTimestamp,
+	})
+}
+
+// pgListWalletsParams translates a page request to ListWallets query
+// parameters, handling optional cursor setup for pagination.
+func pgListWalletsParams(
+	req page.Request[uint32]) sqlcpg.ListWalletsParams {
+
+	params := sqlcpg.ListWalletsParams{
+		PageLimit: int64(req.QueryLimit()),
+	}
+
+	if cursor, ok := req.After(); ok {
+		params.CursorID = sql.NullInt64{
+			Int64: int64(cursor),
+			Valid: true,
+		}
+	}
+
+	return params
 }
 
 // buildPgWalletInfo constructs a WalletInfo from the given wallet row

--- a/wallet/internal/db/wallet_sqlite.go
+++ b/wallet/internal/db/wallet_sqlite.go
@@ -5,7 +5,9 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"iter"
 
+	"github.com/btcsuite/btcwallet/wallet/internal/db/page"
 	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
 )
 
@@ -140,41 +142,46 @@ func (s *SqliteStore) GetWallet(ctx context.Context,
 	})
 }
 
-// ListWallets returns a slice of WalletInfo for all wallets stored in
-// the database. It returns an empty slice if no wallets are found, or
-// an error if the retrieval fails.
-func (s *SqliteStore) ListWallets(ctx context.Context) ([]WalletInfo,
-	error) {
+// ListWallets returns a page of wallets matching the given query.
+func (s *SqliteStore) ListWallets(ctx context.Context,
+	query ListWalletsQuery) (page.Result[WalletInfo, uint32], error) {
 
-	rows, err := s.queries.ListWallets(ctx)
+	rows, err := s.queries.ListWallets(
+		ctx, sqliteListWalletsParams(query.Page),
+	)
 	if err != nil {
-		return nil, fmt.Errorf("list wallets: %w", err)
+		return page.Result[WalletInfo, uint32]{},
+			fmt.Errorf("list wallets page: %w", err)
 	}
 
-	wallets := make([]WalletInfo, len(rows))
+	items := make([]WalletInfo, len(rows))
 	for i, row := range rows {
-		info, err := buildSqliteWalletInfo(sqliteWalletRowParams{
-			id:                     row.ID,
-			name:                   row.WalletName,
-			isImported:             row.IsImported,
-			managerVersion:         row.ManagerVersion,
-			isWatchOnly:            row.IsWatchOnly,
-			syncedHeight:           row.SyncedHeight,
-			syncedBlockHash:        row.SyncedBlockHash,
-			syncedBlockTimestamp:   row.SyncedBlockTimestamp,
-			birthdayHeight:         row.BirthdayHeight,
-			birthdayTimestamp:      row.BirthdayTimestamp,
-			birthdayBlockHash:      row.BirthdayBlockHash,
-			birthdayBlockTimestamp: row.BirthdayBlockTimestamp,
-		})
-		if err != nil {
-			return nil, err
+		item, errMap := sqliteListWalletRowToInfo(row)
+		if errMap != nil {
+			return page.Result[WalletInfo, uint32]{},
+				fmt.Errorf("list wallets page: map row: %w", errMap)
 		}
 
-		wallets[i] = *info
+		items[i] = *item
 	}
 
-	return wallets, nil
+	result := page.BuildResult(
+		query.Page, items,
+		func(item WalletInfo) uint32 {
+			return item.ID
+		},
+	)
+
+	return result, nil
+}
+
+// IterWallets returns an iterator over paginated wallet results.
+func (s *SqliteStore) IterWallets(ctx context.Context,
+	query ListWalletsQuery) iter.Seq2[WalletInfo, error] {
+
+	return page.Iter(
+		ctx, query, s.ListWallets, nextListWalletsQuery,
+	)
 }
 
 // UpdateWallet updates various properties of a wallet, such as its
@@ -288,6 +295,43 @@ type sqliteWalletRowParams struct {
 	birthdayTimestamp      sql.NullTime
 	birthdayBlockHash      []byte
 	birthdayBlockTimestamp sql.NullInt64
+}
+
+// sqliteListWalletRowToInfo converts a ListWallets result row to a WalletInfo
+// struct for pagination.
+func sqliteListWalletRowToInfo(
+	row sqlcsqlite.ListWalletsRow) (*WalletInfo, error) {
+
+	return buildSqliteWalletInfo(sqliteWalletRowParams{
+		id:                     row.ID,
+		name:                   row.WalletName,
+		isImported:             row.IsImported,
+		managerVersion:         row.ManagerVersion,
+		isWatchOnly:            row.IsWatchOnly,
+		syncedHeight:           row.SyncedHeight,
+		syncedBlockHash:        row.SyncedBlockHash,
+		syncedBlockTimestamp:   row.SyncedBlockTimestamp,
+		birthdayHeight:         row.BirthdayHeight,
+		birthdayTimestamp:      row.BirthdayTimestamp,
+		birthdayBlockHash:      row.BirthdayBlockHash,
+		birthdayBlockTimestamp: row.BirthdayBlockTimestamp,
+	})
+}
+
+// sqliteListWalletsParams translates a page request to ListWallets query
+// parameters, handling optional cursor setup for pagination.
+func sqliteListWalletsParams(
+	req page.Request[uint32]) sqlcsqlite.ListWalletsParams {
+
+	params := sqlcsqlite.ListWalletsParams{
+		PageLimit: int64(req.QueryLimit()),
+	}
+
+	if cursor, ok := req.After(); ok {
+		params.CursorID = int64(cursor)
+	}
+
+	return params
 }
 
 // buildSqliteWalletInfo constructs a WalletInfo from the given wallet

--- a/wallet/internal/db/wallets_common.go
+++ b/wallet/internal/db/wallets_common.go
@@ -1,0 +1,9 @@
+package db
+
+// nextListWalletsQuery returns a query with its pagination cursor advanced to
+// the provided value.
+func nextListWalletsQuery(q ListWalletsQuery, cursor uint32) ListWalletsQuery {
+	q.Page = q.Page.WithAfter(cursor)
+
+	return q
+}


### PR DESCRIPTION
This PR adds pagination support to list queries that may return very large result sets, such as addresses.

- List queries are now paginated by default. They require a query struct and return a single page of results, instead of returning the full dataset as before. This changes the behavior of the existing `List*` API.

- New interface methods named `IterSomething` were added. These provide seamless iteration over all results without requiring the caller to manage pagination, using the `iter.Seq2` API, and can be used as a replacement for the previous full-result queries.