### PR TITLE
Fix `make tidy-module`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,6 +286,20 @@ sql-lint-check:
 	@$(call print, "Linting SQL files (sqlite queries).")
 	$(SQLFLUFF) lint --config /sql/.sqlfluff --dialect sqlite $(SQL_SQLITE_QUERIES)
 
+#? sql: Lint, verify, format, and regenerate SQL code for local development
+# First try auto-fixes. If that still fails, rerun lint in check mode so the
+# remaining unfixable violations are printed before aborting the workflow.
+# On success, verify the final SQL is clean before formatting and regeneration.
+sql:
+	@if ! $(MAKE) --no-print-directory --silent sql-lint; then \
+		$(MAKE) --no-print-directory --silent sql-lint-check; \
+		exit 1; \
+	fi
+	@$(MAKE) --no-print-directory --silent sql-lint-check
+	@$(MAKE) --no-print-directory --silent sql-format
+	@$(MAKE) --no-print-directory --silent sqlc
+
+
 .PHONY: all \
 	default \
 	build \
@@ -303,6 +317,7 @@ sql-lint-check:
 	tidy-module \
 	tidy-module-check \
 	sql-parse \
+	sql \
 	sqlc \
 	sqlc-check \
 	sql-format \

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0
+	github.com/docker/go-connections v0.6.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/golang/protobuf v1.5.4
 	github.com/jackc/pgx/v5 v5.5.4
