### PR TITLE
wallet: add tx and utxo store coverage

### DIFF
--- a/wallet/internal/db/data_types_test.go
+++ b/wallet/internal/db/data_types_test.go
@@ -1,0 +1,33 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTxStatusString verifies the public string form for every persisted tx
+// status value.
+func TestTxStatusString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status TxStatus
+		want   string
+	}{
+		{name: "pending", status: TxStatusPending, want: "pending"},
+		{name: "published", status: TxStatusPublished, want: "published"},
+		{name: "replaced", status: TxStatusReplaced, want: "replaced"},
+		{name: "failed", status: TxStatusFailed, want: "failed"},
+		{name: "orphaned", status: TxStatusOrphaned, want: "orphaned"},
+		{name: "unknown", status: TxStatus(99), want: "unknown"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, test.want, test.status.String())
+		})
+	}
+}

--- a/wallet/internal/db/itest/tx_corruption_pg_test.go
+++ b/wallet/internal/db/itest/tx_corruption_pg_test.go
@@ -1,0 +1,161 @@
+//go:build itest && test_db_postgres
+
+package itest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/stretchr/testify/require"
+)
+
+// These postgres-only helpers intentionally drop backend CHECK constraints in
+// the isolated test database so corruption itests can persist rows that normal
+// store writes would reject. The follow-up read paths must treat those rows as
+// corruption instead of silently accepting them.
+
+// corruptTransactionStatus writes an invalid tx status after dropping the
+// validating constraints that normally reject it. The corruption itests use
+// this to verify that reads reject impossible tx states.
+func corruptTransactionStatus(t *testing.T, store *db.PostgresStore,
+	walletID uint32, txHash chainhash.Hash, status int64) {
+	t.Helper()
+
+	for _, stmt := range []string{
+		"ALTER TABLE transactions DROP CONSTRAINT IF EXISTS valid_status",
+		"ALTER TABLE transactions DROP CONSTRAINT IF EXISTS check_orphaned_coinbase_only",
+		"ALTER TABLE transactions DROP CONSTRAINT IF EXISTS check_confirmed_published",
+		"ALTER TABLE transactions DROP CONSTRAINT IF EXISTS check_coinbase_not_pending",
+		"ALTER TABLE transactions DROP CONSTRAINT IF EXISTS check_coinbase_confirmation_state",
+	} {
+		_, err := store.DB().ExecContext(t.Context(), stmt)
+		require.NoError(t, err)
+	}
+
+	result, err := store.DB().ExecContext(
+		t.Context(),
+		"UPDATE transactions SET tx_status = $1 WHERE wallet_id = $2 AND tx_hash = $3",
+		status, int64(walletID), txHash[:],
+	)
+	require.NoError(t, err)
+
+	rows, err := result.RowsAffected()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rows)
+}
+
+// corruptTransactionHash writes malformed tx-hash bytes after dropping the
+// fixed-length hash check. The corruption itests then verify that hash
+// decoding fails with the expected error path.
+func corruptTransactionHash(t *testing.T, store *db.PostgresStore,
+	walletID uint32, txHash chainhash.Hash, hash []byte) {
+	t.Helper()
+
+	_, err := store.DB().ExecContext(
+		t.Context(),
+		"ALTER TABLE transactions DROP CONSTRAINT IF EXISTS transactions_tx_hash_check",
+	)
+	require.NoError(t, err)
+
+	result, err := store.DB().ExecContext(
+		t.Context(),
+		"UPDATE transactions SET tx_hash = $1 WHERE wallet_id = $2 AND tx_hash = $3",
+		hash, int64(walletID), txHash[:],
+	)
+	require.NoError(t, err)
+
+	rows, err := result.RowsAffected()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rows)
+}
+
+// corruptTransactionBlockHeight writes an invalid block height after dropping
+// the non-negative height check and creating a matching block row. The
+// corruption itests use this to verify that reads reject impossible
+// confirmation metadata.
+func corruptTransactionBlockHeight(t *testing.T, store *db.PostgresStore,
+	walletID uint32, txHash chainhash.Hash, height int64) {
+	t.Helper()
+
+	_, err := store.DB().ExecContext(
+		t.Context(),
+		"ALTER TABLE blocks DROP CONSTRAINT IF EXISTS blocks_block_height_check",
+	)
+	require.NoError(t, err)
+
+	blockHash := RandomHash()
+	_, err = store.DB().ExecContext(
+		t.Context(),
+		"INSERT INTO blocks (block_height, header_hash, block_timestamp) VALUES ($1, $2, $3) "+
+			"ON CONFLICT (block_height) DO UPDATE SET header_hash = EXCLUDED.header_hash, "+
+			"block_timestamp = EXCLUDED.block_timestamp",
+		height, blockHash[:], time.Now().Unix(),
+	)
+	require.NoError(t, err)
+
+	result, err := store.DB().ExecContext(
+		t.Context(),
+		"UPDATE transactions SET block_height = $1 WHERE wallet_id = $2 AND tx_hash = $3",
+		height, int64(walletID), txHash[:],
+	)
+	require.NoError(t, err)
+
+	rows, err := result.RowsAffected()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rows)
+}
+
+// corruptUtxoOutputIndex writes an invalid output index after dropping the
+// non-negative output-index check. The corruption itests then verify that UTXO
+// decoding rejects the malformed persisted value.
+func corruptUtxoOutputIndex(t *testing.T, store *db.PostgresStore,
+	walletID uint32, txHash chainhash.Hash, oldIndex uint32, newIndex int64) {
+	t.Helper()
+
+	_, err := store.DB().ExecContext(
+		t.Context(),
+		"ALTER TABLE utxos DROP CONSTRAINT IF EXISTS utxos_output_index_check",
+	)
+	require.NoError(t, err)
+
+	result, err := store.DB().ExecContext(
+		t.Context(),
+		"UPDATE utxos SET output_index = $1 WHERE output_index = $2 "+
+			"AND tx_id = (SELECT id FROM transactions WHERE wallet_id = $3 AND tx_hash = $4)",
+		newIndex, int64(oldIndex), int64(walletID), txHash[:],
+	)
+	require.NoError(t, err)
+
+	rows, err := result.RowsAffected()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rows)
+}
+
+// corruptActiveLeaseLockID writes an invalid lease lock ID after dropping the
+// fixed-length lock-id check. The corruption itests use this to verify that
+// lease reads reject malformed lock identifiers.
+func corruptActiveLeaseLockID(t *testing.T, store *db.PostgresStore,
+	walletID uint32, txHash chainhash.Hash, outputIndex uint32, lockID []byte) {
+	t.Helper()
+
+	_, err := store.DB().ExecContext(
+		t.Context(),
+		"ALTER TABLE utxo_leases DROP CONSTRAINT IF EXISTS utxo_leases_lock_id_check",
+	)
+	require.NoError(t, err)
+
+	result, err := store.DB().ExecContext(
+		t.Context(),
+		"UPDATE utxo_leases SET lock_id = $1 WHERE wallet_id = $2 AND utxo_id = ("+
+			"SELECT u.id FROM utxos u JOIN transactions t ON t.id = u.tx_id "+
+			"WHERE t.wallet_id = $3 AND t.tx_hash = $4 AND u.output_index = $5)",
+		lockID, int64(walletID), int64(walletID), txHash[:], int64(outputIndex),
+	)
+	require.NoError(t, err)
+
+	rows, err := result.RowsAffected()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rows)
+}

--- a/wallet/internal/db/itest/tx_corruption_sqlite_test.go
+++ b/wallet/internal/db/itest/tx_corruption_sqlite_test.go
@@ -1,0 +1,205 @@
+//go:build itest && !test_db_postgres
+
+package itest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/stretchr/testify/require"
+)
+
+// These sqlite-only helpers intentionally bypass CHECK constraints in the
+// isolated test database so corruption itests can persist rows that normal
+// store writes would reject. The follow-up read paths must treat those rows as
+// corruption instead of silently accepting them.
+
+// corruptTransactionStatus writes an invalid tx status into one stored row while
+// sqlite check constraints are disabled inside the surrounding transaction. The
+// corruption itests use this to verify that reads reject impossible tx states.
+func corruptTransactionStatus(t *testing.T, store *db.SqliteStore,
+	walletID uint32, txHash chainhash.Hash, status int64) {
+	t.Helper()
+
+	tx, err := store.DB().BeginTx(t.Context(), nil)
+	require.NoError(t, err)
+	defer func() {
+		_, _ = tx.ExecContext(
+			t.Context(), "PRAGMA ignore_check_constraints = OFF",
+		)
+		_ = tx.Rollback()
+	}()
+
+	_, err = tx.ExecContext(t.Context(), "PRAGMA ignore_check_constraints = ON")
+	require.NoError(t, err)
+
+	result, err := tx.ExecContext(
+		t.Context(),
+		"UPDATE transactions SET tx_status = ? WHERE wallet_id = ? AND tx_hash = ?",
+		status, int64(walletID), txHash[:],
+	)
+	require.NoError(t, err)
+
+	_, err = tx.ExecContext(t.Context(), "PRAGMA ignore_check_constraints = OFF")
+	require.NoError(t, err)
+
+	rows, err := result.RowsAffected()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rows)
+	require.NoError(t, tx.Commit())
+}
+
+// corruptTransactionHash writes malformed tx-hash bytes into one stored row
+// while sqlite check constraints are disabled. The corruption itests then
+// verify that hash decoding fails with the expected error path.
+func corruptTransactionHash(t *testing.T, store *db.SqliteStore,
+	walletID uint32, txHash chainhash.Hash, hash []byte) {
+	t.Helper()
+
+	tx, err := store.DB().BeginTx(t.Context(), nil)
+	require.NoError(t, err)
+	defer func() {
+		_, _ = tx.ExecContext(
+			t.Context(), "PRAGMA ignore_check_constraints = OFF",
+		)
+		_ = tx.Rollback()
+	}()
+
+	_, err = tx.ExecContext(t.Context(), "PRAGMA ignore_check_constraints = ON")
+	require.NoError(t, err)
+
+	result, err := tx.ExecContext(
+		t.Context(),
+		"UPDATE transactions SET tx_hash = ? WHERE wallet_id = ? AND tx_hash = ?",
+		hash, int64(walletID), txHash[:],
+	)
+	require.NoError(t, err)
+
+	_, err = tx.ExecContext(t.Context(), "PRAGMA ignore_check_constraints = OFF")
+	require.NoError(t, err)
+
+	rows, err := result.RowsAffected()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rows)
+	require.NoError(t, tx.Commit())
+}
+
+// corruptTransactionBlockHeight writes an invalid block height after first
+// creating a matching block row in sqlite. The corruption itests use this to
+// verify that reads reject impossible confirmation metadata.
+func corruptTransactionBlockHeight(t *testing.T, store *db.SqliteStore,
+	walletID uint32, txHash chainhash.Hash, height int64) {
+	t.Helper()
+
+	tx, err := store.DB().BeginTx(t.Context(), nil)
+	require.NoError(t, err)
+	defer func() {
+		_, _ = tx.ExecContext(
+			t.Context(), "PRAGMA ignore_check_constraints = OFF",
+		)
+		_ = tx.Rollback()
+	}()
+
+	_, err = tx.ExecContext(t.Context(), "PRAGMA ignore_check_constraints = ON")
+	require.NoError(t, err)
+
+	blockHash := RandomHash()
+	_, err = tx.ExecContext(
+		t.Context(),
+		"INSERT INTO blocks (block_height, header_hash, block_timestamp) VALUES (?, ?, ?) "+
+			"ON CONFLICT(block_height) DO UPDATE SET header_hash = excluded.header_hash, "+
+			"block_timestamp = excluded.block_timestamp",
+		height, blockHash[:], time.Now().Unix(),
+	)
+	require.NoError(t, err)
+
+	result, err := tx.ExecContext(
+		t.Context(),
+		"UPDATE transactions SET block_height = ? WHERE wallet_id = ? AND tx_hash = ?",
+		height, int64(walletID), txHash[:],
+	)
+	require.NoError(t, err)
+
+	_, err = tx.ExecContext(t.Context(), "PRAGMA ignore_check_constraints = OFF")
+	require.NoError(t, err)
+
+	rows, err := result.RowsAffected()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rows)
+	require.NoError(t, tx.Commit())
+}
+
+// corruptUtxoOutputIndex writes an invalid output index into one stored UTXO
+// while sqlite check constraints are disabled. The corruption itests then
+// verify that UTXO decoding rejects the malformed persisted value.
+func corruptUtxoOutputIndex(t *testing.T, store *db.SqliteStore,
+	walletID uint32, txHash chainhash.Hash, oldIndex uint32, newIndex int64) {
+	t.Helper()
+
+	tx, err := store.DB().BeginTx(t.Context(), nil)
+	require.NoError(t, err)
+	defer func() {
+		_, _ = tx.ExecContext(
+			t.Context(), "PRAGMA ignore_check_constraints = OFF",
+		)
+		_ = tx.Rollback()
+	}()
+
+	_, err = tx.ExecContext(t.Context(), "PRAGMA ignore_check_constraints = ON")
+	require.NoError(t, err)
+
+	result, err := tx.ExecContext(
+		t.Context(),
+		"UPDATE utxos SET output_index = ? WHERE output_index = ? "+
+			"AND tx_id = (SELECT id FROM transactions WHERE wallet_id = ? AND tx_hash = ?)",
+		newIndex, int64(oldIndex), int64(walletID), txHash[:],
+	)
+	require.NoError(t, err)
+
+	_, err = tx.ExecContext(t.Context(), "PRAGMA ignore_check_constraints = OFF")
+	require.NoError(t, err)
+
+	rows, err := result.RowsAffected()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rows)
+	require.NoError(t, tx.Commit())
+}
+
+// corruptActiveLeaseLockID writes an invalid lease lock ID into one active
+// lease row while sqlite check constraints are disabled. The corruption itests
+// use this to verify that lease reads reject malformed lock identifiers.
+func corruptActiveLeaseLockID(t *testing.T, store *db.SqliteStore,
+	walletID uint32, txHash chainhash.Hash, outputIndex uint32, lockID []byte) {
+	t.Helper()
+
+	tx, err := store.DB().BeginTx(t.Context(), nil)
+	require.NoError(t, err)
+	defer func() {
+		_, _ = tx.ExecContext(
+			t.Context(), "PRAGMA ignore_check_constraints = OFF",
+		)
+		_ = tx.Rollback()
+	}()
+
+	_, err = tx.ExecContext(t.Context(), "PRAGMA ignore_check_constraints = ON")
+	require.NoError(t, err)
+
+	result, err := tx.ExecContext(
+		t.Context(),
+		"UPDATE utxo_leases SET lock_id = ? WHERE wallet_id = ? AND utxo_id = ("+
+			"SELECT u.id FROM utxos u JOIN transactions t ON t.id = u.tx_id "+
+			"WHERE t.wallet_id = ? AND t.tx_hash = ? AND u.output_index = ?)",
+		lockID, int64(walletID), int64(walletID), txHash[:], int64(outputIndex),
+	)
+	require.NoError(t, err)
+
+	_, err = tx.ExecContext(t.Context(), "PRAGMA ignore_check_constraints = OFF")
+	require.NoError(t, err)
+
+	rows, err := result.RowsAffected()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rows)
+	require.NoError(t, tx.Commit())
+}

--- a/wallet/internal/db/itest/tx_store_corruption_test.go
+++ b/wallet/internal/db/itest/tx_store_corruption_test.go
@@ -1,0 +1,298 @@
+//go:build itest
+
+package itest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetAndListTxRejectCorruptedStatus verifies that tx reads fail loudly when
+// the stored status escapes the supported enum.
+func TestGetAndListTxRejectCorruptedStatus(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-corrupted-tx-status")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	queries := store.Queries()
+	confirmedBlock := CreateBlockFixture(t, queries, 265)
+
+	pendingTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 2100, PkScript: addr.ScriptPubKey}},
+	)
+	err := store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       pendingTx,
+			Received: time.Unix(1710000895, 0),
+			Status:   db.TxStatusPending,
+			Credits:  map[uint32]btcutil.Address{0: nil},
+		},
+	)
+	require.NoError(t, err)
+
+	confirmedTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 3100, PkScript: addr.ScriptPubKey}},
+	)
+	err = store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       confirmedTx,
+			Received: time.Unix(1710000896, 0),
+			Block:    &confirmedBlock,
+			Status:   db.TxStatusPublished,
+			Credits:  map[uint32]btcutil.Address{0: nil},
+		},
+	)
+	require.NoError(t, err)
+
+	corruptTransactionStatus(t, store, walletID, pendingTx.TxHash(), 99)
+
+	_, err = store.GetTx(
+		t.Context(),
+		db.GetTxQuery{
+			WalletID: walletID,
+			Txid:     pendingTx.TxHash(),
+		},
+	)
+	require.ErrorContains(t, err, "invalid tx status")
+
+	_, err = store.ListTxns(
+		t.Context(),
+		db.ListTxnsQuery{
+			WalletID:    walletID,
+			UnminedOnly: true,
+		},
+	)
+	require.ErrorContains(t, err, "invalid tx status")
+
+	corruptTransactionStatus(t, store, walletID, confirmedTx.TxHash(), 99)
+
+	_, err = store.ListTxns(
+		t.Context(),
+		db.ListTxnsQuery{
+			WalletID:    walletID,
+			StartHeight: confirmedBlock.Height,
+			EndHeight:   confirmedBlock.Height,
+		},
+	)
+	require.ErrorContains(t, err, "invalid tx status")
+}
+
+// TestDeleteTxRejectsCorruptedStatus verifies that DeleteTx rejects stored rows
+// with an invalid wallet-visible status code.
+func TestDeleteTxRejectsCorruptedStatus(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-delete-corrupted-status")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 2300, PkScript: addr.ScriptPubKey}},
+	)
+	err := store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710000897, 0),
+			Status:   db.TxStatusPending,
+			Credits:  map[uint32]btcutil.Address{0: nil},
+		},
+	)
+	require.NoError(t, err)
+
+	corruptTransactionStatus(t, store, walletID, tx.TxHash(), 99)
+
+	err = store.DeleteTx(
+		t.Context(),
+		db.DeleteTxParams{
+			WalletID: walletID,
+			Txid:     tx.TxHash(),
+		},
+	)
+	require.ErrorContains(t, err, "invalid tx status")
+}
+
+// TestListTxnsRejectsCorruptedUnminedHash verifies that unmined transaction
+// listings fail when a stored transaction hash cannot be decoded.
+func TestListTxnsRejectsCorruptedUnminedHash(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-corrupted-unmined-hash")
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 2700, PkScript: []byte{0x51}}},
+	)
+	err := store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710001400, 0),
+			Status:   db.TxStatusPending,
+		},
+	)
+	require.NoError(t, err)
+
+	corruptTransactionHash(t, store, walletID, tx.TxHash(), []byte{1, 2, 3})
+
+	_, err = store.ListTxns(
+		t.Context(),
+		db.ListTxnsQuery{
+			WalletID:    walletID,
+			UnminedOnly: true,
+		},
+	)
+	require.ErrorContains(t, err, "tx hash")
+}
+
+// TestGetTxRejectsCorruptedConfirmedBlockHeight verifies that confirmed reads
+// fail when the joined block height cannot map back into the public block model.
+func TestGetTxRejectsCorruptedConfirmedBlockHeight(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-corrupted-confirmed-height")
+	queries := store.Queries()
+	confirmedBlock := CreateBlockFixture(t, queries, 280)
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 2800, PkScript: []byte{0x51}}},
+	)
+	err := store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710001410, 0),
+			Block:    &confirmedBlock,
+			Status:   db.TxStatusPublished,
+		},
+	)
+	require.NoError(t, err)
+
+	corruptTransactionBlockHeight(t, store, walletID, tx.TxHash(), -1)
+
+	_, err = store.GetTx(
+		t.Context(),
+		db.GetTxQuery{
+			WalletID: walletID,
+			Txid:     tx.TxHash(),
+		},
+	)
+	require.ErrorContains(t, err, "block height")
+}
+
+// TestDeleteTxRejectsCorruptedLiveChild verifies that DeleteTx surfaces child
+// decode failures while checking the live leaf invariant.
+func TestDeleteTxRejectsCorruptedLiveChild(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-delete-corrupted-child")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+
+	parentTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 5000, PkScript: addr.ScriptPubKey}},
+	)
+	err := store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       parentTx,
+			Received: time.Unix(1710001015, 0),
+			Status:   db.TxStatusPending,
+			Credits:  map[uint32]btcutil.Address{0: nil},
+		},
+	)
+	require.NoError(t, err)
+
+	childTx := newRegularTx(
+		[]wire.OutPoint{{Hash: parentTx.TxHash(), Index: 0}},
+		[]*wire.TxOut{{Value: 4000, PkScript: []byte{0x51}}},
+	)
+	err = store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       childTx,
+			Received: time.Unix(1710001020, 0),
+			Status:   db.TxStatusPending,
+		},
+	)
+	require.NoError(t, err)
+
+	corruptTransactionHash(t, store, walletID, childTx.TxHash(), []byte{1, 2, 3})
+
+	err = store.DeleteTx(
+		t.Context(),
+		db.DeleteTxParams{
+			WalletID: walletID,
+			Txid:     parentTx.TxHash(),
+		},
+	)
+	require.ErrorContains(t, err, "tx hash")
+}
+
+// TestRollbackToBlockRejectsCorruptedCoinbaseRootHash verifies that rollback
+// fails loudly when a disconnected coinbase root carries an invalid stored hash.
+func TestRollbackToBlockRejectsCorruptedCoinbaseRootHash(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-rollback-corrupted-coinbase-hash")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	queries := store.Queries()
+	coinbaseBlock := CreateBlockFixture(t, queries, 290)
+	coinbaseTx := newCoinbaseTx(addr.ScriptPubKey)
+
+	err := store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       coinbaseTx,
+			Received: time.Unix(1710001420, 0),
+			Block:    &coinbaseBlock,
+			Status:   db.TxStatusPublished,
+			Credits:  map[uint32]btcutil.Address{0: nil},
+		},
+	)
+	require.NoError(t, err)
+
+	corruptTransactionHash(t, store, walletID, coinbaseTx.TxHash(), []byte{1, 2, 3})
+
+	err = store.RollbackToBlock(t.Context(), coinbaseBlock.Height)
+	require.ErrorContains(t, err, "rollback coinbase hash")
+}

