### PR TITLE
wallet+db: handle SQL backend errors

### DIFF
--- a/wallet/internal/db/err/README.md
+++ b/wallet/internal/db/err/README.md
@@ -1,0 +1,16 @@
+# `db/err`
+
+This package provides the shared SQL error taxonomy and normalization layer
+used by the wallet database backends.
+
+It defines the common backend, class, and reason enums, the `SQLError`
+wrapper used to preserve classification data in error chains, normalization
+helpers for mapping backend failures into the shared model, and stats types for
+recording classified SQL errors.
+
+Backend-specific mapping remains in the backend packages, including [`pg`](../pg/errors.go)
+and [`sqlite`](../sqlite/errors.go).
+
+Higher-level runtime behavior such as retry handling, unhealthy-store
+transitions, and transaction execution policy is implemented by callers outside
+this package.

--- a/wallet/internal/db/err/errors.go
+++ b/wallet/internal/db/err/errors.go
@@ -1,0 +1,441 @@
+// Package dberr contains the shared SQL error taxonomy and normalization logic
+// used by backend-specific db packages.
+package dberr
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+)
+
+// unknownString is the fallback text for invalid enum values.
+const unknownString = "unknown"
+
+// Backend identifies which SQL backend produced a classified SQL error.
+//
+// The backend is preserved on SQLError so callers can log raw backend codes,
+// maintain per-backend stats, and keep backend-specific handling separate from
+// the shared error model.
+type Backend string
+
+// Backend constants identify supported SQL backends.
+const (
+	// BackendPostgres identifies the PostgreSQL SQL backend.
+	BackendPostgres Backend = "postgres"
+
+	// BackendSQLite identifies the SQLite SQL backend.
+	BackendSQLite Backend = "sqlite"
+)
+
+// String returns the canonical string form of the backend.
+func (b Backend) String() string {
+	switch b {
+	case BackendPostgres:
+		return string(b)
+
+	case BackendSQLite:
+		return string(b)
+
+	default:
+		return unknownString
+	}
+}
+
+// Valid reports whether the backend is one of the known SQL backends.
+func (b Backend) Valid() bool {
+	switch b {
+	case BackendPostgres:
+		return true
+
+	case BackendSQLite:
+		return true
+
+	default:
+		return false
+	}
+}
+
+// Class describes the caller-facing policy bucket for a classified SQL backend
+// error.
+//
+// The class answers what runtime code should do next:
+//
+//   - Transient: retry the operation when it is safe to retry.
+//   - Permanent: fail the operation immediately without poisoning the store.
+//   - Fatal: fail the operation and mark the store unhealthy so later calls
+//     fail fast until the backend is reopened or repaired.
+type Class uint8
+
+// Class constants identify caller-facing SQL error policy buckets.
+const (
+	// ClassTransient marks failures that may succeed on a later retry.
+	ClassTransient Class = iota
+
+	// ClassPermanent marks failures that should fail the current
+	// operation without retrying or poisoning the store.
+	ClassPermanent
+
+	// ClassFatal marks failures that should fail the current operation
+	// and take the store out of service.
+	ClassFatal
+)
+
+// String returns the canonical string form of the class.
+func (c Class) String() string {
+	switch c {
+	case ClassTransient:
+		return "transient"
+
+	case ClassPermanent:
+		return "permanent"
+
+	case ClassFatal:
+		return "fatal"
+
+	default:
+		return unknownString
+	}
+}
+
+// Valid reports whether the class is recognized.
+func (c Class) Valid() bool {
+	switch c {
+	case ClassTransient:
+		return true
+
+	case ClassPermanent:
+		return true
+
+	case ClassFatal:
+		return true
+
+	default:
+		return false
+	}
+}
+
+// Reason describes the specific backend failure bucket for a classified SQL
+// error.
+//
+// Callers use Reason for diagnosis and metrics, then derive runtime policy
+// through Class(). New or unmapped backend codes should fall back to
+// ReasonUnknown while preserving the raw backend code on SQLError.
+type Reason uint8
+
+// Reason constants identify shared SQL backend failure buckets.
+const (
+	// ReasonUnknown is the fallback reason for uncategorized backend codes.
+	ReasonUnknown Reason = iota
+
+	// ReasonSerialization marks transaction serialization failures
+	// caused by concurrent updates.
+	ReasonSerialization
+
+	// ReasonDeadlock marks deadlock failures where the backend aborts
+	// one participant to break a lock cycle.
+	ReasonDeadlock
+
+	// ReasonBusy marks SQLite busy failures where a lock cannot be
+	// acquired in time.
+	ReasonBusy
+
+	// ReasonLocked marks lock-not-available failures.
+	ReasonLocked
+
+	// ReasonUnavailable marks backend availability and transport
+	// failures.
+	ReasonUnavailable
+
+	// ReasonPoolExhausted marks connection-pool or backend
+	// connection-limit failures.
+	ReasonPoolExhausted
+
+	// ReasonSchemaMismatch marks schema drift or schema version
+	// mismatches.
+	ReasonSchemaMismatch
+
+	// ReasonConstraint marks backend constraint failures.
+	ReasonConstraint
+
+	// ReasonResourceExhausted marks disk, memory, or similar hard
+	// resource failures.
+	ReasonResourceExhausted
+
+	// ReasonReadOnly marks read-only backend failures.
+	ReasonReadOnly
+
+	// ReasonPermission marks backend permission failures.
+	ReasonPermission
+
+	// ReasonCorrupt marks corruption failures.
+	ReasonCorrupt
+)
+
+// Class returns the caller-facing policy bucket derived from the reason.
+func (r Reason) Class() Class {
+	switch r {
+	case ReasonSerialization, ReasonDeadlock, ReasonBusy, ReasonLocked,
+		ReasonUnavailable, ReasonPoolExhausted:
+
+		return ClassTransient
+
+	// Unknown or caller-fixable backend states fail the current operation
+	// without retrying or taking the store out of service.
+	case ReasonSchemaMismatch, ReasonConstraint, ReasonUnknown:
+		return ClassPermanent
+
+	case ReasonResourceExhausted, ReasonReadOnly, ReasonPermission,
+		ReasonCorrupt:
+
+		return ClassFatal
+
+	default:
+		return ClassPermanent
+	}
+}
+
+// String returns the canonical string form of the reason.
+//
+//nolint:cyclop // One explicit enum-to-string switch is the clearest form here.
+func (r Reason) String() string {
+	switch r {
+	case ReasonSerialization:
+		return "serialization"
+
+	case ReasonDeadlock:
+		return "deadlock"
+
+	case ReasonBusy:
+		return "busy"
+
+	case ReasonLocked:
+		return "locked"
+
+	case ReasonUnavailable:
+		return "unavailable"
+
+	case ReasonPoolExhausted:
+		return "pool_exhausted"
+
+	case ReasonSchemaMismatch:
+		return "schema_mismatch"
+
+	case ReasonConstraint:
+		return "constraint"
+
+	case ReasonUnknown:
+		return unknownString
+
+	case ReasonResourceExhausted:
+		return "resource_exhausted"
+
+	case ReasonReadOnly:
+		return "read_only"
+
+	case ReasonPermission:
+		return "permission"
+
+	case ReasonCorrupt:
+		return "corrupt"
+
+	default:
+		return unknownString
+	}
+}
+
+// Valid reports whether the reason is recognized.
+func (r Reason) Valid() bool {
+	return r <= ReasonCorrupt
+}
+
+// SQLError wraps a backend or transport error with stable SQL classification
+// metadata.
+//
+// The wrapper keeps classification data inside ordinary error chains so callers
+// can recover backend, reason, class, and raw codes with errors.As after higher
+// layers add their own context.
+type SQLError struct {
+	// Backend identifies which SQL backend produced the error.
+	Backend Backend
+
+	// Reason identifies the specific backend failure bucket.
+	Reason Reason
+
+	// Code stores the raw backend code used for classification.
+	Code string
+
+	// Err stores the wrapped backend or transport error.
+	Err error
+}
+
+// NewSQLError builds a classified SQL backend error wrapper.
+func NewSQLError(backend Backend, reason Reason, code string,
+	err error) *SQLError {
+
+	return &SQLError{
+		Backend: backend,
+		Reason:  reason,
+		Code:    code,
+		Err:     err,
+	}
+}
+
+// Class returns the caller-facing policy bucket derived from the reason.
+func (e *SQLError) Class() Class {
+	if e == nil {
+		// A missing wrapper is treated like an unknown classified error so
+		// defensive callers do not retry or poison store state based on
+		// absent classification data.
+		return ReasonUnknown.Class()
+	}
+
+	return e.Reason.Class()
+}
+
+// Error returns the printable form of the wrapped backend error.
+func (e *SQLError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+
+	// Normal wrappers carry the backend or transport error, so preserve that
+	// message and leave the remaining branches as defensive fallbacks.
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+
+	// Fall back to synthesized text only for malformed or test-built
+	// wrappers that do not carry an underlying cause.
+	return fmt.Sprintf("%s %s sql error", e.Backend.String(), e.Reason)
+}
+
+// Unwrap returns the wrapped backend error.
+func (e *SQLError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+
+	return e.Err
+}
+
+// Normalize converts one backend error into the shared SQL error model.
+//
+// It handles errors in this order:
+//
+//  1. A nil error stays nil.
+//  2. Context cancellation and deadline errors are returned unchanged,
+//     including any caller-added wrapping context.
+//  3. Existing SQLError wrappers are returned unchanged so Normalize does not
+//     rebuild or strip the original error chain.
+//  4. The mapper gets the first chance to translate backend-native driver
+//     errors into SQLError values.
+//  5. Generic connection and transport failures are classified as
+//     ReasonUnavailable.
+//  6. If the backend is known and no earlier rule matches, err is wrapped as
+//     ReasonUnknown.
+//  7. If the backend is unknown, err is returned unchanged.
+//
+// Normalize is intentionally side-effect free. Callers own follow-up actions
+// such as stats recording or unhealthy-store transitions.
+//
+// The mapper keeps backend-specific matching outside the shared error package
+// so backend packages can return shared SQL errors without introducing import
+// cycles. Callers should pass a no-op mapper when they have no backend-
+// specific codes to inspect.
+func Normalize(backend Backend, mapper func(error) *SQLError, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	// Preserve caller-driven cancellation semantics, including any wrapping
+	// context, instead of reclassifying them as backend errors.
+	contextErr := unwrapContextErr(err)
+	if contextErr != nil {
+		return contextErr
+	}
+
+	// Preserve existing SQL wrappers so caller-added context is not dropped
+	// from the original error chain.
+	if extractSQLError(err) != nil {
+		return err
+	}
+
+	// Ask the backend-specific mapper first so driver-native codes stay as
+	// specific as possible.
+	sqlErr := mapper(err)
+	if sqlErr != nil {
+		return sqlErr
+	}
+
+	// Fall back to transport-level classification for connection-oriented
+	// failures that are not backend-code specific.
+	transportErr := classifyConnErr(backend, err)
+	if transportErr != nil {
+		return transportErr
+	}
+
+	// Unknown backends are left untouched so callers do not accidentally invent
+	// a backend identity the error never had.
+	if !backend.Valid() {
+		return err
+	}
+
+	// Keep backend identity even when the exact backend code is not recognized
+	// so logs and stats retain useful diagnosis data.
+	return NewSQLError(backend, ReasonUnknown, "", err)
+}
+
+// extractSQLError extracts the shared SQL error wrapper from err, if present.
+func extractSQLError(err error) *SQLError {
+	var sqlErr *SQLError
+	if errors.As(err, &sqlErr) {
+		return sqlErr
+	}
+
+	return nil
+}
+
+// classifyConnErr classifies generic connection and transport failures that do
+// not come with backend-specific codes.
+func classifyConnErr(backend Backend, err error) *SQLError {
+	if !backend.Valid() {
+		return nil
+	}
+
+	badConn := errors.Is(err, driver.ErrBadConn)
+	connDone := errors.Is(err, sql.ErrConnDone)
+
+	// Broken-connection sentinels and EOF all mean the caller lost the SQL
+	// transport path before receiving a normal backend result.
+	if badConn || connDone || errors.Is(err, io.EOF) {
+		return NewSQLError(backend, ReasonUnavailable, "", err)
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		// Timeout-only net errors are still transport failures even when the
+		// backend never returned a backend-specific code.
+		if netErr.Timeout() {
+			return NewSQLError(backend, ReasonUnavailable, "", err)
+		}
+	}
+
+	return nil
+}
+
+// unwrapContextErr preserves caller-driven context cancellation and deadlines.
+func unwrapContextErr(err error) error {
+	if errors.Is(err, context.Canceled) {
+		return err
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+
+	return nil
+}

--- a/wallet/internal/db/err/errors_test.go
+++ b/wallet/internal/db/err/errors_test.go
@@ -1,0 +1,270 @@
+package dberr
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var errConstraint = errors.New("constraint")
+
+// noOpMapper is a test helper that leaves backend-specific classification to
+// later Normalize fallbacks.
+func noOpMapper(error) *SQLError {
+	return nil
+}
+
+// TestBackendString verifies the string forms of the SQL backend identifiers.
+func TestBackendString(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "postgres", BackendPostgres.String())
+	require.Equal(t, "sqlite", BackendSQLite.String())
+	require.Equal(t, unknownString, Backend("mysql").String())
+	require.True(t, BackendPostgres.Valid())
+	require.False(t, Backend("mysql").Valid())
+}
+
+// TestClassString verifies the string forms of the exported error classes.
+func TestClassString(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "transient", ClassTransient.String())
+	require.Equal(t, "permanent", ClassPermanent.String())
+	require.Equal(t, "fatal", ClassFatal.String())
+	require.Equal(t, unknownString, Class(99).String())
+	require.True(t, ClassFatal.Valid())
+	require.False(t, Class(99).Valid())
+}
+
+// TestReasonMetadata verifies the string and class metadata of the exported
+// reasons.
+func TestReasonMetadata(t *testing.T) {
+	t.Parallel()
+
+	var zero Reason
+	require.Equal(t, ReasonUnknown, zero)
+
+	require.Equal(t, "serialization", ReasonSerialization.String())
+	require.Equal(t, ClassTransient, ReasonBusy.Class())
+	require.Equal(t, ClassPermanent, ReasonUnknown.Class())
+	require.Equal(t, ClassFatal, ReasonCorrupt.Class())
+	require.Equal(t, unknownString, Reason(99).String())
+	require.False(t, Reason(99).Valid())
+}
+
+// TestReasonClassCoverage verifies that every valid reason maps to the
+// expected caller-facing policy bucket.
+func TestReasonClassCoverage(t *testing.T) {
+	t.Parallel()
+
+	tests := map[Reason]Class{
+		ReasonUnknown:           ClassPermanent,
+		ReasonSerialization:     ClassTransient,
+		ReasonDeadlock:          ClassTransient,
+		ReasonBusy:              ClassTransient,
+		ReasonLocked:            ClassTransient,
+		ReasonUnavailable:       ClassTransient,
+		ReasonPoolExhausted:     ClassTransient,
+		ReasonSchemaMismatch:    ClassPermanent,
+		ReasonConstraint:        ClassPermanent,
+		ReasonResourceExhausted: ClassFatal,
+		ReasonReadOnly:          ClassFatal,
+		ReasonPermission:        ClassFatal,
+		ReasonCorrupt:           ClassFatal,
+	}
+
+	for reason := ReasonUnknown; reason <= ReasonCorrupt; reason++ {
+		wantClass, ok := tests[reason]
+		require.Truef(t, ok, "missing class expectation for reason %v", reason)
+		require.Equal(t, wantClass, reason.Class())
+	}
+}
+
+// TestSQLErrorFormatting verifies the formatting helpers on nil and populated
+// SQL errors.
+func TestSQLErrorFormatting(t *testing.T) {
+	t.Parallel()
+
+	var nilErr *SQLError
+	require.Equal(t, "<nil>", nilErr.Error())
+	require.NoError(t, nilErr.Unwrap())
+	require.Equal(t, ClassPermanent, nilErr.Class())
+
+	err := &SQLError{
+		Backend: BackendSQLite,
+		Reason:  ReasonUnknown,
+	}
+	require.Equal(t, "sqlite unknown sql error", err.Error())
+	require.NoError(t, err.Unwrap())
+}
+
+// TestExtractSQLErrorClass verifies that callers can recover a wrapped SQL
+// error and inspect its derived class with the standard errors.As pattern.
+func TestExtractSQLErrorClass(t *testing.T) {
+	t.Parallel()
+
+	err := fmt.Errorf("wrap: %w", NewSQLError(
+		BackendPostgres,
+		ReasonSerialization,
+		"40001",
+		driver.ErrBadConn,
+	))
+
+	sqlErr := extractSQLError(err)
+	require.NotNil(t, sqlErr)
+	require.Equal(t, ClassTransient, sqlErr.Class())
+
+	require.Nil(t, extractSQLError(errConstraint))
+}
+
+// TestExtractSQLError verifies that callers can recover structured SQL
+// metadata with the standard errors.As pattern.
+func TestExtractSQLError(t *testing.T) {
+	t.Parallel()
+
+	wrapped := fmt.Errorf("outer: %w", NewSQLError(
+		BackendSQLite,
+		ReasonConstraint,
+		"2067",
+		errConstraint,
+	))
+
+	sqlErr := extractSQLError(wrapped)
+	require.NotNil(t, sqlErr)
+	require.Equal(t, BackendSQLite, sqlErr.Backend)
+	require.Equal(t, ReasonConstraint, sqlErr.Reason)
+	require.Equal(t, "2067", sqlErr.Code)
+	require.Equal(t, ClassPermanent, sqlErr.Class())
+}
+
+// TestClassifyConnErr verifies that generic connection failures are classified
+// as transient availability problems.
+func TestClassifyConnErr(t *testing.T) {
+	t.Parallel()
+
+	err := classifyConnErr(BackendPostgres, driver.ErrBadConn)
+	require.NotNil(t, err)
+	require.Equal(t, BackendPostgres, err.Backend)
+	require.Equal(t, ReasonUnavailable, err.Reason)
+	require.Equal(t, ClassTransient, err.Class())
+
+	err = classifyConnErr(BackendSQLite, sql.ErrConnDone)
+	require.NotNil(t, err)
+	require.Equal(t, ReasonUnavailable, err.Reason)
+
+	err = classifyConnErr(BackendSQLite, netTimeoutError{})
+	require.NotNil(t, err)
+	require.Equal(t, ReasonUnavailable, err.Reason)
+
+	err = classifyConnErr(BackendSQLite, temporaryNetError{err: io.EOF})
+	require.Nil(t, err)
+
+	require.Nil(t, classifyConnErr(Backend(""), driver.ErrBadConn))
+	require.Nil(t, classifyConnErr(BackendSQLite, sql.ErrNoRows))
+}
+
+// TestCoreHelpers verifies the remaining backend-agnostic helper branches.
+func TestCoreHelpers(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, context.Canceled, unwrapContextErr(context.Canceled))
+	require.Equal(t, context.DeadlineExceeded,
+		unwrapContextErr(context.DeadlineExceeded))
+
+	wrappedCanceled := fmt.Errorf("query accounts: %w", context.Canceled)
+	require.Same(t, wrappedCanceled, unwrapContextErr(wrappedCanceled))
+	require.NoError(t, unwrapContextErr(sql.ErrNoRows))
+}
+
+// TestNormalize verifies the backend-aware normalization flow that keeps
+// context errors untouched and preserves backend-specific mapping.
+func TestNormalize(t *testing.T) {
+	t.Parallel()
+
+	err := Normalize(BackendPostgres, noOpMapper, context.Canceled)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, extractSQLError(err))
+
+	wrappedCanceled := fmt.Errorf("query accounts: %w", context.Canceled)
+	err = Normalize(BackendPostgres, noOpMapper, wrappedCanceled)
+	require.Same(t, wrappedCanceled, err)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, extractSQLError(err))
+
+	err = Normalize(BackendPostgres, noOpMapper, driver.ErrBadConn)
+
+	sqlErr := extractSQLError(err)
+	require.NotNil(t, sqlErr)
+	require.Equal(t, BackendPostgres, sqlErr.Backend)
+	require.Equal(t, ClassTransient, sqlErr.Class())
+	require.Equal(t, ReasonUnavailable, sqlErr.Reason)
+
+	err = Normalize(BackendSQLite, func(in error) *SQLError {
+		return NewSQLError(BackendSQLite, ReasonUnknown, "", in)
+	}, errConstraint)
+	sqlErr = extractSQLError(err)
+	require.NotNil(t, sqlErr)
+	require.Equal(t, ClassPermanent, sqlErr.Class())
+	require.Equal(t, ReasonUnknown, sqlErr.Reason)
+
+	existing := NewSQLError(Backend(""), ReasonCorrupt, "", io.EOF)
+	err = Normalize(BackendPostgres, noOpMapper, existing)
+	require.Same(t, existing, err)
+	require.Equal(t, Backend(""), extractSQLError(err).Backend)
+
+	wrapped := fmt.Errorf("outer: %w", existing)
+	err = Normalize(BackendSQLite, noOpMapper, wrapped)
+	require.Same(t, wrapped, err)
+	require.Equal(t, Backend(""), extractSQLError(err).Backend)
+
+	require.Same(t, errConstraint,
+		Normalize(Backend(""), noOpMapper, errConstraint))
+}
+
+// temporaryNetError is a test helper that exposes only the legacy Temporary
+// signal without reporting a timeout.
+type temporaryNetError struct {
+	// err is the wrapped error string returned by Error.
+	err error
+}
+
+// Error returns the wrapped error string.
+func (e temporaryNetError) Error() string {
+	return e.err.Error()
+}
+
+// Timeout reports that the test error is not a timeout.
+func (e temporaryNetError) Timeout() bool {
+	return false
+}
+
+// Temporary reports that the test error should be treated as temporary.
+func (e temporaryNetError) Temporary() bool {
+	return true
+}
+
+// netTimeoutError is a test helper that reports a timeout without a legacy
+// Temporary method.
+type netTimeoutError struct{}
+
+// Error returns the static timeout error string.
+func (e netTimeoutError) Error() string {
+	return "timeout"
+}
+
+// Timeout reports that the test error is a timeout.
+func (e netTimeoutError) Timeout() bool {
+	return true
+}
+
+// Temporary reports that the test error is not a legacy temporary error.
+func (e netTimeoutError) Temporary() bool {
+	return false
+}

