### PR TITLE
bwtest: wait for miner p2p readiness

### DIFF
--- a/bwtest/harness.go
+++ b/bwtest/harness.go
@@ -70,6 +70,8 @@ func SetupHarness(t *testing.T, chainBackendType, dbType string) *HarnessTest {
 	minerLogDir := createOrEnsureLogSubDir(t, logDir, "miner")
 	miner := newMiner(t, minerLogDir)
 	miner.SetUp()
+	require.NoError(t, waitForTCPListener(miner.P2PAddress(),
+		defaultTestTimeout), "miner p2p listener not ready")
 
 	// 2. Start Chain Backend.
 	backendLogDir := ""

--- a/bwtest/tcp.go
+++ b/bwtest/tcp.go
@@ -1,0 +1,41 @@
+package bwtest
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/btcsuite/btcwallet/bwtest/wait"
+)
+
+// waitForTCPListener polls until addr accepts TCP connections.
+//
+// The integration harness uses this before starting external backends that
+// immediately dial the miner. Without the extra readiness check, a backend's
+// first outbound peer attempt can race the rpctest miner listener on slower CI
+// runners and leave the backend stuck at height 0 until its next reconnect.
+func waitForTCPListener(addr string, timeout time.Duration) error {
+	err := wait.NoError(func() error {
+		ctx, cancel := context.WithTimeout(
+			context.Background(), wait.PollInterval,
+		)
+		defer cancel()
+
+		dialer := &net.Dialer{}
+
+		conn, err := dialer.DialContext(ctx, "tcp", addr)
+		if err != nil {
+			return fmt.Errorf("dial %s: %w", addr, err)
+		}
+
+		_ = conn.Close()
+
+		return nil
+	}, timeout)
+	if err != nil {
+		return fmt.Errorf("wait for tcp listener %s: %w", addr, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Fix the flake found [here](https://github.com/btcsuite/btcwallet/actions/runs/23540146650/job/68525307167?pr=1186):
```
=== RUN   TestBtcWallet
itest logs dir: test-logs/log-bitcoind-kvdb-20260325-120752
    main_test.go:65: 
        	Error Trace:	/home/runner/work/btcwallet/btcwallet/bwtest/harness.go:86
        	            				/home/runner/work/btcwallet/btcwallet/itest/main_test.go:65
        	Error:      	Received unexpected error:
        	            	bitcoind not ready: bitcoind not synced (height=0); logs: /home/runner/work/btcwallet/btcwallet/itest/test-logs/log-bitcoind-kvdb-20260325-120752/chain-backend/bitcoind.stdout.log /home/runner/work/btcwallet/btcwallet/itest/test-logs/log-bitcoind-kvdb-20260325-120752/chain-backend/bitcoind.stderr.log
        	Test:       	TestBtcWallet
        	Messages:   	failed to start chain backend
--- FAIL: TestBtcWallet (30.33s)
```