### PR TITLE
wallet: fix pg itest connection exhaustion under parallelism

### DIFF
--- a/wallet/internal/db/itest/account_store_test.go
+++ b/wallet/internal/db/itest/account_store_test.go
@@ -51,10 +51,6 @@ func TestCreateAccounts(t *testing.T) {
 func TestCreateDerivedAccountErrors(t *testing.T) {
 	t.Parallel()
 
-	store := NewTestStore(t)
-
-	walletID := newWallet(t, store, "wallet-create-derived-account-errors")
-
 	tests := []struct {
 		name    string
 		params  db.CreateDerivedAccountParams
@@ -63,18 +59,16 @@ func TestCreateDerivedAccountErrors(t *testing.T) {
 		{
 			name: "missing name",
 			params: db.CreateDerivedAccountParams{
-				WalletID: walletID,
-				Scope:    db.KeyScopeBIP0084,
-				Name:     "",
+				Scope: db.KeyScopeBIP0084,
+				Name:  "",
 			},
 			wantErr: db.ErrMissingAccountName,
 		},
 		{
 			name: "unknown scope",
 			params: db.CreateDerivedAccountParams{
-				WalletID: walletID,
-				Scope:    db.KeyScope{Purpose: 999, Coin: 999},
-				Name:     "unknown-scope-account",
+				Scope: db.KeyScope{Purpose: 999, Coin: 999},
+				Name:  "unknown-scope-account",
 			},
 			wantErr: db.ErrUnknownKeyScope,
 		},
@@ -83,6 +77,10 @@ func TestCreateDerivedAccountErrors(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+
+			store := NewTestStore(t)
+			walletID := newWallet(t, store, tc.name+"-wallet")
+			tc.params.WalletID = walletID
 
 			info, err := store.CreateDerivedAccount(t.Context(), tc.params)
 			require.ErrorIs(t, err, tc.wantErr)
@@ -222,10 +220,6 @@ func TestCreateDerivedAccountConcurrent(t *testing.T) {
 func TestCreateImportedAccountErrors(t *testing.T) {
 	t.Parallel()
 
-	store := NewTestStore(t)
-
-	walletID := newWallet(t, store, "wallet-create-imported-account-errors")
-
 	tests := []struct {
 		name    string
 		params  db.CreateImportedAccountParams
@@ -234,7 +228,6 @@ func TestCreateImportedAccountErrors(t *testing.T) {
 		{
 			name: "missing name",
 			params: db.CreateImportedAccountParams{
-				WalletID:           walletID,
 				Name:               "",
 				Scope:              db.KeyScopeBIP0084,
 				EncryptedPublicKey: RandomBytes(32),
@@ -244,7 +237,6 @@ func TestCreateImportedAccountErrors(t *testing.T) {
 		{
 			name: "missing public key",
 			params: db.CreateImportedAccountParams{
-				WalletID:           walletID,
 				Name:               "missing-pubkey",
 				Scope:              db.KeyScopeBIP0084,
 				EncryptedPublicKey: nil,
@@ -254,7 +246,6 @@ func TestCreateImportedAccountErrors(t *testing.T) {
 		{
 			name: "unknown scope",
 			params: db.CreateImportedAccountParams{
-				WalletID:           walletID,
 				Name:               "unknown-scope",
 				Scope:              db.KeyScope{Purpose: 999, Coin: 999},
 				EncryptedPublicKey: RandomBytes(32),
@@ -266,6 +257,10 @@ func TestCreateImportedAccountErrors(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+
+			store := NewTestStore(t)
+			walletID := newWallet(t, store, tc.name+"-wallet")
+			tc.params.WalletID = walletID
 
 			props, err := store.CreateImportedAccount(t.Context(), tc.params)
 			require.ErrorIs(t, err, tc.wantErr)
@@ -345,16 +340,14 @@ func TestGetAccount(t *testing.T) {
 func TestGetAccountNotFound(t *testing.T) {
 	t.Parallel()
 
-	store := NewTestStore(t)
-
-	walletID := newWallet(t, store, "wallet-get-account-not-found")
-
-	createAllAccounts(t, store, walletID)
-
 	scope := db.KeyScopeBIP0084
 
 	t.Run("by name", func(t *testing.T) {
 		t.Parallel()
+
+		store := NewTestStore(t)
+		walletID := newWallet(t, store, "wallet-get-account-not-found-name")
+		createAllAccounts(t, store, walletID)
 
 		query := getAccountQueryByName(walletID, scope, "non-existent")
 		info, err := store.GetAccount(t.Context(), query)
@@ -364,6 +357,10 @@ func TestGetAccountNotFound(t *testing.T) {
 
 	t.Run("by number", func(t *testing.T) {
 		t.Parallel()
+
+		store := NewTestStore(t)
+		walletID := newWallet(t, store, "wallet-get-account-not-found-number")
+		createAllAccounts(t, store, walletID)
 
 		query := getAccountQueryByNumber(walletID, scope, 99999)
 		info, err := store.GetAccount(t.Context(), query)
@@ -380,14 +377,12 @@ func TestListAccounts(t *testing.T) {
 	// Ensure that has at least 3 accounts to be tested.
 	require.GreaterOrEqual(t, len(AllAccountCases), 3)
 
-	store := NewTestStore(t)
-
-	walletID := newWallet(t, store, "wallet-list-accounts")
-
-	createAllAccounts(t, store, walletID)
-
 	t.Run("all accounts", func(t *testing.T) {
 		t.Parallel()
+
+		store := NewTestStore(t)
+		walletID := newWallet(t, store, "wallet-list-accounts-all")
+		createAllAccounts(t, store, walletID)
 
 		query := db.ListAccountsQuery{WalletID: walletID}
 		accounts, err := store.ListAccounts(t.Context(), query)
@@ -401,6 +396,10 @@ func TestListAccounts(t *testing.T) {
 
 	t.Run("filter by scope", func(t *testing.T) {
 		t.Parallel()
+
+		store := NewTestStore(t)
+		walletID := newWallet(t, store, "wallet-list-accounts-scope")
+		createAllAccounts(t, store, walletID)
 
 		scope := db.KeyScopeBIP0084
 		query := db.ListAccountsQuery{
@@ -422,6 +421,10 @@ func TestListAccounts(t *testing.T) {
 	t.Run("filter by name", func(t *testing.T) {
 		t.Parallel()
 
+		store := NewTestStore(t)
+		walletID := newWallet(t, store, "wallet-list-accounts-name")
+		createAllAccounts(t, store, walletID)
+
 		// Ensure that has at least 3 derived accounts to be tested.
 		require.GreaterOrEqual(t, len(DerivedAccountCases), 3)
 
@@ -439,6 +442,8 @@ func TestListAccounts(t *testing.T) {
 
 	t.Run("empty result", func(t *testing.T) {
 		t.Parallel()
+
+		store := NewTestStore(t)
 
 		// Create a new wallet with no accounts.
 		emptyWalletID := newWallet(t, store, "wallet-list-empty")
@@ -605,15 +610,6 @@ func TestRenameAccount(t *testing.T) {
 func TestRenameAccountErrors(t *testing.T) {
 	t.Parallel()
 
-	store := NewTestStore(t)
-
-	walletID := newWallet(t, store, "wallet-rename-account-errors")
-
-	createAllAccounts(t, store, walletID)
-
-	nonExistentName := "nonexistent"
-	nonExistentNum := uint32(99999)
-
 	tests := []struct {
 		name    string
 		params  db.RenameAccountParams
@@ -622,40 +618,35 @@ func TestRenameAccountErrors(t *testing.T) {
 		{
 			name: "not found",
 			params: db.RenameAccountParams{
-				WalletID: walletID,
-				Scope:    db.KeyScopeBIP0084,
-				OldName:  nonExistentName,
-				NewName:  "new-name",
+				Scope:   db.KeyScopeBIP0084,
+				OldName: "nonexistent",
+				NewName: "new-name",
 			},
 			wantErr: db.ErrAccountNotFound,
 		},
 		{
 			name: "invalid - both set",
 			params: db.RenameAccountParams{
-				WalletID:      walletID,
-				Scope:         db.KeyScopeBIP0084,
-				OldName:       nonExistentName,
-				AccountNumber: &nonExistentNum,
-				NewName:       "new-name",
+				Scope:   db.KeyScopeBIP0084,
+				OldName: "nonexistent",
+				NewName: "new-name",
 			},
 			wantErr: db.ErrInvalidAccountQuery,
 		},
 		{
 			name: "invalid - neither set",
 			params: db.RenameAccountParams{
-				WalletID: walletID,
-				Scope:    db.KeyScopeBIP0084,
-				NewName:  "new-name",
+				Scope:   db.KeyScopeBIP0084,
+				NewName: "new-name",
 			},
 			wantErr: db.ErrInvalidAccountQuery,
 		},
 		{
 			name: "invalid - empty new name",
 			params: db.RenameAccountParams{
-				WalletID: walletID,
-				Scope:    db.KeyScopeBIP0084,
-				OldName:  nonExistentName,
-				NewName:  "",
+				Scope:   db.KeyScopeBIP0084,
+				OldName: "nonexistent",
+				NewName: "",
 			},
 			wantErr: db.ErrMissingAccountName,
 		},
@@ -664,6 +655,16 @@ func TestRenameAccountErrors(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+
+			store := NewTestStore(t)
+			walletID := newWallet(t, store, "wallet-rename-account-errors")
+			createAllAccounts(t, store, walletID)
+			tc.params.WalletID = walletID
+
+			if tc.name == "invalid - both set" {
+				num := uint32(99999)
+				tc.params.AccountNumber = &num
+			}
 
 			err := store.RenameAccount(t.Context(), tc.params)
 			require.ErrorIs(t, err, tc.wantErr)

--- a/wallet/internal/db/itest/address_store_test.go
+++ b/wallet/internal/db/itest/address_store_test.go
@@ -572,20 +572,21 @@ func TestGetAddressSecret(t *testing.T) {
 func TestGetAddress(t *testing.T) {
 	t.Parallel()
 
-	store := NewTestStore(t)
-	walletID := newWallet(t, store, "wallet-get-address")
-
 	tests := []struct {
 		name      string
-		setupFunc func(t *testing.T) db.GetAddressQuery
-		wantErr   error
-		validate  func(t *testing.T, addr *db.AddressInfo)
+		setupFunc func(t *testing.T, addrStore db.AddressStore,
+			accountStore db.AccountStore, walletID uint32) db.GetAddressQuery
+		wantErr  error
+		validate func(t *testing.T, addr *db.AddressInfo)
 	}{
 		{
 			name: "get by encrypted script pubkey",
-			setupFunc: func(t *testing.T) db.GetAddressQuery {
+			setupFunc: func(t *testing.T, addrStore db.AddressStore,
+				accountStore db.AccountStore,
+				walletID uint32) db.GetAddressQuery {
+
 				createImportedAccount(
-					t, store, walletID, db.KeyScopeBIP0084, "imported",
+					t, accountStore, walletID, db.KeyScopeBIP0084, "imported",
 				)
 
 				script := RandomBytes(32)
@@ -596,7 +597,7 @@ func TestGetAddress(t *testing.T) {
 					PubKey:       RandomBytes(33),
 					ScriptPubKey: script,
 				}
-				_, err := store.NewImportedAddress(t.Context(), params)
+				_, err := addrStore.NewImportedAddress(t.Context(), params)
 				require.NoError(t, err)
 
 				return db.GetAddressQuery{
@@ -611,7 +612,9 @@ func TestGetAddress(t *testing.T) {
 		},
 		{
 			name: "address not found by script",
-			setupFunc: func(t *testing.T) db.GetAddressQuery {
+			setupFunc: func(_ *testing.T, _ db.AddressStore,
+				_ db.AccountStore, walletID uint32) db.GetAddressQuery {
+
 				return db.GetAddressQuery{
 					WalletID:     walletID,
 					ScriptPubKey: RandomBytes(32),
@@ -621,7 +624,9 @@ func TestGetAddress(t *testing.T) {
 		},
 		{
 			name: "invalid query - empty script pubkey",
-			setupFunc: func(t *testing.T) db.GetAddressQuery {
+			setupFunc: func(_ *testing.T, _ db.AddressStore,
+				_ db.AccountStore, walletID uint32) db.GetAddressQuery {
+
 				return db.GetAddressQuery{
 					WalletID:     walletID,
 					ScriptPubKey: nil,
@@ -634,7 +639,11 @@ func TestGetAddress(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			query := tc.setupFunc(t)
+
+			store := NewTestStore(t)
+			walletID := newWallet(t, store, tc.name+"-wallet")
+
+			query := tc.setupFunc(t, store, store, walletID)
 			addr, err := store.GetAddress(t.Context(), query)
 
 			if tc.wantErr != nil {
@@ -658,25 +667,28 @@ func TestGetAddress(t *testing.T) {
 func TestListAddresses(t *testing.T) {
 	t.Parallel()
 
-	store := NewTestStore(t)
-	walletID := newWallet(t, store, "wallet-list-addresses")
-
 	tests := []struct {
 		name      string
-		setupFunc func(t *testing.T) db.ListAddressesQuery
+		setupFunc func(t *testing.T, addrStore db.AddressStore,
+			accountStore db.AccountStore, walletID uint32) db.ListAddressesQuery
 		wantCount int
 		wantErr   error
 		validate  func(t *testing.T, addrs []db.AddressInfo)
 	}{
 		{
 			name: "list multiple addresses for account",
-			setupFunc: func(t *testing.T) db.ListAddressesQuery {
+			setupFunc: func(t *testing.T, addrStore db.AddressStore,
+				accountStore db.AccountStore,
+				walletID uint32) db.ListAddressesQuery {
+
 				createDerivedAccount(
-					t, store, walletID, db.KeyScopeBIP0044, "test-account",
+					t, accountStore, walletID, db.KeyScopeBIP0044,
+					"test-account",
 				)
 
 				createDerivedAddresses(
-					t, store, walletID, db.KeyScopeBIP0044, "test-account",
+					t, addrStore, walletID, db.KeyScopeBIP0044,
+					"test-account",
 					false, 5,
 				)
 
@@ -698,9 +710,13 @@ func TestListAddresses(t *testing.T) {
 		},
 		{
 			name: "list addresses - empty result",
-			setupFunc: func(t *testing.T) db.ListAddressesQuery {
+			setupFunc: func(t *testing.T, _ db.AddressStore,
+				accountStore db.AccountStore,
+				walletID uint32) db.ListAddressesQuery {
+
 				createDerivedAccount(
-					t, store, walletID, db.KeyScopeBIP0084, "empty-account",
+					t, accountStore, walletID, db.KeyScopeBIP0084,
+					"empty-account",
 				)
 
 				return db.ListAddressesQuery{
@@ -713,22 +729,29 @@ func TestListAddresses(t *testing.T) {
 		},
 		{
 			name: "list addresses filters by scope correctly",
-			setupFunc: func(t *testing.T) db.ListAddressesQuery {
+			setupFunc: func(t *testing.T, addrStore db.AddressStore,
+				accountStore db.AccountStore,
+				walletID uint32) db.ListAddressesQuery {
+
 				// Create accounts in different scopes.
 				createDerivedAccount(
-					t, store, walletID, db.KeyScopeBIP0044, "bip44-multi",
+					t, accountStore, walletID, db.KeyScopeBIP0044,
+					"bip44-multi",
 				)
 				createDerivedAccount(
-					t, store, walletID, db.KeyScopeBIP0049Plus, "bip49-multi",
+					t, accountStore, walletID, db.KeyScopeBIP0049Plus,
+					"bip49-multi",
 				)
 
 				createDerivedAddresses(
-					t, store, walletID, db.KeyScopeBIP0044, "bip44-multi",
+					t, addrStore, walletID, db.KeyScopeBIP0044,
+					"bip44-multi",
 					false, 3,
 				)
 
 				createDerivedAddresses(
-					t, store, walletID, db.KeyScopeBIP0049Plus, "bip49-multi",
+					t, addrStore, walletID, db.KeyScopeBIP0049Plus,
+					"bip49-multi",
 					false, 2,
 				)
 
@@ -752,7 +775,11 @@ func TestListAddresses(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			query := tc.setupFunc(t)
+
+			store := NewTestStore(t)
+			walletID := newWallet(t, store, tc.name+"-wallet")
+
+			query := tc.setupFunc(t, store, store, walletID)
 			addrs, err := store.ListAddresses(t.Context(), query)
 
 			if tc.wantErr != nil {
@@ -966,9 +993,6 @@ func TestListAddressesOrdering(t *testing.T) {
 func TestNewDerivedAddressErrors(t *testing.T) {
 	t.Parallel()
 
-	store := NewTestStore(t)
-	walletID := newWallet(t, store, "wallet-new-derived-address-errors")
-
 	tests := []struct {
 		name    string
 		params  db.NewDerivedAddressParams
@@ -977,7 +1001,6 @@ func TestNewDerivedAddressErrors(t *testing.T) {
 		{
 			name: "non-existent account",
 			params: db.NewDerivedAddressParams{
-				WalletID:    walletID,
 				Scope:       db.KeyScopeBIP0084,
 				AccountName: "non-existent",
 				Change:      false,
@@ -987,7 +1010,6 @@ func TestNewDerivedAddressErrors(t *testing.T) {
 		{
 			name: "empty account name",
 			params: db.NewDerivedAddressParams{
-				WalletID:    walletID,
 				Scope:       db.KeyScopeBIP0044,
 				AccountName: "",
 				Change:      false,
@@ -997,7 +1019,6 @@ func TestNewDerivedAddressErrors(t *testing.T) {
 		{
 			name: "unknown key scope returns account not found",
 			params: db.NewDerivedAddressParams{
-				WalletID: walletID,
 				Scope: db.KeyScope{
 					Purpose: 999,
 					Coin:    999,
@@ -1013,7 +1034,13 @@ func TestNewDerivedAddressErrors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			info, err := store.NewDerivedAddress(t.Context(), tc.params, mockDeriveFunc())
+			store := NewTestStore(t)
+			walletID := newWallet(t, store, tc.name+"-wallet")
+			tc.params.WalletID = walletID
+
+			info, err := store.NewDerivedAddress(
+				t.Context(), tc.params, mockDeriveFunc(),
+			)
 			require.ErrorIs(t, err, tc.wantErr)
 			require.Nil(t, info)
 		})

--- a/wallet/internal/db/itest/address_types_store_test.go
+++ b/wallet/internal/db/itest/address_types_store_test.go
@@ -33,7 +33,6 @@ func TestListAddressTypes(t *testing.T) {
 
 func TestGetAddressType(t *testing.T) {
 	t.Parallel()
-	store := NewTestStore(t)
 
 	tests := []struct {
 		id         db.AddressType
@@ -118,6 +117,8 @@ func TestGetAddressType(t *testing.T) {
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
+
+			store := NewTestStore(t)
 
 			got, err := store.GetAddressType(t.Context(), tc.id)
 

--- a/wallet/internal/db/itest/pg_test.go
+++ b/wallet/internal/db/itest/pg_test.go
@@ -5,9 +5,12 @@ package itest
 import (
 	"context"
 	"database/sql"
+	"flag"
 	"fmt"
 	"os"
 	"regexp"
+	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -22,9 +25,6 @@ import (
 )
 
 var (
-	// Limit concurrent database creation to avoid exhausting connections.
-	pgDBSemaphore = make(chan struct{}, 4)
-
 	// Shared container instance, reused across tests for performance.
 	// This is safe to use concurrently because we only share the container
 	// and not the database inside it. Each test gets its own database.
@@ -45,6 +45,23 @@ var (
 	pgTerminateTimeout = 1 * time.Minute
 )
 
+// testParallelism returns the effective test parallelism level. It reads the
+// -test.parallel flag when set, falling back to GOMAXPROCS (the default used by
+// the Go test runner).
+func testParallelism() int {
+	f := flag.Lookup("test.parallel")
+	if f == nil {
+		return runtime.GOMAXPROCS(0)
+	}
+
+	n, err := strconv.Atoi(f.Value.String())
+	if err != nil || n <= 0 {
+		return runtime.GOMAXPROCS(0)
+	}
+
+	return n
+}
+
 // TestMain ensures the shared postgres container is terminated after the
 // integration test suite completes to avoid leaking docker resources.
 func TestMain(m *testing.M) {
@@ -52,10 +69,16 @@ func TestMain(m *testing.M) {
 
 	// Terminate the container after the test suite completes.
 	if pgContainer != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), pgTerminateTimeout)
+		ctx, cancel := context.WithTimeout(
+			context.Background(), pgTerminateTimeout,
+		)
 		defer cancel()
 
-		err := pgContainer.Terminate(ctx)
+		// As the tests already completed, we can stop the container
+		// immediately.
+		err := pgContainer.Terminate(
+			ctx, testcontainers.StopTimeout(0),
+		)
 		if err != nil {
 			fmt.Printf("failed to terminate postgres container: %v\n", err)
 		}
@@ -91,9 +114,8 @@ func DefaultPostgresConfig() PostgresConfig {
 
 // GetPostgresContainer returns the shared PostgreSQL container instance.
 // The container is created once and reused across all tests for performance.
-//
-// Note: postgres:18-alpine defaults max_connections to 100.
-func GetPostgresContainer(ctx context.Context) (*postgres.PostgresContainer, error) {
+func GetPostgresContainer(ctx context.Context) (*postgres.PostgresContainer,
+	error) {
 	pgContainerOnce.Do(func() {
 		cfg := DefaultPostgresConfig()
 
@@ -115,6 +137,12 @@ func GetPostgresContainer(ctx context.Context) (*postgres.PostgresContainer, err
 			postgres.WithDatabase(cfg.Database),
 			postgres.WithUsername(cfg.Username),
 			postgres.WithPassword(cfg.Password),
+			testcontainers.WithCmd(
+				"-c", fmt.Sprintf(
+					"max_connections=%d",
+					testParallelism()*db.DefaultMaxConnections,
+				),
+			),
 			testcontainers.WithWaitStrategyAndDeadline(
 				pgInitTimeout, waitForSQL,
 			),
@@ -144,17 +172,18 @@ func sanitizedPgDBName(t *testing.T) string {
 }
 
 // NewTestStore creates a new PostgreSQL database connection with migrations
-// applied. Each test gets its own database for isolation.
+// applied. Each parallel subtest must call NewTestStore itself rather than
+// sharing a store created by the parent test. When a parent test creates the
+// store and its subtests call t.Parallel(), the parent finishes and releases
+// its parallel slot while the subtests are still running. A new parent test
+// fills that slot and opens another store, but the original subtests still
+// hold their connections. This leads to more open connections than the parallel
+// limit allows, exhausting the PostgreSQL connection pool. Avoid this by
+// creating NewTestStore inside each parallel subtest so its lifecycle is tied
+// to the subtest's parallel slot.
 func NewTestStore(t *testing.T) *db.PostgresStore {
 	t.Helper()
 	ctx := t.Context()
-
-	// Acquire a semaphore slot to limit concurrent database creation and
-	// parallel test execution that depends on it.
-	pgDBSemaphore <- struct{}{}
-	defer func() {
-		<-pgDBSemaphore
-	}()
 
 	container, err := GetPostgresContainer(ctx)
 	require.NoError(t, err, "failed to get postgres container")

--- a/wallet/internal/db/itest/wallet_store_test.go
+++ b/wallet/internal/db/itest/wallet_store_test.go
@@ -100,8 +100,8 @@ func TestCreateWallet_Variants(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			store := NewTestStore(t)
 			params := tc.params(tc.name)
+			store := NewTestStore(t)
 
 			info, err := store.CreateWallet(t.Context(), params)
 			require.NoError(t, err)


### PR DESCRIPTION
This fixes a bug that had been haunting me for a while in the integration tests.

#### Error
The random error:
```
failed to connect to host=localhost user=postgres database=postgres: server error (FATAL: sorry, too many clients already (SQLSTATE 53300))
```

#### Root cause
We were opening more PostgreSQL connections than the limit.

This happened because:
- Calling `t.Parallel()` inside a `t.Run()` releases the parent goroutine early, so more top-level tests start before the parent store is closed.
- Each `NewTestStore` creates its own database with a pool of up to 25 connections.
- `max_connections` was fixed and did not match the actual connection budget. The semaphore only limited database creation, but not the total number of open connections.

#### Changes
- Store per subtest — each parallel subtest now calls NewTestStore(t) itself so the store lifecycle is tied to the subtest's parallel slot.
- Sized max_connections to parallelism — replaced the fixed limit with testParallelism() * DefaultMaxConnections, matching the actual number of concurrent stores the test runner can open.
- Removed redundant caching — pgMaxConnections() and its package variable pgMaxConns were called once inside a sync.Once; inlined the computation at the call site.
- Table-driven error tests use plain struct params with WalletID injected after wallet creation. Setup funcs in TestGetAddress and TestListAddresses accept store and walletID parameters so each subtest operates on its own isolated database.

#### Result
- No more connection exhaustion errors.
- Tests still run in parallel.

