### PR TITLE
wallet: migrate tx reader to db.Store

### DIFF
--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -314,12 +314,18 @@ type TxStore interface {
 
 	// GetTx retrieves a transaction record by its hash. It takes a context
 	// and GetTxQuery, returning a TxInfo struct or an error if the
-	// transaction is not found. Note that the `Credits` and `Debits` fields
-	// of the returned `TxInfo` are not stored directly in the transaction
-	// record; they are derived by querying the UTXO store and represent
-	// wallet-specific information about the transaction's impact on the
-	// UTXO set.
+	// transaction is not found.
 	GetTx(ctx context.Context, query GetTxQuery) (*TxInfo, error)
+
+	// GetTxDetail retrieves one detailed wallet-scoped transaction view by
+	// hash.
+	GetTxDetail(ctx context.Context, query GetTxDetailQuery) (*TxDetailInfo,
+		error)
+
+	// ListTxDetails lists detailed wallet-scoped transaction views using
+	// wallet tx-reader range semantics.
+	ListTxDetails(ctx context.Context,
+		query ListTxDetailsQuery) ([]TxDetailInfo, error)
 
 	// ListTxns returns a slice of transaction information based on the
 	// provided query parameters. It takes a context and ListTxnsQuery,

--- a/wallet/internal/db/kvdb/txstore.go
+++ b/wallet/internal/db/kvdb/txstore.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/btcsuite/btcwallet/wtxmgr"
 )
 
 // CreateTx is not yet implemented for kvdb.
@@ -56,11 +57,37 @@ func (s *Store) UpdateTx(_ context.Context, params db.UpdateTxParams) error {
 	return nil
 }
 
-// GetTx is not yet implemented for kvdb.
-func (s *Store) GetTx(ctx context.Context,
-	_ db.GetTxQuery) (*db.TxInfo, error) {
+// GetTx retrieves one wallet-scoped transaction snapshot through the legacy
+// wtxmgr query path.
+func (s *Store) GetTx(_ context.Context, query db.GetTxQuery) (
+	*db.TxInfo, error) {
 
-	return nil, notImplemented(ctx, "GetTx")
+	var info *db.TxInfo
+
+	err := walletdb.View(s.db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(wtxmgrNamespaceKey)
+		if ns == nil {
+			return errMissingTxmgrNamespace
+		}
+
+		details, err := s.txStore.TxDetails(ns, &query.Txid)
+		if err != nil {
+			return fmt.Errorf("lookup transaction details: %w", err)
+		}
+
+		if details == nil {
+			return db.ErrTxNotFound
+		}
+
+		info = kvdbTxInfo(details)
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("kvdb.Store.GetTx: %w", err)
+	}
+
+	return info, nil
 }
 
 // ListTxns is not yet implemented for kvdb.
@@ -106,4 +133,38 @@ func validateUpdateTxParams(params db.UpdateTxParams) (*string, error) {
 	}
 
 	return params.Label, nil
+}
+
+// kvdbTxInfo maps legacy wtxmgr detail data into the lightweight db-native
+// transaction summary model.
+func kvdbTxInfo(details *wtxmgr.TxDetails) *db.TxInfo {
+	var block *db.Block
+	if details.Block.Height >= 0 {
+		block = &db.Block{
+			Hash:      details.Block.Hash,
+			Height:    nonNegativeInt32ToUint32(details.Block.Height),
+			Timestamp: details.Block.Time,
+		}
+	}
+
+	return &db.TxInfo{
+		Hash:         details.Hash,
+		SerializedTx: append([]byte(nil), details.SerializedTx...),
+		Received:     details.Received.UTC(),
+		Block:        block,
+
+		// Legacy wtxmgr only exposes transactions it still treats as valid,
+		// and it does not persist pending/replaced/failed/orphaned state.
+		Status: db.TxStatusPublished,
+		Label:  details.Label,
+	}
+}
+
+// nonNegativeInt32ToUint32 converts a non-negative int32 to uint32.
+func nonNegativeInt32ToUint32(value int32) uint32 {
+	if value < 0 {
+		return 0
+	}
+
+	return uint32(value)
 }