--- a/wallet/internal/db/err/stats.go
+++ b/wallet/internal/db/err/stats.go
@@ -1,0 +1,226 @@
+package dberr
+
+import (
+	"errors"
+	"sync/atomic"
+)
+
+// StatsSnapshot is a read-only copy of the SQL backend error counters.
+type StatsSnapshot struct {
+	// Backend identifies which SQL backend produced the snapshot.
+	Backend Backend
+
+	// TotalErrs counts all classified SQL backend errors.
+	TotalErrs uint64
+
+	// TransientErrs counts classified transient SQL backend errors.
+	TransientErrs uint64
+
+	// PermanentErrs counts classified permanent SQL backend errors.
+	PermanentErrs uint64
+
+	// FatalErrs counts classified fatal SQL backend errors.
+	FatalErrs uint64
+
+	// Serialization counts serialization failures.
+	Serialization uint64
+
+	// Deadlocks counts deadlock failures.
+	Deadlocks uint64
+
+	// Busy counts SQLite busy failures.
+	Busy uint64
+
+	// Locked counts lock-not-available failures.
+	Locked uint64
+
+	// Unavailable counts backend availability failures.
+	Unavailable uint64
+
+	// PoolExhausted counts connection exhaustion failures.
+	PoolExhausted uint64
+
+	// ResourceExhausted counts disk, memory, or similar failures.
+	ResourceExhausted uint64
+
+	// ReadOnly counts read-only backend failures.
+	ReadOnly uint64
+
+	// Permission counts backend permission failures.
+	Permission uint64
+
+	// Corrupt counts corruption failures.
+	Corrupt uint64
+
+	// SchemaMismatch counts schema mismatch failures.
+	SchemaMismatch uint64
+
+	// Constraint counts backend constraint failures.
+	Constraint uint64
+
+	// Unknown counts classified backend failures with an unknown reason.
+	Unknown uint64
+}
+
+// Stats stores low-overhead atomic counters for classified SQL errors.
+type Stats struct {
+	// totalErrs counts all classified SQL backend errors.
+	totalErrs atomic.Uint64
+
+	// transientErrs counts transient SQL backend errors.
+	transientErrs atomic.Uint64
+
+	// permanentErrs counts permanent SQL backend errors.
+	permanentErrs atomic.Uint64
+
+	// fatalErrs counts fatal SQL backend errors.
+	fatalErrs atomic.Uint64
+
+	// serialization counts serialization failures.
+	serialization atomic.Uint64
+
+	// deadlocks counts deadlock failures.
+	deadlocks atomic.Uint64
+
+	// busy counts SQLite busy failures.
+	busy atomic.Uint64
+
+	// locked counts lock-not-available failures.
+	locked atomic.Uint64
+
+	// unavailable counts backend availability failures.
+	unavailable atomic.Uint64
+
+	// poolExhausted counts connection exhaustion failures.
+	poolExhausted atomic.Uint64
+
+	// resourceExhausted counts resource exhaustion failures.
+	resourceExhausted atomic.Uint64
+
+	// readOnly counts read-only backend failures.
+	readOnly atomic.Uint64
+
+	// permission counts backend permission failures.
+	permission atomic.Uint64
+
+	// corrupt counts corruption failures.
+	corrupt atomic.Uint64
+
+	// schemaMismatch counts schema mismatch failures.
+	schemaMismatch atomic.Uint64
+
+	// constraint counts backend constraint failures.
+	constraint atomic.Uint64
+
+	// unknown counts classified backend failures with an unknown reason.
+	unknown atomic.Uint64
+}
+
+// reasonRecorder updates one per-reason counter on Stats.
+type reasonRecorder func(*Stats)
+
+// reasonRecorders maps each valid reason to its per-reason counter update.
+var reasonRecorders = [...]reasonRecorder{
+	ReasonSerialization: func(s *Stats) {
+		s.serialization.Add(1)
+	},
+	ReasonDeadlock: func(s *Stats) {
+		s.deadlocks.Add(1)
+	},
+	ReasonBusy: func(s *Stats) {
+		s.busy.Add(1)
+	},
+	ReasonLocked: func(s *Stats) {
+		s.locked.Add(1)
+	},
+	ReasonUnavailable: func(s *Stats) {
+		s.unavailable.Add(1)
+	},
+	ReasonPoolExhausted: func(s *Stats) {
+		s.poolExhausted.Add(1)
+	},
+	ReasonSchemaMismatch: func(s *Stats) {
+		s.schemaMismatch.Add(1)
+	},
+	ReasonConstraint: func(s *Stats) {
+		s.constraint.Add(1)
+	},
+	ReasonUnknown: func(s *Stats) {
+		s.unknown.Add(1)
+	},
+	ReasonResourceExhausted: func(s *Stats) {
+		s.resourceExhausted.Add(1)
+	},
+	ReasonReadOnly: func(s *Stats) {
+		s.readOnly.Add(1)
+	},
+	ReasonPermission: func(s *Stats) {
+		s.permission.Add(1)
+	},
+	ReasonCorrupt: func(s *Stats) {
+		s.corrupt.Add(1)
+	},
+}
+
+// Record updates counters from a classified SQL backend error.
+func (s *Stats) Record(err error) {
+	var sqlErr *SQLError
+	if !errors.As(err, &sqlErr) {
+		return
+	}
+
+	s.totalErrs.Add(1)
+
+	switch sqlErr.Class() {
+	case ClassTransient:
+		s.transientErrs.Add(1)
+
+	case ClassPermanent:
+		s.permanentErrs.Add(1)
+
+	case ClassFatal:
+		s.fatalErrs.Add(1)
+	}
+
+	s.recordReason(sqlErr.Reason)
+}
+
+// Snapshot returns a read-only copy of the current SQL error counters.
+func (s *Stats) Snapshot(backend Backend) StatsSnapshot {
+	return StatsSnapshot{
+		Backend:           backend,
+		TotalErrs:         s.totalErrs.Load(),
+		TransientErrs:     s.transientErrs.Load(),
+		PermanentErrs:     s.permanentErrs.Load(),
+		FatalErrs:         s.fatalErrs.Load(),
+		Serialization:     s.serialization.Load(),
+		Deadlocks:         s.deadlocks.Load(),
+		Busy:              s.busy.Load(),
+		Locked:            s.locked.Load(),
+		Unavailable:       s.unavailable.Load(),
+		PoolExhausted:     s.poolExhausted.Load(),
+		ResourceExhausted: s.resourceExhausted.Load(),
+		ReadOnly:          s.readOnly.Load(),
+		Permission:        s.permission.Load(),
+		Corrupt:           s.corrupt.Load(),
+		SchemaMismatch:    s.schemaMismatch.Load(),
+		Constraint:        s.constraint.Load(),
+		Unknown:           s.unknown.Load(),
+	}
+}
+
+// recordReason updates counters for one classified SQL error reason.
+func (s *Stats) recordReason(reason Reason) {
+	if !reason.Valid() {
+		s.unknown.Add(1)
+		return
+	}
+
+	record := reasonRecorders[reason]
+	if record == nil {
+		s.unknown.Add(1)
+		return
+	}
+
+	record(s)
+}

