### PR TITLE
wallet: fix missing drop statements

### DIFF
--- a/wallet/internal/db/itest/migration_rollback_test.go
+++ b/wallet/internal/db/itest/migration_rollback_test.go
@@ -1,0 +1,25 @@
+//go:build itest
+
+package itest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestMigrationsRollbackReapply ensures that the full migration chain
+// can be cleanly rolled back and then reapplied without errors.
+func TestMigrationsRollbackReapply(t *testing.T) {
+	t.Parallel()
+
+	s := NewTestStore(t)
+
+	err := s.RollbackAllMigrations()
+	require.NoError(t, err, "failed to rollback all migrations")
+
+	// Reapply all migrations to verify that the database can return to a
+	// valid, fully migrated state after a complete rollback.
+	err = s.ApplyAllMigrations()
+	require.NoError(t, err, "failed to reapply all migrations")
+}

--- a/wallet/internal/db/pg/itest.go
+++ b/wallet/internal/db/pg/itest.go
@@ -5,6 +5,7 @@ package pg
 import (
 	"database/sql"
 
+	sqlassetpg "github.com/btcsuite/btcwallet/wallet/internal/sql/pg"
 	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 )
 
@@ -16,4 +17,14 @@ func (s *Store) DB() *sql.DB {
 // Queries returns the underlying sqlc queries for integration testing.
 func (s *Store) Queries() *sqlc.Queries {
 	return s.queries
+}
+
+// RollbackAllMigrations rolls back all PostgreSQL migrations.
+func (s *Store) RollbackAllMigrations() error {
+	return sqlassetpg.RollbackMigrations(s.db)
+}
+
+// ApplyAllMigrations reapplies all PostgreSQL migrations.
+func (s *Store) ApplyAllMigrations() error {
+	return sqlassetpg.ApplyMigrations(s.db)
 }

--- a/wallet/internal/db/sqlite/itest.go
+++ b/wallet/internal/db/sqlite/itest.go
@@ -5,6 +5,7 @@ package sqlite
 import (
 	"database/sql"
 
+	sqlassetsqlite "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite"
 	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 )
 
@@ -16,4 +17,14 @@ func (s *Store) DB() *sql.DB {
 // Queries returns the underlying sqlc queries for integration testing.
 func (s *Store) Queries() *sqlc.Queries {
 	return s.queries
+}
+
+// RollbackAllMigrations rolls back all SQLite migrations.
+func (s *Store) RollbackAllMigrations() error {
+	return sqlassetsqlite.RollbackMigrations(s.db)
+}
+
+// ApplyAllMigrations reapplies all SQLite migrations.
+func (s *Store) ApplyAllMigrations() error {
+	return sqlassetsqlite.ApplyMigrations(s.db)
 }

--- a/wallet/internal/sql/pg/migrations.go
+++ b/wallet/internal/sql/pg/migrations.go
@@ -51,3 +51,18 @@ func ApplyMigrations(db *sql.DB) error {
 
 	return nil
 }
+
+// RollbackMigrations rolls back all PostgreSQL migrations from the database.
+func RollbackMigrations(db *sql.DB) error {
+	m, err := newMigrationInstance(db)
+	if err != nil {
+		return err
+	}
+
+	err = m.Down()
+	if err != nil && !errors.Is(err, gomigrate.ErrNoChange) {
+		return fmt.Errorf("rollback migrations: %w", err)
+	}
+
+	return nil
+}

--- a/wallet/internal/sql/pg/migrations.go
+++ b/wallet/internal/sql/pg/migrations.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	gomigrate "github.com/golang-migrate/migrate/v4"
-	"github.com/golang-migrate/migrate/v4/database"
 	migrate "github.com/golang-migrate/migrate/v4/database/postgres"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
 )
@@ -15,25 +14,34 @@ import (
 //go:embed migrations/*.sql
 var migrationFS embed.FS
 
-type driverFactory func(*sql.DB) (database.Driver, error)
-
-// applyMigrations applies all embedded postgres migrations to one database.
-func applyMigrations(db *sql.DB, newDriver driverFactory) error {
+// newMigrationInstance creates a migrate instance from embedded postgres
+// migrations.
+func newMigrationInstance(db *sql.DB) (*gomigrate.Migrate, error) {
 	sourceDriver, err := iofs.New(migrationFS, "migrations")
 	if err != nil {
-		return fmt.Errorf("create source driver: %w", err)
+		return nil, fmt.Errorf("create source driver: %w", err)
 	}
 
-	driver, err := newDriver(db)
+	driver, err := migrate.WithInstance(db, &migrate.Config{})
 	if err != nil {
-		return fmt.Errorf("create postgres driver: %w", err)
+		return nil, fmt.Errorf("create postgres driver: %w", err)
 	}
 
 	m, err := gomigrate.NewWithInstance(
 		"iofs", sourceDriver, "postgres", driver,
 	)
 	if err != nil {
-		return fmt.Errorf("create migrate instance: %w", err)
+		return nil, fmt.Errorf("create migrate instance: %w", err)
+	}
+
+	return m, nil
+}
+
+// ApplyMigrations applies all PostgreSQL migrations to the database.
+func ApplyMigrations(db *sql.DB) error {
+	m, err := newMigrationInstance(db)
+	if err != nil {
+		return err
 	}
 
 	err = m.Up()
@@ -42,11 +50,4 @@ func applyMigrations(db *sql.DB, newDriver driverFactory) error {
 	}
 
 	return nil
-}
-
-// ApplyMigrations applies all PostgreSQL migrations to the database.
-func ApplyMigrations(db *sql.DB) error {
-	return applyMigrations(db, func(db *sql.DB) (database.Driver, error) {
-		return migrate.WithInstance(db, &migrate.Config{})
-	})
 }

--- a/wallet/internal/sql/pg/migrations/000006_addresses.down.sql
+++ b/wallet/internal/sql/pg/migrations/000006_addresses.down.sql
@@ -1,5 +1,9 @@
 -- Rollback note: Idempotent by design (using "IF EXISTS").
 -- Must succeed even if tables are already dropped or database is in unexpected state.
+DROP TRIGGER IF EXISTS trg_addresses_imported_key_count_insert ON addresses;
+DROP TRIGGER IF EXISTS trg_addresses_imported_key_count_delete ON addresses;
+DROP FUNCTION IF EXISTS sync_account_imported_key_count_insert();
+DROP FUNCTION IF EXISTS sync_account_imported_key_count_delete();
 DROP INDEX IF EXISTS idx_addresses_account_id;
 DROP TABLE IF EXISTS address_secrets;
 DROP TABLE IF EXISTS addresses;

--- a/wallet/internal/sql/sqlite/migrations.go
+++ b/wallet/internal/sql/sqlite/migrations.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	gomigrate "github.com/golang-migrate/migrate/v4"
-	"github.com/golang-migrate/migrate/v4/database"
 	migrate "github.com/golang-migrate/migrate/v4/database/sqlite"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
 )
@@ -15,23 +14,32 @@ import (
 //go:embed migrations/*.sql
 var migrationFS embed.FS
 
-type driverFactory func(*sql.DB) (database.Driver, error)
-
-// applyMigrations applies all embedded sqlite migrations to one database.
-func applyMigrations(db *sql.DB, newDriver driverFactory) error {
+// newMigrationInstance creates a migrate instance from embedded sqlite
+// migrations.
+func newMigrationInstance(db *sql.DB) (*gomigrate.Migrate, error) {
 	sourceDriver, err := iofs.New(migrationFS, "migrations")
 	if err != nil {
-		return fmt.Errorf("create source driver: %w", err)
+		return nil, fmt.Errorf("create source driver: %w", err)
 	}
 
-	driver, err := newDriver(db)
+	driver, err := migrate.WithInstance(db, &migrate.Config{})
 	if err != nil {
-		return fmt.Errorf("create sqlite driver: %w", err)
+		return nil, fmt.Errorf("create sqlite driver: %w", err)
 	}
 
 	m, err := gomigrate.NewWithInstance("iofs", sourceDriver, "sqlite", driver)
 	if err != nil {
-		return fmt.Errorf("create migrate instance: %w", err)
+		return nil, fmt.Errorf("create migrate instance: %w", err)
+	}
+
+	return m, nil
+}
+
+// ApplyMigrations applies all SQLite migrations to the database.
+func ApplyMigrations(db *sql.DB) error {
+	m, err := newMigrationInstance(db)
+	if err != nil {
+		return err
 	}
 
 	err = m.Up()
@@ -40,11 +48,4 @@ func applyMigrations(db *sql.DB, newDriver driverFactory) error {
 	}
 
 	return nil
-}
-
-// ApplyMigrations applies all SQLite migrations to the database.
-func ApplyMigrations(db *sql.DB) error {
-	return applyMigrations(db, func(db *sql.DB) (database.Driver, error) {
-		return migrate.WithInstance(db, &migrate.Config{})
-	})
 }

--- a/wallet/internal/sql/sqlite/migrations.go
+++ b/wallet/internal/sql/sqlite/migrations.go
@@ -49,3 +49,18 @@ func ApplyMigrations(db *sql.DB) error {
 
 	return nil
 }
+
+// RollbackMigrations rolls back all SQLite migrations from the database.
+func RollbackMigrations(db *sql.DB) error {
+	m, err := newMigrationInstance(db)
+	if err != nil {
+		return err
+	}
+
+	err = m.Down()
+	if err != nil && !errors.Is(err, gomigrate.ErrNoChange) {
+		return fmt.Errorf("rollback migrations: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
changes
- add an integration test that rolls SQL migrations all the way down and reapplies them for both SQLite and PostgreSQL
- clean up the Postgres addresses down migration by explicitly dropping the imported-key triggers and functions


test 
```
make itest-db db=sqlite && make itest-db db=postgres
```