--- a/wallet/internal/db/itest/tx_store_corruption_test.go
+++ b/wallet/internal/db/itest/tx_store_corruption_test.go
@@ -3,6 +3,8 @@
 package itest
 
 import (
+	"database/sql"
+	"fmt"
 	"testing"
 	"time"
 
@@ -11,6 +13,21 @@ import (
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/stretchr/testify/require"
 )
+
+// dropTableForCorruption removes one backing table so the public store methods
+// surface the backend query errors exercised by the corruption tests.
+func dropTableForCorruption(t *testing.T, store interface{ DB() *sql.DB },
+	table string) {
+	t.Helper()
+
+	stmt := fmt.Sprintf("DROP TABLE %s", table)
+	if _, ok := any(store).(*db.PostgresStore); ok {
+		stmt += " CASCADE"
+	}
+
+	_, err := store.DB().ExecContext(t.Context(), stmt)
+	require.NoError(t, err)
+}
 
 // TestGetAndListTxRejectCorruptedStatus verifies that tx reads fail loudly when
 // the stored status escapes the supported enum.
@@ -126,6 +143,84 @@ func TestDeleteTxRejectsCorruptedStatus(t *testing.T) {
 	err = store.DeleteTx(
 		t.Context(),
 		db.DeleteTxParams{
+			WalletID: walletID,
+			Txid:     tx.TxHash(),
+		},
+	)
+	require.ErrorContains(t, err, "invalid tx status")
+}
+
+// TestCreateTxRejectsCorruptedExistingStatus verifies that CreateTx surfaces an
+// invalid stored status while checking whether the tx hash already exists.
+func TestCreateTxRejectsCorruptedExistingStatus(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-create-corrupted-existing-status")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 2350, PkScript: addr.ScriptPubKey}},
+	)
+	err := store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710000898, 0),
+			Status:   db.TxStatusPending,
+			Credits:  map[uint32]btcutil.Address{0: nil},
+		},
+	)
+	require.NoError(t, err)
+
+	corruptTransactionStatus(t, store, walletID, tx.TxHash(), 99)
+
+	err = store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710000899, 0),
+			Status:   db.TxStatusPending,
+			Credits:  map[uint32]btcutil.Address{0: nil},
+		},
+	)
+	require.ErrorContains(t, err, "invalid tx status")
+}
+
+// TestInvalidateUnminedTxRejectsCorruptedStatus verifies that invalidation
+// rejects a stored root whose wallet-visible status is corrupted.
+func TestInvalidateUnminedTxRejectsCorruptedStatus(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-invalidate-corrupted-status")
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 2400, PkScript: []byte{0x51}}},
+	)
+	err := store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710000901, 0),
+			Status:   db.TxStatusPending,
+		},
+	)
+	require.NoError(t, err)
+
+	corruptTransactionStatus(t, store, walletID, tx.TxHash(), 99)
+
+	err = store.InvalidateUnminedTx(
+		t.Context(),
+		db.InvalidateUnminedTxParams{
 			WalletID: walletID,
 			Txid:     tx.TxHash(),
 		},
@@ -295,4 +390,236 @@ func TestRollbackToBlockRejectsCorruptedCoinbaseRootHash(t *testing.T) {
 
 	err = store.RollbackToBlock(t.Context(), coinbaseBlock.Height)
 	require.ErrorContains(t, err, "rollback coinbase hash")
+}
+
+// TestCreateTxReturnsQueryErrorWhenTransactionsTableMissing verifies that the
+// backend loadExisting path surfaces query errors from the transactions table.
+func TestCreateTxReturnsQueryErrorWhenTransactionsTableMissing(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-create-missing-transactions-table")
+
+	dropTableForCorruption(t, store, "transactions")
+
+	err := store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       newRegularTx([]wire.OutPoint{randomOutPoint()}, []*wire.TxOut{{Value: 5500, PkScript: []byte{0x51}}}),
+			Received: time.Unix(1710001433, 0),
+			Status:   db.TxStatusPending,
+		},
+	)
+	require.ErrorContains(t, err, "get tx metadata")
+}
+
+// TestCreateTxReturnsQueryErrorWhenUtxosTableMissing verifies that conflict
+// discovery surfaces backend query errors from the UTXO table.
+func TestCreateTxReturnsQueryErrorWhenUtxosTableMissing(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-create-missing-utxos-table")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	parentTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 5600, PkScript: addr.ScriptPubKey}},
+	)
+	err := store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       parentTx,
+			Received: time.Unix(1710001434, 0),
+			Status:   db.TxStatusPending,
+			Credits:  map[uint32]btcutil.Address{0: nil},
+		},
+	)
+	require.NoError(t, err)
+
+	conflictRoot := newRegularTx(
+		[]wire.OutPoint{{Hash: parentTx.TxHash(), Index: 0}},
+		[]*wire.TxOut{{Value: 5500, PkScript: []byte{0x51}}},
+	)
+	err = store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       conflictRoot,
+			Received: time.Unix(1710001435, 0),
+			Status:   db.TxStatusPending,
+		},
+	)
+	require.NoError(t, err)
+
+	confirmedBlock := CreateBlockFixture(t, store.Queries(), 292)
+	dropTableForCorruption(t, store, "utxos")
+
+	err = store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx: newRegularTx(
+				[]wire.OutPoint{{Hash: parentTx.TxHash(), Index: 0}},
+				[]*wire.TxOut{{Value: 5400, PkScript: []byte{0x52}}},
+			),
+			Received: time.Unix(1710001436, 0),
+			Block:    &confirmedBlock,
+			Status:   db.TxStatusPublished,
+		},
+	)
+	require.ErrorContains(t, err, "lookup input conflict")
+}
+
+// TestRollbackToBlockReturnsQueryErrorWhenBlocksTableMissing verifies that the
+// backend rollback queries surface database errors when the block table is gone.
+func TestRollbackToBlockReturnsQueryErrorWhenBlocksTableMissing(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	dropTableForCorruption(t, store, "blocks")
+
+	err := store.RollbackToBlock(t.Context(), 1)
+	require.Error(t, err)
+
+	// SQLite still fails while rewinding wallet sync-state heights because
+	// wallet_sync_states keeps direct block references with ON DELETE RESTRICT.
+	// PostgreSQL drops those dependent rows with CASCADE when the blocks table is
+	// removed, so rollback gets far enough to fail on the block delete instead.
+	_, ok := any(store).(*db.PostgresStore)
+	if ok {
+		require.ErrorContains(t, err, "delete blocks at or above height")
+		return
+	}
+
+	require.ErrorContains(t, err, "rewind wallet sync state heights")
+}
+
+// TestLeaseAndReleaseReturnQueryErrorsWhenLeaseTablesMissing verifies that the
+// backend lease queries surface direct database errors when the lease table has
+// been removed.
+func TestLeaseAndReleaseReturnQueryErrorsWhenLeaseTablesMissing(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-missing-utxo-lease-table")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	confirmedBlock := CreateBlockFixture(t, store.Queries(), 293)
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 5700, PkScript: addr.ScriptPubKey}},
+	)
+	err := store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710001437, 0),
+			Block:    &confirmedBlock,
+			Status:   db.TxStatusPublished,
+			Credits:  map[uint32]btcutil.Address{0: nil},
+		},
+	)
+	require.NoError(t, err)
+
+	outPoint := wire.OutPoint{Hash: tx.TxHash(), Index: 0}
+	leaseID := RandomHash()
+
+	dropTableForCorruption(t, store, "utxo_leases")
+
+	_, err = store.LeaseOutput(
+		t.Context(),
+		db.LeaseOutputParams{
+			WalletID: walletID,
+			ID:       leaseID,
+			OutPoint: outPoint,
+			Duration: time.Minute,
+		},
+	)
+	require.ErrorContains(t, err, "acquire lease row")
+
+	err = store.ReleaseOutput(
+		t.Context(),
+		db.ReleaseOutputParams{
+			WalletID: walletID,
+			ID:       leaseID,
+			OutPoint: outPoint,
+		},
+	)
+	require.ErrorContains(t, err, "release lease row")
+}
+
+// TestCreateTxRejectsCorruptedConflictRootHash verifies that confirmed conflict
+// reconciliation fails loudly when one conflicting unmined root carries an
+// invalid stored hash.
+func TestCreateTxRejectsCorruptedConflictRootHash(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-create-corrupted-conflict-hash")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	parentTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 5400, PkScript: addr.ScriptPubKey}},
+	)
+	err := store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       parentTx,
+			Received: time.Unix(1710001430, 0),
+			Status:   db.TxStatusPending,
+			Credits:  map[uint32]btcutil.Address{0: nil},
+		},
+	)
+	require.NoError(t, err)
+
+	conflictRoot := newRegularTx(
+		[]wire.OutPoint{{Hash: parentTx.TxHash(), Index: 0}},
+		[]*wire.TxOut{{Value: 5300, PkScript: []byte{0x51}}},
+	)
+	err = store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       conflictRoot,
+			Received: time.Unix(1710001431, 0),
+			Status:   db.TxStatusPending,
+		},
+	)
+	require.NoError(t, err)
+
+	corruptTransactionHash(
+		t, store, walletID, conflictRoot.TxHash(), []byte{1, 2, 3},
+	)
+
+	confirmedBlock := CreateBlockFixture(t, store.Queries(), 291)
+	winnerTx := newRegularTx(
+		[]wire.OutPoint{{Hash: parentTx.TxHash(), Index: 0}},
+		[]*wire.TxOut{{Value: 5200, PkScript: []byte{0x52}}},
+	)
+	err = store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       winnerTx,
+			Received: time.Unix(1710001432, 0),
+			Block:    &confirmedBlock,
+			Status:   db.TxStatusPublished,
+		},
+	)
+	require.ErrorContains(t, err, "tx hash")
 }

--- a/wallet/internal/db/itest/tx_store_create_edge_cases_test.go
+++ b/wallet/internal/db/itest/tx_store_create_edge_cases_test.go
@@ -100,3 +100,51 @@ func TestCreateTxRejectsDuplicateConfirmedTransaction(t *testing.T) {
 	err = store.CreateTx(t.Context(), params)
 	require.ErrorIs(t, err, db.ErrTxAlreadyExists)
 }
+
+// TestCreateTxRejectsMissingConfirmingBlockForExistingUnminedRow verifies that
+// re-confirming an existing unmined row still requires the confirming block to
+// exist in block history.
+func TestCreateTxRejectsMissingConfirmingBlockForExistingUnminedRow(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-missing-confirming-block")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 4600, PkScript: addr.ScriptPubKey}},
+	)
+
+	err := store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710000860, 0),
+			Status:   db.TxStatusPending,
+			Credits:  map[uint32]btcutil.Address{0: nil},
+		},
+	)
+	require.NoError(t, err)
+
+	err = store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710000861, 0),
+			Block: &db.Block{
+				Hash:      RandomHash(),
+				Height:    999,
+				Timestamp: time.Unix(1710000862, 0),
+			},
+			Status:  db.TxStatusPublished,
+			Credits: map[uint32]btcutil.Address{0: nil},
+		},
+	)
+	require.ErrorContains(t, err, "require confirming block")
+}

--- a/wallet/internal/db/itest/tx_store_create_edge_cases_test.go
+++ b/wallet/internal/db/itest/tx_store_create_edge_cases_test.go
@@ -1,0 +1,102 @@
+//go:build itest
+
+package itest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateTxRejectsUnknownCreditAddress verifies that credited outputs must
+// resolve to a wallet-owned address before CreateTx can store the UTXO row.
+func TestCreateTxRejectsUnknownCreditAddress(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-unknown-credit-address")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 2500, PkScript: []byte{0x51}}},
+	)
+
+	err := store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710000800, 0),
+			Status:   db.TxStatusPending,
+			Credits:  map[uint32]btcutil.Address{0: nil},
+		},
+	)
+	require.ErrorIs(t, err, db.ErrAddressNotFound)
+
+	_, err = store.GetTx(
+		t.Context(),
+		db.GetTxQuery{
+			WalletID: walletID,
+			Txid:     tx.TxHash(),
+		},
+	)
+	require.ErrorIs(t, err, db.ErrTxNotFound)
+}
+
+// TestCreateTxRejectsInvalidParams verifies that CreateTx returns shared
+// parameter-validation errors before opening a backend transaction.
+func TestCreateTxRejectsInvalidParams(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-invalid-create-tx-params")
+
+	err := store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Status:   db.TxStatusPending,
+		},
+	)
+	require.ErrorContains(t, err, "tx is required")
+}
+
+// TestCreateTxRejectsDuplicateConfirmedTransaction verifies that duplicate
+// confirmed inserts fail instead of silently creating a second row.
+func TestCreateTxRejectsDuplicateConfirmedTransaction(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-duplicate-confirmed-tx")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	queries := store.Queries()
+	confirmedBlock := CreateBlockFixture(t, queries, 261)
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 4500, PkScript: addr.ScriptPubKey}},
+	)
+	params := db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       tx,
+		Received: time.Unix(1710000850, 0),
+		Block:    &confirmedBlock,
+		Status:   db.TxStatusPublished,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	}
+
+	err := store.CreateTx(t.Context(), params)
+	require.NoError(t, err)
+
+	err = store.CreateTx(t.Context(), params)
+	require.ErrorIs(t, err, db.ErrTxAlreadyExists)
+}

--- a/wallet/internal/db/itest/tx_store_edge_cases_test.go
+++ b/wallet/internal/db/itest/tx_store_edge_cases_test.go
@@ -3,6 +3,7 @@
 package itest
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -199,4 +200,39 @@ func TestTxReadsReturnQueryErrorsWhenClosed(t *testing.T) {
 		},
 	)
 	require.ErrorContains(t, err, "list txns by height")
+}
+
+// TestUpdateTxRejectsTooLongLabel verifies that backend label updates surface
+// query errors when the requested label exceeds the stored column limit.
+func TestUpdateTxRejectsTooLongLabel(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-update-label-too-long")
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 9100, PkScript: []byte{0x51}}},
+	)
+	err := store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710001600, 0),
+			Status:   db.TxStatusPending,
+		},
+	)
+	require.NoError(t, err)
+
+	label := strings.Repeat("x", 501)
+	err = store.UpdateTx(
+		t.Context(),
+		db.UpdateTxParams{
+			WalletID: walletID,
+			Txid:     tx.TxHash(),
+			Label:    &label,
+		},
+	)
+	require.ErrorContains(t, err, "update tx label")
 }

--- a/wallet/internal/db/itest/tx_store_edge_cases_test.go
+++ b/wallet/internal/db/itest/tx_store_edge_cases_test.go
@@ -1,0 +1,202 @@
+//go:build itest
+
+package itest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeleteTxRejectsConfirmedAndMissing verifies DeleteTx's live-unconfirmed
+// precondition and not-found handling.
+func TestDeleteTxRejectsConfirmedAndMissing(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-delete-confirmed-or-missing")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	queries := store.Queries()
+	confirmedBlock := CreateBlockFixture(t, queries, 260)
+
+	confirmedTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 5000, PkScript: addr.ScriptPubKey}},
+	)
+	err := store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       confirmedTx,
+			Received: time.Unix(1710000900, 0),
+			Block:    &confirmedBlock,
+			Status:   db.TxStatusPublished,
+			Credits:  map[uint32]btcutil.Address{0: nil},
+		},
+	)
+	require.NoError(t, err)
+
+	err = store.DeleteTx(
+		t.Context(),
+		db.DeleteTxParams{
+			WalletID: walletID,
+			Txid:     confirmedTx.TxHash(),
+		},
+	)
+	require.ErrorContains(t, err, "delete requires an unmined transaction")
+
+	confirmedInfo, err := store.GetTx(
+		t.Context(),
+		db.GetTxQuery{
+			WalletID: walletID,
+			Txid:     confirmedTx.TxHash(),
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, confirmedInfo.Block)
+
+	err = store.DeleteTx(
+		t.Context(),
+		db.DeleteTxParams{
+			WalletID: walletID,
+			Txid:     RandomHash(),
+		},
+	)
+	require.ErrorIs(t, err, db.ErrTxNotFound)
+}
+
+// TestDeleteTxRejectsNonLeafExternalChild verifies that DeleteTx scans the raw
+// unmined graph, not only wallet-owned credit edges, when enforcing leaf-only
+// deletion.
+func TestDeleteTxRejectsNonLeafExternalChild(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-delete-non-leaf-external-child")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+
+	parentTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{
+			{Value: 6000, PkScript: addr.ScriptPubKey},
+			{Value: 500, PkScript: []byte{0x51}},
+		},
+	)
+	err := store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       parentTx,
+			Received: time.Unix(1710001000, 0),
+			Status:   db.TxStatusPending,
+			Credits:  map[uint32]btcutil.Address{0: nil},
+		},
+	)
+	require.NoError(t, err)
+
+	childTx := newRegularTx(
+		[]wire.OutPoint{{Hash: parentTx.TxHash(), Index: 1}},
+		[]*wire.TxOut{{Value: 300, PkScript: []byte{0x52}}},
+	)
+	err = store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       childTx,
+			Received: time.Unix(1710001010, 0),
+			Status:   db.TxStatusPending,
+		},
+	)
+	require.NoError(t, err)
+
+	err = store.DeleteTx(
+		t.Context(),
+		db.DeleteTxParams{
+			WalletID: walletID,
+			Txid:     parentTx.TxHash(),
+		},
+	)
+	require.ErrorIs(t, err, db.ErrDeleteRequiresLeaf)
+
+	parentInfo, err := store.GetTx(
+		t.Context(),
+		db.GetTxQuery{
+			WalletID: walletID,
+			Txid:     parentTx.TxHash(),
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, db.TxStatusPending, parentInfo.Status)
+
+	childInfo, err := store.GetTx(
+		t.Context(),
+		db.GetTxQuery{
+			WalletID: walletID,
+			Txid:     childTx.TxHash(),
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, db.TxStatusPending, childInfo.Status)
+}
+
+// TestTxReadsReturnQueryErrorsWhenClosed verifies that transaction read and
+// update methods wrap backend query errors when the store is closed.
+func TestTxReadsReturnQueryErrorsWhenClosed(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-closed-tx-reads")
+	err := store.Close()
+	require.NoError(t, err)
+
+	label := "closed"
+	err = store.UpdateTx(
+		t.Context(),
+		db.UpdateTxParams{
+			WalletID: walletID,
+			Txid:     RandomHash(),
+			Label:    &label,
+		},
+	)
+	require.ErrorContains(t, err, "begin tx")
+
+	_, err = store.GetTx(
+		t.Context(),
+		db.GetTxQuery{
+			WalletID: walletID,
+			Txid:     RandomHash(),
+		},
+	)
+	require.ErrorContains(t, err, "get tx")
+
+	_, err = store.ListTxns(
+		t.Context(),
+		db.ListTxnsQuery{
+			WalletID:    walletID,
+			UnminedOnly: true,
+		},
+	)
+	require.ErrorContains(t, err, "list txns without block")
+
+	_, err = store.ListTxns(
+		t.Context(),
+		db.ListTxnsQuery{
+			WalletID:    walletID,
+			StartHeight: 1,
+			EndHeight:   1,
+		},
+	)
+	require.ErrorContains(t, err, "list txns by height")
+}

--- a/wallet/internal/db/itest/tx_store_invalidate_edge_cases_test.go
+++ b/wallet/internal/db/itest/tx_store_invalidate_edge_cases_test.go
@@ -1,0 +1,164 @@
+//go:build itest
+
+package itest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInvalidateUnminedTxFailsBranch verifies that invalidating one unmined root
+// fails the whole dependent branch and restores the wallet-owned parent output.
+func TestInvalidateUnminedTxFailsBranch(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-invalidate-unmined-branch")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+
+	rootTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 5000, PkScript: addr.ScriptPubKey}},
+	)
+	err := store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       rootTx,
+			Received: time.Unix(1710003100, 0),
+			Status:   db.TxStatusPending,
+			Credits:  map[uint32]btcutil.Address{0: nil},
+		},
+	)
+	require.NoError(t, err)
+
+	childTx := newRegularTx(
+		[]wire.OutPoint{{Hash: rootTx.TxHash(), Index: 0}},
+		[]*wire.TxOut{{Value: 4900, PkScript: []byte{0x51}}},
+	)
+	err = store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       childTx,
+			Received: time.Unix(1710003110, 0),
+			Status:   db.TxStatusPending,
+		},
+	)
+	require.NoError(t, err)
+
+	grandchildTx := newRegularTx(
+		[]wire.OutPoint{{Hash: childTx.TxHash(), Index: 0}},
+		[]*wire.TxOut{{Value: 4800, PkScript: []byte{0x52}}},
+	)
+	err = store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       grandchildTx,
+			Received: time.Unix(1710003120, 0),
+			Status:   db.TxStatusPending,
+		},
+	)
+	require.NoError(t, err)
+
+	err = store.InvalidateUnminedTx(
+		t.Context(),
+		db.InvalidateUnminedTxParams{
+			WalletID: walletID,
+			Txid:     rootTx.TxHash(),
+		},
+	)
+	require.NoError(t, err)
+
+	rootInfo, err := store.GetTx(
+		t.Context(),
+		db.GetTxQuery{
+			WalletID: walletID,
+			Txid:     rootTx.TxHash(),
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, db.TxStatusFailed, rootInfo.Status)
+	require.Nil(t, rootInfo.Block)
+
+	childInfo, err := store.GetTx(
+		t.Context(),
+		db.GetTxQuery{
+			WalletID: walletID,
+			Txid:     childTx.TxHash(),
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, db.TxStatusFailed, childInfo.Status)
+
+	grandchildInfo, err := store.GetTx(
+		t.Context(),
+		db.GetTxQuery{
+			WalletID: walletID,
+			Txid:     grandchildTx.TxHash(),
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, db.TxStatusFailed, grandchildInfo.Status)
+
+	require.Empty(t, childSpendingTxIDs(t, store, walletID, rootTx.TxHash()))
+}
+
+// TestInvalidateUnminedTxRejectsConfirmedAndMissing verifies the backend load
+// paths for confirmed rows and missing tx hashes.
+func TestInvalidateUnminedTxRejectsConfirmedAndMissing(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-invalidate-unmined-errors")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	block := CreateBlockFixture(t, store.Queries(), 320)
+	confirmedTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 5200, PkScript: addr.ScriptPubKey}},
+	)
+	err := store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       confirmedTx,
+			Received: time.Unix(1710003130, 0),
+			Block:    &block,
+			Status:   db.TxStatusPublished,
+			Credits:  map[uint32]btcutil.Address{0: nil},
+		},
+	)
+	require.NoError(t, err)
+
+	err = store.InvalidateUnminedTx(
+		t.Context(),
+		db.InvalidateUnminedTxParams{
+			WalletID: walletID,
+			Txid:     confirmedTx.TxHash(),
+		},
+	)
+	require.ErrorIs(t, err, db.ErrInvalidateTx)
+
+	err = store.InvalidateUnminedTx(
+		t.Context(),
+		db.InvalidateUnminedTxParams{
+			WalletID: walletID,
+			Txid:     RandomHash(),
+		},
+	)
+	require.ErrorIs(t, err, db.ErrTxNotFound)
+}

