### PR TITLE
wallet: add SQL UTXO store

### DIFF
--- a/wallet/internal/db/README.md
+++ b/wallet/internal/db/README.md
@@ -1,0 +1,109 @@
+# wallet/internal/db
+
+This package keeps the public wallet-store APIs in one place while supporting
+multiple SQL backends.
+
+## Ops interfaces
+
+Some store methods use a small backend-specific `ops` interface together with a
+shared backend-independent helper.
+
+Here, `ops` is short for the backend-specific database operations that one
+shared workflow needs.
+
+We use this pattern because postgres and sqlite usually agree on the high-level
+wallet workflow, but they still differ in important low-level ways:
+
+- sqlc generates different parameter and row types for each backend
+- nullable arguments often have different shapes, such as typed `sql.Null*`
+  values in postgres versus sqlite-specific generated forms
+- integer widths and conversion helpers differ across backend bindings
+- some statements need backend-specific SQL or binding workarounds
+- we still want compile-time checking against each backend's concrete query set
+
+Without a small adapter layer, each backend file tends to duplicate the same
+business workflow with only query-shape differences. That makes reviews noisy
+and makes later invariant changes easy to miss in one backend.
+
+Use this pattern when a method has both of these properties:
+
+- the high-level workflow is the same for postgres and sqlite
+- the SQL query types, nullable argument shapes, or row handling differ by
+  backend
+
+In that case:
+
+- keep the shared workflow in one backend-independent helper
+- keep the backend adapters close to the concrete backend methods
+- keep shared unit tests near the shared workflow
+- keep backend-visible behavior in integration tests
+- document the algorithm in detail on both the `ops` interface and the shared
+  helper so reviewers can see the intended sequencing and ownership boundaries
+
+The abstraction boundary is intentionally narrow:
+
+- one backend-specific `ops` interface per shared method workflow
+- one shared backend-independent workflow helper for that method
+- backend-specific preparation, row-count handling, sqlc binding shapes, and
+  query error mapping stay in backend files
+
+If a helper is only called from backend-specific files and never from the
+shared workflow helper, it should stay in backend-specific files rather than in
+the common workflow file.
+
+This approach is meant to keep one copy of the domain workflow while still
+leaving backend-specific SQL details explicit and close to the actual queries.
+The shared helper owns the sequencing and invariants. The backend `ops`
+implementation owns query calls, generated binding types, backend-specific
+conversions, and any helper code that only those backend methods need.
+
+Examples:
+
+- tx store: `CreateTx`, `UpdateTx`, `DeleteTx`, `RollbackToBlock`
+- utxo store: `LeaseOutput`, `ReleaseOutput`
+
+Minimal example:
+
+```go
+type someMethodOps interface {
+	load(ctx context.Context, id int64) (row, error)
+	write(ctx context.Context, req request) error
+}
+
+func someMethodWithOps(ctx context.Context, req request,
+	ops someMethodOps) error {
+	loaded, err := ops.load(ctx, req.id)
+	if err != nil {
+		return err
+	}
+
+	return ops.write(ctx, mergeRequest(req, loaded))
+}
+```
+
+The shared helper owns the ordering and invariants. Each backend `ops`
+implementation only adapts query calls, generated sqlc types, and backend-
+specific conversions needed by that shared method.
+
+The algorithm docs should be explicit. They should describe the ordered stages
+of the shared workflow, what each stage is responsible for, and why the shared
+helper owns that sequencing instead of leaving it implicit in backend files.
+
+Do not introduce an `ops` interface for thin read methods or simple wrappers.
+If a method is mostly one query plus row conversion, prefer direct backend
+implementations. Examples include `GetTx`, `ListTxns`, `GetUtxo`,
+`ListUTXOs`, `ListLeasedOutputs`, and `Balance`.
+
+Likewise, do not add extra common-file helper layers for backend-only prep
+work. If a helper only exists to support postgres or sqlite methods and is not
+called by the shared workflow helper itself, keep it in backend-specific files.
+
+## File layout
+
+- shared helpers and shared workflows should stay backend-independent
+- backend-specific implementations should stay close to the concrete backend
+- method-specific files are preferred over large backend files that mix many
+  unrelated methods
+
+This layout keeps commit boundaries small, makes review easier, and lets shared
+logic evolve without hiding backend-specific SQL details.

--- a/wallet/internal/db/accounts_pg.go
+++ b/wallet/internal/db/accounts_pg.go
@@ -335,13 +335,10 @@ func (p pgAccountGetQueries) byNumber(ctx context.Context,
 	return getAccount(
 		ctx, p.q.GetAccountByWalletScopeAndNumber,
 		sqlcpg.GetAccountByWalletScopeAndNumberParams{
-			WalletID: int64(query.WalletID),
-			Purpose:  int64(query.Scope.Purpose),
-			CoinType: int64(query.Scope.Coin),
-			AccountNumber: sql.NullInt64{
-				Int64: int64(*query.AccountNumber),
-				Valid: true,
-			},
+			WalletID:      int64(query.WalletID),
+			Purpose:       int64(query.Scope.Purpose),
+			CoinType:      int64(query.Scope.Coin),
+			AccountNumber: nullableUint32ToSQLInt64(query.AccountNumber),
 		}, query, pgAccountRowToInfo,
 	)
 }
@@ -374,14 +371,11 @@ func (p pgAccountRenameQueries) byNumber(ctx context.Context,
 	return renameAccount(
 		ctx, p.q.UpdateAccountNameByWalletScopeAndNumber,
 		sqlcpg.UpdateAccountNameByWalletScopeAndNumberParams{
-			NewName:  params.NewName,
-			WalletID: int64(params.WalletID),
-			Purpose:  int64(params.Scope.Purpose),
-			CoinType: int64(params.Scope.Coin),
-			AccountNumber: sql.NullInt64{
-				Int64: int64(*params.AccountNumber),
-				Valid: true,
-			},
+			NewName:       params.NewName,
+			WalletID:      int64(params.WalletID),
+			Purpose:       int64(params.Scope.Purpose),
+			CoinType:      int64(params.Scope.Coin),
+			AccountNumber: nullableUint32ToSQLInt64(params.AccountNumber),
 		}, params,
 	)
 }

--- a/wallet/internal/db/accounts_sqlite.go
+++ b/wallet/internal/db/accounts_sqlite.go
@@ -331,13 +331,10 @@ func (s sqliteAccountGetQueries) byNumber(ctx context.Context,
 	return getAccount(
 		ctx, s.q.GetAccountByWalletScopeAndNumber,
 		sqlcsqlite.GetAccountByWalletScopeAndNumberParams{
-			WalletID: int64(query.WalletID),
-			Purpose:  int64(query.Scope.Purpose),
-			CoinType: int64(query.Scope.Coin),
-			AccountNumber: sql.NullInt64{
-				Int64: int64(*query.AccountNumber),
-				Valid: true,
-			},
+			WalletID:      int64(query.WalletID),
+			Purpose:       int64(query.Scope.Purpose),
+			CoinType:      int64(query.Scope.Coin),
+			AccountNumber: nullableUint32ToSQLInt64(query.AccountNumber),
 		}, query, sqliteAccountRowToInfo,
 	)
 }
@@ -369,14 +366,11 @@ func (s sqliteAccountRenameQueries) byNumber(ctx context.Context,
 	return renameAccount(
 		ctx, s.q.UpdateAccountNameByWalletScopeAndNumber,
 		sqlcsqlite.UpdateAccountNameByWalletScopeAndNumberParams{
-			NewName:  params.NewName,
-			WalletID: int64(params.WalletID),
-			Purpose:  int64(params.Scope.Purpose),
-			CoinType: int64(params.Scope.Coin),
-			AccountNumber: sql.NullInt64{
-				Int64: int64(*params.AccountNumber),
-				Valid: true,
-			},
+			NewName:       params.NewName,
+			WalletID:      int64(params.WalletID),
+			Purpose:       int64(params.Scope.Purpose),
+			CoinType:      int64(params.Scope.Coin),
+			AccountNumber: nullableUint32ToSQLInt64(params.AccountNumber),
 		}, params,
 	)
 }

--- a/wallet/internal/db/itest/tx_utxo_store_test.go
+++ b/wallet/internal/db/itest/tx_utxo_store_test.go
@@ -1419,6 +1419,106 @@ func TestLeaseOutputRejectsNonPositiveDuration(t *testing.T) {
 	require.ErrorIs(t, err, db.ErrInvalidParam)
 }
 
