### PR TITLE
wallet: simplify pagination api

### DIFF
--- a/wallet/internal/db/addresses_common.go
+++ b/wallet/internal/db/addresses_common.go
@@ -364,7 +364,7 @@ func GetAddress[T any, Args any](ctx context.Context,
 func NextListAddressesQuery(q ListAddressesQuery,
 	cursor uint32) ListAddressesQuery {
 
-	q.Page = q.Page.WithAfter(cursor)
+	q.Page.After = &cursor
 
 	return q
 }

--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -52,7 +52,7 @@ var (
 
 	// ErrInvalidPageLimit is returned when a paginated query is called with a
 	// zero page limit.
-	ErrInvalidPageLimit = errors.New("page limit must be greater than zero")
+	ErrInvalidPageLimit = page.ErrInvalidLimit
 
 	// ErrMissingScriptPubKey is returned when creating an imported
 	// address without the required script public key.

--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -50,6 +50,10 @@ var (
 	// field combinations.
 	ErrInvalidAddressQuery = errors.New("ScriptPubKey must be provided")
 
+	// ErrInvalidPageLimit is returned when a paginated query is called with a
+	// zero page limit.
+	ErrInvalidPageLimit = errors.New("page limit must be greater than zero")
+
 	// ErrMissingScriptPubKey is returned when creating an imported
 	// address without the required script public key.
 	ErrMissingScriptPubKey = errors.New("script pubkey required")

--- a/wallet/internal/db/itest/address_store_test.go
+++ b/wallet/internal/db/itest/address_store_test.go
@@ -738,7 +738,7 @@ func TestListAddresses(t *testing.T) {
 					WalletID:    walletID,
 					Scope:       db.KeyScopeBIP0044,
 					AccountName: "test-account",
-					Page:        page.Request[uint32]{Limit: 10},
+					Page:        newTestReq[uint32](t, 10),
 				}
 			},
 			wantCount: 5,
@@ -766,7 +766,7 @@ func TestListAddresses(t *testing.T) {
 					WalletID:    walletID,
 					Scope:       db.KeyScopeBIP0084,
 					AccountName: "empty-account",
-					Page:        page.Request[uint32]{Limit: 10},
+					Page:        newTestReq[uint32](t, 10),
 				}
 			},
 			wantCount: 0,
@@ -804,7 +804,7 @@ func TestListAddresses(t *testing.T) {
 					WalletID:    walletID,
 					Scope:       db.KeyScopeBIP0044,
 					AccountName: "bip44-multi",
-					Page:        page.Request[uint32]{Limit: 10},
+					Page:        newTestReq[uint32](t, 10),
 				}
 			},
 			wantCount: 3,
@@ -1013,7 +1013,7 @@ func TestListAddressesOrdering(t *testing.T) {
 			WalletID:    walletID,
 			Scope:       db.KeyScopeBIP0084,
 			AccountName: "ordering-account",
-			Page:        page.Request[uint32]{Limit: 10},
+			Page:        newTestReq[uint32](t, 10),
 		},
 	)
 
@@ -1071,7 +1071,7 @@ func TestListAddressesPagination(t *testing.T) {
 		WalletID:    walletID,
 		Scope:       scope,
 		AccountName: "account-a",
-		Page:        page.Request[uint32]{Limit: 2},
+		Page:        newTestReq[uint32](t, 2),
 	}
 
 	page1, err := store.ListAddresses(t.Context(), query)
@@ -1129,7 +1129,7 @@ func TestListAddressesExactBoundary(t *testing.T) {
 		WalletID:    walletID,
 		Scope:       scope,
 		AccountName: accountName,
-		Page:        page.Request[uint32]{Limit: 2},
+		Page:        newTestReq[uint32](t, 2),
 	}
 
 	page1, err := store.ListAddresses(t.Context(), query)
@@ -1168,7 +1168,7 @@ func TestListAddressesPagedEmptyResult(t *testing.T) {
 		WalletID:    walletID,
 		Scope:       scope,
 		AccountName: "empty-account",
-		Page:        page.Request[uint32]{Limit: uint32(pageSize)},
+		Page:        newTestReq[uint32](t, uint32(pageSize)),
 	})
 	require.NoError(t, err)
 	require.Empty(t, pageResult.Items)
@@ -1193,7 +1193,7 @@ func TestListAddressesDeterministicPagination(t *testing.T) {
 		WalletID:    walletID,
 		Scope:       scope,
 		AccountName: accountName,
-		Page:        page.Request[uint32]{Limit: 2},
+		Page:        newTestReq[uint32](t, 2),
 	})
 	require.Len(t, pages, 3)
 	require.Len(t, pages[0].Items, 2)
@@ -1265,7 +1265,7 @@ func TestListAddressesAccountIsolation(t *testing.T) {
 		WalletID:    walletID,
 		Scope:       scope,
 		AccountName: "account-a",
-		Page:        page.Request[uint32]{Limit: 2},
+		Page:        newTestReq[uint32](t, 2),
 	})
 	addresses := flattenAddressPages(pages)
 
@@ -1295,7 +1295,7 @@ func TestListAddressesInsertAfterCursor(t *testing.T) {
 		WalletID:    walletID,
 		Scope:       scope,
 		AccountName: accountName,
-		Page:        page.Request[uint32]{Limit: 2},
+		Page:        newTestReq[uint32](t, 2),
 	}
 	page1, err := store.ListAddresses(t.Context(), query)
 	require.NoError(t, err)
@@ -1330,27 +1330,27 @@ func TestListAddressesCursorEdges(t *testing.T) {
 	createDerivedAccount(t, store, walletID, scope, accountName)
 	createDerivedAddresses(t, store, walletID, scope, accountName, false, 3)
 
+	staleReq := newTestReq[uint32](t, 2)
+	staleReq.After = uint32Ptr(math.MaxUint32)
+
 	stalePage, err := store.ListAddresses(t.Context(), db.ListAddressesQuery{
 		WalletID:    walletID,
 		Scope:       scope,
 		AccountName: accountName,
-		Page: page.Request[uint32]{
-			Limit: 2,
-			After: uint32Ptr(math.MaxUint32),
-		},
+		Page:        staleReq,
 	})
 	require.NoError(t, err)
 	require.Empty(t, stalePage.Items)
 	require.Nil(t, stalePage.Next)
 
+	zeroReq := newTestReq[uint32](t, 2)
+	zeroReq.After = uint32Ptr(0)
+
 	zeroPage, err := store.ListAddresses(t.Context(), db.ListAddressesQuery{
 		WalletID:    walletID,
 		Scope:       scope,
 		AccountName: accountName,
-		Page: page.Request[uint32]{
-			Limit: 2,
-			After: uint32Ptr(0),
-		},
+		Page:        zeroReq,
 	})
 	require.NoError(t, err)
 	require.Len(t, zeroPage.Items, 2)
@@ -1378,7 +1378,7 @@ func TestIterAddresses(t *testing.T) {
 		WalletID:    walletID,
 		Scope:       scope,
 		AccountName: "iter-account",
-		Page:        page.Request[uint32]{Limit: uint32(pageSize)},
+		Page:        newTestReq[uint32](t, uint32(pageSize)),
 	}
 
 	iterAddrs := make([]db.AddressInfo, 0, len(expected))
@@ -1411,7 +1411,7 @@ func TestIterAddressesPaginated(t *testing.T) {
 		WalletID:    walletID,
 		Scope:       scope,
 		AccountName: "iter-account",
-		Page:        page.Request[uint32]{Limit: 2},
+		Page:        newTestReq[uint32](t, 2),
 	}
 
 	pages := collectAddressPages(t, store, query)
@@ -1445,7 +1445,7 @@ func TestIterAddressesEmpty(t *testing.T) {
 		WalletID:    walletID,
 		Scope:       scope,
 		AccountName: "empty-account",
-		Page:        page.Request[uint32]{Limit: 10},
+		Page:        newTestReq[uint32](t, 10),
 	}
 
 	for addr, err := range store.IterAddresses(t.Context(), query) {

--- a/wallet/internal/db/itest/address_store_test.go
+++ b/wallet/internal/db/itest/address_store_test.go
@@ -85,9 +85,8 @@ func getAccountByName(t *testing.T, store db.AccountStore, walletID uint32,
 	return account
 }
 
-// collectAddressPages collects paginated address results by iterating
-// through all pages from ListAddresses, using cursor pagination until
-// Next is nil.
+// collectAddressPages collects paginated address results by iterating through
+// all pages from ListAddresses until Next is nil.
 func collectAddressPages(t *testing.T, store db.AddressStore,
 	query db.ListAddressesQuery) []page.Result[db.AddressInfo, uint32] {
 	t.Helper()
@@ -102,7 +101,7 @@ func collectAddressPages(t *testing.T, store db.AddressStore,
 			return pages
 		}
 
-		query.Page = query.Page.WithAfter(*pageResult.Next)
+		query.Page.After = pageResult.Next
 	}
 }
 
@@ -739,6 +738,7 @@ func TestListAddresses(t *testing.T) {
 					WalletID:    walletID,
 					Scope:       db.KeyScopeBIP0044,
 					AccountName: "test-account",
+					Page:        page.Request[uint32]{Limit: 10},
 				}
 			},
 			wantCount: 5,