--- a/wallet/internal/db/kvdb/txstore.go
+++ b/wallet/internal/db/kvdb/txstore.go
@@ -2,12 +2,18 @@ package kvdb
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"math"
 
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 )
+
+// errLegacyHeightOverflow reports that one db height cannot fit into the
+// signed legacy wtxmgr height domain.
+var errLegacyHeightOverflow = errors.New("legacy height overflows int32")
 
 // CreateTx is not yet implemented for kvdb.
 func (s *Store) CreateTx(ctx context.Context, _ db.CreateTxParams) error {
@@ -90,11 +96,66 @@ func (s *Store) GetTx(_ context.Context, query db.GetTxQuery) (
 	return info, nil
 }
 
-// ListTxns is not yet implemented for kvdb.
-func (s *Store) ListTxns(ctx context.Context,
-	_ db.ListTxnsQuery) ([]db.TxInfo, error) {
+// ListTxns lists wallet-scoped transaction summaries through the legacy wtxmgr
+// range query path.
+func (s *Store) ListTxns(_ context.Context, query db.ListTxnsQuery) (
+	[]db.TxInfo, error) {
 
-	return nil, notImplemented(ctx, "ListTxns")
+	var infos []db.TxInfo
+
+	err := walletdb.View(s.db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(wtxmgrNamespaceKey)
+		if ns == nil {
+			return errMissingTxmgrNamespace
+		}
+
+		if query.UnminedOnly {
+			var err error
+
+			infos, err = s.listTxnsRange(ns, -1, -1, nil)
+
+			return err
+		}
+
+		begin, end, err := kvdbConfirmedTxnsRange(query)
+		if err != nil {
+			return err
+		}
+
+		infos, err = s.listTxnsRange(ns, begin, end, nil)
+
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("kvdb.Store.ListTxns: %w", err)
+	}
+
+	if len(infos) == 0 {
+		return []db.TxInfo{}, nil
+	}
+
+	return infos, nil
+}
+
+// listTxnsRange appends one legacy wtxmgr range scan to the result set.
+func (s *Store) listTxnsRange(ns walletdb.ReadBucket, begin, end int32,
+	infos []db.TxInfo) ([]db.TxInfo, error) {
+
+	err := s.txStore.RangeTransactions(
+		ns, begin, end,
+		func(txDetails []wtxmgr.TxDetails) (bool, error) {
+			for i := range txDetails {
+				infos = append(infos, *kvdbTxInfo(&txDetails[i]))
+			}
+
+			return false, nil
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("range txns %d to %d: %w", begin, end, err)
+	}
+
+	return infos, nil
 }
 
 // DeleteTx is not yet implemented for kvdb.
@@ -158,6 +219,32 @@ func kvdbTxInfo(details *wtxmgr.TxDetails) *db.TxInfo {
 		Status: db.TxStatusPublished,
 		Label:  details.Label,
 	}
+}
+
+// kvdbConfirmedTxnsRange converts the confirmed query heights into the legacy
+// wtxmgr range arguments used by the kvdb adapter.
+func kvdbConfirmedTxnsRange(query db.ListTxnsQuery) (int32, int32, error) {
+	startHeight, err := uint32ToLegacyHeight(query.StartHeight)
+	if err != nil {
+		return 0, 0, fmt.Errorf("convert start height: %w", err)
+	}
+
+	endHeight, err := uint32ToLegacyHeight(query.EndHeight)
+	if err != nil {
+		return 0, 0, fmt.Errorf("convert end height: %w", err)
+	}
+
+	return startHeight, endHeight, nil
+}
+
+// uint32ToLegacyHeight converts a db height into the signed height domain used
+// by the legacy wtxmgr range API.
+func uint32ToLegacyHeight(height uint32) (int32, error) {
+	if height > math.MaxInt32 {
+		return 0, fmt.Errorf("%w: %d", errLegacyHeightOverflow, height)
+	}
+
+	return int32(height), nil
 }
 
 // nonNegativeInt32ToUint32 converts a non-negative int32 to uint32.

--- a/wallet/internal/db/kvdb/txstore.go
+++ b/wallet/internal/db/kvdb/txstore.go
@@ -158,6 +158,39 @@ func (s *Store) listTxnsRange(ns walletdb.ReadBucket, begin, end int32,
 	return infos, nil
 }
 
+// GetTxDetail retrieves one detailed wallet-scoped transaction view through the
+// legacy wtxmgr query path.
+func (s *Store) GetTxDetail(_ context.Context, query db.GetTxDetailQuery) (
+	*db.TxDetailInfo, error) {
+
+	var detail *db.TxDetailInfo
+
+	err := walletdb.View(s.db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(wtxmgrNamespaceKey)
+		if ns == nil {
+			return errMissingTxmgrNamespace
+		}
+
+		txDetails, err := s.txStore.TxDetails(ns, &query.Txid)
+		if err != nil {
+			return fmt.Errorf("lookup transaction details: %w", err)
+		}
+
+		if txDetails == nil {
+			return db.ErrTxNotFound
+		}
+
+		detail = kvdbTxDetailInfo(txDetails)
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("kvdb.Store.GetTxDetail: %w", err)
+	}
+
+	return detail, nil
+}
+
 // DeleteTx is not yet implemented for kvdb.
 func (s *Store) DeleteTx(ctx context.Context, _ db.DeleteTxParams) error {
 	return notImplemented(ctx, "DeleteTx")
@@ -218,6 +251,52 @@ func kvdbTxInfo(details *wtxmgr.TxDetails) *db.TxInfo {
 		// and it does not persist pending/replaced/failed/orphaned state.
 		Status: db.TxStatusPublished,
 		Label:  details.Label,
+	}
+}
+
+// kvdbTxDetailInfo maps legacy wtxmgr detail data into the db-native
+// transaction detail model used by wallet tx-reader code.
+func kvdbTxDetailInfo(details *wtxmgr.TxDetails) *db.TxDetailInfo {
+	var block *db.Block
+	if details.Block.Height >= 0 {
+		block = &db.Block{
+			Hash:      details.Block.Hash,
+			Height:    nonNegativeInt32ToUint32(details.Block.Height),
+			Timestamp: details.Block.Time,
+		}
+	}
+
+	ownedInputs := make([]db.TxOwnedInput, 0, len(details.Debits))
+	for _, debit := range details.Debits {
+		ownedInputs = append(ownedInputs, db.TxOwnedInput{
+			Index:  debit.Index,
+			Amount: debit.Amount,
+		})
+	}
+
+	ownedOutputs := make([]db.TxOwnedOutput, 0, len(details.Credits))
+	for _, credit := range details.Credits {
+		ownedOutputs = append(ownedOutputs, db.TxOwnedOutput{
+			Index:  credit.Index,
+			Amount: credit.Amount,
+		})
+	}
+
+	msgTx := details.MsgTx
+
+	return &db.TxDetailInfo{
+		Hash:         details.Hash,
+		MsgTx:        &msgTx,
+		SerializedTx: append([]byte(nil), details.SerializedTx...),
+		Received:     details.Received.UTC(),
+		Block:        block,
+
+		// Legacy wtxmgr only exposes transactions it still treats as valid,
+		// and it does not persist pending/replaced/failed/orphaned state.
+		Status:       db.TxStatusPublished,
+		Label:        details.Label,
+		OwnedInputs:  ownedInputs,
+		OwnedOutputs: ownedOutputs,
 	}
 }
 

--- a/wallet/internal/db/kvdb/txstore.go
+++ b/wallet/internal/db/kvdb/txstore.go
@@ -37,7 +37,9 @@ func (s *Store) UpdateTx(_ context.Context, params db.UpdateTxParams) error {
 	err = walletdb.Update(s.db, func(tx walletdb.ReadWriteTx) error {
 		ns := tx.ReadWriteBucket(wtxmgrNamespaceKey)
 		if ns == nil {
-			return errMissingTxmgrNamespace
+			return fmt.Errorf(
+				"wtxmgr namespace: %w", walletdb.ErrBucketNotFound,
+			)
 		}
 
 		details, err := s.txStore.TxDetails(ns, &params.Txid)
@@ -73,7 +75,9 @@ func (s *Store) GetTx(_ context.Context, query db.GetTxQuery) (
 	err := walletdb.View(s.db, func(tx walletdb.ReadTx) error {
 		ns := tx.ReadBucket(wtxmgrNamespaceKey)
 		if ns == nil {
-			return errMissingTxmgrNamespace
+			return fmt.Errorf(
+				"wtxmgr namespace: %w", walletdb.ErrBucketNotFound,
+			)
 		}
 
 		details, err := s.txStore.TxDetails(ns, &query.Txid)
@@ -106,7 +110,9 @@ func (s *Store) ListTxns(_ context.Context, query db.ListTxnsQuery) (
 	err := walletdb.View(s.db, func(tx walletdb.ReadTx) error {
 		ns := tx.ReadBucket(wtxmgrNamespaceKey)
 		if ns == nil {
-			return errMissingTxmgrNamespace
+			return fmt.Errorf(
+				"wtxmgr namespace: %w", walletdb.ErrBucketNotFound,
+			)
 		}
 
 		if query.UnminedOnly {
@@ -168,7 +174,9 @@ func (s *Store) GetTxDetail(_ context.Context, query db.GetTxDetailQuery) (
 	err := walletdb.View(s.db, func(tx walletdb.ReadTx) error {
 		ns := tx.ReadBucket(wtxmgrNamespaceKey)
 		if ns == nil {
-			return errMissingTxmgrNamespace
+			return fmt.Errorf(
+				"wtxmgr namespace: %w", walletdb.ErrBucketNotFound,
+			)
 		}
 
 		txDetails, err := s.txStore.TxDetails(ns, &query.Txid)
@@ -201,7 +209,9 @@ func (s *Store) ListTxDetails(_ context.Context, query db.ListTxDetailsQuery) (
 	err := walletdb.View(s.db, func(tx walletdb.ReadTx) error {
 		ns := tx.ReadBucket(wtxmgrNamespaceKey)
 		if ns == nil {
-			return errMissingTxmgrNamespace
+			return fmt.Errorf(
+				"wtxmgr namespace: %w", walletdb.ErrBucketNotFound,
+			)
 		}
 
 		return s.txStore.RangeTransactions(

--- a/wallet/internal/db/kvdb/txstore.go
+++ b/wallet/internal/db/kvdb/txstore.go
@@ -191,6 +191,43 @@ func (s *Store) GetTxDetail(_ context.Context, query db.GetTxDetailQuery) (
 	return detail, nil
 }
 
+// ListTxDetails lists detailed wallet-scoped transaction views through the
+// legacy wtxmgr range path.
+func (s *Store) ListTxDetails(_ context.Context, query db.ListTxDetailsQuery) (
+	[]db.TxDetailInfo, error) {
+
+	var details []db.TxDetailInfo
+
+	err := walletdb.View(s.db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(wtxmgrNamespaceKey)
+		if ns == nil {
+			return errMissingTxmgrNamespace
+		}
+
+		return s.txStore.RangeTransactions(
+			ns, query.StartHeight, query.EndHeight,
+			func(txDetails []wtxmgr.TxDetails) (bool, error) {
+				for i := range txDetails {
+					details = append(
+						details, *kvdbTxDetailInfo(&txDetails[i]),
+					)
+				}
+
+				return false, nil
+			},
+		)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("kvdb.Store.ListTxDetails: %w", err)
+	}
+
+	if len(details) == 0 {
+		return []db.TxDetailInfo{}, nil
+	}
+
+	return details, nil
+}
+
 // DeleteTx is not yet implemented for kvdb.
 func (s *Store) DeleteTx(ctx context.Context, _ db.DeleteTxParams) error {
 	return notImplemented(ctx, "DeleteTx")

--- a/wallet/internal/db/kvdb/txstore_test.go
+++ b/wallet/internal/db/kvdb/txstore_test.go
@@ -173,3 +173,60 @@ func TestUpdateTxLongLabelPreservesLegacyError(t *testing.T) {
 	})
 	require.ErrorIs(t, err, wtxmgr.ErrLabelTooLong)
 }
+
+// TestGetTxSummarySuccess verifies that kvdb.Store adapts legacy tx details to
+// the db-native summary model.
+func TestGetTxSummarySuccess(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore)
+
+	txMsg := &wire.MsgTx{Version: 1}
+	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{20},
+	}})
+	txMsg.AddTxOut(&wire.TxOut{Value: 2_000, PkScript: []byte{0x51}})
+	rec, err := wtxmgr.NewTxRecordFromMsgTx(txMsg, time.Now())
+	require.NoError(t, err)
+
+	err = walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+		require.NotNil(t, ns)
+
+		return txStore.InsertTx(ns, rec, nil)
+	})
+	require.NoError(t, err)
+
+	info, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: 0,
+		Txid:     rec.Hash,
+	})
+	require.NoError(t, err)
+	require.Equal(t, rec.Hash, info.Hash)
+	require.Equal(t, rec.SerializedTx, info.SerializedTx)
+	require.Equal(t, rec.Received.UTC().Unix(), info.Received.Unix())
+	require.Nil(t, info.Block)
+	require.Equal(t, db.TxStatusPublished, info.Status)
+}
+
+// TestGetTxSummaryNotFound verifies that kvdb.Store reports missing
+// transactions through db.ErrTxNotFound.
+func TestGetTxSummaryNotFound(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore)
+
+	_, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: 0,
+		Txid:     chainhash.Hash{42},
+	})
+	require.ErrorIs(t, err, db.ErrTxNotFound)
+}

--- a/wallet/internal/db/kvdb/txstore_test.go
+++ b/wallet/internal/db/kvdb/txstore_test.go
@@ -230,3 +230,156 @@ func TestGetTxSummaryNotFound(t *testing.T) {
 	})
 	require.ErrorIs(t, err, db.ErrTxNotFound)
 }
+
+// TestListTxnsSummaryUnminedOnlySuccess verifies that kvdb.Store can list the
+// legacy unmined set through the db-native summary API.
+func TestListTxnsSummaryUnminedOnlySuccess(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore)
+
+	txMsg := &wire.MsgTx{Version: 1}
+	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{21},
+	}})
+	txMsg.AddTxOut(&wire.TxOut{Value: 2_500, PkScript: []byte{0x51}})
+	rec, err := wtxmgr.NewTxRecordFromMsgTx(txMsg, time.Now())
+	require.NoError(t, err)
+
+	err = walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+		require.NotNil(t, ns)
+
+		return txStore.InsertTx(ns, rec, nil)
+	})
+	require.NoError(t, err)
+
+	infos, err := store.ListTxns(t.Context(), db.ListTxnsQuery{
+		WalletID:    0,
+		UnminedOnly: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, infos, 1)
+	require.Equal(t, rec.Hash, infos[0].Hash)
+	require.Nil(t, infos[0].Block)
+	require.Equal(t, db.TxStatusPublished, infos[0].Status)
+}
+
+// TestListTxnsSummaryConfirmedRangeSuccess verifies that kvdb.Store can adapt
+// the legacy confirmed range iterator to the db-native summary API.
+func TestListTxnsSummaryConfirmedRangeSuccess(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore)
+
+	rec := insertConfirmedTx(t, dbConn, txStore, 144)
+
+	infos, err := store.ListTxns(t.Context(), db.ListTxnsQuery{
+		WalletID:    0,
+		StartHeight: 144,
+		EndHeight:   144,
+	})
+	require.NoError(t, err)
+	require.Len(t, infos, 1)
+	require.Equal(t, rec.Hash, infos[0].Hash)
+	require.NotNil(t, infos[0].Block)
+	require.Equal(t, uint32(144), infos[0].Block.Height)
+	require.Equal(t, db.TxStatusPublished, infos[0].Status)
+}
+
+// TestListTxnsSummaryBoundedRange verifies that kvdb summary reads preserve the
+// confirmed height bounds.
+func TestListTxnsSummaryBoundedRange(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Insert confirmed txns inside and after the requested height
+	// range.
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore)
+
+	insideLow := insertConfirmedTxWithSeed(t, dbConn, txStore, 144, 1)
+	insideHigh := insertConfirmedTxWithSeed(t, dbConn, txStore, 145, 2)
+	outsideHigh := insertConfirmedTxWithSeed(t, dbConn, txStore, 146, 3)
+
+	// Act: List the bounded confirmed range.
+	infos, err := store.ListTxns(t.Context(), db.ListTxnsQuery{
+		WalletID:    0,
+		StartHeight: 144,
+		EndHeight:   145,
+	})
+
+	// Assert: The out-of-range confirmed tx is excluded.
+	require.NoError(t, err)
+	require.NotContains(t, txHashes(infos), outsideHigh.Hash)
+	require.Equal(t, []chainhash.Hash{
+		insideLow.Hash, insideHigh.Hash,
+	}, txHashes(infos))
+}
+
+// insertConfirmedTx inserts one mined transaction into the legacy tx store so
+// kvdb summary reads can exercise confirmed block metadata.
+func insertConfirmedTx(t *testing.T, dbConn walletdb.DB,
+	txStore *wtxmgr.Store, height int32) *wtxmgr.TxRecord {
+
+	t.Helper()
+
+	return insertConfirmedTxWithSeed(t, dbConn, txStore, height, byte(height))
+}
+
+// insertConfirmedTxWithSeed inserts one mined transaction with fixture-specific
+// bytes into the legacy tx store.
+func insertConfirmedTxWithSeed(t *testing.T, dbConn walletdb.DB,
+	txStore *wtxmgr.Store, height int32, seed byte) *wtxmgr.TxRecord {
+
+	t.Helper()
+
+	txMsg := &wire.MsgTx{Version: 1}
+	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{seed},
+	}})
+	txMsg.AddTxOut(&wire.TxOut{
+		Value:    3_000 + int64(seed),
+		PkScript: []byte{0x51, seed},
+	})
+	rec, err := wtxmgr.NewTxRecordFromMsgTx(txMsg, time.Now())
+	require.NoError(t, err)
+
+	block := &wtxmgr.BlockMeta{
+		Block: wtxmgr.Block{
+			Height: height,
+			Hash:   chainhash.Hash{31, seed},
+		},
+		Time: time.Unix(1710002000, 0),
+	}
+
+	err = walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+		require.NotNil(t, ns)
+
+		return txStore.InsertTx(ns, rec, block)
+	})
+	require.NoError(t, err)
+
+	return rec
+}
+
+// txHashes returns transaction hashes in result order.
+func txHashes(infos []db.TxInfo) []chainhash.Hash {
+	hashes := make([]chainhash.Hash, 0, len(infos))
+	for _, info := range infos {
+		hashes = append(hashes, info.Hash)
+	}
+
+	return hashes
+}