--- a/wallet/internal/db/err/stats_test.go
+++ b/wallet/internal/db/err/stats_test.go
@@ -1,0 +1,115 @@
+package dberr
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	errTestSerialization = errors.New("serialization")
+	errTestConstraint    = errors.New("constraint")
+	errTestPlain         = errors.New("plain")
+)
+
+// TestStatsRecord verifies that the stats collector updates class and reason
+// counters from classified SQL backend errors.
+func TestStatsRecord(t *testing.T) {
+	t.Parallel()
+
+	var stats Stats
+
+	stats.Record(NewSQLError(
+		BackendPostgres,
+		ReasonSerialization,
+		"40001",
+		errTestSerialization,
+	))
+	stats.Record(NewSQLError(
+		BackendSQLite,
+		ReasonConstraint,
+		"2067",
+		errTestConstraint,
+	))
+
+	snapshot := stats.Snapshot(BackendPostgres)
+	require.EqualValues(t, 2, snapshot.TotalErrs)
+	require.EqualValues(t, 1, snapshot.TransientErrs)
+	require.EqualValues(t, 1, snapshot.PermanentErrs)
+	require.EqualValues(t, 1, snapshot.Serialization)
+	require.EqualValues(t, 1, snapshot.Constraint)
+}
+
+// TestStatsRecordReasonAll verifies that each reason increments its expected
+// counter.
+func TestStatsRecordReasonAll(t *testing.T) {
+	t.Parallel()
+
+	reasons := []Reason{
+		ReasonSerialization,
+		ReasonDeadlock,
+		ReasonBusy,
+		ReasonLocked,
+		ReasonUnavailable,
+		ReasonPoolExhausted,
+		ReasonResourceExhausted,
+		ReasonReadOnly,
+		ReasonPermission,
+		ReasonCorrupt,
+		ReasonSchemaMismatch,
+		ReasonConstraint,
+		ReasonUnknown,
+	}
+
+	var stats Stats
+	for _, reason := range reasons {
+		stats.recordReason(reason)
+	}
+
+	snapshot := stats.Snapshot(BackendPostgres)
+	require.EqualValues(t, 1, snapshot.Serialization)
+	require.EqualValues(t, 1, snapshot.Deadlocks)
+	require.EqualValues(t, 1, snapshot.Busy)
+	require.EqualValues(t, 1, snapshot.Locked)
+	require.EqualValues(t, 1, snapshot.Unavailable)
+	require.EqualValues(t, 1, snapshot.PoolExhausted)
+	require.EqualValues(t, 1, snapshot.ResourceExhausted)
+	require.EqualValues(t, 1, snapshot.ReadOnly)
+	require.EqualValues(t, 1, snapshot.Permission)
+	require.EqualValues(t, 1, snapshot.Corrupt)
+	require.EqualValues(t, 1, snapshot.SchemaMismatch)
+	require.EqualValues(t, 1, snapshot.Constraint)
+	require.EqualValues(t, 1, snapshot.Unknown)
+}
+
+// TestStatsRecordUnknown verifies that fallback reasons are counted as
+// permanent unknown failures.
+func TestStatsRecordUnknown(t *testing.T) {
+	t.Parallel()
+
+	var stats Stats
+	stats.Record(NewSQLError(BackendSQLite, ReasonUnknown, "", errTestPlain))
+	stats.recordReason(Reason(99))
+
+	snapshot := stats.Snapshot(BackendSQLite)
+	require.EqualValues(t, 1, snapshot.TotalErrs)
+	require.Zero(t, snapshot.TransientErrs)
+	require.EqualValues(t, 1, snapshot.PermanentErrs)
+	require.Zero(t, snapshot.FatalErrs)
+	require.EqualValues(t, 2, snapshot.Unknown)
+}
+
+// TestStatsRecordIgnoresPlainErr verifies that only classified SQL backend
+// errors affect the stats collector.
+func TestStatsRecordIgnoresPlainErr(t *testing.T) {
+	t.Parallel()
+
+	var stats Stats
+
+	stats.Record(errTestPlain)
+
+	snapshot := stats.Snapshot(BackendSQLite)
+	require.Zero(t, snapshot.TotalErrs)
+	require.Zero(t, snapshot.Unknown)
+}