@@ -766,6 +766,7 @@ func TestListAddresses(t *testing.T) {
 					WalletID:    walletID,
 					Scope:       db.KeyScopeBIP0084,
 					AccountName: "empty-account",
+					Page:        page.Request[uint32]{Limit: 10},
 				}
 			},
 			wantCount: 0,
@@ -803,6 +804,7 @@ func TestListAddresses(t *testing.T) {
 					WalletID:    walletID,
 					Scope:       db.KeyScopeBIP0044,
 					AccountName: "bip44-multi",
+					Page:        page.Request[uint32]{Limit: 10},
 				}
 			},
 			wantCount: 3,
@@ -839,6 +841,21 @@ func TestListAddresses(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestListAddressesZeroLimit verifies ListAddresses rejects a zero page limit.
+func TestListAddressesZeroLimit(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-list-addresses-zero-limit")
+
+	_, err := store.ListAddresses(t.Context(), db.ListAddressesQuery{
+		WalletID:    walletID,
+		Scope:       db.KeyScopeBIP0044,
+		AccountName: "test-account",
+	})
+	require.ErrorIs(t, err, db.ErrInvalidPageLimit)
 }
 
 // TestNewDerivedAddress verifies that NewDerivedAddress correctly creates
@@ -996,6 +1013,7 @@ func TestListAddressesOrdering(t *testing.T) {
 			WalletID:    walletID,
 			Scope:       db.KeyScopeBIP0084,
 			AccountName: "ordering-account",
+			Page:        page.Request[uint32]{Limit: 10},
 		},
 	)
 
@@ -1053,7 +1071,7 @@ func TestListAddressesPagination(t *testing.T) {
 		WalletID:    walletID,
 		Scope:       scope,
 		AccountName: "account-a",
-		Page:        page.Request[uint32]{}.WithLimit(2),
+		Page:        page.Request[uint32]{Limit: 2},
 	}
 
 	page1, err := store.ListAddresses(t.Context(), query)
@@ -1062,21 +1080,21 @@ func TestListAddressesPagination(t *testing.T) {
 	require.Equal(t, accountA[:2], page1.Items)
 	require.NotNil(t, page1.Next)
 
-	query.Page = query.Page.WithAfter(*page1.Next)
+	query.Page.After = page1.Next
 	page2, err := store.ListAddresses(t.Context(), query)
 	require.NoError(t, err)
 	require.Len(t, page2.Items, 2)
 	require.Equal(t, accountA[2:4], page2.Items)
 	require.NotNil(t, page2.Next)
 
-	query.Page = query.Page.WithAfter(*page2.Next)
+	query.Page.After = page2.Next
 	page3, err := store.ListAddresses(t.Context(), query)
 	require.NoError(t, err)
 	require.Len(t, page3.Items, 1)
 	require.Equal(t, accountA[4:], page3.Items)
 	require.Nil(t, page3.Next)
 
-	query.Page = query.Page.WithAfter(page3.Items[len(page3.Items)-1].ID)
+	query.Page.After = uint32Ptr(page3.Items[len(page3.Items)-1].ID)
 	page4, err := store.ListAddresses(t.Context(), query)
 	require.NoError(t, err)
 	require.Empty(t, page4.Items)
@@ -1111,7 +1129,7 @@ func TestListAddressesExactBoundary(t *testing.T) {
 		WalletID:    walletID,
 		Scope:       scope,
 		AccountName: accountName,
-		Page:        page.Request[uint32]{}.WithLimit(2),
+		Page:        page.Request[uint32]{Limit: 2},
 	}
 
 	page1, err := store.ListAddresses(t.Context(), query)
@@ -1120,14 +1138,14 @@ func TestListAddressesExactBoundary(t *testing.T) {
 	require.NotNil(t, page1.Next)
 	require.Equal(t, page1.Items[1].ID, *page1.Next)
 
-	query.Page = query.Page.WithAfter(*page1.Next)
+	query.Page.After = page1.Next
 	page2, err := store.ListAddresses(t.Context(), query)
 	require.NoError(t, err)
 	require.Equal(t, expected[2:], page2.Items)
 	require.Nil(t, page2.Next)
 	require.Greater(t, page2.Items[0].ID, *page1.Next)
 
-	query.Page = query.Page.WithAfter(page2.Items[len(page2.Items)-1].ID)
+	query.Page.After = uint32Ptr(page2.Items[len(page2.Items)-1].ID)
 	page3, err := store.ListAddresses(t.Context(), query)
 	require.NoError(t, err)
 	require.Empty(t, page3.Items)
@@ -1150,7 +1168,7 @@ func TestListAddressesPagedEmptyResult(t *testing.T) {
 		WalletID:    walletID,
 		Scope:       scope,
 		AccountName: "empty-account",
-		Page:        page.Request[uint32]{}.WithLimit(uint32(pageSize)),
+		Page:        page.Request[uint32]{Limit: uint32(pageSize)},
 	})
 	require.NoError(t, err)
 	require.Empty(t, pageResult.Items)
@@ -1175,7 +1193,7 @@ func TestListAddressesDeterministicPagination(t *testing.T) {
 		WalletID:    walletID,
 		Scope:       scope,
 		AccountName: accountName,
-		Page:        page.Request[uint32]{}.WithLimit(2),
+		Page:        page.Request[uint32]{Limit: 2},
 	})
 	require.Len(t, pages, 3)
 	require.Len(t, pages[0].Items, 2)
@@ -1247,7 +1265,7 @@ func TestListAddressesAccountIsolation(t *testing.T) {
 		WalletID:    walletID,
 		Scope:       scope,
 		AccountName: "account-a",
-		Page:        page.Request[uint32]{}.WithLimit(2),
+		Page:        page.Request[uint32]{Limit: 2},
 	})
 	addresses := flattenAddressPages(pages)
 
@@ -1277,8 +1295,7 @@ func TestListAddressesInsertAfterCursor(t *testing.T) {
 		WalletID:    walletID,
 		Scope:       scope,
 		AccountName: accountName,
-		Page: page.Request[uint32]{}.
-			WithLimit(2),
+		Page:        page.Request[uint32]{Limit: 2},
 	}
 	page1, err := store.ListAddresses(t.Context(), query)
 	require.NoError(t, err)
@@ -1291,7 +1308,7 @@ func TestListAddressesInsertAfterCursor(t *testing.T) {
 		t, store, walletID, scope, accountName, false,
 	)
 
-	query.Page = query.Page.WithAfter(*page1.Next)
+	query.Page.After = page1.Next
 	page2, err := store.ListAddresses(t.Context(), query)
 	require.NoError(t, err)
 	require.Len(t, page2.Items, 2)
@@ -1317,9 +1334,10 @@ func TestListAddressesCursorEdges(t *testing.T) {
 		WalletID:    walletID,
 		Scope:       scope,
 		AccountName: accountName,
-		Page: page.Request[uint32]{}.
-			WithLimit(2).
-			WithAfter(math.MaxUint32),
+		Page: page.Request[uint32]{
+			Limit: 2,
+			After: uint32Ptr(math.MaxUint32),
+		},
 	})
 	require.NoError(t, err)
 	require.Empty(t, stalePage.Items)
@@ -1329,9 +1347,10 @@ func TestListAddressesCursorEdges(t *testing.T) {
 		WalletID:    walletID,
 		Scope:       scope,
 		AccountName: accountName,
-		Page: page.Request[uint32]{}.
-			WithLimit(2).
-			WithAfter(0),
+		Page: page.Request[uint32]{
+			Limit: 2,
+			After: uint32Ptr(0),
+		},
 	})
 	require.NoError(t, err)
 	require.Len(t, zeroPage.Items, 2)
@@ -1359,7 +1378,7 @@ func TestIterAddresses(t *testing.T) {
 		WalletID:    walletID,
 		Scope:       scope,
 		AccountName: "iter-account",
-		Page:        page.Request[uint32]{}.WithLimit(uint32(pageSize)),
+		Page:        page.Request[uint32]{Limit: uint32(pageSize)},
 	}
 
 	iterAddrs := make([]db.AddressInfo, 0, len(expected))
@@ -1392,8 +1411,7 @@ func TestIterAddressesPaginated(t *testing.T) {
 		WalletID:    walletID,
 		Scope:       scope,
 		AccountName: "iter-account",
-		Page: page.Request[uint32]{}.
-			WithLimit(2),
+		Page:        page.Request[uint32]{Limit: 2},
 	}
 
 	pages := collectAddressPages(t, store, query)