--- a/wallet/internal/db/kvdb/txstore_test.go
+++ b/wallet/internal/db/kvdb/txstore_test.go
@@ -359,6 +359,83 @@ func TestListTxnsSummaryBoundedRange(t *testing.T) {
 	}, txHashes(infos))
 }
 
+// TestListTxDetailsCopiesMsgTx verifies that each returned detail keeps its own
+// stable MsgTx pointer even when RangeTransactions reuses the callback slice.
+func TestListTxDetailsCopiesMsgTx(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Insert two confirmed transactions in different blocks so the
+	// range callback has to cross block boundaries and can reuse its buffer.
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore)
+
+	firstTx := &wire.MsgTx{Version: 1}
+	firstTx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{40},
+	}})
+	firstTx.AddTxOut(&wire.TxOut{Value: 3_000, PkScript: []byte{0x51}})
+	firstRec, err := wtxmgr.NewTxRecordFromMsgTx(
+		firstTx, time.Unix(1710002100, 0),
+	)
+	require.NoError(t, err)
+
+	secondTx := &wire.MsgTx{Version: 1}
+	secondTx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{41},
+	}})
+	secondTx.AddTxOut(&wire.TxOut{Value: 4_000, PkScript: []byte{0x52}})
+	secondRec, err := wtxmgr.NewTxRecordFromMsgTx(
+		secondTx, time.Unix(1710002200, 0),
+	)
+	require.NoError(t, err)
+
+	err = walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+		require.NotNil(t, ns)
+
+		err := txStore.InsertTx(ns, firstRec, &wtxmgr.BlockMeta{
+			Block: wtxmgr.Block{
+				Height: 144,
+				Hash:   chainhash.Hash{50},
+			},
+			Time: time.Unix(1710002300, 0),
+		})
+		require.NoError(t, err)
+
+		return txStore.InsertTx(ns, secondRec, &wtxmgr.BlockMeta{
+			Block: wtxmgr.Block{
+				Height: 145,
+				Hash:   chainhash.Hash{51},
+			},
+			Time: time.Unix(1710002400, 0),
+		})
+	})
+	require.NoError(t, err)
+
+	// Act: Load the detailed range through the kvdb adapter.
+	details, err := store.ListTxDetails(t.Context(), db.ListTxDetailsQuery{
+		WalletID:    0,
+		StartHeight: 144,
+		EndHeight:   145,
+	})
+
+	// Assert: Each returned detail keeps the MsgTx that matches its own hash.
+	require.NoError(t, err)
+	require.Len(t, details, 2)
+
+	msgHashByDetailHash := make(map[chainhash.Hash]chainhash.Hash, len(details))
+	for _, detail := range details {
+		require.NotNil(t, detail.MsgTx)
+		msgHashByDetailHash[detail.Hash] = detail.MsgTx.TxHash()
+	}
+
+	require.Equal(t, firstRec.Hash, msgHashByDetailHash[firstRec.Hash])
+	require.Equal(t, secondRec.Hash, msgHashByDetailHash[secondRec.Hash])
+}
+
 // insertConfirmedTx inserts one mined transaction into the legacy tx store so
 // kvdb summary reads can exercise confirmed block metadata.
 func insertConfirmedTx(t *testing.T, dbConn walletdb.DB,

--- a/wallet/internal/db/kvdb/txstore_test.go
+++ b/wallet/internal/db/kvdb/txstore_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
@@ -213,6 +214,37 @@ func TestGetTxSummarySuccess(t *testing.T) {
 	require.Equal(t, db.TxStatusPublished, info.Status)
 }
 
+// TestGetTxDetailSuccess verifies that kvdb.Store adapts legacy tx details to
+// the db-native detail model.
+func TestGetTxDetailSuccess(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore)
+
+	funding, spend := insertSpendChain(t, dbConn, txStore)
+
+	detail, err := store.GetTxDetail(t.Context(), db.GetTxDetailQuery{
+		WalletID: 0,
+		Txid:     spend.Hash,
+	})
+	require.NoError(t, err)
+	require.Equal(t, spend.Hash, detail.Hash)
+	require.Nil(t, detail.Block)
+	require.Len(t, detail.OwnedInputs, 1)
+	require.Len(t, detail.OwnedOutputs, 2)
+	require.Equal(t, funding.Hash, spend.MsgTx.TxIn[0].PreviousOutPoint.Hash)
+	require.Equal(t, uint32(0), detail.OwnedInputs[0].Index)
+	require.Equal(t, btcutil.Amount(2_000), detail.OwnedInputs[0].Amount)
+	require.Equal(t, uint32(0), detail.OwnedOutputs[0].Index)
+	require.Equal(t, btcutil.Amount(900), detail.OwnedOutputs[0].Amount)
+	require.Equal(t, uint32(1), detail.OwnedOutputs[1].Index)
+	require.Equal(t, btcutil.Amount(800), detail.OwnedOutputs[1].Amount)
+}
+
 // TestGetTxSummaryNotFound verifies that kvdb.Store reports missing
 // transactions through db.ErrTxNotFound.
 func TestGetTxSummaryNotFound(t *testing.T) {
@@ -382,4 +414,55 @@ func txHashes(infos []db.TxInfo) []chainhash.Hash {
 	}
 
 	return hashes
+}
+
+// insertSpendChain inserts one funding tx and one spending tx into the legacy
+// tx store so kvdb detail reads can exercise both owned inputs and outputs.
+func insertSpendChain(t *testing.T, dbConn walletdb.DB,
+	txStore *wtxmgr.Store) (*wtxmgr.TxRecord, *wtxmgr.TxRecord) {
+
+	t.Helper()
+
+	fundingTx := &wire.MsgTx{Version: 1}
+	fundingTx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{20},
+	}})
+	fundingTx.AddTxOut(&wire.TxOut{Value: 2_000, PkScript: []byte{0x51}})
+	fundingRec, err := wtxmgr.NewTxRecordFromMsgTx(fundingTx, time.Now())
+	require.NoError(t, err)
+
+	spendTx := &wire.MsgTx{Version: 1}
+	spendTx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash:  fundingRec.Hash,
+		Index: 0,
+	}})
+	spendTx.AddTxOut(&wire.TxOut{Value: 900, PkScript: []byte{0x51}})
+	spendTx.AddTxOut(&wire.TxOut{Value: 800, PkScript: []byte{0x51}})
+	spendRec, err := wtxmgr.NewTxRecordFromMsgTx(spendTx, time.Now())
+	require.NoError(t, err)
+
+	err = walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+		require.NotNil(t, ns)
+
+		err = txStore.InsertTx(ns, fundingRec, nil)
+		require.NoError(t, err)
+
+		err = txStore.AddCredit(ns, fundingRec, nil, 0, false)
+		require.NoError(t, err)
+
+		err = txStore.InsertTx(ns, spendRec, nil)
+		require.NoError(t, err)
+
+		err = txStore.AddCredit(ns, spendRec, nil, 0, false)
+		require.NoError(t, err)
+
+		err = txStore.AddCredit(ns, spendRec, nil, 1, false)
+		require.NoError(t, err)
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	return fundingRec, spendRec
 }