--- a/wallet/internal/db/pg/errors.go
+++ b/wallet/internal/db/pg/errors.go
@@ -1,0 +1,139 @@
+// Package pg contains PostgreSQL-specific SQL helpers.
+package pg
+
+import (
+	"errors"
+
+	dberr "github.com/btcsuite/btcwallet/wallet/internal/db/err"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// SQLSTATE helper constants support PostgreSQL error classification.
+const (
+	// connectionExceptionClass identifies PostgreSQL SQLSTATE class 08,
+	// which covers connection exceptions.
+	connectionExceptionClass = "08"
+
+	// sqlStateClassLen is the length of a SQLSTATE class prefix.
+	sqlStateClassLen = 2
+)
+
+// SQLSTATE code constants capture the PostgreSQL errors mapped here.
+const (
+	// The SQLSTATE codes below follow PostgreSQL's documented error code
+	// appendix. The wallet intentionally collapses many backend-specific
+	// codes into a smaller caller-facing reason set.
+	//
+	// Reference:
+	// https://www.postgresql.org/docs/current/errcodes-appendix.html
+	codeSerializationFailure = "40001"
+	codeDeadlockDetected     = "40P01"
+	codeLockNotAvailable     = "55P03"
+	codeQueryCanceled        = "57014"
+	codeAdminShutdown        = "57P01"
+	codeCrashShutdown        = "57P02"
+	codeCannotConnectNow     = "57P03"
+	codeTooManyConnections   = "53300"
+	codeDiskFull             = "53100"
+	codeOutOfMemory          = "53200"
+	codeConfigLimitExceeded  = "53400"
+	codeReadOnlyTxn          = "25006"
+	codeInsufficientPriv     = "42501"
+	codeCorruptData          = "XX001"
+	codeCorruptIndex         = "XX002"
+	codeUndefinedTable       = "42P01"
+	codeUndefinedColumn      = "42703"
+	codeUniqueViolation      = "23505"
+	codeForeignKeyViolation  = "23503"
+	codeCheckViolation       = "23514"
+	codeNotNullViolation     = "23502"
+	codeExclusionViolation   = "23P01"
+)
+
+// reasonByCode maps PostgreSQL SQLSTATE codes into the shared SQL error model.
+var reasonByCode = map[string]dberr.Reason{
+	codeSerializationFailure: dberr.ReasonSerialization,
+	codeDeadlockDetected:     dberr.ReasonDeadlock,
+	codeLockNotAvailable:     dberr.ReasonLocked,
+	codeQueryCanceled:        dberr.ReasonUnknown,
+	codeAdminShutdown:        dberr.ReasonUnavailable,
+	codeCrashShutdown:        dberr.ReasonUnavailable,
+	codeCannotConnectNow:     dberr.ReasonUnavailable,
+	codeTooManyConnections:   dberr.ReasonPoolExhausted,
+	codeDiskFull:             dberr.ReasonResourceExhausted,
+	codeOutOfMemory:          dberr.ReasonResourceExhausted,
+	codeConfigLimitExceeded:  dberr.ReasonResourceExhausted,
+	codeReadOnlyTxn:          dberr.ReasonReadOnly,
+	codeInsufficientPriv:     dberr.ReasonPermission,
+	codeCorruptData:          dberr.ReasonCorrupt,
+	codeCorruptIndex:         dberr.ReasonCorrupt,
+	codeUndefinedTable:       dberr.ReasonSchemaMismatch,
+	codeUndefinedColumn:      dberr.ReasonSchemaMismatch,
+	codeUniqueViolation:      dberr.ReasonConstraint,
+	codeForeignKeyViolation:  dberr.ReasonConstraint,
+	codeCheckViolation:       dberr.ReasonConstraint,
+	codeNotNullViolation:     dberr.ReasonConstraint,
+	codeExclusionViolation:   dberr.ReasonConstraint,
+}
+
+// mapErr maps PostgreSQL driver and transport errors into SQLError.
+func mapErr(err error) *dberr.SQLError {
+	// Prefer SQLSTATE-based mapping first so a completed PostgreSQL statement
+	// keeps its specific backend code instead of being collapsed into a generic
+	// transport fallback.
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return mapCode(pgErr.Code, err)
+	}
+
+	var connectErr *pgconn.ConnectError
+
+	// ConnectError means the driver failed while establishing or maintaining
+	// the connection, so callers see the same transient unavailable bucket used
+	// for other connection-path failures.
+	if errors.As(err, &connectErr) {
+		return dberr.NewSQLError(
+			dberr.BackendPostgres, dberr.ReasonUnavailable, "", err,
+		)
+	}
+
+	// Safe-to-retry and timeout failures happen on the connection or transport
+	// path rather than as a completed SQL statement outcome, so they share the
+	// transient backend-unavailable bucket with SQLSTATE connection exceptions.
+	if pgconn.SafeToRetry(err) || pgconn.Timeout(err) {
+		return dberr.NewSQLError(
+			dberr.BackendPostgres, dberr.ReasonUnavailable, "", err,
+		)
+	}
+
+	return nil
+}
+
+// mapCode maps one PostgreSQL SQLSTATE into SQLError.
+func mapCode(code string, err error) *dberr.SQLError {
+	reason, ok := reasonByCode[code]
+	if ok {
+		return dberr.NewSQLError(dberr.BackendPostgres, reason, code, err)
+	}
+
+	if sqlStateClass(code) == connectionExceptionClass {
+		// SQLSTATE class 08 reports connection exceptions rather than completed
+		// statement outcomes, so it maps to the shared unavailable reason.
+		return dberr.NewSQLError(
+			dberr.BackendPostgres, dberr.ReasonUnavailable, code, err,
+		)
+	}
+
+	return dberr.NewSQLError(
+		dberr.BackendPostgres, dberr.ReasonUnknown, code, err,
+	)
+}
+
+// sqlStateClass returns the SQLSTATE class prefix.
+func sqlStateClass(code string) string {
+	if len(code) < sqlStateClassLen {
+		return ""
+	}
+
+	return code[:sqlStateClassLen]
+}

--- a/wallet/internal/db/pg/errors_test.go
+++ b/wallet/internal/db/pg/errors_test.go
@@ -1,0 +1,118 @@
+package pg
+
+import (
+	"io"
+	"testing"
+
+	dberr "github.com/btcsuite/btcwallet/wallet/internal/db/err"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
+)
+
+// codeClassificationTestCase defines one SQLSTATE mapping expectation.
+type codeClassificationTestCase struct {
+	// name describes the subtest.
+	name string
+
+	// code is the PostgreSQL SQLSTATE under test.
+	code string
+
+	// wantReason is the expected shared SQL error reason.
+	wantReason dberr.Reason
+}
+
+// TestMapCode verifies that representative SQLSTATEs map to the expected
+// reason and class buckets.
+func TestMapCode(t *testing.T) {
+	t.Parallel()
+
+	tests := []codeClassificationTestCase{
+		{
+			name:       "serialization",
+			code:       codeSerializationFailure,
+			wantReason: dberr.ReasonSerialization,
+		},
+		{
+			name:       "deadlock",
+			code:       codeDeadlockDetected,
+			wantReason: dberr.ReasonDeadlock,
+		},
+		{
+			name:       "too many connections",
+			code:       codeTooManyConnections,
+			wantReason: dberr.ReasonPoolExhausted,
+		},
+		{
+			name:       "disk full",
+			code:       codeDiskFull,
+			wantReason: dberr.ReasonResourceExhausted,
+		},
+		{
+			name:       "schema mismatch",
+			code:       codeUndefinedTable,
+			wantReason: dberr.ReasonSchemaMismatch,
+		},
+		{
+			name:       "constraint",
+			code:       codeUniqueViolation,
+			wantReason: dberr.ReasonConstraint,
+		},
+		{
+			name:       "not null constraint",
+			code:       codeNotNullViolation,
+			wantReason: dberr.ReasonConstraint,
+		},
+		{
+			name:       "exclusion constraint",
+			code:       codeExclusionViolation,
+			wantReason: dberr.ReasonConstraint,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := mapCode(testCase.code, io.EOF)
+			require.NotNil(t, err)
+			require.Equal(t, dberr.BackendPostgres, err.Backend)
+			require.Equal(t, testCase.wantReason, err.Reason)
+			require.Equal(t, testCase.wantReason.Class(), err.Class())
+			require.Equal(t, testCase.code, err.Code)
+		})
+	}
+}
+
+// TestMapCodeFallback verifies the fallback mapping paths for connection
+// exception classes and unknown SQLSTATEs.
+func TestMapCodeFallback(t *testing.T) {
+	t.Parallel()
+
+	connectionErr := mapCode("08006", io.EOF)
+	require.NotNil(t, connectionErr)
+	require.Equal(t, dberr.ReasonUnavailable, connectionErr.Reason)
+	require.Equal(t, dberr.ClassTransient, connectionErr.Class())
+
+	unknownErr := mapCode("99999", io.EOF)
+	require.NotNil(t, unknownErr)
+	require.Equal(t, dberr.ReasonUnknown, unknownErr.Reason)
+	require.Equal(t, dberr.ClassPermanent, unknownErr.Class())
+
+	require.Equal(t, "08", sqlStateClass("08006"))
+	require.Empty(t, sqlStateClass("0"))
+}
+
+// TestMapErr verifies that driver-specific PostgreSQL errors are recognized and
+// wrapped as SQL errors.
+func TestMapErr(t *testing.T) {
+	t.Parallel()
+
+	err := mapErr(&pgconn.PgError{
+		Code:    codeReadOnlyTxn,
+		Message: "read only",
+	})
+	require.NotNil(t, err)
+	require.Equal(t, dberr.BackendPostgres, err.Backend)
+	require.Equal(t, dberr.ReasonReadOnly, err.Reason)
+	require.Equal(t, dberr.ClassFatal, err.Class())
+}

--- a/wallet/internal/db/runtime/runtime.go
+++ b/wallet/internal/db/runtime/runtime.go
@@ -23,6 +23,12 @@ var (
 	// ErrAmbiguousTxCommit matches commit failures whose final database outcome
 	// is unknown because the commit may already have reached the backend before
 	// the client observed the failure.
+	//
+	// Callers should treat this differently from an ordinary commit failure and
+	// should not blindly retry the transaction. Write returns this through
+	// AmbiguousTxCommitError so callers can use errors.Is(err,
+	// ErrAmbiguousTxCommit) for policy checks while still inspecting the
+	// underlying classified backend error.
 	ErrAmbiguousTxCommit = errors.New("sql ambiguous tx commit")
 )
 
@@ -34,8 +40,8 @@ var (
 	errReadDelayOrder  = errors.New("read base delay exceeds max delay")
 )
 
-// AmbiguousTxCommitError wraps a classified commit error returned when Commit
-// fails after the final database outcome may already be decided by the
+// AmbiguousTxCommitError wraps a classified commit error returned by Write when
+// Commit fails after the final database outcome may already be decided by the
 // backend.
 //
 // This lets callers ask two independent questions about the same failure:
@@ -98,6 +104,25 @@ type ReadHooks interface {
 
 	// RecordRetryExhausted records that retry budget was exhausted.
 	RecordRetryExhausted()
+}
+
+// WriteHooks defines the runtime hooks needed by the shared transaction helper.
+type WriteHooks interface {
+	// CheckHealthy fails fast when the backend has already been marked
+	// unhealthy.
+	CheckHealthy() error
+
+	// ClassifyError maps backend failures into the shared SQL error model.
+	ClassifyError(err error) error
+
+	// RecordError records a classified SQL error.
+	RecordError(err error)
+
+	// RecordAmbiguousTxCommit records a commit failure with unknown outcome.
+	RecordAmbiguousTxCommit()
+
+	// RawDB returns the backend database handle used for transactions.
+	RawDB() *sql.DB
 }
 
 // ReadConfig holds caller-provided retry settings for Read.