@@ -1427,7 +1445,7 @@ func TestIterAddressesEmpty(t *testing.T) {
 		WalletID:    walletID,
 		Scope:       scope,
 		AccountName: "empty-account",
-		Page:        page.Request[uint32]{}.WithLimit(10),
+		Page:        page.Request[uint32]{Limit: 10},
 	}
 
 	for addr, err := range store.IterAddresses(t.Context(), query) {

--- a/wallet/internal/db/itest/wallet_store_test.go
+++ b/wallet/internal/db/itest/wallet_store_test.go
@@ -17,6 +17,16 @@ func uint32Ptr(v uint32) *uint32 {
 	return &v
 }
 
+// newTestReq constructs a valid pagination request for tests.
+func newTestReq[C any](t *testing.T, limit uint32) page.Request[C] {
+	t.Helper()
+
+	req, err := page.NewRequest[C](limit)
+	require.NoError(t, err)
+
+	return req
+}
+
 // TestCreateWallet verifies that CreateWallet correctly creates a wallet
 // and returns its information.
 func TestCreateWallet(t *testing.T) {
@@ -161,7 +171,7 @@ func TestListWallets(t *testing.T) {
 
 	// Initially empty.
 	query := db.ListWalletsQuery{
-		Page: page.Request[uint32]{Limit: 10},
+		Page: newTestReq[uint32](t, 10),
 	}
 
 	pageResult, err := store.ListWallets(t.Context(), query)
@@ -214,7 +224,7 @@ func TestListWalletsPagination(t *testing.T) {
 	}
 
 	query := db.ListWalletsQuery{
-		Page: page.Request[uint32]{Limit: 2},
+		Page: newTestReq[uint32](t, 2),
 	}
 
 	page1, err := store.ListWallets(t.Context(), query)
@@ -261,7 +271,7 @@ func TestListWalletsExactBoundary(t *testing.T) {
 	}
 
 	query := db.ListWalletsQuery{
-		Page: page.Request[uint32]{Limit: 2},
+		Page: newTestReq[uint32](t, 2),
 	}
 
 	page1, err := store.ListWallets(t.Context(), query)
@@ -304,7 +314,7 @@ func TestIterWallets(t *testing.T) {
 	}
 
 	query := db.ListWalletsQuery{
-		Page: page.Request[uint32]{Limit: 2},
+		Page: newTestReq[uint32](t, 2),
 	}
 	expected := flattenWalletPages(collectWalletPages(t, store, query))
 
@@ -332,7 +342,7 @@ func TestIterWalletsPaginated(t *testing.T) {
 	}
 
 	query := db.ListWalletsQuery{
-		Page: page.Request[uint32]{Limit: 2},
+		Page: newTestReq[uint32](t, 2),
 	}
 
 	pages := collectWalletPages(t, store, query)
@@ -368,11 +378,11 @@ func TestListWalletsPagedFromCursor(t *testing.T) {
 		created = append(created, wallet)
 	}
 
+	pageReq := newTestReq[uint32](t, 2)
+	pageReq.After = uint32Ptr(created[1].ID)
+
 	query := db.ListWalletsQuery{
-		Page: page.Request[uint32]{
-			Limit: 2,
-			After: uint32Ptr(created[1].ID),
-		},
+		Page: pageReq,
 	}
 
 	pageResult, err := store.ListWallets(t.Context(), query)
@@ -428,7 +438,7 @@ func TestListWalletsPagedWithSyncMetadata(t *testing.T) {
 	require.NoError(t, err)
 
 	query := db.ListWalletsQuery{
-		Page: page.Request[uint32]{Limit: 1},
+		Page: newTestReq[uint32](t, 1),
 	}
 
 	page1, err := store.ListWallets(t.Context(), query)
@@ -471,7 +481,7 @@ func TestListWalletsDeterministicPagination(t *testing.T) {
 	}
 
 	pages := collectWalletPages(t, store, db.ListWalletsQuery{
-		Page: page.Request[uint32]{Limit: 2},
+		Page: newTestReq[uint32](t, 2),
 	})
 	require.Len(t, pages, 3)
 	require.Len(t, pages[0].Items, 2)
@@ -539,7 +549,7 @@ func TestListWalletsInsertAfterCursor(t *testing.T) {
 	}
 
 	query := db.ListWalletsQuery{
-		Page: page.Request[uint32]{Limit: 2},
+		Page: newTestReq[uint32](t, 2),
 	}
 	page1, err := store.ListWallets(t.Context(), query)
 	require.NoError(t, err)
@@ -577,21 +587,21 @@ func TestListWalletsCursorEdges(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	staleReq := newTestReq[uint32](t, 2)
+	staleReq.After = uint32Ptr(math.MaxUint32)
+
 	stalePage, err := store.ListWallets(t.Context(), db.ListWalletsQuery{
-		Page: page.Request[uint32]{
-			Limit: 2,
-			After: uint32Ptr(math.MaxUint32),
-		},
+		Page: staleReq,
 	})
 	require.NoError(t, err)
 	require.Empty(t, stalePage.Items)
 	require.Nil(t, stalePage.Next)
 
+	zeroReq := newTestReq[uint32](t, 2)
+	zeroReq.After = uint32Ptr(0)
+
 	zeroPage, err := store.ListWallets(t.Context(), db.ListWalletsQuery{
-		Page: page.Request[uint32]{
-			Limit: 2,
-			After: uint32Ptr(0),
-		},
+		Page: zeroReq,
 	})
 	require.NoError(t, err)
 	require.Len(t, zeroPage.Items, 2)

--- a/wallet/internal/db/itest/wallet_store_test.go
+++ b/wallet/internal/db/itest/wallet_store_test.go
@@ -12,6 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// uint32Ptr returns a pointer to the given uint32 value.
+func uint32Ptr(v uint32) *uint32 {
+	return &v
+}
+
 // TestCreateWallet verifies that CreateWallet correctly creates a wallet
 // and returns its information.
 func TestCreateWallet(t *testing.T) {
@@ -156,7 +161,7 @@ func TestListWallets(t *testing.T) {
 
 	// Initially empty.
 	query := db.ListWalletsQuery{
-		Page: page.Request[uint32]{}.WithLimit(10),
+		Page: page.Request[uint32]{Limit: 10},
 	}
 
 	pageResult, err := store.ListWallets(t.Context(), query)
@@ -184,6 +189,16 @@ func TestListWallets(t *testing.T) {
 	require.ElementsMatch(t, names, walletsName)
 }
 
+// TestListWalletsZeroLimit verifies ListWallets rejects a zero page limit.
+func TestListWalletsZeroLimit(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+
+	_, err := store.ListWallets(t.Context(), db.ListWalletsQuery{})
+	require.ErrorIs(t, err, db.ErrInvalidPageLimit)
+}
+
 // TestListWalletsPagination verifies that ListWallets paginates correctly and
 // sets Next without requiring an extra round-trip.
 func TestListWalletsPagination(t *testing.T) {
@@ -199,7 +214,7 @@ func TestListWalletsPagination(t *testing.T) {
 	}
 
 	query := db.ListWalletsQuery{
-		Page: page.Request[uint32]{}.WithLimit(2),
+		Page: page.Request[uint32]{Limit: 2},
 	}
 
 	page1, err := store.ListWallets(t.Context(), query)
@@ -208,13 +223,13 @@ func TestListWalletsPagination(t *testing.T) {
 	require.NotNil(t, page1.Next)
 	require.Equal(t, page1.Items[1].ID, *page1.Next)
 
-	query.Page = query.Page.WithAfter(*page1.Next)
+	query.Page.After = page1.Next
 	page2, err := store.ListWallets(t.Context(), query)
 	require.NoError(t, err)
 	require.Len(t, page2.Items, 2)
 	require.Nil(t, page2.Next)
 
-	query.Page = query.Page.WithAfter(page2.Items[len(page2.Items)-1].ID)
+	query.Page.After = uint32Ptr(page2.Items[len(page2.Items)-1].ID)
 	page3, err := store.ListWallets(t.Context(), query)
 	require.NoError(t, err)
 	require.Empty(t, page3.Items)
@@ -246,7 +261,7 @@ func TestListWalletsExactBoundary(t *testing.T) {
 	}
 
 	query := db.ListWalletsQuery{
-		Page: page.Request[uint32]{}.WithLimit(2),
+		Page: page.Request[uint32]{Limit: 2},
 	}
 
 	page1, err := store.ListWallets(t.Context(), query)
@@ -257,7 +272,7 @@ func TestListWalletsExactBoundary(t *testing.T) {
 	require.NotNil(t, page1.Next)
 	require.Equal(t, page1.Items[1].ID, *page1.Next)
 
-	query.Page = query.Page.WithAfter(*page1.Next)
+	query.Page.After = page1.Next
 	page2, err := store.ListWallets(t.Context(), query)
 	require.NoError(t, err)
 	require.Len(t, page2.Items, 2)
@@ -266,7 +281,7 @@ func TestListWalletsExactBoundary(t *testing.T) {
 	require.Nil(t, page2.Next)
 	require.Greater(t, page2.Items[0].ID, *page1.Next)
 
-	query.Page = query.Page.WithAfter(page2.Items[len(page2.Items)-1].ID)
+	query.Page.After = uint32Ptr(page2.Items[len(page2.Items)-1].ID)
 	page3, err := store.ListWallets(t.Context(), query)
 	require.NoError(t, err)
 	require.Empty(t, page3.Items)
@@ -289,7 +304,7 @@ func TestIterWallets(t *testing.T) {
 	}
 
 	query := db.ListWalletsQuery{
-		Page: page.Request[uint32]{}.WithLimit(2),
+		Page: page.Request[uint32]{Limit: 2},
 	}
 	expected := flattenWalletPages(collectWalletPages(t, store, query))
 
@@ -317,7 +332,7 @@ func TestIterWalletsPaginated(t *testing.T) {
 	}
 
 	query := db.ListWalletsQuery{
-		Page: page.Request[uint32]{}.WithLimit(2),
+		Page: page.Request[uint32]{Limit: 2},
 	}
 
 	pages := collectWalletPages(t, store, query)
@@ -354,7 +369,10 @@ func TestListWalletsPagedFromCursor(t *testing.T) {
 	}
 
 	query := db.ListWalletsQuery{
-		Page: page.Request[uint32]{}.WithLimit(2).WithAfter(created[1].ID),
+		Page: page.Request[uint32]{
+			Limit: 2,
+			After: uint32Ptr(created[1].ID),
+		},
 	}
 
 	pageResult, err := store.ListWallets(t.Context(), query)
@@ -364,7 +382,7 @@ func TestListWalletsPagedFromCursor(t *testing.T) {
 	require.Equal(t, names[3], pageResult.Items[1].Name)
 	require.Nil(t, pageResult.Next)
 
-	query.Page = query.Page.WithAfter(created[3].ID)
+	query.Page.After = uint32Ptr(created[3].ID)
 	pageResult, err = store.ListWallets(t.Context(), query)
 	require.NoError(t, err)
 	require.Empty(t, pageResult.Items)
@@ -410,7 +428,7 @@ func TestListWalletsPagedWithSyncMetadata(t *testing.T) {
 	require.NoError(t, err)
 
 	query := db.ListWalletsQuery{
-		Page: page.Request[uint32]{}.WithLimit(1),
+		Page: page.Request[uint32]{Limit: 1},
 	}
 
 	page1, err := store.ListWallets(t.Context(), query)
@@ -421,7 +439,7 @@ func TestListWalletsPagedWithSyncMetadata(t *testing.T) {
 	require.False(t, page1.Items[0].Birthday.IsZero())
 	require.NotNil(t, page1.Next)
 
-	query.Page = query.Page.WithAfter(*page1.Next)
+	query.Page.After = page1.Next
 	page2, err := store.ListWallets(t.Context(), query)
 	require.NoError(t, err)
 	require.Len(t, page2.Items, 1)
@@ -453,7 +471,7 @@ func TestListWalletsDeterministicPagination(t *testing.T) {
 	}
 
 	pages := collectWalletPages(t, store, db.ListWalletsQuery{
-		Page: page.Request[uint32]{}.WithLimit(2),
+		Page: page.Request[uint32]{Limit: 2},
 	})
 	require.Len(t, pages, 3)
 	require.Len(t, pages[0].Items, 2)
@@ -521,7 +539,7 @@ func TestListWalletsInsertAfterCursor(t *testing.T) {
 	}
 
 	query := db.ListWalletsQuery{
-		Page: page.Request[uint32]{}.WithLimit(2),
+		Page: page.Request[uint32]{Limit: 2},
 	}
 	page1, err := store.ListWallets(t.Context(), query)
 	require.NoError(t, err)
@@ -535,7 +553,7 @@ func TestListWalletsInsertAfterCursor(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	query.Page = query.Page.WithAfter(*page1.Next)
+	query.Page.After = page1.Next
 	page2, err := store.ListWallets(t.Context(), query)
 	require.NoError(t, err)
 	require.Len(t, page2.Items, 2)
@@ -560,14 +578,20 @@ func TestListWalletsCursorEdges(t *testing.T) {
 	}
 
 	stalePage, err := store.ListWallets(t.Context(), db.ListWalletsQuery{
-		Page: page.Request[uint32]{}.WithLimit(2).WithAfter(math.MaxUint32),
+		Page: page.Request[uint32]{
+			Limit: 2,
+			After: uint32Ptr(math.MaxUint32),
+		},
 	})
 	require.NoError(t, err)
 	require.Empty(t, stalePage.Items)
 	require.Nil(t, stalePage.Next)
 
 	zeroPage, err := store.ListWallets(t.Context(), db.ListWalletsQuery{
-		Page: page.Request[uint32]{}.WithLimit(2).WithAfter(0),
+		Page: page.Request[uint32]{
+			Limit: 2,
+			After: uint32Ptr(0),
+		},
 	})
 	require.NoError(t, err)
 	require.Len(t, zeroPage.Items, 2)
@@ -576,9 +600,8 @@ func TestListWalletsCursorEdges(t *testing.T) {
 	require.NotNil(t, zeroPage.Next)
 }
 
-// collectWalletPages collects paginated wallet results by iterating
-// through all pages from ListWallets, using cursor pagination until
-// Next is nil.
+// collectWalletPages collects paginated wallet results by iterating through all
+// pages from ListWallets until Next is nil.
 func collectWalletPages(t *testing.T, store db.WalletStore,
 	query db.ListWalletsQuery) []page.Result[db.WalletInfo, uint32] {
 	t.Helper()
@@ -593,7 +616,7 @@ func collectWalletPages(t *testing.T, store db.WalletStore,
 			return pages
 		}
 
-		query.Page = query.Page.WithAfter(*pageResult.Next)
+		query.Page.After = pageResult.Next
 	}
 }
 

--- a/wallet/internal/db/page/doc.go
+++ b/wallet/internal/db/page/doc.go
@@ -5,15 +5,15 @@
 //
 // A [Request] carries the parameters for a single page fetch: page limit,
 // and an optional after that identifies where the previous page ended.
-// The zero value requests the first page at [DefaultLimit].
 //
 // A [Result] carries the items returned by one fetch together with
-// [Result.Next]. Pass *Next back to [Request.WithAfter] to advance to the
-// next page.
+// [Result.Next]. Assign [Result.Next] to [Request.After] to advance to the next
+// page.
 //
-// Queries fetch normalizedLimit+1 rows internally and return at most
-// normalizedLimit items. If the extra row exists, [Result.Next] is non-nil.
-// If it does not, [Result.Next] is nil and the current page is the last page.
+// Stores require [Request.Limit] to be positive, fetch one extra row
+// internally, and return at most the requested number of items. If the extra
+// row exists, [Result.Next] is non-nil. If it does not, [Result.Next] is nil
+// and the current page is the last page.
 //
 // # Iterating
 //
@@ -24,8 +24,8 @@
 //
 // # Store integration
 //
-// Stores typically translate [Request.After] into an optional backend
-// query parameter, fetch [Request.QueryLimit] rows with a single ordered
-// SQL query, map the raw rows to domain items, and then call
-// [BuildResult] to derive [Result.Next].
+// Stores typically translate [Request.After] into an optional backend query
+// parameter, validate [Request.Limit], fetch `limit+1` rows with a single
+// ordered SQL query, and call [BuildResult] to derive [Result.Next] from the
+// last returned item when another page exists.
 package page

--- a/wallet/internal/db/page/doc.go
+++ b/wallet/internal/db/page/doc.go
@@ -4,7 +4,8 @@
 // # Core types
 //
 // A [Request] carries the parameters for a single page fetch: page limit,
-// and an optional after that identifies where the previous page ended.
+// and an optional after that identifies where the previous page ended. Use
+// [NewRequest] to construct a request with a positive page limit.
 //
 // A [Result] carries the items returned by one fetch together with
 // [Result.Next]. Assign [Result.Next] to [Request.After] to advance to the next

--- a/wallet/internal/db/page/iter_test.go
+++ b/wallet/internal/db/page/iter_test.go
@@ -8,17 +8,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// errTest is a sentinel error used across page package tests to
-// verify error propagation through pagination helpers.
+// errTest is a sentinel error used across page package tests.
 var errTest = errors.New("test error")
 
 // intPtr returns a pointer to the given int value. It is used in tests to
-// construct Result literals that require a *int after.
+// construct Result literals that require a *int cursor.
 func intPtr(v int) *int {
 	return &v
 }
 
-// TestIterTraversal tests the traversal of items using the page iterator.
+// TestIterTraversal verifies that Iter walks all pages in order.
 func TestIterTraversal(t *testing.T) {
 	t.Parallel()
 
@@ -83,8 +82,8 @@ func TestIterTraversal(t *testing.T) {
 				gotItems    []int
 			)
 
-			fetchPage := func(_ context.Context, query int) (Result[int, int],
-				error) {
+			fetchPage := func(_ context.Context,
+				query int) (Result[int, int], error) {
 
 				require.Less(t, fetchCalls, len(tc.pages))
 				require.Equal(t, fetchCalls, query)
@@ -111,9 +110,7 @@ func TestIterTraversal(t *testing.T) {
 				return query + 1
 			}
 
-			for item, err := range Iter(
-				t.Context(), 0, fetchPage, setCursor,
-			) {
+			for item, err := range Iter(t.Context(), 0, fetchPage, setCursor) {
 				require.NoError(t, err)
 
 				gotItems = append(gotItems, item)
@@ -128,13 +125,14 @@ func TestIterTraversal(t *testing.T) {
 }
 
 // TestIterFetchErrorOnFirstCall verifies that Iter yields the error immediately
-// when fetchPage fails on the very first call, before any items are produced.
+// when fetchPage fails on the first call, before any items are produced.
 func TestIterFetchErrorOnFirstCall(t *testing.T) {
 	t.Parallel()
 
-	gotItems := make([]int, 0)
-
-	var iterErr error
+	var (
+		gotItems = make([]int, 0)
+		iterErr  error
+	)
 
 	fetchPage := func(_ context.Context, _ int) (Result[int, int], error) {
 		return Result[int, int]{}, errTest
@@ -144,9 +142,7 @@ func TestIterFetchErrorOnFirstCall(t *testing.T) {
 		return 0
 	}
 
-	for item, err := range Iter(
-		t.Context(), 0, fetchPage, setCursor,
-	) {
+	for item, err := range Iter(t.Context(), 0, fetchPage, setCursor) {
 		if err != nil {
 			iterErr = err
 			break
@@ -168,14 +164,10 @@ func TestIterFetchErrorAfterTwoPages(t *testing.T) {
 		fetchCalls  int
 		nextCursors []int
 		iterErr     error
+		gotItems    = make([]int, 0, 4)
 	)
 
-	gotItems := make([]int, 0)
-
-	fetchPage := func(
-		_ context.Context, _ int,
-	) (Result[int, int], error) {
-
+	fetchPage := func(_ context.Context, _ int) (Result[int, int], error) {
 		fetchCalls++
 		switch fetchCalls {
 		case 1:
@@ -198,9 +190,7 @@ func TestIterFetchErrorAfterTwoPages(t *testing.T) {
 		return query + 1
 	}
 
-	for item, err := range Iter(
-		t.Context(), 0, fetchPage, setCursor,
-	) {
+	for item, err := range Iter(t.Context(), 0, fetchPage, setCursor) {
 		if err != nil {
 			iterErr = err
 			break
@@ -242,11 +232,8 @@ func TestIterContextCancellation(t *testing.T) {
 			wantFetchCalls:   1,
 		},
 		{
-			name: "cancel mid-page stops before next yield",
-			pages: [][]int{
-				{1, 2, 3},
-				{4, 5},
-			},
+			name:             "cancel mid-page stops before next yield",
+			pages:            [][]int{{1, 2, 3}, {4, 5}},
 			cancelAfterItems: 1,
 			wantItems:        []int{1},
 			wantFetchCalls:   1,
@@ -270,25 +257,21 @@ func TestIterContextCancellation(t *testing.T) {
 				cancel()
 			}
 
-			fetchPage := func(ctx context.Context, _ int) (Result[int, int],
-				error) {
+			fetchPage := func(ctx context.Context,
+				_ int) (Result[int, int], error) {
 
 				err := ctx.Err()
 				if err != nil {
 					fetchCalls++
-
 					return Result[int, int]{}, err
 				}
 
 				require.Less(t, fetchCalls, len(tc.pages))
-
 				items := tc.pages[fetchCalls]
 				fetchCalls++
 
-				result := Result[int, int]{
-					Items: items,
-				}
-				if len(items) > 0 {
+				result := Result[int, int]{Items: items}
+				if fetchCalls < len(tc.pages) && len(items) > 0 {
 					last := items[len(items)-1]
 					result.Next = &last
 				}
@@ -300,9 +283,7 @@ func TestIterContextCancellation(t *testing.T) {
 				return query + 1
 			}
 
-			for item, err := range Iter(
-				ctx, 0, fetchPage, setCursor,
-			) {
+			for item, err := range Iter(ctx, 0, fetchPage, setCursor) {
 				if err != nil {
 					iterErr = err
 					break
@@ -323,8 +304,8 @@ func TestIterContextCancellation(t *testing.T) {
 	}
 }
 
-// TestIterConsumerBreaks tests the page iterator when the consumer breaks out
-// of the loop.
+// TestIterConsumerBreaks verifies that Iter stops without fetching another page
+// when the consumer breaks early.
 func TestIterConsumerBreaks(t *testing.T) {
 	t.Parallel()
 
@@ -345,9 +326,6 @@ func TestIterConsumerBreaks(t *testing.T) {
 			wantNextCalls:  0,
 		},
 		{
-			// The consumer stops after consuming all items in the first page.
-			// setCursor is never called because the break happens before the
-			// iterator advances to the next page.
 			name:           "at page boundary",
 			pages:          [][]int{{1, 2}, {3, 4}},
 			stopAfter:      2,
@@ -367,8 +345,8 @@ func TestIterConsumerBreaks(t *testing.T) {
 				gotItems   []int
 			)
 
-			fetchPage := func(_ context.Context, _ int) (Result[int, int],
-				error) {
+			fetchPage := func(_ context.Context,
+				_ int) (Result[int, int], error) {
 
 				require.Less(t, fetchCalls, len(tc.pages))
 
@@ -376,9 +354,7 @@ func TestIterConsumerBreaks(t *testing.T) {
 				hasMore := fetchCalls < len(tc.pages)-1
 				fetchCalls++
 
-				result := Result[int, int]{
-					Items: items,
-				}
+				result := Result[int, int]{Items: items}
 				if hasMore && len(items) > 0 {
 					last := items[len(items)-1]
 					result.Next = &last
@@ -389,13 +365,10 @@ func TestIterConsumerBreaks(t *testing.T) {
 
 			setCursor := func(query int, cursor int) int {
 				nextCalls++
-
 				return query + cursor
 			}
 
-			for item, err := range Iter(
-				t.Context(), 0, fetchPage, setCursor,
-			) {
+			for item, err := range Iter(t.Context(), 0, fetchPage, setCursor) {
 				require.NoError(t, err)
 
 				gotItems = append(gotItems, item)
@@ -411,8 +384,8 @@ func TestIterConsumerBreaks(t *testing.T) {
 	}
 }
 
-// TestIterNextNilTermination verifies Iter stops when Next becomes nil,
-// without requiring an extra empty-page fetch.
+// TestIterNextNilTermination verifies Iter stops when Next becomes nil without
+// requiring an extra empty-page fetch.
 func TestIterNextNilTermination(t *testing.T) {
 	t.Parallel()
 
@@ -433,7 +406,7 @@ func TestIterNextNilTermination(t *testing.T) {
 			wantNextCalls:  0,
 		},
 		{
-			name: "multi-page, stops mid",
+			name: "multi-page stops at nil next",
 			pages: []Result[int, int]{
 				{Items: []int{1, 2}, Next: intPtr(2)},
 				{Items: []int{3}},
@@ -454,8 +427,8 @@ func TestIterNextNilTermination(t *testing.T) {
 				gotItems   []int
 			)
 
-			fetchPage := func(_ context.Context, _ int) (Result[int, int],
-				error) {
+			fetchPage := func(_ context.Context,
+				_ int) (Result[int, int], error) {
 
 				require.Less(t, fetchCalls, len(tc.pages))
 
@@ -471,9 +444,7 @@ func TestIterNextNilTermination(t *testing.T) {
 				return query + 1
 			}
 
-			for item, err := range Iter(
-				t.Context(), 0, fetchPage, setCursor,
-			) {
+			for item, err := range Iter(t.Context(), 0, fetchPage, setCursor) {
 				require.NoError(t, err)
 
 				gotItems = append(gotItems, item)

--- a/wallet/internal/db/page/request.go
+++ b/wallet/internal/db/page/request.go
@@ -1,95 +1,31 @@
 package page
 
-const (
-	// DefaultLimit is the default number of items that can be returned to a
-	// page.
-	DefaultLimit = 100
-
-	// MaxLimit is the maximum number of items that can be returned to a page.
-	// Store implementations may fetch MaxLimit+1 rows internally to detect
-	// whether another page exists.
-	MaxLimit = 1000
-)
-
-// Request holds the parameters for a paginated list query. The zero value is
-// valid and requests the first page at DefaultLimit. All With* methods
-// return a modified shallow copy of the request.
+// Request holds the parameters for a paginated list query.
 //
-// Fields are unexported so that callers must use the With* methods and
-// accessor functions. This design preserves the normalization of limit (zero
-// maps to DefaultLimit via normalizedLimit()) and ensures consistency across
-// all page operations.
+// Limit must be greater than zero.
 type Request[Cursor any] struct {
-	// limit is the maximum number of items to return per page.
-	limit uint32
+	// Limit is the maximum number of items to return in one page.
+	Limit uint32
 
-	// after is the pagination cursor that marks where the next page
-	// starts after. Nil means the first page.
-	after *Cursor
+	// After is the cursor identifying where the next page starts after. Nil
+	// means the request targets the first page.
+	After *Cursor
 }
 
-// QueryLimit returns the number of rows the SQL query should fetch. Queries
-// fetch normalizedLimit+1 rows, so BuildResult can use the extra row as a
-// lookahead signal to determine whether another page exists.
-func (r Request[Cursor]) QueryLimit() uint32 {
-	return r.normalizedLimit() + 1
-}
-
-// WithLimit returns a copy of the request with the limit replaced. The limit is
-// not validated here; normalization (zero -> DefaultLimit, over MaxLimit ->
-// MaxLimit) happens in normalizedLimit() and QueryLimit(). A caller passing
-// 0 or a large value will not see an error, the value will just be normalized
-// later.
-func (r Request[Cursor]) WithLimit(limit uint32) Request[Cursor] {
-	r.limit = limit
-
-	return r
-}
-
-// After returns the pagination after from the previous page.
-// A false ok return value means the first page is being requested.
-func (r Request[Cursor]) After() (Cursor, bool) {
-	if r.after == nil {
-		var zero Cursor
-
-		return zero, false
-	}
-
-	return *r.after, true
-}
-
-// WithAfter returns a copy of the request with the after replaced.
-// Calling this on a zero-value Request produces a request for the second page
-// (the page after this after). It takes the after by value to avoid
-// the caller retaining a pointer into the Request.
-func (r Request[Cursor]) WithAfter(after Cursor) Request[Cursor] {
-	r.after = &after
-
-	return r
-}
-
-// BuildResult assembles a page.Result from a slice of items already fetched by
-// the caller. It uses r.normalizedLimit to determine whether the query fetched
-// an extra lookahead row. The toCursor function is called on the last item of
-// the possibly trimmed slice.
+// BuildResult assembles a page result from a slice of items already fetched by
+// the caller.
 //
-// An empty slice always returns an empty result.
-//
-// If len(items) is greater than normalizedLimit, it trims to normalizedLimit
-// and sets Next to the after of the last item in the trimmed slice.
-// Otherwise, Next is nil.
-func BuildResult[Cursor, Item any](r Request[Cursor], items []Item,
+// The caller must pass a positive limit. BuildResult trims an extra lookahead
+// row when present and derives Next from the last retained item.
+func BuildResult[Cursor, Item any](items []Item, limit uint32,
 	nextOf func(Item) Cursor) Result[Item, Cursor] {
 
 	if len(items) == 0 {
 		return Result[Item, Cursor]{Items: items}
 	}
 
-	limit := r.normalizedLimit()
 	if len(items) <= int(limit) {
-		return Result[Item, Cursor]{
-			Items: items,
-		}
+		return Result[Item, Cursor]{Items: items}
 	}
 
 	items = items[:int(limit)]
@@ -99,21 +35,5 @@ func BuildResult[Cursor, Item any](r Request[Cursor], items []Item,
 	return Result[Item, Cursor]{
 		Items: items,
 		Next:  &cursor,
-	}
-}
-
-// normalizedLimit returns the normalized requested page limit for this request.
-// A limit of zero returns DefaultLimit. A limit greater than MaxLimit is
-// clamped to MaxLimit.
-func (r Request[Cursor]) normalizedLimit() uint32 {
-	switch {
-	case r.limit == 0:
-		return DefaultLimit
-
-	case r.limit > MaxLimit:
-		return MaxLimit
-
-	default:
-		return r.limit
 	}
 }

--- a/wallet/internal/db/page/request.go
+++ b/wallet/internal/db/page/request.go
@@ -1,29 +1,48 @@
 package page
 
+import "errors"
+
+// ErrInvalidLimit is returned when a request is created with a zero page limit.
+var ErrInvalidLimit = errors.New("page limit must be greater than zero")
+
 // Request holds the parameters for a paginated list query.
 //
-// Limit must be greater than zero.
+// Use NewRequest to construct a request with a positive page limit.
 type Request[Cursor any] struct {
-	// Limit is the maximum number of items to return in one page.
-	Limit uint32
+	limit uint32
 
-	// After is the cursor identifying where the next page starts after. Nil
-	// means the request targets the first page.
+	// After is the cursor identifying where the next page starts after.
+	// Nil means the request targets the first page.
 	After *Cursor
+}
+
+// NewRequest returns a Request with the given positive page limit.
+func NewRequest[Cursor any](limit uint32) (Request[Cursor], error) {
+	if limit == 0 {
+		return Request[Cursor]{}, ErrInvalidLimit
+	}
+
+	return Request[Cursor]{limit: limit}, nil
+}
+
+// Limit returns the configured page size.
+func (r Request[Cursor]) Limit() uint32 {
+	return r.limit
 }
 
 // BuildResult assembles a page result from a slice of items already fetched by
 // the caller.
 //
-// The caller must pass a positive limit. BuildResult trims an extra lookahead
-// row when present and derives Next from the last retained item.
-func BuildResult[Cursor, Item any](items []Item, limit uint32,
+// BuildResult uses the request limit to trim an extra lookahead row when
+// present and derives Next from the last retained item.
+func BuildResult[Cursor, Item any](r Request[Cursor], items []Item,
 	nextOf func(Item) Cursor) Result[Item, Cursor] {
 
 	if len(items) == 0 {
 		return Result[Item, Cursor]{Items: items}
 	}
 
+	limit := r.Limit()
 	if len(items) <= int(limit) {
 		return Result[Item, Cursor]{Items: items}
 	}

--- a/wallet/internal/db/page/request_test.go
+++ b/wallet/internal/db/page/request_test.go
@@ -6,183 +6,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestRequestSize verifies that normalizedLimit normalizes the raw limit field.
-func TestRequestSize(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		name     string
-		size     uint32
-		wantSize uint32
-	}{
-		{
-			name:     "zero defaults to DefaultLimit",
-			size:     0,
-			wantSize: DefaultLimit,
-		},
-		{
-			name:     "minimum in range",
-			size:     1,
-			wantSize: 1,
-		},
-		{
-			name:     "exactly MaxLimit passes through",
-			size:     MaxLimit,
-			wantSize: MaxLimit,
-		},
-		{
-			name:     "over MaxLimit clamped to MaxLimit",
-			size:     uint32(MaxLimit) + 1,
-			wantSize: MaxLimit,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			request := Request[uint32]{}.WithLimit(tc.size)
-			require.Equal(t, tc.wantSize, request.normalizedLimit())
-		})
-	}
-}
-
-// TestQueryLimit verifies that QueryLimit returns normalizedLimit+1,
-// including at MaxLimit.
-func TestQueryLimit(t *testing.T) {
-	t.Parallel()
-
-	t.Run("uses limit plus one", func(t *testing.T) {
-		t.Parallel()
-
-		r := Request[uint32]{}.WithLimit(25)
-		require.Equal(t, r.normalizedLimit()+1, r.QueryLimit())
-	})
-
-	t.Run("at max page limit", func(t *testing.T) {
-		t.Parallel()
-
-		r := Request[uint32]{}.WithLimit(MaxLimit)
-		require.Equal(t, uint32(MaxLimit)+1, r.QueryLimit())
-	})
-}
-
-// TestRequestChaining verifies that chaining With* calls produces the
-// expected limit and after on the resulting Request.
-func TestRequestChaining(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		name          string
-		request       Request[uint32]
-		wantSize      uint32
-		wantCursor    uint32
-		wantHasCursor bool
-	}{
-		{
-			name:          "after nil by default",
-			request:       Request[uint32]{},
-			wantSize:      DefaultLimit,
-			wantHasCursor: false,
-		},
-		{
-			name:          "after set without limit",
-			request:       Request[uint32]{}.WithAfter(42),
-			wantSize:      DefaultLimit,
-			wantCursor:    42,
-			wantHasCursor: true,
-		},
-		{
-			name:          "limit and after set together",
-			request:       Request[uint32]{}.WithLimit(50).WithAfter(99),
-			wantSize:      50,
-			wantCursor:    99,
-			wantHasCursor: true,
-		},
-		{
-			name:          "after overwrites previous after",
-			request:       Request[uint32]{}.WithAfter(1).WithAfter(2),
-			wantSize:      DefaultLimit,
-			wantCursor:    2,
-			wantHasCursor: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			require.Equal(t, tc.wantSize, tc.request.normalizedLimit())
-
-			if !tc.wantHasCursor {
-				_, ok := tc.request.After()
-				require.False(t, ok)
-
-				return
-			}
-
-			after, ok := tc.request.After()
-			require.True(t, ok)
-			require.Equal(t, tc.wantCursor, after)
-		})
-	}
-}
-
-// TestRequestWithSizeImmutability verifies that WithLimit returns a new
-// Request and does not modify the original.
-func TestRequestWithSizeImmutability(t *testing.T) {
-	t.Parallel()
-
-	original := Request[uint32]{}.WithLimit(10).WithAfter(7)
-	updated := original.WithLimit(20)
-
-	require.Equal(t, uint32(10), original.normalizedLimit())
-	originalAfter, ok := original.After()
-	require.True(t, ok)
-	require.Equal(t, uint32(7), originalAfter)
-
-	require.Equal(t, uint32(20), updated.normalizedLimit())
-	updatedAfter, ok := updated.After()
-	require.True(t, ok)
-	require.Equal(t, uint32(7), updatedAfter)
-}
-
-// TestRequestWithCursorImmutability verifies that WithAfter returns a new
-// Request and does not modify the original.
-func TestRequestWithCursorImmutability(t *testing.T) {
-	t.Parallel()
-
-	original := Request[uint32]{}.WithLimit(10).WithAfter(7)
-	updated := original.WithAfter(9)
-
-	require.Equal(t, uint32(10), original.normalizedLimit())
-	originalAfter, ok := original.After()
-	require.True(t, ok)
-	require.Equal(t, uint32(7), originalAfter)
-
-	require.Equal(t, uint32(10), updated.normalizedLimit())
-	updatedAfter, ok := updated.After()
-	require.True(t, ok)
-	require.Equal(t, uint32(9), updatedAfter)
-}
-
-// TestRequestAfterReturnsCursorCopy verifies that mutating the local cursor
-// variable returned by After does not mutate the request's internal cursor.
-func TestRequestAfterReturnsCursorCopy(t *testing.T) {
-	t.Parallel()
-
-	request := Request[uint32]{}.WithAfter(7)
-	after, ok := request.After()
-
-	require.True(t, ok)
-	require.Equal(t, uint32(7), after)
-
-	after = 9
-	require.Equal(t, uint32(9), after)
-
-	originalAfter, ok := request.After()
-	require.True(t, ok)
-	require.Equal(t, uint32(7), originalAfter)
+// intPtrRequest returns a pointer to the given int value.
+func intPtrRequest(v int) *int {
+	return &v
 }
 
 // TestBuildResult verifies BuildResult assembles the correct Result using the
@@ -195,37 +21,37 @@ func TestBuildResult(t *testing.T) {
 	testCases := []struct {
 		name      string
 		items     []int
-		size      uint32
+		limit     uint32
 		wantItems []int
 		wantNext  *int
 	}{
 		{
 			name:      "empty slice returns empty result",
 			items:     []int{},
-			size:      100,
+			limit:     100,
 			wantItems: []int{},
 			wantNext:  nil,
 		},
 		{
 			name:      "len less than limit leaves Next nil",
 			items:     []int{1, 2},
-			size:      5,
+			limit:     5,
 			wantItems: []int{1, 2},
 			wantNext:  nil,
 		},
 		{
 			name:      "len equal to limit leaves Next nil",
 			items:     []int{1, 2},
-			size:      2,
+			limit:     2,
 			wantItems: []int{1, 2},
 			wantNext:  nil,
 		},
 		{
 			name:      "len greater than limit trims and sets Next",
 			items:     []int{1, 2, 3},
-			size:      2,
+			limit:     2,
 			wantItems: []int{1, 2},
-			wantNext:  func() *int { v := 2; return &v }(),
+			wantNext:  intPtrRequest(2),
 		},
 	}
 
@@ -233,8 +59,7 @@ func TestBuildResult(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			req := Request[int]{}.WithLimit(tc.size)
-			result := BuildResult(req, tc.items, toCursor)
+			result := BuildResult(tc.items, tc.limit, toCursor)
 
 			require.Equal(t, tc.wantItems, result.Items)
 			require.Equal(t, tc.wantNext, result.Next)

--- a/wallet/internal/db/page/request_test.go
+++ b/wallet/internal/db/page/request_test.go
@@ -11,6 +11,44 @@ func intPtrRequest(v int) *int {
 	return &v
 }
 
+// TestNewRequest verifies NewRequest validates and stores the page limit.
+func TestNewRequest(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		limit     uint32
+		wantLimit uint32
+		wantErr   error
+	}{
+		{
+			name:    "zero limit rejected",
+			limit:   0,
+			wantErr: ErrInvalidLimit,
+		},
+		{
+			name:      "positive limit accepted",
+			limit:     5,
+			wantLimit: 5,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req, err := NewRequest[int](tc.limit)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.wantLimit, req.Limit())
+		})
+	}
+}
+
 // TestBuildResult verifies BuildResult assembles the correct Result using the
 // lookahead row trimming and Next logic.
 func TestBuildResult(t *testing.T) {
@@ -59,7 +97,10 @@ func TestBuildResult(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := BuildResult(tc.items, tc.limit, toCursor)
+			req, err := NewRequest[int](tc.limit)
+			require.NoError(t, err)
+
+			result := BuildResult(req, tc.items, toCursor)
 
 			require.Equal(t, tc.wantItems, result.Items)
 			require.Equal(t, tc.wantNext, result.Next)

--- a/wallet/internal/db/page/result.go
+++ b/wallet/internal/db/page/result.go
@@ -6,7 +6,7 @@ type Result[T any, C any] struct {
 	// page.
 	Items []T
 
-	// Next is the after to use for fetching the next page. It is nil when
-	// no more pages exist.
+	// Next is the after to use for fetching the next page. It is nil when no
+	// more pages exist.
 	Next *C
 }

--- a/wallet/internal/db/pg/addresses.go
+++ b/wallet/internal/db/pg/addresses.go
@@ -37,7 +37,8 @@ func (s *Store) GetAddress(ctx context.Context,
 // ListAddresses returns a page of addresses matching the given query.
 func (s *Store) ListAddresses(ctx context.Context,
 	query db.ListAddressesQuery) (page.Result[db.AddressInfo, uint32], error) {
-	if query.Page.Limit == 0 {
+
+	if query.Page.Limit() == 0 {
 		return page.Result[db.AddressInfo, uint32]{}, db.ErrInvalidPageLimit
 	}
 
@@ -47,7 +48,7 @@ func (s *Store) ListAddresses(ctx context.Context,
 	}
 
 	result := page.BuildResult(
-		items, query.Page.Limit,
+		query.Page, items,
 		func(item db.AddressInfo) uint32 {
 			return item.ID
 		},
@@ -358,7 +359,7 @@ func buildAddressPageParams(
 		Purpose:     int64(q.Scope.Purpose),
 		CoinType:    int64(q.Scope.Coin),
 		AccountName: q.AccountName,
-		PageLimit:   int64(q.Page.Limit) + 1,
+		PageLimit:   int64(q.Page.Limit()) + 1,
 	}
 
 	if q.Page.After != nil {

--- a/wallet/internal/db/pg/addresses.go
+++ b/wallet/internal/db/pg/addresses.go
@@ -37,6 +37,9 @@ func (s *Store) GetAddress(ctx context.Context,
 // ListAddresses returns a page of addresses matching the given query.
 func (s *Store) ListAddresses(ctx context.Context,
 	query db.ListAddressesQuery) (page.Result[db.AddressInfo, uint32], error) {
+	if query.Page.Limit == 0 {
+		return page.Result[db.AddressInfo, uint32]{}, db.ErrInvalidPageLimit
+	}
 
 	items, err := listAddressesByAccount(ctx, s.queries, query)
 	if err != nil {
@@ -44,7 +47,7 @@ func (s *Store) ListAddresses(ctx context.Context,
 	}
 
 	result := page.BuildResult(
-		query.Page, items,
+		items, query.Page.Limit,
 		func(item db.AddressInfo) uint32 {
 			return item.ID
 		},
@@ -355,12 +358,12 @@ func buildAddressPageParams(
 		Purpose:     int64(q.Scope.Purpose),
 		CoinType:    int64(q.Scope.Coin),
 		AccountName: q.AccountName,
-		PageLimit:   int64(q.Page.QueryLimit()),
+		PageLimit:   int64(q.Page.Limit) + 1,
 	}
 
-	if cursor, ok := q.Page.After(); ok {
+	if q.Page.After != nil {
 		params.CursorID = sql.NullInt64{
-			Int64: int64(cursor),
+			Int64: int64(*q.Page.After),
 			Valid: true,
 		}
 	}

--- a/wallet/internal/db/pg/wallet.go
+++ b/wallet/internal/db/pg/wallet.go
@@ -147,6 +147,10 @@ func (s *Store) GetWallet(ctx context.Context,
 func (s *Store) ListWallets(ctx context.Context,
 	query db.ListWalletsQuery) (page.Result[db.WalletInfo, uint32], error) {
 
+	if query.Page.Limit == 0 {
+		return page.Result[db.WalletInfo, uint32]{}, db.ErrInvalidPageLimit
+	}
+
 	rows, err := s.queries.ListWallets(ctx, listWalletsParams(query.Page))
 	if err != nil {
 		return page.Result[db.WalletInfo, uint32]{},
@@ -165,7 +169,7 @@ func (s *Store) ListWallets(ctx context.Context,
 	}
 
 	result := page.BuildResult(
-		query.Page, items,
+		items, query.Page.Limit,
 		func(item db.WalletInfo) uint32 {
 			return item.ID
 		},
@@ -322,12 +326,12 @@ func listWalletsParams(
 	req page.Request[uint32]) sqlc.ListWalletsParams {
 
 	params := sqlc.ListWalletsParams{
-		PageLimit: int64(req.QueryLimit()),
+		PageLimit: int64(req.Limit) + 1,
 	}
 
-	if cursor, ok := req.After(); ok {
+	if req.After != nil {
 		params.CursorID = sql.NullInt64{
-			Int64: int64(cursor),
+			Int64: int64(*req.After),
 			Valid: true,
 		}
 	}

--- a/wallet/internal/db/pg/wallet.go
+++ b/wallet/internal/db/pg/wallet.go
@@ -147,7 +147,7 @@ func (s *Store) GetWallet(ctx context.Context,
 func (s *Store) ListWallets(ctx context.Context,
 	query db.ListWalletsQuery) (page.Result[db.WalletInfo, uint32], error) {
 
-	if query.Page.Limit == 0 {
+	if query.Page.Limit() == 0 {
 		return page.Result[db.WalletInfo, uint32]{}, db.ErrInvalidPageLimit
 	}
 
@@ -169,7 +169,7 @@ func (s *Store) ListWallets(ctx context.Context,
 	}
 
 	result := page.BuildResult(
-		items, query.Page.Limit,
+		query.Page, items,
 		func(item db.WalletInfo) uint32 {
 			return item.ID
 		},
@@ -326,7 +326,7 @@ func listWalletsParams(
 	req page.Request[uint32]) sqlc.ListWalletsParams {
 
 	params := sqlc.ListWalletsParams{
-		PageLimit: int64(req.Limit) + 1,
+		PageLimit: int64(req.Limit()) + 1,
 	}
 
 	if req.After != nil {

--- a/wallet/internal/db/sqlite/addresses.go
+++ b/wallet/internal/db/sqlite/addresses.go
@@ -37,6 +37,9 @@ func (s *Store) GetAddress(ctx context.Context,
 // ListAddresses returns a page of addresses matching the given query.
 func (s *Store) ListAddresses(ctx context.Context,
 	query db.ListAddressesQuery) (page.Result[db.AddressInfo, uint32], error) {
+	if query.Page.Limit == 0 {
+		return page.Result[db.AddressInfo, uint32]{}, db.ErrInvalidPageLimit
+	}
 
 	items, err := listAddressesByAccount(ctx, s.queries, query)
 	if err != nil {
@@ -44,7 +47,7 @@ func (s *Store) ListAddresses(ctx context.Context,
 	}
 
 	result := page.BuildResult(
-		query.Page, items,
+		items, query.Page.Limit,
 		func(item db.AddressInfo) uint32 {
 			return item.ID
 		},
@@ -351,11 +354,11 @@ func buildAddressPageParams(
 		Purpose:     int64(q.Scope.Purpose),
 		CoinType:    int64(q.Scope.Coin),
 		AccountName: q.AccountName,
-		PageLimit:   int64(q.Page.QueryLimit()),
+		PageLimit:   int64(q.Page.Limit) + 1,
 	}
 
-	if cursor, ok := q.Page.After(); ok {
-		params.CursorID = int64(cursor)
+	if q.Page.After != nil {
+		params.CursorID = int64(*q.Page.After)
 	}
 
 	return params

--- a/wallet/internal/db/sqlite/addresses.go
+++ b/wallet/internal/db/sqlite/addresses.go
@@ -37,7 +37,8 @@ func (s *Store) GetAddress(ctx context.Context,
 // ListAddresses returns a page of addresses matching the given query.
 func (s *Store) ListAddresses(ctx context.Context,
 	query db.ListAddressesQuery) (page.Result[db.AddressInfo, uint32], error) {
-	if query.Page.Limit == 0 {
+
+	if query.Page.Limit() == 0 {
 		return page.Result[db.AddressInfo, uint32]{}, db.ErrInvalidPageLimit
 	}
 
@@ -47,7 +48,7 @@ func (s *Store) ListAddresses(ctx context.Context,
 	}
 
 	result := page.BuildResult(
-		items, query.Page.Limit,
+		query.Page, items,
 		func(item db.AddressInfo) uint32 {
 			return item.ID
 		},
@@ -354,7 +355,7 @@ func buildAddressPageParams(
 		Purpose:     int64(q.Scope.Purpose),
 		CoinType:    int64(q.Scope.Coin),
 		AccountName: q.AccountName,
-		PageLimit:   int64(q.Page.Limit) + 1,
+		PageLimit:   int64(q.Page.Limit()) + 1,
 	}
 
 	if q.Page.After != nil {

--- a/wallet/internal/db/sqlite/wallet.go
+++ b/wallet/internal/db/sqlite/wallet.go
@@ -147,7 +147,7 @@ func (s *Store) GetWallet(ctx context.Context,
 func (s *Store) ListWallets(ctx context.Context,
 	query db.ListWalletsQuery) (page.Result[db.WalletInfo, uint32], error) {
 
-	if query.Page.Limit == 0 {
+	if query.Page.Limit() == 0 {
 		return page.Result[db.WalletInfo, uint32]{}, db.ErrInvalidPageLimit
 	}
 
@@ -171,7 +171,7 @@ func (s *Store) ListWallets(ctx context.Context,
 	}
 
 	result := page.BuildResult(
-		items, query.Page.Limit,
+		query.Page, items,
 		func(item db.WalletInfo) uint32 {
 			return item.ID
 		},
@@ -329,7 +329,7 @@ func listWalletsParams(
 	req page.Request[uint32]) sqlc.ListWalletsParams {
 
 	params := sqlc.ListWalletsParams{
-		PageLimit: int64(req.Limit) + 1,
+		PageLimit: int64(req.Limit()) + 1,
 	}
 
 	if req.After != nil {

--- a/wallet/internal/db/sqlite/wallet.go
+++ b/wallet/internal/db/sqlite/wallet.go
@@ -147,6 +147,10 @@ func (s *Store) GetWallet(ctx context.Context,
 func (s *Store) ListWallets(ctx context.Context,
 	query db.ListWalletsQuery) (page.Result[db.WalletInfo, uint32], error) {
 
+	if query.Page.Limit == 0 {
+		return page.Result[db.WalletInfo, uint32]{}, db.ErrInvalidPageLimit
+	}
+
 	rows, err := s.queries.ListWallets(
 		ctx, listWalletsParams(query.Page),
 	)
@@ -167,7 +171,7 @@ func (s *Store) ListWallets(ctx context.Context,
 	}
 
 	result := page.BuildResult(
-		query.Page, items,
+		items, query.Page.Limit,
 		func(item db.WalletInfo) uint32 {
 			return item.ID
 		},
@@ -325,11 +329,11 @@ func listWalletsParams(
 	req page.Request[uint32]) sqlc.ListWalletsParams {
 
 	params := sqlc.ListWalletsParams{
-		PageLimit: int64(req.QueryLimit()),
+		PageLimit: int64(req.Limit) + 1,
 	}
 
-	if cursor, ok := req.After(); ok {
-		params.CursorID = int64(cursor)
+	if req.After != nil {
+		params.CursorID = int64(*req.After)
 	}
 
 	return params

--- a/wallet/internal/db/wallets_common.go
+++ b/wallet/internal/db/wallets_common.go
@@ -3,7 +3,7 @@ package db
 // NextListWalletsQuery returns a query with its pagination cursor advanced to
 // the provided value.
 func NextListWalletsQuery(q ListWalletsQuery, cursor uint32) ListWalletsQuery {
-	q.Page = q.Page.WithAfter(cursor)
+	q.Page.After = &cursor
 
 	return q
 }


### PR DESCRIPTION
## Summary
- remove builder-style pagination request methods and require explicit, non-zero page limits
- drop shared default and max-limit policy from `page`, leaving query sizing and validation to wallet/address store code
- simplify manual pagination by using pointer-style `After`/`Next` tokens and update tests/docs to match

## Why
The current pagination API still exposes more policy and plumbing than necessary for callers. This change keeps the shared `page` package focused on the pagination contract itself while letting stores own query sizing and validation. It also makes page-by-page call sites more direct by forwarding `Next` into `After` without extra helper or presence-flag state.

## Testing
- `GOWORK=off go test ./wallet/internal/db/page ./wallet/internal/db`
- `GOWORK=off go test -tags itest ./wallet/internal/db/itest -run 'TestListWallets|TestListWalletsZeroLimit|TestIterWallets|TestListAddresses|TestListAddressesZeroLimit|TestListAddressesOrdering|TestIterAddresses'`
- `GOWORK=off go test ./wallet/internal/db/...`