--- a/wallet/internal/db/kvdb/utxostore.go
+++ b/wallet/internal/db/kvdb/utxostore.go
@@ -16,10 +16,6 @@ var (
 	// errNotImplemented is returned for unimplemented kvdb store methods.
 	errNotImplemented = errors.New("not implemented")
 
-	// errMissingTxmgrNamespace is returned when the `wtxmgr` namespace bucket
-	// cannot be found in a walletdb transaction.
-	errMissingTxmgrNamespace = errors.New("missing wtxmgr namespace")
-
 	// wtxmgrNamespaceKey is the walletdb top-level bucket key used by the
 	// transaction manager.
 	//
@@ -73,7 +69,9 @@ func (s *Store) ReleaseOutput(_ context.Context,
 	err := walletdb.Update(s.db, func(tx walletdb.ReadWriteTx) error {
 		ns := tx.ReadWriteBucket(wtxmgrNamespaceKey)
 		if ns == nil {
-			return errMissingTxmgrNamespace
+			return fmt.Errorf(
+				"wtxmgr namespace: %w", walletdb.ErrBucketNotFound,
+			)
 		}
 
 		err := s.txStore.UnlockOutput(ns, lockID, op)

--- a/wallet/internal/db/kvdb/utxostore_test.go
+++ b/wallet/internal/db/kvdb/utxostore_test.go
@@ -110,5 +110,5 @@ func TestReleaseOutputMissingNamespace(t *testing.T) {
 		OutPoint: wire.OutPoint{Hash: [32]byte{1}, Index: 0},
 	})
 	require.Error(t, err)
-	require.ErrorIs(t, err, errMissingTxmgrNamespace)
+	require.ErrorIs(t, err, walletdb.ErrBucketNotFound)
 }

--- a/wallet/mock_test.go
+++ b/wallet/mock_test.go
@@ -147,6 +147,18 @@ func (m *mockStore) GetTx(ctx context.Context,
 	return args.Get(0).(*db.TxInfo), args.Error(1)
 }
 
+// GetTxDetail implements the db.TxStore interface.
+func (m *mockStore) GetTxDetail(ctx context.Context,
+	query db.GetTxDetailQuery) (*db.TxDetailInfo, error) {
+
+	args := m.Called(ctx, query)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*db.TxDetailInfo), args.Error(1)
+}
+
 // ListTxns implements the db.TxStore interface.
 func (m *mockStore) ListTxns(ctx context.Context,
 	query db.ListTxnsQuery) ([]db.TxInfo, error) {
@@ -157,6 +169,18 @@ func (m *mockStore) ListTxns(ctx context.Context,
 	}
 
 	return args.Get(0).([]db.TxInfo), args.Error(1)
+}
+
+// ListTxDetails implements the db.TxStore interface.
+func (m *mockStore) ListTxDetails(ctx context.Context,
+	query db.ListTxDetailsQuery) ([]db.TxDetailInfo, error) {
+
+	args := m.Called(ctx, query)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).([]db.TxDetailInfo), args.Error(1)
 }
 
 // DeleteTx implements the db.TxStore interface.