--- a/wallet/internal/db/itest/tx_store_pg_only_test.go
+++ b/wallet/internal/db/itest/tx_store_pg_only_test.go
@@ -1,0 +1,81 @@
+//go:build itest && test_db_postgres
+
+package itest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateTxRejectsBlockHeightOverflowPostgres verifies postgres-specific
+// block-height conversion failures surface before insert.
+func TestCreateTxRejectsBlockHeightOverflowPostgres(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-create-overflow-height-pg")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 1000, PkScript: []byte{0x51}}},
+	)
+	err := store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710005000, 0),
+			Block: &db.Block{
+				Height:    ^uint32(0),
+				Hash:      RandomHash(),
+				Timestamp: time.Unix(1710005001, 0),
+			},
+			Status: db.TxStatusPublished,
+		},
+	)
+	require.ErrorContains(t, err, "convert block height")
+}
+
+// TestListTxnsRejectHeightOverflowPostgres verifies postgres-specific height
+// conversion failures for confirmed transaction listings.
+func TestListTxnsRejectHeightOverflowPostgres(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-list-height-overflow-pg")
+
+	_, err := store.ListTxns(
+		t.Context(),
+		db.ListTxnsQuery{
+			WalletID:    walletID,
+			StartHeight: ^uint32(0),
+			EndHeight:   0,
+		},
+	)
+	require.ErrorContains(t, err, "convert start height")
+
+	_, err = store.ListTxns(
+		t.Context(),
+		db.ListTxnsQuery{
+			WalletID:    walletID,
+			StartHeight: 0,
+			EndHeight:   ^uint32(0),
+		},
+	)
+	require.ErrorContains(t, err, "convert end height")
+}
+
+// TestRollbackToBlockRejectsHeightOverflowPostgres verifies postgres-specific
+// rollback height conversion failures.
+func TestRollbackToBlockRejectsHeightOverflowPostgres(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	err := store.RollbackToBlock(t.Context(), ^uint32(0))
+	require.ErrorContains(t, err, "convert rollback height")
+}

--- a/wallet/internal/db/itest/utxo_store_edge_cases_test.go
+++ b/wallet/internal/db/itest/utxo_store_edge_cases_test.go
@@ -1,0 +1,305 @@
+//go:build itest
+
+package itest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLeaseOutputMissingUtxo verifies that leasing a missing outpoint returns
+// the public not-found error.
+func TestLeaseOutputMissingUtxo(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-lease-missing-utxo")
+
+	_, err := store.LeaseOutput(
+		t.Context(),
+		db.LeaseOutputParams{
+			WalletID: walletID,
+			ID:       RandomHash(),
+			OutPoint: wire.OutPoint{Hash: RandomHash(), Index: 0},
+			Duration: time.Minute,
+		},
+	)
+	require.ErrorIs(t, err, db.ErrUtxoNotFound)
+}
+
+// TestReleaseOutputMissingUtxo verifies that releasing a missing outpoint
+// returns the public not-found error.
+func TestReleaseOutputMissingUtxo(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-release-missing-utxo")
+
+	err := store.ReleaseOutput(
+		t.Context(),
+		db.ReleaseOutputParams{
+			WalletID: walletID,
+			ID:       RandomHash(),
+			OutPoint: wire.OutPoint{Hash: RandomHash(), Index: 0},
+		},
+	)
+	require.ErrorIs(t, err, db.ErrUtxoNotFound)
+}
+
+// TestReleaseOutputTwiceIsNoOp verifies that a second release becomes a no-op
+// after the original lease has already been removed.
+func TestReleaseOutputTwiceIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-release-output-twice")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	queries := store.Queries()
+	confirmedBlock := CreateBlockFixture(t, queries, 270)
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 8000, PkScript: addr.ScriptPubKey}},
+	)
+	err := store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710001300, 0),
+			Block:    &confirmedBlock,
+			Status:   db.TxStatusPublished,
+			Credits:  map[uint32]btcutil.Address{0: nil},
+		},
+	)
+	require.NoError(t, err)
+
+	leaseOutPoint := wire.OutPoint{Hash: tx.TxHash(), Index: 0}
+	leaseID := RandomHash()
+	_, err = store.LeaseOutput(
+		t.Context(),
+		db.LeaseOutputParams{
+			WalletID: walletID,
+			ID:       leaseID,
+			OutPoint: leaseOutPoint,
+			Duration: time.Hour,
+		},
+	)
+	require.NoError(t, err)
+
+	err = store.ReleaseOutput(
+		t.Context(),
+		db.ReleaseOutputParams{
+			WalletID: walletID,
+			ID:       leaseID,
+			OutPoint: leaseOutPoint,
+		},
+	)
+	require.NoError(t, err)
+
+	err = store.ReleaseOutput(
+		t.Context(),
+		db.ReleaseOutputParams{
+			WalletID: walletID,
+			ID:       leaseID,
+			OutPoint: leaseOutPoint,
+		},
+	)
+	require.NoError(t, err)
+
+	leases, err := store.ListLeasedOutputs(t.Context(), walletID)
+	require.NoError(t, err)
+	require.Empty(t, leases)
+}
+
+// TestListLeasedOutputsRejectsCorruptedLockID verifies that active lease reads
+// fail loudly when the stored lock ID cannot be decoded.
+func TestListLeasedOutputsRejectsCorruptedLockID(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-corrupted-lease-lock-id")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	queries := store.Queries()
+	confirmedBlock := CreateBlockFixture(t, queries, 271)
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 8100, PkScript: addr.ScriptPubKey}},
+	)
+	err := store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710001430, 0),
+			Block:    &confirmedBlock,
+			Status:   db.TxStatusPublished,
+			Credits:  map[uint32]btcutil.Address{0: nil},
+		},
+	)
+	require.NoError(t, err)
+
+	leaseID := RandomHash()
+	_, err = store.LeaseOutput(
+		t.Context(),
+		db.LeaseOutputParams{
+			WalletID: walletID,
+			ID:       leaseID,
+			OutPoint: wire.OutPoint{Hash: tx.TxHash(), Index: 0},
+			Duration: time.Minute,
+		},
+	)
+	require.NoError(t, err)
+
+	corruptActiveLeaseLockID(t, store, walletID, tx.TxHash(), 0, []byte{1, 2, 3})
+
+	_, err = store.ListLeasedOutputs(t.Context(), walletID)
+	require.ErrorContains(t, err, "lock id")
+}
+
+// TestListLeasedOutputsRejectsCorruptedOutputIndex verifies that active lease
+// reads fail when the joined UTXO output index falls outside the public range.
+func TestListLeasedOutputsRejectsCorruptedOutputIndex(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-corrupted-lease-output-index")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	queries := store.Queries()
+	confirmedBlock := CreateBlockFixture(t, queries, 272)
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 8200, PkScript: addr.ScriptPubKey}},
+	)
+	err := store.CreateTx(
+		t.Context(),
+		db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710001440, 0),
+			Block:    &confirmedBlock,
+			Status:   db.TxStatusPublished,
+			Credits:  map[uint32]btcutil.Address{0: nil},
+		},
+	)
+	require.NoError(t, err)
+
+	leaseID := RandomHash()
+	_, err = store.LeaseOutput(
+		t.Context(),
+		db.LeaseOutputParams{
+			WalletID: walletID,
+			ID:       leaseID,
+			OutPoint: wire.OutPoint{Hash: tx.TxHash(), Index: 0},
+			Duration: time.Minute,
+		},
+	)
+	require.NoError(t, err)
+
+	corruptUtxoOutputIndex(t, store, walletID, tx.TxHash(), 0, -1)
+
+	_, err = store.ListLeasedOutputs(t.Context(), walletID)
+	require.ErrorContains(t, err, "lease output index")
+}
+
+// TestGetUtxoAndLeaseRejectLargeOutputIndex verifies backend-specific handling
+// for outpoint indexes that exceed the supported SQL integer range.
+func TestGetUtxoAndLeaseRejectLargeOutputIndex(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-large-output-index")
+	outPoint := wire.OutPoint{Hash: RandomHash(), Index: ^uint32(0)}
+
+	_, err := store.GetUtxo(
+		t.Context(),
+		db.GetUtxoQuery{
+			WalletID: walletID,
+			OutPoint: outPoint,
+		},
+	)
+
+	_, leaseErr := store.LeaseOutput(
+		t.Context(),
+		db.LeaseOutputParams{
+			WalletID: walletID,
+			ID:       RandomHash(),
+			OutPoint: outPoint,
+			Duration: time.Minute,
+		},
+	)
+
+	releaseErr := store.ReleaseOutput(
+		t.Context(),
+		db.ReleaseOutputParams{
+			WalletID: walletID,
+			ID:       RandomHash(),
+			OutPoint: outPoint,
+		},
+	)
+
+	if _, ok := any(store).(*db.PostgresStore); ok {
+		require.ErrorContains(t, err, "convert output index")
+		require.ErrorContains(t, leaseErr, "convert output index")
+		require.ErrorContains(t, releaseErr, "could not cast")
+		return
+	}
+
+	require.ErrorIs(t, err, db.ErrUtxoNotFound)
+	require.ErrorIs(t, leaseErr, db.ErrUtxoNotFound)
+	require.ErrorIs(t, releaseErr, db.ErrUtxoNotFound)
+}
+
+// TestUtxoReadsReturnQueryErrorsWhenClosed verifies that UTXO read methods wrap
+// backend query errors when the underlying connection is closed.
+func TestUtxoReadsReturnQueryErrorsWhenClosed(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-closed-utxo-reads")
+	err := store.Close()
+	require.NoError(t, err)
+
+	_, err = store.GetUtxo(
+		t.Context(),
+		db.GetUtxoQuery{
+			WalletID: walletID,
+			OutPoint: wire.OutPoint{Hash: RandomHash(), Index: 0},
+		},
+	)
+	require.ErrorContains(t, err, "get utxo")
+
+	_, err = store.ListUTXOs(
+		t.Context(),
+		db.ListUtxosQuery{WalletID: walletID},
+	)
+	require.ErrorContains(t, err, "list utxos")
+
+	_, err = store.ListLeasedOutputs(t.Context(), walletID)
+	require.ErrorContains(t, err, "list active utxo leases")
+
+	_, err = store.Balance(
+		t.Context(),
+		db.BalanceParams{WalletID: walletID},
+	)
+	require.ErrorContains(t, err, "balance")
+}

--- a/wallet/internal/db/mock_test.go
+++ b/wallet/internal/db/mock_test.go
@@ -1,0 +1,13 @@
+package db
+
+import (
+	"errors"
+	"fmt"
+)
+
+var errMockType = errors.New("mock arg type")
+
+// mockTypeError wraps the shared mock type sentinel with call-site context.
+func mockTypeError(detail string) error {
+	return fmt.Errorf("%w: %s", errMockType, detail)
+}

--- a/wallet/internal/db/tx_store_backend_error_test.go
+++ b/wallet/internal/db/tx_store_backend_error_test.go
@@ -1,0 +1,114 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
+	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
+	"github.com/stretchr/testify/require"
+)
+
+var errDummy = errors.New("dummy")
+
+// errorDBTX forces sqlc exec/query calls down their wrapped error paths.
+type errorDBTX struct {
+	execErr  error
+	queryErr error
+}
+
+// ExecContext implements the sqlc DBTX interface.
+func (e errorDBTX) ExecContext(context.Context, string,
+	...interface{}) (sql.Result, error) {
+
+	return nil, e.execErr
+}
+
+// PrepareContext implements the sqlc DBTX interface.
+func (e errorDBTX) PrepareContext(context.Context,
+	string) (*sql.Stmt, error) {
+
+	return nil, errDummy
+}
+
+// QueryContext implements the sqlc DBTX interface.
+func (e errorDBTX) QueryContext(context.Context, string,
+	...interface{}) (*sql.Rows, error) {
+
+	return nil, e.queryErr
+}
+
+// QueryRowContext implements the sqlc DBTX interface.
+func (e errorDBTX) QueryRowContext(context.Context, string,
+	...interface{}) *sql.Row {
+
+	return &sql.Row{}
+}
+
+// TestPgDeleteAndRollbackOpsWrapBackendErrors verifies that the postgres delete
+// and rollback adapters preserve their step-specific error context when sqlc
+// exec and query calls fail.
+func TestPgDeleteAndRollbackOpsWrapBackendErrors(t *testing.T) {
+	t.Parallel()
+
+	qtx := sqlcpg.New(errorDBTX{
+		execErr:  errDummy,
+		queryErr: errDummy,
+	})
+	deleteOps := pgDeleteTxOps{qtx: qtx}
+	rollbackOps := pgRollbackToBlockOps{qtx: qtx}
+
+	err := deleteOps.clearSpentUtxos(t.Context(), 1, 2)
+	require.ErrorContains(t, err, "clear spent utxo rows")
+
+	err = deleteOps.deleteCreatedUtxos(t.Context(), 1, 2)
+	require.ErrorContains(t, err, "delete created utxo rows")
+
+	_, err = deleteOps.deleteUnminedTransaction(
+		t.Context(), 1, chainhash.Hash{1},
+	)
+	require.ErrorContains(t, err, "delete unmined tx row")
+
+	_, err = rollbackOps.listUnminedTxRecords(t.Context(), 1)
+	require.ErrorContains(t, err, "list unmined txns")
+
+	err = rollbackOps.clearDescendantSpends(t.Context(), 1, 2)
+	require.ErrorContains(t, err, "clear descendant spends")
+
+	err = rollbackOps.markDescendantsFailed(t.Context(), 1, []int64{2})
+	require.ErrorContains(t, err, "mark descendants failed")
+}
+
+// TestSqliteDeleteAndRollbackOpsWrapBackendErrors verifies that the sqlite
+// delete and rollback adapters preserve their step-specific error context when
+// sqlc exec and query calls fail.
+func TestSqliteDeleteAndRollbackOpsWrapBackendErrors(t *testing.T) {
+	t.Parallel()
+
+	qtx := sqlcsqlite.New(errorDBTX{execErr: errDummy, queryErr: errDummy})
+	deleteOps := sqliteDeleteTxOps{qtx: qtx}
+	rollbackOps := sqliteRollbackToBlockOps{qtx: qtx}
+
+	err := deleteOps.clearSpentUtxos(t.Context(), 1, 2)
+	require.ErrorContains(t, err, "clear spent utxo rows")
+
+	err = deleteOps.deleteCreatedUtxos(t.Context(), 1, 2)
+	require.ErrorContains(t, err, "delete created utxo rows")
+
+	_, err = deleteOps.deleteUnminedTransaction(
+		t.Context(), 1, chainhash.Hash{1},
+	)
+	require.ErrorContains(t, err, "delete unmined tx row")
+
+	_, err = rollbackOps.listUnminedTxRecords(t.Context(), 1)
+	require.ErrorContains(t, err, "list unmined txns")
+
+	err = rollbackOps.clearDescendantSpends(t.Context(), 1, 2)
+	require.ErrorContains(t, err, "clear descendant spends")
+
+	err = rollbackOps.markDescendantsFailed(t.Context(), 1, []int64{2})
+	require.ErrorContains(t, err, "mark descendants failed")
+}

--- a/wallet/internal/db/tx_store_backend_error_test.go
+++ b/wallet/internal/db/tx_store_backend_error_test.go
@@ -317,14 +317,16 @@ func TestPgBackendHelpersRejectOverflow(t *testing.T) {
 	}}, map[int64]struct{}{1: {}})
 	require.ErrorContains(t, err, "tx hash")
 