+// TestReleaseOutputUnlocksMatchingLease verifies that ReleaseOutput removes the
+// active lease when the caller presents the matching lock ID.
+func TestReleaseOutputUnlocksMatchingLease(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-release-output")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 20000, PkScript: addr.ScriptPubKey}},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       tx,
+		Received: time.Unix(1710001900, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	leaseID := RandomHash()
+	_, err = store.LeaseOutput(t.Context(), db.LeaseOutputParams{
+		WalletID: walletID,
+		ID:       leaseID,
+		OutPoint: wire.OutPoint{Hash: tx.TxHash(), Index: 0},
+		Duration: time.Minute,
+	})
+	require.NoError(t, err)
+
+	err = store.ReleaseOutput(t.Context(), db.ReleaseOutputParams{
+		WalletID: walletID,
+		ID:       leaseID,
+		OutPoint: wire.OutPoint{Hash: tx.TxHash(), Index: 0},
+	})
+
+	require.NoError(t, err)
+
+	otherID := RandomHash()
+	_, err = store.LeaseOutput(t.Context(), db.LeaseOutputParams{
+		WalletID: walletID,
+		ID:       otherID,
+		OutPoint: wire.OutPoint{Hash: tx.TxHash(), Index: 0},
+		Duration: time.Minute,
+	})
+	require.NoError(t, err)
+}
+
+// TestReleaseOutputRejectsWrongLockID verifies that ReleaseOutput reports the
+// public unlock error when another active lock still owns the output.
+func TestReleaseOutputRejectsWrongLockID(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-release-conflict")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 21000, PkScript: addr.ScriptPubKey}},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       tx,
+		Received: time.Unix(1710002000, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	leaseID := RandomHash()
+	_, err = store.LeaseOutput(t.Context(), db.LeaseOutputParams{
+		WalletID: walletID,
+		ID:       leaseID,
+		OutPoint: wire.OutPoint{Hash: tx.TxHash(), Index: 0},
+		Duration: time.Minute,
+	})
+	require.NoError(t, err)
+
+	wrongID := RandomHash()
+	err = store.ReleaseOutput(t.Context(), db.ReleaseOutputParams{
+		WalletID: walletID,
+		ID:       wrongID,
+		OutPoint: wire.OutPoint{Hash: tx.TxHash(), Index: 0},
+	})
+
+	require.ErrorIs(t, err, db.ErrOutputUnlockNotAllowed)
+}
+
 // newCoinbaseTx builds a simple coinbase fixture transaction.
 func newCoinbaseTx(pkScript []byte) *wire.MsgTx {
 	tx := wire.NewMsgTx(2)

--- a/wallet/internal/db/itest/tx_utxo_store_test.go
+++ b/wallet/internal/db/itest/tx_utxo_store_test.go
@@ -1316,6 +1316,109 @@ func TestListUTXOsFiltersByAccount(t *testing.T) {
 	require.Equal(t, txSavings.TxHash(), utxos[0].OutPoint.Hash)
 }
 
+// TestLeaseOutputLocksCurrentUtxo verifies that LeaseOutput returns the active
+// lease metadata for a current wallet-owned output.
+func TestLeaseOutputLocksCurrentUtxo(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-lease-output")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 18000, PkScript: addr.ScriptPubKey}},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       tx,
+		Received: time.Unix(1710001700, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	lease, err := store.LeaseOutput(t.Context(), db.LeaseOutputParams{
+		WalletID: walletID,
+		OutPoint: wire.OutPoint{Hash: tx.TxHash(), Index: 0},
+		ID:       db.LockID{1},
+		Duration: 30 * time.Minute,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, tx.TxHash(), lease.OutPoint.Hash)
+	require.Equal(t, uint32(0), lease.OutPoint.Index)
+	require.Equal(t, db.LockID{1}, lease.LockID)
+	require.True(t, lease.Expiration.After(time.Now().UTC()))
+}
+
+// TestLeaseOutputRejectsAlreadyLeasedUtxo verifies that LeaseOutput reports
+// ErrOutputAlreadyLeased when another active lock already owns the same output.
+func TestLeaseOutputRejectsAlreadyLeasedUtxo(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-lease-output-conflict")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 19000, PkScript: addr.ScriptPubKey}},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       tx,
+		Received: time.Unix(1710001710, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	_, err = store.LeaseOutput(t.Context(), db.LeaseOutputParams{
+		WalletID: walletID,
+		OutPoint: wire.OutPoint{Hash: tx.TxHash(), Index: 0},
+		ID:       db.LockID{1},
+		Duration: 30 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	_, err = store.LeaseOutput(t.Context(), db.LeaseOutputParams{
+		WalletID: walletID,
+		OutPoint: wire.OutPoint{Hash: tx.TxHash(), Index: 0},
+		ID:       db.LockID{2},
+		Duration: 30 * time.Minute,
+	})
+	require.ErrorIs(t, err, db.ErrOutputAlreadyLeased)
+}
+
+// TestLeaseOutputRejectsNonPositiveDuration verifies that LeaseOutput rejects a
+// non-positive duration before it attempts any lease write.
+func TestLeaseOutputRejectsNonPositiveDuration(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-lease-output-duration")
+
+	_, err := store.LeaseOutput(t.Context(), db.LeaseOutputParams{
+		WalletID: walletID,
+		OutPoint: randomOutPoint(),
+		ID:       db.LockID{3},
+		Duration: 0,
+	})
+
+	require.ErrorIs(t, err, db.ErrInvalidParam)
+}
+
 // newCoinbaseTx builds a simple coinbase fixture transaction.
 func newCoinbaseTx(pkScript []byte) *wire.MsgTx {
 	tx := wire.NewMsgTx(2)

--- a/wallet/internal/db/itest/tx_utxo_store_test.go
+++ b/wallet/internal/db/itest/tx_utxo_store_test.go
@@ -1612,6 +1612,64 @@ func TestListLeasedOutputsExcludesReleasedLease(t *testing.T) {
 	require.Empty(t, leases)
 }
 
+// TestBalanceReturnsTotalAndLocked verifies that Balance returns the filtered
+// total UTXO value together with the locked subset covered by active leases.
+func TestBalanceReturnsTotalAndLocked(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-balance")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+
+	txOne := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 24000, PkScript: addr.ScriptPubKey}},
+	)
+	txTwo := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 26000, PkScript: addr.ScriptPubKey}},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       txOne,
+		Received: time.Unix(1710002300, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       txTwo,
+		Received: time.Unix(1710002310, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	leaseID := RandomHash()
+	_, err = store.LeaseOutput(t.Context(), db.LeaseOutputParams{
+		WalletID: walletID,
+		ID:       leaseID,
+		OutPoint: wire.OutPoint{Hash: txOne.TxHash(), Index: 0},
+		Duration: time.Minute,
+	})
+	require.NoError(t, err)
+
+	balance, err := store.Balance(t.Context(), db.BalanceParams{
+		WalletID: walletID,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(50000), balance.Total)
+	require.Equal(t, btcutil.Amount(24000), balance.Locked)
+}
+
 // newCoinbaseTx builds a simple coinbase fixture transaction.
 func newCoinbaseTx(pkScript []byte) *wire.MsgTx {
 	tx := wire.NewMsgTx(2)

--- a/wallet/internal/db/itest/tx_utxo_store_test.go
+++ b/wallet/internal/db/itest/tx_utxo_store_test.go
@@ -1519,6 +1519,99 @@ func TestReleaseOutputRejectsWrongLockID(t *testing.T) {
 	require.ErrorIs(t, err, db.ErrOutputUnlockNotAllowed)
 }
 
+// TestListLeasedOutputsReturnsActiveLeases verifies that ListLeasedOutputs
+// returns the currently active wallet lease set.
+func TestListLeasedOutputsReturnsActiveLeases(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-list-leases")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 22000, PkScript: addr.ScriptPubKey}},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       tx,
+		Received: time.Unix(1710002100, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	leaseID := RandomHash()
+	_, err = store.LeaseOutput(t.Context(), db.LeaseOutputParams{
+		WalletID: walletID,
+		ID:       leaseID,
+		OutPoint: wire.OutPoint{Hash: tx.TxHash(), Index: 0},
+		Duration: time.Minute,
+	})
+	require.NoError(t, err)
+
+	leases, err := store.ListLeasedOutputs(t.Context(), walletID)
+
+	require.NoError(t, err)
+	require.Len(t, leases, 1)
+	require.Equal(t, tx.TxHash(), leases[0].OutPoint.Hash)
+	require.Equal(t, db.LockID(leaseID), leases[0].LockID)
+}
+
+// TestListLeasedOutputsExcludesReleasedLease verifies that ListLeasedOutputs
+// reflects a successful release immediately.
+func TestListLeasedOutputsExcludesReleasedLease(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-list-leases-after-release")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 23000, PkScript: addr.ScriptPubKey}},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       tx,
+		Received: time.Unix(1710002200, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	leaseID := RandomHash()
+	_, err = store.LeaseOutput(t.Context(), db.LeaseOutputParams{
+		WalletID: walletID,
+		ID:       leaseID,
+		OutPoint: wire.OutPoint{Hash: tx.TxHash(), Index: 0},
+		Duration: time.Minute,
+	})
+	require.NoError(t, err)
+
+	err = store.ReleaseOutput(t.Context(), db.ReleaseOutputParams{
+		WalletID: walletID,
+		ID:       leaseID,
+		OutPoint: wire.OutPoint{Hash: tx.TxHash(), Index: 0},
+	})
+	require.NoError(t, err)
+
+	leases, err := store.ListLeasedOutputs(t.Context(), walletID)
+
+	require.NoError(t, err)
+	require.Empty(t, leases)
+}
+
 // newCoinbaseTx builds a simple coinbase fixture transaction.
 func newCoinbaseTx(pkScript []byte) *wire.MsgTx {
 	tx := wire.NewMsgTx(2)

--- a/wallet/internal/db/itest/tx_utxo_store_test.go
+++ b/wallet/internal/db/itest/tx_utxo_store_test.go
@@ -1211,6 +1211,111 @@ func TestGetUtxoNotFound(t *testing.T) {
 	require.ErrorIs(t, err, db.ErrUtxoNotFound)
 }
 
+// TestListUTXOsReturnsCurrentWalletOutputs verifies that ListUTXOs returns the
+// current wallet-owned outputs created by pending transactions.
+func TestListUTXOsReturnsCurrentWalletOutputs(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-list-utxos")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+
+	txOne := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 15000, PkScript: addr.ScriptPubKey}},
+	)
+	txTwo := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 12000, PkScript: addr.ScriptPubKey}},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       txOne,
+		Received: time.Unix(1710001500, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       txTwo,
+		Received: time.Unix(1710001510, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	utxos, err := store.ListUTXOs(t.Context(), db.ListUtxosQuery{
+		WalletID: walletID,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, utxos, 2)
+	require.Equal(t, txTwo.TxHash(), utxos[0].OutPoint.Hash)
+	require.Equal(t, txOne.TxHash(), utxos[1].OutPoint.Hash)
+}
+
+// TestListUTXOsFiltersByAccount verifies that ListUTXOs applies the optional
+// account filter without affecting the underlying wallet ownership checks.
+func TestListUTXOsFiltersByAccount(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-list-utxos-account")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "savings")
+
+	defaultAddr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	savingsAddr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "savings", false,
+	)
+
+	txDefault := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 16000, PkScript: defaultAddr.ScriptPubKey}},
+	)
+	txSavings := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 17000, PkScript: savingsAddr.ScriptPubKey}},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       txDefault,
+		Received: time.Unix(1710001600, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       txSavings,
+		Received: time.Unix(1710001610, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	account := uint32(1)
+	utxos, err := store.ListUTXOs(t.Context(), db.ListUtxosQuery{
+		WalletID: walletID,
+		Account:  &account,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, utxos, 1)
+	require.Equal(t, txSavings.TxHash(), utxos[0].OutPoint.Hash)
+}
+
 // newCoinbaseTx builds a simple coinbase fixture transaction.
 func newCoinbaseTx(pkScript []byte) *wire.MsgTx {
 	tx := wire.NewMsgTx(2)

--- a/wallet/internal/db/itest/tx_utxo_store_test.go
+++ b/wallet/internal/db/itest/tx_utxo_store_test.go
@@ -1156,6 +1156,61 @@ func TestRollbackToBlockFailsCoinbaseDescendants(t *testing.T) {
 	require.Empty(t, childSpendingTxIDs(t, store, walletID, childTx.TxHash()))
 }
 
+// TestGetUtxoReturnsCurrentWalletOutput verifies that GetUtxo returns a stored
+// wallet-owned output created by an unmined transaction.
+func TestGetUtxoReturnsCurrentWalletOutput(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-get-utxo")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 15000, PkScript: addr.ScriptPubKey}},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       tx,
+		Received: time.Unix(1710001400, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	utxo, err := store.GetUtxo(t.Context(), db.GetUtxoQuery{
+		WalletID: walletID,
+		OutPoint: wire.OutPoint{Hash: tx.TxHash(), Index: 0},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, tx.TxHash(), utxo.OutPoint.Hash)
+	require.Equal(t, uint32(0), utxo.OutPoint.Index)
+	require.Equal(t, btcutil.Amount(15000), utxo.Amount)
+	require.Equal(t, db.UnminedHeight, utxo.Height)
+}
+
+// TestGetUtxoNotFound verifies that GetUtxo returns ErrUtxoNotFound when the
+// requested outpoint is not part of the current wallet UTXO set.
+func TestGetUtxoNotFound(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-get-utxo-missing")
+
+	_, err := store.GetUtxo(t.Context(), db.GetUtxoQuery{
+		WalletID: walletID,
+		OutPoint: randomOutPoint(),
+	})
+
+	require.ErrorIs(t, err, db.ErrUtxoNotFound)
+}
+
 // newCoinbaseTx builds a simple coinbase fixture transaction.
 func newCoinbaseTx(pkScript []byte) *wire.MsgTx {
 	tx := wire.NewMsgTx(2)

--- a/wallet/internal/db/postgres_utxostore_balance.go
+++ b/wallet/internal/db/postgres_utxostore_balance.go
@@ -18,10 +18,10 @@ func (s *PostgresStore) Balance(ctx context.Context,
 	balance, err := s.queries.Balance(ctx, sqlcpg.BalanceParams{
 		NowUtc:           nowUTC,
 		WalletID:         int64(params.WalletID),
-		AccountNumber:    nullableUint32Int64Pg(params.Account),
-		MinConfirms:      nullableInt32Pg(params.MinConfs),
-		MaxConfirms:      nullableInt32Pg(params.MaxConfs),
-		CoinbaseMaturity: nullableInt32Pg(params.CoinbaseMaturity),
+		AccountNumber:    nullableUint32ToSQLInt64(params.Account),
+		MinConfirms:      nullableInt32ToSQLInt32(params.MinConfs),
+		MaxConfirms:      nullableInt32ToSQLInt32(params.MaxConfs),
+		CoinbaseMaturity: nullableInt32ToSQLInt32(params.CoinbaseMaturity),
 	})
 	if err != nil {
 		return BalanceResult{}, fmt.Errorf("balance: %w", err)

--- a/wallet/internal/db/postgres_utxostore_balance.go
+++ b/wallet/internal/db/postgres_utxostore_balance.go
@@ -1,0 +1,34 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
+)
+
+// Balance returns the sum of wallet-owned current UTXOs after optional filters.
+func (s *PostgresStore) Balance(ctx context.Context,
+	params BalanceParams) (BalanceResult, error) {
+
+	nowUTC := time.Now().UTC()
+
+	balance, err := s.queries.Balance(ctx, sqlcpg.BalanceParams{
+		NowUtc:           nowUTC,
+		WalletID:         int64(params.WalletID),
+		AccountNumber:    nullableUint32Int64Pg(params.Account),
+		MinConfirms:      nullableInt32Pg(params.MinConfs),
+		MaxConfirms:      nullableInt32Pg(params.MaxConfs),
+		CoinbaseMaturity: nullableInt32Pg(params.CoinbaseMaturity),
+	})
+	if err != nil {
+		return BalanceResult{}, fmt.Errorf("balance: %w", err)
+	}
+
+	return BalanceResult{
+		Total:  btcutil.Amount(balance.TotalBalance),
+		Locked: btcutil.Amount(balance.LockedBalance),
+	}, nil
+}

--- a/wallet/internal/db/postgres_utxostore_getutxo.go
+++ b/wallet/internal/db/postgres_utxostore_getutxo.go
@@ -1,0 +1,71 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
+)
+
+// GetUtxo retrieves one current wallet-owned UTXO by outpoint.
+//
+// The output must still be unspent and its creating transaction must still be
+// in `pending` or `published` status.
+func (s *PostgresStore) GetUtxo(ctx context.Context,
+	query GetUtxoQuery) (*UtxoInfo, error) {
+
+	outputIndex, err := uint32ToInt32(query.OutPoint.Index)
+	if err != nil {
+		return nil, fmt.Errorf("convert output index: %w", err)
+	}
+
+	row, err := s.queries.GetUtxoByOutpoint(
+		ctx, sqlcpg.GetUtxoByOutpointParams{
+			WalletID:    int64(query.WalletID),
+			TxHash:      query.OutPoint.Hash[:],
+			OutputIndex: outputIndex,
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("utxo %s: %w", query.OutPoint,
+				ErrUtxoNotFound)
+		}
+
+		return nil, fmt.Errorf("get utxo: %w", err)
+	}
+
+	return utxoInfoFromPgRow(
+		row.TxHash, row.OutputIndex, row.Amount, row.ScriptPubKey,
+		row.ReceivedTime, row.IsCoinbase, row.BlockHeight,
+	)
+}
+
+// utxoInfoFromPgRow converts one normalized postgres query row into the public
+// UtxoInfo shape.
+func utxoInfoFromPgRow(hash []byte, outputIndex int32, amount int64,
+	pkScript []byte, received time.Time, isCoinbase bool,
+	blockHeight sql.NullInt32) (*UtxoInfo, error) {
+
+	index, err := int64ToUint32(int64(outputIndex))
+	if err != nil {
+		return nil, fmt.Errorf("utxo output index: %w", err)
+	}
+
+	var height *uint32
+	if blockHeight.Valid {
+		heightValue, err := nullInt32ToUint32(blockHeight)
+		if err != nil {
+			return nil, fmt.Errorf("utxo block height: %w", err)
+		}
+
+		height = &heightValue
+	}
+
+	return buildUtxoInfo(
+		hash, index, amount, pkScript, received, isCoinbase, height,
+	)
+}

--- a/wallet/internal/db/postgres_utxostore_leaseoutput.go
+++ b/wallet/internal/db/postgres_utxostore_leaseoutput.go
@@ -1,0 +1,108 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
+)
+
+// LeaseOutput atomically acquires or renews a lease for one current UTXO.
+//
+// The lease lookup and acquisition run in one transaction so competing calls
+// cannot observe a partially-written lease. Expiration timestamps are
+// normalized to UTC before insert.
+func (s *PostgresStore) LeaseOutput(ctx context.Context,
+	params LeaseOutputParams) (*LeasedOutput, error) {
+
+	var lease *LeasedOutput
+
+	err := s.ExecuteTx(ctx, func(qtx *sqlcpg.Queries) error {
+		acquiredLease, err := leaseOutputWithOps(
+			ctx, params, &pgLeaseOutputOps{qtx: qtx},
+		)
+		if err != nil {
+			return err
+		}
+
+		lease = acquiredLease
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return lease, nil
+}
+
+// pgLeaseOutputOps adapts postgres sqlc queries to the shared LeaseOutput
+// workflow.
+type pgLeaseOutputOps struct {
+	qtx *sqlcpg.Queries
+}
+
+var _ leaseOutputOps = (*pgLeaseOutputOps)(nil)
+
+// acquire attempts to write or renew one postgres lease row for the requested
+// outpoint.
+func (o *pgLeaseOutputOps) acquire(ctx context.Context,
+	params LeaseOutputParams, nowUTC time.Time,
+	expiresAt time.Time) (time.Time, error) {
+
+	outputIndex, err := uint32ToInt32(params.OutPoint.Index)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("convert output index: %w", err)
+	}
+
+	expiration, err := o.qtx.AcquireUtxoLease(
+		ctx, sqlcpg.AcquireUtxoLeaseParams{
+			WalletID:    int64(params.WalletID),
+			LockID:      params.ID[:],
+			ExpiresAt:   expiresAt,
+			TxHash:      params.OutPoint.Hash[:],
+			OutputIndex: outputIndex,
+			NowUtc:      nowUTC,
+		},
+	)
+	if err == nil {
+		return expiration, nil
+	}
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return time.Time{}, errLeaseOutputNoRow
+	}
+
+	return time.Time{}, fmt.Errorf("acquire lease row: %w", err)
+}
+
+// hasUtxo reports whether the requested outpoint still exists as a current
+// wallet-owned UTXO.
+func (o *pgLeaseOutputOps) hasUtxo(ctx context.Context,
+	params LeaseOutputParams) (bool, error) {
+
+	outputIndex, err := uint32ToInt32(params.OutPoint.Index)
+	if err != nil {
+		return false, fmt.Errorf("convert output index: %w", err)
+	}
+
+	_, err = o.qtx.GetUtxoIDByOutpoint(
+		ctx, sqlcpg.GetUtxoIDByOutpointParams{
+			WalletID:    int64(params.WalletID),
+			TxHash:      params.OutPoint.Hash[:],
+			OutputIndex: outputIndex,
+		},
+	)
+	if err == nil {
+		return true, nil
+	}
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+
+	return false, fmt.Errorf("lookup utxo row: %w", err)
+}

--- a/wallet/internal/db/postgres_utxostore_listleasedoutputs.go
+++ b/wallet/internal/db/postgres_utxostore_listleasedoutputs.go
@@ -1,0 +1,45 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
+)
+
+// ListLeasedOutputs lists all active leases for current wallet-owned UTXOs.
+func (s *PostgresStore) ListLeasedOutputs(ctx context.Context,
+	walletID uint32) ([]LeasedOutput, error) {
+
+	nowUTC := time.Now().UTC()
+
+	rows, err := s.queries.ListActiveUtxoLeases(
+		ctx, sqlcpg.ListActiveUtxoLeasesParams{
+			WalletID: int64(walletID),
+			NowUtc:   nowUTC,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list active utxo leases: %w", err)
+	}
+
+	leases := make([]LeasedOutput, len(rows))
+	for i, row := range rows {
+		outputIndex, err := int64ToUint32(int64(row.OutputIndex))
+		if err != nil {
+			return nil, fmt.Errorf("lease output index: %w", err)
+		}
+
+		lease, err := buildLeasedOutput(
+			row.TxHash, outputIndex, row.LockID, row.ExpiresAt,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		leases[i] = *lease
+	}
+
+	return leases, nil
+}

--- a/wallet/internal/db/postgres_utxostore_listutxos.go
+++ b/wallet/internal/db/postgres_utxostore_listutxos.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 
 	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
@@ -41,28 +40,8 @@ func (s *PostgresStore) ListUTXOs(ctx context.Context,
 func buildListUtxosParamsPg(query ListUtxosQuery) sqlcpg.ListUtxosParams {
 	return sqlcpg.ListUtxosParams{
 		WalletID:      int64(query.WalletID),
-		AccountNumber: nullableUint32Int64Pg(query.Account),
-		MinConfirms:   nullableInt32Pg(query.MinConfs),
-		MaxConfirms:   nullableInt32Pg(query.MaxConfs),
+		AccountNumber: nullableUint32ToSQLInt64(query.Account),
+		MinConfirms:   nullableInt32ToSQLInt32(query.MinConfs),
+		MaxConfirms:   nullableInt32ToSQLInt32(query.MaxConfs),
 	}
-}
-
-// nullableUint32Int64Pg converts an optional uint32 filter into the typed null
-// form used by postgres sqlc queries.
-func nullableUint32Int64Pg(value *uint32) sql.NullInt64 {
-	if value == nil {
-		return sql.NullInt64{}
-	}
-
-	return sql.NullInt64{Int64: int64(*value), Valid: true}
-}
-
-// nullableInt32Pg converts an optional int32 filter into the typed null form
-// used by postgres sqlc queries.
-func nullableInt32Pg(value *int32) sql.NullInt32 {
-	if value == nil {
-		return sql.NullInt32{}
-	}
-
-	return sql.NullInt32{Int32: *value, Valid: true}
 }

--- a/wallet/internal/db/postgres_utxostore_listutxos.go
+++ b/wallet/internal/db/postgres_utxostore_listutxos.go
@@ -1,0 +1,68 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
+)
+
+// ListUTXOs lists all current wallet-owned UTXOs matching the caller filters.
+//
+// The result set is already constrained to outputs whose creating
+// transactions are still in `pending` or `published` status.
+func (s *PostgresStore) ListUTXOs(ctx context.Context,
+	query ListUtxosQuery) ([]UtxoInfo, error) {
+
+	rows, err := s.queries.ListUtxos(ctx, buildListUtxosParamsPg(query))
+	if err != nil {
+		return nil, fmt.Errorf("list utxos: %w", err)
+	}
+
+	utxos := make([]UtxoInfo, len(rows))
+	for i, row := range rows {
+		utxo, err := utxoInfoFromPgRow(
+			row.TxHash, row.OutputIndex, row.Amount, row.ScriptPubKey,
+			row.ReceivedTime, row.IsCoinbase, row.BlockHeight,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		utxos[i] = *utxo
+	}
+
+	return utxos, nil
+}
+
+// buildListUtxosParamsPg prepares the typed nullable filters required by the
+// postgres ListUtxos query.
+func buildListUtxosParamsPg(query ListUtxosQuery) sqlcpg.ListUtxosParams {
+	return sqlcpg.ListUtxosParams{
+		WalletID:      int64(query.WalletID),
+		AccountNumber: nullableUint32Int64Pg(query.Account),
+		MinConfirms:   nullableInt32Pg(query.MinConfs),
+		MaxConfirms:   nullableInt32Pg(query.MaxConfs),
+	}
+}
+
+// nullableUint32Int64Pg converts an optional uint32 filter into the typed null
+// form used by postgres sqlc queries.
+func nullableUint32Int64Pg(value *uint32) sql.NullInt64 {
+	if value == nil {
+		return sql.NullInt64{}
+	}
+
+	return sql.NullInt64{Int64: int64(*value), Valid: true}
+}
+
+// nullableInt32Pg converts an optional int32 filter into the typed null form
+// used by postgres sqlc queries.
+func nullableInt32Pg(value *int32) sql.NullInt32 {
+	if value == nil {
+		return sql.NullInt32{}
+	}
+
+	return sql.NullInt32{Int32: *value, Valid: true}
+}

--- a/wallet/internal/db/postgres_utxostore_releaseoutput.go
+++ b/wallet/internal/db/postgres_utxostore_releaseoutput.go
@@ -1,0 +1,104 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
+)
+
+// ReleaseOutput atomically releases a lease when the caller provides the
+// active lock ID.
+//
+// The ownership check and lease deletion run in one transaction so callers
+// cannot unlock a UTXO using stale state from a separate read.
+func (s *PostgresStore) ReleaseOutput(ctx context.Context,
+	params ReleaseOutputParams) error {
+
+	return s.ExecuteTx(ctx, func(qtx *sqlcpg.Queries) error {
+		return releaseOutputWithOps(
+			ctx, params, &pgReleaseOutputOps{qtx: qtx},
+		)
+	})
+}
+
+// pgReleaseOutputOps adapts postgres sqlc queries to the shared ReleaseOutput
+// workflow.
+type pgReleaseOutputOps struct {
+	qtx *sqlcpg.Queries
+}
+
+var _ releaseOutputOps = (*pgReleaseOutputOps)(nil)
+
+// lookupUtxoID resolves the wallet-owned outpoint to its stable postgres UTXO
+// row ID.
+func (o *pgReleaseOutputOps) lookupUtxoID(ctx context.Context,
+	params ReleaseOutputParams) (int64, error) {
+
+	outputIndex, err := uint32ToInt32(params.OutPoint.Index)
+	if err != nil {
+		return 0, err
+	}
+
+	utxoID, err := o.qtx.GetUtxoIDByOutpoint(
+		ctx, sqlcpg.GetUtxoIDByOutpointParams{
+			WalletID:    int64(params.WalletID),
+			TxHash:      params.OutPoint.Hash[:],
+			OutputIndex: outputIndex,
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, errReleaseOutputUtxoNotFound
+		}
+
+		return 0, fmt.Errorf("lookup utxo row: %w", err)
+	}
+
+	return utxoID, nil
+}
+
+// release attempts to delete the postgres lease row for the provided UTXO ID
+// and lock ID.
+func (o *pgReleaseOutputOps) release(ctx context.Context, walletID uint32,
+	utxoID int64, lockID [32]byte) (int64, error) {
+
+	rows, err := o.qtx.ReleaseUtxoLease(
+		ctx, sqlcpg.ReleaseUtxoLeaseParams{
+			WalletID: int64(walletID),
+			UtxoID:   utxoID,
+			LockID:   lockID[:],
+		},
+	)
+	if err != nil {
+		return 0, fmt.Errorf("release lease row: %w", err)
+	}
+
+	return rows, nil
+}
+
+// activeLockID returns the currently active postgres lease lock ID for the
+// provided UTXO ID.
+func (o *pgReleaseOutputOps) activeLockID(ctx context.Context, walletID uint32,
+	utxoID int64, nowUTC time.Time) ([]byte, error) {
+
+	activeLockID, err := o.qtx.GetActiveUtxoLeaseLockID(
+		ctx, sqlcpg.GetActiveUtxoLeaseLockIDParams{
+			WalletID: int64(walletID),
+			UtxoID:   utxoID,
+			NowUtc:   nowUTC,
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errReleaseOutputNoActiveLease
+		}
+
+		return nil, fmt.Errorf("lookup active lease row: %w", err)
+	}
+
+	return activeLockID, nil
+}

--- a/wallet/internal/db/queries/sqlite/utxos.sql
+++ b/wallet/internal/db/queries/sqlite/utxos.sql
@@ -139,12 +139,12 @@ WHERE
     AND u.spent_by_tx_id IS NULL
     AND t.tx_status IN (0, 1)
     AND (
-        sqlc.narg('account_number') IS NULL
-        OR acc.account_number = sqlc.narg('account_number')
+        cast(sqlc.narg('account_number') AS INTEGER) IS NULL
+        OR acc.account_number = cast(sqlc.narg('account_number') AS INTEGER)
     )
     AND (
-        sqlc.narg('min_confirms') IS NULL
-        OR sqlc.narg('min_confirms') = 0
+        cast(sqlc.narg('min_confirms') AS INTEGER) IS NULL
+        OR cast(sqlc.narg('min_confirms') AS INTEGER) = 0
         OR (
             CASE
                 WHEN t.block_height IS NULL THEN 0
@@ -152,10 +152,10 @@ WHERE
                 WHEN t.block_height > s.synced_height THEN NULL
                 ELSE s.synced_height - t.block_height + 1
             END
-        ) >= sqlc.narg('min_confirms')
+        ) >= cast(sqlc.narg('min_confirms') AS INTEGER)
     )
     AND (
-        sqlc.narg('max_confirms') IS NULL
+        cast(sqlc.narg('max_confirms') AS INTEGER) IS NULL
         OR (
             CASE
                 WHEN t.block_height IS NULL THEN 0
@@ -163,7 +163,7 @@ WHERE
                 WHEN t.block_height > s.synced_height THEN NULL
                 ELSE s.synced_height - t.block_height + 1
             END
-        ) <= sqlc.narg('max_confirms')
+        ) <= cast(sqlc.narg('max_confirms') AS INTEGER)
     )
 ORDER BY u.amount, t.tx_hash, u.output_index;
 
@@ -220,12 +220,12 @@ WHERE
     AND u.spent_by_tx_id IS NULL
     AND t.tx_status IN (0, 1)
     AND (
-        sqlc.narg('account_number') IS NULL
-        OR acc.account_number = sqlc.narg('account_number')
+        cast(sqlc.narg('account_number') AS INTEGER) IS NULL
+        OR acc.account_number = cast(sqlc.narg('account_number') AS INTEGER)
     )
     AND (
-        sqlc.narg('min_confirms') IS NULL
-        OR sqlc.narg('min_confirms') = 0
+        cast(sqlc.narg('min_confirms') AS INTEGER) IS NULL
+        OR cast(sqlc.narg('min_confirms') AS INTEGER) = 0
         OR (
             CASE
                 WHEN t.block_height IS NULL THEN 0
@@ -233,10 +233,10 @@ WHERE
                 WHEN t.block_height > s.synced_height THEN NULL
                 ELSE s.synced_height - t.block_height + 1
             END
-        ) >= sqlc.narg('min_confirms')
+        ) >= cast(sqlc.narg('min_confirms') AS INTEGER)
     )
     AND (
-        sqlc.narg('max_confirms') IS NULL
+        cast(sqlc.narg('max_confirms') AS INTEGER) IS NULL
         OR (
             CASE
                 WHEN t.block_height IS NULL THEN 0
@@ -244,11 +244,11 @@ WHERE
                 WHEN t.block_height > s.synced_height THEN NULL
                 ELSE s.synced_height - t.block_height + 1
             END
-        ) <= sqlc.narg('max_confirms')
+        ) <= cast(sqlc.narg('max_confirms') AS INTEGER)
     )
     AND (
-        sqlc.narg('coinbase_maturity') IS NULL
-        OR sqlc.narg('coinbase_maturity') = 0
+        cast(sqlc.narg('coinbase_maturity') AS INTEGER) IS NULL
+        OR cast(sqlc.narg('coinbase_maturity') AS INTEGER) = 0
         OR NOT t.is_coinbase
         OR (
             CASE
@@ -257,7 +257,7 @@ WHERE
                 WHEN t.block_height > s.synced_height THEN NULL
                 ELSE s.synced_height - t.block_height + 1
             END
-        ) >= sqlc.narg('coinbase_maturity')
+        ) >= cast(sqlc.narg('coinbase_maturity') AS INTEGER)
     );
 
 -- name: ListSpendingTxIDsByParentTxID :many

--- a/wallet/internal/db/safecasting.go
+++ b/wallet/internal/db/safecasting.go
@@ -94,6 +94,33 @@ func uint32ToNullInt32(v uint32) (sql.NullInt32, error) {
 	return sql.NullInt32{Int32: toInt32, Valid: true}, nil
 }
 
+// nullableInt32ToSQLInt32 converts an optional int32 to sql.NullInt32.
+func nullableInt32ToSQLInt32(v *int32) sql.NullInt32 {
+	if v == nil {
+		return sql.NullInt32{}
+	}
+
+	return sql.NullInt32{Int32: *v, Valid: true}
+}
+
+// nullableInt32ToSQLInt64 converts an optional int32 to sql.NullInt64.
+func nullableInt32ToSQLInt64(v *int32) sql.NullInt64 {
+	if v == nil {
+		return sql.NullInt64{}
+	}
+
+	return sql.NullInt64{Int64: int64(*v), Valid: true}
+}
+
+// nullableUint32ToSQLInt64 converts an optional uint32 to sql.NullInt64.
+func nullableUint32ToSQLInt64(v *uint32) sql.NullInt64 {
+	if v == nil {
+		return sql.NullInt64{}
+	}
+
+	return sql.NullInt64{Int64: int64(*v), Valid: true}
+}
+
 // nullInt32ToUint32 safely casts a sql.NullInt32 to an uint32, returning
 // an error if the value is out of range or invalid.
 func nullInt32ToUint32(n sql.NullInt32) (uint32, error) {

--- a/wallet/internal/db/safecasting_test.go
+++ b/wallet/internal/db/safecasting_test.go
@@ -371,3 +371,45 @@ func TestNullInt32ToUint32(t *testing.T) {
 		})
 	}
 }
+
+// TestNullableInt32ToSQLInt32 checks that optional int32 values become a valid
+// sql.NullInt32 only when the pointer is present.
+func TestNullableInt32ToSQLInt32(t *testing.T) {
+	t.Parallel()
+
+	value := int32(42)
+
+	require.Equal(t, sql.NullInt32{}, nullableInt32ToSQLInt32(nil))
+	require.Equal(t,
+		sql.NullInt32{Int32: value, Valid: true},
+		nullableInt32ToSQLInt32(&value),
+	)
+}
+
+// TestNullableInt32ToSQLInt64 checks that optional int32 values become a valid
+// sql.NullInt64 only when the pointer is present.
+func TestNullableInt32ToSQLInt64(t *testing.T) {
+	t.Parallel()
+
+	value := int32(42)
+
+	require.Equal(t, sql.NullInt64{}, nullableInt32ToSQLInt64(nil))
+	require.Equal(t,
+		sql.NullInt64{Int64: int64(value), Valid: true},
+		nullableInt32ToSQLInt64(&value),
+	)
+}
+
+// TestNullableUint32ToSQLInt64 checks that optional uint32 values become a
+// valid sql.NullInt64 only when the pointer is present.
+func TestNullableUint32ToSQLInt64(t *testing.T) {
+	t.Parallel()
+
+	value := uint32(42)
+
+	require.Equal(t, sql.NullInt64{}, nullableUint32ToSQLInt64(nil))
+	require.Equal(t,
+		sql.NullInt64{Int64: int64(value), Valid: true},
+		nullableUint32ToSQLInt64(&value),
+	)
+}

--- a/wallet/internal/db/sqlc/sqlite/utxos.sql.go
+++ b/wallet/internal/db/sqlc/sqlite/utxos.sql.go
@@ -44,12 +44,12 @@ WHERE
     AND u.spent_by_tx_id IS NULL
     AND t.tx_status IN (0, 1)
     AND (
-        ?3 IS NULL
-        OR acc.account_number = ?3
+        cast(?3 AS INTEGER) IS NULL
+        OR acc.account_number = cast(?3 AS INTEGER)
     )
     AND (
-        ?4 IS NULL
-        OR ?4 = 0
+        cast(?4 AS INTEGER) IS NULL
+        OR cast(?4 AS INTEGER) = 0
         OR (
             CASE
                 WHEN t.block_height IS NULL THEN 0
@@ -57,10 +57,10 @@ WHERE
                 WHEN t.block_height > s.synced_height THEN NULL
                 ELSE s.synced_height - t.block_height + 1
             END
-        ) >= ?4
+        ) >= cast(?4 AS INTEGER)
     )
     AND (
-        ?5 IS NULL
+        cast(?5 AS INTEGER) IS NULL
         OR (
             CASE
                 WHEN t.block_height IS NULL THEN 0
@@ -68,11 +68,11 @@ WHERE
                 WHEN t.block_height > s.synced_height THEN NULL
                 ELSE s.synced_height - t.block_height + 1
             END
-        ) <= ?5
+        ) <= cast(?5 AS INTEGER)
     )
     AND (
-        ?6 IS NULL
-        OR ?6 = 0
+        cast(?6 AS INTEGER) IS NULL
+        OR cast(?6 AS INTEGER) = 0
         OR NOT t.is_coinbase
         OR (
             CASE
@@ -81,17 +81,17 @@ WHERE
                 WHEN t.block_height > s.synced_height THEN NULL
                 ELSE s.synced_height - t.block_height + 1
             END
-        ) >= ?6
+        ) >= cast(?6 AS INTEGER)
     )
 `
 
 type BalanceParams struct {
 	NowUtc           time.Time
 	WalletID         int64
-	AccountNumber    interface{}
-	MinConfirms      interface{}
-	MaxConfirms      interface{}
-	CoinbaseMaturity interface{}
+	AccountNumber    sql.NullInt64
+	MinConfirms      sql.NullInt64
+	MaxConfirms      sql.NullInt64
+	CoinbaseMaturity sql.NullInt64
 }
 
 type BalanceRow struct {
@@ -522,12 +522,12 @@ WHERE
     AND u.spent_by_tx_id IS NULL
     AND t.tx_status IN (0, 1)
     AND (
-        ?2 IS NULL
-        OR acc.account_number = ?2
+        cast(?2 AS INTEGER) IS NULL
+        OR acc.account_number = cast(?2 AS INTEGER)
     )
     AND (
-        ?3 IS NULL
-        OR ?3 = 0
+        cast(?3 AS INTEGER) IS NULL
+        OR cast(?3 AS INTEGER) = 0
         OR (
             CASE
                 WHEN t.block_height IS NULL THEN 0
@@ -535,10 +535,10 @@ WHERE
                 WHEN t.block_height > s.synced_height THEN NULL
                 ELSE s.synced_height - t.block_height + 1
             END
-        ) >= ?3
+        ) >= cast(?3 AS INTEGER)
     )
     AND (
-        ?4 IS NULL
+        cast(?4 AS INTEGER) IS NULL
         OR (
             CASE
                 WHEN t.block_height IS NULL THEN 0
@@ -546,16 +546,16 @@ WHERE
                 WHEN t.block_height > s.synced_height THEN NULL
                 ELSE s.synced_height - t.block_height + 1
             END
-        ) <= ?4
+        ) <= cast(?4 AS INTEGER)
     )
 ORDER BY u.amount, t.tx_hash, u.output_index
 `
 
 type ListUtxosParams struct {
 	WalletID      int64
-	AccountNumber interface{}
-	MinConfirms   interface{}
-	MaxConfirms   interface{}
+	AccountNumber sql.NullInt64
+	MinConfirms   sql.NullInt64
+	MaxConfirms   sql.NullInt64
 }
 
 type ListUtxosRow struct {

--- a/wallet/internal/db/sqlite_utxostore_balance.go
+++ b/wallet/internal/db/sqlite_utxostore_balance.go
@@ -1,0 +1,34 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
+)
+
+// Balance returns the sum of wallet-owned current UTXOs after optional filters.
+func (s *SqliteStore) Balance(ctx context.Context,
+	params BalanceParams) (BalanceResult, error) {
+
+	nowUTC := time.Now().UTC()
+
+	balance, err := s.queries.Balance(ctx, sqlcsqlite.BalanceParams{
+		NowUtc:           nowUTC,
+		WalletID:         int64(params.WalletID),
+		AccountNumber:    optionalUint32Int64Sqlite(params.Account),
+		MinConfirms:      optionalInt32Sqlite(params.MinConfs),
+		MaxConfirms:      optionalInt32Sqlite(params.MaxConfs),
+		CoinbaseMaturity: optionalInt32Sqlite(params.CoinbaseMaturity),
+	})
+	if err != nil {
+		return BalanceResult{}, fmt.Errorf("balance: %w", err)
+	}
+
+	return BalanceResult{
+		Total:  btcutil.Amount(balance.TotalBalance),
+		Locked: btcutil.Amount(balance.LockedBalance),
+	}, nil
+}