@@ -273,6 +298,106 @@ func readAttempt[Q any, T any](ctx context.Context, hooks ReadHooks, queries Q,
 	//nolint:wrapcheck
 	// We need to return the exact classified error to be wrapped by Read.
 	return zero, true, classifiedErr
+}
+
+// Write executes a transactional SQL callback without retrying it.
+//
+// Write returns the callback result only after Commit succeeds. If Begin,
+// callback execution, or Commit fails, it returns the zero value of T together
+// with the resulting error.
+//
+// hooks supplies the shared health check, error classification, SQL error
+// recording, ambiguous-commit accounting, and raw database handle used by the
+// helper.
+//
+// bind converts the started *sql.Tx into the caller's transactional query
+// handle, such as a sqlc Queries value bound to that transaction.
+//
+// fn performs the transactional work with that bound handle. SQL and backend
+// callback failures are normalized through hooks.ClassifyError, while ordinary
+// domain errors pass through unchanged.
+//
+// If Commit fails after the backend may already have applied the transaction,
+// Write returns an AmbiguousTxCommitError. Callers should detect that case
+// with errors.Is(err, ErrAmbiguousTxCommit) before deciding whether retrying
+// or compensating work is safe.
+func Write[Q any, T any](ctx context.Context, hooks WriteHooks,
+	bind func(*sql.Tx) Q, fn func(Q) (T, error)) (T, error) {
+
+	var zero T
+
+	// Fail fast if a prior fatal backend error already poisoned the store.
+	err := hooks.CheckHealthy()
+	if err != nil {
+		return zero, fmt.Errorf("check store health: %w", err)
+	}
+
+	// Begin the transaction before invoking the callback so begin failures are
+	// still classified and recorded consistently.
+	tx, err := hooks.RawDB().BeginTx(ctx, nil)
+	if err != nil {
+		classifiedErr := hooks.ClassifyError(err)
+		hooks.RecordError(classifiedErr)
+
+		return zero, fmt.Errorf("begin tx: %w", classifiedErr)
+	}
+
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	// Callback errors are normalized through the backend classifier so SQL
+	// driver failures reach callers consistently while non-SQL domain errors
+	// pass through unchanged.
+	result, err := fn(bind(tx))
+	if err != nil {
+		classifiedErr := hooks.ClassifyError(err)
+		recordWriteCallbackError(hooks, classifiedErr)
+
+		return zero, normalizeWriteCallbackError(err, classifiedErr)
+	}
+
+	// Commit transport failures are wrapped so callers know the final
+	// transaction outcome is unknown.
+	err = tx.Commit()
+	if err != nil {
+		classifiedErr := hooks.ClassifyError(err)
+		hooks.RecordError(classifiedErr)
+
+		if isCommitTransportError(err) {
+			hooks.RecordAmbiguousTxCommit()
+
+			return zero, &AmbiguousTxCommitError{
+				Err: fmt.Errorf("commit tx: %w", classifiedErr),
+			}
+		}
+
+		return zero, fmt.Errorf("commit tx: %w", classifiedErr)
+	}
+
+	return result, nil
+}
+
+// normalizeWriteCallbackError preserves unchanged callback errors while
+// returning normalized SQL backend failures when classification added one.
+func normalizeWriteCallbackError(err, classifiedErr error) error {
+	var sqlErr *dberr.SQLError
+	if !errors.As(classifiedErr, &sqlErr) {
+		return err
+	}
+
+	return classifiedErr
+}
+
+// recordWriteCallbackError records one classified SQL callback error while
+// leaving non-SQL callback failures out of SQL error accounting.
+func recordWriteCallbackError(hooks WriteHooks, classifiedErr error) {
+	var sqlErr *dberr.SQLError
+	if !errors.As(classifiedErr, &sqlErr) {
+		return
+	}
+
+	hooks.RecordError(classifiedErr)
 }
 
 // retryDelay applies bounded exponential backoff for retry attempts.

--- a/wallet/internal/db/runtime/runtime.go
+++ b/wallet/internal/db/runtime/runtime.go
@@ -1,0 +1,90 @@
+// Package runtime provides shared SQL execution helpers for split backend
+// packages.
+package runtime
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+)
+
+// Runtime sentinel errors returned by the shared SQL helpers.
+var (
+	// ErrAmbiguousTxCommit matches commit failures whose final database outcome
+	// is unknown because the commit may already have reached the backend before
+	// the client observed the failure.
+	ErrAmbiguousTxCommit = errors.New("sql ambiguous tx commit")
+)
+
+// AmbiguousTxCommitError wraps a classified commit error returned when Commit
+// fails after the final database outcome may already be decided by the
+// backend.
+//
+// This lets callers ask two independent questions about the same failure:
+//
+//   - errors.Is(err, ErrAmbiguousTxCommit) reports that the transaction outcome
+//     is unknown and should not be retried blindly.
+//   - errors.As / errors.Unwrap expose the classified backend error for
+//     logging, metrics, or backend-specific handling.
+type AmbiguousTxCommitError struct {
+	// Err is the classified backend error observed during commit.
+	Err error
+}
+
+// Error returns the wrapped error string.
+func (e *AmbiguousTxCommitError) Error() string {
+	if e == nil || e.Err == nil {
+		return ErrAmbiguousTxCommit.Error()
+	}
+
+	return e.Err.Error()
+}
+
+// Unwrap returns the wrapped classified commit error.
+func (e *AmbiguousTxCommitError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+
+	return e.Err
+}
+
+// Is reports whether target matches the ambiguous commit sentinel.
+func (e *AmbiguousTxCommitError) Is(target error) bool {
+	switch target {
+	case ErrAmbiguousTxCommit:
+		return true
+
+	default:
+		return false
+	}
+}
+
+// isCommitTransportError reports whether commit failed after the request may
+// already have reached the backend.
+func isCommitTransportError(err error) bool {
+	if errors.Is(err, driver.ErrBadConn) || errors.Is(err, sql.ErrConnDone) ||
+		errors.Is(err, io.EOF) {
+
+		return true
+	}
+
+	return extractNetError(err) != nil
+}
+
+// extractNetError extracts a net.Error used by commit transport checks.
+func extractNetError(err error) netError {
+	var transportErr netError
+	if errors.As(err, &transportErr) {
+		return transportErr
+	}
+
+	return nil
+}
+
+// netError captures the net.Error behavior needed for commit transport checks.
+type netError interface {
+	error
+	Timeout() bool
+}

--- a/wallet/internal/db/runtime/runtime.go
+++ b/wallet/internal/db/runtime/runtime.go
@@ -3,18 +3,35 @@
 package runtime
 
 import (
+	"context"
 	"database/sql"
 	"database/sql/driver"
 	"errors"
+	"fmt"
 	"io"
+	"time"
+
+	dberr "github.com/btcsuite/btcwallet/wallet/internal/db/err"
 )
 
 // Runtime sentinel errors returned by the shared SQL helpers.
 var (
+	// ErrStoreUnhealthy is returned when a runtime helper operates on an
+	// already unhealthy store.
+	ErrStoreUnhealthy = errors.New("sql store unhealthy")
+
 	// ErrAmbiguousTxCommit matches commit failures whose final database outcome
 	// is unknown because the commit may already have reached the backend before
 	// the client observed the failure.
 	ErrAmbiguousTxCommit = errors.New("sql ambiguous tx commit")
+)
+
+// Read config validation errors returned by Read.
+var (
+	errReadMaxAttempts = errors.New("read max attempts must be positive")
+	errReadBaseDelay   = errors.New("read base delay must be positive")
+	errReadMaxDelay    = errors.New("read max delay must be positive")
+	errReadDelayOrder  = errors.New("read base delay exceeds max delay")
 )
 
 // AmbiguousTxCommitError wraps a classified commit error returned when Commit
@@ -59,6 +76,274 @@ func (e *AmbiguousTxCommitError) Is(target error) bool {
 	default:
 		return false
 	}