--- a/wallet/tx_reader.go
+++ b/wallet/tx_reader.go
@@ -18,8 +18,6 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/pkg/btcunit"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
-	"github.com/btcsuite/btcwallet/walletdb"
-	"github.com/btcsuite/btcwallet/wtxmgr"
 )
 
 var (
@@ -37,8 +35,7 @@ type TxReader interface {
 	// GetTx returns a detailed description of a tx given its tx hash.
 	GetTx(ctx context.Context, txHash chainhash.Hash) (*TxDetail, error)
 
-	// ListTxns returns a list of all txns which are relevant to the wallet
-	// over a given block range.
+	// ListTxns returns detailed transaction views over a block range.
 	ListTxns(ctx context.Context, startHeight, endHeight int32) (
 		[]*TxDetail, error)
 }
@@ -146,12 +143,6 @@ type TxDetail struct {
 // GetTx returns a detailed description of a tx given its tx hash.
 //
 // NOTE: This method is part of the TxReader interface.
-//
-// Time complexity: O(log n + I + O), where n is the number of
-// transactions in the database, I is the number of inputs, and O is the
-// number of outputs. The lookup is dominated by a key-based B-tree lookup
-// in the database and the processing of the transaction's inputs and
-// outputs.
 func (w *Wallet) GetTx(ctx context.Context, txHash chainhash.Hash) (
 	*TxDetail, error) {
 
@@ -165,70 +156,20 @@ func (w *Wallet) GetTx(ctx context.Context, txHash chainhash.Hash) (
 	return w.getTxDetail(ctx, txHash, currentHeight)
 }
 
-// ListTxns returns a list of all txns which are relevant to the
-// wallet over a given block range. The block range is inclusive of the
-// start and end heights.
-//
-// The underlying transaction store allows for reverse iteration, so if
-// startHeight > endHeight, the transactions will be returned in reverse
-// order.
-//
-// The special height -1 may be used to include unmined transactions. For
-// example, to get all transactions from block 100 to the current tip including
-// unmined, use a startHeight of 100 and an endHeight of -1. To get all
-// transactions in the wallet, use a startHeight of 0 and an endHeight of -1.
+// ListTxns returns detailed transaction views over a block range.
 //
 // NOTE: This method is part of the TxReader interface.
-//
-// Time complexity: O(B + N), where B is the number of blocks in the
-// range and N is the total number of inputs and outputs across all
-// transactions in the range.
-func (w *Wallet) ListTxns(_ context.Context, startHeight,
-	endHeight int32) ([]*TxDetail, error) {
+func (w *Wallet) ListTxns(ctx context.Context, startHeight, endHeight int32) (
+	[]*TxDetail, error) {
 
 	err := w.state.validateStarted()
 	if err != nil {
 		return nil, err
 	}
 
-	bestBlock := w.SyncedTo()
-	currentHeight := bestBlock.Height
+	currentHeight := w.SyncedTo().Height
 
-	// We'll first fetch all the transaction records from the database
-	// within a single database transaction. This is done to minimize the
-	// time we hold the database lock.
-	var records []wtxmgr.TxDetails
-
-	err = walletdb.View(w.cfg.DB, func(dbtx walletdb.ReadTx) error {
-		txmgrNs := dbtx.ReadBucket(wtxmgrNamespaceKey)
-
-		err := w.txStore.RangeTransactions(
-			txmgrNs, startHeight, endHeight,
-			func(d []wtxmgr.TxDetails) (bool, error) {
-				records = append(records, d...)
-
-				return false, nil
-			},
-		)
-		if err != nil {
-			return fmt.Errorf("tx range failed: %w", err)
-		}
-
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to view wallet db: %w", err)
-	}
-
-	// Now that we have all the records, we can build the detailed
-	// response without holding the database lock.
-	details := make([]*TxDetail, 0, len(records))
-	for _, detail := range records {
-		txDetail := w.buildTxDetail(&detail, currentHeight)
-		details = append(details, txDetail)
-	}
-
-	return details, nil
+	return w.listTxDetails(ctx, startHeight, endHeight, currentHeight)
 }
 
 // getTxDetail loads one transaction through the detailed store path and builds
@@ -251,6 +192,33 @@ func (w *Wallet) getTxDetail(ctx context.Context, txHash chainhash.Hash,
 	return w.buildTxDetailFromStore(txDetails, currentHeight)
 }
 
+// listTxDetails loads detailed transactions over the requested wallet range and
+// builds full wallet responses.
+func (w *Wallet) listTxDetails(ctx context.Context, startHeight,
+	endHeight int32, currentHeight int32) ([]*TxDetail, error) {
+
+	records, err := w.store.ListTxDetails(ctx, db.ListTxDetailsQuery{
+		WalletID:    w.id,
+		StartHeight: startHeight,
+		EndHeight:   endHeight,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list tx details: %w", err)
+	}
+
+	details := make([]*TxDetail, 0, len(records))
+	for i := range records {
+		txDetail, err := w.buildTxDetailFromStore(&records[i], currentHeight)
+		if err != nil {
+			return nil, err
+		}
+
+		details = append(details, txDetail)
+	}
+
+	return details, nil
+}
+
 // buildTxDetailFromStore builds a wallet tx response from the db-native detail
 // shape returned by db.Store.
 func (w *Wallet) buildTxDetailFromStore(txDetails *db.TxDetailInfo,
@@ -260,139 +228,93 @@ func (w *Wallet) buildTxDetailFromStore(txDetails *db.TxDetailInfo,
 		return nil, errNilTxDetailMsgTx
 	}
 
-	legacyDetails := txDetailInfoToLegacy(txDetails)
+	msgTx := txDetails.MsgTx
 
-	return w.buildTxDetail(legacyDetails, currentHeight), nil
+	details := buildBasicTxDetail(
+		txDetails.Hash, txDetails.SerializedTx, txDetails.Label,
+		txDetails.Received, msgTx,
+	)
+
+	w.populateBlockDetails(details, txDetails.Block, currentHeight)
+	w.calculateValueAndFeeFromStore(details, txDetails, msgTx)
+	w.populateOutputs(details, msgTx, txDetails.OwnedOutputs)
+	w.populatePrevOuts(details, msgTx, txDetails.OwnedInputs)
+
+	return details, nil
 }
 
-// txDetailInfoToLegacy converts a db-native detail row into the legacy shape
-// still used by ListTxns until its store-backed path is wired in.
-func txDetailInfoToLegacy(details *db.TxDetailInfo) *wtxmgr.TxDetails {
-	block := wtxmgr.BlockMeta{
-		Block: wtxmgr.Block{Height: -1},
-	}
-	if details.Block != nil {
-		height, ok := safeUint32ToInt32(details.Block.Height)
-		if ok {
-			block = wtxmgr.BlockMeta{
-				Block: wtxmgr.Block{
-					Hash:   details.Block.Hash,
-					Height: height,
-				},
-				Time: details.Block.Timestamp,
-			}
-		}
-	}
+// buildBasicTxDetail builds the common non-wallet-relative fields for one tx
+// response.
+func buildBasicTxDetail(hash chainhash.Hash, rawTx []byte, label string,
+	received time.Time, msgTx *wire.MsgTx) *TxDetail {
 
-	debits := make([]wtxmgr.DebitRecord, 0, len(details.OwnedInputs))
-	for _, input := range details.OwnedInputs {
-		debits = append(debits, wtxmgr.DebitRecord{
-			Index:  input.Index,
-			Amount: input.Amount,
-		})
-	}
-
-	credits := make([]wtxmgr.CreditRecord, 0, len(details.OwnedOutputs))
-	for _, output := range details.OwnedOutputs {
-		credits = append(credits, wtxmgr.CreditRecord{
-			Index:  output.Index,
-			Amount: output.Amount,
-		})
-	}
-
-	return &wtxmgr.TxDetails{
-		TxRecord: wtxmgr.TxRecord{
-			MsgTx:        *details.MsgTx,
-			Hash:         details.Hash,
-			Received:     details.Received,
-			SerializedTx: details.SerializedTx,
-		},
-		Block:   block,
-		Credits: credits,
-		Debits:  debits,
-		Label:   details.Label,
-	}
-}
-
-// buildTxDetail builds a TxDetail from the given wtxmgr.TxDetails.
-func (w *Wallet) buildTxDetail(txDetails *wtxmgr.TxDetails,
-	currentHeight int32) *TxDetail {
-
-	details := w.buildBasicTxDetail(txDetails)
-
-	w.populateBlockDetails(details, txDetails, currentHeight)
-	w.calculateValueAndFee(details, txDetails)
-	w.populateOutputs(details, txDetails)
-	w.populatePrevOuts(details, txDetails)
-
-	return details
-}
-
-// buildBasicTxDetail builds the basic TxDetail from the given wtxmgr.TxDetails.
-func (w *Wallet) buildBasicTxDetail(txDetails *wtxmgr.TxDetails) *TxDetail {
 	txWeight := blockchain.GetTransactionWeight(
-		btcutil.NewTx(&txDetails.MsgTx),
+		btcutil.NewTx(msgTx),
 	)
 
 	return &TxDetail{
-		Hash:         txDetails.Hash,
-		RawTx:        txDetails.SerializedTx,
-		Label:        txDetails.Label,
-		ReceivedTime: txDetails.Received,
+		Hash:         hash,
+		RawTx:        rawTx,
+		Label:        label,
+		ReceivedTime: received,
 		Weight:       safeInt64ToWeightUnit(txWeight),
 		FeeRate:      btcunit.ZeroSatPerVByte,
 	}
 }
 
 // populateBlockDetails populates the block details for the given TxDetail.
-func (w *Wallet) populateBlockDetails(details *TxDetail,
-	txDetails *wtxmgr.TxDetails, currentHeight int32) {
+func (w *Wallet) populateBlockDetails(details *TxDetail, block *db.Block,
+	currentHeight int32) {
 
-	height := txDetails.Block.Height
-	if height == -1 {
+	if block == nil {
+		return
+	}
+
+	height, ok := safeUint32ToInt32(block.Height)
+	if !ok {
+		log.Warnf("Block height %d out of int32 range", block.Height)
+
 		return
 	}
 
 	details.Block = &BlockDetails{
-		Hash:      txDetails.Block.Hash,
-		Height:    txDetails.Block.Height,
-		Timestamp: txDetails.Block.Time.Unix(),
+		Hash:      block.Hash,
+		Height:    height,
+		Timestamp: block.Timestamp.Unix(),
 	}
 
 	details.Confirmations = calcConf(height, currentHeight)
 }
 
-// calculateValueAndFee calculates the value and fee for the given TxDetail.
-func (w *Wallet) calculateValueAndFee(details *TxDetail,
-	txDetails *wtxmgr.TxDetails) {
+// calculateValueAndFeeFromStore calculates the value and fee for the given
+// store-backed TxDetail.
+func (w *Wallet) calculateValueAndFeeFromStore(details *TxDetail,
+	txDetails *db.TxDetailInfo, msgTx *wire.MsgTx) {
 
 	var balanceDelta btcutil.Amount
-	for _, debit := range txDetails.Debits {
+	for _, debit := range txDetails.OwnedInputs {
 		balanceDelta -= debit.Amount
 	}
 
-	for _, credit := range txDetails.Credits {
+	for _, credit := range txDetails.OwnedOutputs {
 		balanceDelta += credit.Amount
 	}
 
 	details.Value = balanceDelta
 
-	// If not all inputs are ours, we can't calculate the total fee.
-	// txDetails.Debits contains only our inputs, while
-	// txDetails.MsgTx.TxIn contains all inputs. If they differ, some
-	// inputs belong to external wallets and we don't know their input
-	// values.
-	if len(txDetails.Debits) != len(txDetails.MsgTx.TxIn) {
+	// If not all inputs are ours, we can't calculate the total fee because
+	// external input values are unknown.
+	if len(txDetails.OwnedInputs) != len(msgTx.TxIn) {
 		return
 	}
 
 	var totalInput btcutil.Amount
-	for _, debit := range txDetails.Debits {
+	for _, debit := range txDetails.OwnedInputs {
 		totalInput += debit.Amount
 	}
 
 	var totalOutput btcutil.Amount
-	for _, txOut := range txDetails.MsgTx.TxOut {
+	for _, txOut := range msgTx.TxOut {
 		totalOutput += btcutil.Amount(txOut.Value)
 	}
 
@@ -402,16 +324,16 @@ func (w *Wallet) calculateValueAndFee(details *TxDetail,
 	)
 }
 
-// populateOutputs populates the outputs for the given TxDetail.
-func (w *Wallet) populateOutputs(details *TxDetail,
-	txDetails *wtxmgr.TxDetails) {
+// populateOutputs populates outputs for a store-backed TxDetail.
+func (w *Wallet) populateOutputs(details *TxDetail, msgTx *wire.MsgTx,
+	ownedOutputs []db.TxOwnedOutput) {
 
 	isOurAddress := make(map[uint32]bool)
-	for _, credit := range txDetails.Credits {
+	for _, credit := range ownedOutputs {
 		isOurAddress[credit.Index] = true
 	}
 
-	for i, txOut := range txDetails.MsgTx.TxOut {
+	for i, txOut := range msgTx.TxOut {
 		sc, outAddresses, _, err := txscript.ExtractPkScriptAddrs(
 			txOut.PkScript, w.cfg.ChainParams,
 		)
@@ -430,41 +352,37 @@ func (w *Wallet) populateOutputs(details *TxDetail,
 			continue
 		}
 
-		details.Outputs = append(
-			details.Outputs, Output{
-				Type:      sc,
-				Addresses: addresses,
-				PkScript:  txOut.PkScript,
-				Index:     i,
-				Amount:    btcutil.Amount(txOut.Value),
-				IsOurs:    isOurAddress[idx],
-			},
-		)
+		details.Outputs = append(details.Outputs, Output{
+			Type:      sc,
+			Addresses: addresses,
+			PkScript:  txOut.PkScript,
+			Index:     i,
+			Amount:    btcutil.Amount(txOut.Value),
+			IsOurs:    isOurAddress[idx],
+		})
 	}
 }
 
-// populatePrevOuts populates the previous outputs for the given TxDetail.
-func (w *Wallet) populatePrevOuts(details *TxDetail,
-	txDetails *wtxmgr.TxDetails) {
+// populatePrevOuts populates prevouts for a store-backed TxDetail.
+func (w *Wallet) populatePrevOuts(details *TxDetail, msgTx *wire.MsgTx,
+	ownedInputs []db.TxOwnedInput) {
 
 	isOurOutput := make(map[uint32]bool)
-	for _, debit := range txDetails.Debits {
+	for _, debit := range ownedInputs {
 		isOurOutput[debit.Index] = true
 	}
 
-	for i, txIn := range txDetails.MsgTx.TxIn {
+	for i, txIn := range msgTx.TxIn {
 		idx, ok := safeIntToUint32(i)
 		if !ok {
 			log.Warnf("Input index %d out of uint32 range", i)
 			continue
 		}
 
-		details.PrevOuts = append(
-			details.PrevOuts, PrevOut{
-				OutPoint: txIn.PreviousOutPoint,
-				IsOurs:   isOurOutput[idx],
-			},
-		)
+		details.PrevOuts = append(details.PrevOuts, PrevOut{
+			OutPoint: txIn.PreviousOutPoint,
+			IsOurs:   isOurOutput[idx],
+		})
 	}
 }
 

--- a/wallet/tx_reader.go
+++ b/wallet/tx_reader.go
@@ -17,6 +17,7 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/pkg/btcunit"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 )
@@ -25,6 +26,10 @@ var (
 	// ErrTxNotFound is returned when a transaction is not found in the
 	// store.
 	ErrTxNotFound = errors.New("tx not found")
+
+	// errNilTxDetailMsgTx is returned when a store detail row violates the
+	// TxDetailInfo contract and omits the parsed transaction.
+	errNilTxDetailMsgTx = errors.New("tx detail MsgTx is nil")
 )
 
 // TxReader provides an interface for querying tx history.
@@ -147,7 +152,7 @@ type TxDetail struct {
 // number of outputs. The lookup is dominated by a key-based B-tree lookup
 // in the database and the processing of the transaction's inputs and
 // outputs.
-func (w *Wallet) GetTx(_ context.Context, txHash chainhash.Hash) (
+func (w *Wallet) GetTx(ctx context.Context, txHash chainhash.Hash) (
 	*TxDetail, error) {
 
 	err := w.state.validateStarted()
@@ -155,15 +160,9 @@ func (w *Wallet) GetTx(_ context.Context, txHash chainhash.Hash) (
 		return nil, err
 	}
 
-	txDetails, err := w.fetchTxDetails(&txHash)
-	if err != nil {
-		return nil, err
-	}
+	currentHeight := w.SyncedTo().Height
 
-	bestBlock := w.SyncedTo()
-	currentHeight := bestBlock.Height
-
-	return w.buildTxDetail(txDetails, currentHeight), nil
+	return w.getTxDetail(ctx, txHash, currentHeight)
 }
 
 // ListTxns returns a list of all txns which are relevant to the
@@ -230,6 +229,89 @@ func (w *Wallet) ListTxns(_ context.Context, startHeight,
 	}
 
 	return details, nil
+}
+
+// getTxDetail loads one transaction through the detailed store path and builds
+// the full wallet response.
+func (w *Wallet) getTxDetail(ctx context.Context, txHash chainhash.Hash,
+	currentHeight int32) (*TxDetail, error) {
+
+	txDetails, err := w.store.GetTxDetail(ctx, db.GetTxDetailQuery{
+		WalletID: w.id,
+		Txid:     txHash,
+	})
+	if err != nil {
+		if errors.Is(err, db.ErrTxNotFound) {
+			return nil, ErrTxNotFound
+		}
+
+		return nil, fmt.Errorf("get tx detail: %w", err)
+	}
+
+	return w.buildTxDetailFromStore(txDetails, currentHeight)
+}
+
+// buildTxDetailFromStore builds a wallet tx response from the db-native detail
+// shape returned by db.Store.
+func (w *Wallet) buildTxDetailFromStore(txDetails *db.TxDetailInfo,
+	currentHeight int32) (*TxDetail, error) {
+
+	if txDetails.MsgTx == nil {
+		return nil, errNilTxDetailMsgTx
+	}
+
+	legacyDetails := txDetailInfoToLegacy(txDetails)
+
+	return w.buildTxDetail(legacyDetails, currentHeight), nil
+}
+
+// txDetailInfoToLegacy converts a db-native detail row into the legacy shape
+// still used by ListTxns until its store-backed path is wired in.
+func txDetailInfoToLegacy(details *db.TxDetailInfo) *wtxmgr.TxDetails {
+	block := wtxmgr.BlockMeta{
+		Block: wtxmgr.Block{Height: -1},
+	}
+	if details.Block != nil {
+		height, ok := safeUint32ToInt32(details.Block.Height)
+		if ok {
+			block = wtxmgr.BlockMeta{
+				Block: wtxmgr.Block{
+					Hash:   details.Block.Hash,
+					Height: height,
+				},
+				Time: details.Block.Timestamp,
+			}
+		}
+	}
+
+	debits := make([]wtxmgr.DebitRecord, 0, len(details.OwnedInputs))
+	for _, input := range details.OwnedInputs {
+		debits = append(debits, wtxmgr.DebitRecord{
+			Index:  input.Index,
+			Amount: input.Amount,
+		})
+	}
+
+	credits := make([]wtxmgr.CreditRecord, 0, len(details.OwnedOutputs))
+	for _, output := range details.OwnedOutputs {
+		credits = append(credits, wtxmgr.CreditRecord{
+			Index:  output.Index,
+			Amount: output.Amount,
+		})
+	}
+
+	return &wtxmgr.TxDetails{
+		TxRecord: wtxmgr.TxRecord{
+			MsgTx:        *details.MsgTx,
+			Hash:         details.Hash,
+			Received:     details.Received,
+			SerializedTx: details.SerializedTx,
+		},
+		Block:   block,
+		Credits: credits,
+		Debits:  debits,
+		Label:   details.Label,
+	}
 }
 
 // buildTxDetail builds a TxDetail from the given wtxmgr.TxDetails.
@@ -404,4 +486,14 @@ func safeIntToUint32(i int) (uint32, bool) {
 	}
 
 	return uint32(i), true
+}
+
+// safeUint32ToInt32 converts a uint32 to an int32, returning false if the
+// conversion would overflow.
+func safeUint32ToInt32(u uint32) (int32, bool) {
+	if u > math.MaxInt32 {
+		return 0, false
+	}
+
+	return int32(u), true
 }

--- a/wallet/tx_reader_benchmark_test.go
+++ b/wallet/tx_reader_benchmark_test.go
@@ -168,7 +168,7 @@ func BenchmarkGetTxAPI(b *testing.B) {
 			//     legacy API
 			//   - Regression prevention for future changes
 			assertGetTxAPIsEquivalent(
-				b, bw.Wallet, beforeResult, afterResult,
+				b, beforeResult, afterResult,
 			)
 		})
 	}
@@ -263,11 +263,6 @@ func BenchmarkGetTxAPIConcurrently(b *testing.B) {
 			medianIndex := len(bw.allTxs) / 2
 			testTxHash := bw.allTxs[medianIndex].TxHash()
 
-			var (
-				before *GetTransactionResult
-				after  *TxDetail
-			)
-
 			b.Run("0-Before", func(b *testing.B) {
 				b.ReportAllocs()
 				b.ResetTimer()
@@ -277,10 +272,8 @@ func BenchmarkGetTxAPIConcurrently(b *testing.B) {
 						res, err := bw.GetTransaction(
 							testTxHash,
 						)
-						before = res
-
 						require.NoError(b, err)
-						require.NotNil(b, before)
+						require.NotNil(b, res)
 					}
 				})
 			})
@@ -294,15 +287,19 @@ func BenchmarkGetTxAPIConcurrently(b *testing.B) {
 						res, err := bw.GetTx(
 							b.Context(), testTxHash,
 						)
-						after = res
-
 						require.NoError(b, err)
-						require.NotNil(b, after)
+						require.NotNil(b, res)
 					}
 				})
 			})
 
-			assertGetTxAPIsEquivalent(b, bw.Wallet, before, after)
+			before, err := bw.GetTransaction(testTxHash)
+			require.NoError(b, err)
+
+			after, err := bw.GetTx(b.Context(), testTxHash)
+			require.NoError(b, err)
+
+			assertGetTxAPIsEquivalent(b, before, after)
 		})
 	}
 }
@@ -449,8 +446,7 @@ func BenchmarkListTxnsAPI(b *testing.B) {
 
 				for i := 0; b.Loop(); i++ {
 					result, err = bw.ListTxns(
-						b.Context(), startHeight,
-						endHeight,
+						b.Context(), startHeight, endHeight,
 					)
 					require.NoError(b, err)
 
@@ -476,7 +472,7 @@ func BenchmarkListTxnsAPI(b *testing.B) {
 			//     legacy API
 			//   - Regression prevention for future changes
 			assertListTxnsAPIsEquivalent(
-				b, bw.Wallet, beforeResult, afterResult,
+				b, beforeResult, afterResult,
 			)
 		})
 	}
@@ -571,11 +567,6 @@ func BenchmarkListTxnsAPIConcurrently(b *testing.B) {
 				endHeight   int32 = -1
 			)
 
-			var (
-				beforeResult *GetTransactionsResult
-				afterResult  []*TxDetail
-			)
-
 			b.Run("0-Before", func(b *testing.B) {
 				b.ReportAllocs()
 				b.ResetTimer()
@@ -586,8 +577,6 @@ func BenchmarkListTxnsAPIConcurrently(b *testing.B) {
 							startBlock, endBlock,
 							"", nil,
 						)
-						beforeResult = res
-
 						require.NoError(b, err)
 						require.NotNil(b, res)
 					}
@@ -601,19 +590,26 @@ func BenchmarkListTxnsAPIConcurrently(b *testing.B) {
 				b.RunParallel(func(pb *testing.PB) {
 					for pb.Next() {
 						res, err := bw.ListTxns(
-							b.Context(),
-							startHeight, endHeight,
+							b.Context(), startHeight, endHeight,
 						)
-						afterResult = res
-
 						require.NoError(b, err)
 						require.NotNil(b, res)
 					}
 				})
 			})
 
+			beforeResult, err := bw.GetTransactions(
+				startBlock, endBlock, "", nil,
+			)
+			require.NoError(b, err)
+
+			afterResult, err := bw.ListTxns(
+				b.Context(), startHeight, endHeight,
+			)
+			require.NoError(b, err)
+
 			assertListTxnsAPIsEquivalent(
-				b, bw.Wallet, beforeResult, afterResult,
+				b, beforeResult, afterResult,
 			)
 		})
 	}
@@ -621,57 +617,175 @@ func BenchmarkListTxnsAPIConcurrently(b *testing.B) {
 
 // assertGetTxAPIsEquivalent verifies that GetTransaction (legacy) and GetTx
 // (new) return equivalent data for the same transaction.
-func assertGetTxAPIsEquivalent(b *testing.B, w *Wallet,
-	before *GetTransactionResult, after *TxDetail) {
+func assertGetTxAPIsEquivalent(b *testing.B, before *GetTransactionResult,
+	after *TxDetail) {
 
 	b.Helper()
 
 	require.NotNil(b, before)
 	require.NotNil(b, after)
 
-	afterConverted, err := w.GetTransaction(after.Hash)
-	require.NoError(b, err)
-
-	require.GreaterOrEqual(b, afterConverted.Confirmations, int32(0))
-
-	require.Equal(b, before, afterConverted)
+	assertTxSummaryMatchesDetail(b, before.Summary, after)
+	assertGetTxBlockMatchesDetail(b, before, after)
 }
 
 // assertListTxnsAPIsEquivalent verifies that GetTransactions (legacy) and
 // ListTxns (new) return equivalent data for the same block range.
-func assertListTxnsAPIsEquivalent(b *testing.B, w *Wallet,
-	before *GetTransactionsResult, after []*TxDetail) {
+func assertListTxnsAPIsEquivalent(b *testing.B, before *GetTransactionsResult,
+	after []*TxDetail) {
 
 	b.Helper()
 
 	require.NotNil(b, before)
 	require.NotNil(b, after)
 
-	// Use GetTransactions API to fetch all transactions (both confirmed
-	// and unconfirmed) for comparison. Parameters match the benchmark's
-	// "before" case:
-	// - startBlock: nil (from genesis)
-	// - endBlock: nil (to current tip)
-	// - accountName: "" (all accounts)
-	// - cancel: nil (no cancellation)
-	var (
-		startBlock  *BlockIdentifier
-		endBlock    *BlockIdentifier
-		accountName string
-		cancel      <-chan struct{}
-	)
-
-	afterConverted, err := w.GetTransactions(
-		startBlock, endBlock, accountName, cancel,
-	)
-	require.NoError(b, err)
-
 	require.NotEmpty(b, before.MinedTransactions)
 	require.NotEmpty(b, before.UnminedTransactions)
 
-	require.Equal(
-		b, before, afterConverted,
-		"GetTransactions and ListTxns APIs should return equivalent "+
-			"data",
-	)
+	totalTxns := len(before.UnminedTransactions)
+	for _, block := range before.MinedTransactions {
+		totalTxns += len(block.Transactions)
+	}
+
+	require.Len(b, after, totalTxns)
+
+	var idx int
+	for _, block := range before.MinedTransactions {
+		for _, txSummary := range block.Transactions {
+			txDetail := after[idx]
+			assertListedTxBlockMatchesDetail(b, block, txDetail)
+			assertTxSummaryMatchesDetail(b, txSummary, txDetail)
+
+			idx++
+		}
+	}
+
+	for _, txSummary := range before.UnminedTransactions {
+		txDetail := after[idx]
+		require.Nil(b, txDetail.Block)
+		require.Zero(b, txDetail.Confirmations)
+		assertTxSummaryMatchesDetail(b, txSummary, txDetail)
+
+		idx++
+	}
+}
+
+// assertGetTxBlockMatchesDetail verifies that GetTx preserves the block fields
+// returned by GetTransaction.
+func assertGetTxBlockMatchesDetail(b *testing.B,
+	before *GetTransactionResult, after *TxDetail) {
+
+	b.Helper()
+
+	require.Equal(b, before.Confirmations, after.Confirmations)
+
+	if before.BlockHash == nil {
+		require.Nil(b, after.Block)
+		require.Equal(b, int32(-1), before.Height)
+		require.Zero(b, before.Timestamp)
+
+		return
+	}
+
+	require.NotNil(b, after.Block)
+	require.Equal(b, *before.BlockHash, after.Block.Hash)
+	require.Equal(b, before.Height, after.Block.Height)
+	require.Equal(b, before.Timestamp, after.Block.Timestamp)
+}
+
+// assertListedTxBlockMatchesDetail verifies that ListTxns preserves mined block
+// metadata from GetTransactions.
+func assertListedTxBlockMatchesDetail(b *testing.B, block Block,
+	after *TxDetail) {
+
+	b.Helper()
+
+	require.NotNil(b, block.Hash)
+	require.NotNil(b, after.Block)
+	require.Equal(b, *block.Hash, after.Block.Hash)
+	require.Equal(b, block.Height, after.Block.Height)
+	require.Equal(b, block.Timestamp, after.Block.Timestamp)
+	require.Positive(b, after.Confirmations)
+}
+
+// assertTxSummaryMatchesDetail verifies that the wallet tx detail preserves the
+// fields exposed by the legacy transaction summary.
+func assertTxSummaryMatchesDetail(b *testing.B, before TransactionSummary,
+	after *TxDetail) {
+
+	b.Helper()
+
+	require.NotNil(b, before.Hash)
+	require.NotNil(b, before.Tx)
+	require.Equal(b, *before.Hash, after.Hash)
+	require.Equal(b, before.Transaction, after.RawTx)
+	require.Equal(b, before.Fee, after.Fee)
+	require.Equal(b, before.Timestamp, after.ReceivedTime.Unix())
+	require.Equal(b, before.Label, after.Label)
+
+	assertTxInputsMatchDetail(b, before, after)
+	assertTxOutputsMatchDetail(b, before, after)
+	require.Equal(b, expectedSummaryValue(before), int64(after.Value))
+}
+
+// assertTxInputsMatchDetail verifies input order and wallet ownership markers.
+func assertTxInputsMatchDetail(b *testing.B, before TransactionSummary,
+	after *TxDetail) {
+
+	b.Helper()
+
+	ownedInputs := make(map[uint32]struct{}, len(before.MyInputs))
+	for _, input := range before.MyInputs {
+		ownedInputs[input.Index] = struct{}{}
+	}
+
+	require.Len(b, after.PrevOuts, len(before.Tx.TxIn))
+
+	for i, txIn := range before.Tx.TxIn {
+		prevOut := after.PrevOuts[i]
+		require.Equal(b, txIn.PreviousOutPoint, prevOut.OutPoint)
+
+		_, isOwned := ownedInputs[uint32(i)]
+		require.Equal(b, isOwned, prevOut.IsOurs)
+	}
+}
+
+// assertTxOutputsMatchDetail verifies output order, values, scripts, and wallet
+// ownership markers.
+func assertTxOutputsMatchDetail(b *testing.B, before TransactionSummary,
+	after *TxDetail) {
+
+	b.Helper()
+
+	ownedOutputs := make(map[uint32]struct{}, len(before.MyOutputs))
+	for _, output := range before.MyOutputs {
+		ownedOutputs[output.Index] = struct{}{}
+	}
+
+	require.Len(b, after.Outputs, len(before.Tx.TxOut))
+
+	for i, txOut := range before.Tx.TxOut {
+		output := after.Outputs[i]
+		require.Equal(b, i, output.Index)
+		require.Equal(b, txOut.Value, int64(output.Amount))
+		require.Equal(b, txOut.PkScript, output.PkScript)
+
+		_, isOwned := ownedOutputs[uint32(i)]
+		require.Equal(b, isOwned, output.IsOurs)
+	}
+}
+
+// expectedSummaryValue calculates the wallet balance delta encoded by the
+// legacy transaction summary.
+func expectedSummaryValue(summary TransactionSummary) int64 {
+	var value int64
+	for _, input := range summary.MyInputs {
+		value -= int64(input.PreviousAmount)
+	}
+
+	for _, output := range summary.MyOutputs {
+		value += summary.Tx.TxOut[output.Index].Value
+	}
+
+	return value
 }

--- a/wallet/tx_reader_test.go
+++ b/wallet/tx_reader_test.go
@@ -115,6 +115,30 @@ func TestGetTxPropagatesNilMsgTx(t *testing.T) {
 	require.ErrorIs(t, err, errNilTxDetailMsgTx)
 }
 
+// TestListTxnsPropagatesNilMsgTx tests that ListTxns returns store detail
+// contract violations to callers.
+func TestListTxnsPropagatesNilMsgTx(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Mock one listed store detail row that omits the parsed
+	// transaction.
+	minedDetails, _ := createMinedTxDetail(t)
+	txDetails := txDetailInfoFromLegacy(minedDetails)
+	txDetails.MsgTx = nil
+	w, mocks := createStartedWalletWithMocks(t)
+	mocks.store.On("ListTxDetails", mock.Anything, db.ListTxDetailsQuery{
+		WalletID:    w.id,
+		StartHeight: 0,
+		EndHeight:   1000,
+	}).Return([]db.TxDetailInfo{*txDetails}, nil).Once()
+
+	// Act: List transactions through the public wallet method.
+	_, err := w.ListTxns(t.Context(), 0, 1000)
+
+	// Assert: Check that the contract violation is propagated.
+	require.ErrorIs(t, err, errNilTxDetailMsgTx)
+}
+
 // TestGetTxSuccess tests the GetTx method of the wallet for success scenarios.
 func TestGetTxSuccess(t *testing.T) {
 	t.Parallel()
@@ -166,8 +190,8 @@ func TestGetTxSuccess(t *testing.T) {
 func TestGetTxNotFound(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Create a test wallet with mocks and mock the detail read to
-	// return ErrTxNotFound, simulating a non-existing tx.
+	// Arrange: Create a test wallet with mocks and mock the TxDetails call
+	// to return nil, simulating a non-existing tx.
 	w, mocks := createStartedWalletWithMocks(t)
 	mocks.store.On("GetTxDetail", mock.Anything, db.GetTxDetailQuery{
 		WalletID: w.id,
@@ -191,23 +215,13 @@ func TestListTxnsSuccess(t *testing.T) {
 
 	// SyncedTo is mocked in createStartedWalletWithMocks (height 1).
 
-	// Set up the mock for the tx store. We use .Run to execute the
-	// callback function that's passed in as an argument to the mock.
-	mocks.txStore.On("RangeTransactions",
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-	).Run(func(args mock.Arguments) {
-		// Get the callback function from the arguments.
-		f, ok := args.Get(3).(func([]wtxmgr.TxDetails) (bool, error))
-		require.True(t, ok)
-
-		// Create the mock details to pass to the callback.
-		minedDetails, _ := createMinedTxDetail(t)
-		details := []wtxmgr.TxDetails{*minedDetails}
-
-		// Call the callback.
-		_, err := f(details)
-		require.NoError(t, err)
-	}).Return(nil).Once()
+	minedDetails, _ := createMinedTxDetail(t)
+	mocks.store.On("ListTxDetails", mock.Anything, db.ListTxDetailsQuery{
+		WalletID:    w.id,
+		StartHeight: 0,
+		EndHeight:   1000,
+	}).Return([]db.TxDetailInfo{*txDetailInfoFromLegacy(minedDetails)}, nil).
+		Once()
 
 	// Act: List txns.
 	details, err := w.ListTxns(t.Context(), 0, 1000)

--- a/wallet/tx_reader_test.go
+++ b/wallet/tx_reader_test.go
@@ -13,13 +13,14 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcwallet/pkg/btcunit"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
-// TestBuildTxDetail tests the buildTxDetail function.
-func TestBuildTxDetail(t *testing.T) {
+// TestBuildTxDetailFromStore tests the detailed store-backed tx builder.
+func TestBuildTxDetailFromStore(t *testing.T) {
 	t.Parallel()
 
 	// Create the various test cases.
@@ -63,12 +64,55 @@ func TestBuildTxDetail(t *testing.T) {
 			currentHeight := int32(1)
 
 			// Act: Build the TxDetail.
-			result := w.buildTxDetail(tc.details, currentHeight)
+			result, err := w.buildTxDetailFromStore(
+				txDetailInfoFromLegacy(tc.details), currentHeight,
+			)
 
 			// Assert: Check that the correct details are returned.
+			require.NoError(t, err)
 			require.Equal(t, tc.expectedTxDetail, result)
 		})
 	}
+}
+
+// TestBuildTxDetailFromStoreRequiresMsgTx tests that store rows must include a
+// parsed transaction.
+func TestBuildTxDetailFromStoreRequiresMsgTx(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a store detail row that violates the MsgTx contract.
+	minedDetails, _ := createMinedTxDetail(t)
+	txDetails := txDetailInfoFromLegacy(minedDetails)
+	txDetails.MsgTx = nil
+	w, _ := createStartedWalletWithMocks(t)
+
+	// Act: Build the TxDetail from the malformed store row.
+	_, err := w.buildTxDetailFromStore(txDetails, 1)
+
+	// Assert: Check that the contract violation is reported.
+	require.ErrorIs(t, err, errNilTxDetailMsgTx)
+}
+
+// TestGetTxPropagatesNilMsgTx tests that GetTx returns store detail contract
+// violations to callers.
+func TestGetTxPropagatesNilMsgTx(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Mock a store detail row that omits the parsed transaction.
+	minedDetails, _ := createMinedTxDetail(t)
+	txDetails := txDetailInfoFromLegacy(minedDetails)
+	txDetails.MsgTx = nil
+	w, mocks := createStartedWalletWithMocks(t)
+	mocks.store.On("GetTxDetail", mock.Anything, db.GetTxDetailQuery{
+		WalletID: w.id,
+		Txid:     *TstTxHash,
+	}).Return(txDetails, nil).Once()
+
+	// Act: Get the transaction through the public wallet method.
+	_, err := w.GetTx(t.Context(), *TstTxHash)
+
+	// Assert: Check that the contract violation is propagated.
+	require.ErrorIs(t, err, errNilTxDetailMsgTx)
 }
 
 // TestGetTxSuccess tests the GetTx method of the wallet for success scenarios.
@@ -80,17 +124,17 @@ func TestGetTxSuccess(t *testing.T) {
 
 	testCases := []struct {
 		name             string
-		mockDetails      *wtxmgr.TxDetails
+		mockDetails      *db.TxDetailInfo
 		expectedTxDetail *TxDetail
 	}{
 		{
 			name:             "mined tx",
-			mockDetails:      minedDetails,
+			mockDetails:      txDetailInfoFromLegacy(minedDetails),
 			expectedTxDetail: minedTxDetail,
 		},
 		{
 			name:             "unmined tx",
-			mockDetails:      unminedDetails,
+			mockDetails:      txDetailInfoFromLegacy(unminedDetails),
 			expectedTxDetail: unminedTxDetail,
 		},
 	}
@@ -102,8 +146,10 @@ func TestGetTxSuccess(t *testing.T) {
 			w, mocks := createStartedWalletWithMocks(t)
 			// SyncedTo is mocked in createStartedWalletWithMocks (height 1).
 
-			mocks.txStore.On("TxDetails", mock.Anything, TstTxHash).
-				Return(tc.mockDetails, nil).Once()
+			mocks.store.On("GetTxDetail", mock.Anything, db.GetTxDetailQuery{
+				WalletID: w.id,
+				Txid:     *TstTxHash,
+			}).Return(tc.mockDetails, nil).Once()
 
 			// Act: Get the transaction.
 			details, err := w.GetTx(t.Context(), *TstTxHash)
@@ -120,11 +166,13 @@ func TestGetTxSuccess(t *testing.T) {
 func TestGetTxNotFound(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Create a test wallet with mocks and mock the TxDetails call
-	// to return nil, simulating a non-existing tx.
+	// Arrange: Create a test wallet with mocks and mock the detail read to
+	// return ErrTxNotFound, simulating a non-existing tx.
 	w, mocks := createStartedWalletWithMocks(t)
-	mocks.txStore.On("TxDetails", mock.Anything, TstTxHash).
-		Return(nil, nil).Once()
+	mocks.store.On("GetTxDetail", mock.Anything, db.GetTxDetailQuery{
+		WalletID: w.id,
+		Txid:     *TstTxHash,
+	}).Return(nil, db.ErrTxNotFound).Once()
 
 	// Act: Attempt to get the transaction.
 	_, err := w.GetTx(t.Context(), *TstTxHash)
@@ -301,4 +349,45 @@ func createMinedTxDetail(t *testing.T) (*wtxmgr.TxDetails, *TxDetail) {
 	}
 
 	return minedDetails, minedTxDetail
+}
+
+// txDetailInfoFromLegacy converts one legacy wtxmgr transaction fixture into
+// the db-native detail shape consumed by store-backed reader tests.
+func txDetailInfoFromLegacy(details *wtxmgr.TxDetails) *db.TxDetailInfo {
+	var block *db.Block
+	if details.Block.Height >= 0 {
+		block = &db.Block{
+			Hash:      details.Block.Hash,
+			Height:    uint32(details.Block.Height),
+			Timestamp: details.Block.Time,
+		}
+	}
+
+	ownedInputs := make([]db.TxOwnedInput, 0, len(details.Debits))
+	for _, debit := range details.Debits {
+		ownedInputs = append(ownedInputs, db.TxOwnedInput{
+			Index:  debit.Index,
+			Amount: debit.Amount,
+		})
+	}
+
+	ownedOutputs := make([]db.TxOwnedOutput, 0, len(details.Credits))
+	for _, credit := range details.Credits {
+		ownedOutputs = append(ownedOutputs, db.TxOwnedOutput{
+			Index:  credit.Index,
+			Amount: credit.Amount,
+		})
+	}
+
+	return &db.TxDetailInfo{
+		Hash:         details.Hash,
+		MsgTx:        &details.MsgTx,
+		SerializedTx: details.SerializedTx,
+		Received:     details.Received,
+		Block:        block,
+		Status:       db.TxStatusPublished,
+		Label:        details.Label,
+		OwnedInputs:  ownedInputs,
+		OwnedOutputs: ownedOutputs,
+	}
 }


### PR DESCRIPTION
## Summary
- add store-backed transaction detail and transaction listing queries
- route wallet tx-reader paths through `db.Store` instead of direct legacy tx-manager reads
- remove legacy tx-reader builder code that is no longer needed after the migration

## Why
- the tx-reader path still depended on direct `walletdb` and legacy `wtxmgr` access
- moving reads behind `db.Store` keeps the wallet package on the same transitional surface as the writer and upcoming utxo/address work
- this also aligns the reader branch with the new SQL package layout from `sql-wallet`

## What Changed
- added store support for:
  - `GetTxDetail`
  - `ListTxDetails`
- updated wallet tx-reader callers to use `w.store`
- removed legacy tx-reader-specific builder/adaptation code
- adapted the branch to the new `wallet/internal/sql/.../sqlc` package layout

## Testing
- `GOWORK=off scripts/check-each-commit.sh impl-tx-writer-store`
- `GOWORK=off go test ./wallet/internal/db/... ./wallet`
- `GOWORK=off make lint-check`