### PR TITLE
wallet: refactor itest testing his name

### DIFF
--- a/wallet/internal/db/itest/account_store_test.go
+++ b/wallet/internal/db/itest/account_store_test.go
@@ -610,6 +610,9 @@ func TestRenameAccount(t *testing.T) {
 func TestRenameAccountErrors(t *testing.T) {
 	t.Parallel()
 
+	accountNumber := uint32(99999)
+	accountPointer := &accountNumber
+
 	tests := []struct {
 		name    string
 		params  db.RenameAccountParams
@@ -627,9 +630,10 @@ func TestRenameAccountErrors(t *testing.T) {
 		{
 			name: "invalid - both set",
 			params: db.RenameAccountParams{
-				Scope:   db.KeyScopeBIP0084,
-				OldName: "nonexistent",
-				NewName: "new-name",
+				Scope:         db.KeyScopeBIP0084,
+				OldName:       "nonexistent",
+				AccountNumber: accountPointer,
+				NewName:       "new-name",
 			},
 			wantErr: db.ErrInvalidAccountQuery,
 		},
@@ -660,11 +664,6 @@ func TestRenameAccountErrors(t *testing.T) {
 			walletID := newWallet(t, store, "wallet-rename-account-errors")
 			createAllAccounts(t, store, walletID)
 			tc.params.WalletID = walletID
-
-			if tc.name == "invalid - both set" {
-				num := uint32(99999)
-				tc.params.AccountNumber = &num
-			}
 
 			err := store.RenameAccount(t.Context(), tc.params)
 			require.ErrorIs(t, err, tc.wantErr)

--- a/wallet/internal/db/itest/pg_test.go
+++ b/wallet/internal/db/itest/pg_test.go
@@ -132,16 +132,33 @@ func GetPostgresContainer(ctx context.Context) (*postgres.PostgresContainer,
 			},
 		).WithStartupTimeout(pgInitTimeout)
 
+		p := testParallelism()
+		m := db.DefaultMaxConnections
+
+		// pgMaxConns is the Postgres max_connections budget for the
+		// test container. It is sized as P*M + M + 3*P where:
+		//
+		//   P*M — steady-state: up to P parallel tests each holding a
+		//         pool of at most M connections (db.SetMaxOpenConns).
+		//
+		//   +M  — teardown latency: one extra store-equivalent for a
+		//         store that has called Close() but whose connections
+		//         have not yet fully disappeared from Postgres.
+		//
+		//   +3*P — per-slot bootstrap overlap: each slot needs roughly
+		//          3 transient connections while a new test starts —
+		//          one admin connection for CREATE DATABASE, ~1 for
+		//          PingContext, and ~1 for migration setup — so 3*P
+		//          covers all slots transitioning simultaneously.
+		pgMaxConns := p*m + m + 3*p
+
 		pgContainer, pgContainerErr = postgres.Run(ctx,
 			cfg.Image,
 			postgres.WithDatabase(cfg.Database),
 			postgres.WithUsername(cfg.Username),
 			postgres.WithPassword(cfg.Password),
 			testcontainers.WithCmd(
-				"-c", fmt.Sprintf(
-					"max_connections=%d",
-					testParallelism()*db.DefaultMaxConnections,
-				),
+				"-c", fmt.Sprintf("max_connections=%d", pgMaxConns),
 			),
 			testcontainers.WithWaitStrategyAndDeadline(
 				pgInitTimeout, waitForSQL,


### PR DESCRIPTION
just remove a `if tc.name == "invalid - both set"` inside a subtest, bc it's too fragile.