+}
+
+// ReadHooks defines the runtime hooks needed by the shared read helper.
+type ReadHooks interface {
+	// CheckHealthy fails fast when the backend has already been marked
+	// unhealthy.
+	CheckHealthy() error
+
+	// ClassifyError maps backend failures into the shared SQL error model.
+	ClassifyError(err error) error
+
+	// RecordError records a classified SQL error.
+	RecordError(err error)
+
+	// RecordRetryAttempt records one retry backoff attempt.
+	RecordRetryAttempt()
+
+	// RecordRetrySuccess records a successful retry outcome.
+	RecordRetrySuccess()
+
+	// RecordRetryExhausted records that retry budget was exhausted.
+	RecordRetryExhausted()
+}
+
+// ReadConfig holds caller-provided retry settings for Read.
+//
+// Callers should derive this from backend or wallet configuration so retry
+// policy stays outside the shared runtime helper package.
+type ReadConfig struct {
+	// MaxAttempts is the maximum number of callback attempts, including the
+	// first attempt. Set this to 1 to disable retries.
+	MaxAttempts int
+
+	// BaseDelay is the starting backoff delay before jitter is applied.
+	// Ignored when MaxAttempts is 1.
+	BaseDelay time.Duration
+
+	// MaxDelay is the upper bound for the exponential backoff delay.
+	// Ignored when MaxAttempts is 1.
+	MaxDelay time.Duration
+}
+
+// readConfig holds the retry settings used by readWithConfig.
+type readConfig struct {
+	// attempts is the maximum number of callback attempts.
+	attempts int
+
+	// base is the starting backoff delay before jitter is applied.
+	base time.Duration
+
+	// max is the upper bound for the exponential backoff delay.
+	max time.Duration
+
+	// jitter rewrites one calculated delay before waiting.
+	jitter func(time.Duration) time.Duration
+
+	// timer waits for one retry delay.
+	timer func(time.Duration) *time.Timer
+}
+
+// Read executes a read-only SQL callback with transient retry handling.
+//
+// Read returns the callback result from the first successful attempt. On any
+// failure, it returns the zero value of T together with the final error.
+func Read[Q any, T any](ctx context.Context, hooks ReadHooks, queries Q,
+	config ReadConfig,
+	fn func(context.Context, Q) (T, error)) (T, error) {
+
+	execConfig, err := buildReadConfig(config)
+	if err != nil {
+		var zero T
+
+		return zero, fmt.Errorf("build read config: %w", err)
+	}
+
+	return readWithConfig(ctx, hooks, queries, fn, execConfig)
+}
+
+// buildReadConfig converts the caller-facing config into runtime settings.
+func buildReadConfig(config ReadConfig) (readConfig, error) {
+	switch {
+	case config.MaxAttempts <= 0:
+		return readConfig{}, errReadMaxAttempts
+
+	case config.MaxAttempts > 1 && config.BaseDelay <= 0:
+		return readConfig{}, errReadBaseDelay
+
+	case config.MaxAttempts > 1 && config.MaxDelay <= 0:
+		return readConfig{}, errReadMaxDelay
+
+	case config.MaxAttempts > 1 && config.BaseDelay > config.MaxDelay:
+		return readConfig{}, errReadDelayOrder
+	}
+
+	return readConfig{
+		attempts: config.MaxAttempts,
+		base:     config.BaseDelay,
+		max:      config.MaxDelay,
+		jitter: func(delay time.Duration) time.Duration {
+			return delay
+		},
+		timer: time.NewTimer,
+	}, nil
+}
+
+// readWithConfig executes Read with injected retry settings.
+func readWithConfig[Q any, T any](ctx context.Context, hooks ReadHooks,
+	queries Q, fn func(context.Context, Q) (T, error),
+	config readConfig) (T, error) {
+
+	var zero T
+
+	// Fail fast if a prior fatal backend error already poisoned the store.
+	err := hooks.CheckHealthy()
+	if err != nil {
+		return zero, fmt.Errorf("check store health: %w", err)
+	}
+
+	for attempt := range config.attempts {
+		result, shouldRetry, err := readAttempt(ctx, hooks, queries, fn)
+		if !shouldRetry && err == nil {
+			if attempt > 0 {
+				hooks.RecordRetrySuccess()
+			}
+
+			return result, nil
+		}
+
+		if !shouldRetry {
+			return zero, err
+		}
+
+		if attempt == config.attempts-1 {
+			hooks.RecordRetryExhausted()
+			return zero, fmt.Errorf("read: %w", err)
+		}
+
+		hooks.RecordRetryAttempt()
+
+		// Use exponential backoff with injectable jitter and timer hooks so the
+		// helper stays deterministic under test.
+		delay := retryDelay(attempt, config.base, config.max)
+		delay = config.jitter(delay)
+
+		err = waitForRetry(ctx, config.timer, delay)
+		if err != nil {
+			return zero, err
+		}
+	}
+
+	return zero, ErrStoreUnhealthy
+}
+
+// readAttempt executes one read callback attempt.
+//
+// It returns the callback result on success. On failure, it returns the zero
+// value of T together with either an immediate return error or a classified
+// transient error for the outer retry loop.
+func readAttempt[Q any, T any](ctx context.Context, hooks ReadHooks, queries Q,
+	fn func(context.Context, Q) (T, error)) (T, bool, error) {
+
+	var zero T
+
+	// Run the read callback first so successful reads never pay any
+	// classification or retry overhead.
+	result, err := fn(ctx, queries)
+	if err == nil {
+		return result, false, nil
+	}
+
+	// Preserve caller-driven cancellation and no-row results unchanged.
+	ctxErr := unwrapContextError(err)
+	if ctxErr != nil {
+		return zero, false, ctxErr
+	}
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return zero, false, err
+	}
+
+	// Classify the backend failure once before deciding whether the read is
+	// safe to retry.
+	classifiedErr := hooks.ClassifyError(err)
+	hooks.RecordError(classifiedErr)
+
+	// Retry only transient classified failures. Everything else returns to the
+	// caller immediately with context.
+	var sqlErr *dberr.SQLError
+	if !errors.As(classifiedErr, &sqlErr) ||
+		sqlErr.Class() != dberr.ClassTransient {
+
+		return zero, false, fmt.Errorf("read: %w", classifiedErr)
+	}
+
+	//nolint:wrapcheck
+	// We need to return the exact classified error to be wrapped by Read.
+	return zero, true, classifiedErr
+}
+
+// retryDelay applies bounded exponential backoff for retry attempts.
+func retryDelay(attempt int, baseDelay, maxDelay time.Duration) time.Duration {
+	// The first retry waits for the configured base delay. Each later retry
+	// doubles the previous delay until the backoff reaches the configured cap.
+	delay := baseDelay
+
+	for range attempt {
+		// Saturate before doubling once the next step would reach or exceed the
+		// cap. The maxDelay/2 check avoids computing delay*2 when the bounded
+		// result must already be maxDelay.
+		if delay >= maxDelay || delay > maxDelay/2 {
+			return maxDelay
+		}
+
+		delay *= 2
+	}
+
+	// Keep the helper defensive when called directly with unchecked values.
+	if delay > maxDelay {
+		return maxDelay
+	}
+
+	return delay
+}
+
+// waitForRetry waits for the next retry delay or returns ctx.Err when the
+// caller cancels first.
+func waitForRetry(ctx context.Context,
+	timer func(time.Duration) *time.Timer, delay time.Duration) error {
+
+	retryTimer := timer(delay)
+	defer stopRetryTimer(retryTimer)
+
+	select {
+	case <-retryTimer.C:
+		return nil
+
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// stopRetryTimer stops a retry timer and drains a fired value when needed.
+func stopRetryTimer(timer *time.Timer) {
+	if timer == nil {
+		return
+	}
+
+	if timer.Stop() {
+		return
+	}
+
+	select {
+	case <-timer.C:
+	default:
+	}
+}
+
+// unwrapContextError preserves caller-driven cancellation and deadlines.
+func unwrapContextError(err error) error {
+	if errors.Is(err, context.Canceled) {
+		return err
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+
+	return nil
 }
 
 // isCommitTransportError reports whether commit failed after the request may

--- a/wallet/internal/db/runtime/runtime_bench_test.go
+++ b/wallet/internal/db/runtime/runtime_bench_test.go
@@ -1,0 +1,64 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	dberr "github.com/btcsuite/btcwallet/wallet/internal/db/err"
+)
+
+// BenchmarkReadSuccess measures a successful read with no retries.
+func BenchmarkReadSuccess(b *testing.B) {
+	hooks := &fakeStore{}
+	for range b.N {
+		_, _ = readWithConfig(
+			context.Background(), hooks, struct{}{},
+			func(context.Context, struct{}) (struct{}, error) {
+				return struct{}{}, nil
+			},
+			readConfig{
+				attempts: 1,
+				base:     time.Millisecond,
+				max:      time.Millisecond,
+				timer:    time.NewTimer,
+				jitter: func(delay time.Duration) time.Duration {
+					return delay
+				},
+			},
+		)
+	}
+}
+
+// BenchmarkReadTransientRetry measures one retry before success.
+func BenchmarkReadTransientRetry(b *testing.B) {
+	hooks := &fakeStore{classifyFn: func(err error) error {
+		return dberr.NewSQLError(
+			dberr.BackendSQLite, dberr.ReasonBusy, "5", err,
+		)
+	}}
+
+	for range b.N {
+		attempts := 0
+		_, _ = readWithConfig(
+			context.Background(), hooks, struct{}{},
+			func(context.Context, struct{}) (struct{}, error) {
+				attempts++
+				if attempts == 1 {
+					return struct{}{}, errRuntimeBusy
+				}
+
+				return struct{}{}, nil
+			},
+			readConfig{
+				attempts: 2,
+				base:     time.Millisecond,
+				max:      time.Millisecond,
+				timer:    immediateTimer,
+				jitter: func(delay time.Duration) time.Duration {
+					return delay
+				},
+			},
+		)
+	}
+}

--- a/wallet/internal/db/runtime/runtime_test.go
+++ b/wallet/internal/db/runtime/runtime_test.go
@@ -1,0 +1,60 @@
+package runtime
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test errors used by the runtime helper tests.
+var errRuntimeOther = errors.New("other")
+
+// TestAmbiguousTxCommitError verifies the sentinel-matching and unwrap
+// behavior of AmbiguousTxCommitError.
+func TestAmbiguousTxCommitError(t *testing.T) {
+	t.Parallel()
+
+	err := &AmbiguousTxCommitError{Err: io.EOF}
+	wrappedSentinel := fmt.Errorf("wrap: %w", ErrAmbiguousTxCommit)
+
+	require.ErrorIs(t, err, ErrAmbiguousTxCommit)
+	require.False(t, err.Is(wrappedSentinel))
+	require.Equal(t, io.EOF.Error(), err.Error())
+	require.ErrorIs(t, err, io.EOF)
+	require.Equal(
+		t, ErrAmbiguousTxCommit.Error(), (&AmbiguousTxCommitError{}).Error(),
+	)
+	require.NoError(t, (*AmbiguousTxCommitError)(nil).Unwrap())
+}
+
+// TestCommitTransportError verifies that transport-shaped commit failures are
+// detected as ambiguous-outcome candidates.
+func TestCommitTransportError(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, isCommitTransportError(io.EOF))
+	require.True(t, isCommitTransportError(driver.ErrBadConn))
+	require.True(t, isCommitTransportError(sql.ErrConnDone))
+	require.True(t, isCommitTransportError(netTimeoutError{}))
+	require.False(t, isCommitTransportError(errRuntimeOther))
+	require.NotNil(t, extractNetError(netTimeoutError{}))
+	require.Nil(t, extractNetError(errRuntimeOther))
+}
+
+// netTimeoutError is a test helper that reports a transport timeout.
+type netTimeoutError struct{}
+
+// Error returns the static timeout error string.
+func (e netTimeoutError) Error() string {
+	return "timeout"
+}
+
+// Timeout reports that the test error is a timeout.
+func (e netTimeoutError) Timeout() bool {
+	return true
+}

--- a/wallet/internal/db/runtime/runtime_test.go
+++ b/wallet/internal/db/runtime/runtime_test.go
@@ -1,18 +1,70 @@
 package runtime
 
 import (
+	"context"
 	"database/sql"
 	"database/sql/driver"
 	"errors"
 	"fmt"
 	"io"
 	"testing"
+	"time"
 
+	dberr "github.com/btcsuite/btcwallet/wallet/internal/db/err"
 	"github.com/stretchr/testify/require"
 )
 
 // Test errors used by the runtime helper tests.
-var errRuntimeOther = errors.New("other")
+var (
+	errRuntimeBusy  = errors.New("busy")
+	errRuntimeRetry = errors.New("retry")
+	errRuntimeOther = errors.New("other")
+)
+
+// fakeStore implements the runtime hook interfaces for tests.
+type fakeStore struct {
+	healthyErr      error
+	classifyFn      func(error) error
+	errorCount      int
+	retryAttempts   int
+	retrySuccesses  int
+	retryExhausted  int
+	ambiguousCommit int
+}
+
+// CheckHealthy returns the configured health-check result for fakeStore.
+func (s *fakeStore) CheckHealthy() error {
+	return s.healthyErr
+}
+
+// ClassifyError applies the configured classifier when one is present.
+func (s *fakeStore) ClassifyError(err error) error {
+	if s.classifyFn != nil {
+		return s.classifyFn(err)
+	}
+
+	return err
+}
+
+// RecordError increments the fake classified-error counter.
+func (s *fakeStore) RecordError(error) {
+	s.errorCount++
+}
+
+// RecordRetryAttempt increments the fake retry-attempt counter.
+func (s *fakeStore) RecordRetryAttempt() {
+	s.retryAttempts++
+}
+
+// RecordRetrySuccess increments the fake retry-success counter.
+func (s *fakeStore) RecordRetrySuccess() {
+	s.retrySuccesses++
+}
+
+// RecordRetryExhausted increments the fake retry-exhausted counter.
+func (s *fakeStore) RecordRetryExhausted() {
+	s.retryExhausted++
+}
 
 // TestAmbiguousTxCommitError verifies the sentinel-matching and unwrap
 // behavior of AmbiguousTxCommitError.
@@ -44,6 +96,212 @@ func TestCommitTransportError(t *testing.T) {
 	require.False(t, isCommitTransportError(errRuntimeOther))
 	require.NotNil(t, extractNetError(netTimeoutError{}))
 	require.Nil(t, extractNetError(errRuntimeOther))
+}
+
+// TestReadHealthyCheck verifies that unhealthy stores fail fast.
+func TestReadHealthyCheck(t *testing.T) {
+	t.Parallel()
+
+	hooks := &fakeStore{healthyErr: ErrStoreUnhealthy}
+	_, err := Read(context.Background(), hooks, struct{}{}, ReadConfig{
+		MaxAttempts: 1,
+		BaseDelay:   time.Millisecond,
+		MaxDelay:    time.Millisecond,
+	},
+		func(context.Context, struct{}) (struct{}, error) {
+			return struct{}{}, nil
+		})
+	require.ErrorIs(t, err, ErrStoreUnhealthy)
+}
+
+// TestReadInvalidConfig verifies that invalid retry settings fail fast.
+func TestReadInvalidConfig(t *testing.T) {
+	t.Parallel()
+
+	_, err := Read(context.Background(), &fakeStore{}, struct{}{},
+		ReadConfig{}, func(context.Context, struct{}) (struct{}, error) {
+			return struct{}{}, nil
+		})
+	require.EqualError(t, err,
+		"build read config: read max attempts must be positive")
+}
+
+// TestReadReturnsValue verifies that successful reads return their value and do
+// not force disabled retries to provide unused backoff delays.
+func TestReadReturnsValue(t *testing.T) {
+	t.Parallel()
+
+	hooks := &fakeStore{}
+	result, err := Read(context.Background(), hooks, struct{}{}, ReadConfig{
+		MaxAttempts: 1,
+	},
+		func(context.Context, struct{}) (string, error) {
+			return "ok", nil
+		})
+	require.NoError(t, err)
+	require.Equal(t, "ok", result)
+}
+
+// TestReadNoRowsPassthrough verifies that no-row results are preserved.
+func TestReadNoRowsPassthrough(t *testing.T) {
+	t.Parallel()
+
+	hooks := &fakeStore{}
+	result, err := Read(context.Background(), hooks, struct{}{}, ReadConfig{
+		MaxAttempts: 1,
+		BaseDelay:   time.Millisecond,
+		MaxDelay:    time.Millisecond,
+	},
+		func(context.Context, struct{}) (string, error) {
+			return "", sql.ErrNoRows
+		})
+	require.ErrorIs(t, err, sql.ErrNoRows)
+	require.Empty(t, result)
+	require.Zero(t, hooks.errorCount)
+}
+
+// TestReadRetriesTransientError verifies that transient read failures retry,
+// record stats, and eventually succeed.
+func TestReadRetriesTransientError(t *testing.T) {
+	t.Parallel()
+
+	hooks := &fakeStore{classifyFn: func(err error) error {
+		return dberr.NewSQLError(
+			dberr.BackendSQLite, dberr.ReasonBusy, "5", err,
+		)
+	}}
+
+	attempts := 0
+	result, err := readWithConfig(
+		context.Background(), hooks, struct{}{},
+		func(context.Context, struct{}) (string, error) {
+			attempts++
+			if attempts == 1 {
+				return "", errRuntimeBusy
+			}
+
+			return "ok", nil
+		},
+		readConfig{
+			attempts: 2,
+			base:     time.Millisecond,
+			max:      time.Millisecond,
+			jitter:   func(delay time.Duration) time.Duration { return delay },
+			timer:    immediateTimer,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, "ok", result)
+	require.Equal(t, 1, hooks.retryAttempts)
+	require.Equal(t, 1, hooks.retrySuccesses)
+	require.Equal(t, 1, hooks.errorCount)
+}
+
+// TestReadRetryExhausted verifies that transient reads return the final
+// classified error and a zero value after their retry budget is exhausted.
+func TestReadRetryExhausted(t *testing.T) {
+	t.Parallel()
+
+	hooks := &fakeStore{classifyFn: func(err error) error {
+		return dberr.NewSQLError(
+			dberr.BackendPostgres, dberr.ReasonSerialization,
+			"40001", err,
+		)
+	}}
+
+	result, err := readWithConfig(
+		context.Background(), hooks, struct{}{},
+		func(context.Context, struct{}) (string, error) {
+			return "", errRuntimeRetry
+		},
+		readConfig{
+			attempts: 1,
+			base:     time.Millisecond,
+			max:      time.Millisecond,
+			jitter:   func(delay time.Duration) time.Duration { return delay },
+			timer:    immediateTimer,
+		},
+	)
+
+	var sqlErr *dberr.SQLError
+
+	require.Empty(t, result)
+	require.ErrorAs(t, err, &sqlErr)
+	require.Equal(t, dberr.ClassTransient, sqlErr.Class())
+	require.Equal(t, 1, hooks.retryExhausted)
+}
+
+// TestReadWrappedContextCancellation verifies that wrapped caller cancellation
+// is not hidden behind retry logic.
+func TestReadWrappedContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	hooks := &fakeStore{}
+	wrappedCanceled := fmt.Errorf("read accounts: %w", context.Canceled)
+
+	result, err := Read(context.Background(), hooks, struct{}{}, ReadConfig{
+		MaxAttempts: 1,
+		BaseDelay:   time.Millisecond,
+		MaxDelay:    time.Millisecond,
+	},
+		func(context.Context, struct{}) (string, error) {
+			return "", wrappedCanceled
+		})
+	require.Empty(t, result)
+	require.Same(t, wrappedCanceled, err)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// TestReadWaitCancellation verifies that cancellation during backoff returns
+// ctx.Err.
+func TestReadWaitCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	hooks := &fakeStore{classifyFn: func(err error) error {
+		return dberr.NewSQLError(
+			dberr.BackendSQLite, dberr.ReasonBusy, "5", err,
+		)
+	}}
+
+	result, err := readWithConfig(
+		ctx, hooks, struct{}{},
+		func(context.Context, struct{}) (string, error) {
+			return "", errRuntimeBusy
+		},
+		readConfig{
+			attempts: 2,
+			base:     time.Millisecond,
+			max:      time.Millisecond,
+			jitter:   func(delay time.Duration) time.Duration { return delay },
+			timer:    time.NewTimer,
+		},
+	)
+	require.Empty(t, result)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// TestReadUtilities verifies the remaining read helper branches.
+func TestReadUtilities(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, 100*time.Millisecond,
+		retryDelay(10, 10*time.Millisecond, 100*time.Millisecond))
+	require.Equal(t, 100*time.Millisecond,
+		retryDelay(63, 10*time.Millisecond, 100*time.Millisecond))
+	require.Equal(t, context.DeadlineExceeded,
+		unwrapContextError(context.DeadlineExceeded))
+
+	wrappedCanceled := fmt.Errorf("read: %w", context.Canceled)
+	require.Same(t, wrappedCanceled, unwrapContextError(wrappedCanceled))
+	require.NoError(t, unwrapContextError(sql.ErrNoRows))
+}
+
+// immediateTimer returns a timer that fires immediately.
+func immediateTimer(time.Duration) *time.Timer {
+	return time.NewTimer(0)
 }
 
 // netTimeoutError is a test helper that reports a transport timeout.

--- a/wallet/internal/db/runtime/runtime_test.go
+++ b/wallet/internal/db/runtime/runtime_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -16,20 +17,23 @@ import (
 
 // Test errors used by the runtime helper tests.
 var (
-	errRuntimeBusy  = errors.New("busy")
-	errRuntimeRetry = errors.New("retry")
-	errRuntimeOther = errors.New("other")
+	errRuntimeBusy     = errors.New("busy")
+	errRuntimeRetry    = errors.New("retry")
+	errRuntimeCallback = errors.New("callback failed")
+	errRuntimeOther    = errors.New("other")
+	errRuntimeUnused   = errors.New("unused")
 )
 
 // fakeStore implements the runtime hook interfaces for tests.
 type fakeStore struct {
-	healthyErr      error
-	classifyFn      func(error) error
-	errorCount      int
-	retryAttempts   int
-	retrySuccesses  int
-	retryExhausted  int
-	ambiguousCommit int
+	healthyErr       error
+	classifyFn       func(error) error
+	errorCount       int
+	retryAttempts    int
+	retrySuccesses   int
+	retryExhausted   int
+	ambiguousCommits int
+	db               *sql.DB
 }
 
 // CheckHealthy returns the configured health-check result for fakeStore.
@@ -66,36 +70,14 @@ func (s *fakeStore) RecordRetryExhausted() {
 	s.retryExhausted++
 }
 
-// TestAmbiguousTxCommitError verifies the sentinel-matching and unwrap
-// behavior of AmbiguousTxCommitError.
-func TestAmbiguousTxCommitError(t *testing.T) {
-	t.Parallel()
-
-	err := &AmbiguousTxCommitError{Err: io.EOF}
-	wrappedSentinel := fmt.Errorf("wrap: %w", ErrAmbiguousTxCommit)
-
-	require.ErrorIs(t, err, ErrAmbiguousTxCommit)
-	require.False(t, err.Is(wrappedSentinel))
-	require.Equal(t, io.EOF.Error(), err.Error())
-	require.ErrorIs(t, err, io.EOF)
-	require.Equal(
-		t, ErrAmbiguousTxCommit.Error(), (&AmbiguousTxCommitError{}).Error(),
-	)
-	require.NoError(t, (*AmbiguousTxCommitError)(nil).Unwrap())
+// RecordAmbiguousTxCommit increments the fake ambiguous-commit counter.
+func (s *fakeStore) RecordAmbiguousTxCommit() {
+	s.ambiguousCommits++
 }
 
-// TestCommitTransportError verifies that transport-shaped commit failures are
-// detected as ambiguous-outcome candidates.
-func TestCommitTransportError(t *testing.T) {
-	t.Parallel()
-
-	require.True(t, isCommitTransportError(io.EOF))
-	require.True(t, isCommitTransportError(driver.ErrBadConn))
-	require.True(t, isCommitTransportError(sql.ErrConnDone))
-	require.True(t, isCommitTransportError(netTimeoutError{}))
-	require.False(t, isCommitTransportError(errRuntimeOther))
-	require.NotNil(t, extractNetError(netTimeoutError{}))
-	require.Nil(t, extractNetError(errRuntimeOther))
+// RawDB returns the fake database handle used by transaction tests.
+func (s *fakeStore) RawDB() *sql.DB {
+	return s.db
 }
 
 // TestReadHealthyCheck verifies that unhealthy stores fail fast.
@@ -299,20 +281,241 @@ func TestReadUtilities(t *testing.T) {
 	require.NoError(t, unwrapContextError(sql.ErrNoRows))
 }
 
+// TestWriteHealthyCheck verifies that unhealthy stores fail fast before
+// starting a transaction.
+func TestWriteHealthyCheck(t *testing.T) {
+	t.Parallel()
+
+	hooks := &fakeStore{healthyErr: ErrStoreUnhealthy}
+	result, err := Write(context.Background(), hooks, func(*sql.Tx) struct{} {
+		return struct{}{}
+	}, func(struct{}) (string, error) { return "", nil })
+	require.Empty(t, result)
+	require.ErrorIs(t, err, ErrStoreUnhealthy)
+}
+
+// TestWriteReturnsValue verifies that successful writes return their value only
+// after commit succeeds.
+func TestWriteReturnsValue(t *testing.T) {
+	t.Parallel()
+
+	dbConn := newTestDB(t, beginErrDriver{})
+	hooks := &fakeStore{db: dbConn}
+
+	result, err := Write(context.Background(), hooks, func(tx *sql.Tx) *sql.Tx {
+		return tx
+	}, func(*sql.Tx) (string, error) {
+		return "ok", nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, "ok", result)
+}
+
+// TestWriteBeginFailure verifies that begin failures are classified and
+// recorded.
+func TestWriteBeginFailure(t *testing.T) {
+	t.Parallel()
+
+	dbConn := newTestDB(t, beginErrDriver{err: driver.ErrBadConn})
+	hooks := &fakeStore{db: dbConn, classifyFn: func(err error) error {
+		return dberr.NewSQLError(
+			dberr.BackendPostgres, dberr.ReasonUnavailable, "", err,
+		)
+	}}
+
+	result, err := Write(context.Background(), hooks, func(*sql.Tx) struct{} {
+		return struct{}{}
+	}, func(struct{}) (string, error) { return "", nil })
+
+	var sqlErr *dberr.SQLError
+
+	require.Empty(t, result)
+	require.ErrorAs(t, err, &sqlErr)
+	require.Equal(t, dberr.ReasonUnavailable, sqlErr.Reason)
+	require.Equal(t, 1, hooks.errorCount)
+}
+
+// TestWriteCallbackErrorPassthrough verifies that non-SQL callback errors pass
+// through unchanged and do not leak a result value.
+func TestWriteCallbackErrorPassthrough(t *testing.T) {
+	t.Parallel()
+
+	dbConn := newTestDB(t, beginErrDriver{})
+	hooks := &fakeStore{db: dbConn}
+	callbackErr := errRuntimeCallback
+
+	result, err := Write(context.Background(), hooks, func(tx *sql.Tx) *sql.Tx {
+		return tx
+	}, func(*sql.Tx) (string, error) {
+		return "", callbackErr
+	})
+	require.Empty(t, result)
+	require.ErrorIs(t, err, callbackErr)
+	require.Zero(t, hooks.errorCount)
+}
+
+// TestWriteCallbackErrorClassified verifies that SQL-like callback failures are
+// normalized through the backend classifier before they reach callers.
+func TestWriteCallbackErrorClassified(t *testing.T) {
+	t.Parallel()
+
+	dbConn := newTestDB(t, beginErrDriver{})
+	hooks := &fakeStore{db: dbConn, classifyFn: func(err error) error {
+		return dberr.NewSQLError(
+			dberr.BackendPostgres, dberr.ReasonConstraint, "23505", err,
+		)
+	}}
+
+	result, err := Write(context.Background(), hooks, func(tx *sql.Tx) *sql.Tx {
+		return tx
+	}, func(*sql.Tx) (string, error) {
+		return "", errRuntimeCallback
+	})
+
+	var sqlErr *dberr.SQLError
+
+	require.Empty(t, result)
+	require.ErrorAs(t, err, &sqlErr)
+	require.Equal(t, dberr.ReasonConstraint, sqlErr.Reason)
+	require.Equal(t, 1, hooks.errorCount)
+}
+
+// TestWriteCommitAmbiguous verifies that transport failures during commit are
+// wrapped as ambiguous commit errors, recorded, and return a zero value.
+func TestWriteCommitAmbiguous(t *testing.T) {
+	t.Parallel()
+
+	dbConn := newTestDB(t, beginErrDriver{commitErr: io.EOF})
+	hooks := &fakeStore{db: dbConn, classifyFn: func(err error) error {
+		return dberr.NewSQLError(
+			dberr.BackendPostgres, dberr.ReasonUnavailable,
+			"08006", err,
+		)
+	}}
+
+	result, err := Write(context.Background(), hooks, func(tx *sql.Tx) *sql.Tx {
+		return tx
+	}, func(*sql.Tx) (string, error) {
+		return "applied", nil
+	})
+	require.Empty(t, result)
+	require.ErrorIs(t, err, ErrAmbiguousTxCommit)
+
+	var sqlErr *dberr.SQLError
+	require.ErrorAs(t, err, &sqlErr)
+	require.Equal(t, dberr.ReasonUnavailable, sqlErr.Reason)
+	require.Equal(t, 1, hooks.ambiguousCommits)
+	require.Equal(t, 1, hooks.errorCount)
+}
+
+// TestWriteCommitUnavailable verifies that classified availability errors
+// without a transport failure stay ordinary commit errors.
+func TestWriteCommitUnavailable(t *testing.T) {
+	t.Parallel()
+
+	dbConn := newTestDB(t, beginErrDriver{commitErr: errRuntimeOther})
+	hooks := &fakeStore{db: dbConn, classifyFn: func(err error) error {
+		return dberr.NewSQLError(
+			dberr.BackendPostgres, dberr.ReasonUnavailable,
+			"08006", err,
+		)
+	}}
+
+	result, err := Write(context.Background(), hooks, func(tx *sql.Tx) *sql.Tx {
+		return tx
+	}, func(*sql.Tx) (string, error) {
+		return "applied", nil
+	})
+	require.Empty(t, result)
+	require.NotErrorIs(t, err, ErrAmbiguousTxCommit)
+
+	var sqlErr *dberr.SQLError
+	require.ErrorAs(t, err, &sqlErr)
+	require.Equal(t, dberr.ReasonUnavailable, sqlErr.Reason)
+	require.Zero(t, hooks.ambiguousCommits)
+	require.Equal(t, 1, hooks.errorCount)
+}
+
 // immediateTimer returns a timer that fires immediately.
 func immediateTimer(time.Duration) *time.Timer {
 	return time.NewTimer(0)
 }
 
-// netTimeoutError is a test helper that reports a transport timeout.
-type netTimeoutError struct{}
-
-// Error returns the static timeout error string.
-func (e netTimeoutError) Error() string {
-	return "timeout"
+// beginErrDriver is a test SQL driver that injects begin and commit failures.
+type beginErrDriver struct {
+	err       error
+	commitErr error
 }
 
-// Timeout reports that the test error is a timeout.
-func (e netTimeoutError) Timeout() bool {
-	return true
+// Open returns a connection that injects the configured failures.
+func (d beginErrDriver) Open(string) (driver.Conn, error) {
+	return beginErrConn(d), nil
+}
+
+// beginErrConn is a test connection that injects begin and commit failures.
+type beginErrConn struct {
+	err       error
+	commitErr error
+}
+
+// Prepare returns an unused statement error for the test driver.
+func (c beginErrConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errRuntimeUnused
+}
+
+// Close reports success for the test connection close path.
+func (c beginErrConn) Close() error {
+	return nil
+}
+
+// Begin returns the legacy unused error because tests use BeginTx instead.
+func (c beginErrConn) Begin() (driver.Tx, error) {
+	return nil, errRuntimeUnused
+}
+
+// BeginTx returns the configured begin error or a transaction test double.
+func (c beginErrConn) BeginTx(ctx context.Context,
+	_ driver.TxOptions) (driver.Tx, error) {
+
+	_ = ctx
+
+	if c.err != nil {
+		return nil, c.err
+	}
+
+	return beginErrTx{commitErr: c.commitErr}, nil
+}
+
+// beginErrTx is a test transaction that injects a commit failure.
+type beginErrTx struct {
+	commitErr error
+}
+
+// Commit returns the configured commit error.
+func (tx beginErrTx) Commit() error {
+	return tx.commitErr
+}
+
+// Rollback reports success for the test rollback path.
+func (tx beginErrTx) Rollback() error {
+	return nil
+}
+
+// testDriverSeq keeps each registered test driver name unique.
+var testDriverSeq atomic.Uint64
+
+// newTestDB registers one test driver instance and opens a matching database.
+func newTestDB(t *testing.T, drv beginErrDriver) *sql.DB {
+	t.Helper()
+
+	name := fmt.Sprintf("runtime-test-%d", testDriverSeq.Add(1))
+	sql.Register(name, drv)
+
+	dbConn, err := sql.Open(name, "")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, dbConn.Close())
+	})
+
+	return dbConn
 }

--- a/wallet/internal/db/sqlite/errors.go
+++ b/wallet/internal/db/sqlite/errors.go
@@ -1,0 +1,71 @@
+package sqlite
+
+import (
+	"errors"
+	"strconv"
+
+	dberr "github.com/btcsuite/btcwallet/wallet/internal/db/err"
+	"modernc.org/sqlite"
+	sqlite3 "modernc.org/sqlite/lib"
+)
+
+// SQLite result-code helper constants support error classification.
+const (
+	// primaryCodeMask strips a SQLite extended result code to its primary
+	// result code.
+	primaryCodeMask = 0xff
+)
+
+// reasonByCode maps SQLite primary result codes into the shared SQL error
+// model.
+var reasonByCode = map[int]dberr.Reason{
+	sqlite3.SQLITE_BUSY:       dberr.ReasonBusy,
+	sqlite3.SQLITE_LOCKED:     dberr.ReasonLocked,
+	sqlite3.SQLITE_INTERRUPT:  dberr.ReasonUnknown,
+	sqlite3.SQLITE_CONSTRAINT: dberr.ReasonConstraint,
+	sqlite3.SQLITE_FULL:       dberr.ReasonResourceExhausted,
+	sqlite3.SQLITE_NOMEM:      dberr.ReasonResourceExhausted,
+	sqlite3.SQLITE_IOERR:      dberr.ReasonResourceExhausted,
+	sqlite3.SQLITE_PROTOCOL:   dberr.ReasonUnavailable,
+	sqlite3.SQLITE_READONLY:   dberr.ReasonReadOnly,
+	sqlite3.SQLITE_PERM:       dberr.ReasonPermission,
+	sqlite3.SQLITE_CORRUPT:    dberr.ReasonCorrupt,
+	sqlite3.SQLITE_NOTADB:     dberr.ReasonCorrupt,
+	sqlite3.SQLITE_NOTFOUND:   dberr.ReasonUnknown,
+	sqlite3.SQLITE_SCHEMA:     dberr.ReasonSchemaMismatch,
+	sqlite3.SQLITE_CANTOPEN:   dberr.ReasonUnknown,
+}
+
+// mapErr maps SQLite result codes into SQLError.
+func mapErr(err error) *dberr.SQLError {
+	// Start by extracting the SQLite driver error so the backend package can
+	// inspect its numeric result code.
+	var sqliteErr *sqlite.Error
+	if !errors.As(err, &sqliteErr) {
+		return nil
+	}
+
+	code := sqliteErr.Code()
+
+	// Reduce extended result codes to their primary code before consulting the
+	// shared reason map so related variants share one caller-facing bucket.
+	primaryCode := primaryCode(code)
+	codeString := codeString(code)
+
+	reason, ok := reasonByCode[primaryCode]
+	if !ok {
+		reason = dberr.ReasonUnknown
+	}
+
+	return dberr.NewSQLError(dberr.BackendSQLite, reason, codeString, err)
+}
+
+// codeString formats a SQLite numeric result code for logs and stats.
+func codeString(code int) string {
+	return strconv.Itoa(code)
+}
+
+// primaryCode strips a SQLite extended result code to its primary code.
+func primaryCode(code int) int {
+	return code & primaryCodeMask
+}

--- a/wallet/internal/db/sqlite/errors_test.go
+++ b/wallet/internal/db/sqlite/errors_test.go
@@ -1,0 +1,89 @@
+package sqlite
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	dberr "github.com/btcsuite/btcwallet/wallet/internal/db/err"
+	"github.com/stretchr/testify/require"
+	sqlite3 "modernc.org/sqlite/lib"
+)
+
+// TestMapErrConstraint verifies that SQLite constraint violations are mapped to
+// permanent constraint failures.
+func TestMapErrConstraint(t *testing.T) {
+	t.Parallel()
+
+	dbConn, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "wallet.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, dbConn.Close())
+	})
+
+	ctx := t.Context()
+
+	_, err = dbConn.ExecContext(
+		ctx, `CREATE TABLE demo (id INTEGER PRIMARY KEY, val TEXT UNIQUE)`,
+	)
+	require.NoError(t, err)
+
+	_, err = dbConn.ExecContext(ctx, `INSERT INTO demo (val) VALUES ('dup')`)
+	require.NoError(t, err)
+
+	_, err = dbConn.ExecContext(ctx, `INSERT INTO demo (val) VALUES ('dup')`)
+	require.Error(t, err)
+
+	sqlErr := mapErr(err)
+	require.NotNil(t, sqlErr)
+	require.Equal(t, dberr.BackendSQLite, sqlErr.Backend)
+	require.Equal(t, dberr.ReasonConstraint, sqlErr.Reason)
+	require.Equal(t, dberr.ClassPermanent, sqlErr.Class())
+	require.NotEmpty(t, sqlErr.Code)
+}
+
+// TestMapErrReadOnly verifies that SQLite query-only failures are mapped to
+// fatal read-only backend errors.
+func TestMapErrReadOnly(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "wallet.db")
+	dbConn, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+
+	_, err = dbConn.ExecContext(
+		ctx, `CREATE TABLE demo (id INTEGER PRIMARY KEY, val TEXT)`,
+	)
+	require.NoError(t, err)
+	require.NoError(t, dbConn.Close())
+
+	roDB, err := sql.Open("sqlite", dbPath+"?_pragma=query_only=on")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, roDB.Close())
+	})
+
+	_, err = roDB.ExecContext(ctx, `INSERT INTO demo (val) VALUES ('x')`)
+	require.Error(t, err)
+
+	sqlErr := mapErr(err)
+	require.NotNil(t, sqlErr)
+	require.Equal(t, dberr.BackendSQLite, sqlErr.Backend)
+	require.Equal(t, dberr.ReasonReadOnly, sqlErr.Reason)
+	require.Equal(t, dberr.ClassFatal, sqlErr.Class())
+}
+
+// TestHelpers verifies the SQLite-specific helper paths.
+func TestHelpers(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "5", codeString(5))
+	require.Equal(t, dberr.ReasonUnavailable,
+		reasonByCode[sqlite3.SQLITE_PROTOCOL])
+	require.Equal(t, dberr.ReasonUnknown,
+		reasonByCode[sqlite3.SQLITE_NOTFOUND])
+	require.Equal(t, sqlite3.SQLITE_CONSTRAINT,
+		primaryCode(sqlite3.SQLITE_CONSTRAINT_UNIQUE))
+}


### PR DESCRIPTION
## Summary
- introduce the shared SQL error framework in `wallet/internal/db/err`, including the shared taxonomy, wrapper, normalization helpers, stats collector, and package README
- add backend-specific SQL error mapper packages in `wallet/internal/db/postgres` and `wallet/internal/db/sqlite`, with same-package tests and private helper details
- add the shared `wallet/internal/db/runtime` helper framework for retry, unhealthy-store checks, transaction execution, and ambiguous commit handling
- keep this PR focused on framework code only; production store wiring and runtime integration remain follow-up work once store code moves into the backend packages

## Follow-up Plan
- move store code into `wallet/internal/db/postgres` and `wallet/internal/db/sqlite`
- integrate production normalization, stats recording, and runtime/store reaction logic in their final package locations
- wire the shared runtime helper package on top of the backend-owned store implementations

## Testing
- make lint
- GOWORK=off go test ./wallet/internal/db/... ./wallet
- GOWORK=off go test ./wallet/internal/db/runtime
- GOWORK=off go test -run '^$' -bench . ./wallet/internal/db/runtime