### PR TITLE
Prep address manager for store migration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,10 +123,22 @@ jobs:
     steps:
       - name: extract bitcoind from docker image
         run: |-
-          docker pull ${{ env.BITCOIND_IMAGE }}:${{ env.BITCOIND_VERSION }}
-          CONTAINER_ID=$(docker create ${{ env.BITCOIND_IMAGE }}:${{ env.BITCOIND_VERSION }})
-          sudo docker cp $CONTAINER_ID:/opt/bitcoin-${{ env.BITCOIND_VERSION }}/bin/bitcoind /usr/local/bin/bitcoind
+          IMAGE=${{ env.BITCOIND_IMAGE }}:${{ env.BITCOIND_VERSION }}
+          docker pull $IMAGE
+
+          BIN_PATH=$(docker run --rm --entrypoint sh $IMAGE -c '
+            command -v bitcoind ||
+            find /opt /usr -type f -name bitcoind 2>/dev/null | head -n 1
+          ')
+          if [ -z "$BIN_PATH" ]; then
+            echo "could not locate bitcoind in $IMAGE" >&2
+            exit 1
+          fi
+
+          CONTAINER_ID=$(docker create $IMAGE)
+          sudo docker cp $CONTAINER_ID:$BIN_PATH /usr/local/bin/bitcoind
           docker rm $CONTAINER_ID
+          bitcoind --version
 
       - name: git checkout
         uses: actions/checkout@v5
@@ -323,20 +335,20 @@ jobs:
       # matrix covers both bitcoind v30 (latest) and v28 (older).
       - name: extract bitcoind from docker image (${{ matrix.bitcoind_version }})
         run: |-
-          docker pull ${{ env.BITCOIND_IMAGE }}:${{ matrix.bitcoind_version }}
-          CONTAINER_ID=$(docker create ${{ env.BITCOIND_IMAGE }}:${{ matrix.bitcoind_version }})
+          IMAGE=${{ env.BITCOIND_IMAGE }}:${{ matrix.bitcoind_version }}
+          docker pull $IMAGE
 
-          # Different upstream image tags use slightly different install paths.
-          # Try common variants in order until one succeeds.
-          for BIN_PATH in \
-            "/opt/bitcoin-${{ matrix.bitcoind_version }}/bin/bitcoind" \
-            "/opt/bitcoin-${{ matrix.bitcoind_version }}.0/bin/bitcoind" \
-            "/opt/bitcoin-${{ matrix.bitcoind_version }}.0.0/bin/bitcoind"; do
-            if sudo docker cp $CONTAINER_ID:${BIN_PATH} /usr/local/bin/bitcoind; then
-              break
-            fi
-          done
+          BIN_PATH=$(docker run --rm --entrypoint sh $IMAGE -c '
+            command -v bitcoind ||
+            find /opt /usr -type f -name bitcoind 2>/dev/null | head -n 1
+          ')
+          if [ -z "$BIN_PATH" ]; then
+            echo "could not locate bitcoind in $IMAGE" >&2
+            exit 1
+          fi
 
+          CONTAINER_ID=$(docker create $IMAGE)
+          sudo docker cp $CONTAINER_ID:$BIN_PATH /usr/local/bin/bitcoind
           docker rm $CONTAINER_ID
           bitcoind --version
 

--- a/waddrmgr/addr_type.go
+++ b/waddrmgr/addr_type.go
@@ -112,6 +112,48 @@ const (
 	DerivationSchemeBIP86
 )
 
+// AddressTypeForScope returns the default address type used by the given key
+// scope.
+func AddressTypeForScope(scope KeyScope) (AddressType, error) {
+	switch scope {
+	case KeyScopeBIP0044:
+		return PubKeyHash, nil
+
+	case KeyScopeBIP0049Plus:
+		return NestedWitnessPubKey, nil
+
+	case KeyScopeBIP0084:
+		return WitnessPubKey, nil
+
+	case KeyScopeBIP0086:
+		return TaprootPubKey, nil
+
+	default:
+		return 0, fmt.Errorf("%w: %v", ErrUnknownAddressType, scope)
+	}
+}
+
+// AddressTypeForPurpose returns the default address type used by the given BIP
+// purpose.
+func AddressTypeForPurpose(purpose uint32) (AddressType, error) {
+	switch purpose {
+	case KeyScopeBIP0044.Purpose:
+		return PubKeyHash, nil
+
+	case KeyScopeBIP0049Plus.Purpose:
+		return NestedWitnessPubKey, nil
+
+	case KeyScopeBIP0084.Purpose:
+		return WitnessPubKey, nil
+
+	case KeyScopeBIP0086.Purpose:
+		return TaprootPubKey, nil
+
+	default:
+		return 0, fmt.Errorf("%w: %d", ErrUnknownAddressType, purpose)
+	}
+}
+
 // SpendType returns the spend behavior implied by the address type. Unknown
 // address types return SpendTypeUnknown.
 func (a AddressType) SpendType() SpendType {
@@ -160,6 +202,51 @@ func (a AddressType) DerivationScheme() DerivationScheme {
 
 	default:
 		return DerivationSchemeNone
+	}
+}
+
+// KeyScope returns the preferred scoped-manager key scope for the address type.
+func (a AddressType) KeyScope() (KeyScope, error) {
+	switch a {
+	case PubKeyHash:
+		return KeyScopeBIP0044, nil
+
+	case NestedWitnessPubKey:
+		return KeyScopeBIP0049Plus, nil
+
+	case WitnessPubKey:
+		return KeyScopeBIP0084, nil
+
+	case TaprootPubKey:
+		return KeyScopeBIP0086, nil
+
+	default:
+		return KeyScope{}, fmt.Errorf("%w: %v", ErrUnsupportedAddressType, a)
+	}
+}
+
+// ScopeAddrSchema returns the scoped-manager external/internal schema for the
+// address type.
+func (a AddressType) ScopeAddrSchema() (*ScopeAddrSchema, error) {
+	switch a {
+	// BIP49 keeps nested witness on the external branch but uses native
+	// witness change outputs on the internal branch.
+	case NestedWitnessPubKey:
+		return &ScopeAddrSchema{
+			ExternalAddrType: NestedWitnessPubKey,
+			InternalAddrType: WitnessPubKey,
+		}, nil
+
+	// The other key-derived scopes use the same address type for both
+	// external receives and internal change.
+	case PubKeyHash, WitnessPubKey, TaprootPubKey:
+		return &ScopeAddrSchema{
+			ExternalAddrType: a,
+			InternalAddrType: a,
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("%w: %v", ErrUnsupportedAddressType, a)
 	}
 }
 

--- a/waddrmgr/addr_type.go
+++ b/waddrmgr/addr_type.go
@@ -112,6 +112,24 @@ const (
 	DerivationSchemeBIP86
 )
 
+// SigningMethod identifies the wallet signing flow currently supported for an
+// address type.
+type SigningMethod uint8
+
+const (
+	// SigningMethodLegacy indicates legacy ECDSA signing against a non-witness
+	// pkScript, for example PubKeyHash.
+	SigningMethodLegacy SigningMethod = iota
+
+	// SigningMethodWitnessV0 indicates SegWit v0 ECDSA signing, for example
+	// WitnessPubKey or NestedWitnessPubKey.
+	SigningMethodWitnessV0
+
+	// SigningMethodTaprootKeySpend indicates Taproot key-path Schnorr signing,
+	// for example TaprootPubKey.
+	SigningMethodTaprootKeySpend
+)
+
 // AddressTypeForScope returns the default address type used by the given key
 // scope.
 func AddressTypeForScope(scope KeyScope) (AddressType, error) {
@@ -286,5 +304,24 @@ func (a AddressType) WitnessVersion() (byte, error) {
 
 	default:
 		return 0, fmt.Errorf("%w: %v", ErrUnsupportedAddressType, a)
+	}
+}
+
+// SigningMethod returns the wallet signing method for the address type.
+func (a AddressType) SigningMethod() (SigningMethod, error) {
+	switch a {
+	case PubKeyHash:
+		return SigningMethodLegacy, nil
+
+	case NestedWitnessPubKey, WitnessPubKey:
+		return SigningMethodWitnessV0, nil
+
+	case TaprootPubKey:
+		return SigningMethodTaprootKeySpend, nil
+
+	case Script, RawPubKey, WitnessScript, TaprootScript:
+		return 0, fmt.Errorf("%w: %v", ErrUnsupportedAddressType, a)
+	default:
+		return 0, fmt.Errorf("%w: %v", ErrUnknownAddressType, a)
 	}
 }

--- a/waddrmgr/addr_type.go
+++ b/waddrmgr/addr_type.go
@@ -1,0 +1,203 @@
+package waddrmgr
+
+import (
+	"errors"
+	"fmt"
+)
+
+const (
+	// p2pkhPkScriptSize is the fixed scriptPubKey size for P2PKH outputs.
+	// 25 bytes = OP_DUP (1) + OP_HASH160 (1) + OP_DATA_20 (1) +
+	// <pubkey hash> (20) + OP_EQUALVERIFY (1) + OP_CHECKSIG (1).
+	p2pkhPkScriptSize = 25
+
+	// p2shPkScriptSize is the fixed scriptPubKey size for P2SH outputs.
+	// 23 bytes = OP_HASH160 (1) + OP_DATA_20 (1) + <script hash> (20) +
+	// OP_EQUAL (1).
+	p2shPkScriptSize = 23
+
+	// p2wpkhPkScriptSize is the fixed scriptPubKey size for native P2WPKH
+	// outputs.
+	// 22 bytes = OP_0 (1) + OP_DATA_20 (1) + <pubkey hash> (20).
+	p2wpkhPkScriptSize = 22
+
+	// p2wshPkScriptSize is the fixed scriptPubKey size for native P2WSH
+	// outputs.
+	// 34 bytes = OP_0 (1) + OP_DATA_32 (1) + <script hash> (32).
+	p2wshPkScriptSize = 34
+
+	// p2trPkScriptSize is the fixed scriptPubKey size for P2TR outputs.
+	// 34 bytes = OP_1 (1) + OP_DATA_32 (1) + <x-only output key> (32).
+	p2trPkScriptSize = 34
+
+	// nestedP2WPKHPkScriptSize is the outer P2SH scriptPubKey size used by
+	// nested P2WPKH outputs.
+	// 23 bytes = OP_HASH160 (1) + OP_DATA_20 (1) +
+	// HASH160(<inner witness program>) (20) + OP_EQUAL (1).
+	nestedP2WPKHPkScriptSize = p2shPkScriptSize
+)
+
+var (
+	// ErrUnknownAddressType is returned when no supported address type exists
+	// for a lookup key.
+	ErrUnknownAddressType = errors.New("unknown address type")
+
+	// ErrUnsupportedAddressType is returned when an address type is known but a
+	// specific API does not support it.
+	ErrUnsupportedAddressType = errors.New("unsupported address type")
+)
+
+// SpendType captures the spend behavior implied by an address type.
+type SpendType uint8
+
+const (
+	// SpendTypeUnknown is used when no standard spend template applies, such as
+	// RawPubKey.
+	SpendTypeUnknown SpendType = iota
+
+	// SpendTypeLegacyKey is a direct legacy key spend, for example PubKeyHash.
+	SpendTypeLegacyKey
+
+	// SpendTypeScriptHash is a generic redeem-script spend, for example Script.
+	SpendTypeScriptHash
+
+	// SpendTypeNestedWitnessKey is a nested P2WPKH-in-P2SH spend, for example
+	// NestedWitnessPubKey.
+	SpendTypeNestedWitnessKey
+
+	// SpendTypeWitnessKey is a native witness key spend, for example
+	// WitnessPubKey.
+	SpendTypeWitnessKey
+
+	// SpendTypeWitnessScript is a witness-script spend, for example
+	// WitnessScript.
+	SpendTypeWitnessScript
+
+	// SpendTypeTaprootKeyPath is a taproot key-path spend, for example
+	// TaprootPubKey.
+	SpendTypeTaprootKeyPath
+
+	// SpendTypeTaprootScriptPath is a taproot script-path spend, for example
+	// TaprootScript.
+	SpendTypeTaprootScriptPath
+
+	// SpendTypeAnyoneCanSpend is an anyone-can-spend policy output, for
+	// example a future anchor-only address type.
+	SpendTypeAnyoneCanSpend
+)
+
+// DerivationScheme captures the wallet derivation policy implied by an address
+// type.
+type DerivationScheme uint8
+
+const (
+	// DerivationSchemeNone indicates that no standard account derivation scheme
+	// applies, for example Script or TaprootScript.
+	DerivationSchemeNone DerivationScheme = iota
+
+	// DerivationSchemeBIP44 indicates BIP44 account derivation, for example the
+	// mainnet path m/44'/0'/0'/0/7.
+	DerivationSchemeBIP44
+
+	// DerivationSchemeBIP49 indicates BIP49 account derivation, for example the
+	// mainnet path m/49'/0'/0'/0/7.
+	DerivationSchemeBIP49
+
+	// DerivationSchemeBIP84 indicates BIP84 account derivation, for example the
+	// mainnet path m/84'/0'/0'/0/7.
+	DerivationSchemeBIP84
+
+	// DerivationSchemeBIP86 indicates BIP86 account derivation, for example the
+	// mainnet path m/86'/0'/0'/0/7.
+	DerivationSchemeBIP86
+)
+
+// SpendType returns the spend behavior implied by the address type. Unknown
+// address types return SpendTypeUnknown.
+func (a AddressType) SpendType() SpendType {
+	switch a {
+	case PubKeyHash:
+		return SpendTypeLegacyKey
+
+	case Script:
+		return SpendTypeScriptHash
+
+	case NestedWitnessPubKey:
+		return SpendTypeNestedWitnessKey
+
+	case WitnessPubKey:
+		return SpendTypeWitnessKey
+
+	case WitnessScript:
+		return SpendTypeWitnessScript
+
+	case TaprootPubKey:
+		return SpendTypeTaprootKeyPath
+
+	case TaprootScript:
+		return SpendTypeTaprootScriptPath
+
+	default:
+		return SpendTypeUnknown
+	}
+}
+
+// DerivationScheme returns the wallet derivation scheme implied by the address
+// type. Unknown address types return DerivationSchemeNone.
+func (a AddressType) DerivationScheme() DerivationScheme {
+	switch a {
+	case PubKeyHash:
+		return DerivationSchemeBIP44
+
+	case NestedWitnessPubKey:
+		return DerivationSchemeBIP49
+
+	case WitnessPubKey:
+		return DerivationSchemeBIP84
+
+	case TaprootPubKey:
+		return DerivationSchemeBIP86
+
+	default:
+		return DerivationSchemeNone
+	}
+}
+
+// ScriptPubKeySize returns the fixed outer scriptPubKey size for the address
+// type, if the outer form has one.
+func (a AddressType) ScriptPubKeySize() (int, error) {
+	switch a {
+	case PubKeyHash:
+		return p2pkhPkScriptSize, nil
+
+	case Script, NestedWitnessPubKey:
+		return p2shPkScriptSize, nil
+
+	case WitnessPubKey:
+		return p2wpkhPkScriptSize, nil
+
+	case WitnessScript:
+		return p2wshPkScriptSize, nil
+
+	case TaprootPubKey, TaprootScript:
+		return p2trPkScriptSize, nil
+
+	default:
+		return 0, fmt.Errorf("%w: %v", ErrUnsupportedAddressType, a)
+	}
+}
+
+// WitnessVersion returns the witness version for the address type, if it uses
+// a witness program.
+func (a AddressType) WitnessVersion() (byte, error) {
+	switch a {
+	case NestedWitnessPubKey, WitnessPubKey, WitnessScript:
+		return witnessVersionV0, nil
+
+	case TaprootPubKey, TaprootScript:
+		return witnessVersionV1, nil
+
+	default:
+		return 0, fmt.Errorf("%w: %v", ErrUnsupportedAddressType, a)
+	}
+}

--- a/waddrmgr/addr_type.go
+++ b/waddrmgr/addr_type.go
@@ -3,6 +3,12 @@ package waddrmgr
 import (
 	"errors"
 	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
 )
 
 const (
@@ -197,6 +203,9 @@ func (a AddressType) SpendType() SpendType {
 	case TaprootScript:
 		return SpendTypeTaprootScriptPath
 
+	case RawPubKey:
+		return SpendTypeUnknown
+
 	default:
 		return SpendTypeUnknown
 	}
@@ -218,6 +227,9 @@ func (a AddressType) DerivationScheme() DerivationScheme {
 	case TaprootPubKey:
 		return DerivationSchemeBIP86
 
+	case Script, RawPubKey, WitnessScript, TaprootScript:
+		return DerivationSchemeNone
+
 	default:
 		return DerivationSchemeNone
 	}
@@ -238,8 +250,11 @@ func (a AddressType) KeyScope() (KeyScope, error) {
 	case TaprootPubKey:
 		return KeyScopeBIP0086, nil
 
-	default:
+	case Script, RawPubKey, WitnessScript, TaprootScript:
 		return KeyScope{}, fmt.Errorf("%w: %v", ErrUnsupportedAddressType, a)
+
+	default:
+		return KeyScope{}, fmt.Errorf("%w: %v", ErrUnknownAddressType, a)
 	}
 }
 
@@ -263,8 +278,11 @@ func (a AddressType) ScopeAddrSchema() (*ScopeAddrSchema, error) {
 			InternalAddrType: a,
 		}, nil
 
-	default:
+	case Script, RawPubKey, WitnessScript, TaprootScript:
 		return nil, fmt.Errorf("%w: %v", ErrUnsupportedAddressType, a)
+
+	default:
+		return nil, fmt.Errorf("%w: %v", ErrUnknownAddressType, a)
 	}
 }
 
@@ -287,8 +305,11 @@ func (a AddressType) ScriptPubKeySize() (int, error) {
 	case TaprootPubKey, TaprootScript:
 		return p2trPkScriptSize, nil
 
-	default:
+	case RawPubKey:
 		return 0, fmt.Errorf("%w: %v", ErrUnsupportedAddressType, a)
+
+	default:
+		return 0, fmt.Errorf("%w: %v", ErrUnknownAddressType, a)
 	}
 }
 
@@ -302,8 +323,11 @@ func (a AddressType) WitnessVersion() (byte, error) {
 	case TaprootPubKey, TaprootScript:
 		return witnessVersionV1, nil
 
-	default:
+	case PubKeyHash, Script, RawPubKey:
 		return 0, fmt.Errorf("%w: %v", ErrUnsupportedAddressType, a)
+
+	default:
+		return 0, fmt.Errorf("%w: %v", ErrUnknownAddressType, a)
 	}
 }
 
@@ -321,7 +345,110 @@ func (a AddressType) SigningMethod() (SigningMethod, error) {
 
 	case Script, RawPubKey, WitnessScript, TaprootScript:
 		return 0, fmt.Errorf("%w: %v", ErrUnsupportedAddressType, a)
+
 	default:
 		return 0, fmt.Errorf("%w: %v", ErrUnknownAddressType, a)
 	}
+}
+
+// AddrFromPubKeyBytes reconstructs the standard address from the serialized
+// public key form stored by the wallet.
+func (a AddressType) AddrFromPubKeyBytes(pubKeyBytes []byte,
+	net *chaincfg.Params) (btcutil.Address, error) {
+
+	switch a {
+	case PubKeyHash:
+		address, err := btcutil.NewAddressPubKeyHash(
+			btcutil.Hash160(pubKeyBytes), net,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("new pubkey hash address: %w", err)
+		}
+
+		return address, nil
+
+	case NestedWitnessPubKey:
+		return nestedWitnessAddrFromPubKeyBytes(pubKeyBytes, net)
+
+	case WitnessPubKey:
+		address, err := btcutil.NewAddressWitnessPubKeyHash(
+			btcutil.Hash160(pubKeyBytes), net,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("new witness pubkey hash address: %w", err)
+		}
+
+		return address, nil
+
+	case TaprootPubKey:
+		return taprootAddrFromPubKeyBytes(pubKeyBytes, net)
+
+	case Script, RawPubKey, WitnessScript, TaprootScript:
+		return nil, fmt.Errorf("%w: %v", ErrUnsupportedAddressType, a)
+
+	default:
+		return nil, fmt.Errorf("%w: %v", ErrUnknownAddressType, a)
+	}
+}
+
+// nestedWitnessProgramFromPubKeyBytes builds the nested witness redeem program
+// from serialized pubkey bytes.
+func nestedWitnessProgramFromPubKeyBytes(pubKeyBytes []byte,
+	net *chaincfg.Params) ([]byte, error) {
+
+	witnessAddr, err := btcutil.NewAddressWitnessPubKeyHash(
+		btcutil.Hash160(pubKeyBytes), net,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("new witness pubkey hash: %w", err)
+	}
+
+	script, err := txscript.PayToAddrScript(witnessAddr)
+	if err != nil {
+		return nil, fmt.Errorf("pay to witness address: %w", err)
+	}
+
+	return script, nil
+}
+
+// nestedWitnessAddrFromPubKeyBytes builds the outer P2SH address for a nested
+// witness pubkey-hash spend.
+func nestedWitnessAddrFromPubKeyBytes(pubKeyBytes []byte,
+	net *chaincfg.Params) (btcutil.Address, error) {
+
+	witnessProgram, err := nestedWitnessProgramFromPubKeyBytes(
+		pubKeyBytes, net,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("build nested witness program: %w", err)
+	}
+
+	address, err := btcutil.NewAddressScriptHash(witnessProgram, net)
+	if err != nil {
+		return nil, fmt.Errorf("new nested witness address: %w", err)
+	}
+
+	return address, nil
+}
+
+// taprootAddrFromPubKeyBytes builds a P2TR address from serialized internal
+// pubkey bytes.
+func taprootAddrFromPubKeyBytes(pubKeyBytes []byte,
+	net *chaincfg.Params) (btcutil.Address, error) {
+
+	internalPubKey, err := btcec.ParsePubKey(pubKeyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse taproot internal pubkey: %w", err)
+	}
+
+	outputKey := schnorr.SerializePubKey(
+		txscript.ComputeTaprootKeyNoScript(internalPubKey),
+	)
+
+	address, err := btcutil.NewAddressTaproot(outputKey, net)
+	if err != nil {
+		return nil, fmt.Errorf("new taproot address: %w", err)
+	}
+
+	return address, nil
 }

--- a/waddrmgr/addr_type_test.go
+++ b/waddrmgr/addr_type_test.go
@@ -6,6 +6,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestAddressTypeLookups verifies the supported address-type lookup paths.
+func TestAddressTypeLookups(t *testing.T) {
+	t.Parallel()
+
+	scope, err := PubKeyHash.KeyScope()
+	require.NoError(t, err)
+	require.Equal(t, KeyScopeBIP0044, scope)
+
+	schema, err := NestedWitnessPubKey.ScopeAddrSchema()
+	require.NoError(t, err)
+	require.Equal(t, NestedWitnessPubKey, schema.ExternalAddrType)
+	require.Equal(t, WitnessPubKey, schema.InternalAddrType)
+
+	addrTypeByScope, err := AddressTypeForScope(KeyScopeBIP0049Plus)
+	require.NoError(t, err)
+	require.Equal(t, NestedWitnessPubKey, addrTypeByScope)
+
+	addrTypeByPurpose, err := AddressTypeForPurpose(KeyScopeBIP0086.Purpose)
+	require.NoError(t, err)
+	require.Equal(t, TaprootPubKey, addrTypeByPurpose)
+
+	_, err = AddressTypeForScope(KeyScope{Purpose: 1017, Coin: 0})
+	require.ErrorIs(t, err, ErrUnknownAddressType)
+
+	_, err = AddressTypeForPurpose(1017)
+	require.ErrorIs(t, err, ErrUnknownAddressType)
+}
+
 // TestPubKeyAddressTypeMetadata verifies the common metadata for pubkey address
 // types.
 func TestPubKeyAddressTypeMetadata(t *testing.T) {

--- a/waddrmgr/addr_type_test.go
+++ b/waddrmgr/addr_type_test.go
@@ -1,0 +1,164 @@
+package waddrmgr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPubKeyAddressTypeMetadata verifies the common metadata for pubkey address
+// types.
+func TestPubKeyAddressTypeMetadata(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name              string
+		addrType          AddressType
+		spendType         SpendType
+		derivationScheme  DerivationScheme
+		pkScriptSize      int
+		hasWitnessVersion bool
+		witnessVersion    byte
+	}{
+		{
+			name:             "pubkey hash",
+			addrType:         PubKeyHash,
+			spendType:        SpendTypeLegacyKey,
+			derivationScheme: DerivationSchemeBIP44,
+			pkScriptSize:     p2pkhPkScriptSize,
+		},
+		{
+			name:              "nested witness pubkey",
+			addrType:          NestedWitnessPubKey,
+			spendType:         SpendTypeNestedWitnessKey,
+			derivationScheme:  DerivationSchemeBIP49,
+			pkScriptSize:      nestedP2WPKHPkScriptSize,
+			hasWitnessVersion: true,
+			witnessVersion:    witnessVersionV0,
+		},
+		{
+			name:              "witness pubkey",
+			addrType:          WitnessPubKey,
+			spendType:         SpendTypeWitnessKey,
+			derivationScheme:  DerivationSchemeBIP84,
+			pkScriptSize:      p2wpkhPkScriptSize,
+			hasWitnessVersion: true,
+			witnessVersion:    witnessVersionV0,
+		},
+		{
+			name:              "taproot pubkey",
+			addrType:          TaprootPubKey,
+			spendType:         SpendTypeTaprootKeyPath,
+			derivationScheme:  DerivationSchemeBIP86,
+			pkScriptSize:      p2trPkScriptSize,
+			hasWitnessVersion: true,
+			witnessVersion:    witnessVersionV1,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, testCase.spendType,
+				testCase.addrType.SpendType())
+			require.Equal(t, testCase.derivationScheme,
+				testCase.addrType.DerivationScheme())
+
+			pkScriptSize, err := testCase.addrType.ScriptPubKeySize()
+			require.NoError(t, err)
+			require.Equal(t, testCase.pkScriptSize, pkScriptSize)
+
+			version, err := testCase.addrType.WitnessVersion()
+			if testCase.hasWitnessVersion {
+				require.NoError(t, err)
+				require.Equal(t, testCase.witnessVersion, version)
+			} else {
+				require.ErrorIs(t, err, ErrUnsupportedAddressType)
+			}
+		})
+	}
+}
+
+// TestScriptAddressTypeMetadata verifies the common metadata for script-driven
+// address types.
+func TestScriptAddressTypeMetadata(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name              string
+		addrType          AddressType
+		spendType         SpendType
+		pkScriptSize      int
+		hasWitnessVersion bool
+		witnessVersion    byte
+	}{
+		{
+			name:         "script hash",
+			addrType:     Script,
+			spendType:    SpendTypeScriptHash,
+			pkScriptSize: p2shPkScriptSize,
+		},
+		{
+			name:              "witness script hash",
+			addrType:          WitnessScript,
+			spendType:         SpendTypeWitnessScript,
+			pkScriptSize:      p2wshPkScriptSize,
+			hasWitnessVersion: true,
+			witnessVersion:    witnessVersionV0,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, testCase.spendType,
+				testCase.addrType.SpendType())
+
+			pkScriptSize, err := testCase.addrType.ScriptPubKeySize()
+			require.NoError(t, err)
+			require.Equal(t, testCase.pkScriptSize, pkScriptSize)
+
+			version, err := testCase.addrType.WitnessVersion()
+			if testCase.hasWitnessVersion {
+				require.NoError(t, err)
+				require.Equal(t, testCase.witnessVersion, version)
+			} else {
+				require.ErrorIs(t, err, ErrUnsupportedAddressType)
+			}
+		})
+	}
+}
+
+// TestTaprootScriptAddressType verifies the taproot script type still has
+// meaningful common metadata.
+func TestTaprootScriptAddressType(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, SpendTypeTaprootScriptPath, TaprootScript.SpendType())
+	require.Equal(t, DerivationSchemeNone, TaprootScript.DerivationScheme())
+
+	size, err := TaprootScript.ScriptPubKeySize()
+	require.NoError(t, err)
+	require.Equal(t, p2trPkScriptSize, size)
+
+	version, err := TaprootScript.WitnessVersion()
+	require.NoError(t, err)
+	require.Equal(t, witnessVersionV1, version)
+}
+
+// TestRawPubKeyAddressType verifies the raw-pubkey address type retains only
+// the common metadata that naturally applies to it.
+func TestRawPubKeyAddressType(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, SpendTypeUnknown, RawPubKey.SpendType())
+	require.Equal(t, DerivationSchemeNone, RawPubKey.DerivationScheme())
+
+	_, err := RawPubKey.ScriptPubKeySize()
+	require.ErrorIs(t, err, ErrUnsupportedAddressType)
+
+	_, err = RawPubKey.WitnessVersion()
+	require.ErrorIs(t, err, ErrUnsupportedAddressType)
+}