--- a/wallet/internal/db/sqlite_utxostore_balance.go
+++ b/wallet/internal/db/sqlite_utxostore_balance.go
@@ -18,10 +18,10 @@ func (s *SqliteStore) Balance(ctx context.Context,
 	balance, err := s.queries.Balance(ctx, sqlcsqlite.BalanceParams{
 		NowUtc:           nowUTC,
 		WalletID:         int64(params.WalletID),
-		AccountNumber:    optionalUint32Int64Sqlite(params.Account),
-		MinConfirms:      optionalInt32Sqlite(params.MinConfs),
-		MaxConfirms:      optionalInt32Sqlite(params.MaxConfs),
-		CoinbaseMaturity: optionalInt32Sqlite(params.CoinbaseMaturity),
+		AccountNumber:    nullableUint32ToSQLInt64(params.Account),
+		MinConfirms:      nullableInt32ToSQLInt64(params.MinConfs),
+		MaxConfirms:      nullableInt32ToSQLInt64(params.MaxConfs),
+		CoinbaseMaturity: nullableInt32ToSQLInt64(params.CoinbaseMaturity),
 	})
 	if err != nil {
 		return BalanceResult{}, fmt.Errorf("balance: %w", err)

--- a/wallet/internal/db/sqlite_utxostore_getutxo.go
+++ b/wallet/internal/db/sqlite_utxostore_getutxo.go
@@ -1,0 +1,66 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
+)
+
+// GetUtxo retrieves one current wallet-owned UTXO by outpoint.
+//
+// The output must still be unspent and its creating transaction must still be
+// in `pending` or `published` status.
+func (s *SqliteStore) GetUtxo(ctx context.Context,
+	query GetUtxoQuery) (*UtxoInfo, error) {
+
+	row, err := s.queries.GetUtxoByOutpoint(
+		ctx, sqlcsqlite.GetUtxoByOutpointParams{
+			WalletID:    int64(query.WalletID),
+			TxHash:      query.OutPoint.Hash[:],
+			OutputIndex: int64(query.OutPoint.Index),
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("utxo %s: %w", query.OutPoint,
+				ErrUtxoNotFound)
+		}
+
+		return nil, fmt.Errorf("get utxo: %w", err)
+	}
+
+	return utxoInfoFromSqliteRow(
+		row.TxHash, row.OutputIndex, row.Amount, row.ScriptPubKey,
+		row.ReceivedTime, row.IsCoinbase, row.BlockHeight,
+	)
+}
+
+// utxoInfoFromSqliteRow converts one normalized sqlite query row into the
+// public UtxoInfo shape.
+func utxoInfoFromSqliteRow(hash []byte, outputIndex int64, amount int64,
+	pkScript []byte, received time.Time, isCoinbase bool,
+	blockHeight sql.NullInt64) (*UtxoInfo, error) {
+
+	index, err := int64ToUint32(outputIndex)
+	if err != nil {
+		return nil, fmt.Errorf("utxo output index: %w", err)
+	}
+
+	var height *uint32
+	if blockHeight.Valid {
+		heightValue, err := int64ToUint32(blockHeight.Int64)
+		if err != nil {
+			return nil, fmt.Errorf("utxo block height: %w", err)
+		}
+
+		height = &heightValue
+	}
+
+	return buildUtxoInfo(
+		hash, index, amount, pkScript, received, isCoinbase, height,
+	)
+}

--- a/wallet/internal/db/sqlite_utxostore_leaseoutput.go
+++ b/wallet/internal/db/sqlite_utxostore_leaseoutput.go
@@ -1,0 +1,98 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
+)
+
+// LeaseOutput atomically acquires or renews a lease for one current UTXO.
+//
+// The lease lookup and acquisition run in one transaction so competing calls
+// cannot observe a partially-written lease. Expiration timestamps are
+// normalized to UTC before insert.
+func (s *SqliteStore) LeaseOutput(ctx context.Context,
+	params LeaseOutputParams) (*LeasedOutput, error) {
+
+	var lease *LeasedOutput
+
+	err := s.ExecuteTx(ctx, func(qtx *sqlcsqlite.Queries) error {
+		acquiredLease, err := leaseOutputWithOps(
+			ctx, params, &sqliteLeaseOutputOps{qtx: qtx},
+		)
+		if err != nil {
+			return err
+		}
+
+		lease = acquiredLease
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return lease, nil
+}
+
+// sqliteLeaseOutputOps adapts sqlite sqlc queries to the shared LeaseOutput
+// workflow.
+type sqliteLeaseOutputOps struct {
+	qtx *sqlcsqlite.Queries
+}
+
+var _ leaseOutputOps = (*sqliteLeaseOutputOps)(nil)
+
+// acquire attempts to write or renew one sqlite lease row for the requested
+// outpoint.
+func (o *sqliteLeaseOutputOps) acquire(ctx context.Context,
+	params LeaseOutputParams, nowUTC time.Time,
+	expiresAt time.Time) (time.Time, error) {
+
+	expiration, err := o.qtx.AcquireUtxoLease(
+		ctx, sqlcsqlite.AcquireUtxoLeaseParams{
+			WalletID:    int64(params.WalletID),
+			LockID:      params.ID[:],
+			ExpiresAt:   expiresAt,
+			TxHash:      params.OutPoint.Hash[:],
+			OutputIndex: int64(params.OutPoint.Index),
+			NowUtc:      nowUTC,
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return time.Time{}, errLeaseOutputNoRow
+		}
+
+		return time.Time{}, fmt.Errorf("acquire lease row: %w", err)
+	}
+
+	return expiration, nil
+}
+
+// hasUtxo reports whether the requested outpoint still exists as a current
+// wallet-owned UTXO.
+func (o *sqliteLeaseOutputOps) hasUtxo(ctx context.Context,
+	params LeaseOutputParams) (bool, error) {
+
+	_, err := o.qtx.GetUtxoIDByOutpoint(
+		ctx, sqlcsqlite.GetUtxoIDByOutpointParams{
+			WalletID:    int64(params.WalletID),
+			TxHash:      params.OutPoint.Hash[:],
+			OutputIndex: int64(params.OutPoint.Index),
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("lookup utxo row: %w", err)
+	}
+
+	return true, nil
+}

--- a/wallet/internal/db/sqlite_utxostore_listleasedoutputs.go
+++ b/wallet/internal/db/sqlite_utxostore_listleasedoutputs.go
@@ -1,0 +1,45 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
+)
+
+// ListLeasedOutputs lists all active leases for current wallet-owned UTXOs.
+func (s *SqliteStore) ListLeasedOutputs(ctx context.Context,
+	walletID uint32) ([]LeasedOutput, error) {
+
+	nowUTC := time.Now().UTC()
+
+	rows, err := s.queries.ListActiveUtxoLeases(
+		ctx, sqlcsqlite.ListActiveUtxoLeasesParams{
+			WalletID: int64(walletID),
+			NowUtc:   nowUTC,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list active utxo leases: %w", err)
+	}
+
+	leases := make([]LeasedOutput, len(rows))
+	for i, row := range rows {
+		outputIndex, err := int64ToUint32(row.OutputIndex)
+		if err != nil {
+			return nil, fmt.Errorf("lease output index: %w", err)
+		}
+
+		lease, err := buildLeasedOutput(
+			row.TxHash, outputIndex, row.LockID, row.ExpiresAt,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		leases[i] = *lease
+	}
+
+	return leases, nil
+}

--- a/wallet/internal/db/sqlite_utxostore_listutxos.go
+++ b/wallet/internal/db/sqlite_utxostore_listutxos.go
@@ -1,0 +1,61 @@
+package db
+
+import (
+	"context"
+	"fmt"
+
+	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
+)
+
+// ListUTXOs lists all current wallet-owned UTXOs matching the caller filters.
+//
+// The result set is already constrained to outputs whose creating
+// transactions are still in `pending` or `published` status.
+func (s *SqliteStore) ListUTXOs(ctx context.Context,
+	query ListUtxosQuery) ([]UtxoInfo, error) {
+
+	rows, err := s.queries.ListUtxos(ctx, sqlcsqlite.ListUtxosParams{
+		WalletID:      int64(query.WalletID),
+		AccountNumber: optionalUint32Int64Sqlite(query.Account),
+		MinConfirms:   optionalInt32Sqlite(query.MinConfs),
+		MaxConfirms:   optionalInt32Sqlite(query.MaxConfs),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list utxos: %w", err)
+	}
+
+	utxos := make([]UtxoInfo, len(rows))
+	for i, row := range rows {
+		utxo, err := utxoInfoFromSqliteRow(
+			row.TxHash, row.OutputIndex, row.Amount, row.ScriptPubKey,
+			row.ReceivedTime, row.IsCoinbase, row.BlockHeight,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		utxos[i] = *utxo
+	}
+
+	return utxos, nil
+}
+
+// optionalUint32Int64Sqlite converts an optional uint32 filter into the
+// nullable form used by sqlite sqlc queries.
+func optionalUint32Int64Sqlite(value *uint32) any {
+	if value == nil {
+		return nil
+	}
+
+	return int64(*value)
+}
+
+// optionalInt32Sqlite converts an optional int32 filter into the nullable form
+// used by sqlite sqlc queries.
+func optionalInt32Sqlite(value *int32) any {
+	if value == nil {
+		return nil
+	}
+
+	return *value
+}

--- a/wallet/internal/db/sqlite_utxostore_listutxos.go
+++ b/wallet/internal/db/sqlite_utxostore_listutxos.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 
 	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
@@ -17,9 +16,9 @@ func (s *SqliteStore) ListUTXOs(ctx context.Context,
 
 	rows, err := s.queries.ListUtxos(ctx, sqlcsqlite.ListUtxosParams{
 		WalletID:      int64(query.WalletID),
-		AccountNumber: optionalUint32Int64Sqlite(query.Account),
-		MinConfirms:   optionalInt32Sqlite(query.MinConfs),
-		MaxConfirms:   optionalInt32Sqlite(query.MaxConfs),
+		AccountNumber: nullableUint32ToSQLInt64(query.Account),
+		MinConfirms:   nullableInt32ToSQLInt64(query.MinConfs),
+		MaxConfirms:   nullableInt32ToSQLInt64(query.MaxConfs),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list utxos: %w", err)
@@ -39,24 +38,4 @@ func (s *SqliteStore) ListUTXOs(ctx context.Context,
 	}
 
 	return utxos, nil
-}
-
-// optionalUint32Int64Sqlite converts an optional uint32 filter into the typed
-// nullable form used by sqlite sqlc queries.
-func optionalUint32Int64Sqlite(value *uint32) sql.NullInt64 {
-	if value == nil {
-		return sql.NullInt64{}
-	}
-
-	return sql.NullInt64{Int64: int64(*value), Valid: true}
-}
-
-// optionalInt32Sqlite converts an optional int32 filter into the typed nullable
-// form used by sqlite sqlc queries.
-func optionalInt32Sqlite(value *int32) sql.NullInt64 {
-	if value == nil {
-		return sql.NullInt64{}
-	}
-
-	return sql.NullInt64{Int64: int64(*value), Valid: true}
 }

--- a/wallet/internal/db/sqlite_utxostore_listutxos.go
+++ b/wallet/internal/db/sqlite_utxostore_listutxos.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
 	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
@@ -40,22 +41,22 @@ func (s *SqliteStore) ListUTXOs(ctx context.Context,
 	return utxos, nil
 }
 
-// optionalUint32Int64Sqlite converts an optional uint32 filter into the
+// optionalUint32Int64Sqlite converts an optional uint32 filter into the typed
 // nullable form used by sqlite sqlc queries.
-func optionalUint32Int64Sqlite(value *uint32) any {
+func optionalUint32Int64Sqlite(value *uint32) sql.NullInt64 {
 	if value == nil {
-		return nil
+		return sql.NullInt64{}
 	}
 
-	return int64(*value)
+	return sql.NullInt64{Int64: int64(*value), Valid: true}
 }
 
-// optionalInt32Sqlite converts an optional int32 filter into the nullable form
-// used by sqlite sqlc queries.
-func optionalInt32Sqlite(value *int32) any {
+// optionalInt32Sqlite converts an optional int32 filter into the typed nullable
+// form used by sqlite sqlc queries.
+func optionalInt32Sqlite(value *int32) sql.NullInt64 {
 	if value == nil {
-		return nil
+		return sql.NullInt64{}
 	}
 
-	return *value
+	return sql.NullInt64{Int64: int64(*value), Valid: true}
 }

--- a/wallet/internal/db/sqlite_utxostore_releaseoutput.go
+++ b/wallet/internal/db/sqlite_utxostore_releaseoutput.go
@@ -1,0 +1,99 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
+)
+
+// ReleaseOutput atomically releases a lease when the caller provides the
+// active lock ID.
+//
+// The ownership check and lease deletion run in one transaction so callers
+// cannot unlock a UTXO using stale state from a separate read.
+func (s *SqliteStore) ReleaseOutput(ctx context.Context,
+	params ReleaseOutputParams) error {
+
+	return s.ExecuteTx(ctx, func(qtx *sqlcsqlite.Queries) error {
+		return releaseOutputWithOps(
+			ctx, params, &sqliteReleaseOutputOps{qtx: qtx},
+		)
+	})
+}
+
+// sqliteReleaseOutputOps adapts sqlite sqlc queries to the shared
+// ReleaseOutput workflow.
+type sqliteReleaseOutputOps struct {
+	qtx *sqlcsqlite.Queries
+}
+
+var _ releaseOutputOps = (*sqliteReleaseOutputOps)(nil)
+
+// lookupUtxoID resolves the wallet-owned outpoint to its stable sqlite UTXO row
+// ID.
+func (o *sqliteReleaseOutputOps) lookupUtxoID(ctx context.Context,
+	params ReleaseOutputParams) (int64, error) {
+
+	utxoID, err := o.qtx.GetUtxoIDByOutpoint(
+		ctx, sqlcsqlite.GetUtxoIDByOutpointParams{
+			WalletID:    int64(params.WalletID),
+			TxHash:      params.OutPoint.Hash[:],
+			OutputIndex: int64(params.OutPoint.Index),
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, errReleaseOutputUtxoNotFound
+		}
+
+		return 0, fmt.Errorf("lookup utxo row: %w", err)
+	}
+
+	return utxoID, nil
+}
+
+// release attempts to delete the sqlite lease row for the provided UTXO ID and
+// lock ID.
+func (o *sqliteReleaseOutputOps) release(ctx context.Context, walletID uint32,
+	utxoID int64, lockID [32]byte) (int64, error) {
+
+	rows, err := o.qtx.ReleaseUtxoLease(
+		ctx, sqlcsqlite.ReleaseUtxoLeaseParams{
+			WalletID: int64(walletID),
+			UtxoID:   utxoID,
+			LockID:   lockID[:],
+		},
+	)
+	if err != nil {
+		return 0, fmt.Errorf("release lease row: %w", err)
+	}
+
+	return rows, nil
+}
+
+// activeLockID returns the currently active sqlite lease lock ID for the
+// provided UTXO ID.
+func (o *sqliteReleaseOutputOps) activeLockID(ctx context.Context,
+	walletID uint32, utxoID int64, nowUTC time.Time) ([]byte, error) {
+
+	activeLockID, err := o.qtx.GetActiveUtxoLeaseLockID(
+		ctx, sqlcsqlite.GetActiveUtxoLeaseLockIDParams{
+			WalletID: int64(walletID),
+			UtxoID:   utxoID,
+			NowUtc:   nowUTC,
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errReleaseOutputNoActiveLease
+		}
+
+		return nil, fmt.Errorf("lookup active lease row: %w", err)
+	}
+
+	return activeLockID, nil
+}

--- a/wallet/internal/db/utxo_store_common.go
+++ b/wallet/internal/db/utxo_store_common.go
@@ -1,7 +1,7 @@
 package db
 
 import (
-	"database/sql"
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -23,6 +23,10 @@ var (
 	// ErrOutputUnlockNotAllowed reports that a UTXO release request used a lock
 	// ID different from the active lease.
 	ErrOutputUnlockNotAllowed = errors.New("output unlock not allowed")
+
+	// errLeaseOutputNoRow indicates that the backend lease write found no
+	// leasable current UTXO row for the requested outpoint.
+	errLeaseOutputNoRow = errors.New("lease output no row")
 )
 
 // buildOutPoint converts database tx-hash and output-index fields into a
@@ -86,42 +90,71 @@ func buildLeasedOutput(hash []byte, outputIndex uint32, lockID []byte,
 	}, nil
 }
 
-// optionalUint32Int64 converts an optional uint32 filter into the nullable any
-// form used by sqlite sqlc queries.
-func optionalUint32Int64(value *uint32) any {
-	if value == nil {
-		return nil
-	}
+// leaseOutputOps is the backend adapter the shared LeaseOutput workflow uses.
+//
+// The shared lease algorithm is intentionally ordered:
+//   - validate the public lease request up front
+//   - attempt the atomic lease write or renewal next
+//   - if the write reports no row, distinguish a missing UTXO from an active
+//     conflicting lease
+//   - return the public leased-output view only after the write succeeds
+//
+// The adapter methods map directly to those stages so the shared helper keeps
+// the policy and sequencing while each backend keeps only query details.
+type leaseOutputOps interface {
+	// acquire attempts to write or renew the lease and returns the stored
+	// expiration timestamp when the write succeeds.
+	acquire(ctx context.Context, params LeaseOutputParams, nowUTC time.Time,
+		expiresAt time.Time) (time.Time, error)
 
-	return int64(*value)
+	// hasUtxo reports whether the requested outpoint still exists as a current
+	// wallet-owned UTXO.
+	hasUtxo(ctx context.Context, params LeaseOutputParams) (bool, error)
 }
 
-// optionalInt32 converts an optional int32 filter into the nullable any form
-// used by sqlite sqlc queries.
-func optionalInt32(value *int32) any {
-	if value == nil {
-		return nil
+// leaseOutputWithOps runs the backend-independent LeaseOutput workflow once the
+// caller has opened a backend-specific SQL transaction.
+//
+// The helper owns the lease sequencing so every backend answers the same two
+// questions in the same order: did the lease write succeed, and if not, was the
+// target output missing or merely already leased by a different lock?
+func leaseOutputWithOps(ctx context.Context, params LeaseOutputParams,
+	ops leaseOutputOps) (*LeasedOutput, error) {
+
+	if params.Duration <= 0 {
+		return nil, fmt.Errorf("%w: lease duration must be positive",
+			ErrInvalidParam)
 	}
 
-	return *value
-}
+	nowUTC := time.Now().UTC()
+	expiresAt := nowUTC.Add(params.Duration)
 
-// nullableUint32Int64 converts an optional uint32 filter into the typed null
-// form used by postgres sqlc queries.
-func nullableUint32Int64(value *uint32) sql.NullInt64 {
-	if value == nil {
-		return sql.NullInt64{}
+	expiration, err := ops.acquire(ctx, params, nowUTC, expiresAt)
+	if err == nil {
+		return &LeasedOutput{
+			OutPoint:   params.OutPoint,
+			LockID:     LockID(params.ID),
+			Expiration: expiration.UTC(),
+		}, nil
 	}
 
-	return sql.NullInt64{Int64: int64(*value), Valid: true}
-}
-
-// nullableInt32 converts an optional int32 filter into the typed null form
-// used by postgres sqlc queries.
-func nullableInt32(value *int32) sql.NullInt32 {
-	if value == nil {
-		return sql.NullInt32{}
+	if !errors.Is(err, errLeaseOutputNoRow) {
+		return nil, fmt.Errorf("acquire utxo lease: %w", err)
 	}
 
-	return sql.NullInt32{Int32: *value, Valid: true}
+	// A no-row acquire means the write path found no leasable row.
+	// Distinguish a missing UTXO from an already-active lease before
+	// returning a public error.
+	exists, err := ops.hasUtxo(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("lookup utxo before lease conflict: %w", err)
+	}
+
+	if !exists {
+		return nil, fmt.Errorf("utxo %s: %w", params.OutPoint,
+			ErrUtxoNotFound)
+	}
+
+	return nil, fmt.Errorf("utxo %s: %w", params.OutPoint,
+		ErrOutputAlreadyLeased)
 }

--- a/wallet/internal/db/utxo_store_common.go
+++ b/wallet/internal/db/utxo_store_common.go
@@ -1,0 +1,127 @@
+package db
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+)
+
+var (
+	// errInvalidLockID indicates that a lease row contained bytes that cannot
+	// be represented as a fixed-size LockID.
+	errInvalidLockID = errors.New("invalid lock id length")
+
+	// ErrOutputAlreadyLeased reports that a UTXO lease request conflicted with
+	// another active lock on the same output.
+	ErrOutputAlreadyLeased = errors.New("output already leased")
+
+	// ErrOutputUnlockNotAllowed reports that a UTXO release request used a lock
+	// ID different from the active lease.
+	ErrOutputUnlockNotAllowed = errors.New("output unlock not allowed")
+)
+
+// buildOutPoint converts database tx-hash and output-index fields into a
+// wire.OutPoint.
+func buildOutPoint(hash []byte, outputIndex uint32) (wire.OutPoint, error) {
+	txHash, err := chainhash.NewHash(hash)
+	if err != nil {
+		return wire.OutPoint{}, fmt.Errorf("utxo hash: %w", err)
+	}
+
+	return wire.OutPoint{Hash: *txHash, Index: outputIndex}, nil
+}
+
+// buildUtxoInfo converts normalized SQL result fields into the public UtxoInfo
+// shape returned by the db interfaces.
+func buildUtxoInfo(hash []byte, outputIndex uint32, amount int64,
+	pkScript []byte, received time.Time, isCoinbase bool,
+	blockHeight *uint32) (*UtxoInfo, error) {
+
+	outPoint, err := buildOutPoint(hash, outputIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	height := UnminedHeight
+	if blockHeight != nil {
+		height = *blockHeight
+	}
+
+	return &UtxoInfo{
+		OutPoint:     outPoint,
+		Amount:       btcutil.Amount(amount),
+		PkScript:     pkScript,
+		Received:     received.UTC(),
+		FromCoinBase: isCoinbase,
+		Height:       height,
+	}, nil
+}
+
+// buildLeasedOutput converts SQL lease-row fields into the public LeasedOutput
+// type.
+func buildLeasedOutput(hash []byte, outputIndex uint32, lockID []byte,
+	expiration time.Time) (*LeasedOutput, error) {
+
+	outPoint, err := buildOutPoint(hash, outputIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(lockID) != len(LockID{}) {
+		return nil, fmt.Errorf("lock id: %w", errInvalidLockID)
+	}
+
+	var id LockID
+	copy(id[:], lockID)
+
+	return &LeasedOutput{
+		OutPoint:   outPoint,
+		LockID:     id,
+		Expiration: expiration.UTC(),
+	}, nil
+}
+
+// optionalUint32Int64 converts an optional uint32 filter into the nullable any
+// form used by sqlite sqlc queries.
+func optionalUint32Int64(value *uint32) any {
+	if value == nil {
+		return nil
+	}
+
+	return int64(*value)
+}
+
+// optionalInt32 converts an optional int32 filter into the nullable any form
+// used by sqlite sqlc queries.
+func optionalInt32(value *int32) any {
+	if value == nil {
+		return nil
+	}
+
+	return *value
+}
+
+// nullableUint32Int64 converts an optional uint32 filter into the typed null
+// form used by postgres sqlc queries.
+func nullableUint32Int64(value *uint32) sql.NullInt64 {
+	if value == nil {
+		return sql.NullInt64{}
+	}
+
+	return sql.NullInt64{Int64: int64(*value), Valid: true}
+}
+
+// nullableInt32 converts an optional int32 filter into the typed null form
+// used by postgres sqlc queries.
+func nullableInt32(value *int32) sql.NullInt32 {
+	if value == nil {
+		return sql.NullInt32{}
+	}
+
+	return sql.NullInt32{Int32: *value, Valid: true}
+}

--- a/wallet/internal/db/utxo_store_common.go
+++ b/wallet/internal/db/utxo_store_common.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -27,6 +28,19 @@ var (
 	// errLeaseOutputNoRow indicates that the backend lease write found no
 	// leasable current UTXO row for the requested outpoint.
 	errLeaseOutputNoRow = errors.New("lease output no row")
+
+	// errReleaseOutputUtxoNotFound indicates that ReleaseOutput could not
+	// resolve the requested outpoint to a current wallet-owned UTXO row.
+	errReleaseOutputUtxoNotFound = errors.New(
+		"release output utxo not found",
+	)
+
+	// errReleaseOutputNoActiveLease indicates that the target UTXO no longer
+	// has an active lease row by the time ReleaseOutput checks the fallback
+	// path.
+	errReleaseOutputNoActiveLease = errors.New(
+		"release output no active lease",
+	)
 )
 
 // buildOutPoint converts database tx-hash and output-index fields into a
@@ -157,4 +171,85 @@ func leaseOutputWithOps(ctx context.Context, params LeaseOutputParams,
 
 	return nil, fmt.Errorf("utxo %s: %w", params.OutPoint,
 		ErrOutputAlreadyLeased)
+}
+
+// releaseOutputOps is the backend adapter the shared ReleaseOutput workflow
+// uses.
+//
+// The shared release algorithm is intentionally ordered:
+//   - resolve the wallet-owned outpoint to a stable UTXO row first
+//   - attempt the lease delete by lock ID second
+//   - if no row is deleted, check the active lease state for that UTXO
+//   - treat a missing active lease as a no-op
+//   - map a different active lock to ErrOutputUnlockNotAllowed
+//
+// The adapter methods map directly to those stages so the shared helper keeps
+// the release policy and sequencing while each backend keeps only query
+// details.
+type releaseOutputOps interface {
+	// lookupUtxoID resolves the current wallet-owned outpoint to its stable
+	// UTXO row ID.
+	lookupUtxoID(ctx context.Context, params ReleaseOutputParams) (int64, error)
+
+	// release attempts to delete the lease row for the provided UTXO ID and
+	// lock ID, returning the number of deleted rows.
+	release(ctx context.Context, walletID uint32, utxoID int64,
+		lockID [32]byte) (int64, error)
+
+	// activeLockID returns the currently active lock ID for the provided UTXO
+	// ID.
+	activeLockID(ctx context.Context, walletID uint32, utxoID int64,
+		nowUTC time.Time) ([]byte, error)
+}
+
+// releaseOutputWithOps runs the backend-independent ReleaseOutput workflow once
+// the caller has opened a backend-specific SQL transaction.
+//
+// The helper resolves the stable UTXO row first, attempts the lock-specific
+// delete second, and only falls back to the active-lock lookup when no row was
+// deleted. That keeps a released-or-expired lease as a no-op while still
+// surfacing conflicting active locks consistently across backends.
+func releaseOutputWithOps(ctx context.Context, params ReleaseOutputParams,
+	ops releaseOutputOps) error {
+
+	nowUTC := time.Now().UTC()
+
+	utxoID, err := ops.lookupUtxoID(ctx, params)
+	if err != nil {
+		if errors.Is(err, errReleaseOutputUtxoNotFound) {
+			return fmt.Errorf("utxo %s: %w", params.OutPoint,
+				ErrUtxoNotFound)
+		}
+
+		return fmt.Errorf("lookup utxo for release: %w", err)
+	}
+
+	rows, err := ops.release(ctx, params.WalletID, utxoID, params.ID)
+	if err != nil {
+		return fmt.Errorf("release utxo lease: %w", err)
+	}
+
+	if rows != 0 {
+		return nil
+	}
+
+	// No row was deleted, so either the lease already expired or was released,
+	// or a different active lock still owns this UTXO.
+	activeLockID, err := ops.activeLockID(
+		ctx, params.WalletID, utxoID, nowUTC,
+	)
+	if err != nil {
+		if errors.Is(err, errReleaseOutputNoActiveLease) {
+			return nil
+		}
+
+		return fmt.Errorf("lookup active utxo lease: %w", err)
+	}
+
+	if !bytes.Equal(activeLockID, params.ID[:]) {
+		return fmt.Errorf("utxo %s: %w", params.OutPoint,
+			ErrOutputUnlockNotAllowed)
+	}
+
+	return nil
 }

--- a/wallet/internal/db/utxo_store_common_test.go
+++ b/wallet/internal/db/utxo_store_common_test.go
@@ -1,10 +1,12 @@
 package db
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/stretchr/testify/require"
 )
 
@@ -180,4 +182,128 @@ func TestBuildLeasedOutput_InvalidLockID(t *testing.T) {
 
 	// Assert: The helper returns the invalid-lock-ID sentinel.
 	require.ErrorIs(t, err, errInvalidLockID)
+}
+
+// TestLeaseOutputWithOps verifies that the shared LeaseOutput helper returns
+// the leased outpoint when the backend acquire step succeeds.
+func TestLeaseOutputWithOps(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Build one valid lease request and one successful stub adapter.
+	params := LeaseOutputParams{
+		WalletID: 5,
+		OutPoint: testLeaseOutPoint(),
+		ID:       LockID{7},
+		Duration: time.Minute,
+	}
+	ops := &stubLeaseOutputOps{
+		acquireExpiration: time.Unix(333, 0).In(time.FixedZone("X", 3600)),
+	}
+
+	// Act: Run the shared LeaseOutput flow.
+	lease, err := leaseOutputWithOps(context.Background(), params, ops)
+
+	// Assert: The helper returns the leased outpoint and UTC expiration.
+	require.NoError(t, err)
+	require.Equal(t, params.OutPoint, lease.OutPoint)
+	require.Equal(t, LockID(params.ID), lease.LockID)
+	require.Equal(t, time.UTC, lease.Expiration.Location())
+	require.Equal(t, []string{"acquire"}, ops.calls)
+}
+
+// TestLeaseOutputWithOpsRejectsNonPositiveDuration verifies that the shared
+// LeaseOutput helper rejects an already-expired lease request up front.
+func TestLeaseOutputWithOpsRejectsNonPositiveDuration(t *testing.T) {
+	t.Parallel()
+
+	params := LeaseOutputParams{
+		WalletID: 5,
+		OutPoint: testLeaseOutPoint(),
+		ID:       LockID{7},
+		Duration: 0,
+	}
+	ops := &stubLeaseOutputOps{}
+
+	_, err := leaseOutputWithOps(context.Background(), params, ops)
+	require.ErrorIs(t, err, ErrInvalidParam)
+	require.Empty(t, ops.calls)
+}
+
+// TestLeaseOutputWithOpsMissingUtxo verifies that the shared LeaseOutput helper
+// maps a no-row acquire and missing outpoint lookup to ErrUtxoNotFound.
+func TestLeaseOutputWithOpsMissingUtxo(t *testing.T) {
+	t.Parallel()
+
+	params := LeaseOutputParams{
+		WalletID: 5,
+		OutPoint: testLeaseOutPoint(),
+		ID:       LockID{7},
+		Duration: time.Minute,
+	}
+	ops := &stubLeaseOutputOps{
+		acquireErr: errLeaseOutputNoRow,
+	}
+
+	_, err := leaseOutputWithOps(context.Background(), params, ops)
+	require.ErrorIs(t, err, ErrUtxoNotFound)
+	require.Equal(t, []string{"acquire", "has-utxo"}, ops.calls)
+}
+
+// TestLeaseOutputWithOpsAlreadyLeased verifies that the shared LeaseOutput
+// helper maps a no-row acquire and existing outpoint to ErrOutputAlreadyLeased.
+func TestLeaseOutputWithOpsAlreadyLeased(t *testing.T) {
+	t.Parallel()
+
+	params := LeaseOutputParams{
+		WalletID: 5,
+		OutPoint: testLeaseOutPoint(),
+		ID:       LockID{7},
+		Duration: time.Minute,
+	}
+	ops := &stubLeaseOutputOps{
+		acquireErr:    errLeaseOutputNoRow,
+		hasUtxoResult: true,
+	}
+
+	_, err := leaseOutputWithOps(context.Background(), params, ops)
+	require.ErrorIs(t, err, ErrOutputAlreadyLeased)
+	require.Equal(t, []string{"acquire", "has-utxo"}, ops.calls)
+}
+
+// stubLeaseOutputOps records how the shared LeaseOutput helper drives one
+// backend adapter while letting each test control the returned results.
+type stubLeaseOutputOps struct {
+	acquireExpiration time.Time
+	acquireErr        error
+	hasUtxoResult     bool
+
+	calls []string
+}
+
+var _ leaseOutputOps = (*stubLeaseOutputOps)(nil)
+
+// acquire records the shared write attempt and returns the test-controlled
+// lease result.
+func (s *stubLeaseOutputOps) acquire(_ context.Context,
+	_ LeaseOutputParams, _ time.Time, _ time.Time) (time.Time, error) {
+
+	s.calls = append(s.calls, "acquire")
+
+	return s.acquireExpiration, s.acquireErr
+}
+
+// hasUtxo records the fallback ownership lookup and returns the test-controlled
+// result.
+func (s *stubLeaseOutputOps) hasUtxo(_ context.Context,
+	_ LeaseOutputParams) (bool, error) {
+
+	s.calls = append(s.calls, "has-utxo")
+
+	return s.hasUtxoResult, nil
+}
+
+// testLeaseOutPoint builds one stable outpoint fixture for shared UTXO lease
+// helper tests.
+func testLeaseOutPoint() wire.OutPoint {
+	return wire.OutPoint{Hash: chainhash.Hash{7}, Index: 1}
 }

--- a/wallet/internal/db/utxo_store_common_test.go
+++ b/wallet/internal/db/utxo_store_common_test.go
@@ -270,6 +270,96 @@ func TestLeaseOutputWithOpsAlreadyLeased(t *testing.T) {
 	require.Equal(t, []string{"acquire", "has-utxo"}, ops.calls)
 }
 
+// TestReleaseOutputWithOps verifies that the shared ReleaseOutput helper
+// returns nil when the backend delete removes the matching lease row.
+func TestReleaseOutputWithOps(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Build one valid release request and one successful stub adapter.
+	params := ReleaseOutputParams{
+		WalletID: 5,
+		OutPoint: testLeaseOutPoint(),
+		ID:       [32]byte{9},
+	}
+	ops := &stubReleaseOutputOps{
+		lookupUtxoIDResult: 11,
+		releaseRows:        1,
+	}
+
+	// Act: Run the shared ReleaseOutput flow.
+	err := releaseOutputWithOps(context.Background(), params, ops)
+
+	// Assert: The helper stops after the successful delete path.
+	require.NoError(t, err)
+	require.Equal(t, []string{"lookup-utxo", "release"}, ops.calls)
+}
+
+// TestReleaseOutputWithOpsMissingUtxo verifies that the shared ReleaseOutput
+// helper maps a missing current outpoint to ErrUtxoNotFound.
+func TestReleaseOutputWithOpsMissingUtxo(t *testing.T) {
+	t.Parallel()
+
+	params := ReleaseOutputParams{
+		WalletID: 5,
+		OutPoint: testLeaseOutPoint(),
+		ID:       [32]byte{9},
+	}
+	ops := &stubReleaseOutputOps{
+		lookupUtxoIDErr: errReleaseOutputUtxoNotFound,
+	}
+
+	err := releaseOutputWithOps(context.Background(), params, ops)
+	require.ErrorIs(t, err, ErrUtxoNotFound)
+	require.Equal(t, []string{"lookup-utxo"}, ops.calls)
+}
+
+// TestReleaseOutputWithOpsWrongLock verifies that the shared ReleaseOutput
+// helper maps a different active lock to ErrOutputUnlockNotAllowed.
+func TestReleaseOutputWithOpsWrongLock(t *testing.T) {
+	t.Parallel()
+
+	params := ReleaseOutputParams{
+		WalletID: 5,
+		OutPoint: testLeaseOutPoint(),
+		ID:       [32]byte{9},
+	}
+	ops := &stubReleaseOutputOps{
+		lookupUtxoIDResult: 11,
+		activeLockIDResult: []byte{1, 2, 3},
+	}
+
+	err := releaseOutputWithOps(context.Background(), params, ops)
+	require.ErrorIs(t, err, ErrOutputUnlockNotAllowed)
+	require.Equal(t,
+		[]string{"lookup-utxo", "release", "active-lock"},
+		ops.calls,
+	)
+}
+
+// TestReleaseOutputWithOpsMissingActiveLease verifies that the shared
+// ReleaseOutput helper treats an already-expired or already-cleared lease as a
+// no-op.
+func TestReleaseOutputWithOpsMissingActiveLease(t *testing.T) {
+	t.Parallel()
+
+	params := ReleaseOutputParams{
+		WalletID: 5,
+		OutPoint: testLeaseOutPoint(),
+		ID:       [32]byte{9},
+	}
+	ops := &stubReleaseOutputOps{
+		lookupUtxoIDResult: 11,
+		activeLockIDErr:    errReleaseOutputNoActiveLease,
+	}
+
+	err := releaseOutputWithOps(context.Background(), params, ops)
+	require.NoError(t, err)
+	require.Equal(t,
+		[]string{"lookup-utxo", "release", "active-lock"},
+		ops.calls,
+	)
+}
+
 // stubLeaseOutputOps records how the shared LeaseOutput helper drives one
 // backend adapter while letting each test control the returned results.
 type stubLeaseOutputOps struct {
@@ -300,6 +390,51 @@ func (s *stubLeaseOutputOps) hasUtxo(_ context.Context,
 	s.calls = append(s.calls, "has-utxo")
 
 	return s.hasUtxoResult, nil
+}
+
+// stubReleaseOutputOps records how the shared ReleaseOutput helper drives one
+// backend adapter while letting each test control the returned results.
+type stubReleaseOutputOps struct {
+	lookupUtxoIDResult int64
+	lookupUtxoIDErr    error
+	releaseRows        int64
+	releaseErr         error
+	activeLockIDResult []byte
+	activeLockIDErr    error
+
+	calls []string
+}
+
+var _ releaseOutputOps = (*stubReleaseOutputOps)(nil)
+
+// lookupUtxoID records the shared outpoint lookup and returns the test-
+// controlled result.
+func (s *stubReleaseOutputOps) lookupUtxoID(_ context.Context,
+	_ ReleaseOutputParams) (int64, error) {
+
+	s.calls = append(s.calls, "lookup-utxo")
+
+	return s.lookupUtxoIDResult, s.lookupUtxoIDErr
+}
+
+// release records the shared delete attempt and returns the test-controlled row
+// count.
+func (s *stubReleaseOutputOps) release(_ context.Context, _ uint32,
+	_ int64, _ [32]byte) (int64, error) {
+
+	s.calls = append(s.calls, "release")
+
+	return s.releaseRows, s.releaseErr
+}
+
+// activeLockID records the fallback active-lock lookup and returns the test-
+// controlled result.
+func (s *stubReleaseOutputOps) activeLockID(_ context.Context, _ uint32,
+	_ int64, _ time.Time) ([]byte, error) {
+
+	s.calls = append(s.calls, "active-lock")
+
+	return s.activeLockIDResult, s.activeLockIDErr
 }
 
 // testLeaseOutPoint builds one stable outpoint fixture for shared UTXO lease

--- a/wallet/internal/db/utxo_store_common_test.go
+++ b/wallet/internal/db/utxo_store_common_test.go
@@ -1,0 +1,183 @@
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildOutPoint verifies the common hash/index conversion shared by both
+// SQL backends when building a valid public outpoint.
+//
+// Scenario:
+// - One normalized outpoint row is read back from the store.
+// Setup:
+// - Build a valid transaction hash.
+// Action:
+// - Convert the normalized hash/index pair into a wire.OutPoint.
+// Assertions:
+// - The public outpoint preserves the original hash and output index.
+func TestBuildOutPoint(t *testing.T) {
+	t.Parallel()
+
+	// Scenario: One normalized outpoint row is read back from the store.
+	// Setup: Build a valid transaction hash.
+	hash := chainhash.Hash{1, 2, 3}
+
+	// Act: Build the public outpoint from normalized DB fields.
+	outPoint, err := buildOutPoint(hash[:], 7)
+
+	// Assert: The helper preserves the hash and output index.
+	require.NoError(t, err)
+	require.Equal(t, hash, outPoint.Hash)
+	require.Equal(t, uint32(7), outPoint.Index)
+}
+
+// TestBuildOutPoint_InvalidHash verifies that buildOutPoint rejects malformed
+// hash bytes.
+//
+// Scenario:
+// - A normalized outpoint row carries malformed hash bytes.
+// Setup:
+// - Use a short hash payload.
+// Action:
+// - Attempt to convert the malformed row into a wire.OutPoint.
+// Assertions:
+// - The helper returns an error instead of building a partial outpoint.
+func TestBuildOutPoint_InvalidHash(t *testing.T) {
+	t.Parallel()
+
+	// Scenario: A normalized outpoint row carries invalid hash bytes.
+	// Setup: Use a malformed hash payload.
+	malformedHash := []byte{1, 2, 3}
+
+	// Act: Attempt to build the public outpoint.
+	_, err := buildOutPoint(malformedHash, 0)
+
+	// Assert: The helper rejects the malformed hash.
+	require.Error(t, err)
+}
+
+// TestBuildUtxoInfo_Confirmed verifies that buildUtxoInfo preserves confirmed
+// UTXO metadata.
+//
+// Scenario:
+// - One confirmed UTXO row is read back from the store.
+// Setup:
+// - Build a valid hash and confirmed block height.
+// Action:
+// - Convert the normalized row into a public UtxoInfo value.
+// Assertions:
+// - The mined height and outpoint metadata are preserved.
+func TestBuildUtxoInfo_Confirmed(t *testing.T) {
+	t.Parallel()
+
+	// Scenario: One confirmed UTXO row is read back from the store.
+	// Setup: Build a valid hash and confirmed block height.
+	hash := chainhash.Hash{9}
+	confirmedHeight := uint32(33)
+
+	// Act: Build the public UTXO view for the confirmed row.
+	confirmed, err := buildUtxoInfo(
+		hash[:], 1, 1234, []byte{0x51}, time.Unix(111, 0), true,
+		&confirmedHeight,
+	)
+
+	// Assert: The helper preserves the mined height and outpoint metadata.
+	require.NoError(t, err)
+	require.Equal(t, confirmedHeight, confirmed.Height)
+	require.Equal(t, hash, confirmed.OutPoint.Hash)
+	require.Equal(t, uint32(1), confirmed.OutPoint.Index)
+}
+
+// TestBuildUtxoInfo_Unconfirmed verifies that buildUtxoInfo maps unconfirmed
+// rows to the public unmined sentinel.
+//
+// Scenario:
+// - One unconfirmed UTXO row is read back from the store.
+// Setup:
+// - Build a valid hash with no block height.
+// Action:
+// - Convert the normalized row into a public UtxoInfo value.
+// Assertions:
+//   - The missing height maps to UnminedHeight and the timestamp is stored in
+//     UTC.
+func TestBuildUtxoInfo_Unconfirmed(t *testing.T) {
+	t.Parallel()
+
+	// Scenario: One unconfirmed UTXO row is read back from the store.
+	// Setup: Build a valid hash with no block height.
+	hash := chainhash.Hash{9}
+
+	// Act: Build the public UTXO view for the unconfirmed row.
+	unconfirmed, err := buildUtxoInfo(
+		hash[:], 2, 5678, []byte{0x52}, time.Unix(222, 0), false, nil,
+	)
+
+	// Assert: The helper maps the missing height to UnminedHeight and stores
+	// timestamps in UTC.
+	require.NoError(t, err)
+	require.Equal(t, UnminedHeight, unconfirmed.Height)
+	require.Equal(t, time.UTC, unconfirmed.Received.Location())
+}
+
+// TestBuildLeasedOutput verifies the common conversion used by both SQL
+// backends when surfacing one valid active lease.
+//
+// Scenario:
+// - One active lease row is read back from the store.
+// Setup:
+// - Build a valid hash and 32-byte lock ID.
+// Action:
+// - Convert the normalized row into a public LeasedOutput value.
+// Assertions:
+// - The outpoint, lock ID, and UTC expiration are preserved.
+func TestBuildLeasedOutput(t *testing.T) {
+	t.Parallel()
+
+	// Scenario: One active lease row is read back from the store.
+	// Setup: Build a valid hash and 32-byte lock ID.
+	hash := chainhash.Hash{4, 5, 6}
+	lockID := make([]byte, 32)
+	lockID[0] = 7
+
+	// Act: Build the public leased-output view.
+	lease, err := buildLeasedOutput(
+		hash[:], 9, lockID, time.Unix(333, 0).In(time.FixedZone("X", 3600)),
+	)
+
+	// Assert: The helper preserves the outpoint, lock ID, and UTC expiration.
+	require.NoError(t, err)
+	require.Equal(t, hash, lease.OutPoint.Hash)
+	require.Equal(t, uint32(9), lease.OutPoint.Index)
+	require.Equal(t, byte(7), lease.LockID[0])
+	require.Equal(t, time.UTC, lease.Expiration.Location())
+}
+
+// TestBuildLeasedOutput_InvalidLockID verifies that buildLeasedOutput rejects
+// malformed lock IDs.
+//
+// Scenario:
+// - A lease row carries an invalid lock ID payload.
+// Setup:
+// - Build a valid hash with a short lock ID.
+// Action:
+// - Attempt to convert the malformed row into a public LeasedOutput value.
+// Assertions:
+// - The helper returns errInvalidLockID.
+func TestBuildLeasedOutput_InvalidLockID(t *testing.T) {
+	t.Parallel()
+
+	// Scenario: A lease row carries an invalid lock ID payload.
+	// Setup: Build a valid hash with a short lock ID.
+	hash := chainhash.Hash{4, 5, 6}
+	shortLockID := []byte{1, 2, 3}
+
+	// Act: Attempt to build the public leased-output view.
+	_, err := buildLeasedOutput(hash[:], 0, shortLockID, time.Now())
+
+	// Assert: The helper returns the invalid-lock-ID sentinel.
+	require.ErrorIs(t, err, errInvalidLockID)
+}


### PR DESCRIPTION
This PR builds on https://github.com/btcsuite/btcwallet/pull/1186
and adds the SQL-backed `UTXOStore` implementations for postgres
and sqlite, along with the shared helpers and tests needed to exercise the new
store read/write paths.