@@ -54,7 +55,6 @@ require (
 	github.com/decred/dcrd/lru v1.1.2 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v28.5.1+incompatible // indirect
-	github.com/docker/go-connections v0.6.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ebitengine/purego v0.8.4 // indirect

--- a/scripts/tidy_modules.sh
+++ b/scripts/tidy_modules.sh
@@ -1,17 +1,58 @@
 #!/bin/bash
 
-SUBMODULES=$(find . -mindepth 2 -name "go.mod" | cut -d'/' -f2)
+# Keep unset-variable and pipeline safety, but do NOT use `set -e` here.
+#
+# We want two properties at the same time:
+# 1. `go mod tidy` should run for the root module and every nested module, so we
+#    still auto-fix any module that *can* be tidied in the current run.
+# 2. A failure in one module must still make the overall script fail so CI does
+#    not silently pass over a broken submodule.
+#
+# Using `set -e` would stop on the first failing module and skip the remaining
+# tidies. Instead, we run each module explicitly, collect failures, and exit
+# non-zero at the end if any module failed.
+set -uo pipefail
 
+# Collect module directories whose `go mod tidy` invocation failed.
+failures=()
 
-# Run 'go mod tidy' for root.
-go mod tidy
+run_tidy() {
+  local module_dir="$1"
 
-# Run 'go mod tidy' for each module.
-for submodule in $SUBMODULES
-do
-  pushd $submodule
+  # Run each tidy in the target module directory so the command behaves as if a
+  # developer had entered that module and run `go mod tidy` manually.
+  echo "Running 'go mod tidy' in ${module_dir}"
 
-  go mod tidy
+  if ! (
+    # Turn off any parent go.work file. We want to validate each module as an
+    # independent module, because CI and release consumers will resolve module
+    # dependencies that way.
+    cd "$module_dir"
+    GOWORK=off go mod tidy
+  ); then
+    # Keep going so other modules still get tidied, but remember the failure so
+    # the script can fail loudly once every module has been attempted.
+    failures+=("$module_dir")
+  fi
+}
 
-  popd
-done
+# Tidy the repository root module first.
+run_tidy "."
+
+# Tidy every actual nested Go module.
+#
+# We intentionally discover module directories from real `go.mod` paths instead
+# of truncating the path (for example, `wallet/txauthor`, `wallet/txrules`, and
+# `wallet/txsizes` are distinct modules and must be tidied separately).
+while IFS= read -r submodule; do
+  run_tidy "$submodule"
+done < <(find . -mindepth 2 -name "go.mod" -exec dirname {} \; | sort -u)
+
+# Fail at the end if any module failed to tidy. This preserves the previous
+# “tidy as much as possible” behavior while making module errors visible to CI.
+if [ ${#failures[@]} -ne 0 ]; then
+  echo
+  echo "go mod tidy failed for the following modules:"
+  printf '  - %s\n' "${failures[@]}"
+  exit 1
+fi

--- a/wallet/internal/db/itest/account_store_test.go
+++ b/wallet/internal/db/itest/account_store_test.go
@@ -499,11 +499,18 @@ func TestAccountCreatedAtTimestamp(t *testing.T) {
 
 	scope := db.KeyScopeBIP0084
 
+	type createdAccount struct {
+		info        db.AccountInfo
+		createdNear time.Time
+	}
+
 	// Create three accounts with slight delays to ensure different
 	// timestamps.
-	var accounts []db.AccountInfo
+	var accounts []createdAccount
 	for i := range 3 {
 		time.Sleep(1 * time.Second)
+
+		createdNear := time.Now()
 		params := db.CreateDerivedAccountParams{
 			WalletID: walletID,
 			Scope:    scope,
@@ -511,21 +518,24 @@ func TestAccountCreatedAtTimestamp(t *testing.T) {
 		}
 		info, err := store.CreateDerivedAccount(t.Context(), params)
 		require.NoError(t, err)
-		accounts = append(accounts, *info)
+		accounts = append(accounts, createdAccount{
+			info:        *info,
+			createdNear: createdNear,
+		})
 	}
 
 	// Verify all accounts have CreatedAt populated.
 	for i, acc := range accounts {
-		require.False(t, acc.CreatedAt.IsZero(),
+		require.False(t, acc.info.CreatedAt.IsZero(),
 			"account %d should have CreatedAt set", i)
-		require.WithinDuration(t, time.Now(), acc.CreatedAt, 5*time.Second,
-			"account %d CreatedAt should be recent", i)
+		require.WithinDuration(t, acc.createdNear, acc.info.CreatedAt,
+			5*time.Second, "account %d CreatedAt should track creation", i)
 	}
 
 	// Verify accounts are ordered by creation time.
-	require.True(t, accounts[0].CreatedAt.Before(accounts[1].CreatedAt),
+	require.True(t, accounts[0].info.CreatedAt.Before(accounts[1].info.CreatedAt),
 		"account 0 should have CreatedAt before account 1")
-	require.True(t, accounts[1].CreatedAt.Before(accounts[2].CreatedAt),
+	require.True(t, accounts[1].info.CreatedAt.Before(accounts[2].info.CreatedAt),
 		"account 1 should have CreatedAt before account 2")
 }
 
@@ -800,10 +810,13 @@ func requireAccountMatches(t *testing.T, info *db.AccountInfo,
 	require.Equal(t, tc.Origin, info.Origin)
 	require.Equal(t, tc.IsWatchOnly, info.IsWatchOnly)
 
-	// Verify CreatedAt is populated and recent.
+	// Verify CreatedAt is populated and not in the future. The account may have
+	// been created several seconds earlier in the test when parallel database
+	// setup runs under the race detector, so a strict "recent" assertion here is
+	// unnecessarily flaky.
 	require.False(t, info.CreatedAt.IsZero(), "CreatedAt should be set")
-	require.WithinDuration(t, time.Now(), info.CreatedAt, 5*time.Second,
-		"CreatedAt should be recent")
+	require.False(t, info.CreatedAt.After(time.Now().Add(5*time.Second)),
+		"CreatedAt should not be in the future")
 }
 
 // requireAccountPropertiesMatches asserts that the provided AccountProperties
@@ -819,10 +832,12 @@ func requireAccountPropertiesMatches(t *testing.T, props *db.AccountProperties,
 	require.Equal(t, tc.Origin, props.Origin)
 	require.Equal(t, tc.IsWatchOnly, props.IsWatchOnly)
 
-	// Verify CreatedAt is populated and recent.
+	// Verify CreatedAt is populated and not in the future. Imported-account test
+	// fixtures can be created well before these assertions run under heavy CI
+	// contention, so only the forward-time invariant is stable here.
 	require.False(t, props.CreatedAt.IsZero(), "CreatedAt should be set")
-	require.WithinDuration(t, time.Now(), props.CreatedAt, 5*time.Second,
-		"CreatedAt should be recent")
+	require.False(t, props.CreatedAt.After(time.Now().Add(5*time.Second)),
+		"CreatedAt should not be in the future")
 }
 
 // findAccountInList searches for an account in the provided list that matches

--- a/wallet/internal/db/itest/pg_test.go
+++ b/wallet/internal/db/itest/pg_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
@@ -96,13 +97,26 @@ func GetPostgresContainer(ctx context.Context) (*postgres.PostgresContainer, err
 	pgContainerOnce.Do(func() {
 		cfg := DefaultPostgresConfig()
 
-		pgContainer, pgContainerErr = postgres.RunContainer(ctx,
-			testcontainers.WithImage(cfg.Image),
+		// PostgreSQL 18 can begin listening on the TCP port before it is
+		// ready to handle client queries, so wait for a successful SQL round
+		// trip instead of only waiting for the port to open.
+		waitForSQL := wait.ForSQL(
+			"5432/tcp", "pgx", func(host string, port nat.Port) string {
+				return fmt.Sprintf(
+					"postgres://%s:%s@%s:%s/%s?sslmode=disable",
+					cfg.Username, cfg.Password, host, port.Port(),
+					cfg.Database,
+				)
+			},
+		).WithStartupTimeout(pgInitTimeout)
+
+		pgContainer, pgContainerErr = postgres.Run(ctx,
+			cfg.Image,
 			postgres.WithDatabase(cfg.Database),
 			postgres.WithUsername(cfg.Username),
 			postgres.WithPassword(cfg.Password),
 			testcontainers.WithWaitStrategyAndDeadline(
-				pgInitTimeout, wait.ForListeningPort("5432/tcp"),
+				pgInitTimeout, waitForSQL,
 			),
 		)
 	})

--- a/wallet/internal/db/sqlite.go
+++ b/wallet/internal/db/sqlite.go
@@ -31,6 +31,7 @@ func NewSqliteStore(ctx context.Context, cfg SqliteConfig) (*SqliteStore,
 	dsn += "&_pragma=journal_mode=WAL"
 	dsn += "&_txlock=immediate"
 	dsn += "&_pragma=busy_timeout=5000"
+	dsn += "&_time_format=sqlite"
 
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {

--- a/wtxmgr/log.go
+++ b/wtxmgr/log.go
@@ -4,20 +4,12 @@
 
 package wtxmgr
 
-import (
-	"github.com/btcsuite/btclog"
-	"github.com/btcsuite/btcwallet/build"
-)
+import "github.com/btcsuite/btclog"
 
-// log is a logger that is initialized with no output filters.  This
-// means the package will not perform any logging by default until the caller
-// requests it.
-var log btclog.Logger
-
-// The default amount of logging is none.
-func init() {
-	UseLogger(build.NewSubLogger("TMGR", nil))
-}
+// log is a logger that is initialized as disabled (no output). This means
+// the package will not perform any logging by default until the caller
+// configures a logger via UseLogger or SetLogWriter.
+var log = btclog.Disabled
 
 // DisableLog disables all library log output.  Logging output is disabled
 // by default until either UseLogger or SetLogWriter are called.


### PR DESCRIPTION
Moving a few fixes from #1185 to keep that branch focused on SQL only. Included here,
- fix `make tidy-module`, which was silently failing before.
- fix the flake in `TestAccountCreatedAtTimestamp`
- enforce sqlite datetime format