--- a/waddrmgr/addr_type_test.go
+++ b/waddrmgr/addr_type_test.go
@@ -1,9 +1,17 @@
 package waddrmgr
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/stretchr/testify/require"
 )
+
+var testChainParams = chaincfg.RegressionNetParams
 
 // TestAddressTypeLookups verifies the supported address-type lookup paths.
 func TestAddressTypeLookups(t *testing.T) {
@@ -26,11 +34,17 @@ func TestAddressTypeLookups(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, TaprootPubKey, addrTypeByPurpose)
 
+	_, err = AddressType(255).AddrFromPubKeyBytes(nil, &testChainParams)
+	require.ErrorIs(t, err, ErrUnknownAddressType)
+
 	_, err = AddressTypeForScope(KeyScope{Purpose: 1017, Coin: 0})
 	require.ErrorIs(t, err, ErrUnknownAddressType)
 
 	_, err = AddressTypeForPurpose(1017)
 	require.ErrorIs(t, err, ErrUnknownAddressType)
+
+	_, err = Script.AddrFromPubKeyBytes(nil, &testChainParams)
+	require.ErrorIs(t, err, ErrUnsupportedAddressType)
 }
 
 // TestPubKeyAddressTypeMetadata verifies the common metadata for pubkey address
@@ -228,6 +242,78 @@ func TestSupportedSigningAddressType(t *testing.T) {
 			signingMethod, err := testCase.addrType.SigningMethod()
 			require.NoError(t, err)
 			require.Equal(t, testCase.signingMethod, signingMethod)
+		})
+	}
+}
+
+// TestUnsupportedSigningAddressType verifies unsupported address types report
+// no wallet signing path.
+func TestUnsupportedSigningAddressType(t *testing.T) {
+	t.Parallel()
+
+	_, err := WitnessScript.SigningMethod()
+	require.ErrorIs(t, err, ErrUnsupportedAddressType)
+
+	_, err = AddressType(255).SigningMethod()
+	require.ErrorIs(t, err, ErrUnknownAddressType)
+}
+
+// TestAddrFromPubKeyBytes verifies address reconstruction from the wallet's
+// stored pubkey bytes for supported pubkey address types.
+func TestAddrFromPubKeyBytes(t *testing.T) {
+	t.Parallel()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	serializedPubKey := privKey.PubKey().SerializeCompressed()
+
+	testCases := []struct {
+		name     string
+		addrType AddressType
+		want     []byte
+	}{
+		{
+			name:     "pubkey hash",
+			addrType: PubKeyHash,
+			want:     btcutil.Hash160(serializedPubKey),
+		},
+		{
+			name:     "nested witness pubkey",
+			addrType: NestedWitnessPubKey,
+			want: func() []byte {
+				witnessProgram, err := nestedWitnessProgramFromPubKeyBytes(
+					serializedPubKey, &testChainParams,
+				)
+				require.NoError(t, err)
+
+				return btcutil.Hash160(witnessProgram)
+			}(),
+		},
+		{
+			name:     "witness pubkey",
+			addrType: WitnessPubKey,
+			want:     btcutil.Hash160(serializedPubKey),
+		},
+		{
+			name:     "taproot pubkey",
+			addrType: TaprootPubKey,
+			want: schnorr.SerializePubKey(
+				txscript.ComputeTaprootKeyNoScript(privKey.PubKey()),
+			),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			address, err := testCase.addrType.AddrFromPubKeyBytes(
+				serializedPubKey, &testChainParams,
+			)
+			require.NoError(t, err)
+
+			require.Equal(t, testCase.want, address.ScriptAddress())
 		})
 	}
 }

--- a/waddrmgr/addr_type_test.go
+++ b/waddrmgr/addr_type_test.go
@@ -1,9 +1,8 @@
 package waddrmgr
 
 import (
-	"testing"
-
 	"github.com/stretchr/testify/require"
+	"testing"
 )
 
 // TestAddressTypeLookups verifies the supported address-type lookup paths.
@@ -189,4 +188,46 @@ func TestRawPubKeyAddressType(t *testing.T) {
 
 	_, err = RawPubKey.WitnessVersion()
 	require.ErrorIs(t, err, ErrUnsupportedAddressType)
+}
+
+// TestSupportedSigningAddressType verifies signing metadata for the supported
+// pubkey address types.
+func TestSupportedSigningAddressType(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		addrType      AddressType
+		signingMethod SigningMethod
+	}{
+		{
+			name:          "pubkey hash",
+			addrType:      PubKeyHash,
+			signingMethod: SigningMethodLegacy,
+		},
+		{
+			name:          "nested witness pubkey",
+			addrType:      NestedWitnessPubKey,
+			signingMethod: SigningMethodWitnessV0,
+		},
+		{
+			name:          "witness pubkey",
+			addrType:      WitnessPubKey,
+			signingMethod: SigningMethodWitnessV0,
+		},
+		{
+			name:          "taproot pubkey",
+			addrType:      TaprootPubKey,
+			signingMethod: SigningMethodTaprootKeySpend,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			signingMethod, err := testCase.addrType.SigningMethod()
+			require.NoError(t, err)
+			require.Equal(t, testCase.signingMethod, signingMethod)
+		})
+	}
 }

--- a/waddrmgr/address.go
+++ b/waddrmgr/address.go
@@ -16,7 +16,6 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
-	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcwallet/internal/zero"
 	"github.com/btcsuite/btcwallet/walletdb"
 )