-	_, err = (&pgLeaseOutputOps{}).acquire(t.Context(), LeaseOutputParams{
+	leaseOps := &pgLeaseOutputOps{}
+
+	_, err = leaseOps.acquire(t.Context(), LeaseOutputParams{
 		WalletID: 1,
 		OutPoint: wire.OutPoint{Hash: chainhash.Hash{1}, Index: ^uint32(0)},
 		ID:       [32]byte{1},
 	}, time.Now(), time.Now().Add(time.Minute))
 	require.ErrorContains(t, err, "convert output index")
 
-	_, err = (&pgLeaseOutputOps{}).hasUtxo(t.Context(), LeaseOutputParams{
+	_, err = leaseOps.hasUtxo(t.Context(), LeaseOutputParams{
 		WalletID: 1,
 		OutPoint: wire.OutPoint{Hash: chainhash.Hash{1}, Index: ^uint32(0)},
 		ID:       [32]byte{1},

--- a/wallet/internal/db/tx_store_backend_error_test.go
+++ b/wallet/internal/db/tx_store_backend_error_test.go
@@ -5,8 +5,10 @@ import (
 	"database/sql"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
 	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
 	"github.com/stretchr/testify/require"
@@ -111,4 +113,221 @@ func TestSqliteDeleteAndRollbackOpsWrapBackendErrors(t *testing.T) {
 
 	err = rollbackOps.markDescendantsFailed(t.Context(), 1, []int64{2})
 	require.ErrorContains(t, err, "mark descendants failed")
+}
+
+// TestPgTxStoreOpsWrapBackendErrors verifies that the postgres tx-store helper
+// adapters preserve step-specific error context for create, invalidate,
+// rollback, update, and release workflows.
+func TestPgTxStoreOpsWrapBackendErrors(t *testing.T) {
+	t.Parallel()
+
+	qtx := sqlcpg.New(errorDBTX{execErr: errDummy, queryErr: errDummy})
+	createOps := &pgCreateTxOps{
+		pgInvalidateUnminedTxOps: pgInvalidateUnminedTxOps{qtx: qtx},
+	}
+	invalidateOps := pgInvalidateUnminedTxOps{qtx: qtx}
+	rollbackOps := pgRollbackToBlockOps{qtx: qtx}
+	updateOps := &pgUpdateTxOps{qtx: qtx}
+	releaseOps := pgReleaseOutputOps{qtx: qtx}
+
+	err := createOps.markTxnsReplaced(
+		t.Context(), 1, []int64{2},
+	)
+	require.ErrorContains(t, err, "mark txns replaced")
+
+	err = createOps.insertReplacementEdges(
+		t.Context(), 1, []int64{2}, 3,
+	)
+	require.ErrorContains(t, err, "insert replacement edge")
+
+	err = markInputsSpentPg(t.Context(), qtx, CreateTxParams{
+		WalletID: 1,
+		Tx:       testRegularMsgTx(),
+		Received: time.Unix(1, 0),
+		Status:   TxStatusPending,
+	}, 7)
+	require.ErrorContains(t, err, "mark spent input 0")
+
+	_, err = invalidateOps.listUnminedTxRecords(t.Context(), 1)
+	require.ErrorContains(t, err, "list unmined txns")
+
+	err = invalidateOps.clearSpentUtxos(t.Context(), 1, 2)
+	require.ErrorContains(t, err, "clear spent utxos")
+
+	err = invalidateOps.markTxnsFailed(t.Context(), 1, []int64{2})
+	require.ErrorContains(t, err, "mark txns failed")
+
+	_, err = rollbackOps.listRollbackRootHashes(t.Context(), 1)
+	require.ErrorContains(t, err, "query rollback coinbase roots")
+
+	err = rollbackOps.rewindWalletSyncStateHeights(t.Context(), 1)
+	require.ErrorContains(t, err, "rewind wallet sync state heights query")
+
+	err = rollbackOps.deleteBlocksAtOrAboveHeight(t.Context(), 1)
+	require.ErrorContains(t, err, "delete blocks at or above height query")
+
+	err = rollbackOps.markTxRootsOrphaned(
+		t.Context(), 1, []chainhash.Hash{{1}},
+	)
+	require.ErrorContains(t, err, "update rollback coinbase state query")
+
+	updateOps.blockHeight = sql.NullInt32{}
+	updateOps.status = int16(TxStatusPublished)
+	err = updateOps.updateState(t.Context(), 1, chainhash.Hash{1},
+		UpdateTxState{Status: TxStatusPublished})
+	require.ErrorContains(t, err, "update tx state query")
+
+	err = updateOps.updateLabel(t.Context(), 1, chainhash.Hash{1}, "note")
+	require.ErrorContains(t, err, "update tx label query")
+
+	_, err = releaseOps.release(t.Context(), 1, 2, [32]byte{1})
+	require.ErrorContains(t, err, "release lease row")
+}
+
+// TestSqliteTxStoreOpsWrapBackendErrors verifies that the sqlite tx-store
+// helper adapters preserve step-specific error context for create, invalidate,
+// rollback, update, and release workflows.
+func TestSqliteTxStoreOpsWrapBackendErrors(t *testing.T) {
+	t.Parallel()
+
+	qtx := sqlcsqlite.New(errorDBTX{execErr: errDummy, queryErr: errDummy})
+	createOps := &sqliteCreateTxOps{
+		sqliteInvalidateUnminedTxOps: sqliteInvalidateUnminedTxOps{
+			qtx: qtx,
+		},
+	}
+	invalidateOps := sqliteInvalidateUnminedTxOps{qtx: qtx}
+	rollbackOps := sqliteRollbackToBlockOps{qtx: qtx}
+	updateOps := &sqliteUpdateTxOps{qtx: qtx}
+	releaseOps := sqliteReleaseOutputOps{qtx: qtx}
+
+	err := createOps.markTxnsReplaced(
+		t.Context(), 1, []int64{2},
+	)
+	require.ErrorContains(t, err, "mark txns replaced")
+
+	err = createOps.insertReplacementEdges(
+		t.Context(), 1, []int64{2}, 3,
+	)
+	require.ErrorContains(t, err, "insert replacement edge")
+
+	err = markInputsSpentSqlite(t.Context(), qtx, CreateTxParams{
+		WalletID: 1,
+		Tx:       testRegularMsgTx(),
+		Received: time.Unix(1, 0),
+		Status:   TxStatusPending,
+	}, 7)
+	require.ErrorContains(t, err, "mark spent input 0")
+
+	_, err = invalidateOps.listUnminedTxRecords(t.Context(), 1)
+	require.ErrorContains(t, err, "list unmined txns")
+
+	err = invalidateOps.clearSpentUtxos(t.Context(), 1, 2)
+	require.ErrorContains(t, err, "clear spent utxos")
+
+	err = invalidateOps.markTxnsFailed(t.Context(), 1, []int64{2})
+	require.ErrorContains(t, err, "mark txns failed")
+
+	_, err = rollbackOps.listRollbackRootHashes(t.Context(), 1)
+	require.ErrorContains(t, err, "query rollback coinbase roots")
+
+	err = rollbackOps.rewindWalletSyncStateHeights(t.Context(), 1)
+	require.ErrorContains(t, err, "rewind wallet sync state heights query")
+
+	err = rollbackOps.deleteBlocksAtOrAboveHeight(t.Context(), 1)
+	require.ErrorContains(t, err, "delete blocks at or above height query")
+
+	err = rollbackOps.markTxRootsOrphaned(
+		t.Context(), 1, []chainhash.Hash{{1}},
+	)
+	require.ErrorContains(t, err, "update rollback coinbase state query")
+
+	updateOps.blockHeight = sql.NullInt64{}
+	updateOps.status = int64(TxStatusPublished)
+	err = updateOps.updateState(t.Context(), 1, chainhash.Hash{1},
+		UpdateTxState{Status: TxStatusPublished})
+	require.ErrorContains(t, err, "update tx state query")
+
+	err = updateOps.updateLabel(t.Context(), 1, chainhash.Hash{1}, "note")
+	require.ErrorContains(t, err, "update tx label query")
+
+	_, err = releaseOps.release(t.Context(), 1, 2, [32]byte{1})
+	require.ErrorContains(t, err, "release lease row")
+}
+
+// TestPgBackendHelpersRejectOverflow verifies the remaining postgres helper
+// branches that fail before issuing any SQL query.
+func TestPgBackendHelpersRejectOverflow(t *testing.T) {
+	t.Parallel()
+
+	req, err := newCreateTxRequest(CreateTxParams{
+		WalletID: 1,
+		Tx: &wire.MsgTx{
+			Version: wire.TxVersion,
+			TxIn: []*wire.TxIn{{
+				PreviousOutPoint: wire.OutPoint{
+					Hash:  chainhash.Hash{1},
+					Index: ^uint32(0),
+				},
+			}},
+			TxOut: []*wire.TxOut{{Value: 1, PkScript: []byte{0x51}}},
+		},
+		Received: time.Unix(1, 0),
+		Status:   TxStatusPending,
+	})
+	require.NoError(t, err)
+
+	_, err = collectPgConflictRootIDs(
+		t.Context(), nil, req,
+	)
+	require.ErrorContains(t, err, "convert input outpoint index 0")
+
+	_, err = creditExistsPg(t.Context(), nil, 1, chainhash.Hash{1}, ^uint32(0))
+	require.ErrorContains(t, err, "convert credit index")
+
+	err = markInputsSpentPg(t.Context(), nil, CreateTxParams{
+		WalletID: 1,
+		Tx: &wire.MsgTx{
+			Version: wire.TxVersion,
+			TxIn: []*wire.TxIn{{
+				PreviousOutPoint: wire.OutPoint{
+					Hash:  chainhash.Hash{1},
+					Index: ^uint32(0),
+				},
+			}},
+		},
+		Status: TxStatusPending,
+	}, 3)
+	require.ErrorContains(t, err, "convert input outpoint index 0")
+
+	err = pgRollbackToBlockOps{}.rewindWalletSyncStateHeights(
+		t.Context(), ^uint32(0),
+	)
+	require.ErrorContains(t, err, "convert rollback height")
+
+	err = pgRollbackToBlockOps{}.deleteBlocksAtOrAboveHeight(
+		t.Context(), ^uint32(0),
+	)
+	require.ErrorContains(t, err, "convert rollback height")
+
+	_, _, err = buildPgConflictRoots([]sqlcpg.ListUnminedTransactionsRow{{
+		ID:       1,
+		TxHash:   []byte{1},
+		TxStatus: 0,
+	}}, map[int64]struct{}{1: {}})
+	require.ErrorContains(t, err, "tx hash")
+
+	_, err = (&pgLeaseOutputOps{}).acquire(t.Context(), LeaseOutputParams{
+		WalletID: 1,
+		OutPoint: wire.OutPoint{Hash: chainhash.Hash{1}, Index: ^uint32(0)},
+		ID:       [32]byte{1},
+	}, time.Now(), time.Now().Add(time.Minute))
+	require.ErrorContains(t, err, "convert output index")
+
+	_, err = (&pgLeaseOutputOps{}).hasUtxo(t.Context(), LeaseOutputParams{
+		WalletID: 1,
+		OutPoint: wire.OutPoint{Hash: chainhash.Hash{1}, Index: ^uint32(0)},
+		ID:       [32]byte{1},
+	})
+	require.ErrorContains(t, err, "convert output index")
 }

--- a/wallet/internal/db/tx_store_backend_rows_test.go
+++ b/wallet/internal/db/tx_store_backend_rows_test.go
@@ -1,0 +1,215 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	sqlcpg "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/postgres"
+	sqlcsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlc/sqlite"
+	"github.com/stretchr/testify/require"
+)
+
+// staticResult is a minimal sql.Result stub with a caller-controlled row count.
+type staticResult struct {
+	rows int64
+}
+
+// LastInsertId implements sql.Result.
+func (r staticResult) LastInsertId() (int64, error) {
+	return 0, nil
+}
+
+// RowsAffected implements sql.Result.
+func (r staticResult) RowsAffected() (int64, error) {
+	return r.rows, nil
+}
+
+// rowDBTX is a sqlc DBTX stub that lets tests mix fixed exec counts with
+// query-row scan failures from a temporary sqlite handle.
+type rowDBTX struct {
+	row      *sql.Row
+	queryErr error
+	execErr  error
+	rows     int64
+}
+
+// ExecContext implements the sqlc DBTX interface.
+func (r rowDBTX) ExecContext(context.Context, string,
+	...interface{}) (sql.Result, error) {
+
+	if r.execErr != nil {
+		return nil, r.execErr
+	}
+
+	return staticResult{rows: r.rows}, nil
+}
+
+// PrepareContext implements the sqlc DBTX interface.
+func (r rowDBTX) PrepareContext(context.Context, string) (*sql.Stmt, error) {
+	return nil, errDummy
+}
+
+// QueryContext implements the sqlc DBTX interface.
+func (r rowDBTX) QueryContext(context.Context, string,
+	...interface{}) (*sql.Rows, error) {
+
+	return nil, r.queryErr
+}
+
+// QueryRowContext implements the sqlc DBTX interface.
+func (r rowDBTX) QueryRowContext(context.Context, string,
+	...interface{}) *sql.Row {
+
+	if r.row != nil {
+		return r.row
+	}
+
+	return &sql.Row{}
+}
+
+// newSQLiteRow creates a query row backed by an in-memory sqlite database so
+// sqlc scan paths can fail without standing up a real store.
+func newSQLiteRow(t *testing.T, query string, args ...interface{}) *sql.Row {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	return db.QueryRowContext(t.Context(), query, args...)
+}
+
+// TestPgCreateTxOpsAdditionalBranches covers remaining postgres CreateTx helper
+// branches that are hard to reach through public integration tests alone.
+func TestPgCreateTxOpsAdditionalBranches(t *testing.T) {
+	t.Parallel()
+
+	req := testCreateTxRequest(t)
+	ctx := context.Background()
+
+	_, err := (&pgCreateTxOps{
+		pgInvalidateUnminedTxOps: pgInvalidateUnminedTxOps{
+			qtx: sqlcpg.New(rowDBTX{
+				row: newSQLiteRow(t, "SELECT * FROM missing_table"),
+			}),
+		},
+	}).loadExisting(ctx, req)
+	require.ErrorContains(t, err, "get tx metadata")
+
+	block := &Block{
+		Hash:      chainhash.Hash{3},
+		Height:    7,
+		Timestamp: time.Unix(77, 0),
+	}
+	err = (&pgCreateTxOps{
+		pgInvalidateUnminedTxOps: pgInvalidateUnminedTxOps{
+			qtx: sqlcpg.New(rowDBTX{
+				row: newSQLiteRow(
+					t, "SELECT ?, ?, ?",
+					int64(block.Height), block.Hash[:],
+					block.Timestamp.Unix(),
+				),
+				rows: 0,
+			}),
+		},
+	}).confirmExisting(ctx, createTxRequest{
+		params: CreateTxParams{WalletID: 1, Block: block},
+		txHash: chainhash.Hash{9},
+	}, createTxExistingTarget{})
+	require.ErrorIs(t, err, ErrTxNotFound)
+
+	_, _, err = (&pgCreateTxOps{
+		pgInvalidateUnminedTxOps: pgInvalidateUnminedTxOps{
+			qtx: sqlcpg.New(rowDBTX{
+				row:      newSQLiteRow(t, "SELECT ?", int64(5)),
+				queryErr: errDummy,
+			}),
+		},
+	}).listConflictTxns(ctx, req)
+	require.ErrorContains(t, err, "list unmined txns")
+}
+
+// TestSqliteCreateTxOpsAdditionalBranches covers remaining sqlite CreateTx
+// helper branches that are hard to reach through public integration tests
+// alone.
+func TestSqliteCreateTxOpsAdditionalBranches(t *testing.T) {
+	t.Parallel()
+
+	req := testCreateTxRequest(t)
+	ctx := context.Background()
+
+	_, err := (&sqliteCreateTxOps{
+		sqliteInvalidateUnminedTxOps: sqliteInvalidateUnminedTxOps{
+			qtx: sqlcsqlite.New(rowDBTX{
+				row: newSQLiteRow(t, "SELECT * FROM missing_table"),
+			}),
+		},
+	}).loadExisting(ctx, req)
+	require.ErrorContains(t, err, "get tx metadata")
+
+	block := &Block{
+		Hash:      chainhash.Hash{4},
+		Height:    8,
+		Timestamp: time.Unix(88, 0),
+	}
+	err = (&sqliteCreateTxOps{
+		sqliteInvalidateUnminedTxOps: sqliteInvalidateUnminedTxOps{
+			qtx: sqlcsqlite.New(rowDBTX{
+				row: newSQLiteRow(
+					t, "SELECT ?, ?, ?",
+					int64(block.Height), block.Hash[:],
+					block.Timestamp.Unix(),
+				),
+				rows: 0,
+			}),
+		},
+	}).confirmExisting(ctx, createTxRequest{
+		params: CreateTxParams{WalletID: 1, Block: block},
+		txHash: chainhash.Hash{9},
+	}, createTxExistingTarget{})
+	require.ErrorIs(t, err, ErrTxNotFound)
+
+	err = (&sqliteCreateTxOps{
+		sqliteInvalidateUnminedTxOps: sqliteInvalidateUnminedTxOps{
+			qtx: sqlcsqlite.New(rowDBTX{
+				row: newSQLiteRow(t, "SELECT * FROM missing_table"),
+			}),
+		},
+	}).prepareBlock(ctx, createTxRequest{
+		params: CreateTxParams{WalletID: 1, Block: block},
+	})
+	require.ErrorContains(t, err, "get block by height")
+
+	_, _, err = (&sqliteCreateTxOps{
+		sqliteInvalidateUnminedTxOps: sqliteInvalidateUnminedTxOps{
+			qtx: sqlcsqlite.New(rowDBTX{
+				row:      newSQLiteRow(t, "SELECT ?", int64(5)),
+				queryErr: errDummy,
+			}),
+		},
+	}).listConflictTxns(ctx, req)
+	require.ErrorContains(t, err, "list unmined txns")
+}
+
+// TestSqliteReleaseOutputOpsAdditionalBranches covers the remaining sqlite
+// release-helper query-row error wrappers.
+func TestSqliteReleaseOutputOpsAdditionalBranches(t *testing.T) {
+	t.Parallel()
+
+	ops := &sqliteReleaseOutputOps{qtx: sqlcsqlite.New(rowDBTX{
+		row: newSQLiteRow(t, "SELECT * FROM missing_table"),
+	})}
+
+	_, err := ops.lookupUtxoID(context.Background(), ReleaseOutputParams{
+		WalletID: 1,
+		OutPoint: wire.OutPoint{Hash: chainhash.Hash{1}, Index: 0},
+	})
+	require.ErrorContains(t, err, "lookup utxo row")
+
+	_, err = ops.activeLockID(context.Background(), 1, 2, time.Now())
+	require.ErrorContains(t, err, "lookup active lease row")
+}

--- a/wallet/internal/db/tx_store_backend_rows_test.go
+++ b/wallet/internal/db/tx_store_backend_rows_test.go
@@ -78,7 +78,9 @@ func newSQLiteRow(t *testing.T, query string, args ...interface{}) *sql.Row {
 
 	db, err := sql.Open("sqlite", ":memory:")
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = db.Close() })
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
 
 	return db.QueryRowContext(t.Context(), query, args...)
 }
@@ -90,14 +92,15 @@ func TestPgCreateTxOpsAdditionalBranches(t *testing.T) {
 
 	req := testCreateTxRequest(t)
 	ctx := context.Background()
-
-	_, err := (&pgCreateTxOps{
+	loadOps := &pgCreateTxOps{
 		pgInvalidateUnminedTxOps: pgInvalidateUnminedTxOps{
 			qtx: sqlcpg.New(rowDBTX{
 				row: newSQLiteRow(t, "SELECT * FROM missing_table"),
 			}),
 		},
-	}).loadExisting(ctx, req)
+	}
+
+	_, err := loadOps.loadExisting(ctx, req)
 	require.ErrorContains(t, err, "get tx metadata")
 
 	block := &Block{
@@ -105,7 +108,7 @@ func TestPgCreateTxOpsAdditionalBranches(t *testing.T) {
 		Height:    7,
 		Timestamp: time.Unix(77, 0),
 	}
-	err = (&pgCreateTxOps{
+	confirmOps := &pgCreateTxOps{
 		pgInvalidateUnminedTxOps: pgInvalidateUnminedTxOps{
 			qtx: sqlcpg.New(rowDBTX{
 				row: newSQLiteRow(
@@ -116,20 +119,22 @@ func TestPgCreateTxOpsAdditionalBranches(t *testing.T) {
 				rows: 0,
 			}),
 		},
-	}).confirmExisting(ctx, createTxRequest{
+	}
+	err = confirmOps.confirmExisting(ctx, createTxRequest{
 		params: CreateTxParams{WalletID: 1, Block: block},
 		txHash: chainhash.Hash{9},
 	}, createTxExistingTarget{})
 	require.ErrorIs(t, err, ErrTxNotFound)
 
-	_, _, err = (&pgCreateTxOps{
+	conflictOps := &pgCreateTxOps{
 		pgInvalidateUnminedTxOps: pgInvalidateUnminedTxOps{
 			qtx: sqlcpg.New(rowDBTX{
 				row:      newSQLiteRow(t, "SELECT ?", int64(5)),
 				queryErr: errDummy,
 			}),
 		},
-	}).listConflictTxns(ctx, req)
+	}
+	_, _, err = conflictOps.listConflictTxns(ctx, req)
 	require.ErrorContains(t, err, "list unmined txns")
 }
 
@@ -141,14 +146,15 @@ func TestSqliteCreateTxOpsAdditionalBranches(t *testing.T) {
 
 	req := testCreateTxRequest(t)
 	ctx := context.Background()
-
-	_, err := (&sqliteCreateTxOps{
+	loadOps := &sqliteCreateTxOps{
 		sqliteInvalidateUnminedTxOps: sqliteInvalidateUnminedTxOps{
 			qtx: sqlcsqlite.New(rowDBTX{
 				row: newSQLiteRow(t, "SELECT * FROM missing_table"),
 			}),
 		},
-	}).loadExisting(ctx, req)
+	}
+
+	_, err := loadOps.loadExisting(ctx, req)
 	require.ErrorContains(t, err, "get tx metadata")
 
 	block := &Block{
@@ -156,7 +162,7 @@ func TestSqliteCreateTxOpsAdditionalBranches(t *testing.T) {
 		Height:    8,
 		Timestamp: time.Unix(88, 0),
 	}
-	err = (&sqliteCreateTxOps{
+	confirmOps := &sqliteCreateTxOps{
 		sqliteInvalidateUnminedTxOps: sqliteInvalidateUnminedTxOps{
 			qtx: sqlcsqlite.New(rowDBTX{
 				row: newSQLiteRow(
@@ -167,31 +173,34 @@ func TestSqliteCreateTxOpsAdditionalBranches(t *testing.T) {
 				rows: 0,
 			}),
 		},
-	}).confirmExisting(ctx, createTxRequest{
+	}
+	err = confirmOps.confirmExisting(ctx, createTxRequest{
 		params: CreateTxParams{WalletID: 1, Block: block},
 		txHash: chainhash.Hash{9},
 	}, createTxExistingTarget{})
 	require.ErrorIs(t, err, ErrTxNotFound)
 
-	err = (&sqliteCreateTxOps{
+	prepareOps := &sqliteCreateTxOps{
 		sqliteInvalidateUnminedTxOps: sqliteInvalidateUnminedTxOps{
 			qtx: sqlcsqlite.New(rowDBTX{
 				row: newSQLiteRow(t, "SELECT * FROM missing_table"),
 			}),
 		},
-	}).prepareBlock(ctx, createTxRequest{
+	}
+	err = prepareOps.prepareBlock(ctx, createTxRequest{
 		params: CreateTxParams{WalletID: 1, Block: block},
 	})
 	require.ErrorContains(t, err, "get block by height")
 
-	_, _, err = (&sqliteCreateTxOps{
+	conflictOps := &sqliteCreateTxOps{
 		sqliteInvalidateUnminedTxOps: sqliteInvalidateUnminedTxOps{
 			qtx: sqlcsqlite.New(rowDBTX{
 				row:      newSQLiteRow(t, "SELECT ?", int64(5)),
 				queryErr: errDummy,
 			}),
 		},
-	}).listConflictTxns(ctx, req)
+	}
+	_, _, err = conflictOps.listConflictTxns(ctx, req)
 	require.ErrorContains(t, err, "list unmined txns")
 }
 
@@ -212,4 +221,64 @@ func TestSqliteReleaseOutputOpsAdditionalBranches(t *testing.T) {
 
 	_, err = ops.activeLockID(context.Background(), 1, 2, time.Now())
 	require.ErrorContains(t, err, "lookup active lease row")
+}
+
+// TestPgUpdateTxOpsAdditionalBranches covers the remaining postgres UpdateTx
+// helper branches that are hard to reach through public integration tests
+// alone.
+func TestPgUpdateTxOpsAdditionalBranches(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	txHash := chainhash.Hash{9}
+	loadOps := &pgUpdateTxOps{qtx: sqlcpg.New(rowDBTX{
+		row: newSQLiteRow(t, "SELECT * FROM missing_table"),
+	})}
+	stateOps := &pgUpdateTxOps{
+		qtx:         sqlcpg.New(rowDBTX{rows: 0}),
+		blockHeight: sql.NullInt32{},
+		status:      int16(TxStatusPublished),
+	}
+	labelOps := &pgUpdateTxOps{qtx: sqlcpg.New(rowDBTX{rows: 0})}
+
+	_, err := loadOps.loadIsCoinbase(ctx, 1, txHash)
+	require.ErrorContains(t, err, "get tx metadata")
+
+	err = stateOps.updateState(ctx, 1, txHash, UpdateTxState{
+		Status: TxStatusPublished,
+	})
+	require.ErrorIs(t, err, ErrTxNotFound)
+
+	err = labelOps.updateLabel(ctx, 1, txHash, "note")
+	require.ErrorIs(t, err, ErrTxNotFound)
+}
+
+// TestSqliteUpdateTxOpsAdditionalBranches covers the remaining sqlite UpdateTx
+// helper branches that are hard to reach through public integration tests
+// alone.
+func TestSqliteUpdateTxOpsAdditionalBranches(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	txHash := chainhash.Hash{9}
+	loadOps := &sqliteUpdateTxOps{qtx: sqlcsqlite.New(rowDBTX{
+		row: newSQLiteRow(t, "SELECT * FROM missing_table"),
+	})}
+	stateOps := &sqliteUpdateTxOps{
+		qtx:         sqlcsqlite.New(rowDBTX{rows: 0}),
+		blockHeight: sql.NullInt64{},
+		status:      int64(TxStatusPublished),
+	}
+	labelOps := &sqliteUpdateTxOps{qtx: sqlcsqlite.New(rowDBTX{rows: 0})}
+
+	_, err := loadOps.loadIsCoinbase(ctx, 1, txHash)
+	require.ErrorContains(t, err, "get tx metadata")
+
+	err = stateOps.updateState(ctx, 1, txHash, UpdateTxState{
+		Status: TxStatusPublished,
+	})
+	require.ErrorIs(t, err, ErrTxNotFound)
+
+	err = labelOps.updateLabel(ctx, 1, txHash, "note")
+	require.ErrorIs(t, err, ErrTxNotFound)
 }

--- a/wallet/internal/db/tx_store_common_test.go
+++ b/wallet/internal/db/tx_store_common_test.go
@@ -365,7 +365,9 @@ func TestCreateTxWithOpsInsert(t *testing.T) {
 	)
 
 	ops := &mockCreateTxOps{}
-	t.Cleanup(func() { ops.AssertExpectations(t) })
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
 
 	ops.On("loadExisting", mock.Anything, req).Return(
 		nil, errCreateTxExistingNotFound).Once()
@@ -413,7 +415,9 @@ func TestCreateTxWithOpsDuplicate(t *testing.T) {
 
 	req := testCreateTxRequest(t)
 	ops := &mockCreateTxOps{}
-	t.Cleanup(func() { ops.AssertExpectations(t) })
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
 
 	ops.On("loadExisting", mock.Anything, req).Return(
 		&createTxExistingTarget{id: 4}, nil).Once()
@@ -444,7 +448,9 @@ func TestCreateTxWithOpsConfirmExisting(t *testing.T) {
 		hasBlock: false,
 	}
 	ops := &mockCreateTxOps{}
-	t.Cleanup(func() { ops.AssertExpectations(t) })
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
 
 	ops.On("loadExisting", mock.Anything, req).Return(&existing, nil).Once()
 
@@ -473,7 +479,9 @@ func TestCreateTxWithOpsReplaceConflicts(t *testing.T) {
 	rootIDs := []int64{5}
 	rootHashes := []chainhash.Hash{{9}}
 	ops := &mockCreateTxOps{}
-	t.Cleanup(func() { ops.AssertExpectations(t) })
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
 
 	ops.On("loadExisting", mock.Anything, req).Return(
 		nil, errCreateTxExistingNotFound).Once()
@@ -791,7 +799,9 @@ func TestCollectConflictDescendants(t *testing.T) {
 		}}},
 	}}
 	ops := &mockCreateTxOps{}
-	t.Cleanup(func() { ops.AssertExpectations(t) })
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
 
 	rootIDs := []int64{11, 12}
 	rootHashes := []chainhash.Hash{{1}, {2}}
@@ -838,7 +848,9 @@ func TestHandleTxConflicts(t *testing.T) {
 	}}
 
 	ops := &mockCreateTxOps{}
-	t.Cleanup(func() { ops.AssertExpectations(t) })
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
 
 	ops.On("listConflictTxns", mock.Anything, req).Return(
 		[]int64{1}, []chainhash.Hash{rootHash}, nil,
@@ -888,7 +900,9 @@ func TestHandleTxConflictsKeepsDirectRootsReplaced(t *testing.T) {
 	require.NoError(t, err)
 
 	ops := &mockCreateTxOps{}
-	t.Cleanup(func() { ops.AssertExpectations(t) })
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
 
 	ops.On("listConflictTxns", mock.Anything, req).Return(
 		[]int64{1, 2},
@@ -915,8 +929,8 @@ func TestHandleTxConflictsKeepsDirectRootsReplaced(t *testing.T) {
 		Once()
 	ops.On("clearSpentUtxos", mock.Anything, int64(7), int64(2)).Return(nil).
 		Once()
-	ops.On("markTxnsReplaced", mock.Anything, int64(7), []int64{1, 2}).Return(nil).
-		Once()
+	ops.On("markTxnsReplaced", mock.Anything, int64(7), []int64{1, 2}).
+		Return(nil).Once()
 	ops.On("insertReplacementEdges", mock.Anything, int64(7), []int64{1, 2},
 		int64(9)).Return(nil).Once()
 	ops.On("clearSpentUtxos", mock.Anything, int64(7), int64(3)).Return(nil).
@@ -943,7 +957,9 @@ func TestHandleTxConflictsNoDescendants(t *testing.T) {
 	require.NoError(t, err)
 
 	ops := &mockCreateTxOps{}
-	t.Cleanup(func() { ops.AssertExpectations(t) })
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
 
 	ops.On("listConflictTxns", mock.Anything, req).Return(
 		[]int64{1}, []chainhash.Hash{{1}}, nil,
@@ -978,7 +994,9 @@ func TestHandleTxConflictsMarkFailedError(t *testing.T) {
 	require.NoError(t, err)
 
 	ops := &mockCreateTxOps{}
-	t.Cleanup(func() { ops.AssertExpectations(t) })
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
 
 	ops.On("listConflictTxns", mock.Anything, req).Return(
 		[]int64{1}, []chainhash.Hash{{1}}, nil,
@@ -1034,7 +1052,9 @@ func TestUpdateTxWithOpsLabelAndState(t *testing.T) {
 	)
 
 	ops := &mockUpdateTxOps{}
-	t.Cleanup(func() { ops.AssertExpectations(t) })
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
 
 	ops.On("loadIsCoinbase", mock.Anything, uint32(5), chainhash.Hash{1}).
 		Return(false, nil).Once()
@@ -1078,10 +1098,12 @@ func TestUpdateTxWithOpsEmptyPatch(t *testing.T) {
 		Txid:     chainhash.Hash{1},
 	}
 	ops := &mockUpdateTxOps{}
-	t.Cleanup(func() { ops.AssertExpectations(t) })
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
 
-	ops.On("loadIsCoinbase", mock.Anything, uint32(5), chainhash.Hash{1}).Return(
-		false, nil).Once()
+	ops.On("loadIsCoinbase", mock.Anything, uint32(5), chainhash.Hash{1}).
+		Return(false, nil).Once()
 
 	err := updateTxWithOps(context.Background(), params, ops)
 	require.ErrorIs(t, err, ErrInvalidParam)
@@ -1142,10 +1164,13 @@ func TestUpdateTxWithOpsRejectsInvalidatingStates(t *testing.T) {
 				State:    &test.state,
 			}
 			ops := &mockUpdateTxOps{}
-			t.Cleanup(func() { ops.AssertExpectations(t) })
+			t.Cleanup(func() {
+				ops.AssertExpectations(t)
+			})
 
-			ops.On("loadIsCoinbase", mock.Anything, uint32(5), chainhash.Hash{1}).
-				Return(test.isCoinbase, nil).Once()
+			ops.On(
+				"loadIsCoinbase", mock.Anything, uint32(5), chainhash.Hash{1},
+			).Return(test.isCoinbase, nil).Once()
 
 			err := updateTxWithOps(context.Background(), params, ops)
 			require.ErrorIs(t, err, ErrInvalidParam)

--- a/wallet/internal/db/tx_store_common_test.go
+++ b/wallet/internal/db/tx_store_common_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -319,28 +320,55 @@ func TestNewCreateTxRequest(t *testing.T) {
 func TestCreateTxWithOpsInsert(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Build one prepared CreateTx request and one stub adapter.
+	// Arrange: Build one prepared CreateTx request and one mock adapter.
 	req := testCreateTxRequest(t)
-	ops := &stubCreateTxOps{insertTxID: 11}
+
+	var (
+		insertReq createTxRequest
+		creditsID int64
+		inputsID  int64
+	)
+
+	ops := &mockCreateTxOps{}
+	t.Cleanup(func() { ops.AssertExpectations(t) })
+
+	ops.On("loadExisting", mock.Anything, req).Return(
+		nil, errCreateTxExistingNotFound).Once()
+
+	ops.On("prepareBlock", mock.Anything, req).Return(nil).Once()
+
+	ops.On("insert", mock.Anything, req).Return(int64(11), nil).Run(
+		func(args mock.Arguments) {
+			reqArg, ok := args.Get(1).(createTxRequest)
+			require.True(t, ok)
+			insertReq = reqArg
+		},
+	).Once()
+
+	ops.On("insertCredits", mock.Anything, req, int64(11)).Return(nil).Run(
+		func(args mock.Arguments) {
+			txID, ok := args.Get(2).(int64)
+			require.True(t, ok)
+			creditsID = txID
+		},
+	).Once()
+
+	ops.On("markInputsSpent", mock.Anything, req, int64(11)).Return(nil).Run(
+		func(args mock.Arguments) {
+			txID, ok := args.Get(2).(int64)
+			require.True(t, ok)
+			inputsID = txID
+		},
+	).Once()
 
 	// Act: Run createTxWithOps.
 	err := createTxWithOps(context.Background(), req, ops)
 	require.NoError(t, err)
 
-	// Assert: The shared flow executes the expected write sequence.
-	require.Equal(t,
-		[]string{
-			"load-existing",
-			"prepare-block",
-			"insert",
-			"credits",
-			"inputs",
-		},
-		ops.calls,
-	)
-	require.Equal(t, int64(11), ops.creditsTxID)
-	require.Equal(t, int64(11), ops.inputsTxID)
-	require.Equal(t, req.txHash, ops.insertReq.txHash)
+	// Assert: The shared flow uses the inserted tx ID consistently.
+	require.Equal(t, int64(11), creditsID)
+	require.Equal(t, int64(11), inputsID)
+	require.Equal(t, req.txHash, insertReq.txHash)
 }
 
 // TestCreateTxWithOpsDuplicate verifies that the shared CreateTx helper maps an
@@ -349,11 +377,14 @@ func TestCreateTxWithOpsDuplicate(t *testing.T) {
 	t.Parallel()
 
 	req := testCreateTxRequest(t)
-	ops := &stubCreateTxOps{existing: &createTxExistingTarget{id: 4}}
+	ops := &mockCreateTxOps{}
+	t.Cleanup(func() { ops.AssertExpectations(t) })
+
+	ops.On("loadExisting", mock.Anything, req).Return(
+		&createTxExistingTarget{id: 4}, nil).Once()
 
 	err := createTxWithOps(context.Background(), req, ops)
 	require.ErrorIs(t, err, ErrTxAlreadyExists)
-	require.Equal(t, []string{"load-existing"}, ops.calls)
 }
 
 // TestCreateTxWithOpsConfirmExisting verifies that the shared CreateTx flow can
@@ -372,15 +403,20 @@ func TestCreateTxWithOpsConfirmExisting(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ops := &stubCreateTxOps{existing: &createTxExistingTarget{
+	existing := createTxExistingTarget{
 		id:       7,
 		status:   TxStatusPending,
 		hasBlock: false,
-	}}
+	}
+	ops := &mockCreateTxOps{}
+	t.Cleanup(func() { ops.AssertExpectations(t) })
+
+	ops.On("loadExisting", mock.Anything, req).Return(&existing, nil).Once()
+
+	ops.On("confirmExisting", mock.Anything, req, existing).Return(nil).Once()
 
 	err = createTxWithOps(context.Background(), req, ops)
 	require.NoError(t, err)
-	require.Equal(t, []string{"load-existing", "confirm-existing"}, ops.calls)
 }
 
 // TestCreateTxWithOpsReplaceConflicts verifies that the shared CreateTx flow
@@ -399,27 +435,40 @@ func TestCreateTxWithOpsReplaceConflicts(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ops := &stubCreateTxOps{
-		insertTxID:     11,
-		conflictIDs:    []int64{5},
-		conflictHashes: []chainhash.Hash{{9}},
-	}
+	rootIDs := []int64{5}
+	rootHashes := []chainhash.Hash{{9}}
+	ops := &mockCreateTxOps{}
+	t.Cleanup(func() { ops.AssertExpectations(t) })
+
+	ops.On("loadExisting", mock.Anything, req).Return(
+		nil, errCreateTxExistingNotFound).Once()
+
+	ops.On("prepareBlock", mock.Anything, req).Return(nil).Once()
+
+	ops.On("insert", mock.Anything, req).Return(int64(11), nil).Once()
+
+	ops.On("listConflictTxns", mock.Anything, req).Return(
+		rootIDs, rootHashes, nil,
+	).Once()
+
+	ops.On("listUnminedTxRecords", mock.Anything, int64(5)).Return(
+		[]unminedTxRecord(nil), nil).Once()
+
+	ops.On("clearSpentUtxos", mock.Anything, int64(5), int64(5)).Return(nil).
+		Once()
+
+	ops.On("markTxnsReplaced", mock.Anything, int64(5), []int64{5}).Return(nil).
+		Once()
+
+	ops.On("insertReplacementEdges", mock.Anything, int64(5), []int64{5},
+		int64(11)).Return(nil).Once()
+
+	ops.On("insertCredits", mock.Anything, req, int64(11)).Return(nil).Once()
+
+	ops.On("markInputsSpent", mock.Anything, req, int64(11)).Return(nil).Once()
 
 	err = createTxWithOps(context.Background(), req, ops)
 	require.NoError(t, err)
-	require.Equal(t, []string{
-		"load-existing",
-		"prepare-block",
-		"insert",
-		"list-conflicts",
-		"list-unmined-records",
-		"clear-spent-utxos",
-		"mark-txns-replaced",
-		"insert-replacement-edges",
-		"credits",
-		"inputs",
-	}, ops.calls)
-	require.Equal(t, int64(11), ops.replacedConflictTxID)
 }
 
 // testBlock builds a simple block fixture for CreateTx validation tests.
@@ -452,183 +501,221 @@ func testCoinbaseMsgTx() *wire.MsgTx {
 	return tx
 }
 
-// stubCreateTxOps records how the shared CreateTx helper drives one backend
-// adapter while letting each test control the returned transaction IDs.
-type stubCreateTxOps struct {
-	existing       *createTxExistingTarget
-	insertTxID     int64
-	conflictIDs    []int64
-	conflictHashes []chainhash.Hash
-	unminedTxns    []unminedTxRecord
-
-	listConflictsErr error
-	listUnminedErr   error
-	clearSpentErr    error
-	markFailedErr    error
-
-	calls                []string
-	insertReq            createTxRequest
-	creditsTxID          int64
-	inputsTxID           int64
-	clearedTxIDs         []int64
-	replacedTxIDs        []int64
-	failedTxIDs          []int64
-	replacementEdgeTxIDs []int64
-	replacedConflictTxID int64
+// mockCreateTxOps is a mock implementation of createTxOps.
+type mockCreateTxOps struct {
+	mock.Mock
 }
 
-var _ createTxOps = (*stubCreateTxOps)(nil)
+var _ createTxOps = (*mockCreateTxOps)(nil)
 
-// loadExisting records that the shared flow checked whether the tx hash already
-// exists and returns the test-controlled result.
-func (s *stubCreateTxOps) loadExisting(_ context.Context,
-	_ createTxRequest) (*createTxExistingTarget, error) {
+// loadExisting implements createTxOps.
+func (m *mockCreateTxOps) loadExisting(ctx context.Context,
+	req createTxRequest) (*createTxExistingTarget, error) {
 
-	s.calls = append(s.calls, "load-existing")
-
-	return s.existing, nil
-}
-
-// confirmExisting records that the shared flow promoted one existing row.
-func (s *stubCreateTxOps) confirmExisting(_ context.Context,
-	_ createTxRequest,
-	_ createTxExistingTarget) error {
-
-	s.calls = append(s.calls, "confirm-existing")
-
-	return nil
-}
-
-// prepareBlock records that the shared flow validated any optional block
-// assignment before insert.
-func (s *stubCreateTxOps) prepareBlock(_ context.Context,
-	_ createTxRequest) error {
-
-	s.calls = append(s.calls, "prepare-block")
-
-	return nil
-}
-
-// listConflictTxns records that the shared flow checked for direct wallet-owned
-// conflicts after insert and before input claims.
-func (s *stubCreateTxOps) listConflictTxns(_ context.Context,
-	_ createTxRequest) ([]int64, []chainhash.Hash, error) {
-
-	s.calls = append(s.calls, "list-conflicts")
-
-	if s.listConflictsErr != nil {
-		return nil, nil, s.listConflictsErr
+	args := m.Called(ctx, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
 	}
 
-	return s.conflictIDs, s.conflictHashes, nil
-}
-
-// loadInvalidateTarget satisfies the embedded invalidateUnminedTxOps interface
-// for the shared CreateTx orchestration tests.
-func (s *stubCreateTxOps) loadInvalidateTarget(_ context.Context, _ uint32,
-	_ chainhash.Hash) (invalidateUnminedTxTarget, error) {
-
-	return invalidateUnminedTxTarget{}, nil
-}
-
-// listUnminedTxRecords satisfies the embedded invalidateUnminedTxOps interface
-// for the shared CreateTx orchestration tests.
-func (s *stubCreateTxOps) listUnminedTxRecords(_ context.Context,
-	_ int64) ([]unminedTxRecord, error) {
-
-	s.calls = append(s.calls, "list-unmined-records")
-
-	if s.listUnminedErr != nil {
-		return nil, s.listUnminedErr
+	existing, ok := args.Get(0).(*createTxExistingTarget)
+	if !ok {
+		return nil, mockTypeError("loadExisting result")
 	}
 
-	return s.unminedTxns, nil
+	return existing, args.Error(1)
 }
 
-// clearSpentUtxos satisfies the embedded invalidateUnminedTxOps interface for
-// the shared CreateTx orchestration tests.
-func (s *stubCreateTxOps) clearSpentUtxos(_ context.Context, _ int64,
+// confirmExisting implements createTxOps.
+func (m *mockCreateTxOps) confirmExisting(ctx context.Context,
+	req createTxRequest, existing createTxExistingTarget) error {
+
+	args := m.Called(ctx, req, existing)
+
+	return args.Error(0)
+}
+
+// prepareBlock implements createTxOps.
+func (m *mockCreateTxOps) prepareBlock(ctx context.Context,
+	req createTxRequest) error {
+
+	args := m.Called(ctx, req)
+
+	return args.Error(0)
+}
+
+// listConflictTxns implements createTxOps.
+func (m *mockCreateTxOps) listConflictTxns(ctx context.Context,
+	req createTxRequest) ([]int64, []chainhash.Hash, error) {
+
+	args := m.Called(ctx, req)
+	if args.Get(0) == nil {
+		return nil, nil, args.Error(2)
+	}
+
+	txIDs, ok := args.Get(0).([]int64)
+	if !ok {
+		return nil, nil, mockTypeError("listConflictTxns ids")
+	}
+
+	hashes, ok := args.Get(1).([]chainhash.Hash)
+	if !ok {
+		return nil, nil, mockTypeError("listConflictTxns hashes")
+	}
+
+	return txIDs, hashes, args.Error(2)
+}
+
+// loadInvalidateTarget implements invalidateUnminedTxOps.
+func (m *mockCreateTxOps) loadInvalidateTarget(ctx context.Context,
+	walletID uint32,
+	txHash chainhash.Hash) (invalidateUnminedTxTarget, error) {
+
+	var zeroTarget invalidateUnminedTxTarget
+
+	args := m.Called(ctx, walletID, txHash)
+	if args.Get(0) == nil {
+		return zeroTarget, args.Error(1)
+	}
+
+	target, ok := args.Get(0).(invalidateUnminedTxTarget)
+	if !ok {
+		return zeroTarget, mockTypeError("loadInvalidateTarget result")
+	}
+
+	return target, args.Error(1)
+}
+
+// listUnminedTxRecords implements invalidateUnminedTxOps.
+func (m *mockCreateTxOps) listUnminedTxRecords(ctx context.Context,
+	walletID int64) ([]unminedTxRecord, error) {
+
+	args := m.Called(ctx, walletID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	records, ok := args.Get(0).([]unminedTxRecord)
+	if !ok {
+		return nil, mockTypeError("listUnminedTxRecords result")
+	}
+
+	return records, args.Error(1)
+}
+
+// clearSpentUtxos implements invalidateUnminedTxOps.
+func (m *mockCreateTxOps) clearSpentUtxos(ctx context.Context, walletID int64,
 	txID int64) error {
 
-	s.calls = append(s.calls, "clear-spent-utxos")
-	s.clearedTxIDs = append(s.clearedTxIDs, txID)
+	args := m.Called(ctx, walletID, txID)
 
-	if s.clearSpentErr != nil {
-		return s.clearSpentErr
-	}
-
-	return nil
+	return args.Error(0)
 }
 
-// markTxnsFailed satisfies the embedded invalidateUnminedTxOps interface for
-// the shared CreateTx orchestration tests.
-func (s *stubCreateTxOps) markTxnsFailed(_ context.Context, _ int64,
+// markTxnsFailed implements invalidateUnminedTxOps.
+func (m *mockCreateTxOps) markTxnsFailed(ctx context.Context, walletID int64,
 	txIDs []int64) error {
 
-	s.calls = append(s.calls, "mark-txns-failed")
-	s.failedTxIDs = append([]int64(nil), txIDs...)
+	args := m.Called(ctx, walletID, txIDs)
 
-	if s.markFailedErr != nil {
-		return s.markFailedErr
-	}
-
-	return nil
+	return args.Error(0)
 }
 
-// markTxnsReplaced satisfies the replacement hooks CreateTx uses for direct
-// conflict reconciliation.
-func (s *stubCreateTxOps) markTxnsReplaced(_ context.Context, _ int64,
+// markTxnsReplaced implements createTxOps.
+func (m *mockCreateTxOps) markTxnsReplaced(ctx context.Context, walletID int64,
 	txIDs []int64) error {
 
-	s.calls = append(s.calls, "mark-txns-replaced")
-	s.replacedTxIDs = append([]int64(nil), txIDs...)
+	args := m.Called(ctx, walletID, txIDs)
 
-	return nil
+	return args.Error(0)
 }
 
-// insertReplacementEdges satisfies the replacement hooks CreateTx uses for
-// direct conflict reconciliation.
-func (s *stubCreateTxOps) insertReplacementEdges(_ context.Context, _ int64,
-	replacedTxIDs []int64, replacementTxID int64) error {
+// insertReplacementEdges implements createTxOps.
+func (m *mockCreateTxOps) insertReplacementEdges(ctx context.Context,
+	walletID int64, replacedTxIDs []int64, replacementTxID int64) error {
 
-	s.calls = append(s.calls, "insert-replacement-edges")
-	s.replacementEdgeTxIDs = append([]int64(nil), replacedTxIDs...)
-	s.replacedConflictTxID = replacementTxID
+	args := m.Called(ctx, walletID, replacedTxIDs, replacementTxID)
 
-	return nil
+	return args.Error(0)
 }
 
-// insert records the request that the shared flow would store as a fresh
-// transaction row.
-func (s *stubCreateTxOps) insert(_ context.Context,
+// insert implements createTxOps.
+func (m *mockCreateTxOps) insert(ctx context.Context,
 	req createTxRequest) (int64, error) {
 
-	s.calls = append(s.calls, "insert")
-	s.insertReq = req
+	args := m.Called(ctx, req)
 
-	return s.insertTxID, nil
+	txID, ok := args.Get(0).(int64)
+	if !ok {
+		return 0, mockTypeError("insert result")
+	}
+
+	return txID, args.Error(1)
 }
 
-// insertCredits records the transaction ID the shared flow used when
-// reconciling wallet-owned outputs.
-func (s *stubCreateTxOps) insertCredits(_ context.Context,
-	_ createTxRequest, txID int64) error {
+// insertCredits implements createTxOps.
+func (m *mockCreateTxOps) insertCredits(ctx context.Context,
+	req createTxRequest, txID int64) error {
 
-	s.calls = append(s.calls, "credits")
-	s.creditsTxID = txID
+	args := m.Called(ctx, req, txID)
 
-	return nil
+	return args.Error(0)
 }
 
-// markInputsSpent records the transaction ID the shared flow used when
-// attaching wallet-owned spent inputs.
-func (s *stubCreateTxOps) markInputsSpent(_ context.Context,
-	_ createTxRequest, txID int64) error {
+// markInputsSpent implements createTxOps.
+func (m *mockCreateTxOps) markInputsSpent(ctx context.Context,
+	req createTxRequest, txID int64) error {
 
-	s.calls = append(s.calls, "inputs")
-	s.inputsTxID = txID
+	args := m.Called(ctx, req, txID)
 
-	return nil
+	return args.Error(0)
+}
+
+// mockUpdateTxOps is a mock implementation of updateTxOps.
+type mockUpdateTxOps struct {
+	mock.Mock
+}
+
+var _ updateTxOps = (*mockUpdateTxOps)(nil)
+
+// loadIsCoinbase implements updateTxOps.
+func (m *mockUpdateTxOps) loadIsCoinbase(ctx context.Context, walletID uint32,
+	txHash chainhash.Hash) (bool, error) {
+
+	args := m.Called(ctx, walletID, txHash)
+
+	isCoinbase, ok := args.Get(0).(bool)
+	if !ok {
+		return false, mockTypeError("loadIsCoinbase result")
+	}
+
+	return isCoinbase, args.Error(1)
+}
+
+// prepareState implements updateTxOps.
+func (m *mockUpdateTxOps) prepareState(ctx context.Context,
+	state UpdateTxState) error {
+
+	args := m.Called(ctx, state)
+
+	return args.Error(0)
+}
+
+// updateLabel implements updateTxOps.
+func (m *mockUpdateTxOps) updateLabel(ctx context.Context, walletID uint32,
+	txHash chainhash.Hash, label string) error {
+
+	args := m.Called(ctx, walletID, txHash, label)
+
+	return args.Error(0)
+}
+
+// updateState implements updateTxOps.
+func (m *mockUpdateTxOps) updateState(ctx context.Context, walletID uint32,
+	txHash chainhash.Hash, state UpdateTxState) error {
+
+	args := m.Called(ctx, walletID, txHash, state)
+
+	return args.Error(0)
 }
 
 // testCreateTxRequest builds one valid normalized CreateTx request for the
@@ -668,17 +755,20 @@ func TestCollectConflictDescendants(t *testing.T) {
 			PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{2}, Index: 0},
 		}}},
 	}}
-	ops := &stubCreateTxOps{unminedTxns: candidates}
+	ops := &mockCreateTxOps{}
+	t.Cleanup(func() { ops.AssertExpectations(t) })
 
 	rootIDs := []int64{11, 12}
 	rootHashes := []chainhash.Hash{{1}, {2}}
+
+	ops.On("listUnminedTxRecords", mock.Anything, int64(7)).Return(
+		candidates, nil).Once()
 
 	descendantIDs, err := collectConflictDescendants(
 		context.Background(), 7, rootHashes, rootIDs, ops,
 	)
 	require.NoError(t, err)
 	require.Equal(t, []int64{13}, descendantIDs)
-	require.Equal(t, []string{"list-unmined-records"}, ops.calls)
 }
 
 // TestHandleTxConflicts verifies the shared replacement flow for
@@ -712,29 +802,36 @@ func TestHandleTxConflicts(t *testing.T) {
 		}}},
 	}}
 
-	ops := &stubCreateTxOps{
-		conflictIDs:    []int64{1},
-		conflictHashes: []chainhash.Hash{rootHash},
-		unminedTxns:    candidates,
-	}
+	ops := &mockCreateTxOps{}
+	t.Cleanup(func() { ops.AssertExpectations(t) })
+
+	ops.On("listConflictTxns", mock.Anything, req).Return(
+		[]int64{1}, []chainhash.Hash{rootHash}, nil,
+	).Once()
+
+	ops.On("listUnminedTxRecords", mock.Anything, int64(7)).Return(
+		candidates, nil).Once()
+
+	ops.On("clearSpentUtxos", mock.Anything, int64(7), int64(1)).Return(nil).
+		Once()
+
+	ops.On("markTxnsReplaced", mock.Anything, int64(7), []int64{1}).Return(nil).
+		Once()
+
+	ops.On("insertReplacementEdges", mock.Anything, int64(7), []int64{1},
+		int64(9)).Return(nil).Once()
+
+	ops.On("clearSpentUtxos", mock.Anything, int64(7), int64(2)).Return(nil).
+		Once()
+
+	ops.On("clearSpentUtxos", mock.Anything, int64(7), int64(3)).Return(nil).
+		Once()
+
+	ops.On("markTxnsFailed", mock.Anything, int64(7), []int64{2, 3}).
+		Return(nil).Once()
 
 	err = handleTxConflicts(t.Context(), req, 9, ops)
 	require.NoError(t, err)
-	require.Equal(t, []string{
-		"list-conflicts",
-		"list-unmined-records",
-		"clear-spent-utxos",
-		"mark-txns-replaced",
-		"insert-replacement-edges",
-		"clear-spent-utxos",
-		"clear-spent-utxos",
-		"mark-txns-failed",
-	}, ops.calls)
-	require.Equal(t, []int64{1, 2, 3}, ops.clearedTxIDs)
-	require.Equal(t, []int64{1}, ops.replacedTxIDs)
-	require.Equal(t, []int64{2, 3}, ops.failedTxIDs)
-	require.Equal(t, []int64{1}, ops.replacementEdgeTxIDs)
-	require.Equal(t, int64(9), ops.replacedConflictTxID)
 }
 
 // TestHandleTxConflictsKeepsDirectRootsReplaced verifies that a
@@ -755,10 +852,17 @@ func TestHandleTxConflictsKeepsDirectRootsReplaced(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ops := &stubCreateTxOps{
-		conflictIDs:    []int64{1, 2},
-		conflictHashes: []chainhash.Hash{rootAHash, rootBHash},
-		unminedTxns: []unminedTxRecord{{
+	ops := &mockCreateTxOps{}
+	t.Cleanup(func() { ops.AssertExpectations(t) })
+
+	ops.On("listConflictTxns", mock.Anything, req).Return(
+		[]int64{1, 2},
+		[]chainhash.Hash{rootAHash, rootBHash},
+		nil,
+	).Once()
+
+	ops.On("listUnminedTxRecords", mock.Anything, int64(7)).Return(
+		[]unminedTxRecord{{
 			id:   2,
 			hash: rootBHash,
 			tx: &wire.MsgTx{TxIn: []*wire.TxIn{{
@@ -770,25 +874,23 @@ func TestHandleTxConflictsKeepsDirectRootsReplaced(t *testing.T) {
 			tx: &wire.MsgTx{TxIn: []*wire.TxIn{{
 				PreviousOutPoint: wire.OutPoint{Hash: rootBHash, Index: 0},
 			}}},
-		}},
-	}
+		}}, nil).Once()
+
+	ops.On("clearSpentUtxos", mock.Anything, int64(7), int64(1)).Return(nil).
+		Once()
+	ops.On("clearSpentUtxos", mock.Anything, int64(7), int64(2)).Return(nil).
+		Once()
+	ops.On("markTxnsReplaced", mock.Anything, int64(7), []int64{1, 2}).Return(nil).
+		Once()
+	ops.On("insertReplacementEdges", mock.Anything, int64(7), []int64{1, 2},
+		int64(9)).Return(nil).Once()
+	ops.On("clearSpentUtxos", mock.Anything, int64(7), int64(3)).Return(nil).
+		Once()
+	ops.On("markTxnsFailed", mock.Anything, int64(7), []int64{3}).Return(nil).
+		Once()
 
 	err = handleTxConflicts(t.Context(), req, 9, ops)
 	require.NoError(t, err)
-	require.Equal(t, []string{
-		"list-conflicts",
-		"list-unmined-records",
-		"clear-spent-utxos",
-		"clear-spent-utxos",
-		"mark-txns-replaced",
-		"insert-replacement-edges",
-		"clear-spent-utxos",
-		"mark-txns-failed",
-	}, ops.calls)
-	require.Equal(t, []int64{1, 2, 3}, ops.clearedTxIDs)
-	require.Equal(t, []int64{1, 2}, ops.replacedTxIDs)
-	require.Equal(t, []int64{3}, ops.failedTxIDs)
-	require.Equal(t, []int64{1, 2}, ops.replacementEdgeTxIDs)
 }
 
 // TestHandleTxConflictsNoDescendants verifies that the helper
@@ -805,25 +907,25 @@ func TestHandleTxConflictsNoDescendants(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ops := &stubCreateTxOps{
-		conflictIDs:    []int64{1},
-		conflictHashes: []chainhash.Hash{{1}},
-	}
+	ops := &mockCreateTxOps{}
+	t.Cleanup(func() { ops.AssertExpectations(t) })
+
+	ops.On("listConflictTxns", mock.Anything, req).Return(
+		[]int64{1}, []chainhash.Hash{{1}}, nil,
+	).Once()
+
+	ops.On("listUnminedTxRecords", mock.Anything, int64(7)).Return(
+		[]unminedTxRecord(nil), nil).Once()
+
+	ops.On("clearSpentUtxos", mock.Anything, int64(7), int64(1)).Return(nil).
+		Once()
+	ops.On("markTxnsReplaced", mock.Anything, int64(7), []int64{1}).Return(nil).
+		Once()
+	ops.On("insertReplacementEdges", mock.Anything, int64(7), []int64{1},
+		int64(9)).Return(nil).Once()
 
 	err = handleTxConflicts(t.Context(), req, 9, ops)
 	require.NoError(t, err)
-	require.Equal(t, []string{
-		"list-conflicts",
-		"list-unmined-records",
-		"clear-spent-utxos",
-		"mark-txns-replaced",
-		"insert-replacement-edges",
-	}, ops.calls)
-	require.Equal(t, []int64{1}, ops.clearedTxIDs)
-	require.Equal(t, []int64{1}, ops.replacedTxIDs)
-	require.Empty(t, ops.failedTxIDs)
-	require.Equal(t, []int64{1}, ops.replacementEdgeTxIDs)
-	require.Equal(t, int64(9), ops.replacedConflictTxID)
 }
 
 // TestHandleTxConflictsMarkFailedError verifies that the helper records
@@ -840,10 +942,15 @@ func TestHandleTxConflictsMarkFailedError(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ops := &stubCreateTxOps{
-		conflictIDs:    []int64{1},
-		conflictHashes: []chainhash.Hash{{1}},
-		unminedTxns: []unminedTxRecord{{
+	ops := &mockCreateTxOps{}
+	t.Cleanup(func() { ops.AssertExpectations(t) })
+
+	ops.On("listConflictTxns", mock.Anything, req).Return(
+		[]int64{1}, []chainhash.Hash{{1}}, nil,
+	).Once()
+
+	ops.On("listUnminedTxRecords", mock.Anything, int64(7)).Return(
+		[]unminedTxRecord{{
 			id:   2,
 			hash: chainhash.Hash{2},
 			tx: &wire.MsgTx{TxIn: []*wire.TxIn{{
@@ -852,22 +959,22 @@ func TestHandleTxConflictsMarkFailedError(t *testing.T) {
 					Index: 0,
 				},
 			}}},
-		}},
-		markFailedErr: errConflictMarkFailed,
-	}
+		}}, nil).Once()
+
+	ops.On("clearSpentUtxos", mock.Anything, int64(7), int64(1)).Return(nil).
+		Once()
+	ops.On("markTxnsReplaced", mock.Anything, int64(7), []int64{1}).Return(nil).
+		Once()
+	ops.On("insertReplacementEdges", mock.Anything, int64(7), []int64{1},
+		int64(9)).Return(nil).Once()
+	ops.On("clearSpentUtxos", mock.Anything, int64(7), int64(2)).Return(nil).
+		Once()
+	ops.On("markTxnsFailed", mock.Anything, int64(7), []int64{2}).Return(
+		errConflictMarkFailed).Once()
 
 	err = handleTxConflicts(t.Context(), req, 9, ops)
 	require.ErrorIs(t, err, errConflictMarkFailed)
 	require.ErrorContains(t, err, "mark conflict descendants failed")
-	require.Equal(t, []string{
-		"list-conflicts",
-		"list-unmined-records",
-		"clear-spent-utxos",
-		"mark-txns-replaced",
-		"insert-replacement-edges",
-		"clear-spent-utxos",
-		"mark-txns-failed",
-	}, ops.calls)
 }
 
 // TestUpdateTxWithOpsLabelAndState verifies that the shared UpdateTx workflow
@@ -885,19 +992,45 @@ func TestUpdateTxWithOpsLabelAndState(t *testing.T) {
 			Status: TxStatusPublished,
 		},
 	}
-	ops := &stubUpdateTxOps{isCoinbase: false}
+
+	var (
+		updatedLabel string
+		updatedState UpdateTxState
+	)
+
+	ops := &mockUpdateTxOps{}
+	t.Cleanup(func() { ops.AssertExpectations(t) })
+
+	ops.On("loadIsCoinbase", mock.Anything, uint32(5), chainhash.Hash{1}).
+		Return(false, nil).Once()
+
+	ops.On("prepareState", mock.Anything, UpdateTxState{
+		Status: TxStatusPublished,
+	}).Return(nil).Once()
+
+	ops.On("updateLabel", mock.Anything, uint32(5), chainhash.Hash{1},
+		label).Return(nil).Run(func(args mock.Arguments) {
+		labelArg, ok := args.Get(3).(string)
+		require.True(t, ok)
+		updatedLabel = labelArg
+	}).Once()
+
+	ops.On("updateState", mock.Anything, uint32(5), chainhash.Hash{1},
+		UpdateTxState{Status: TxStatusPublished}).Return(nil).Run(
+		func(args mock.Arguments) {
+			stateArg, ok := args.Get(3).(UpdateTxState)
+			require.True(t, ok)
+			updatedState = stateArg
+		},
+	).Once()
 
 	// Act: Run updateTxWithOps against a stub backend adapter.
 	err := updateTxWithOps(context.Background(), params, ops)
 	require.NoError(t, err)
 
-	// Assert: The shared flow loads, prepares, and applies both patches.
-	require.Equal(t,
-		[]string{"load", "prepare-state", "label", "state"},
-		ops.calls,
-	)
-	require.Equal(t, label, ops.updatedLabel)
-	require.Equal(t, TxStatusPublished, ops.updatedState.Status)
+	// Assert: The shared flow applies both patches.
+	require.Equal(t, label, updatedLabel)
+	require.Equal(t, TxStatusPublished, updatedState.Status)
 }
 
 // TestUpdateTxWithOpsEmptyPatch verifies that the shared UpdateTx helper
@@ -909,11 +1042,14 @@ func TestUpdateTxWithOpsEmptyPatch(t *testing.T) {
 		WalletID: 5,
 		Txid:     chainhash.Hash{1},
 	}
-	ops := &stubUpdateTxOps{isCoinbase: false}
+	ops := &mockUpdateTxOps{}
+	t.Cleanup(func() { ops.AssertExpectations(t) })
+
+	ops.On("loadIsCoinbase", mock.Anything, uint32(5), chainhash.Hash{1}).Return(
+		false, nil).Once()
 
 	err := updateTxWithOps(context.Background(), params, ops)
 	require.ErrorIs(t, err, ErrInvalidParam)
-	require.Equal(t, []string{"load"}, ops.calls)
 }
 
 // TestUpdateTxWithOpsRejectsInvalidatingStates verifies that UpdateTx rejects
@@ -970,65 +1106,15 @@ func TestUpdateTxWithOpsRejectsInvalidatingStates(t *testing.T) {
 				Txid:     chainhash.Hash{1},
 				State:    &test.state,
 			}
-			ops := &stubUpdateTxOps{isCoinbase: test.isCoinbase}
+			ops := &mockUpdateTxOps{}
+			t.Cleanup(func() { ops.AssertExpectations(t) })
+
+			ops.On("loadIsCoinbase", mock.Anything, uint32(5), chainhash.Hash{1}).
+				Return(test.isCoinbase, nil).Once()
 
 			err := updateTxWithOps(context.Background(), params, ops)
 			require.ErrorIs(t, err, ErrInvalidParam)
 			require.ErrorIs(t, err, ErrInvalidStatus)
-			require.Equal(t, []string{"load"}, ops.calls)
 		})
 	}
-}
-
-// stubUpdateTxOps records how the shared UpdateTx helper drives one backend
-// adapter while letting tests control the loaded metadata.
-type stubUpdateTxOps struct {
-	isCoinbase   bool
-	calls        []string
-	updatedLabel string
-	updatedState UpdateTxState
-}
-
-var _ updateTxOps = (*stubUpdateTxOps)(nil)
-
-// loadIsCoinbase records that the shared flow loaded the existing transaction
-// row metadata.
-func (s *stubUpdateTxOps) loadIsCoinbase(_ context.Context, _ uint32,
-	_ chainhash.Hash) (bool, error) {
-
-	s.calls = append(s.calls, "load")
-
-	return s.isCoinbase, nil
-}
-
-// prepareState records that the shared flow validated and prepared one state
-// patch before applying it.
-func (s *stubUpdateTxOps) prepareState(_ context.Context,
-	_ UpdateTxState) error {
-
-	s.calls = append(s.calls, "prepare-state")
-
-	return nil
-}
-
-// updateLabel records the label value the shared flow asked the backend to
-// write.
-func (s *stubUpdateTxOps) updateLabel(_ context.Context, _ uint32,
-	_ chainhash.Hash, label string) error {
-
-	s.calls = append(s.calls, "label")
-	s.updatedLabel = label
-
-	return nil
-}
-
-// updateState records the state patch the shared flow asked the backend to
-// write.
-func (s *stubUpdateTxOps) updateState(_ context.Context, _ uint32,
-	_ chainhash.Hash, state UpdateTxState) error {
-
-	s.calls = append(s.calls, "state")
-	s.updatedState = state
-
-	return nil
 }

--- a/wallet/internal/db/tx_store_common_test.go
+++ b/wallet/internal/db/tx_store_common_test.go
@@ -80,6 +80,41 @@ func TestParseTxStatus(t *testing.T) {
 	}
 }
 
+// TestParseTxStatusNegativeValue verifies that parseTxStatus rejects negative
+// stored values before they can map into the public TxStatus enum.
+func TestParseTxStatusNegativeValue(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseTxStatus(-1)
+	require.ErrorIs(t, err, ErrInvalidStatus)
+}
+
+// TestIsUnminedStatus verifies the delete-specific classification for each
+// tx status.
+func TestIsUnminedStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status TxStatus
+		want   bool
+	}{
+		{name: "pending", status: TxStatusPending, want: true},
+		{name: "published", status: TxStatusPublished, want: true},
+		{name: "replaced", status: TxStatusReplaced, want: false},
+		{name: "failed", status: TxStatusFailed, want: false},
+		{name: "orphaned", status: TxStatusOrphaned, want: false},
+		{name: "unknown", status: TxStatus(99), want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, test.want, isUnminedStatus(test.status))
+		})
+	}
+}
+
 // TestBuildTxInfo verifies the shared row-to-domain conversion used by both
 // SQL backends when returning a valid TxInfo value.
 func TestBuildTxInfo(t *testing.T) {

--- a/wallet/internal/db/tx_store_common_test.go
+++ b/wallet/internal/db/tx_store_common_test.go
@@ -1153,3 +1153,309 @@ func TestUpdateTxWithOpsRejectsInvalidatingStates(t *testing.T) {
 		})
 	}
 }
+
+var errCreateTxTest = errors.New("create tx test")
+
+// TestCheckReuseCreateTx verifies the shared reuse decision for existing rows.
+func TestCheckReuseCreateTx(t *testing.T) {
+	t.Parallel()
+
+	coinbaseReq, err := newCreateTxRequest(CreateTxParams{
+		WalletID: 9,
+		Tx:       testCoinbaseMsgTx(),
+		Received: time.Unix(555, 0),
+		Block:    testBlock(22),
+		Status:   TxStatusPublished,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	confirmedReq, err := newCreateTxRequest(CreateTxParams{
+		WalletID: 9,
+		Tx:       testRegularMsgTx(),
+		Received: time.Unix(556, 0),
+		Block:    testBlock(23),
+		Status:   TxStatusPublished,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		req      createTxRequest
+		existing createTxExistingTarget
+		want     bool
+	}{
+		{
+			name: "confirmed unmined row reused",
+			req:  confirmedReq,
+			existing: createTxExistingTarget{
+				status: TxStatusPending,
+			},
+			want: true,
+		},
+		{
+			name: "missing block not reused",
+			req:  testCreateTxRequest(t),
+			existing: createTxExistingTarget{
+				status: TxStatusPending,
+			},
+		},
+		{
+			name: "existing confirmed row not reused",
+			req:  confirmedReq,
+			existing: createTxExistingTarget{
+				status:   TxStatusPublished,
+				hasBlock: true,
+			},
+		},
+		{
+			name: "non coinbase orphan not reused",
+			req:  confirmedReq,
+			existing: createTxExistingTarget{
+				status: TxStatusOrphaned,
+			},
+		},
+		{
+			name: "orphaned coinbase reused",
+			req:  coinbaseReq,
+			existing: createTxExistingTarget{
+				status:     TxStatusOrphaned,
+				isCoinbase: true,
+			},
+			want: true,
+		},
+		{
+			name: "coinbase row not reused for non coinbase tx",
+			req:  confirmedReq,
+			existing: createTxExistingTarget{
+				status:     TxStatusOrphaned,
+				isCoinbase: true,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, test.want,
+				checkReuseCreateTx(test.req, test.existing))
+		})
+	}
+}
+
+// TestLoadCreateTxExisting verifies not-found and wrapped-error handling for
+// the shared existing-row lookup.
+func TestLoadCreateTxExisting(t *testing.T) {
+	t.Parallel()
+
+	req := testCreateTxRequest(t)
+	ops := &mockCreateTxOps{}
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
+
+	ops.On("loadExisting", mock.Anything, req).Return(
+		nil, errCreateTxExistingNotFound).Once()
+
+	existing, found, err := loadCreateTxExisting(context.Background(), req, ops)
+	require.NoError(t, err)
+	require.False(t, found)
+	require.Nil(t, existing)
+
+	ops.On("loadExisting", mock.Anything, req).Return(nil, nil).Once()
+
+	existing, found, err = loadCreateTxExisting(context.Background(), req, ops)
+	require.NoError(t, err)
+	require.False(t, found)
+	require.Nil(t, existing)
+
+	ops.On("loadExisting", mock.Anything, req).Return(
+		nil, errCreateTxTest,
+	).Once()
+
+	_, _, err = loadCreateTxExisting(context.Background(), req, ops)
+	require.ErrorIs(t, err, errCreateTxTest)
+	require.ErrorContains(t, err, "load create tx target")
+}
+
+// TestHandleRootTxnsClearError verifies that root spend-clearing failures are
+// returned before the helper mutates any later replacement state.
+func TestHandleRootTxnsClearError(t *testing.T) {
+	t.Parallel()
+
+	ops := &mockCreateTxOps{}
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
+
+	ops.On("clearSpentUtxos", mock.Anything, int64(9), int64(1)).Return(
+		errCreateTxTest).Once()
+
+	err := handleRootTxns(context.Background(), 9, []int64{1}, 11, ops)
+	require.ErrorIs(t, err, errCreateTxTest)
+	require.ErrorContains(t, err, "clear replaced root spent utxos")
+}
+
+// TestHandleTxConflictsEdgeError verifies that replacement edge writes are
+// wrapped after the branch state has been updated.
+func TestHandleTxConflictsEdgeError(t *testing.T) {
+	t.Parallel()
+
+	req, err := newCreateTxRequest(CreateTxParams{
+		WalletID: 7,
+		Tx:       testRegularMsgTx(),
+		Received: time.Unix(456, 0),
+		Block:    testBlock(77),
+		Status:   TxStatusPublished,
+	})
+	require.NoError(t, err)
+
+	ops := &mockCreateTxOps{}
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
+
+	ops.On("listConflictTxns", mock.Anything, req).Return(
+		[]int64{1}, []chainhash.Hash{{1}}, nil,
+	).Once()
+	ops.On("listUnminedTxRecords", mock.Anything, int64(7)).Return(
+		[]unminedTxRecord(nil), nil).Once()
+	ops.On("clearSpentUtxos", mock.Anything, int64(7), int64(1)).Return(
+		nil,
+	).Once()
+	ops.On("markTxnsReplaced", mock.Anything, int64(7), []int64{1}).Return(
+		nil,
+	).Once()
+	ops.On("insertReplacementEdges", mock.Anything, int64(7), []int64{1},
+		int64(9)).Return(errCreateTxTest).Once()
+
+	err = handleTxConflicts(context.Background(), req, 9, ops)
+	require.ErrorIs(t, err, errCreateTxTest)
+	require.ErrorContains(t, err, "record conflict replacement edges")
+}
+
+// TestHandleTxConflictsListError verifies that the helper returns
+// descendant-discovery load failures before mutating the branch.
+func TestHandleTxConflictsListError(t *testing.T) {
+	t.Parallel()
+
+	req, err := newCreateTxRequest(CreateTxParams{
+		WalletID: 7,
+		Tx:       testRegularMsgTx(),
+		Received: time.Unix(456, 0),
+		Block:    testBlock(77),
+		Status:   TxStatusPublished,
+	})
+	require.NoError(t, err)
+
+	ops := &mockCreateTxOps{}
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
+
+	ops.On("listConflictTxns", mock.Anything, req).Return(
+		[]int64{1}, []chainhash.Hash{{1}}, nil,
+	).Once()
+	ops.On("listUnminedTxRecords", mock.Anything, int64(7)).Return(
+		nil, errCreateTxTest).Once()
+
+	err = handleTxConflicts(context.Background(), req, 9, ops)
+	require.ErrorIs(t, err, errCreateTxTest)
+	require.ErrorContains(t, err, "list create tx conflict candidates")
+}
+
+// TestHandleTxConflictsMarkReplacedError verifies that the helper wraps
+// direct-root replacement failures.
+func TestHandleTxConflictsMarkReplacedError(t *testing.T) {
+	t.Parallel()
+
+	req, err := newCreateTxRequest(CreateTxParams{
+		WalletID: 7,
+		Tx:       testRegularMsgTx(),
+		Received: time.Unix(456, 0),
+		Block:    testBlock(77),
+		Status:   TxStatusPublished,
+	})
+	require.NoError(t, err)
+
+	ops := &mockCreateTxOps{}
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
+
+	ops.On("listConflictTxns", mock.Anything, req).Return(
+		[]int64{1}, []chainhash.Hash{{1}}, nil,
+	).Once()
+	ops.On("listUnminedTxRecords", mock.Anything, int64(7)).Return(
+		[]unminedTxRecord(nil), nil).Once()
+	ops.On("clearSpentUtxos", mock.Anything, int64(7), int64(1)).Return(
+		nil,
+	).Once()
+	ops.On("markTxnsReplaced", mock.Anything, int64(7), []int64{1}).Return(
+		errCreateTxTest).Once()
+
+	err = handleTxConflicts(context.Background(), req, 9, ops)
+	require.ErrorIs(t, err, errCreateTxTest)
+	require.ErrorContains(t, err, "mark direct conflicts replaced")
+}
+
+// TestValidateUpdateTxState verifies the remaining shared UpdateTx state
+// invariants not covered by the integration tests.
+func TestValidateUpdateTxState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		state      UpdateTxState
+		isCoinbase bool
+		wantErr    error
+	}{
+		{
+			name:    "invalid status",
+			state:   UpdateTxState{Status: TxStatus(99)},
+			wantErr: ErrInvalidParam,
+		},
+		{
+			name:    "non coinbase cannot orphan",
+			state:   UpdateTxState{Status: TxStatusOrphaned},
+			wantErr: ErrInvalidParam,
+		},
+		{
+			name: "confirmed must be published",
+			state: UpdateTxState{
+				Status: TxStatusFailed,
+				Block:  testBlock(44),
+			},
+			wantErr: ErrInvalidParam,
+		},
+		{
+			name:       "coinbase patch rejected",
+			state:      UpdateTxState{Status: TxStatusPublished},
+			isCoinbase: true,
+			wantErr:    ErrInvalidParam,
+		},
+		{
+			name: "published confirmed valid",
+			state: UpdateTxState{
+				Status: TxStatusPublished,
+				Block:  testBlock(45),
+			},
+			wantErr: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateUpdateTxState(test.state, test.isCoinbase)
+			if test.wantErr != nil {
+				require.ErrorIs(t, err, test.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}

--- a/wallet/internal/db/utxo_store_common_test.go
+++ b/wallet/internal/db/utxo_store_common_test.go
@@ -201,7 +201,9 @@ func TestLeaseOutputWithOps(t *testing.T) {
 	}
 	acquireExpiration := time.Unix(333, 0).In(time.FixedZone("X", 3600))
 	ops := &mockLeaseOutputOps{}
-	t.Cleanup(func() { ops.AssertExpectations(t) })
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
 
 	nowMatcher := mock.AnythingOfType("time.Time")
 	ops.On("acquire", mock.Anything, params, nowMatcher, nowMatcher).Return(
@@ -229,7 +231,9 @@ func TestLeaseOutputWithOpsRejectsNonPositiveDuration(t *testing.T) {
 		Duration: 0,
 	}
 	ops := &mockLeaseOutputOps{}
-	t.Cleanup(func() { ops.AssertExpectations(t) })
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
 
 	_, err := leaseOutputWithOps(context.Background(), params, ops)
 	require.ErrorIs(t, err, ErrInvalidParam)
@@ -249,7 +253,9 @@ func TestLeaseOutputWithOpsMissingUtxo(t *testing.T) {
 		Duration: time.Minute,
 	}
 	ops := &mockLeaseOutputOps{}
-	t.Cleanup(func() { ops.AssertExpectations(t) })
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
 
 	nowMatcher := mock.AnythingOfType("time.Time")
 	ops.On("acquire", mock.Anything, params, nowMatcher, nowMatcher).Return(
@@ -273,7 +279,9 @@ func TestLeaseOutputWithOpsAlreadyLeased(t *testing.T) {
 		Duration: time.Minute,
 	}
 	ops := &mockLeaseOutputOps{}
-	t.Cleanup(func() { ops.AssertExpectations(t) })
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
 
 	nowMatcher := mock.AnythingOfType("time.Time")
 	ops.On("acquire", mock.Anything, params, nowMatcher, nowMatcher).Return(
@@ -297,7 +305,9 @@ func TestReleaseOutputWithOps(t *testing.T) {
 		ID:       [32]byte{9},
 	}
 	ops := &mockReleaseOutputOps{}
-	t.Cleanup(func() { ops.AssertExpectations(t) })
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
 
 	ops.On("lookupUtxoID", mock.Anything, params).Return(int64(11), nil).Once()
 
@@ -322,7 +332,9 @@ func TestReleaseOutputWithOpsMissingUtxo(t *testing.T) {
 		ID:       [32]byte{9},
 	}
 	ops := &mockReleaseOutputOps{}
-	t.Cleanup(func() { ops.AssertExpectations(t) })
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
 
 	ops.On("lookupUtxoID", mock.Anything, params).Return(
 		int64(0), errReleaseOutputUtxoNotFound).Once()
@@ -342,7 +354,9 @@ func TestReleaseOutputWithOpsWrongLock(t *testing.T) {
 		ID:       [32]byte{9},
 	}
 	ops := &mockReleaseOutputOps{}
-	t.Cleanup(func() { ops.AssertExpectations(t) })
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
 
 	releaseTimeMatcher := mock.AnythingOfType("time.Time")
 	ops.On("lookupUtxoID", mock.Anything, params).Return(int64(11), nil).Once()
@@ -369,7 +383,9 @@ func TestReleaseOutputWithOpsMissingActiveLease(t *testing.T) {
 		ID:       [32]byte{9},
 	}
 	ops := &mockReleaseOutputOps{}
-	t.Cleanup(func() { ops.AssertExpectations(t) })
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
 
 	releaseTimeMatcher := mock.AnythingOfType("time.Time")
 	ops.On("lookupUtxoID", mock.Anything, params).Return(int64(11), nil).Once()

--- a/wallet/internal/db/utxo_store_common_test.go
+++ b/wallet/internal/db/utxo_store_common_test.go
@@ -2,9 +2,11 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/stretchr/testify/mock"
@@ -474,4 +476,99 @@ func (m *mockReleaseOutputOps) activeLockID(ctx context.Context,
 // helper tests.
 func testLeaseOutPoint() wire.OutPoint {
 	return wire.OutPoint{Hash: chainhash.Hash{7}, Index: 1}
+}
+
+// TestBuildUtxoInfoMaxAmount verifies that buildUtxoInfo preserves the largest
+// valid satoshi amount.
+func TestBuildUtxoInfoMaxAmount(t *testing.T) {
+	t.Parallel()
+
+	hash := chainhash.Hash{10}
+	info, err := buildUtxoInfo(
+		hash[:], 3, int64(btcutil.MaxSatoshi), []byte{0x53},
+		time.Unix(333, 0), false, nil,
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(btcutil.MaxSatoshi), info.Amount)
+	require.Equal(t, UnminedHeight, info.Height)
+}
+
+// TestBuildUtxoInfoInvalidHash verifies that buildUtxoInfo rejects malformed
+// hash bytes.
+func TestBuildUtxoInfoInvalidHash(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildUtxoInfo(
+		[]byte{1, 2, 3}, 6, 1000, []byte{0x56}, time.Unix(666, 0), false, nil,
+	)
+
+	require.Error(t, err)
+}
+
+// TestBuildLeasedOutputInvalidHash verifies that buildLeasedOutput rejects
+// malformed hash bytes.
+func TestBuildLeasedOutputInvalidHash(t *testing.T) {
+	t.Parallel()
+
+	lockID := make([]byte, 32)
+	_, err := buildLeasedOutput([]byte{1, 2, 3}, 7, lockID, time.Unix(777, 0))
+
+	require.Error(t, err)
+}
+
+// TestUtxoInfoFromSqliteRowInvalidOutputIndex verifies that the sqlite row
+// decoder rejects output indexes outside the uint32 range.
+func TestUtxoInfoFromSqliteRowInvalidOutputIndex(t *testing.T) {
+	t.Parallel()
+
+	hash := chainhash.Hash{13}
+	_, err := utxoInfoFromSqliteRow(
+		hash[:], -1, 1000, []byte{0x57}, time.Unix(888, 0), false,
+		sql.NullInt64{},
+	)
+
+	require.ErrorContains(t, err, "utxo output index")
+}
+
+// TestUtxoInfoFromSqliteRowInvalidBlockHeight verifies that the sqlite row
+// decoder rejects invalid confirmed block heights.
+func TestUtxoInfoFromSqliteRowInvalidBlockHeight(t *testing.T) {
+	t.Parallel()
+
+	hash := chainhash.Hash{14}
+	_, err := utxoInfoFromSqliteRow(
+		hash[:], 0, 1000, []byte{0x58}, time.Unix(999, 0), false,
+		sql.NullInt64{Int64: -1, Valid: true},
+	)
+
+	require.ErrorContains(t, err, "utxo block height")
+}
+
+// TestUtxoInfoFromPgRowInvalidOutputIndex verifies that the postgres row
+// decoder rejects output indexes outside the uint32 range.
+func TestUtxoInfoFromPgRowInvalidOutputIndex(t *testing.T) {
+	t.Parallel()
+
+	hash := chainhash.Hash{15}
+	_, err := utxoInfoFromPgRow(
+		hash[:], -1, 1000, []byte{0x59}, time.Unix(1000, 0), false,
+		sql.NullInt32{},
+	)
+
+	require.ErrorContains(t, err, "utxo output index")
+}
+
+// TestUtxoInfoFromPgRowInvalidBlockHeight verifies that the postgres row
+// decoder rejects invalid confirmed block heights.
+func TestUtxoInfoFromPgRowInvalidBlockHeight(t *testing.T) {
+	t.Parallel()
+
+	hash := chainhash.Hash{16}
+	_, err := utxoInfoFromPgRow(
+		hash[:], 0, 1000, []byte{0x5a}, time.Unix(1001, 0), false,
+		sql.NullInt32{Int32: -1, Valid: true},
+	)
+
+	require.ErrorContains(t, err, "utxo block height")
 }

--- a/wallet/internal/db/utxo_store_common_test.go
+++ b/wallet/internal/db/utxo_store_common_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -196,9 +197,13 @@ func TestLeaseOutputWithOps(t *testing.T) {
 		ID:       LockID{7},
 		Duration: time.Minute,
 	}
-	ops := &stubLeaseOutputOps{
-		acquireExpiration: time.Unix(333, 0).In(time.FixedZone("X", 3600)),
-	}
+	acquireExpiration := time.Unix(333, 0).In(time.FixedZone("X", 3600))
+	ops := &mockLeaseOutputOps{}
+	t.Cleanup(func() { ops.AssertExpectations(t) })
+
+	nowMatcher := mock.AnythingOfType("time.Time")
+	ops.On("acquire", mock.Anything, params, nowMatcher, nowMatcher).Return(
+		acquireExpiration, nil).Once()
 
 	// Act: Run the shared LeaseOutput flow.
 	lease, err := leaseOutputWithOps(context.Background(), params, ops)
@@ -208,7 +213,6 @@ func TestLeaseOutputWithOps(t *testing.T) {
 	require.Equal(t, params.OutPoint, lease.OutPoint)
 	require.Equal(t, LockID(params.ID), lease.LockID)
 	require.Equal(t, time.UTC, lease.Expiration.Location())
-	require.Equal(t, []string{"acquire"}, ops.calls)
 }
 
 // TestLeaseOutputWithOpsRejectsNonPositiveDuration verifies that the shared
@@ -222,11 +226,13 @@ func TestLeaseOutputWithOpsRejectsNonPositiveDuration(t *testing.T) {
 		ID:       LockID{7},
 		Duration: 0,
 	}
-	ops := &stubLeaseOutputOps{}
+	ops := &mockLeaseOutputOps{}
+	t.Cleanup(func() { ops.AssertExpectations(t) })
 
 	_, err := leaseOutputWithOps(context.Background(), params, ops)
 	require.ErrorIs(t, err, ErrInvalidParam)
-	require.Empty(t, ops.calls)
+	ops.AssertNotCalled(t, "acquire", mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything)
 }
 
 // TestLeaseOutputWithOpsMissingUtxo verifies that the shared LeaseOutput helper
@@ -240,13 +246,17 @@ func TestLeaseOutputWithOpsMissingUtxo(t *testing.T) {
 		ID:       LockID{7},
 		Duration: time.Minute,
 	}
-	ops := &stubLeaseOutputOps{
-		acquireErr: errLeaseOutputNoRow,
-	}
+	ops := &mockLeaseOutputOps{}
+	t.Cleanup(func() { ops.AssertExpectations(t) })
+
+	nowMatcher := mock.AnythingOfType("time.Time")
+	ops.On("acquire", mock.Anything, params, nowMatcher, nowMatcher).Return(
+		time.Time{}, errLeaseOutputNoRow).Once()
+
+	ops.On("hasUtxo", mock.Anything, params).Return(false, nil).Once()
 
 	_, err := leaseOutputWithOps(context.Background(), params, ops)
 	require.ErrorIs(t, err, ErrUtxoNotFound)
-	require.Equal(t, []string{"acquire", "has-utxo"}, ops.calls)
 }
 
 // TestLeaseOutputWithOpsAlreadyLeased verifies that the shared LeaseOutput
@@ -260,14 +270,17 @@ func TestLeaseOutputWithOpsAlreadyLeased(t *testing.T) {
 		ID:       LockID{7},
 		Duration: time.Minute,
 	}
-	ops := &stubLeaseOutputOps{
-		acquireErr:    errLeaseOutputNoRow,
-		hasUtxoResult: true,
-	}
+	ops := &mockLeaseOutputOps{}
+	t.Cleanup(func() { ops.AssertExpectations(t) })
+
+	nowMatcher := mock.AnythingOfType("time.Time")
+	ops.On("acquire", mock.Anything, params, nowMatcher, nowMatcher).Return(
+		time.Time{}, errLeaseOutputNoRow).Once()
+
+	ops.On("hasUtxo", mock.Anything, params).Return(true, nil).Once()
 
 	_, err := leaseOutputWithOps(context.Background(), params, ops)
 	require.ErrorIs(t, err, ErrOutputAlreadyLeased)
-	require.Equal(t, []string{"acquire", "has-utxo"}, ops.calls)
 }
 
 // TestReleaseOutputWithOps verifies that the shared ReleaseOutput helper
@@ -281,17 +294,19 @@ func TestReleaseOutputWithOps(t *testing.T) {
 		OutPoint: testLeaseOutPoint(),
 		ID:       [32]byte{9},
 	}
-	ops := &stubReleaseOutputOps{
-		lookupUtxoIDResult: 11,
-		releaseRows:        1,
-	}
+	ops := &mockReleaseOutputOps{}
+	t.Cleanup(func() { ops.AssertExpectations(t) })
+
+	ops.On("lookupUtxoID", mock.Anything, params).Return(int64(11), nil).Once()
+
+	ops.On("release", mock.Anything, uint32(5), int64(11), [32]byte{9}).Return(
+		int64(1), nil).Once()
 
 	// Act: Run the shared ReleaseOutput flow.
 	err := releaseOutputWithOps(context.Background(), params, ops)
 
 	// Assert: The helper stops after the successful delete path.
 	require.NoError(t, err)
-	require.Equal(t, []string{"lookup-utxo", "release"}, ops.calls)
 }
 
 // TestReleaseOutputWithOpsMissingUtxo verifies that the shared ReleaseOutput
@@ -304,13 +319,14 @@ func TestReleaseOutputWithOpsMissingUtxo(t *testing.T) {
 		OutPoint: testLeaseOutPoint(),
 		ID:       [32]byte{9},
 	}
-	ops := &stubReleaseOutputOps{
-		lookupUtxoIDErr: errReleaseOutputUtxoNotFound,
-	}
+	ops := &mockReleaseOutputOps{}
+	t.Cleanup(func() { ops.AssertExpectations(t) })
+
+	ops.On("lookupUtxoID", mock.Anything, params).Return(
+		int64(0), errReleaseOutputUtxoNotFound).Once()
 
 	err := releaseOutputWithOps(context.Background(), params, ops)
 	require.ErrorIs(t, err, ErrUtxoNotFound)
-	require.Equal(t, []string{"lookup-utxo"}, ops.calls)
 }
 
 // TestReleaseOutputWithOpsWrongLock verifies that the shared ReleaseOutput
@@ -323,17 +339,20 @@ func TestReleaseOutputWithOpsWrongLock(t *testing.T) {
 		OutPoint: testLeaseOutPoint(),
 		ID:       [32]byte{9},
 	}
-	ops := &stubReleaseOutputOps{
-		lookupUtxoIDResult: 11,
-		activeLockIDResult: []byte{1, 2, 3},
-	}
+	ops := &mockReleaseOutputOps{}
+	t.Cleanup(func() { ops.AssertExpectations(t) })
+
+	releaseTimeMatcher := mock.AnythingOfType("time.Time")
+	ops.On("lookupUtxoID", mock.Anything, params).Return(int64(11), nil).Once()
+
+	ops.On("release", mock.Anything, uint32(5), int64(11), [32]byte{9}).Return(
+		int64(0), nil).Once()
+
+	ops.On("activeLockID", mock.Anything, uint32(5), int64(11),
+		releaseTimeMatcher).Return([]byte{1, 2, 3}, nil).Once()
 
 	err := releaseOutputWithOps(context.Background(), params, ops)
 	require.ErrorIs(t, err, ErrOutputUnlockNotAllowed)
-	require.Equal(t,
-		[]string{"lookup-utxo", "release", "active-lock"},
-		ops.calls,
-	)
 }
 
 // TestReleaseOutputWithOpsMissingActiveLease verifies that the shared
@@ -347,94 +366,108 @@ func TestReleaseOutputWithOpsMissingActiveLease(t *testing.T) {
 		OutPoint: testLeaseOutPoint(),
 		ID:       [32]byte{9},
 	}
-	ops := &stubReleaseOutputOps{
-		lookupUtxoIDResult: 11,
-		activeLockIDErr:    errReleaseOutputNoActiveLease,
-	}
+	ops := &mockReleaseOutputOps{}
+	t.Cleanup(func() { ops.AssertExpectations(t) })
+
+	releaseTimeMatcher := mock.AnythingOfType("time.Time")
+	ops.On("lookupUtxoID", mock.Anything, params).Return(int64(11), nil).Once()
+
+	ops.On("release", mock.Anything, uint32(5), int64(11), [32]byte{9}).Return(
+		int64(0), nil).Once()
+
+	ops.On("activeLockID", mock.Anything, uint32(5), int64(11),
+		releaseTimeMatcher).Return(nil, errReleaseOutputNoActiveLease).Once()
 
 	err := releaseOutputWithOps(context.Background(), params, ops)
 	require.NoError(t, err)
-	require.Equal(t,
-		[]string{"lookup-utxo", "release", "active-lock"},
-		ops.calls,
-	)
 }
 
-// stubLeaseOutputOps records how the shared LeaseOutput helper drives one
-// backend adapter while letting each test control the returned results.
-type stubLeaseOutputOps struct {
-	acquireExpiration time.Time
-	acquireErr        error
-	hasUtxoResult     bool
-
-	calls []string
+// mockLeaseOutputOps is a mock implementation of leaseOutputOps.
+type mockLeaseOutputOps struct {
+	mock.Mock
 }
 
-var _ leaseOutputOps = (*stubLeaseOutputOps)(nil)
+var _ leaseOutputOps = (*mockLeaseOutputOps)(nil)
 
-// acquire records the shared write attempt and returns the test-controlled
-// lease result.
-func (s *stubLeaseOutputOps) acquire(_ context.Context,
-	_ LeaseOutputParams, _ time.Time, _ time.Time) (time.Time, error) {
+// acquire implements leaseOutputOps.
+func (m *mockLeaseOutputOps) acquire(ctx context.Context,
+	params LeaseOutputParams, start time.Time,
+	expiration time.Time) (time.Time, error) {
 
-	s.calls = append(s.calls, "acquire")
+	args := m.Called(ctx, params, start, expiration)
 
-	return s.acquireExpiration, s.acquireErr
+	leaseExpiration, ok := args.Get(0).(time.Time)
+	if !ok {
+		return time.Time{}, errMockType
+	}
+
+	return leaseExpiration, args.Error(1)
 }
 
-// hasUtxo records the fallback ownership lookup and returns the test-controlled
-// result.
-func (s *stubLeaseOutputOps) hasUtxo(_ context.Context,
-	_ LeaseOutputParams) (bool, error) {
+// hasUtxo implements leaseOutputOps.
+func (m *mockLeaseOutputOps) hasUtxo(ctx context.Context,
+	params LeaseOutputParams) (bool, error) {
 
-	s.calls = append(s.calls, "has-utxo")
+	args := m.Called(ctx, params)
 
-	return s.hasUtxoResult, nil
+	hasUtxo, ok := args.Get(0).(bool)
+	if !ok {
+		return false, errMockType
+	}
+
+	return hasUtxo, args.Error(1)
 }
 
-// stubReleaseOutputOps records how the shared ReleaseOutput helper drives one
-// backend adapter while letting each test control the returned results.
-type stubReleaseOutputOps struct {
-	lookupUtxoIDResult int64
-	lookupUtxoIDErr    error
-	releaseRows        int64
-	releaseErr         error
-	activeLockIDResult []byte
-	activeLockIDErr    error
-
-	calls []string
+// mockReleaseOutputOps is a mock implementation of releaseOutputOps.
+type mockReleaseOutputOps struct {
+	mock.Mock
 }
 
-var _ releaseOutputOps = (*stubReleaseOutputOps)(nil)
+var _ releaseOutputOps = (*mockReleaseOutputOps)(nil)
 
-// lookupUtxoID records the shared outpoint lookup and returns the test-
-// controlled result.
-func (s *stubReleaseOutputOps) lookupUtxoID(_ context.Context,
-	_ ReleaseOutputParams) (int64, error) {
+// lookupUtxoID implements releaseOutputOps.
+func (m *mockReleaseOutputOps) lookupUtxoID(ctx context.Context,
+	params ReleaseOutputParams) (int64, error) {
 
-	s.calls = append(s.calls, "lookup-utxo")
+	args := m.Called(ctx, params)
 
-	return s.lookupUtxoIDResult, s.lookupUtxoIDErr
+	utxoID, ok := args.Get(0).(int64)
+	if !ok {
+		return 0, errMockType
+	}
+
+	return utxoID, args.Error(1)
 }
 
-// release records the shared delete attempt and returns the test-controlled row
-// count.
-func (s *stubReleaseOutputOps) release(_ context.Context, _ uint32,
-	_ int64, _ [32]byte) (int64, error) {
+// release implements releaseOutputOps.
+func (m *mockReleaseOutputOps) release(ctx context.Context, walletID uint32,
+	utxoID int64, lockID [32]byte) (int64, error) {
 
-	s.calls = append(s.calls, "release")
+	args := m.Called(ctx, walletID, utxoID, lockID)
 
-	return s.releaseRows, s.releaseErr
+	releasedRows, ok := args.Get(0).(int64)
+	if !ok {
+		return 0, errMockType
+	}
+
+	return releasedRows, args.Error(1)
 }
 
-// activeLockID records the fallback active-lock lookup and returns the test-
-// controlled result.
-func (s *stubReleaseOutputOps) activeLockID(_ context.Context, _ uint32,
-	_ int64, _ time.Time) ([]byte, error) {
+// activeLockID implements releaseOutputOps.
+func (m *mockReleaseOutputOps) activeLockID(ctx context.Context,
+	walletID uint32, utxoID int64, now time.Time) ([]byte, error) {
 
-	s.calls = append(s.calls, "active-lock")
+	args := m.Called(ctx, walletID, utxoID, now)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 
-	return s.activeLockIDResult, s.activeLockIDErr
+	lockID, ok := args.Get(0).([]byte)
+	if !ok {
+		return nil, errMockType
+	}
+
+	return lockID, args.Error(1)
 }
 
 // testLeaseOutPoint builds one stable outpoint fixture for shared UTXO lease


### PR DESCRIPTION
## Summary

- add additive-only unit coverage for tx status parsing, backend error wrapping, and shared tx/utxo helper workflows
- add additive integration coverage for CreateTx edge cases, tx invalidation flows, tx corruption handling, tx edge cases, utxo edge cases, and postgres-only overflow paths
- keep the branch test-only and additive on top of `adr-0006-enhance`

## Coverage

Measured from a fresh local rerun of the db-only coverage flow implied by the repo test targets:

- `make unit-cover pkg=wallet/internal/db`
- `make itest-db db=sqlite cover=1`
- `make itest-db db=postgres cover=1`

The figures below merge those three `wallet/internal/db` coverage profiles and list the current production files added since `sql-wallet`. All of them are now at or above 90% statement coverage.

### Shared

- `wallet/internal/db/tx_store_common.go` — 93.1%
- `wallet/internal/db/tx_store_invalidateunmined_common.go` — 90.3%
- `wallet/internal/db/utxo_store_common.go` — 94.3%

### Postgres

- `wallet/internal/db/postgres_txstore_createtx.go` — 90.1%
- `wallet/internal/db/postgres_txstore_deletetx.go` — 95.6%
- `wallet/internal/db/postgres_txstore_gettx.go` — 100.0%
- `wallet/internal/db/postgres_txstore_invalidateunmined.go` — 95.8%
- `wallet/internal/db/postgres_txstore_listtxns.go` — 96.9%
- `wallet/internal/db/postgres_txstore_rollback.go` — 95.0%
- `wallet/internal/db/postgres_txstore_updatetx.go` — 100.0%
- `wallet/internal/db/postgres_utxostore_balance.go` — 100.0%
- `wallet/internal/db/postgres_utxostore_getutxo.go` — 94.7%
- `wallet/internal/db/postgres_utxostore_leaseoutput.go` — 96.4%
- `wallet/internal/db/postgres_utxostore_listleasedoutputs.go` — 100.0%
- `wallet/internal/db/postgres_utxostore_listutxos.go` — 90.9%
- `wallet/internal/db/postgres_utxostore_releaseoutput.go` — 90.5%

### Sqlite

- `wallet/internal/db/sqlite_txstore_createtx.go` — 90.6%
- `wallet/internal/db/sqlite_txstore_deletetx.go` — 95.6%
- `wallet/internal/db/sqlite_txstore_gettx.go` — 100.0%
- `wallet/internal/db/sqlite_txstore_invalidateunmined.go` — 95.8%
- `wallet/internal/db/sqlite_txstore_listtxns.go` — 96.2%
- `wallet/internal/db/sqlite_txstore_rollback.go` — 95.9%
- `wallet/internal/db/sqlite_txstore_updatetx.go` — 100.0%
- `wallet/internal/db/sqlite_utxostore_balance.go` — 100.0%
- `wallet/internal/db/sqlite_utxostore_getutxo.go` — 93.8%
- `wallet/internal/db/sqlite_utxostore_leaseoutput.go` — 95.5%
- `wallet/internal/db/sqlite_utxostore_listleasedoutputs.go` — 100.0%
- `wallet/internal/db/sqlite_utxostore_listutxos.go` — 90.0%
- `wallet/internal/db/sqlite_utxostore_releaseoutput.go` — 100.0%

## Notes

- this branch only adds tests and test fixtures; it does not change production store behavior
- the coverage additions are intentionally additive: existing tests are not renamed or rewritten
- backend-specific corruption helpers live in `wallet/internal/db/itest/tx_corruption_pg_test.go` and `wallet/internal/db/itest/tx_corruption_sqlite_test.go`
- the stack is intended to pass `scripts/check-each-commit.sh origin/adr-0006-enhance`