@@ -542,75 +541,16 @@ func newManagedAddressWithoutPrivKey(m *ScopedKeyManager,
 	derivationPath DerivationPath, pubKey *btcec.PublicKey, compressed bool,
 	addrType AddressType) (*managedAddress, error) {
 
-	// Create a pay-to-pubkey-hash address from the public key.
-	var pubKeyHash []byte
-	if compressed {
-		pubKeyHash = btcutil.Hash160(pubKey.SerializeCompressed())
-	} else {
-		pubKeyHash = btcutil.Hash160(pubKey.SerializeUncompressed())
+	pubKeyBytes := pubKey.SerializeCompressed()
+	if !compressed {
+		pubKeyBytes = pubKey.SerializeUncompressed()
 	}
 
-	var address btcutil.Address
-	var err error
-
-	switch addrType {
-
-	case NestedWitnessPubKey:
-		// For this address type we'll generate an address which is
-		// backwards compatible to Bitcoin nodes running 0.6.0 onwards, but
-		// allows us to take advantage of segwit's scripting improvements,
-		// and malleability fixes.
-
-		// First, we'll generate a normal p2wkh address from the pubkey hash.
-		witAddr, err := btcutil.NewAddressWitnessPubKeyHash(
-			pubKeyHash, m.rootManager.chainParams,
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		// Next we'll generate the witness program which can be used as a
-		// pkScript to pay to this generated address.
-		witnessProgram, err := txscript.PayToAddrScript(witAddr)
-		if err != nil {
-			return nil, err
-		}
-
-		// Finally, we'll use the witness program itself as the pre-image
-		// to a p2sh address. In order to spend, we first use the
-		// witnessProgram as the sigScript, then present the proper
-		// <sig, pubkey> pair as the witness.
-		address, err = btcutil.NewAddressScriptHash(
-			witnessProgram, m.rootManager.chainParams,
-		)
-		if err != nil {
-			return nil, err
-		}
-
-	case PubKeyHash:
-		address, err = btcutil.NewAddressPubKeyHash(
-			pubKeyHash, m.rootManager.chainParams,
-		)
-		if err != nil {
-			return nil, err
-		}
-
-	case WitnessPubKey:
-		address, err = btcutil.NewAddressWitnessPubKeyHash(
-			pubKeyHash, m.rootManager.chainParams,
-		)
-		if err != nil {
-			return nil, err
-		}
-
-	case TaprootPubKey:
-		tapKey := txscript.ComputeTaprootKeyNoScript(pubKey)
-		address, err = btcutil.NewAddressTaproot(
-			schnorr.SerializePubKey(tapKey), m.rootManager.chainParams,
-		)
-		if err != nil {
-			return nil, err
-		}
+	address, err := addrType.AddrFromPubKeyBytes(
+		pubKeyBytes, m.rootManager.chainParams,
+	)
+	if err != nil {
+		return nil, err
 	}
 
 	return &managedAddress{

--- a/waddrmgr/address.go
+++ b/waddrmgr/address.go
@@ -7,6 +7,7 @@ package waddrmgr
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -35,6 +36,10 @@ var (
 	// invalid.
 	ErrInvalidSignature = fmt.Errorf("private key sig doesn't validate " +
 		"against pubkey")
+
+	// ErrUnknownSigningMethod is returned when an address type reports a
+	// signing method the current validation path does not understand.
+	ErrUnknownSigningMethod = errors.New("unknown signing method")
 )
 
 // AddressType represents the various address types waddrmgr is currently able
@@ -498,21 +503,20 @@ func (a *managedAddress) Validate(msg [32]byte, priv *btcec.PrivateKey) error {
 	// make sure we can generate a signature that verifies under the target
 	// public key.
 	//
-	// TODO(roasbeef): potentially run _all_ checks then see which one
-	// fails?
 	var sig signature
 
 	addrPrivKey, _ := btcec.PrivKeyFromBytes(a.privKeyCT)
 
-	switch a.addrType {
-	// For the "legacy" addr types, we'll generate an ECDSA signature to
-	// verify against.
-	case NestedWitnessPubKey, PubKeyHash, WitnessPubKey:
+	signingMethod, err := a.addrType.SigningMethod()
+	if err != nil {
+		return err
+	}
+
+	switch signingMethod {
+	case SigningMethodLegacy, SigningMethodWitnessV0:
 		sig = ecdsa.Sign(addrPrivKey, msg[:])
 
-	// For the newer taproot addr type, we'll generate a schnorr signature
-	// to verify against.
-	case TaprootPubKey:
+	case SigningMethodTaprootKeySpend:
 		sig, err = schnorr.Sign(addrPrivKey, msg[:])
 		if err != nil {
 			return fmt.Errorf("unable to generate validate "+
@@ -520,8 +524,8 @@ func (a *managedAddress) Validate(msg [32]byte, priv *btcec.PrivateKey) error {
 		}
 
 	default:
-		return fmt.Errorf("unable to validate addr, unknown type: %v",
-			a.addrType)
+		return fmt.Errorf("%w: %v", ErrUnknownSigningMethod,
+			signingMethod)
 	}
 
 	if !sig.Verify(msg[:], basePubKey) {

--- a/waddrmgr/interface.go
+++ b/waddrmgr/interface.go
@@ -240,8 +240,12 @@ type AccountStore interface {
 	DeriveFromKeyPath(ns walletdb.ReadBucket,
 		path DerivationPath) (ManagedAddress, error)
 
-	// CanAddAccount returns an error if a new account cannot be created.
-	CanAddAccount() error
+	// CanAddAccountDeprecated returns an error if a new account cannot be
+	// created.
+	//
+	// Deprecated: use NewAccount directly so validation stays coupled to the
+	// mutation path. This is only kept for legacy callers.
+	CanAddAccountDeprecated() error
 
 	// NewAccount creates a new account.
 	NewAccount(ns walletdb.ReadWriteBucket, name string) (uint32, error)

--- a/waddrmgr/manager.go
+++ b/waddrmgr/manager.go
@@ -430,24 +430,31 @@ func (m *Manager) IsWatchOnlyAccount(ns walletdb.ReadBucket, keyScope KeyScope,
 // TODO(yy): Rename this to wipe memory for priv keys.
 func (m *Manager) lock() {
 	for _, manager := range m.scopedManagers {
+		manager.mtx.Lock()
+
 		// Clear all of the account private keys.
-		for _, acctInfo := range manager.accountInfo() {
+		for _, acctInfo := range manager.acctInfo {
 			if acctInfo.acctKeyPriv != nil {
 				acctInfo.acctKeyPriv.Zero()
 			}
 			acctInfo.acctKeyPriv = nil
+
+			// loadAccountInfo warms the last external/internal addresses while
+			// unlocked, so those managed-address instances may also hold
+			// cleartext private key bytes outside the LRU cache.
+			wipeAddressSecret(acctInfo.lastExternalAddr)
+			wipeAddressSecret(acctInfo.lastInternalAddr)
 		}
 
 		// Remove clear text private keys and scripts from all address
 		// entries.
-		for _, ma := range manager.addresses() {
-			switch addr := ma.(type) {
-			case *managedAddress:
-				addr.lock()
-			case *scriptAddress:
-				addr.lock()
-			}
-		}
+		manager.addrs.Range(func(_ addrKey, cachedAddr *cachedAddr) bool {
+			wipeAddressSecret(cachedAddr.addr)
+
+			return true
+		})
+
+		manager.mtx.Unlock()
 	}
 
 	// Remove clear text private master and crypto keys from memory.
@@ -608,7 +615,7 @@ func (m *Manager) NewScopedKeyManager(ns walletdb.ReadWriteBucket,
 		scope:       scope,
 		addrSchema:  addrSchema,
 		rootManager: m,
-		addrs:       make(map[addrKey]ManagedAddress),
+		addrs:       newAddrCache(defaultAddrCacheSize),
 		acctInfo:    make(map[uint32]*accountInfo),
 		privKeyCache: lru.NewCache[DerivationPath, *cachedKey](
 			defaultPrivKeyCacheSize,
@@ -1132,17 +1139,17 @@ func (m *Manager) ConvertToWatchingOnly(ns walletdb.ReadWriteBucket) error {
 
 	// Clear and remove all of the encrypted acount private keys.
 	for _, manager := range m.scopedManagers {
+		manager.mtx.Lock()
+
 		for _, acctInfo := range manager.acctInfo {
 			zero.Bytes(acctInfo.acctKeyEncrypted)
 			acctInfo.acctKeyEncrypted = nil
 		}
-	}
 
-	// Clear and remove encrypted private keys and encrypted scripts from
-	// all address entries.
-	for _, manager := range m.scopedManagers {
-		for _, ma := range manager.addrs {
-			switch addr := ma.(type) {
+		// Clear and remove encrypted private keys and encrypted scripts from
+		// all address entries.
+		manager.addrs.Range(func(_ addrKey, cachedAddr *cachedAddr) bool {
+			switch addr := cachedAddr.addr.(type) {
 			case *managedAddress:
 				zero.Bytes(addr.privKeyEncrypted)
 				addr.privKeyEncrypted = nil
@@ -1150,7 +1157,10 @@ func (m *Manager) ConvertToWatchingOnly(ns walletdb.ReadWriteBucket) error {
 				zero.Bytes(addr.scriptEncrypted)
 				addr.scriptEncrypted = nil
 			}
-		}
+
+			return true
+		})
+		manager.mtx.Unlock()
 	}
 
 	// Clear and remove encrypted private and script crypto keys.
@@ -1667,7 +1677,7 @@ func loadManager(ns walletdb.ReadBucket, pubPassphrase []byte,
 		scopedManagers[scope] = &ScopedKeyManager{
 			scope:      scope,
 			addrSchema: *scopeSchema,
-			addrs:      make(map[addrKey]ManagedAddress),
+			addrs:      newAddrCache(defaultAddrCacheSize),
 			acctInfo:   make(map[uint32]*accountInfo),
 			privKeyCache: lru.NewCache[DerivationPath, *cachedKey](
 				defaultPrivKeyCacheSize,

--- a/waddrmgr/manager_test.go
+++ b/waddrmgr/manager_test.go
@@ -1402,7 +1402,11 @@ func testChangePassphrase(tc *testContext) bool {
 func testNewAccount(tc *testContext) bool {
 	if tc.watchingOnly {
 		// Creating new accounts in watching-only mode should return ErrWatchingOnly
-		err := tc.manager.CanAddAccount()
+		err := walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
+			ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+			_, err := tc.manager.NewAccount(ns, "acct-watch-only")
+			return err
+		})
 		if !checkManagerError(
 			tc.t, "Create account in watching-only mode", err,
 			ErrWatchingOnly,
@@ -1413,7 +1417,11 @@ func testNewAccount(tc *testContext) bool {
 		return true
 	}
 	// Creating new accounts when wallet is locked should return ErrLocked
-	err := tc.manager.CanAddAccount()
+	err := walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+		_, err := tc.manager.NewAccount(ns, "acct-locked")
+		return err
+	})
 	if !checkManagerError(
 		tc.t, "Create account when wallet is locked", err, ErrLocked,
 	) {
@@ -2584,6 +2592,71 @@ func TestScopedKeyManagerManagement(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to find addr: %v", err)
 	}
+}
+
+// TestManagerLockWipesLastAccountAddresses verifies that locking the root
+// manager also zeroes the cleartext private key bytes held by the account-level
+// last external and internal managed addresses.
+func TestManagerLockWipesLastAccountAddresses(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create and unlock a manager, then warm the default account info
+	// while unlocked so its cached last addresses hold cleartext private keys.
+	teardown, db, mgr := setupManager(t)
+	t.Cleanup(teardown)
+
+	err := walletdb.View(db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+		return mgr.Unlock(ns, privPassphrase)
+	})
+	require.NoError(t, err)
+
+	acctStore, err := mgr.FetchScopedKeyManager(KeyScopeBIP0084)
+	require.NoError(t, err)
+
+	scopedMgr, ok := acctStore.(*ScopedKeyManager)
+	require.True(t, ok)
+
+	var (
+		lastExternalAddr *managedAddress
+		lastInternalAddr *managedAddress
+	)
+
+	err = walletdb.View(db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+
+		scopedMgr.mtx.Lock()
+		defer scopedMgr.mtx.Unlock()
+
+		acctInfo, err := scopedMgr.loadAccountInfo(ns, DefaultAccountNum)
+		if err != nil {
+			return err
+		}
+
+		var ok bool
+
+		lastExternalAddr, ok = acctInfo.lastExternalAddr.(*managedAddress)
+		require.True(t, ok)
+
+		lastInternalAddr, ok = acctInfo.lastInternalAddr.(*managedAddress)
+		require.True(t, ok)
+
+		return nil
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, lastExternalAddr.privKeyCT)
+	require.NotEmpty(t, lastInternalAddr.privKeyCT)
+
+	// Act: Lock the root manager, which should wipe all cached cleartext key
+	// material.
+	mgr.mtx.Lock()
+	mgr.lock()
+	mgr.mtx.Unlock()
+
+	// Assert: The account-level last addresses no longer retain cleartext key
+	// bytes.
+	require.Nil(t, lastExternalAddr.privKeyCT)
+	require.Nil(t, lastInternalAddr.privKeyCT)
 }
 
 // TestRootHDKeyNeutering tests that callers are unable to create new scoped

--- a/waddrmgr/scoped_manager.go
+++ b/waddrmgr/scoped_manager.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
-	"maps"
 	"sync"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -61,6 +60,13 @@ const (
 	// the wallet. With the default sisize, we'll allocate up to 320 KB to
 	// caching private keys (ignoring pointer overhead, etc).
 	defaultPrivKeyCacheSize = 10_000
+
+	// defaultAddrCacheSize is the default number of managed addresses that
+	// each scoped manager keeps hot in memory. We bound this by entry count
+	// rather than bytes because cached address records vary by type, but at
+	// the default size the LRU bookkeeping is still only on the order of
+	// 10 MiB while covering recent lookups for large wallets.
+	defaultAddrCacheSize = 100_000
 )
 
 // DerivationPath represents a derivation path from a particular key manager's
@@ -334,9 +340,9 @@ type ScopedKeyManager struct {
 	// derive any new accounts of child keys of accounts.
 	rootManager *Manager
 
-	// addrs is a cached map of all the addresses that we currently
-	// manage.
-	addrs map[addrKey]ManagedAddress
+	// addrs caches recently used managed addresses. The cache is bounded so a
+	// long-lived wallet does not retain an ever-growing in-memory address map.
+	addrs *lru.Cache[addrKey, *cachedAddr]
 
 	// acctInfo houses information about accounts including what is needed
 	// to generate deterministic chained keys for each created account.
@@ -718,11 +724,59 @@ type cachedKey struct {
 	key btcec.PrivateKey
 }
 
+// cachedAddr is an address-cache entry in the scoped manager LRU.
+type cachedAddr struct {
+	addr ManagedAddress
+}
+
+// secretWiper is implemented by cached address types that can eagerly zero
+// sensitive material from memory.
+type secretWiper interface {
+	lock()
+}
+
+// wipeAddressSecret zeroes any cleartext secret material held by one managed
+// address when the concrete type supports eager wiping.
+func wipeAddressSecret(addr ManagedAddress) {
+	if addr == nil {
+		return
+	}
+
+	if addr, ok := addr.(secretWiper); ok {
+		addr.lock()
+	}
+}
+
+// newAddrCache constructs one bounded address cache with eviction-time
+// zeroing for cached secret material.
+func newAddrCache(capacity uint64) *lru.Cache[addrKey, *cachedAddr] {
+	return lru.NewCache[addrKey, *cachedAddr](
+		capacity,
+		lru.WithDeleteCallback(func(_ addrKey, cachedAddr *cachedAddr) {
+			// The callback may be invoked with a nil entry during
+			// cache-internal delete paths, so guard before touching cached
+			// state.
+			if cachedAddr == nil {
+				return
+			}
+
+			// This zeroes cached secret material on eviction. It is not a mutex
+			// lock, so there is no corresponding unlock step.
+			wipeAddressSecret(cachedAddr.addr)
+		}),
+	)
+}
+
 // Size returns the size of this element. Rather than have the cache limit
 // based on bytes, we simply report that each element is of size 1, meaning we
 // can set our cached based on the amount of keys we want to store, rather than
 // the total size of all the keys.
 func (c *cachedKey) Size() (uint64, error) {
+	return 1, nil
+}
+
+// Size returns the size of the cached address entry.
+func (c *cachedAddr) Size() (uint64, error) {
 	return 1, nil
 }
 
@@ -990,7 +1044,10 @@ func (s *ScopedKeyManager) loadAndCacheAddress(ns walletdb.ReadBucket,
 	}
 
 	// Cache and return the new managed address.
-	s.addrs[addrKey(managedAddr.Address().ScriptAddress())] = managedAddr
+	_, _ = s.addrs.Put(
+		addrKey(managedAddr.Address().ScriptAddress()),
+		&cachedAddr{addr: managedAddr},
+	)
 
 	return managedAddr, nil
 }
@@ -1001,7 +1058,8 @@ func (s *ScopedKeyManager) loadAndCacheAddress(ns walletdb.ReadBucket,
 // This function MUST be called with the manager lock held for reads.
 func (s *ScopedKeyManager) existsAddress(ns walletdb.ReadBucket, addressID []byte) bool {
 	// Check the in-memory map first since it's faster than a db access.
-	if _, ok := s.addrs[addrKey(addressID)]; ok {
+	_, err := s.addrs.Get(addrKey(addressID))
+	if err == nil {
 		return true
 	}
 
@@ -1031,9 +1089,11 @@ func (s *ScopedKeyManager) Address(ns walletdb.ReadBucket,
 	// NOTE: Not using a defer on the lock here since a write lock is
 	// needed if the lookup fails.
 	s.mtx.RLock()
-	if ma, ok := s.addrs[addrKey(address.ScriptAddress())]; ok {
+
+	cachedAddr, err := s.addrs.Get(addrKey(address.ScriptAddress()))
+	if err == nil {
 		s.mtx.RUnlock()
-		return ma, nil
+		return cachedAddr.addr, nil
 	}
 	s.mtx.RUnlock()
 
@@ -1288,8 +1348,7 @@ func (s *ScopedKeyManager) nextAddresses(ns walletdb.ReadWriteBucket,
 		if ma.Address().String() != diskAddr.Address().String() {
 			// The address didn't match up, so we'll manually
 			// delete it from the cache.
-			delete(
-				s.addrs,
+			s.addrs.Delete(
 				addrKey(diskAddr.Address().ScriptAddress()),
 			)
 
@@ -1319,7 +1378,10 @@ func (s *ScopedKeyManager) nextAddresses(ns walletdb.ReadWriteBucket,
 
 		for _, info := range addressInfo {
 			ma := info.managedAddr
-			s.addrs[addrKey(ma.Address().ScriptAddress())] = ma
+			_, _ = s.addrs.Put(
+				addrKey(ma.Address().ScriptAddress()),
+				&cachedAddr{addr: ma},
+			)
 
 			// Add the new managed address to the list of addresses
 			// that need their private keys derived when the
@@ -1529,7 +1591,10 @@ func (s *ScopedKeyManager) extendAddresses(ns walletdb.ReadWriteBucket,
 	// added to the db.
 	for _, info := range addressInfo {
 		ma := info.managedAddr
-		s.addrs[addrKey(ma.Address().ScriptAddress())] = ma
+		_, _ = s.addrs.Put(
+			addrKey(ma.Address().ScriptAddress()),
+			&cachedAddr{addr: ma},
+		)
 
 		// Add the new managed address to the list of addresses that
 		// need their private keys derived when the address manager is
@@ -1885,7 +1950,16 @@ func (s *ScopedKeyManager) newAccount(ns walletdb.ReadWriteBucket,
 	}
 
 	// Save last account metadata
-	return putLastAccount(ns, &s.scope, account)
+	err = putLastAccount(ns, &s.scope, account)
+	if err != nil {
+		return err
+	}
+
+	// Warm the account cache explicitly so callers do not need a follow-up
+	// AccountProperties read to make the new account visible in memory.
+	_, err = s.loadAccountInfo(ns, account)
+
+	return err
 }
 
 // NewAccountWatchingOnly is similar to NewAccount, but for watch-only wallets.
@@ -1974,7 +2048,16 @@ func (s *ScopedKeyManager) newAccountWatchingOnly(ns walletdb.ReadWriteBucket,
 	}
 
 	// Save last account metadata
-	return putLastAccount(ns, &s.scope, account)
+	err = putLastAccount(ns, &s.scope, account)
+	if err != nil {
+		return err
+	}
+
+	// Warm the account cache explicitly so callers do not need a follow-up
+	// AccountProperties read to make the new account visible in memory.
+	_, err = s.loadAccountInfo(ns, account)
+
+	return err
 }
 
 // RenameAccount renames an account stored in the manager based on the given
@@ -2333,7 +2416,10 @@ func (s *ScopedKeyManager) toImportedPrivateManagedAddress(
 
 	// Add the new managed address to the cache of recent addresses and
 	// return it.
-	s.addrs[addrKey(managedAddr.Address().ScriptAddress())] = managedAddr
+	_, _ = s.addrs.Put(
+		addrKey(managedAddr.Address().ScriptAddress()),
+		&cachedAddr{addr: managedAddr},
+	)
 	return managedAddr, nil
 }
 
@@ -2356,7 +2442,10 @@ func (s *ScopedKeyManager) toImportedPublicManagedAddress(
 
 	// Add the new managed address to the cache of recent addresses and
 	// return it.
-	s.addrs[addrKey(managedAddr.Address().ScriptAddress())] = managedAddr
+	_, _ = s.addrs.Put(
+		addrKey(managedAddr.Address().ScriptAddress()),
+		&cachedAddr{addr: managedAddr},
+	)
 	return managedAddr, nil
 }
 
@@ -2560,7 +2649,10 @@ func (s *ScopedKeyManager) importScriptAddress(ns walletdb.ReadWriteBucket,
 
 	// Add the new managed address to the cache of recent addresses and
 	// return it.
-	s.addrs[addrKey(scriptIdent)] = managedAddr
+	_, _ = s.addrs.Put(
+		addrKey(managedAddr.Address().ScriptAddress()),
+		&cachedAddr{addr: managedAddr},
+	)
 
 	if updateStartBlock {
 		// Now that the database has been updated, update the start block in
@@ -2614,7 +2706,7 @@ func (s *ScopedKeyManager) MarkUsed(ns walletdb.ReadWriteBucket,
 
 	// Clear caches which might have stale entries for used addresses
 	s.mtx.Lock()
-	delete(s.addrs, addrKey(addressID))
+	s.addrs.Delete(addrKey(addressID))
 	s.mtx.Unlock()
 	return nil
 }
@@ -2952,28 +3044,4 @@ func (s *ScopedKeyManager) deriveAddr(acctInfo *accountInfo, account, branch,
 	}
 
 	return addr, script, nil
-}
-
-// accountInfo returns a copy of the account info map.
-func (s *ScopedKeyManager) accountInfo() map[uint32]*accountInfo {
-	s.mtx.RLock()
-	defer s.mtx.RUnlock()
-
-	acctInfoCopy := make(map[uint32]*accountInfo, len(s.acctInfo))
-	maps.Copy(acctInfoCopy, s.acctInfo)
-
-	return acctInfoCopy
-}
-
-// addresses returns a slice of all managed addresses.
-func (s *ScopedKeyManager) addresses() []ManagedAddress {
-	s.mtx.RLock()
-	defer s.mtx.RUnlock()
-
-	addrs := make([]ManagedAddress, 0, len(s.addrs))
-	for _, ma := range s.addrs {
-		addrs = append(addrs, ma)
-	}
-
-	return addrs
 }

--- a/waddrmgr/scoped_manager.go
+++ b/waddrmgr/scoped_manager.go
@@ -1782,10 +1782,11 @@ func (s *ScopedKeyManager) LastInternalAddress(ns walletdb.ReadBucket,
 	return nil, managerError(ErrAddressNotFound, "no previous internal address", nil)
 }
 
-// CanAddAccount returns an error if a new account cannot be created.
-// This is the case if the manager is watch-only or is locked. A descriptive
-// error is returned in these cases.
-func (s *ScopedKeyManager) CanAddAccount() error {
+// CanAddAccountDeprecated returns an error if a new account cannot be created.
+//
+// Deprecated: use NewAccount directly so validation stays coupled to the
+// mutation path. This wrapper is only kept for legacy callers.
+func (s *ScopedKeyManager) CanAddAccountDeprecated() error {
 	if s.rootManager.WatchOnly() {
 		return managerError(ErrWatchingOnly, errWatchingOnly, nil)
 	}
@@ -1878,6 +1879,13 @@ func (s *ScopedKeyManager) NewAccount(ns walletdb.ReadWriteBucket, name string) 
 // NOTE: This function MUST be called with the manager lock held for writes.
 func (s *ScopedKeyManager) newAccount(ns walletdb.ReadWriteBucket,
 	account uint32, name string) error {
+	if s.rootManager.WatchOnly() {
+		return managerError(ErrWatchingOnly, errWatchingOnly, nil)
+	}
+
+	if s.rootManager.IsLocked() {
+		return managerError(ErrLocked, errLocked, nil)
+	}
 
 	// Validate the account name.
 	if err := ValidateAccountName(name); err != nil {

--- a/waddrmgr/scoped_manager.go
+++ b/waddrmgr/scoped_manager.go
@@ -2310,45 +2310,21 @@ func (s *ScopedKeyManager) importPublicKey(ns walletdb.ReadWriteBucket,
 	serializedPubKey, encryptedPrivKey []byte, addrType AddressType,
 	bs *BlockStamp) error {
 
-	// Compute the addressID for our key based on its address type.
-	var addressID []byte
-	switch addrType {
-	case PubKeyHash, WitnessPubKey:
-		addressID = btcutil.Hash160(serializedPubKey)
-
-	case NestedWitnessPubKey:
-		pubKeyHash := btcutil.Hash160(serializedPubKey)
-		p2wkhAddr, err := btcutil.NewAddressWitnessPubKeyHash(
-			pubKeyHash, s.rootManager.chainParams,
-		)
-		if err != nil {
-			return err
-		}
-		witnessScript, err := txscript.PayToAddrScript(p2wkhAddr)
-		if err != nil {
-			return err
-		}
-		addressID = btcutil.Hash160(witnessScript)
-
-	case TaprootPubKey:
-		internalPubKey, err := btcec.ParsePubKey(serializedPubKey)
-		if err != nil {
-			return err
-		}
-		taprootPubKey := txscript.ComputeTaprootKeyNoScript(
-			internalPubKey,
-		)
-		addressID = schnorr.SerializePubKey(taprootPubKey)
-
-	default:
-		return fmt.Errorf("unsupported address type %v", addrType)
+	address, err := addrType.AddrFromPubKeyBytes(
+		serializedPubKey, s.rootManager.chainParams,
+	)
+	if err != nil {
+		return fmt.Errorf("compute imported address id: %w", err)
 	}
 
+	scriptAddress := address.ScriptAddress()
+
 	// Prevent duplicates.
-	alreadyExists := s.existsAddress(ns, addressID)
+	alreadyExists := s.existsAddress(ns, scriptAddress)
 	if alreadyExists {
 		str := fmt.Sprintf("address for public key %x already exists",
 			serializedPubKey)
+
 		return managerError(ErrDuplicateAddress, str, nil)
 	}
 
@@ -2359,6 +2335,7 @@ func (s *ScopedKeyManager) importPublicKey(ns walletdb.ReadWriteBucket,
 	if err != nil {
 		str := fmt.Sprintf("failed to encrypt public key for %x",
 			serializedPubKey)
+
 		return managerError(ErrCrypto, str, err)
 	}
 
@@ -2372,7 +2349,7 @@ func (s *ScopedKeyManager) importPublicKey(ns walletdb.ReadWriteBucket,
 	// Save the new imported address to the db and update start block (if
 	// needed) in a single transaction.
 	err = putImportedAddress(
-		ns, &s.scope, addressID, ImportedAddrAccount, ssNone,
+		ns, &s.scope, scriptAddress, ImportedAddrAccount, ssNone,
 		encryptedPubKey, encryptedPrivKey,
 	)
 	if err != nil {

--- a/waddrmgr/scoped_manager.go
+++ b/waddrmgr/scoped_manager.go
@@ -2235,6 +2235,77 @@ func (s *ScopedKeyManager) ImportPublicKey(ns walletdb.ReadWriteBucket,
 	return s.toImportedPublicManagedAddress(pubKey, true)
 }
 
+// importPublicKey imports a public key into the address manager and updates the
+// wallet's start block if necessary. An error is returned if the public key
+// already exists.
+func (s *ScopedKeyManager) importPublicKey(ns walletdb.ReadWriteBucket,
+	serializedPubKey, encryptedPrivKey []byte, addrType AddressType,
+	bs *BlockStamp) error {
+
+	address, err := addrType.AddrFromPubKeyBytes(
+		serializedPubKey, s.rootManager.chainParams,
+	)
+	if err != nil {
+		return fmt.Errorf("compute imported address id: %w", err)
+	}
+
+	scriptAddress := address.ScriptAddress()
+
+	// Prevent duplicates.
+	alreadyExists := s.existsAddress(ns, scriptAddress)
+	if alreadyExists {
+		str := fmt.Sprintf("address for public key %x already exists",
+			serializedPubKey)
+
+		return managerError(ErrDuplicateAddress, str, nil)
+	}
+
+	// Encrypt public key.
+	encryptedPubKey, err := s.rootManager.cryptoKeyPub.Encrypt(
+		serializedPubKey,
+	)
+	if err != nil {
+		str := fmt.Sprintf("failed to encrypt public key for %x",
+			serializedPubKey)
+
+		return managerError(ErrCrypto, str, err)
+	}
+
+	// The start block needs to be updated when the newly imported address
+	// is before the current one.
+	s.rootManager.mtx.Lock()
+	updateStartBlock := bs != nil &&
+		bs.Height < s.rootManager.syncState.startBlock.Height
+	s.rootManager.mtx.Unlock()
+
+	// Save the new imported address to the db and update start block (if
+	// needed) in a single transaction.
+	err = putImportedAddress(
+		ns, &s.scope, scriptAddress, ImportedAddrAccount, ssNone,
+		encryptedPubKey, encryptedPrivKey,
+	)
+	if err != nil {
+		return err
+	}
+
+	if updateStartBlock {
+		err := putStartBlock(ns, bs)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Now that the database has been updated, update the start block in
+	// memory too if needed.
+	if updateStartBlock {
+		s.rootManager.mtx.Lock()
+		s.rootManager.syncState.startBlock = *bs
+		s.rootManager.mtx.Unlock()
+	}
+
+	return nil
+}
+
 // DeriveAddr derives a single address and its corresponding pkScript for the
 // given account, branch, and index. This method relies on the in-memory
 // account state and extended public keys, avoiding database access.
@@ -2309,77 +2380,6 @@ func (s *ScopedKeyManager) DeriveAddrs(account uint32, branch uint32,
 	}
 
 	return addrs, scripts, nil
-}
-
-// importPublicKey imports a public key into the address manager and updates the
-// wallet's start block if necessary. An error is returned if the public key
-// already exists.
-func (s *ScopedKeyManager) importPublicKey(ns walletdb.ReadWriteBucket,
-	serializedPubKey, encryptedPrivKey []byte, addrType AddressType,
-	bs *BlockStamp) error {
-
-	address, err := addrType.AddrFromPubKeyBytes(
-		serializedPubKey, s.rootManager.chainParams,
-	)
-	if err != nil {
-		return fmt.Errorf("compute imported address id: %w", err)
-	}
-
-	scriptAddress := address.ScriptAddress()
-
-	// Prevent duplicates.
-	alreadyExists := s.existsAddress(ns, scriptAddress)
-	if alreadyExists {
-		str := fmt.Sprintf("address for public key %x already exists",
-			serializedPubKey)
-
-		return managerError(ErrDuplicateAddress, str, nil)
-	}
-
-	// Encrypt public key.
-	encryptedPubKey, err := s.rootManager.cryptoKeyPub.Encrypt(
-		serializedPubKey,
-	)
-	if err != nil {
-		str := fmt.Sprintf("failed to encrypt public key for %x",
-			serializedPubKey)
-
-		return managerError(ErrCrypto, str, err)
-	}
-
-	// The start block needs to be updated when the newly imported address
-	// is before the current one.
-	s.rootManager.mtx.Lock()
-	updateStartBlock := bs != nil &&
-		bs.Height < s.rootManager.syncState.startBlock.Height
-	s.rootManager.mtx.Unlock()
-
-	// Save the new imported address to the db and update start block (if
-	// needed) in a single transaction.
-	err = putImportedAddress(
-		ns, &s.scope, scriptAddress, ImportedAddrAccount, ssNone,
-		encryptedPubKey, encryptedPrivKey,
-	)
-	if err != nil {
-		return err
-	}
-
-	if updateStartBlock {
-		err := putStartBlock(ns, bs)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Now that the database has been updated, update the start block in
-	// memory too if needed.
-	if updateStartBlock {
-		s.rootManager.mtx.Lock()
-		s.rootManager.syncState.startBlock = *bs
-		s.rootManager.mtx.Unlock()
-	}
-
-	return nil
 }
 
 // toImportedPrivateManagedAddress converts an imported private key to an

--- a/waddrmgr/scoped_manager_test.go
+++ b/waddrmgr/scoped_manager_test.go
@@ -1,6 +1,7 @@
 package waddrmgr
 
 import (
+	"bytes"
 	"math"
 	"testing"
 
@@ -10,6 +11,281 @@ import (
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/stretchr/testify/require"
 )
+
+// TestNewAccountCachesAccountInfo verifies that creating a new account makes it
+// visible in the scoped-manager cache without requiring a follow-up read.
+func TestNewAccountCachesAccountInfo(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create and unlock a manager, then fetch the scoped manager.
+	teardown, db, mgr := setupManager(t)
+	t.Cleanup(teardown)
+
+	err := walletdb.View(db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+		return mgr.Unlock(ns, privPassphrase)
+	})
+	require.NoError(t, err)
+
+	acctStore, err := mgr.FetchScopedKeyManager(KeyScopeBIP0044)
+	require.NoError(t, err)
+
+	scopedMgr, ok := acctStore.(*ScopedKeyManager)
+	require.True(t, ok)
+
+	var account uint32
+
+	// Act: Create the new account through the scoped manager.
+	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+		account, err = scopedMgr.NewAccount(ns, "acct-1")
+
+		return err
+	})
+	require.NoError(t, err)
+	require.Contains(t, scopedMgr.ActiveAccounts(), account)
+
+	// Assert: The new account is immediately visible in the cache.
+	scopedMgr.mtx.RLock()
+	acctInfo, ok := scopedMgr.acctInfo[account]
+	scopedMgr.mtx.RUnlock()
+	require.True(t, ok)
+	require.Equal(t, "acct-1", acctInfo.acctName)
+	require.Equal(t, uint32(0), acctInfo.nextExternalIndex)
+	require.Equal(t, uint32(0), acctInfo.nextInternalIndex)
+}
+
+// TestNewAccountWatchingOnlyCachesAccountInfo verifies that importing a
+// watch-only account updates the scoped-manager cache immediately.
+func TestNewAccountWatchingOnlyCachesAccountInfo(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create the manager, fetch the scoped manager, and derive the
+	// account public key to import.
+	teardown, db, mgr := setupManager(t)
+	t.Cleanup(teardown)
+
+	acctStore, err := mgr.FetchScopedKeyManager(KeyScopeBIP0044)
+	require.NoError(t, err)
+
+	scopedMgr, ok := acctStore.(*ScopedKeyManager)
+	require.True(t, ok)
+
+	accountKey := deriveTestAccountKey(t)
+	require.NotNil(t, accountKey)
+
+	acctKeyPub, err := accountKey.Neuter()
+	require.NoError(t, err)
+
+	var account uint32
+
+	// Act: Import the watching-only account.
+	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+		account, err = scopedMgr.NewAccountWatchingOnly(
+			ns, "watch-1", acctKeyPub, 123, nil,
+		)
+
+		return err
+	})
+	require.NoError(t, err)
+	require.Contains(t, scopedMgr.ActiveAccounts(), account)
+
+	// Assert: The imported account metadata is immediately visible in the
+	// cache.
+	scopedMgr.mtx.RLock()
+	acctInfo, ok := scopedMgr.acctInfo[account]
+	scopedMgr.mtx.RUnlock()
+	require.True(t, ok)
+	require.Equal(t, "watch-1", acctInfo.acctName)
+	require.Equal(t, uint32(123), acctInfo.masterKeyFingerprint)
+	require.Nil(t, acctInfo.addrSchema)
+}
+
+// TestScopedManagerAddressCacheBounded verifies that the scoped-manager address
+// cache stays within its configured capacity while still reloading evicted
+// addresses from disk.
+func TestScopedManagerAddressCacheBounded(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create and unlock a manager, then replace the scoped address
+	// cache with a one-entry cache.
+	teardown, db, mgr := setupManager(t)
+	t.Cleanup(teardown)
+
+	err := walletdb.View(db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+		return mgr.Unlock(ns, privPassphrase)
+	})
+	require.NoError(t, err)
+
+	acctStore, err := mgr.FetchScopedKeyManager(KeyScopeBIP0084)
+	require.NoError(t, err)
+
+	scopedMgr, ok := acctStore.(*ScopedKeyManager)
+	require.True(t, ok)
+
+	scopedMgr.addrs = newAddrCache(1)
+
+	var firstAddr ManagedAddress
+
+	// Act: Derive two addresses so the first is evicted, then load the first
+	// address again from disk.
+	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+		addrs, err := scopedMgr.NextExternalAddresses(ns, DefaultAccountNum, 2)
+		if err != nil {
+			return err
+		}
+
+		firstAddr = addrs[0]
+
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, scopedMgr.addrs.Len())
+
+	// Assert: The evicted address can still be reloaded and the cache remains
+	// bounded.
+	err = walletdb.View(db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+
+		addr, err := scopedMgr.Address(ns, firstAddr.Address())
+		require.NoError(t, err)
+		require.Equal(t, firstAddr.Address().String(), addr.Address().String())
+
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, scopedMgr.addrs.Len())
+}
+
+// TestForEachActiveAddressIgnoresCacheEviction verifies that active-address
+// iteration still walks the full DB-backed address set after cache eviction.
+func TestForEachActiveAddressIgnoresCacheEviction(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create and unlock a manager, then force the scoped address cache
+	// down to one entry.
+	teardown, db, mgr := setupManager(t)
+	t.Cleanup(teardown)
+
+	err := walletdb.View(db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+		return mgr.Unlock(ns, privPassphrase)
+	})
+	require.NoError(t, err)
+
+	acctStore, err := mgr.FetchScopedKeyManager(KeyScopeBIP0084)
+	require.NoError(t, err)
+
+	scopedMgr, ok := acctStore.(*ScopedKeyManager)
+	require.True(t, ok)
+
+	scopedMgr.addrs = newAddrCache(1)
+
+	// Act: Derive two addresses so one is evicted, then iterate the active
+	// addresses from the DB-backed manager state.
+	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+		_, err := scopedMgr.NextExternalAddresses(ns, DefaultAccountNum, 2)
+
+		return err
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, scopedMgr.addrs.Len())
+
+	var seen []string
+
+	// Assert: Iteration still sees both active addresses even though the cache
+	// only holds one entry.
+	err = walletdb.View(db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+
+		return scopedMgr.ForEachActiveAddress(
+			ns, func(addr btcutil.Address) error {
+				seen = append(seen, addr.String())
+				return nil
+			},
+		)
+	})
+	require.NoError(t, err)
+	require.Len(t, seen, 2)
+}
+
+// TestScopedManagerAddressEvictionLocksSecrets verifies that evicting an
+// address from the bounded cache zeroes any cleartext private key bytes held by
+// that managed address.
+func TestScopedManagerAddressEvictionLocksSecrets(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create and unlock a manager, then force the scoped address cache
+	// down to one entry.
+	teardown, db, mgr := setupManager(t)
+	t.Cleanup(teardown)
+
+	err := walletdb.View(db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+		return mgr.Unlock(ns, privPassphrase)
+	})
+	require.NoError(t, err)
+
+	acctStore, err := mgr.FetchScopedKeyManager(KeyScopeBIP0084)
+	require.NoError(t, err)
+
+	scopedMgr, ok := acctStore.(*ScopedKeyManager)
+	require.True(t, ok)
+
+	scopedMgr.addrs = newAddrCache(1)
+
+	var firstAddr *managedAddress
+
+	// Act: Derive one address, capture its cleartext key bytes, then derive a
+	// second address so the first is evicted.
+	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+		addrs, err := scopedMgr.NextExternalAddresses(ns, DefaultAccountNum, 1)
+		if err != nil {
+			return err
+		}
+
+		var ok bool
+
+		firstAddr, ok = addrs[0].(*managedAddress)
+		if !ok {
+			return nil
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+	require.NotNil(t, firstAddr)
+	require.NotEmpty(t, firstAddr.privKeyCT)
+
+	firstPrivKeyCT := firstAddr.privKeyCT
+
+	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+		_, err := scopedMgr.NextExternalAddresses(ns, DefaultAccountNum, 1)
+
+		return err
+	})
+	require.NoError(t, err)
+
+	// Assert: Eviction zeroes and clears the original managed address's
+	// cleartext private key bytes.
+	require.Nil(t, firstAddr.privKeyCT)
+	require.True(t, bytes.Equal(
+		firstPrivKeyCT, make([]byte, len(firstPrivKeyCT)),
+	))
+	require.Equal(t, 1, scopedMgr.addrs.Len())
+}
 
 // TestDeriveAddrs verifies that DeriveAddrs correctly derives addresses using
 // in-memory state, producing the same results as database-backed derivation.

--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -127,12 +127,6 @@ func (w *Wallet) NewAccount(_ context.Context, scope waddrmgr.KeyScope,
 		return nil, err
 	}
 
-	// Validate that the scope manager can add this new account.
-	err = manager.CanAddAccount()
-	if err != nil {
-		return nil, err
-	}
-
 	var props *waddrmgr.AccountProperties
 
 	err = walletdb.Update(w.cfg.DB, func(tx walletdb.ReadWriteTx) error {

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -90,7 +90,6 @@ func TestNewAccount(t *testing.T) {
 	deps.addrStore.On("FetchScopedKeyManager", scope).
 		Return(deps.accountManager, nil).Once()
 
-	deps.accountManager.On("CanAddAccount").Return(nil).Once()
 	deps.accountManager.On("NewAccount", mock.Anything, testAccountName).
 		Return(uint32(1), nil).Once()
 	deps.accountManager.On("AccountProperties", mock.Anything, uint32(1)).
@@ -130,7 +129,6 @@ func TestNewAccount(t *testing.T) {
 	deps.addrStore.On("FetchScopedKeyManager", scope).
 		Return(deps.accountManager, nil).Once()
 
-	deps.accountManager.On("CanAddAccount").Return(nil).Once()
 	deps.accountManager.On("NewAccount", mock.Anything, testAccountName).
 		Return(uint32(0), waddrmgr.ManagerError{
 			ErrorCode: waddrmgr.ErrDuplicateAccount,
@@ -153,8 +151,8 @@ func TestNewAccount(t *testing.T) {
 	deps.addrStore.On("FetchScopedKeyManager", scope).
 		Return(deps.accountManager, nil).Once()
 
-	deps.accountManager.On("CanAddAccount").
-		Return(waddrmgr.ManagerError{
+	deps.accountManager.On("NewAccount", mock.Anything, "test2").
+		Return(uint32(0), waddrmgr.ManagerError{
 			ErrorCode: waddrmgr.ErrLocked,
 		}).Once()
 
@@ -177,7 +175,6 @@ func TestListAccounts(t *testing.T) {
 	deps.addrStore.On("FetchScopedKeyManager", scope).
 		Return(deps.accountManager, nil).Once()
 
-	deps.accountManager.On("CanAddAccount").Return(nil).Once()
 	deps.accountManager.On("NewAccount", mock.Anything, testAccountName).
 		Return(uint32(1), nil).Once()
 	deps.accountManager.On("AccountProperties", mock.Anything, uint32(1)).
@@ -259,7 +256,6 @@ func TestListAccountsByScope(t *testing.T) {
 	deps.addrStore.On("FetchScopedKeyManager", scopeBIP84).
 		Return(deps.accountManager, nil).Once()
 
-	deps.accountManager.On("CanAddAccount").Return(nil).Once()
 	deps.accountManager.On("NewAccount", mock.Anything, accBIP84Name).
 		Return(uint32(1), nil).Once()
 	deps.accountManager.On("AccountProperties", mock.Anything, uint32(1)).
@@ -277,7 +273,6 @@ func TestListAccountsByScope(t *testing.T) {
 	deps.addrStore.On("FetchScopedKeyManager", scopeBIP49).
 		Return(deps.accountManager, nil).Once()
 
-	deps.accountManager.On("CanAddAccount").Return(nil).Once()
 	deps.accountManager.On("NewAccount", mock.Anything, accBIP49Name).
 		Return(uint32(1), nil).Once()
 	deps.accountManager.On("AccountProperties", mock.Anything, uint32(1)).
@@ -377,7 +372,6 @@ func TestListAccountsByName(t *testing.T) {
 
 	deps.addrStore.On("FetchScopedKeyManager", scopeBIP84).
 		Return(deps.accountManager, nil).Once()
-	deps.accountManager.On("CanAddAccount").Return(nil).Once()
 	deps.accountManager.On("NewAccount", mock.Anything, accBIP84Name).
 		Return(uint32(1), nil).Once()
 	deps.accountManager.On("AccountProperties", mock.Anything, uint32(1)).
@@ -394,7 +388,6 @@ func TestListAccountsByName(t *testing.T) {
 
 	deps.addrStore.On("FetchScopedKeyManager", scopeBIP49).
 		Return(deps.accountManager, nil).Once()
-	deps.accountManager.On("CanAddAccount").Return(nil).Once()
 	deps.accountManager.On("NewAccount", mock.Anything, accBIP49Name).
 		Return(uint32(1), nil).Once()
 	deps.accountManager.On("AccountProperties", mock.Anything, uint32(1)).
@@ -484,7 +477,6 @@ func TestGetAccount(t *testing.T) {
 	scope := waddrmgr.KeyScopeBIP0084
 	deps.addrStore.On("FetchScopedKeyManager", scope).
 		Return(deps.accountManager, nil).Once()
-	deps.accountManager.On("CanAddAccount").Return(nil).Once()
 	deps.accountManager.On("NewAccount", mock.Anything, testAccountName).
 		Return(uint32(1), nil).Once()
 	deps.accountManager.On("AccountProperties", mock.Anything, uint32(1)).
@@ -566,7 +558,6 @@ func TestRenameAccount(t *testing.T) {
 
 	deps.addrStore.On("FetchScopedKeyManager", scope).
 		Return(deps.accountManager, nil).Once()
-	deps.accountManager.On("CanAddAccount").Return(nil).Once()
 	deps.accountManager.On("NewAccount", mock.Anything, oldName).
 		Return(uint32(1), nil).Once()
 	deps.accountManager.On("AccountProperties", mock.Anything, uint32(1)).
@@ -676,7 +667,6 @@ func TestBalance(t *testing.T) {
 		Return(deps.accountManager, nil).
 		Once()
 
-	deps.accountManager.On("CanAddAccount").Return(nil).Once()
 	deps.accountManager.On("NewAccount", mock.Anything, testAccountName).
 		Return(uint32(1), nil).Once()
 	deps.accountManager.On("AccountProperties", mock.Anything, uint32(1)).
@@ -993,7 +983,6 @@ func TestFetchAccountBalances(t *testing.T) {
 		deps.addrStore.On("FetchScopedKeyManager", waddrmgr.KeyScopeBIP0084).
 			Return(deps.accountManager, nil).
 			Once()
-		deps.accountManager.On("CanAddAccount").Return(nil).Once()
 		deps.accountManager.On("NewAccount", mock.Anything, "acc1-bip84").
 			Return(uint32(1), nil).
 			Once()
@@ -1013,7 +1002,6 @@ func TestFetchAccountBalances(t *testing.T) {
 			"FetchScopedKeyManager", waddrmgr.KeyScopeBIP0049Plus,
 		).Return(deps.accountManager, nil).Once()
 
-		deps.accountManager.On("CanAddAccount").Return(nil).Once()
 		deps.accountManager.On("NewAccount", mock.Anything, "acc1-bip49").
 			Return(uint32(1), nil).
 			Once()
@@ -1153,7 +1141,6 @@ func TestFetchAccountBalances(t *testing.T) {
 				deps.addrStore.On(
 					"FetchScopedKeyManager", waddrmgr.KeyScopeBIP0084,
 				).Return(deps.accountManager, nil).Once()
-				deps.accountManager.On("CanAddAccount").Return(nil).Once()
 				deps.accountManager.On(
 					"NewAccount", mock.Anything, "no-balance",
 				).Return(uint32(2), nil).Once()
@@ -1228,7 +1215,6 @@ func TestListAccountsWithBalances(t *testing.T) {
 	deps.addrStore.On("FetchScopedKeyManager", scope).
 		Return(deps.accountManager, nil).Once()
 
-	deps.accountManager.On("CanAddAccount").Return(nil).Once()
 	deps.accountManager.On("NewAccount", mock.Anything, acc1Name).
 		Return(uint32(1), nil).Once()
 	deps.accountManager.On("AccountProperties", mock.Anything, uint32(1)).
@@ -1245,7 +1231,6 @@ func TestListAccountsWithBalances(t *testing.T) {
 	deps.addrStore.On("FetchScopedKeyManager", scope).
 		Return(deps.accountManager, nil).Once()
 
-	deps.accountManager.On("CanAddAccount").Return(nil).Once()
 	deps.accountManager.On("NewAccount", mock.Anything, acc2Name).
 		Return(uint32(2), nil).Once()
 	deps.accountManager.On("AccountProperties", mock.Anything, uint32(2)).

--- a/wallet/address_info_test.go
+++ b/wallet/address_info_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAddressInfoFromManagedAddressPubKey verifies conversion of a managed
+// pubkey address into wallet-owned metadata.
+func TestAddressInfoFromManagedAddressPubKey(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create one managed pubkey address mock with derivation data.
+	_, mocks := createStartedWalletWithMocks(t)
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	addr, err := btcutil.NewAddressWitnessPubKeyHash(
+		btcutil.Hash160(privKey.PubKey().SerializeCompressed()),
+		&chainParams,
+	)
+	require.NoError(t, err)
+
+	mocks.pubKeyAddr.On("Address").Return(addr).Once()
+	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
+	mocks.pubKeyAddr.On("Imported").Return(false).Once()
+	mocks.pubKeyAddr.On("Internal").Return(true).Once()
+	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
+	mocks.pubKeyAddr.On("PubKey").Return(privKey.PubKey()).Once()
+	mocks.pubKeyAddr.On("DerivationInfo").Return(
+		waddrmgr.KeyScopeBIP0084,
+		waddrmgr.DerivationPath{
+			Account:              1,
+			Branch:               1,
+			Index:                7,
+			MasterKeyFingerprint: 99,
+		},
+		true,
+	).Once()
+
+	// Act: Convert the managed address into wallet-owned metadata.
+	info, err := addressInfoFromManagedAddress(mocks.pubKeyAddr)
+	require.NoError(t, err)
+
+	// Assert: The converted metadata retains the managed address fields and
+	// derivation information.
+	require.Equal(t, addr, info.Addr)
+	require.Equal(t, waddrmgr.WitnessPubKey, info.AddrType)
+	require.False(t, info.Imported)
+	require.True(t, info.Internal)
+	require.True(t, info.Compressed)
+	require.Equal(t, privKey.PubKey(), info.PubKey)
+	require.NotNil(t, info.Derivation)
+	require.Equal(t, waddrmgr.KeyScopeBIP0084, info.Derivation.KeyScope)
+	require.Equal(t, uint32(1), info.Derivation.Account)
+	require.Equal(t, uint32(1), info.Derivation.Branch)
+	require.Equal(t, uint32(7), info.Derivation.Index)
+	require.Equal(t, uint32(99), info.Derivation.MasterKeyFingerprint)
+}

--- a/wallet/address_manager.go
+++ b/wallet/address_manager.go
@@ -168,9 +168,9 @@ type AddressManager interface {
 		addrType waddrmgr.AddressType, change bool) (
 		btcutil.Address, error)
 
-	// AddressInfo returns detailed information about a managed address. If
+	// GetAddressInfo returns detailed information about a managed address. If
 	// the address is not known to the wallet, an error is returned.
-	AddressInfo(ctx context.Context,
+	GetAddressInfo(ctx context.Context,
 		a btcutil.Address) (waddrmgr.ManagedAddress, error)
 
 	// ListAddresses lists all addresses for a given account, including
@@ -522,7 +522,7 @@ func (w *Wallet) findUnusedAddress(manager waddrmgr.AccountStore,
 	return unusedAddr, err
 }
 
-// AddressInfo returns detailed information regarding a wallet address.
+// GetAddressInfo returns detailed information regarding a wallet address.
 //
 // This method provides metadata about a managed address, such as its type,
 // derivation path, and whether it's internal or compressed.
@@ -546,7 +546,7 @@ func (w *Wallet) findUnusedAddress(manager waddrmgr.AccountStore,
 //   - The operation is a direct database lookup, making its complexity roughly
 //     O(1) or O(log N) depending on the database backend's indexing strategy
 //     for addresses. It is a very fast operation.
-func (w *Wallet) AddressInfo(_ context.Context,
+func (w *Wallet) GetAddressInfo(_ context.Context,
 	a btcutil.Address) (waddrmgr.ManagedAddress, error) {
 
 	err := w.state.validateStarted()
@@ -850,7 +850,7 @@ func (w *Wallet) ScriptForOutput(ctx context.Context, output wire.TxOut) (
 
 	// We'll then use the address to look up the managed address from the
 	// database.
-	managedAddr, err := w.AddressInfo(ctx, addr)
+	managedAddr, err := w.GetAddressInfo(ctx, addr)
 	if err != nil {
 		return Script{}, fmt.Errorf("unable to get address info "+
 			"for %s: %w", addr.String(), err)
@@ -939,7 +939,7 @@ func (w *Wallet) GetDerivationInfo(ctx context.Context,
 	}
 
 	// We'll use the address to look up the derivation path.
-	managedAddr, err := w.AddressInfo(ctx, addr)
+	managedAddr, err := w.GetAddressInfo(ctx, addr)
 	if err != nil {
 		return nil, err
 	}

--- a/wallet/address_manager.go
+++ b/wallet/address_manager.go
@@ -304,9 +304,9 @@ func (w *Wallet) NewAddress(_ context.Context, accountName string,
 		return nil, ErrImportedAccountNoAddrGen
 	}
 
-	keyScope, err := w.keyScopeFromAddrType(addrType)
+	keyScope, err := addrType.KeyScope()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %v", ErrUnknownAddrType, addrType)
 	}
 
 	manager, err := w.addrStore.FetchScopedKeyManager(keyScope)
@@ -326,51 +326,6 @@ func (w *Wallet) NewAddress(_ context.Context, accountName string,
 	}
 
 	return addr, nil
-}
-
-// keyScopeFromAddrType determines the appropriate key scope for a given
-// address type.
-//
-// NOTE: While it may seem intuitive to iterate over the waddrmgr.ScopeAddrMap
-// to act as a single source of truth, doing so is unsafe. The map contains
-// ambiguities where a single address type, such as waddrmgr.WitnessPubKey, can
-// map to multiple key scopes (e.g., KeyScopeBIP0084 and
-// KeyScopeBIP0049Plus). Because map iteration in Go is non-deterministic, this
-// would lead to unpredictable behavior. The switch statement is used here
-// intentionally to enforce a clear, deterministic policy, ensuring that
-// ambiguous types always resolve to their preferred, modern key scope.
-func (w *Wallet) keyScopeFromAddrType(
-	addrType waddrmgr.AddressType) (waddrmgr.KeyScope, error) {
-
-	// Map the requested address type to its key scope.
-	var addrKeyScope waddrmgr.KeyScope
-	switch addrType {
-	case waddrmgr.PubKeyHash:
-		addrKeyScope = waddrmgr.KeyScopeBIP0044
-
-	case waddrmgr.WitnessPubKey:
-		addrKeyScope = waddrmgr.KeyScopeBIP0084
-
-	case waddrmgr.NestedWitnessPubKey:
-		addrKeyScope = waddrmgr.KeyScopeBIP0049Plus
-
-	case waddrmgr.TaprootPubKey:
-		addrKeyScope = waddrmgr.KeyScopeBIP0086
-
-	// The following address types are not supported by this function as
-	// they are not derived from a single public key using a key scope.
-	// They are typically imported or involve more complex script-based
-	// constructions.
-	case waddrmgr.Script, waddrmgr.RawPubKey,
-		waddrmgr.WitnessScript, waddrmgr.TaprootScript:
-		return waddrmgr.KeyScope{}, fmt.Errorf("%w: %v",
-			ErrUnknownAddrType, addrType)
-	default:
-		return waddrmgr.KeyScope{}, fmt.Errorf("%w: %v",
-			ErrUnknownAddrType, addrType)
-	}
-
-	return addrKeyScope, nil
 }
 
 // newAddress returns the next external chained address for a wallet. It
@@ -450,9 +405,9 @@ func (w *Wallet) GetUnusedAddress(ctx context.Context, accountName string,
 		return nil, ErrImportedAccountNoAddrGen
 	}
 
-	keyScope, err := w.keyScopeFromAddrType(addrType)
+	keyScope, err := addrType.KeyScope()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %v", ErrUnknownAddrType, addrType)
 	}
 
 	manager, err := w.addrStore.FetchScopedKeyManager(keyScope)
@@ -638,9 +593,9 @@ func (w *Wallet) ListAddresses(_ context.Context, accountName string,
 			addrToBalance[addr.String()] += utxo.Amount
 		}
 
-		keyScope, err := w.keyScopeFromAddrType(addrType)
+		keyScope, err := addrType.KeyScope()
 		if err != nil {
-			return err
+			return fmt.Errorf("%w: %v", ErrUnknownAddrType, addrType)
 		}
 
 		manager, err := w.addrStore.FetchScopedKeyManager(keyScope)
@@ -708,9 +663,9 @@ func (w *Wallet) ImportPublicKey(_ context.Context, pubKey *btcec.PublicKey,
 		return err
 	}
 
-	keyScope, err := w.keyScopeFromAddrType(addrType)
+	keyScope, err := addrType.KeyScope()
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: %v", ErrUnknownAddrType, addrType)
 	}
 
 	manager, err := w.addrStore.FetchScopedKeyManager(keyScope)

--- a/wallet/address_manager.go
+++ b/wallet/address_manager.go
@@ -855,32 +855,6 @@ func nestedWitnessProgramFromPubKey(pubKey *btcec.PublicKey,
 	return witnessProgram, nil
 }
 
-// buildScriptsForManagedAddress constructs the witness and redeem scripts for a
-// given managed public key address and its corresponding pkScript.
-func buildScriptsForManagedAddress(pubKeyAddr waddrmgr.ManagedPubKeyAddress,
-	pkScript []byte, chainParams *chaincfg.Params) ([]byte, []byte, error) {
-
-	addressInfo, err := addressInfoFromManagedAddress(pubKeyAddr)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	witnessProgram := pkScript
-	var redeemScript []byte
-	if addressInfo.AddrType == waddrmgr.NestedWitnessPubKey {
-		redeemScript, err = nestedWitnessProgramFromPubKey(
-			addressInfo.PubKey, chainParams,
-		)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		witnessProgram = redeemScript
-	}
-
-	return witnessProgram, redeemScript, nil
-}
-
 // GetDerivationInfo returns the BIP-32 derivation path for a given address.
 func (w *Wallet) GetDerivationInfo(ctx context.Context,
 	addr btcutil.Address) (*psbt.Bip32Derivation, error) {
@@ -935,17 +909,4 @@ func derivationForAddressInfo(addressInfo AddressInfo) (
 			addressInfo.Derivation.Index,
 		},
 	}, nil
-}
-
-// derivationForManagedAddress constructs a PSBT Bip32Derivation struct from a
-// managed public key address.
-func derivationForManagedAddress(pubKeyAddr waddrmgr.ManagedPubKeyAddress) (
-	*psbt.Bip32Derivation, error) {
-
-	addressInfo, err := addressInfoFromManagedAddress(pubKeyAddr)
-	if err != nil {
-		return nil, err
-	}
-
-	return derivationForAddressInfo(addressInfo)
 }

--- a/wallet/address_manager.go
+++ b/wallet/address_manager.go
@@ -124,22 +124,11 @@ type OutputScriptInfo struct {
 	// program, for example `OP_0 <20-byte-key-hash>`.
 	WitnessProgram []byte
 
-	// RedeemScript is the P2SH redeem script that must be pushed into sigScript
-	// when the output is wrapped in P2SH. This is only set for nested witness
-	// spends, where it is a single push of the inner witness program. Native
-	// witness spends, such as P2WPKH and P2TR, leave this nil.
-	RedeemScript []byte
-}
-
-// Script represents the script information required to spend a UTXO.
-type Script struct {
-	// Addr is the managed address of the UTXO.
-	Addr waddrmgr.ManagedAddress
-
-	// WitnessProgram is the witness program of the UTXO.
-	WitnessProgram []byte
-
-	// RedeemScript is the redeem script of the UTXO.
+	// RedeemScript is the redeem script committed to by the outer P2SH output.
+	// For nested P2WPKH-in-P2SH spends, this is the inner witness program, for
+	// example `OP_0 <20-byte-key-hash>`. Native witness spends, such as P2WPKH
+	// and P2TR, leave this nil. The final scriptSig wrapper for nested witness
+	// spends can be rebuilt from this script when assembling the input.
 	RedeemScript []byte
 }
 
@@ -186,9 +175,10 @@ type AddressManager interface {
 	ImportTaprootScript(ctx context.Context,
 		tapscript waddrmgr.Tapscript) (AddressInfo, error)
 
-	// ScriptForOutput returns the address, witness program, and redeem
-	// script for a given UTXO.
-	ScriptForOutput(ctx context.Context, output wire.TxOut) (Script, error)
+	// ScriptForOutput returns the wallet metadata and spending scripts for a
+	// given UTXO.
+	ScriptForOutput(ctx context.Context, output wire.TxOut) (
+		OutputScriptInfo, error)
 
 	// GetDerivationInfo returns the BIP-32 derivation path for a given
 	// address.
@@ -759,56 +749,8 @@ func (w *Wallet) ImportTaprootScript(_ context.Context,
 	return addressInfoFromManagedAddress(addr)
 }
 
-// buildScriptsForAddressInfo constructs the witness and redeem scripts for a
-// wallet-owned address metadata record and its corresponding pkScript.
-func buildScriptsForAddressInfo(addressInfo AddressInfo, pkScript []byte,
-	chainParams *chaincfg.Params) ([]byte, []byte, error) {
-
-	if addressInfo.PubKey == nil {
-		return nil, nil, fmt.Errorf("%w: addr %s", ErrNotPubKeyAddress,
-			addressInfo.Addr)
-	}
-
-	var (
-		witnessProgram []byte
-		redeemScript   []byte
-	)
-
-	switch {
-	case addressInfo.AddrType == waddrmgr.NestedWitnessPubKey:
-		pubKeyHash := btcutil.Hash160(
-			addressInfo.PubKey.SerializeCompressed(),
-		)
-
-		p2wkhAddr, err := btcutil.NewAddressWitnessPubKeyHash(
-			pubKeyHash, chainParams,
-		)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		witnessProgram, err = txscript.PayToAddrScript(p2wkhAddr)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		bldr := txscript.NewScriptBuilder()
-		bldr.AddData(witnessProgram)
-
-		redeemScript, err = bldr.Script()
-		if err != nil {
-			return nil, nil, err
-		}
-
-	default:
-		witnessProgram = pkScript
-	}
-
-	return witnessProgram, redeemScript, nil
-}
-
-// ScriptForOutput returns the address, witness program, and redeem script
-// for a given UTXO.
+// ScriptForOutput returns the address metadata and spending scripts for a given
+// UTXO.
 //
 // This method is essential for constructing the necessary scripts to spend a
 // transaction output. It provides the components required to build the
@@ -825,10 +767,10 @@ func buildScriptsForAddressInfo(addressInfo AddressInfo, pkScript []byte,
 //  2. Verify that the address is a public key address that the wallet can
 //     sign for (e.g., P2WKH, NP2WKH, P2TR).
 //  3. Based on the address type, construct the appropriate scripts:
-//     - For nested P2WKH (NP2WKH), it creates a redeem script
-//     (`sigScript`) that contains the P2WKH witness program.
-//     - For native SegWit outputs (P2WKH, P2TR), the `witnessProgram` is
-//     the output's `pkScript`, and the `sigScript` is nil.
+//     - For nested P2WKH (NP2WKH), it returns the inner witness program as the
+//     redeem script.
+//     - For native SegWit outputs (P2WKH, P2TR), the `witnessProgram` is the
+//     output's `pkScript`, while the redeem script is nil.
 //
 // Database Actions:
 //   - This method performs a read-only database access to fetch address
@@ -839,53 +781,78 @@ func buildScriptsForAddressInfo(addressInfo AddressInfo, pkScript []byte,
 //     is typically fast (O(log N) or O(1) with indexing). The script
 //     generation is a constant-time operation.
 func (w *Wallet) ScriptForOutput(ctx context.Context, output wire.TxOut) (
-	Script, error) {
+	OutputScriptInfo, error) {
 
 	err := w.state.validateStarted()
 	if err != nil {
-		return Script{}, err
+		return OutputScriptInfo{}, err
 	}
 
 	// First, we'll extract the address from the output's pkScript.
 	addr := extractAddrFromPKScript(output.PkScript, w.cfg.ChainParams)
 	if addr == nil {
-		return Script{}, fmt.Errorf("%w: from pkscript %x",
+		return OutputScriptInfo{}, fmt.Errorf("%w: from pkscript %x",
 			ErrUnableToExtractAddress, output.PkScript)
 	}
 
-	// We'll then use the address to look up the managed address from the
-	// database.
-	var managedAddr waddrmgr.ManagedAddress
-	err = walletdb.View(w.cfg.DB, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-
-		managedAddr, err = w.addrStore.Address(addrmgrNs, addr)
-
-		return err
-	})
+	addressInfo, err := w.GetAddressInfo(ctx, addr)
 	if err != nil {
-		return Script{}, fmt.Errorf("unable to get address info "+
+		return OutputScriptInfo{}, fmt.Errorf("unable to get address info "+
 			"for %s: %w", addr.String(), err)
 	}
 
-	pubKeyAddr, ok := managedAddr.(waddrmgr.ManagedPubKeyAddress)
-	if !ok {
-		return Script{}, fmt.Errorf("%w: addr %s",
-			ErrNotPubKeyAddress, managedAddr.Address())
+	if addressInfo.PubKey == nil {
+		return OutputScriptInfo{}, fmt.Errorf("%w: addr %s",
+			ErrNotPubKeyAddress, addressInfo.Addr)
 	}
 
-	witnessProgram, redeemScript, err := buildScriptsForManagedAddress(
-		pubKeyAddr, output.PkScript, w.cfg.ChainParams,
-	)
-	if err != nil {
-		return Script{}, err
+	witnessProgram := output.PkScript
+
+	var redeemScript []byte
+	if addressInfo.AddrType == waddrmgr.NestedWitnessPubKey {
+		redeemScript, err = nestedWitnessProgramFromPubKey(
+			addressInfo.PubKey, w.cfg.ChainParams,
+		)
+		if err != nil {
+			return OutputScriptInfo{}, err
+		}
+
+		// For nested P2WPKH-in-P2SH, the redeem script committed by the outer
+		// P2SH output is the same inner witness program used for signing.
+		witnessProgram = redeemScript
+	} else if addressInfo.AddrType != waddrmgr.PubKeyHash &&
+		addressInfo.AddrType != waddrmgr.WitnessPubKey &&
+		addressInfo.AddrType != waddrmgr.TaprootPubKey {
+
+		return OutputScriptInfo{}, fmt.Errorf("%w: %v",
+			ErrUnsupportedAddressType, addressInfo.AddrType)
 	}
 
-	return Script{
-		Addr:           managedAddr,
+	return OutputScriptInfo{
+		AddressInfo:    addressInfo,
 		WitnessProgram: witnessProgram,
 		RedeemScript:   redeemScript,
 	}, nil
+}
+
+// nestedWitnessProgramFromPubKey builds the inner witness program used by a
+// nested P2WPKH-in-P2SH output from one compressed public key.
+func nestedWitnessProgramFromPubKey(pubKey *btcec.PublicKey,
+	chainParams *chaincfg.Params) ([]byte, error) {
+
+	witnessAddr, err := btcutil.NewAddressWitnessPubKeyHash(
+		btcutil.Hash160(pubKey.SerializeCompressed()), chainParams,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("new witness pubkey hash: %w", err)
+	}
+
+	witnessProgram, err := txscript.PayToAddrScript(witnessAddr)
+	if err != nil {
+		return nil, fmt.Errorf("pay to witness address: %w", err)
+	}
+
+	return witnessProgram, nil
 }
 
 // buildScriptsForManagedAddress constructs the witness and redeem scripts for a
@@ -893,49 +860,22 @@ func (w *Wallet) ScriptForOutput(ctx context.Context, output wire.TxOut) (
 func buildScriptsForManagedAddress(pubKeyAddr waddrmgr.ManagedPubKeyAddress,
 	pkScript []byte, chainParams *chaincfg.Params) ([]byte, []byte, error) {
 
-	var (
-		witnessProgram []byte
-		redeemScript   []byte
-	)
+	addressInfo, err := addressInfoFromManagedAddress(pubKeyAddr)
+	if err != nil {
+		return nil, nil, err
+	}
 
-	switch {
-	// If we're spending p2wkh output nested within a p2sh output, then
-	// we'll need to attach a sigScript in addition to witness data.
-	case pubKeyAddr.AddrType() == waddrmgr.NestedWitnessPubKey:
-		pubKey := pubKeyAddr.PubKey()
-		pubKeyHash := btcutil.Hash160(pubKey.SerializeCompressed())
-
-		// Next, we'll generate a valid sigScript that will allow us to
-		// spend the p2sh output. The sigScript will contain only a
-		// single push of the p2wkh witness program corresponding to
-		// the matching public key of this address.
-		p2wkhAddr, err := btcutil.NewAddressWitnessPubKeyHash(
-			pubKeyHash, chainParams,
+	witnessProgram := pkScript
+	var redeemScript []byte
+	if addressInfo.AddrType == waddrmgr.NestedWitnessPubKey {
+		redeemScript, err = nestedWitnessProgramFromPubKey(
+			addressInfo.PubKey, chainParams,
 		)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		witnessProgram, err = txscript.PayToAddrScript(p2wkhAddr)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		bldr := txscript.NewScriptBuilder()
-		bldr.AddData(witnessProgram)
-
-		redeemScript, err = bldr.Script()
-		if err != nil {
-			return nil, nil, err
-		}
-
-	// Otherwise, this is a regular p2wkh or p2tr output, so we include the
-	// witness program itself as the subscript to generate the proper
-	// sighash digest. As part of the new sighash digest algorithm, the
-	// p2wkh witness program will be expanded into a regular p2kh
-	// script.
-	default:
-		witnessProgram = pkScript
+		witnessProgram = redeemScript
 	}
 
 	return witnessProgram, redeemScript, nil
@@ -951,28 +891,50 @@ func (w *Wallet) GetDerivationInfo(ctx context.Context,
 	}
 
 	// We'll use the address to look up the derivation path.
-	var managedAddr waddrmgr.ManagedAddress
-
-	err = walletdb.View(w.cfg.DB, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-
-		managedAddr, err = w.addrStore.Address(addrmgrNs, addr)
-
-		return err
-	})
+	addressInfo, err := w.GetAddressInfo(ctx, addr)
 	if err != nil {
 		return nil, err
 	}
 
-	// We only care about pubkey addresses, as they are the only
-	// ones with derivation paths.
-	pubKeyAddr, ok := managedAddr.(waddrmgr.ManagedPubKeyAddress)
-	if !ok {
-		return nil, fmt.Errorf("%w: addr=%v not found",
-			ErrDerivationPathNotFound, addr)
+	return derivationForAddressInfo(addressInfo)
+}
+
+// derivationForAddressInfo constructs a PSBT Bip32Derivation struct from a
+// wallet-owned address metadata record.
+func derivationForAddressInfo(addressInfo AddressInfo) (
+	*psbt.Bip32Derivation, error) {
+
+	// Imported addresses don't have derivation paths.
+	if addressInfo.Imported {
+		return nil, fmt.Errorf("%w: addr=%v is imported",
+			ErrDerivationPathNotFound, addressInfo.Addr)
 	}
 
-	return derivationForManagedAddress(pubKeyAddr)
+	// Only public key addresses carry derivation metadata.
+	if addressInfo.PubKey == nil {
+		return nil, fmt.Errorf("%w: addr=%v not found",
+			ErrDerivationPathNotFound, addressInfo.Addr)
+	}
+
+	// Rebuild the BIP-32 path from the wallet-owned derivation metadata.
+	if addressInfo.Derivation == nil {
+		return nil, fmt.Errorf("%w: derivation info not found for %v",
+			ErrDerivationPathNotFound, addressInfo.Addr)
+	}
+
+	keyScope := addressInfo.Derivation.KeyScope
+
+	return &psbt.Bip32Derivation{
+		PubKey:               addressInfo.PubKey.SerializeCompressed(),
+		MasterKeyFingerprint: addressInfo.Derivation.MasterKeyFingerprint,
+		Bip32Path: []uint32{
+			keyScope.Purpose + hdkeychain.HardenedKeyStart,
+			keyScope.Coin + hdkeychain.HardenedKeyStart,
+			addressInfo.Derivation.Account + hdkeychain.HardenedKeyStart,
+			addressInfo.Derivation.Branch,
+			addressInfo.Derivation.Index,
+		},
+	}, nil
 }
 
 // derivationForManagedAddress constructs a PSBT Bip32Derivation struct from a
@@ -980,33 +942,10 @@ func (w *Wallet) GetDerivationInfo(ctx context.Context,
 func derivationForManagedAddress(pubKeyAddr waddrmgr.ManagedPubKeyAddress) (
 	*psbt.Bip32Derivation, error) {
 
-	// Imported addresses don't have derivation paths.
-	if pubKeyAddr.Imported() {
-		return nil, fmt.Errorf("%w: addr=%v is imported",
-			ErrDerivationPathNotFound, pubKeyAddr.Address())
+	addressInfo, err := addressInfoFromManagedAddress(pubKeyAddr)
+	if err != nil {
+		return nil, err
 	}
 
-	// Get the derivation info.
-	keyScope, derivPath, ok := pubKeyAddr.DerivationInfo()
-	if !ok {
-		return nil, fmt.Errorf("%w: derivation info not found for %v",
-			ErrDerivationPathNotFound, pubKeyAddr.Address())
-	}
-
-	// Get the public key.
-	pubKey := pubKeyAddr.PubKey()
-
-	derivationInfo := &psbt.Bip32Derivation{
-		PubKey:               pubKey.SerializeCompressed(),
-		MasterKeyFingerprint: derivPath.MasterKeyFingerprint,
-		Bip32Path: []uint32{
-			keyScope.Purpose + hdkeychain.HardenedKeyStart,
-			keyScope.Coin + hdkeychain.HardenedKeyStart,
-			derivPath.Account,
-			derivPath.Branch,
-			derivPath.Index,
-		},
-	}
-
-	return derivationInfo, nil
+	return derivationForAddressInfo(addressInfo)
 }

--- a/wallet/address_manager.go
+++ b/wallet/address_manager.go
@@ -170,8 +170,7 @@ type AddressManager interface {
 
 	// GetAddressInfo returns detailed information about a managed address. If
 	// the address is not known to the wallet, an error is returned.
-	GetAddressInfo(ctx context.Context,
-		a btcutil.Address) (waddrmgr.ManagedAddress, error)
+	GetAddressInfo(ctx context.Context, a btcutil.Address) (AddressInfo, error)
 
 	// ListAddresses lists all addresses for a given account, including
 	// their balances.
@@ -185,7 +184,7 @@ type AddressManager interface {
 	// ImportTaprootScript imports a taproot script for tracking and
 	// spending.
 	ImportTaprootScript(ctx context.Context,
-		tapscript waddrmgr.Tapscript) (waddrmgr.ManagedAddress, error)
+		tapscript waddrmgr.Tapscript) (AddressInfo, error)
 
 	// ScriptForOutput returns the address, witness program, and redeem
 	// script for a given UTXO.
@@ -546,12 +545,12 @@ func (w *Wallet) findUnusedAddress(manager waddrmgr.AccountStore,
 //   - The operation is a direct database lookup, making its complexity roughly
 //     O(1) or O(log N) depending on the database backend's indexing strategy
 //     for addresses. It is a very fast operation.
-func (w *Wallet) GetAddressInfo(_ context.Context,
-	a btcutil.Address) (waddrmgr.ManagedAddress, error) {
+func (w *Wallet) GetAddressInfo(_ context.Context, a btcutil.Address) (
+	AddressInfo, error) {
 
 	err := w.state.validateStarted()
 	if err != nil {
-		return nil, err
+		return AddressInfo{}, err
 	}
 
 	var managedAddress waddrmgr.ManagedAddress
@@ -563,8 +562,11 @@ func (w *Wallet) GetAddressInfo(_ context.Context,
 
 		return err
 	})
+	if err != nil {
+		return AddressInfo{}, err
+	}
 
-	return managedAddress, err
+	return addressInfoFromManagedAddress(managedAddress)
 }
 
 // ListAddresses lists all addresses for a given account, including their
@@ -765,18 +767,18 @@ func (w *Wallet) ImportPublicKey(_ context.Context, pubKey *btcec.PublicKey,
 //   - Similar to ImportPublicKey, this operation is dominated by a database
 //     write, making it a fast operation with a complexity of roughly O(1).
 func (w *Wallet) ImportTaprootScript(_ context.Context,
-	tapscript waddrmgr.Tapscript) (waddrmgr.ManagedAddress, error) {
+	tapscript waddrmgr.Tapscript) (AddressInfo, error) {
 
 	err := w.state.validateStarted()
 	if err != nil {
-		return nil, err
+		return AddressInfo{}, err
 	}
 
 	manager, err := w.addrStore.FetchScopedKeyManager(
 		waddrmgr.KeyScopeBIP0086,
 	)
 	if err != nil {
-		return nil, err
+		return AddressInfo{}, err
 	}
 
 	var addr waddrmgr.ManagedAddress
@@ -791,15 +793,63 @@ func (w *Wallet) ImportTaprootScript(_ context.Context,
 		return err
 	})
 	if err != nil {
-		return nil, err
+		return AddressInfo{}, err
 	}
 
 	err = w.cfg.Chain.NotifyReceived([]btcutil.Address{addr.Address()})
 	if err != nil {
-		return nil, err
+		return AddressInfo{}, err
 	}
 
-	return addr, nil
+	return addressInfoFromManagedAddress(addr)
+}
+
+// buildScriptsForAddressInfo constructs the witness and redeem scripts for a
+// wallet-owned address metadata record and its corresponding pkScript.
+func buildScriptsForAddressInfo(addressInfo AddressInfo, pkScript []byte,
+	chainParams *chaincfg.Params) ([]byte, []byte, error) {
+
+	if addressInfo.PubKey == nil {
+		return nil, nil, fmt.Errorf("%w: addr %s", ErrNotPubKeyAddress,
+			addressInfo.Addr)
+	}
+
+	var (
+		witnessProgram []byte
+		redeemScript   []byte
+	)
+
+	switch {
+	case addressInfo.AddrType == waddrmgr.NestedWitnessPubKey:
+		pubKeyHash := btcutil.Hash160(
+			addressInfo.PubKey.SerializeCompressed(),
+		)
+
+		p2wkhAddr, err := btcutil.NewAddressWitnessPubKeyHash(
+			pubKeyHash, chainParams,
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		witnessProgram, err = txscript.PayToAddrScript(p2wkhAddr)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		bldr := txscript.NewScriptBuilder()
+		bldr.AddData(witnessProgram)
+
+		redeemScript, err = bldr.Script()
+		if err != nil {
+			return nil, nil, err
+		}
+
+	default:
+		witnessProgram = pkScript
+	}
+
+	return witnessProgram, redeemScript, nil
 }
 
 // ScriptForOutput returns the address, witness program, and redeem script
@@ -850,7 +900,14 @@ func (w *Wallet) ScriptForOutput(ctx context.Context, output wire.TxOut) (
 
 	// We'll then use the address to look up the managed address from the
 	// database.
-	managedAddr, err := w.GetAddressInfo(ctx, addr)
+	var managedAddr waddrmgr.ManagedAddress
+	err = walletdb.View(w.cfg.DB, func(tx walletdb.ReadTx) error {
+		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+
+		managedAddr, err = w.addrStore.Address(addrmgrNs, addr)
+
+		return err
+	})
 	if err != nil {
 		return Script{}, fmt.Errorf("unable to get address info "+
 			"for %s: %w", addr.String(), err)
@@ -939,7 +996,15 @@ func (w *Wallet) GetDerivationInfo(ctx context.Context,
 	}
 
 	// We'll use the address to look up the derivation path.
-	managedAddr, err := w.GetAddressInfo(ctx, addr)
+	var managedAddr waddrmgr.ManagedAddress
+
+	err = walletdb.View(w.cfg.DB, func(tx walletdb.ReadTx) error {
+		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+
+		managedAddr, err = w.addrStore.Address(addrmgrNs, addr)
+
+		return err
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/wallet/address_manager.go
+++ b/wallet/address_manager.go
@@ -5,8 +5,6 @@
 // Package wallet provides the AddressManager interface for generating and
 // inspecting wallet addresses and scripts.
 //
-// TODO(yy): bring wrapcheck back when implementing the `Store` interface.
-//
 //nolint:wrapcheck
 package wallet
 
@@ -65,6 +63,72 @@ type AddressProperty struct {
 	// Balance is the total unspent balance of the address, including both
 	// confirmed and unconfirmed funds.
 	Balance btcutil.Amount
+}
+
+// AddressInfo describes wallet-owned metadata about one managed address.
+type AddressInfo struct {
+	// Addr is the bitcoin address itself.
+	Addr btcutil.Address
+
+	// AddrType identifies the wallet-managed address type for this concrete
+	// address.
+	AddrType waddrmgr.AddressType
+
+	// Imported reports whether the address was imported instead of derived
+	// from a wallet scope.
+	Imported bool
+
+	// Internal reports whether the address belongs to the wallet's internal
+	// branch.
+	Internal bool
+
+	// Compressed reports whether the underlying pubkey address uses
+	// compressed keys.
+	Compressed bool
+
+	// PubKey is set for managed pubkey addresses.
+	PubKey *btcec.PublicKey
+
+	// Derivation is set when the wallet knows how to derive the address from a
+	// wallet scope.
+	Derivation *AddressDerivation
+}
+
+// AddressDerivation captures the wallet derivation metadata for one address.
+type AddressDerivation struct {
+	// KeyScope identifies the scope that owns the address.
+	KeyScope waddrmgr.KeyScope
+
+	// Account is the BIP-32 account within the scope.
+	Account uint32
+
+	// Branch is the BIP-32 branch within the scope.
+	Branch uint32
+
+	// Index is the child index within the branch.
+	Index uint32
+
+	// MasterKeyFingerprint is the root fingerprint used by
+	// hardware-wallet-aware flows.
+	MasterKeyFingerprint uint32
+}
+
+// OutputScriptInfo captures the address metadata and scripts needed to spend a
+// wallet-controlled output.
+type OutputScriptInfo struct {
+	AddressInfo
+
+	// WitnessProgram is the script passed as the witness subscript for witness
+	// signing. For native P2WPKH and P2TR spends, this is the output pkScript
+	// itself. For nested P2WPKH-in-P2SH spends, this is the inner witness
+	// program, for example `OP_0 <20-byte-key-hash>`.
+	WitnessProgram []byte
+
+	// RedeemScript is the P2SH redeem script that must be pushed into sigScript
+	// when the output is wrapped in P2SH. This is only set for nested witness
+	// spends, where it is a single push of the inner witness program. Native
+	// witness spends, such as P2WPKH and P2TR, leave this nil.
+	RedeemScript []byte
 }
 
 // Script represents the script information required to spend a UTXO.
@@ -135,6 +199,42 @@ type AddressManager interface {
 
 // A compile time check to ensure that Wallet implements the interface.
 var _ AddressManager = (*Wallet)(nil)
+
+// addressInfoFromManagedAddress converts one legacy managed address into the
+// wallet-owned metadata shape used by the prep work.
+func addressInfoFromManagedAddress(
+	managedAddr waddrmgr.ManagedAddress) (AddressInfo, error) {
+
+	info := AddressInfo{
+		Addr:       managedAddr.Address(),
+		AddrType:   managedAddr.AddrType(),
+		Imported:   managedAddr.Imported(),
+		Internal:   managedAddr.Internal(),
+		Compressed: managedAddr.Compressed(),
+	}
+
+	pubKeyAddr, ok := managedAddr.(waddrmgr.ManagedPubKeyAddress)
+	if !ok {
+		return info, nil
+	}
+
+	info.PubKey = pubKeyAddr.PubKey()
+
+	keyScope, derivationPath, ok := pubKeyAddr.DerivationInfo()
+	if !ok {
+		return info, nil
+	}
+
+	info.Derivation = &AddressDerivation{
+		KeyScope:             keyScope,
+		Account:              derivationPath.Account,
+		Branch:               derivationPath.Branch,
+		Index:                derivationPath.Index,
+		MasterKeyFingerprint: derivationPath.MasterKeyFingerprint,
+	}
+
+	return info, nil
+}
 
 // NewAddress returns a new address for the given account and address type.
 // This method is a low-level primitive that will always derive a new, unused

--- a/wallet/address_manager_benchmark_test.go
+++ b/wallet/address_manager_benchmark_test.go
@@ -110,11 +110,11 @@ func BenchmarkListAddressesAPI(b *testing.B) {
 	}
 }
 
-// BenchmarkAddressInfoAPI benchmarks AddressInfo API and its deprecated
+// BenchmarkGetAddressInfoAPI benchmarks GetAddressInfo API and its deprecated
 // variant using same key scope and identical test data across multiple
 // dataset sizes. Test names start with dataset size to group API comparisons
 // for benchstat analysis.
-func BenchmarkAddressInfoAPI(b *testing.B) {
+func BenchmarkGetAddressInfoAPI(b *testing.B) {
 	const (
 		// startGrowthIteration is the starting iteration index for the
 		// growth sequence.
@@ -198,7 +198,7 @@ func BenchmarkAddressInfoAPI(b *testing.B) {
 			b.ResetTimer()
 
 			for b.Loop() {
-				_, err := bw.AddressInfo(b.Context(), testAddr)
+				_, err := bw.GetAddressInfo(b.Context(), testAddr)
 				require.NoError(b, err)
 			}
 		})

--- a/wallet/address_manager_test.go
+++ b/wallet/address_manager_test.go
@@ -195,7 +195,11 @@ func TestNewAddress(t *testing.T) {
 				Return(nil).
 				Once()
 
+			deps.addr.On("Address").Return(addr).Once()
+			deps.addr.On("AddrType").Return(tc.addrType).Once()
+			deps.addr.On("Imported").Return(false).Once()
 			deps.addr.On("Internal").Return(tc.change).Once()
+			deps.addr.On("Compressed").Return(true).Once()
 
 			// Attempt to generate a new address with the specified
 			// parameters.
@@ -213,7 +217,7 @@ func TestNewAddress(t *testing.T) {
 			// internal or external.
 			addrInfo, err := w.GetAddressInfo(t.Context(), addr)
 			require.NoError(t, err)
-			require.Equal(t, tc.change, addrInfo.Internal())
+			require.Equal(t, tc.change, addrInfo.Internal)
 		})
 	}
 }
@@ -449,11 +453,11 @@ func TestGetAddressInfo(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check the external address info.
-	require.Equal(t, extAddr.String(), extInfo.Address().String())
-	require.False(t, extInfo.Internal())
-	require.True(t, extInfo.Compressed())
-	require.False(t, extInfo.Imported())
-	require.Equal(t, waddrmgr.WitnessPubKey, extInfo.AddrType())
+	require.Equal(t, extAddr.String(), extInfo.Addr.String())
+	require.False(t, extInfo.Internal)
+	require.True(t, extInfo.Compressed)
+	require.False(t, extInfo.Imported)
+	require.Equal(t, waddrmgr.WitnessPubKey, extInfo.AddrType)
 
 	// Get a new internal address to test with.
 	addr, _ = btcutil.NewAddressWitnessPubKeyHash(
@@ -485,11 +489,11 @@ func TestGetAddressInfo(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check the internal address info.
-	require.Equal(t, intAddr.String(), intInfo.Address().String())
-	require.True(t, intInfo.Internal())
-	require.True(t, intInfo.Compressed())
-	require.False(t, intInfo.Imported())
-	require.Equal(t, waddrmgr.WitnessPubKey, intInfo.AddrType())
+	require.Equal(t, intAddr.String(), intInfo.Addr.String())
+	require.True(t, intInfo.Internal)
+	require.True(t, intInfo.Compressed)
+	require.False(t, intInfo.Imported)
+	require.Equal(t, waddrmgr.WitnessPubKey, intInfo.AddrType)
 }
 
 // TestGetDerivationInfoExternalAddressSuccess tests that we can successfully
@@ -519,7 +523,11 @@ func TestGetDerivationInfoExternalAddressSuccess(t *testing.T) {
 	// Act: Get the derivation info for the address.
 	deps.addrStore.On("Address", mock.Anything, addr).
 		Return(deps.pubKeyAddr, nil).Once()
+	deps.pubKeyAddr.On("Address").Return(addr).Once()
+	deps.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
 	deps.pubKeyAddr.On("Imported").Return(false).Once()
+	deps.pubKeyAddr.On("Internal").Return(false).Once()
+	deps.pubKeyAddr.On("Compressed").Return(true).Once()
 
 	privKey, _ := btcec.NewPrivateKey()
 	pubKey := privKey.PubKey()
@@ -581,7 +589,11 @@ func TestGetDerivationInfoInternalAddressSuccess(t *testing.T) {
 	// Act: Get the derivation info for the address.
 	deps.addrStore.On("Address", mock.Anything, addr).
 		Return(deps.pubKeyAddr, nil).Once()
+	deps.pubKeyAddr.On("Address").Return(addr).Once()
+	deps.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
 	deps.pubKeyAddr.On("Imported").Return(false).Once()
+	deps.pubKeyAddr.On("Internal").Return(true).Once()
+	deps.pubKeyAddr.On("Compressed").Return(true).Once()
 
 	privKey, _ := btcec.NewPrivateKey()
 	pubKey := privKey.PubKey()
@@ -645,7 +657,7 @@ func TestGetDerivationInfoNoDerivationInfo(t *testing.T) {
 		Return(deps.accountManager, nil).Once()
 	deps.accountManager.On("ImportPublicKey", mock.Anything, pubKey,
 		mock.Anything).Return(deps.pubKeyAddr, nil).Once()
-	deps.pubKeyAddr.On("Address").Return(addr).Maybe()
+	deps.pubKeyAddr.On("Address").Return(addr).Twice()
 	deps.chain.On("NotifyReceived", []btcutil.Address{addr}).
 		Return(nil).Once()
 
@@ -656,7 +668,14 @@ func TestGetDerivationInfoNoDerivationInfo(t *testing.T) {
 	// imported key.
 	deps.addrStore.On("Address", mock.Anything, addr).
 		Return(deps.pubKeyAddr, nil).Once()
+	deps.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
 	deps.pubKeyAddr.On("Imported").Return(true).Once()
+	deps.pubKeyAddr.On("Internal").Return(false).Once()
+	deps.pubKeyAddr.On("Compressed").Return(true).Once()
+	deps.pubKeyAddr.On("PubKey").Return(pubKey).Once()
+	deps.pubKeyAddr.On("DerivationInfo").Return(
+		waddrmgr.KeyScope{}, waddrmgr.DerivationPath{}, false,
+	).Once()
 
 	_, err = w.GetDerivationInfo(t.Context(), addr)
 	require.ErrorIs(t, err, ErrDerivationPathNotFound)
@@ -797,6 +816,15 @@ func TestImportPublicKey(t *testing.T) {
 	// Check that the address is now managed by the wallet.
 	deps.addrStore.On("Address", mock.Anything, addr).
 		Return(deps.pubKeyAddr, nil).Once()
+	deps.pubKeyAddr.On("Address").Return(addr).Once()
+	deps.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
+	deps.pubKeyAddr.On("Imported").Return(true).Once()
+	deps.pubKeyAddr.On("Internal").Return(false).Once()
+	deps.pubKeyAddr.On("Compressed").Return(true).Once()
+	deps.pubKeyAddr.On("PubKey").Return(pubKey).Once()
+	deps.pubKeyAddr.On("DerivationInfo").Return(
+		waddrmgr.KeyScope{}, waddrmgr.DerivationPath{}, false,
+	).Once()
 
 	info, err := w.GetAddressInfo(t.Context(), addr)
 	require.NoError(t, err)
@@ -847,20 +875,19 @@ func TestImportTaprootScript(t *testing.T) {
 	deps.accountManager.On("ImportTaprootScript", mock.Anything,
 		mock.Anything, mock.Anything, uint8(1), false).
 		Return(deps.taprootAddr, nil).Once()
-	deps.taprootAddr.On("Address").Return(addr).Once()
+	deps.taprootAddr.On("Address").Return(addr).Twice()
+	deps.taprootAddr.On("AddrType").Return(waddrmgr.TaprootScript).Once()
+	deps.taprootAddr.On("Imported").Return(true).Once()
+	deps.taprootAddr.On("Internal").Return(false).Once()
+	deps.taprootAddr.On("Compressed").Return(false).Once()
 	deps.chain.On("NotifyReceived", []btcutil.Address{addr}).
 		Return(nil).Once()
 
-	_, err = w.ImportTaprootScript(t.Context(), tapscript)
+	info, err := w.ImportTaprootScript(t.Context(), tapscript)
 	require.NoError(t, err)
-
-	// Check that the address is now managed by the wallet.
-	deps.addrStore.On("Address", mock.Anything, addr).
-		Return(deps.taprootAddr, nil).Once()
-
-	info, err := w.GetAddressInfo(t.Context(), addr)
-	require.NoError(t, err)
-	require.NotNil(t, info)
+	require.Equal(t, addr, info.Addr)
+	require.Equal(t, waddrmgr.TaprootScript, info.AddrType)
+	require.True(t, info.Imported)
 }
 
 // TestScriptForOutput tests the ScriptForOutput method to ensure it returns the

--- a/wallet/address_manager_test.go
+++ b/wallet/address_manager_test.go
@@ -211,7 +211,7 @@ func TestNewAddress(t *testing.T) {
 
 			// Verify that the address is correctly marked as
 			// internal or external.
-			addrInfo, err := w.AddressInfo(t.Context(), addr)
+			addrInfo, err := w.GetAddressInfo(t.Context(), addr)
 			require.NoError(t, err)
 			require.Equal(t, tc.change, addrInfo.Internal())
 		})
@@ -409,9 +409,9 @@ func TestGetUnusedAddress(t *testing.T) {
 	require.Equal(t, changeAddr.String(), unusedChangeAddr.String())
 }
 
-// TestAddressInfo tests the AddressInfo method to ensure it returns correct
+// TestGetAddressInfo tests the GetAddressInfo method to ensure it returns
 // information for both internal and external addresses.
-func TestAddressInfo(t *testing.T) {
+func TestGetAddressInfo(t *testing.T) {
 	t.Parallel()
 
 	// Create a new test wallet.
@@ -445,7 +445,7 @@ func TestAddressInfo(t *testing.T) {
 	deps.addr.On("Imported").Return(false).Once()
 	deps.addr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
 
-	extInfo, err := w.AddressInfo(t.Context(), extAddr)
+	extInfo, err := w.GetAddressInfo(t.Context(), extAddr)
 	require.NoError(t, err)
 
 	// Check the external address info.
@@ -481,7 +481,7 @@ func TestAddressInfo(t *testing.T) {
 	deps.addr.On("Imported").Return(false).Once()
 	deps.addr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
 
-	intInfo, err := w.AddressInfo(t.Context(), intAddr)
+	intInfo, err := w.GetAddressInfo(t.Context(), intAddr)
 	require.NoError(t, err)
 
 	// Check the internal address info.
@@ -798,7 +798,7 @@ func TestImportPublicKey(t *testing.T) {
 	deps.addrStore.On("Address", mock.Anything, addr).
 		Return(deps.pubKeyAddr, nil).Once()
 
-	info, err := w.AddressInfo(t.Context(), addr)
+	info, err := w.GetAddressInfo(t.Context(), addr)
 	require.NoError(t, err)
 	require.NotNil(t, info)
 }
@@ -858,7 +858,7 @@ func TestImportTaprootScript(t *testing.T) {
 	deps.addrStore.On("Address", mock.Anything, addr).
 		Return(deps.taprootAddr, nil).Once()
 
-	info, err := w.AddressInfo(t.Context(), addr)
+	info, err := w.GetAddressInfo(t.Context(), addr)
 	require.NoError(t, err)
 	require.NotNil(t, info)
 }

--- a/wallet/address_manager_test.go
+++ b/wallet/address_manager_test.go
@@ -494,7 +494,7 @@ func TestGetDerivationInfoExternalAddressSuccess(t *testing.T) {
 	expectedPath := []uint32{
 		scope.Purpose + hdkeychain.HardenedKeyStart,
 		scope.Coin + hdkeychain.HardenedKeyStart,
-		path.Account,
+		path.Account + hdkeychain.HardenedKeyStart,
 		path.Branch,
 		path.Index,
 	}
@@ -560,7 +560,7 @@ func TestGetDerivationInfoInternalAddressSuccess(t *testing.T) {
 	expectedPath := []uint32{
 		scope.Purpose + hdkeychain.HardenedKeyStart,
 		scope.Coin + hdkeychain.HardenedKeyStart,
-		path.Account,
+		path.Account + hdkeychain.HardenedKeyStart,
 		path.Branch,
 		path.Index,
 	}

--- a/wallet/address_manager_test.go
+++ b/wallet/address_manager_test.go
@@ -838,7 +838,8 @@ func TestImportTaprootScript(t *testing.T) {
 func TestScriptForOutput(t *testing.T) {
 	t.Parallel()
 
-	// Create a new test wallet.
+	// Arrange: Create a started wallet, one witness output, and matching
+	// managed address metadata.
 	w, deps := createStartedWalletWithMocks(t)
 
 	// Create a new p2wkh address and output.
@@ -865,15 +866,75 @@ func TestScriptForOutput(t *testing.T) {
 		PkScript: pkScript,
 	}
 
-	// Get the script for the output.
+	_, pubKey := deterministicPrivKey(t)
+
 	deps.addrStore.On("Address", mock.Anything, addr).
 		Return(deps.pubKeyAddr, nil).Once()
+	deps.pubKeyAddr.On("Address").Return(addr).Once()
 	deps.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
+	deps.pubKeyAddr.On("Imported").Return(false).Once()
+	deps.pubKeyAddr.On("Internal").Return(false).Once()
+	deps.pubKeyAddr.On("Compressed").Return(true).Once()
+	deps.pubKeyAddr.On("PubKey").Return(pubKey).Once()
+	deps.pubKeyAddr.On("DerivationInfo").Return(
+		waddrmgr.KeyScopeBIP0084, waddrmgr.DerivationPath{}, false,
+	).Once()
 
+	// Act: Build the spending metadata for the witness output.
 	script, err := w.ScriptForOutput(t.Context(), output)
 	require.NoError(t, err)
 
-	// Check that the script is correct.
+	// Assert: The output metadata matches the native witness spend shape.
+	require.Equal(t, addr, script.Addr)
+	require.Equal(t, waddrmgr.WitnessPubKey, script.AddrType)
 	require.Equal(t, pkScript, script.WitnessProgram)
 	require.Nil(t, script.RedeemScript)
+}
+
+// TestScriptForOutputNestedWitness tests that ScriptForOutput carries the
+// redeem script needed for nested witness outputs.
+func TestScriptForOutputNestedWitness(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a started wallet, a nested witness output, and matching
+	// managed address metadata.
+	w, deps := createStartedWalletWithMocks(t)
+	_, pubKey := deterministicPrivKey(t)
+	witnessProgram, err := txscript.NewScriptBuilder().
+		AddOp(txscript.OP_0).
+		AddData(btcutil.Hash160(pubKey.SerializeCompressed())).
+		Script()
+	require.NoError(t, err)
+
+	addr, err := btcutil.NewAddressScriptHash(witnessProgram, w.cfg.ChainParams)
+	require.NoError(t, err)
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	deps.addrStore.On("Address", mock.Anything, addr).
+		Return(deps.pubKeyAddr, nil).Once()
+	deps.pubKeyAddr.On("Address").Return(addr).Once()
+	deps.pubKeyAddr.On("AddrType").Return(waddrmgr.NestedWitnessPubKey).Once()
+	deps.pubKeyAddr.On("Imported").Return(false).Once()
+	deps.pubKeyAddr.On("Internal").Return(false).Once()
+	deps.pubKeyAddr.On("Compressed").Return(true).Once()
+	deps.pubKeyAddr.On("PubKey").Return(pubKey).Once()
+	deps.pubKeyAddr.On("DerivationInfo").Return(
+		waddrmgr.KeyScopeBIP0049Plus, waddrmgr.DerivationPath{}, false,
+	).Once()
+
+	// Act: Build the spending metadata for the nested witness output.
+	scriptInfo, err := w.ScriptForOutput(t.Context(), wire.TxOut{
+		Value:    1000,
+		PkScript: pkScript,
+	})
+	require.NoError(t, err)
+
+	// Assert: The output metadata carries the inner witness program and redeem
+	// script required for nested witness spends.
+	require.Equal(t, addr, scriptInfo.Addr)
+	require.Equal(t, waddrmgr.NestedWitnessPubKey,
+		scriptInfo.AddrType)
+	require.Equal(t, witnessProgram, scriptInfo.WitnessProgram)
+	require.Equal(t, witnessProgram, scriptInfo.RedeemScript)
 }

--- a/wallet/address_manager_test.go
+++ b/wallet/address_manager_test.go
@@ -21,63 +21,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestKeyScopeFromAddrType tests the keyScopeFromAddrType method to ensure
-// it correctly maps address types to their corresponding key scopes.
-func TestKeyScopeFromAddrType(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		name          string
-		addrType      waddrmgr.AddressType
-		expectedScope waddrmgr.KeyScope
-		expectedErr   error
-	}{
-		{
-			name:          "pubkey hash",
-			addrType:      waddrmgr.PubKeyHash,
-			expectedScope: waddrmgr.KeyScopeBIP0044,
-			expectedErr:   nil,
-		},
-		{
-			name:          "witness pubkey",
-			addrType:      waddrmgr.WitnessPubKey,
-			expectedScope: waddrmgr.KeyScopeBIP0084,
-			expectedErr:   nil,
-		},
-		{
-			name:          "nested witness pubkey",
-			addrType:      waddrmgr.NestedWitnessPubKey,
-			expectedScope: waddrmgr.KeyScopeBIP0049Plus,
-			expectedErr:   nil,
-		},
-		{
-			name:          "taproot pubkey",
-			addrType:      waddrmgr.TaprootPubKey,
-			expectedScope: waddrmgr.KeyScopeBIP0086,
-			expectedErr:   nil,
-		},
-		{
-			name:        "unknown address type",
-			addrType:    waddrmgr.WitnessScript,
-			expectedErr: ErrUnknownAddrType,
-		},
-	}
-
-	w := &Wallet{
-		cfg: Config{},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			scope, err := w.keyScopeFromAddrType(tc.addrType)
-			require.ErrorIs(t, err, tc.expectedErr)
-			require.Equal(t, tc.expectedScope, scope)
-		})
-	}
-}
-
 // TestNewAddress tests the NewAddress method, ensuring it can generate
 // various address types for different accounts and correctly handles both
 // internal and external address generation.
@@ -249,7 +192,7 @@ func TestGetUnusedAddress(t *testing.T) {
 
 	// The first unused address should be the one we just created.
 	// GetUnusedAddress calls:
-	// - w.keyScopeFromAddrType
+	// - addrType.KeyScope
 	// - w.addrStore.FetchScopedKeyManager
 	// - w.findUnusedAddress (calls manager.LookupAccount and
 	//   ForEachAccountAddress)

--- a/wallet/deprecated.go
+++ b/wallet/deprecated.go
@@ -48,8 +48,7 @@ func (w *Wallet) NextAccount(scope waddrmgr.KeyScope, name string) (uint32, erro
 		return 0, err
 	}
 
-	// Validate that the scope manager can add this new account.
-	err = manager.CanAddAccount()
+	err = manager.CanAddAccountDeprecated()
 	if err != nil {
 		return 0, err
 	}

--- a/wallet/deprecated.go
+++ b/wallet/deprecated.go
@@ -5952,20 +5952,10 @@ func (w *Wallet) ImportAccountDryRun(name string,
 func (w *Wallet) ImportPublicKeyDeprecated(pubKey *btcec.PublicKey,
 	addrType waddrmgr.AddressType) error {
 
-	// Determine what key scope the public key should belong to and import
-	// it into the key scope's default imported account.
-	var keyScope waddrmgr.KeyScope
-	switch addrType {
-	case waddrmgr.NestedWitnessPubKey:
-		keyScope = waddrmgr.KeyScopeBIP0049Plus
-
-	case waddrmgr.WitnessPubKey:
-		keyScope = waddrmgr.KeyScopeBIP0084
-
-	case waddrmgr.TaprootPubKey:
-		keyScope = waddrmgr.KeyScopeBIP0086
-
-	default:
+	// Determine what key scope the public key should belong to and import it into
+	// the key scope's default imported account.
+	keyScope, err := addrType.KeyScope()
+	if err != nil {
 		return fmt.Errorf("address type %v is not supported", addrType)
 	}
 

--- a/wallet/deprecated.go
+++ b/wallet/deprecated.go
@@ -874,6 +874,32 @@ func (w *Wallet) DecorateInputsDeprecated(packet *psbt.Packet, failOnUnknown boo
 	return nil
 }
 
+// addInputInfoSegWitV0 is a deprecated compatibility wrapper for legacy PSBT
+// callers that still pass a managed pubkey address directly.
+func addInputInfoSegWitV0(in *psbt.PInput, prevTx *wire.MsgTx,
+	utxo *wire.TxOut, derivationInfo *psbt.Bip32Derivation,
+	addr waddrmgr.ManagedPubKeyAddress, redeemScript []byte) {
+
+	addInputInfoSegWitV0Common(
+		in, prevTx, utxo, derivationInfo,
+		addr.AddrType().SpendType() == waddrmgr.SpendTypeNestedWitnessKey,
+		redeemScript,
+	)
+}
+
+// createOutputInfo is a deprecated compatibility wrapper for legacy PSBT
+// callers that still pass a managed pubkey address directly.
+func createOutputInfo(txOut *wire.TxOut,
+	addr waddrmgr.ManagedPubKeyAddress) (*psbt.POutput, error) {
+
+	addressInfo, err := addressInfoFromManagedAddress(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	return createOutputInfoFromAddressInfo(txOut, addressInfo)
+}
+
 // FinalizePsbtDeprecated expects a partial transaction with all inputs and outputs fully
 // declared and tries to sign all inputs that belong to the wallet. Our wallet
 // must be the last signer of the transaction. That means, if there are any

--- a/wallet/mock_test.go
+++ b/wallet/mock_test.go
@@ -662,8 +662,8 @@ func (m *mockAccountStore) DeriveFromKeyPath(ns walletdb.ReadBucket,
 	return args.Get(0).(waddrmgr.ManagedAddress), args.Error(1)
 }
 
-// CanAddAccount implements the waddrmgr.AccountStore interface.
-func (m *mockAccountStore) CanAddAccount() error {
+// CanAddAccountDeprecated implements the waddrmgr.AccountStore interface.
+func (m *mockAccountStore) CanAddAccountDeprecated() error {
 	args := m.Called()
 	return args.Error(0)
 }

--- a/wallet/psbt_manager.go
+++ b/wallet/psbt_manager.go
@@ -431,7 +431,7 @@ func (w *Wallet) decorateInput(ctx context.Context, pInput *psbt.PInput,
 
 	// We'll then use the address to look up the managed address from the
 	// database. This will give us access to the derivation information.
-	managedAddr, err := w.AddressInfo(ctx, addr)
+	managedAddr, err := w.GetAddressInfo(ctx, addr)
 	if err != nil {
 		return fmt.Errorf("unable to get address info for %s: %w",
 			addr.String(), err)
@@ -678,7 +678,7 @@ func (w *Wallet) addChangeOutputInfo(ctx context.Context, packet *psbt.Packet,
 	}
 
 	// Then, we'll get the managed address for the change output.
-	changeAddr, err := w.AddressInfo(ctx, changeScriptInfo.Addr.Address())
+	changeAddr, err := w.GetAddressInfo(ctx, changeScriptInfo.Addr.Address())
 	if err != nil {
 		return err
 	}

--- a/wallet/psbt_manager.go
+++ b/wallet/psbt_manager.go
@@ -682,16 +682,15 @@ func (w *Wallet) addChangeOutputInfo(ctx context.Context, packet *psbt.Packet,
 	}
 
 	// We'll ensure that the change address is a public key address.
-	managedPubKeyAddr, ok := changeScriptInfo.Addr.(waddrmgr.ManagedPubKeyAddress)
-	if !ok {
+	if changeScriptInfo.PubKey == nil {
 		return ErrChangeAddressNotManagedPubKey
 	}
 
 	// With the managed address, we can now create the PSBT output
 	// information.
-	changeOutputInfo, err := createOutputInfo(
+	changeOutputInfo, err := createOutputInfoFromAddressInfo(
 		authoredTx.Tx.TxOut[authoredTx.ChangeIndex],
-		managedPubKeyAddr,
+		changeScriptInfo.AddressInfo,
 	)
 	if err != nil {
 		return err
@@ -2255,30 +2254,42 @@ func addInputInfoSegWitV1(in *psbt.PInput, utxo *wire.TxOut,
 	}}
 }
 
-// createOutputInfo creates the BIP32 derivation info for an output from our
-// internal wallet.
+// createOutputInfo creates the BIP32 derivation info for an output from a
+// managed wallet pubkey address.
 func createOutputInfo(txOut *wire.TxOut,
 	addr waddrmgr.ManagedPubKeyAddress) (*psbt.POutput, error) {
+
+	addressInfo, err := addressInfoFromManagedAddress(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	return createOutputInfoFromAddressInfo(txOut, addressInfo)
+}
+
+// createOutputInfoFromAddressInfo creates the BIP32 derivation info for an
+// output from wallet-owned address metadata.
+func createOutputInfoFromAddressInfo(txOut *wire.TxOut,
+	addr AddressInfo) (*psbt.POutput, error) {
 
 	// We don't know the derivation path for imported keys. Those shouldn't
 	// be selected as change outputs in the first place, but just to make
 	// sure we don't run into an issue, we return early for imported keys.
-	keyScope, derivationPath, isKnown := addr.DerivationInfo()
-	if !isKnown {
+	if addr.Derivation == nil || addr.PubKey == nil {
 		return nil, fmt.Errorf("error adding output info to PSBT: %w",
 			ErrImportedAddrNoDerivation)
 	}
 
 	// Include the derivation path for this output.
 	derivation := &psbt.Bip32Derivation{
-		PubKey:               addr.PubKey().SerializeCompressed(),
-		MasterKeyFingerprint: derivationPath.MasterKeyFingerprint,
+		PubKey:               addr.PubKey.SerializeCompressed(),
+		MasterKeyFingerprint: addr.Derivation.MasterKeyFingerprint,
 		Bip32Path: []uint32{
-			keyScope.Purpose + hdkeychain.HardenedKeyStart,
-			keyScope.Coin + hdkeychain.HardenedKeyStart,
-			derivationPath.Account,
-			derivationPath.Branch,
-			derivationPath.Index,
+			addr.Derivation.KeyScope.Purpose + hdkeychain.HardenedKeyStart,
+			addr.Derivation.KeyScope.Coin + hdkeychain.HardenedKeyStart,
+			addr.Derivation.Account,
+			addr.Derivation.Branch,
+			addr.Derivation.Index,
 		},
 	}
 	out := &psbt.POutput{

--- a/wallet/psbt_manager.go
+++ b/wallet/psbt_manager.go
@@ -20,6 +20,7 @@ import (
 	"github.com/btcsuite/btcwallet/pkg/btcunit"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/txauthor"
+	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 )
 
@@ -429,24 +430,33 @@ func (w *Wallet) decorateInput(ctx context.Context, pInput *psbt.PInput,
 			ErrUnableToExtractAddress, utxo.PkScript)
 	}
 
-	// We'll then use the address to look up the managed address from the
-	// database. This will give us access to the derivation information.
-	managedAddr, err := w.GetAddressInfo(ctx, addr)
+	var (
+		managedAddr waddrmgr.ManagedAddress
+		err         error
+	)
+
+	err = walletdb.View(w.cfg.DB, func(tx walletdb.ReadTx) error {
+		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+
+		managedAddr, err = w.addrStore.Address(addrmgrNs, addr)
+
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("unable to get address info for %s: %w",
 			addr.String(), err)
 	}
 
-	// We'll ensure that the managed address is a public key address, as
-	// we can only decorate inputs for which we have the private key.
+	// We'll ensure that the managed address is a public key address, as we can
+	// only decorate inputs for which we have the private key.
 	pubKeyAddr, ok := managedAddr.(waddrmgr.ManagedPubKeyAddress)
 	if !ok {
 		return fmt.Errorf("%w: addr %s", ErrNotPubKeyAddress,
 			managedAddr.Address())
 	}
 
-	// With the managed address, we can now get the derivation information
-	// for the address.
+	// With the managed address, we can now get the derivation information for the
+	// address.
 	derivation, err := derivationForManagedAddress(pubKeyAddr)
 	if err != nil {
 		return err
@@ -663,12 +673,6 @@ func (w *Wallet) populatePsbtPacket(ctx context.Context, packet *psbt.Packet,
 func (w *Wallet) addChangeOutputInfo(ctx context.Context, packet *psbt.Packet,
 	authoredTx *txauthor.AuthoredTx) error {
 
-	// TODO(yy): The calls to `w.ScriptForOutput` and `w.AddressInfo` both
-	// involve database lookups. This could be optimized to a single
-	// database call to fetch all necessary address information. However,
-	// for now, this approach favors readability over micro-optimization,
-	// as this path is not performance-critical.
-	//
 	// First, we'll get the script information for the change output.
 	changeScriptInfo, err := w.ScriptForOutput(
 		ctx, *authoredTx.Tx.TxOut[authoredTx.ChangeIndex],
@@ -677,14 +681,8 @@ func (w *Wallet) addChangeOutputInfo(ctx context.Context, packet *psbt.Packet,
 		return err
 	}
 
-	// Then, we'll get the managed address for the change output.
-	changeAddr, err := w.GetAddressInfo(ctx, changeScriptInfo.Addr.Address())
-	if err != nil {
-		return err
-	}
-
 	// We'll ensure that the change address is a public key address.
-	managedPubKeyAddr, ok := changeAddr.(waddrmgr.ManagedPubKeyAddress)
+	managedPubKeyAddr, ok := changeScriptInfo.Addr.(waddrmgr.ManagedPubKeyAddress)
 	if !ok {
 		return ErrChangeAddressNotManagedPubKey
 	}

--- a/wallet/psbt_manager.go
+++ b/wallet/psbt_manager.go
@@ -1058,22 +1058,12 @@ func addressTypeFromPurpose(purpose uint32) (waddrmgr.AddressType, error) {
 	// determine supported key scopes configured in the database, allowing
 	// for custom purposes (e.g., LND's 1017 purpose key) to be seamlessly
 	// supported without code changes here.
-	switch purpose {
-	case waddrmgr.KeyScopeBIP0044.Purpose:
-		return waddrmgr.PubKeyHash, nil
-
-	case waddrmgr.KeyScopeBIP0049Plus.Purpose:
-		return waddrmgr.NestedWitnessPubKey, nil
-
-	case waddrmgr.KeyScopeBIP0084.Purpose:
-		return waddrmgr.WitnessPubKey, nil
-
-	case waddrmgr.KeyScopeBIP0086.Purpose:
-		return waddrmgr.TaprootPubKey, nil
-
-	default:
+	addrType, err := waddrmgr.AddressTypeForPurpose(purpose)
+	if err != nil {
 		return 0, fmt.Errorf("%w: %d", ErrUnknownBip32Purpose, purpose)
 	}
+
+	return addrType, nil
 }
 
 // shouldSkipInput determines whether the input at the given index should be

--- a/wallet/psbt_manager.go
+++ b/wallet/psbt_manager.go
@@ -20,7 +20,6 @@ import (
 	"github.com/btcsuite/btcwallet/pkg/btcunit"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/txauthor"
-	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 )
 
@@ -421,43 +420,16 @@ func (w *Wallet) DecorateInputs(ctx context.Context, packet *psbt.Packet,
 func (w *Wallet) decorateInput(ctx context.Context, pInput *psbt.PInput,
 	tx *wire.MsgTx, utxo *wire.TxOut) error {
 
-	// We'll start by extracting the address from the UTXO's pkScript.
-	// This will be used to look up the managed address from the
-	// database.
-	addr := extractAddrFromPKScript(utxo.PkScript, w.cfg.ChainParams)
-	if addr == nil {
-		return fmt.Errorf("%w: from pkscript %x",
-			ErrUnableToExtractAddress, utxo.PkScript)
-	}
-
-	var (
-		managedAddr waddrmgr.ManagedAddress
-		err         error
-	)
-
-	err = walletdb.View(w.cfg.DB, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-
-		managedAddr, err = w.addrStore.Address(addrmgrNs, addr)
-
-		return err
-	})
+	// Reuse the same wallet lookup and script-construction path as the signer,
+	// so PSBT decoration and spending metadata stay in sync.
+	scriptInfo, err := w.ScriptForOutput(ctx, *utxo)
 	if err != nil {
-		return fmt.Errorf("unable to get address info for %s: %w",
-			addr.String(), err)
+		return err
 	}
 
-	// We'll ensure that the managed address is a public key address, as we can
-	// only decorate inputs for which we have the private key.
-	pubKeyAddr, ok := managedAddr.(waddrmgr.ManagedPubKeyAddress)
-	if !ok {
-		return fmt.Errorf("%w: addr %s", ErrNotPubKeyAddress,
-			managedAddr.Address())
-	}
-
-	// With the managed address, we can now get the derivation information for the
-	// address.
-	derivation, err := derivationForManagedAddress(pubKeyAddr)
+	// With the managed address, we can now get the derivation information
+	// for the address.
+	derivation, err := derivationForAddressInfo(scriptInfo.AddressInfo)
 	if err != nil {
 		return err
 	}
@@ -472,18 +444,12 @@ func (w *Wallet) decorateInput(ctx context.Context, pInput *psbt.PInput,
 
 	// For SegWit v0 inputs, we'll use the SegWit v0 helper.
 	default:
-		// We'll need to build the redeem script for the input.
-		_, redeemScript, err := buildScriptsForManagedAddress(
-			pubKeyAddr, utxo.PkScript, w.cfg.ChainParams,
-		)
-		if err != nil {
-			return err
-		}
-
-		// With the redeem script, we can now populate the PSBT
-		// input.
-		addInputInfoSegWitV0(
-			pInput, tx, utxo, derivation, managedAddr, redeemScript,
+		// With the redeem script, we can now populate the PSBT input.
+		addInputInfoSegWitV0Common(
+			pInput, tx, utxo, derivation,
+			scriptInfo.AddrType.SpendType() ==
+				waddrmgr.SpendTypeNestedWitnessKey,
+			scriptInfo.RedeemScript,
 		)
 	}
 
@@ -672,7 +638,6 @@ func (w *Wallet) populatePsbtPacket(ctx context.Context, packet *psbt.Packet,
 // for a change output to a PSBT packet.
 func (w *Wallet) addChangeOutputInfo(ctx context.Context, packet *psbt.Packet,
 	authoredTx *txauthor.AuthoredTx) error {
-
 	// First, we'll get the script information for the change output.
 	changeScriptInfo, err := w.ScriptForOutput(
 		ctx, *authoredTx.Tx.TxOut[authoredTx.ChangeIndex],
@@ -1385,40 +1350,15 @@ func createTaprootSpendDetails(pInput *psbt.PInput,
 // Returns `ErrUnknownAddressType` if the address type is not supported.
 // Returns `errAlreadySigned` if a valid signature for the derived key already
 // exists.
+//
+// NOTE: Taproot key-path spends must be routed through the taproot-specific
+// signing path before reaching this helper. Grouping `TaprootPubKey` with other
+// unsupported families here used to hide that misrouting.
 func createBip32SpendDetails(pInput *psbt.PInput, utxo *wire.TxOut,
 	addrType waddrmgr.AddressType,
 	derivation *psbt.Bip32Derivation) (SpendDetails, error) {
 
-	// Determine the script to use for signing (subScript).
-	var subScript []byte
-	switch {
-	case len(pInput.RedeemScript) > 0:
-		subScript = pInput.RedeemScript
-
-	case len(pInput.WitnessScript) > 0:
-		subScript = pInput.WitnessScript
-
-	default:
-		subScript = utxo.PkScript
-	}
-
-	var details SpendDetails
-	switch addrType {
-	case waddrmgr.WitnessPubKey, waddrmgr.NestedWitnessPubKey:
-		details = SegwitV0SpendDetails{WitnessScript: subScript}
-
-	case waddrmgr.PubKeyHash:
-		details = LegacySpendDetails{RedeemScript: subScript}
-
-	case waddrmgr.Script, waddrmgr.RawPubKey,
-		waddrmgr.WitnessScript, waddrmgr.TaprootPubKey,
-		waddrmgr.TaprootScript:
-		return nil, fmt.Errorf("%w: %v", ErrUnknownAddressType,
-			addrType)
-	default:
-		return nil, fmt.Errorf("%w: %v", ErrUnknownAddressType,
-			addrType)
-	}
+	subScript := bip32SubScript(pInput, utxo)
 
 	// Check if we have already signed this input.
 	for _, sig := range pInput.PartialSigs {
@@ -1427,7 +1367,41 @@ func createBip32SpendDetails(pInput *psbt.PInput, utxo *wire.TxOut,
 		}
 	}
 
-	return details, nil
+	signingMethod, err := addrType.SigningMethod()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrUnknownAddressType,
+			addrType)
+	}
+
+	switch signingMethod {
+	case waddrmgr.SigningMethodWitnessV0:
+		return SegwitV0SpendDetails{WitnessScript: subScript}, nil
+
+	case waddrmgr.SigningMethodLegacy:
+		return LegacySpendDetails{RedeemScript: subScript}, nil
+
+	case waddrmgr.SigningMethodTaprootKeySpend:
+		return nil, fmt.Errorf("%w: %v", ErrUnknownAddressType,
+			addrType)
+	}
+
+	return nil, fmt.Errorf("%w: %v", ErrUnknownAddressType,
+		addrType)
+}
+
+// bip32SubScript returns the subscript that should be used for bip32-based
+// signing decisions.
+func bip32SubScript(pInput *psbt.PInput, utxo *wire.TxOut) []byte {
+	switch {
+	case len(pInput.RedeemScript) > 0:
+		return pInput.RedeemScript
+
+	case len(pInput.WitnessScript) > 0:
+		return pInput.WitnessScript
+
+	default:
+		return utxo.PkScript
+	}
 }
 
 // signTaprootPsbtInput attempts to sign a single Taproot input of a PSBT.
@@ -2196,12 +2170,10 @@ func mergeOutputScripts(dest, src *psbt.POutput) error {
 	return nil
 }
 
-// addInputInfoSegWitV0 adds the UTXO and BIP32 derivation info for a
-// SegWit v0 PSBT input (p2wkh, np2wkh) from the given wallet
-// information.
-func addInputInfoSegWitV0(in *psbt.PInput, prevTx *wire.MsgTx, utxo *wire.TxOut,
-	derivationInfo *psbt.Bip32Derivation, addr waddrmgr.ManagedAddress,
-	witnessProgram []byte) {
+// addInputInfoSegWitV0Common adds the common PSBT fields for SegWit v0 inputs.
+func addInputInfoSegWitV0Common(in *psbt.PInput, prevTx *wire.MsgTx,
+	utxo *wire.TxOut, derivationInfo *psbt.Bip32Derivation,
+	isNestedWitness bool, redeemScript []byte) {
 
 	// As a fix for CVE-2020-14199 we have to always include the full
 	// non-witness UTXO in the PSBT for segwit v0.
@@ -2223,8 +2195,8 @@ func addInputInfoSegWitV0(in *psbt.PInput, prevTx *wire.MsgTx, utxo *wire.TxOut,
 	// For nested P2WKH we need to add the redeem script to the input,
 	// otherwise an offline wallet won't be able to sign for it. For normal
 	// P2WKH this will be nil.
-	if addr.AddrType() == waddrmgr.NestedWitnessPubKey {
-		in.RedeemScript = witnessProgram
+	if isNestedWitness {
+		in.RedeemScript = redeemScript
 	}
 }
 
@@ -2254,19 +2226,6 @@ func addInputInfoSegWitV1(in *psbt.PInput, utxo *wire.TxOut,
 	}}
 }
 
-// createOutputInfo creates the BIP32 derivation info for an output from a
-// managed wallet pubkey address.
-func createOutputInfo(txOut *wire.TxOut,
-	addr waddrmgr.ManagedPubKeyAddress) (*psbt.POutput, error) {
-
-	addressInfo, err := addressInfoFromManagedAddress(addr)
-	if err != nil {
-		return nil, err
-	}
-
-	return createOutputInfoFromAddressInfo(txOut, addressInfo)
-}
-
 // createOutputInfoFromAddressInfo creates the BIP32 derivation info for an
 // output from wallet-owned address metadata.
 func createOutputInfoFromAddressInfo(txOut *wire.TxOut,
@@ -2287,7 +2246,7 @@ func createOutputInfoFromAddressInfo(txOut *wire.TxOut,
 		Bip32Path: []uint32{
 			addr.Derivation.KeyScope.Purpose + hdkeychain.HardenedKeyStart,
 			addr.Derivation.KeyScope.Coin + hdkeychain.HardenedKeyStart,
-			addr.Derivation.Account,
+			addr.Derivation.Account + hdkeychain.HardenedKeyStart,
 			addr.Derivation.Branch,
 			addr.Derivation.Index,
 		},

--- a/wallet/psbt_manager_test.go
+++ b/wallet/psbt_manager_test.go
@@ -543,7 +543,7 @@ func TestDecorateInputErrImported(t *testing.T) {
 	).Return(mocks.pubKeyAddr, nil)
 
 	mocks.pubKeyAddr.On("Imported").Return(true)
-	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr)
+	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Maybe()
 
 	utxo := &wire.TxOut{
 		Value:    1000,
@@ -590,7 +590,7 @@ func TestDecorateInputErrDerivationMissing(t *testing.T) {
 	mocks.pubKeyAddr.On("DerivationInfo").Return(
 		waddrmgr.KeyScope{}, waddrmgr.DerivationPath{}, false,
 	)
-	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr)
+	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Maybe()
 
 	utxo := &wire.TxOut{
 		Value:    1000,
@@ -1166,7 +1166,7 @@ func TestAddChangeOutputInfoSuccess(t *testing.T) {
 	).Return(mocks.pubKeyAddr, nil)
 
 	// Arrange: Mock ManagedPubKeyAddress methods.
-	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr)
+	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Maybe()
 	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey)
 	mocks.pubKeyAddr.On("PubKey").Return(pubKey)
 	// Removed Imported() as addChangeOutputInfo does not call it.
@@ -1309,7 +1309,7 @@ func TestAddChangeOutputInfoErrDerivationUnknown(t *testing.T) {
 	).Return(mocks.pubKeyAddr, nil)
 
 	// Arrange: Mock ManagedPubKeyAddress methods.
-	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr)
+	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Maybe()
 	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey)
 	// PubKey is not called because DerivationInfo returns false.
 	// DerivationInfo returns false (unknown/imported).
@@ -1509,7 +1509,7 @@ func TestPopulatePsbtPacketSuccess(t *testing.T) {
 	)
 	mocks.pubKeyAddr.On("PubKey").Return(pubKey)
 	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey)
-	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr)
+	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Maybe()
 
 	// Act: Call populatePsbtPacket.
 	updatedPacket, changeIdx, err := w.populatePsbtPacket(
@@ -1648,7 +1648,7 @@ func TestFundPsbtWorkflow(t *testing.T) {
 		mock.MatchedBy(func(addr btcutil.Address) bool {
 			return addr.String() == p2wkhAddr.String()
 		}),
-	).Return(mocks.pubKeyAddr, nil).Times(3)
+	).Return(mocks.pubKeyAddr, nil).Times(2)
 
 	// --- Mock accountManager ---
 	// 3. Mock `accountManager.LookupAccount` for the default account:

--- a/wallet/psbt_manager_test.go
+++ b/wallet/psbt_manager_test.go
@@ -300,12 +300,15 @@ func TestDecorateInputSegWitV0(t *testing.T) {
 
 	// Arrange: Mock the ManagedPubKeyAddress methods to return relevant
 	// derivation and public key information.
-	mocks.pubKeyAddr.On("Imported").Return(false)
+	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Once()
+	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
+	mocks.pubKeyAddr.On("Imported").Return(false).Once()
+	mocks.pubKeyAddr.On("Internal").Return(false).Once()
+	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
+	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
 	mocks.pubKeyAddr.On("DerivationInfo").Return(
 		keyScope, derivationPath, true,
-	)
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey)
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey)
+	).Once()
 
 	// Arrange: Create a UTXO with the P2WKH script and an empty PSBT input.
 	utxo := &wire.TxOut{
@@ -377,11 +380,15 @@ func TestDecorateInputTaproot(t *testing.T) {
 	// derivation and public key information. AddrType is not strictly
 	// checked for Taproot inputs in decorateInput, so no mock is needed
 	// for it.
-	mocks.pubKeyAddr.On("Imported").Return(false)
+	mocks.pubKeyAddr.On("Address").Return(taprootAddr).Once()
+	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.TaprootPubKey).Once()
+	mocks.pubKeyAddr.On("Imported").Return(false).Once()
+	mocks.pubKeyAddr.On("Internal").Return(false).Once()
+	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
+	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
 	mocks.pubKeyAddr.On("DerivationInfo").Return(
 		keyScope, derivationPath, true,
-	)
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey)
+	).Once()
 
 	// Arrange: Create a UTXO with the Taproot script and an empty PSBT
 	// input.
@@ -500,6 +507,10 @@ func TestDecorateInputErrNotPubKey(t *testing.T) {
 	).Return(mocks.addr, nil)
 
 	mocks.addr.On("Address").Return(p2wkhAddr)
+	mocks.addr.On("AddrType").Return(waddrmgr.Script)
+	mocks.addr.On("Imported").Return(false)
+	mocks.addr.On("Internal").Return(false)
+	mocks.addr.On("Compressed").Return(false)
 
 	utxo := &wire.TxOut{
 		Value:    1000,
@@ -542,8 +553,15 @@ func TestDecorateInputErrImported(t *testing.T) {
 		"Address", mock.Anything, mock.Anything,
 	).Return(mocks.pubKeyAddr, nil)
 
-	mocks.pubKeyAddr.On("Imported").Return(true)
-	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Maybe()
+	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Once()
+	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
+	mocks.pubKeyAddr.On("Imported").Return(true).Once()
+	mocks.pubKeyAddr.On("Internal").Return(false).Once()
+	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
+	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
+	mocks.pubKeyAddr.On("DerivationInfo").Return(
+		waddrmgr.KeyScope{}, waddrmgr.DerivationPath{}, false,
+	).Once()
 
 	utxo := &wire.TxOut{
 		Value:    1000,
@@ -586,11 +604,15 @@ func TestDecorateInputErrDerivationMissing(t *testing.T) {
 		"Address", mock.Anything, mock.Anything,
 	).Return(mocks.pubKeyAddr, nil)
 
-	mocks.pubKeyAddr.On("Imported").Return(false)
+	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Once()
+	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
+	mocks.pubKeyAddr.On("Imported").Return(false).Once()
+	mocks.pubKeyAddr.On("Internal").Return(false).Once()
+	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
+	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
 	mocks.pubKeyAddr.On("DerivationInfo").Return(
 		waddrmgr.KeyScope{}, waddrmgr.DerivationPath{}, false,
-	)
-	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Maybe()
+	).Once()
 
 	utxo := &wire.TxOut{
 		Value:    1000,
@@ -604,6 +626,60 @@ func TestDecorateInputErrDerivationMissing(t *testing.T) {
 
 	// Assert: Verify the error.
 	require.ErrorIs(t, err, ErrDerivationPathNotFound)
+}
+
+// TestDecorateInputNestedWitnessUsesRedeemScript verifies that nested witness
+// PSBT decoration stores the inner witness program in the PSBT redeem script
+// field.
+func TestDecorateInputNestedWitnessUsesRedeemScript(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a nested witness UTXO and matching managed address
+	// metadata.
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	pubKey := privKey.PubKey()
+	witnessProgram, err := txscript.NewScriptBuilder().
+		AddOp(txscript.OP_0).
+		AddData(btcutil.Hash160(pubKey.SerializeCompressed())).
+		Script()
+	require.NoError(t, err)
+
+	nestedAddr, err := btcutil.NewAddressScriptHash(
+		witnessProgram, &chainParams,
+	)
+	require.NoError(t, err)
+
+	pkScript, err := txscript.PayToAddrScript(nestedAddr)
+	require.NoError(t, err)
+
+	w, mocks := createStartedWalletWithMocks(t)
+	mocks.addrStore.On(
+		"Address", mock.Anything, mock.Anything,
+	).Return(mocks.pubKeyAddr, nil)
+
+	mocks.pubKeyAddr.On("Address").Return(nestedAddr).Once()
+	mocks.pubKeyAddr.On("AddrType").Return(
+		waddrmgr.NestedWitnessPubKey,
+	).Once()
+	mocks.pubKeyAddr.On("Imported").Return(false).Once()
+	mocks.pubKeyAddr.On("Internal").Return(false).Once()
+	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
+	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
+	mocks.pubKeyAddr.On("DerivationInfo").Return(
+		waddrmgr.KeyScopeBIP0049Plus, waddrmgr.DerivationPath{}, true,
+	).Once()
+
+	pInput := &psbt.PInput{}
+	utxo := &wire.TxOut{Value: 1000, PkScript: pkScript}
+
+	// Act: Decorate the nested witness input.
+	err = w.decorateInput(t.Context(), pInput, wire.NewMsgTx(1), utxo)
+	require.NoError(t, err)
+
+	// Assert: The PSBT redeem script stores the inner witness program.
+	require.Equal(t, witnessProgram, pInput.RedeemScript)
 }
 
 // TestDecorateInputsSuccess tests that DecorateInputs correctly decorates
@@ -707,12 +783,24 @@ func TestDecorateInputsSuccess(t *testing.T) {
 	).Return(mocks.pubKeyAddr, nil)
 
 	// Arrange: Mock ManagedPubKeyAddress methods.
-	mocks.pubKeyAddr.On("Imported").Return(false)
+	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Once()
+	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
+	mocks.pubKeyAddr.On("Imported").Return(false).Once()
+	mocks.pubKeyAddr.On("Internal").Return(false).Once()
+	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
+	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
 	mocks.pubKeyAddr.On("DerivationInfo").Return(
 		waddrmgr.KeyScopeBIP0084, waddrmgr.DerivationPath{}, true,
-	)
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey)
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey)
+	).Once()
+	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Once()
+	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
+	mocks.pubKeyAddr.On("Imported").Return(false).Once()
+	mocks.pubKeyAddr.On("Internal").Return(false).Once()
+	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
+	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
+	mocks.pubKeyAddr.On("DerivationInfo").Return(
+		waddrmgr.KeyScopeBIP0084, waddrmgr.DerivationPath{}, true,
+	).Once()
 
 	// Act: Call DecorateInputs with skipUnknown=true.
 	_, err = w.DecorateInputs(t.Context(), packet, true)
@@ -1165,14 +1253,15 @@ func TestAddChangeOutputInfoSuccess(t *testing.T) {
 		}),
 	).Return(mocks.pubKeyAddr, nil)
 
-	// Arrange: Mock ManagedPubKeyAddress methods.
-	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Maybe()
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey)
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey)
-	// Removed Imported() as addChangeOutputInfo does not call it.
+	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Once()
+	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
+	mocks.pubKeyAddr.On("Imported").Return(false).Once()
+	mocks.pubKeyAddr.On("Internal").Return(false).Once()
+	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
+	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
 	mocks.pubKeyAddr.On("DerivationInfo").Return(
 		waddrmgr.KeyScopeBIP0084, waddrmgr.DerivationPath{}, true,
-	)
+	).Once()
 
 	// Act: Call addChangeOutputInfo.
 	err = w.addChangeOutputInfo(t.Context(), packet, authoredTx)
@@ -1264,6 +1353,10 @@ func TestAddChangeOutputInfoErrNotPubKey(t *testing.T) {
 		"Address", mock.Anything, mock.Anything,
 	).Return(mocks.addr, nil)
 	mocks.addr.On("Address").Return(p2wkhAddr)
+	mocks.addr.On("AddrType").Return(waddrmgr.WitnessPubKey)
+	mocks.addr.On("Imported").Return(false)
+	mocks.addr.On("Internal").Return(false)
+	mocks.addr.On("Compressed").Return(true)
 
 	// Act: Call addChangeOutputInfo.
 	err = w.addChangeOutputInfo(t.Context(), packet, authoredTx)
@@ -1308,14 +1401,15 @@ func TestAddChangeOutputInfoErrDerivationUnknown(t *testing.T) {
 		"Address", mock.Anything, mock.Anything,
 	).Return(mocks.pubKeyAddr, nil)
 
-	// Arrange: Mock ManagedPubKeyAddress methods.
-	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Maybe()
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey)
-	// PubKey is not called because DerivationInfo returns false.
-	// DerivationInfo returns false (unknown/imported).
+	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Once()
+	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
+	mocks.pubKeyAddr.On("Imported").Return(false).Once()
+	mocks.pubKeyAddr.On("Internal").Return(false).Once()
+	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
+	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
 	mocks.pubKeyAddr.On("DerivationInfo").Return(
 		waddrmgr.KeyScope{}, waddrmgr.DerivationPath{}, false,
-	)
+	).Once()
 
 	// Act: Call addChangeOutputInfo.
 	err = w.addChangeOutputInfo(t.Context(), packet, authoredTx)
@@ -1411,13 +1505,15 @@ func TestPopulatePsbtPacketErrors(t *testing.T) {
 			}),
 		).Return(mocks.pubKeyAddr, nil)
 
-		mocks.pubKeyAddr.On("Imported").Return(false)
+		mocks.pubKeyAddr.On("Address").Return(addrIn).Once()
+		mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
+		mocks.pubKeyAddr.On("Imported").Return(false).Once()
+		mocks.pubKeyAddr.On("Internal").Return(false).Once()
+		mocks.pubKeyAddr.On("Compressed").Return(true).Once()
+		mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
 		mocks.pubKeyAddr.On("DerivationInfo").Return(
-			waddrmgr.KeyScopeBIP0084, waddrmgr.DerivationPath{},
-			true,
-		)
-		mocks.pubKeyAddr.On("PubKey").Return(pubKey)
-		mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey)
+			waddrmgr.KeyScopeBIP0084, waddrmgr.DerivationPath{}, true,
+		).Once()
 
 		// Mock Address lookup for Output (Fail)
 		mocks.addrStore.On(
@@ -1502,14 +1598,26 @@ func TestPopulatePsbtPacketSuccess(t *testing.T) {
 	mocks.addrStore.On("Address", mock.Anything, mock.Anything).
 		Return(mocks.pubKeyAddr, nil)
 
-	// Arrange: Mock ManagedPubKeyAddress methods.
-	mocks.pubKeyAddr.On("Imported").Return(false)
+	// Arrange: Mock ManagedPubKeyAddress methods for both input decoration and
+	// change output info.
+	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Once()
+	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
+	mocks.pubKeyAddr.On("Imported").Return(false).Once()
+	mocks.pubKeyAddr.On("Internal").Return(false).Once()
+	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
+	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
 	mocks.pubKeyAddr.On("DerivationInfo").Return(
 		waddrmgr.KeyScopeBIP0084, waddrmgr.DerivationPath{}, true,
-	)
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey)
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey)
-	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Maybe()
+	).Once()
+	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Once()
+	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
+	mocks.pubKeyAddr.On("Imported").Return(false).Once()
+	mocks.pubKeyAddr.On("Internal").Return(false).Once()
+	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
+	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
+	mocks.pubKeyAddr.On("DerivationInfo").Return(
+		waddrmgr.KeyScopeBIP0084, waddrmgr.DerivationPath{}, true,
+	).Once()
 
 	// Act: Call populatePsbtPacket.
 	updatedPacket, changeIdx, err := w.populatePsbtPacket(
@@ -1674,16 +1782,30 @@ func TestFundPsbtWorkflow(t *testing.T) {
 	).Return([]waddrmgr.ManagedAddress{mockManagedAddr}, nil).Once()
 
 	// --- Mock pubKeyAddr (and ManagedAddress) ---
-	// 6. Mock `mockManagedAddr.Address` to return the change address:
-	mockManagedAddr.On("Address").Return(changeAddr)
+	// 6. The generated change address is read directly while assembling the
+	// transaction.
+	mockManagedAddr.On("Address").Return(changeAddr).Once()
 
-	// 9. Mock `ManagedPubKeyAddress` methods for `decorateInput`:
-	mocks.pubKeyAddr.On("Imported").Return(false)
+	// 9. Mock the metadata reads needed by both input decoration and change
+	// output info.
+	mocks.pubKeyAddr.On("Address").Return(changeAddr).Once()
+	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
+	mocks.pubKeyAddr.On("Imported").Return(false).Once()
+	mocks.pubKeyAddr.On("Internal").Return(false).Once()
+	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
+	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
 	mocks.pubKeyAddr.On("DerivationInfo").Return(
 		waddrmgr.KeyScopeBIP0084, waddrmgr.DerivationPath{}, true,
-	)
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey)
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey)
+	).Once()
+	mocks.pubKeyAddr.On("Address").Return(changeAddr).Once()
+	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
+	mocks.pubKeyAddr.On("Imported").Return(false).Once()
+	mocks.pubKeyAddr.On("Internal").Return(false).Once()
+	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
+	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
+	mocks.pubKeyAddr.On("DerivationInfo").Return(
+		waddrmgr.KeyScopeBIP0084, waddrmgr.DerivationPath{}, true,
+	).Once()
 
 	// Act: Execute the FundPsbt workflow with the configured intent.
 	fundedPacket, changeIndex, err := w.FundPsbt(t.Context(), intent)
@@ -3403,9 +3525,20 @@ func TestFinalizeInput(t *testing.T) {
 		// Arrange: Mock dependencies.
 		mocks.addrStore.On(
 			"Address", mock.Anything, mock.Anything,
-		).Return(mocks.pubKeyAddr, nil)
-		mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey)
-		mocks.pubKeyAddr.On("PrivKey").Return(privKey, nil)
+		).Return(mocks.pubKeyAddr, nil).Twice()
+		mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Once()
+		mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
+		mocks.pubKeyAddr.On("Imported").Return(false).Once()
+		mocks.pubKeyAddr.On("Internal").Return(false).Once()
+		mocks.pubKeyAddr.On("Compressed").Return(true).Once()
+		mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
+		mocks.pubKeyAddr.On("DerivationInfo").Return(
+			waddrmgr.KeyScopeBIP0084, waddrmgr.DerivationPath{}, true,
+		).Once()
+		expectDerivedSignerPrivKey(
+			t, mocks, waddrmgr.KeyScopeBIP0084,
+			waddrmgr.DerivationPath{}, privKey,
+		)
 
 		sigHashes := txscript.NewTxSigHashes(
 			tx, txscript.NewCannedPrevOutputFetcher(
@@ -3532,6 +3665,11 @@ func TestFinalizePsbtSuccess(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
+			keyScope := waddrmgr.KeyScopeBIP0084
+			if tc.addrType == waddrmgr.TaprootPubKey {
+				keyScope = waddrmgr.KeyScopeBIP0086
+			}
+
 			// Arrange: Create PSBT.
 			tx := wire.NewMsgTx(2)
 			tx.AddTxIn(&wire.TxIn{})
@@ -3553,18 +3691,24 @@ func TestFinalizePsbtSuccess(t *testing.T) {
 				mock.MatchedBy(func(a btcutil.Address) bool {
 					return a.String() == tc.addr.String()
 				}),
-			).Return(mocks.pubKeyAddr, nil)
-
-			// Arrange: Mock ManagedPubKeyAddress.
-			// Note: Address() and PubKey() are not called for
-			// P2WKH/Taproot signing paths in
-			// ComputeUnlockingScript.
-			mocks.pubKeyAddr.On("AddrType").Return(tc.addrType)
+			).Return(mocks.pubKeyAddr, nil).Twice()
+			mocks.pubKeyAddr.On("Address").Return(tc.addr).Once()
+			mocks.pubKeyAddr.On("AddrType").Return(tc.addrType).Once()
+			mocks.pubKeyAddr.On("Imported").Return(false).Once()
+			mocks.pubKeyAddr.On("Internal").Return(false).Once()
+			mocks.pubKeyAddr.On("Compressed").Return(true).Once()
+			mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
+			mocks.pubKeyAddr.On("DerivationInfo").Return(
+				keyScope, waddrmgr.DerivationPath{}, true,
+			).Once()
 
 			// Create a copy of the private key to avoid data races
 			// when parallel tests call Zero() on it.
 			privKeyCopy := *privKey
-			mocks.pubKeyAddr.On("PrivKey").Return(&privKeyCopy, nil)
+			expectDerivedSignerPrivKey(
+				t, mocks, keyScope, waddrmgr.DerivationPath{},
+				&privKeyCopy,
+			)
 
 			// Act: Call FinalizePsbt.
 			err = w.FinalizePsbt(t.Context(), packet)
@@ -3906,9 +4050,9 @@ func TestMergePsbtOutputs(t *testing.T) {
 	})
 }
 
-// TestAddInputInfoSegWitV0 tests the legacy helper for adding SegWit v0 input
-// info.
-func TestAddInputInfoSegWitV0(t *testing.T) {
+// TestAddInputInfoSegWitV0Common tests the shared helper for adding SegWit v0
+// input info.
+func TestAddInputInfoSegWitV0Common(t *testing.T) {
 	t.Parallel()
 
 	// Arrange: Setup input parameters (prevTx, utxo, derivation).
@@ -3916,15 +4060,12 @@ func TestAddInputInfoSegWitV0(t *testing.T) {
 	prevTx := wire.NewMsgTx(1)
 	utxo := &wire.TxOut{Value: 1000, PkScript: []byte{1}}
 	derivation := &psbt.Bip32Derivation{PubKey: []byte{2}}
-	witnessProgram := []byte{3}
-
-	// Mock address type.
-	mockAddr := &mockManagedAddress{}
-	mockAddr.On("AddrType").Return(waddrmgr.NestedWitnessPubKey)
+	redeemScript := []byte{3}
 
 	// Act: Call the helper.
-	addInputInfoSegWitV0(in, prevTx, utxo, derivation, mockAddr,
-		witnessProgram)
+	addInputInfoSegWitV0Common(
+		in, prevTx, utxo, derivation, true, redeemScript,
+	)
 
 	// Assert: Verify fields are populated correctly.
 	require.Equal(t, prevTx, in.NonWitnessUtxo)
@@ -3932,7 +4073,7 @@ func TestAddInputInfoSegWitV0(t *testing.T) {
 	require.Equal(t, utxo.PkScript, in.WitnessUtxo.PkScript)
 	require.Equal(t, txscript.SigHashAll, in.SighashType)
 	require.Equal(t, derivation, in.Bip32Derivation[0])
-	require.Equal(t, witnessProgram, in.RedeemScript)
+	require.Equal(t, redeemScript, in.RedeemScript)
 }
 
 // TestAddInputInfoSegWitV1 tests the legacy helper for adding SegWit v1 input

--- a/wallet/signer.go
+++ b/wallet/signer.go
@@ -796,11 +796,11 @@ func (w *Wallet) resolvePrivKey(pubKeyAddr waddrmgr.ManagedPubKeyAddress) (
 // and script assembly for a given set of parameters and a private key.
 func signAndAssembleScript(params *UnlockingScriptParams,
 	privKey *btcec.PrivateKey,
-	scriptInfo *Script) (*UnlockingScript, error) {
+	scriptInfo *OutputScriptInfo) (*UnlockingScript, error) {
 
 	// Dispatch to the correct signing logic based on the address type of
 	// the output.
-	switch scriptInfo.Addr.AddrType() {
+	switch scriptInfo.AddrType {
 	// For Taproot key-path spends, we produce a Schnorr signature.
 	case waddrmgr.TaprootPubKey:
 		witness, err := txscript.TaprootWitnessSignature(
@@ -827,9 +827,20 @@ func signAndAssembleScript(params *UnlockingScriptParams,
 			return nil, fmt.Errorf("witness sig error: %w", err)
 		}
 
+		var sigScript []byte
+		if len(scriptInfo.RedeemScript) > 0 {
+			builder := txscript.NewScriptBuilder()
+			builder.AddData(scriptInfo.RedeemScript)
+
+			sigScript, err = builder.Script()
+			if err != nil {
+				return nil, fmt.Errorf("build sig script: %w", err)
+			}
+		}
+
 		return &UnlockingScript{
 			Witness:   witness,
-			SigScript: scriptInfo.RedeemScript,
+			SigScript: sigScript,
 		}, nil
 
 	// For legacy P2PKH outputs, we'll generate a signature script.
@@ -850,11 +861,11 @@ func signAndAssembleScript(params *UnlockingScriptParams,
 	case waddrmgr.Script, waddrmgr.RawPubKey, waddrmgr.WitnessScript,
 		waddrmgr.TaprootScript:
 		return nil, fmt.Errorf("%w: %v", ErrUnsupportedAddressType,
-			scriptInfo.Addr.AddrType())
+			scriptInfo.AddrType)
 
 	default:
 		return nil, fmt.Errorf("%w: %v", ErrUnsupportedAddressType,
-			scriptInfo.Addr.AddrType())
+			scriptInfo.AddrType)
 	}
 }
 

--- a/wallet/signer.go
+++ b/wallet/signer.go
@@ -697,14 +697,7 @@ func (w *Wallet) ComputeUnlockingScript(ctx context.Context,
 	}
 
 	// The address must be a public key address.
-	pubKeyAddr, ok := scriptInfo.Addr.(waddrmgr.ManagedPubKeyAddress)
-	if !ok {
-		return nil, fmt.Errorf("%w: addr %s",
-			ErrNotPubKeyAddress, scriptInfo.Addr.Address())
-	}
-
-	// Get the private key for the derived address.
-	privKey, err := pubKeyAddr.PrivKey()
+	privKey, err := w.privKeyForOutput(*params.Output)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get private key: %w", err)
 	}
@@ -722,6 +715,81 @@ func (w *Wallet) ComputeUnlockingScript(ctx context.Context,
 	// With the private key retrieved and tweaked, we can now generate the
 	// unlocking script.
 	return signAndAssembleScript(params, privKey, &scriptInfo)
+}
+
+// privKeyForOutput returns the private key needed to sign for the given
+// previous output.
+func (w *Wallet) privKeyForOutput(output wire.TxOut) (
+	*btcec.PrivateKey, error) {
+
+	addr := extractAddrFromPKScript(output.PkScript, w.cfg.ChainParams)
+	if addr == nil {
+		return nil, fmt.Errorf("%w: from pkscript %x",
+			ErrUnableToExtractAddress, output.PkScript)
+	}
+
+	pubKeyAddr, err := w.loadManagedPubKeyAddr(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	return w.resolvePrivKey(pubKeyAddr)
+}
+
+// loadManagedPubKeyAddr loads a managed pubkey address for signer-private key
+// access.
+func (w *Wallet) loadManagedPubKeyAddr(addr btcutil.Address) (
+	waddrmgr.ManagedPubKeyAddress, error) {
+
+	var pubKeyAddr waddrmgr.ManagedPubKeyAddress
+
+	err := walletdb.View(w.cfg.DB, func(tx walletdb.ReadTx) error {
+		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+
+		managedAddr, err := w.addrStore.Address(addrmgrNs, addr)
+		if err != nil {
+			return err
+		}
+
+		var ok bool
+		pubKeyAddr, ok = managedAddr.(waddrmgr.ManagedPubKeyAddress)
+		if !ok {
+			return fmt.Errorf("%w: addr %s", ErrNotPubKeyAddress,
+				managedAddr.Address())
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return pubKeyAddr, nil
+}
+
+// resolvePrivKey resolves the private key for a managed pubkey address without
+// using output-script inspection as the private-key lookup seam.
+func (w *Wallet) resolvePrivKey(pubKeyAddr waddrmgr.ManagedPubKeyAddress) (
+	*btcec.PrivateKey, error) {
+
+	// Imported spendable keys have no derivation path, so we fall back to the
+	// dedicated private-key lookup exposed by the managed pubkey address.
+	if pubKeyAddr.Imported() {
+		return pubKeyAddr.PrivKey()
+	}
+
+	keyScope, derivationPath, ok := pubKeyAddr.DerivationInfo()
+	if !ok {
+		return nil, fmt.Errorf("%w: addr=%v", ErrDerivationPathNotFound,
+			pubKeyAddr.Address())
+	}
+
+	accountManager, err := w.addrStore.FetchScopedKeyManager(keyScope)
+	if err != nil {
+		return nil, err
+	}
+
+	return accountManager.DeriveFromKeyPathCache(derivationPath)
 }
 
 // signAndAssembleScript is a helper function that performs the final signing

--- a/wallet/signer.go
+++ b/wallet/signer.go
@@ -696,10 +696,9 @@ func (w *Wallet) ComputeUnlockingScript(ctx context.Context,
 		return nil, err
 	}
 
-	// The address must be a public key address.
-	privKey, err := w.privKeyForOutput(*params.Output)
+	privKey, err := w.privKeyForOutput(scriptInfo.Addr)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get private key: %w", err)
+		return nil, err
 	}
 	defer privKey.Zero()
 
@@ -718,15 +717,9 @@ func (w *Wallet) ComputeUnlockingScript(ctx context.Context,
 }
 
 // privKeyForOutput returns the private key needed to sign for the given
-// previous output.
-func (w *Wallet) privKeyForOutput(output wire.TxOut) (
+// wallet-controlled address.
+func (w *Wallet) privKeyForOutput(addr btcutil.Address) (
 	*btcec.PrivateKey, error) {
-
-	addr := extractAddrFromPKScript(output.PkScript, w.cfg.ChainParams)
-	if addr == nil {
-		return nil, fmt.Errorf("%w: from pkscript %x",
-			ErrUnableToExtractAddress, output.PkScript)
-	}
 
 	pubKeyAddr, err := w.loadManagedPubKeyAddr(addr)
 	if err != nil {
@@ -748,10 +741,11 @@ func (w *Wallet) loadManagedPubKeyAddr(addr btcutil.Address) (
 
 		managedAddr, err := w.addrStore.Address(addrmgrNs, addr)
 		if err != nil {
-			return err
+			return fmt.Errorf("fetch address: %w", err)
 		}
 
 		var ok bool
+
 		pubKeyAddr, ok = managedAddr.(waddrmgr.ManagedPubKeyAddress)
 		if !ok {
 			return fmt.Errorf("%w: addr %s", ErrNotPubKeyAddress,
@@ -761,7 +755,7 @@ func (w *Wallet) loadManagedPubKeyAddr(addr btcutil.Address) (
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("view signer address: %w", err)
 	}
 
 	return pubKeyAddr, nil
@@ -775,7 +769,12 @@ func (w *Wallet) resolvePrivKey(pubKeyAddr waddrmgr.ManagedPubKeyAddress) (
 	// Imported spendable keys have no derivation path, so we fall back to the
 	// dedicated private-key lookup exposed by the managed pubkey address.
 	if pubKeyAddr.Imported() {
-		return pubKeyAddr.PrivKey()
+		privKey, err := pubKeyAddr.PrivKey()
+		if err != nil {
+			return nil, fmt.Errorf("fetch imported private key: %w", err)
+		}
+
+		return privKey, nil
 	}
 
 	keyScope, derivationPath, ok := pubKeyAddr.DerivationInfo()
@@ -786,10 +785,59 @@ func (w *Wallet) resolvePrivKey(pubKeyAddr waddrmgr.ManagedPubKeyAddress) (
 
 	accountManager, err := w.addrStore.FetchScopedKeyManager(keyScope)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("fetch scoped key manager: %w", err)
 	}
 
-	return accountManager.DeriveFromKeyPathCache(derivationPath)
+	privKey, err := accountManager.DeriveFromKeyPathCache(derivationPath)
+	if err == nil {
+		return privKey, nil
+	}
+
+	// Only a cold account cache warrants the slower DB-backed fallback. Other
+	// derivation errors are real failures that re-running through the database
+	// will not repair.
+	if !waddrmgr.IsError(err, waddrmgr.ErrAccountNotCached) {
+		return nil, fmt.Errorf("derive private key from cache: %w", err)
+	}
+
+	return w.resolveDerivedPrivKey(accountManager, derivationPath)
+}
+
+// resolveDerivedPrivKey resolves one derived private key through the normal
+// database-backed derivation path after a cache miss.
+func (w *Wallet) resolveDerivedPrivKey(accountManager waddrmgr.AccountStore,
+	derivationPath waddrmgr.DerivationPath) (*btcec.PrivateKey, error) {
+
+	var privKey *btcec.PrivateKey
+
+	err := walletdb.View(w.cfg.DB, func(tx walletdb.ReadTx) error {
+		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+
+		managedAddr, err := accountManager.DeriveFromKeyPath(
+			addrmgrNs, derivationPath,
+		)
+		if err != nil {
+			return fmt.Errorf("derive private key from db: %w", err)
+		}
+
+		pubKeyAddr, ok := managedAddr.(waddrmgr.ManagedPubKeyAddress)
+		if !ok {
+			return fmt.Errorf("%w: addr %s", ErrNotPubKeyAddress,
+				managedAddr.Address())
+		}
+
+		privKey, err = pubKeyAddr.PrivKey()
+		if err != nil {
+			return fmt.Errorf("fetch derived private key: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("view signer derivation: %w", err)
+	}
+
+	return privKey, nil
 }
 
 // signAndAssembleScript is a helper function that performs the final signing
@@ -798,11 +846,15 @@ func signAndAssembleScript(params *UnlockingScriptParams,
 	privKey *btcec.PrivateKey,
 	scriptInfo *OutputScriptInfo) (*UnlockingScript, error) {
 
-	// Dispatch to the correct signing logic based on the address type of
-	// the output.
-	switch scriptInfo.AddrType {
-	// For Taproot key-path spends, we produce a Schnorr signature.
-	case waddrmgr.TaprootPubKey:
+	// Dispatch to the correct signing logic based on the address type signing
+	// method.
+	signingMethod, err := scriptInfo.AddrType.SigningMethod()
+	if err != nil {
+		return nil, fmt.Errorf("determine signing method: %w", err)
+	}
+
+	switch signingMethod {
+	case waddrmgr.SigningMethodTaprootKeySpend:
 		witness, err := txscript.TaprootWitnessSignature(
 			params.Tx, params.SigHashes, params.InputIndex,
 			params.Output.Value, params.Output.PkScript,
@@ -812,12 +864,9 @@ func signAndAssembleScript(params *UnlockingScriptParams,
 			return nil, fmt.Errorf("taproot witness error: %w", err)
 		}
 
-		return &UnlockingScript{
-			Witness: witness,
-		}, nil
+		return &UnlockingScript{Witness: witness}, nil
 
-	// For SegWit v0 outputs, we'll generate a standard ECDSA signature.
-	case waddrmgr.WitnessPubKey, waddrmgr.NestedWitnessPubKey:
+	case waddrmgr.SigningMethodWitnessV0:
 		witness, err := txscript.WitnessSignature(
 			params.Tx, params.SigHashes, params.InputIndex,
 			params.Output.Value, scriptInfo.WitnessProgram,
@@ -827,15 +876,9 @@ func signAndAssembleScript(params *UnlockingScriptParams,
 			return nil, fmt.Errorf("witness sig error: %w", err)
 		}
 
-		var sigScript []byte
-		if len(scriptInfo.RedeemScript) > 0 {
-			builder := txscript.NewScriptBuilder()
-			builder.AddData(scriptInfo.RedeemScript)
-
-			sigScript, err = builder.Script()
-			if err != nil {
-				return nil, fmt.Errorf("build sig script: %w", err)
-			}
+		sigScript, err := redeemSigScript(scriptInfo.RedeemScript)
+		if err != nil {
+			return nil, err
 		}
 
 		return &UnlockingScript{
@@ -843,8 +886,7 @@ func signAndAssembleScript(params *UnlockingScriptParams,
 			SigScript: sigScript,
 		}, nil
 
-	// For legacy P2PKH outputs, we'll generate a signature script.
-	case waddrmgr.PubKeyHash:
+	case waddrmgr.SigningMethodLegacy:
 		sigScript, err := txscript.SignatureScript(
 			params.Tx, params.InputIndex, params.Output.PkScript,
 			params.HashType, privKey, true,
@@ -853,20 +895,30 @@ func signAndAssembleScript(params *UnlockingScriptParams,
 			return nil, fmt.Errorf("sig script error: %w", err)
 		}
 
-		return &UnlockingScript{
-			SigScript: sigScript,
-		}, nil
-
-	// The following address types are not supported by this function.
-	case waddrmgr.Script, waddrmgr.RawPubKey, waddrmgr.WitnessScript,
-		waddrmgr.TaprootScript:
-		return nil, fmt.Errorf("%w: %v", ErrUnsupportedAddressType,
-			scriptInfo.AddrType)
+		return &UnlockingScript{SigScript: sigScript}, nil
 
 	default:
 		return nil, fmt.Errorf("%w: %v", ErrUnsupportedAddressType,
 			scriptInfo.AddrType)
 	}
+}
+
+// redeemSigScript wraps a redeem script into the final scriptSig push required
+// for nested witness spends.
+func redeemSigScript(redeemScript []byte) ([]byte, error) {
+	if len(redeemScript) == 0 {
+		return nil, nil
+	}
+
+	builder := txscript.NewScriptBuilder()
+	builder.AddData(redeemScript)
+
+	sigScript, err := builder.Script()
+	if err != nil {
+		return nil, fmt.Errorf("build sig script: %w", err)
+	}
+
+	return sigScript, nil
 }
 
 // ComputeRawSig generates a raw signature for a single transaction input. The

--- a/wallet/signer_test.go
+++ b/wallet/signer_test.go
@@ -251,6 +251,22 @@ func deterministicPrivKey(t *testing.T) (*btcec.PrivateKey, *btcec.PublicKey) {
 	return privKey, pubKey
 }
 
+// expectDerivedSignerPrivKey wires the signer-private key lookup path for a
+// derived managed pubkey address.
+func expectDerivedSignerPrivKey(t *testing.T, mocks *mockWalletDeps,
+	scope waddrmgr.KeyScope, path waddrmgr.DerivationPath,
+	privKey *btcec.PrivateKey) {
+
+	t.Helper()
+
+	mocks.pubKeyAddr.On("Imported").Return(false).Once()
+	mocks.pubKeyAddr.On("DerivationInfo").Return(scope, path, true).Once()
+	mocks.addrStore.On("FetchScopedKeyManager", scope).
+		Return(mocks.accountManager, nil).Once()
+	mocks.accountManager.On("DeriveFromKeyPathCache", path).
+		Return(privKey, nil).Once()
+}
+
 // TestSignDigest tests the signing of a message digest with different signature
 // types.
 func TestSignDigest(t *testing.T) {
@@ -564,14 +580,21 @@ func TestComputeUnlockingScriptP2PKH(t *testing.T) {
 	// fetch the key from the database.
 	mocks.addrStore.On("Address",
 		mock.Anything, addr,
-	).Return(mocks.pubKeyAddr, nil)
+	).Return(mocks.pubKeyAddr, nil).Twice()
 	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.PubKeyHash).Twice()
 
 	// Configure the full mock chain to return the test private key.
 	//
 	// NOTE: We must use a copy since the ECDH method will zero out the key.
 	privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
-	mocks.pubKeyAddr.On("PrivKey").Return(privKeyCopy, nil)
+	expectDerivedSignerPrivKey(
+		t, mocks, waddrmgr.KeyScopeBIP0044, waddrmgr.DerivationPath{
+			InternalAccount: 0,
+			Account:         0,
+			Branch:          0,
+			Index:           0,
+		}, privKeyCopy,
+	)
 
 	// Act: With the setup complete, we can now ask the wallet to compute
 	// the unlocking script.
@@ -635,14 +658,21 @@ func TestComputeUnlockingScriptP2WKH(t *testing.T) {
 	// when queried, will provide the private key for signing.
 	mocks.addrStore.On("Address",
 		mock.Anything, addr,
-	).Return(mocks.pubKeyAddr, nil)
+	).Return(mocks.pubKeyAddr, nil).Twice()
 	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Twice()
 
 	// Configure the full mock chain to return the test private key.
 	//
 	// NOTE: We must use a copy since the ECDH method will zero out the key.
 	privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
-	mocks.pubKeyAddr.On("PrivKey").Return(privKeyCopy, nil)
+	expectDerivedSignerPrivKey(
+		t, mocks, waddrmgr.KeyScopeBIP0084, waddrmgr.DerivationPath{
+			InternalAccount: 0,
+			Account:         0,
+			Branch:          0,
+			Index:           0,
+		}, privKeyCopy,
+	)
 
 	// Act: With the setup complete, we can now ask the wallet to compute
 	// the unlocking script.
@@ -710,7 +740,7 @@ func TestComputeUnlockingScriptNP2WKH(t *testing.T) {
 	// program, so we mock that as well.
 	mocks.addrStore.On("Address",
 		mock.Anything, addr,
-	).Return(mocks.pubKeyAddr, nil)
+	).Return(mocks.pubKeyAddr, nil).Twice()
 	mocks.pubKeyAddr.On("AddrType").Return(
 		waddrmgr.NestedWitnessPubKey).Twice()
 	mocks.pubKeyAddr.On("PubKey").Return(pubKey)
@@ -719,7 +749,14 @@ func TestComputeUnlockingScriptNP2WKH(t *testing.T) {
 	//
 	// NOTE: We must use a copy since the ECDH method will zero out the key.
 	privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
-	mocks.pubKeyAddr.On("PrivKey").Return(privKeyCopy, nil)
+	expectDerivedSignerPrivKey(
+		t, mocks, waddrmgr.KeyScopeBIP0049Plus, waddrmgr.DerivationPath{
+			InternalAccount: 0,
+			Account:         0,
+			Branch:          0,
+			Index:           0,
+		}, privKeyCopy,
+	)
 
 	// Act: With the setup complete, we can now ask the wallet to compute
 	// the unlocking script.
@@ -785,14 +822,21 @@ func TestComputeUnlockingScriptP2TR(t *testing.T) {
 	// when queried, will provide the private key for signing.
 	mocks.addrStore.On("Address",
 		mock.Anything, addr,
-	).Return(mocks.pubKeyAddr, nil)
+	).Return(mocks.pubKeyAddr, nil).Twice()
 	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.TaprootPubKey).Twice()
 
 	// Configure the full mock chain to return the test private key.
 	//
 	// NOTE: We must use a copy since the ECDH method will zero out the key.
 	privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
-	mocks.pubKeyAddr.On("PrivKey").Return(privKeyCopy, nil)
+	expectDerivedSignerPrivKey(
+		t, mocks, waddrmgr.KeyScopeBIP0086, waddrmgr.DerivationPath{
+			InternalAccount: 0,
+			Account:         0,
+			Branch:          0,
+			Index:           0,
+		}, privKeyCopy,
+	)
 
 	// Act: With the setup complete, we can now ask the wallet to compute
 	// the unlocking script. For Taproot, we must use a multi-output
@@ -901,12 +945,29 @@ func TestComputeUnlockingScriptFail_PrivKey(t *testing.T) {
 
 	// Mock address store and managed address.
 	mocks.addrStore.On("Address", mock.Anything, addr).
-		Return(mocks.pubKeyAddr, nil).Once()
+		Return(mocks.pubKeyAddr, nil).Twice()
 	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.PubKeyHash)
 
-	// Mock private key retrieval failure.
-	mocks.pubKeyAddr.On("PrivKey").Return((*btcec.PrivateKey)(nil),
-		errPrivKeyMock).Once()
+	mocks.pubKeyAddr.On("Imported").Return(false).Once()
+	mocks.pubKeyAddr.On("DerivationInfo").Return(
+		waddrmgr.KeyScopeBIP0044,
+		waddrmgr.DerivationPath{
+			InternalAccount: 0,
+			Account:         0,
+			Branch:          0,
+			Index:           0,
+		}, true,
+	).Once()
+	mocks.addrStore.On("FetchScopedKeyManager", waddrmgr.KeyScopeBIP0044).
+		Return(mocks.accountManager, nil).Once()
+	mocks.accountManager.On("DeriveFromKeyPathCache",
+		waddrmgr.DerivationPath{
+			InternalAccount: 0,
+			Account:         0,
+			Branch:          0,
+			Index:           0,
+		},
+	).Return((*btcec.PrivateKey)(nil), errPrivKeyMock).Once()
 
 	params := &UnlockingScriptParams{
 		Tx:        tx,
@@ -947,11 +1008,18 @@ func TestComputeUnlockingScriptFail_Tweak(t *testing.T) {
 
 	// Mock address store and managed address.
 	mocks.addrStore.On("Address", mock.Anything, addr).
-		Return(mocks.pubKeyAddr, nil).Once()
+		Return(mocks.pubKeyAddr, nil).Twice()
 	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.PubKeyHash)
 
 	privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
-	mocks.pubKeyAddr.On("PrivKey").Return(privKeyCopy, nil).Once()
+	expectDerivedSignerPrivKey(
+		t, mocks, waddrmgr.KeyScopeBIP0044, waddrmgr.DerivationPath{
+			InternalAccount: 0,
+			Account:         0,
+			Branch:          0,
+			Index:           0,
+		}, privKeyCopy,
+	)
 
 	// Define failing tweaker.
 	params := &UnlockingScriptParams{
@@ -997,9 +1065,10 @@ func TestComputeUnlockingScriptFail_UnsupportedAddr(t *testing.T) {
 
 	// Mock address store and managed address.
 	mocks.addrStore.On("Address", mock.Anything, addr).
-		Return(mocks.pubKeyAddr, nil).Once()
+		Return(mocks.pubKeyAddr, nil).Twice()
 
 	privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
+	mocks.pubKeyAddr.On("Imported").Return(true).Once()
 	mocks.pubKeyAddr.On("PrivKey").Return(privKeyCopy, nil).Once()
 
 	// Mock unsupported address type.
@@ -1042,9 +1111,10 @@ func TestComputeUnlockingScriptUnknownAddrType(t *testing.T) {
 
 	// Mock address lookup to return a valid managed address.
 	mocks.addrStore.On("Address", mock.Anything, addr).
-		Return(mocks.pubKeyAddr, nil).Once()
+		Return(mocks.pubKeyAddr, nil).Twice()
 
 	// Mock private key retrieval to succeed.
+	mocks.pubKeyAddr.On("Imported").Return(true).Once()
 	mocks.pubKeyAddr.On("PrivKey").Return(privKeyCopy, nil).Once()
 
 	// Mock the address type to return an unknown type (e.g. 99) that falls

--- a/wallet/signer_test.go
+++ b/wallet/signer_test.go
@@ -581,7 +581,20 @@ func TestComputeUnlockingScriptP2PKH(t *testing.T) {
 	mocks.addrStore.On("Address",
 		mock.Anything, addr,
 	).Return(mocks.pubKeyAddr, nil).Twice()
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.PubKeyHash).Twice()
+	mocks.pubKeyAddr.On("Address").Return(addr).Once()
+	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.PubKeyHash).Once()
+	mocks.pubKeyAddr.On("Imported").Return(false).Once()
+	mocks.pubKeyAddr.On("Internal").Return(false).Once()
+	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
+	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
+	mocks.pubKeyAddr.On("DerivationInfo").Return(
+		waddrmgr.KeyScopeBIP0044, waddrmgr.DerivationPath{
+			InternalAccount: 0,
+			Account:         0,
+			Branch:          0,
+			Index:           0,
+		}, true,
+	).Once()
 
 	// Configure the full mock chain to return the test private key.
 	//
@@ -659,7 +672,20 @@ func TestComputeUnlockingScriptP2WKH(t *testing.T) {
 	mocks.addrStore.On("Address",
 		mock.Anything, addr,
 	).Return(mocks.pubKeyAddr, nil).Twice()
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Twice()
+	mocks.pubKeyAddr.On("Address").Return(addr).Once()
+	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
+	mocks.pubKeyAddr.On("Imported").Return(false).Once()
+	mocks.pubKeyAddr.On("Internal").Return(false).Once()
+	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
+	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
+	mocks.pubKeyAddr.On("DerivationInfo").Return(
+		waddrmgr.KeyScopeBIP0084, waddrmgr.DerivationPath{
+			InternalAccount: 0,
+			Account:         0,
+			Branch:          0,
+			Index:           0,
+		}, true,
+	).Once()
 
 	// Configure the full mock chain to return the test private key.
 	//
@@ -741,9 +767,20 @@ func TestComputeUnlockingScriptNP2WKH(t *testing.T) {
 	mocks.addrStore.On("Address",
 		mock.Anything, addr,
 	).Return(mocks.pubKeyAddr, nil).Twice()
-	mocks.pubKeyAddr.On("AddrType").Return(
-		waddrmgr.NestedWitnessPubKey).Twice()
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey)
+	mocks.pubKeyAddr.On("Address").Return(addr).Once()
+	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.NestedWitnessPubKey).Once()
+	mocks.pubKeyAddr.On("Imported").Return(false).Once()
+	mocks.pubKeyAddr.On("Internal").Return(false).Once()
+	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
+	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
+	mocks.pubKeyAddr.On("DerivationInfo").Return(
+		waddrmgr.KeyScopeBIP0049Plus, waddrmgr.DerivationPath{
+			InternalAccount: 0,
+			Account:         0,
+			Branch:          0,
+			Index:           0,
+		}, true,
+	).Once()
 
 	// Configure the full mock chain to return the test private key.
 	//
@@ -823,7 +860,20 @@ func TestComputeUnlockingScriptP2TR(t *testing.T) {
 	mocks.addrStore.On("Address",
 		mock.Anything, addr,
 	).Return(mocks.pubKeyAddr, nil).Twice()
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.TaprootPubKey).Twice()
+	mocks.pubKeyAddr.On("Address").Return(addr).Once()
+	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.TaprootPubKey).Once()
+	mocks.pubKeyAddr.On("Imported").Return(false).Once()
+	mocks.pubKeyAddr.On("Internal").Return(false).Once()
+	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
+	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
+	mocks.pubKeyAddr.On("DerivationInfo").Return(
+		waddrmgr.KeyScopeBIP0086, waddrmgr.DerivationPath{
+			InternalAccount: 0,
+			Account:         0,
+			Branch:          0,
+			Index:           0,
+		}, true,
+	).Once()
 
 	// Configure the full mock chain to return the test private key.
 	//
@@ -946,8 +996,20 @@ func TestComputeUnlockingScriptFail_PrivKey(t *testing.T) {
 	// Mock address store and managed address.
 	mocks.addrStore.On("Address", mock.Anything, addr).
 		Return(mocks.pubKeyAddr, nil).Twice()
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.PubKeyHash)
-
+	mocks.pubKeyAddr.On("Address").Return(addr).Once()
+	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.PubKeyHash).Once()
+	mocks.pubKeyAddr.On("Imported").Return(false).Once()
+	mocks.pubKeyAddr.On("Internal").Return(false).Once()
+	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
+	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
+	mocks.pubKeyAddr.On("DerivationInfo").Return(
+		waddrmgr.KeyScopeBIP0044, waddrmgr.DerivationPath{
+			InternalAccount: 0,
+			Account:         0,
+			Branch:          0,
+			Index:           0,
+		}, true,
+	).Once()
 	mocks.pubKeyAddr.On("Imported").Return(false).Once()
 	mocks.pubKeyAddr.On("DerivationInfo").Return(
 		waddrmgr.KeyScopeBIP0044,
@@ -958,6 +1020,7 @@ func TestComputeUnlockingScriptFail_PrivKey(t *testing.T) {
 			Index:           0,
 		}, true,
 	).Once()
+
 	mocks.addrStore.On("FetchScopedKeyManager", waddrmgr.KeyScopeBIP0044).
 		Return(mocks.accountManager, nil).Once()
 	mocks.accountManager.On("DeriveFromKeyPathCache",
@@ -981,6 +1044,48 @@ func TestComputeUnlockingScriptFail_PrivKey(t *testing.T) {
 
 	// Assert: Verify error.
 	require.ErrorContains(t, err, "privkey error")
+}
+
+// TestResolvePrivKeyFallsBackAfterCacheMiss tests that derived private key
+// resolution falls back to DB-backed derivation when the account cache is cold.
+func TestResolvePrivKeyFallsBackAfterCacheMiss(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a started wallet and configure the signer key lookup path
+	// to miss the account cache before falling back to DB-backed derivation.
+	w, mocks := createStartedWalletWithMocks(t)
+	privKey, _ := deterministicPrivKey(t)
+	path := waddrmgr.DerivationPath{
+		InternalAccount: 0,
+		Account:         0,
+		Branch:          0,
+		Index:           1,
+	}
+
+	mocks.pubKeyAddr.On("Imported").Return(false).Once()
+	mocks.pubKeyAddr.On("DerivationInfo").Return(
+		waddrmgr.KeyScopeBIP0084, path, true,
+	).Once()
+	mocks.addrStore.On("FetchScopedKeyManager", waddrmgr.KeyScopeBIP0084).
+		Return(mocks.accountManager, nil).Once()
+	mocks.accountManager.On("DeriveFromKeyPathCache", path).
+		Return(
+			(*btcec.PrivateKey)(nil),
+			waddrmgr.ManagerError{
+				ErrorCode:   waddrmgr.ErrAccountNotCached,
+				Description: "account not cached",
+			},
+		).Once()
+	mocks.accountManager.On("DeriveFromKeyPath", mock.Anything, path).
+		Return(mocks.pubKeyAddr, nil).Once()
+	mocks.pubKeyAddr.On("PrivKey").Return(privKey, nil).Once()
+
+	// Act: Resolve the private key for the managed pubkey address.
+	resolvedPrivKey, err := w.resolvePrivKey(mocks.pubKeyAddr)
+	require.NoError(t, err)
+
+	// Assert: The fallback path returns the same private key bytes.
+	require.Equal(t, privKey.Serialize(), resolvedPrivKey.Serialize())
 }
 
 // TestComputeUnlockingScriptFail_Tweak tests failure when the tweaker fails.
@@ -1009,7 +1114,20 @@ func TestComputeUnlockingScriptFail_Tweak(t *testing.T) {
 	// Mock address store and managed address.
 	mocks.addrStore.On("Address", mock.Anything, addr).
 		Return(mocks.pubKeyAddr, nil).Twice()
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.PubKeyHash)
+	mocks.pubKeyAddr.On("Address").Return(addr).Once()
+	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.PubKeyHash).Once()
+	mocks.pubKeyAddr.On("Imported").Return(false).Once()
+	mocks.pubKeyAddr.On("Internal").Return(false).Once()
+	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
+	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
+	mocks.pubKeyAddr.On("DerivationInfo").Return(
+		waddrmgr.KeyScopeBIP0044, waddrmgr.DerivationPath{
+			InternalAccount: 0,
+			Account:         0,
+			Branch:          0,
+			Index:           0,
+		}, true,
+	).Once()
 
 	privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
 	expectDerivedSignerPrivKey(
@@ -1045,7 +1163,7 @@ func TestComputeUnlockingScriptFail_UnsupportedAddr(t *testing.T) {
 	t.Parallel()
 
 	// Arrange: Set up keys, address, and transaction.
-	privKey, pubKey := deterministicPrivKey(t)
+	_, pubKey := deterministicPrivKey(t)
 	addr, err := btcutil.NewAddressPubKeyHash(
 		btcutil.Hash160(pubKey.SerializeCompressed()), &chainParams,
 	)
@@ -1065,14 +1183,16 @@ func TestComputeUnlockingScriptFail_UnsupportedAddr(t *testing.T) {
 
 	// Mock address store and managed address.
 	mocks.addrStore.On("Address", mock.Anything, addr).
-		Return(mocks.pubKeyAddr, nil).Twice()
-
-	privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
-	mocks.pubKeyAddr.On("Imported").Return(true).Once()
-	mocks.pubKeyAddr.On("PrivKey").Return(privKeyCopy, nil).Once()
-
-	// Mock unsupported address type.
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.RawPubKey)
+		Return(mocks.pubKeyAddr, nil).Once()
+	mocks.pubKeyAddr.On("Address").Return(addr).Once()
+	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.RawPubKey).Once()
+	mocks.pubKeyAddr.On("Imported").Return(false).Once()
+	mocks.pubKeyAddr.On("Internal").Return(false).Once()
+	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
+	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
+	mocks.pubKeyAddr.On("DerivationInfo").Return(
+		waddrmgr.KeyScopeBIP0044, waddrmgr.DerivationPath{}, false,
+	).Once()
 
 	params := &UnlockingScriptParams{
 		Tx:        tx,
@@ -1096,8 +1216,7 @@ func TestComputeUnlockingScriptUnknownAddrType(t *testing.T) {
 	// Arrange: Set up the wallet, mocks, keys, and transaction.
 	w, mocks := createUnlockedWalletWithMocks(t)
 
-	privKey, pubKey := deterministicPrivKey(t)
-	privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
+	_, pubKey := deterministicPrivKey(t)
 	addr, err := btcutil.NewAddressPubKeyHash(
 		btcutil.Hash160(pubKey.SerializeCompressed()),
 		w.cfg.ChainParams,
@@ -1111,14 +1230,18 @@ func TestComputeUnlockingScriptUnknownAddrType(t *testing.T) {
 
 	// Mock address lookup to return a valid managed address.
 	mocks.addrStore.On("Address", mock.Anything, addr).
-		Return(mocks.pubKeyAddr, nil).Twice()
+		Return(mocks.pubKeyAddr, nil).Once()
+	mocks.pubKeyAddr.On("Address").Return(addr).Once()
+	mocks.pubKeyAddr.On("Imported").Return(false).Once()
+	mocks.pubKeyAddr.On("Internal").Return(false).Once()
+	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
+	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
+	mocks.pubKeyAddr.On("DerivationInfo").Return(
+		waddrmgr.KeyScope{}, waddrmgr.DerivationPath{}, false,
+	).Once()
 
-	// Mock private key retrieval to succeed.
-	mocks.pubKeyAddr.On("Imported").Return(true).Once()
-	mocks.pubKeyAddr.On("PrivKey").Return(privKeyCopy, nil).Once()
-
-	// Mock the address type to return an unknown type (e.g. 99) that falls
-	// through the switch statement in signAndAssembleScript.
+	// Mock the address type to return an unknown type (e.g. 99) so the address
+	// descriptor lookup fails before signing begins.
 	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.AddressType(99))
 
 	fetcher := txscript.NewCannedPrevOutputFetcher(pkScript, 10000)
@@ -1133,7 +1256,8 @@ func TestComputeUnlockingScriptUnknownAddrType(t *testing.T) {
 	// Act: Attempt to compute the unlocking script.
 	_, err = w.ComputeUnlockingScript(t.Context(), params)
 
-	// Assert: Verify that the unsupported address type error is returned.
+	// Assert: Verify that the unknown address type is rejected while building
+	// output metadata.
 	require.ErrorIs(t, err, ErrUnsupportedAddressType)
 }
 

--- a/wallet/tx_creator.go
+++ b/wallet/tx_creator.go
@@ -1006,31 +1006,6 @@ func inputYieldsPositively(credit *wire.TxOut,
 	return inputFee < btcutil.Amount(credit.Value)
 }
 
-func getScriptSize(addrType waddrmgr.AddressType) (int, error) {
-	switch addrType {
-	case waddrmgr.PubKeyHash:
-		return txsizes.P2PKHPkScriptSize, nil
-
-	case waddrmgr.NestedWitnessPubKey:
-		return txsizes.NestedP2WPKHPkScriptSize, nil
-
-	case waddrmgr.WitnessPubKey:
-		return txsizes.P2WPKHPkScriptSize, nil
-
-	case waddrmgr.TaprootPubKey:
-		return txsizes.P2TRPkScriptSize, nil
-
-	case waddrmgr.Script, waddrmgr.RawPubKey, waddrmgr.WitnessScript,
-		waddrmgr.TaprootScript:
-		return 0, fmt.Errorf("%w: %v", ErrUnsupportedAddressType,
-			addrType)
-
-	default:
-		return 0, fmt.Errorf("%w: %v", ErrUnsupportedAddressType,
-			addrType)
-	}
-}
-
 // addrMgrWithChangeSource returns the address manager bucket and a change
 // source that returns change addresses from said address manager. The change
 // addresses will come from the specified key scope and account, unless a key
@@ -1067,9 +1042,10 @@ func (w *Wallet) addrMgrWithChangeSource(dbtx walletdb.ReadWriteTx,
 	}
 
 	// Compute the expected size of the script for the change address type.
-	scriptSize, err := getScriptSize(addrType)
+	scriptSize, err := addrType.ScriptPubKeySize()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("%w: %v", ErrUnsupportedAddressType,
+			addrType)
 	}
 
 	newChangeScript := func() ([]byte, error) {


### PR DESCRIPTION
## Summary
- add wallet-owned `AddressInfo` and `OutputScriptInfo` types so wallet-facing lookup paths stop exposing `waddrmgr.ManagedAddress`
- separate signer private-key access from general address inspection, keeping key retrieval on signer-specific paths while preserving existing signing behavior
- centralize address metadata, signing policy, and imported pubkey derivation on `waddrmgr.AddressType` so wallet and manager code can use methods instead of repeating address-type switches

## Testing
- `GOWORK=off go test ./waddrmgr ./wallet ./wallet/internal/db/...`