### PR TITLE
wallet: migrate address manager to db.Store

### DIFF
--- a/wallet/address_manager.go
+++ b/wallet/address_manager.go
@@ -21,6 +21,9 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/addresstype"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/db/page"
 	"github.com/btcsuite/btcwallet/walletdb"
 )
 
@@ -49,11 +52,14 @@ var (
 	// ErrUnableToExtractAddress is returned when an address cannot be
 	// extracted from a pkscript.
 	ErrUnableToExtractAddress = errors.New("unable to extract address")
-
 	// errStopIteration is a special error used to stop the iteration in
 	// ForEachAccountAddress.
 	errStopIteration = errors.New("stop iteration")
 )
+
+// addressManagerPageLimit is the transitional address iteration page size.
+// TODO(yy): Make this configurable once the address store is fully wired.
+const addressManagerPageLimit = 500
 
 // AddressProperty represents an address and its balance.
 type AddressProperty struct {
@@ -127,9 +133,14 @@ type OutputScriptInfo struct {
 	// RedeemScript is the redeem script committed to by the outer P2SH output.
 	// For nested P2WPKH-in-P2SH spends, this is the inner witness program, for
 	// example `OP_0 <20-byte-key-hash>`. Native witness spends, such as P2WPKH
-	// and P2TR, leave this nil. The final scriptSig wrapper for nested witness
-	// spends can be rebuilt from this script when assembling the input.
+	// and P2TR, leave this nil.
 	RedeemScript []byte
+
+	// SigScript is the final scriptSig wrapper needed to spend outputs that are
+	// wrapped in P2SH.
+	// For nested P2WPKH-in-P2SH spends, this is a single push of RedeemScript.
+	// Native witness spends leave this nil.
+	SigScript []byte
 }
 
 // AddressManager provides an interface for generating and inspecting wallet
@@ -223,6 +234,77 @@ func addressInfoFromManagedAddress(
 	}
 
 	return info, nil
+}
+
+// addressPageRequest returns the standard page request used by address-manager
+// iteration helpers.
+func addressPageRequest() (page.Request[uint32], error) {
+	return page.NewRequest[uint32](addressManagerPageLimit)
+}
+
+// addressInfoFromStoreAddress converts one db-native address record into the
+// wallet-owned address metadata shape exposed by the public API.
+func addressInfoFromStoreAddress(storeAddr *db.AddressInfo,
+	chainParams *chaincfg.Params) (AddressInfo, error) {
+
+	addr := extractAddrFromPKScript(storeAddr.ScriptPubKey, chainParams)
+	if addr == nil {
+		return AddressInfo{}, fmt.Errorf("%w: from pkscript %x",
+			ErrUnableToExtractAddress, storeAddr.ScriptPubKey)
+	}
+
+	addrType, err := addresstype.ToWallet(
+		storeAddr.AddrType, storeAddr.HasScript,
+	)
+	if err != nil {
+		return AddressInfo{}, fmt.Errorf("%w: %v", ErrUnknownAddrType,
+			storeAddr.AddrType)
+	}
+
+	internal := storeAddr.Origin == db.DerivedAccount &&
+		storeAddr.Branch == 1
+
+	info := AddressInfo{
+		Addr:       addr,
+		AddrType:   addrType,
+		Imported:   storeAddr.Origin == db.ImportedAccount,
+		Internal:   internal,
+		Compressed: storeAddressPubKeyCompressed(storeAddr.PubKey),
+	}
+
+	if len(storeAddr.PubKey) == 0 {
+		return info, nil
+	}
+
+	pubKey, err := btcec.ParsePubKey(storeAddr.PubKey)
+	if err != nil {
+		return AddressInfo{}, fmt.Errorf("parse pubkey: %w", err)
+	}
+
+	info.PubKey = pubKey
+
+	if info.Imported {
+		return info, nil
+	}
+
+	info.Derivation = &AddressDerivation{
+		KeyScope: waddrmgr.KeyScope{
+			Purpose: storeAddr.KeyScope.Purpose,
+			Coin:    storeAddr.KeyScope.Coin,
+		},
+		Account:              storeAddr.AccountNumber,
+		Branch:               storeAddr.Branch,
+		Index:                storeAddr.Index,
+		MasterKeyFingerprint: storeAddr.MasterKeyFingerprint,
+	}
+
+	return info, nil
+}
+
+// storeAddressPubKeyCompressed reports whether store pubkey bytes use the
+// compressed secp256k1 encoding.
+func storeAddressPubKeyCompressed(pubKey []byte) bool {
+	return len(pubKey) == btcec.PubKeyBytesLenCompressed
 }
 
 // NewAddress returns a new address for the given account and address type.
@@ -660,7 +742,7 @@ func (w *Wallet) ImportPublicKey(_ context.Context, pubKey *btcec.PublicKey,
 
 	manager, err := w.addrStore.FetchScopedKeyManager(keyScope)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: %v", ErrUnknownAddrType, addrType)
 	}
 
 	var addr btcutil.Address
@@ -898,7 +980,7 @@ func derivationForAddressInfo(addressInfo AddressInfo) (
 
 	keyScope := addressInfo.Derivation.KeyScope
 
-	return &psbt.Bip32Derivation{
+	derivationInfo := &psbt.Bip32Derivation{
 		PubKey:               addressInfo.PubKey.SerializeCompressed(),
 		MasterKeyFingerprint: addressInfo.Derivation.MasterKeyFingerprint,
 		Bip32Path: []uint32{
@@ -908,5 +990,7 @@ func derivationForAddressInfo(addressInfo AddressInfo) (
 			addressInfo.Derivation.Branch,
 			addressInfo.Derivation.Index,
 		},
-	}, nil
+	}
+
+	return derivationInfo, nil
 }

--- a/wallet/address_manager.go
+++ b/wallet/address_manager.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/btcutil/psbt"
@@ -24,6 +25,7 @@ import (
 	"github.com/btcsuite/btcwallet/wallet/internal/addresstype"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wallet/internal/db/page"
+	"github.com/btcsuite/btcwallet/wallet/internal/keyvault"
 	"github.com/btcsuite/btcwallet/walletdb"
 )
 
@@ -671,35 +673,7 @@ func (w *Wallet) ListAddresses(_ context.Context, accountName string,
 }
 
 // ImportPublicKey imports a single public key as a watch-only address.
-//
-// This method allows the wallet to track transactions related to a specific
-// public key without having access to the corresponding private key. This is
-// useful for monitoring addresses without compromising their security.
-//
-// How it works:
-// The method determines the appropriate key scope based on the provided
-// address type and then uses the corresponding scoped key manager to import
-// the public key.
-//
-// Logical Steps:
-//  1. Determine the key scope from the address type (e.g., P2WKH, NP2WKH).
-//  2. Fetch the scoped key manager for that scope.
-//  3. Initiate a database transaction.
-//  4. Within the transaction, call the underlying address manager's
-//     ImportPublicKey method to store the key.
-//  5. Commit the transaction.
-//
-// Database Actions:
-//   - This method performs a single database write transaction
-//     (`walletdb.Update`).
-//   - It stores the public key and its associated address information within
-//     the `waddrmgr` namespace.
-//
-// Time Complexity:
-//   - The operation is dominated by the database write, making its complexity
-//     roughly O(1) or O(log N) depending on the database backend's indexing
-//     strategy for keys. It is generally a fast operation.
-func (w *Wallet) ImportPublicKey(_ context.Context, pubKey *btcec.PublicKey,
+func (w *Wallet) ImportPublicKey(ctx context.Context, pubKey *btcec.PublicKey,
 	addrType waddrmgr.AddressType) error {
 
 	err := w.state.validateStarted()
@@ -712,25 +686,34 @@ func (w *Wallet) ImportPublicKey(_ context.Context, pubKey *btcec.PublicKey,
 		return fmt.Errorf("%w: %v", ErrUnknownAddrType, addrType)
 	}
 
-	manager, err := w.addrStore.FetchScopedKeyManager(keyScope)
+	storeAddrType, err := addresstype.FromWallet(addrType)
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrUnknownAddrType, addrType)
 	}
 
-	var addr btcutil.Address
+	serializedPubKey := pubKey.SerializeCompressed()
 
-	err = walletdb.Update(w.cfg.DB, func(tx walletdb.ReadWriteTx) error {
-		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+	addr, err := addrType.AddrFromPubKeyBytes(
+		serializedPubKey, w.cfg.ChainParams,
+	)
+	if err != nil {
+		return fmt.Errorf("derive imported address: %w", err)
+	}
 
-		ma, err := manager.ImportPublicKey(addrmgrNs, pubKey, nil)
-		if err != nil {
-			return err
-		}
+	scriptPubKey, err := txscript.PayToAddrScript(addr)
+	if err != nil {
+		return fmt.Errorf("pay to addr script: %w", err)
+	}
 
-		addr = ma.Address()
-
-		return nil
-	})
+	_, err = w.store.NewImportedAddress(
+		ctx, db.NewImportedAddressParams{
+			WalletID:     w.id,
+			Scope:        db.KeyScope(keyScope),
+			AddressType:  storeAddrType.Type,
+			ScriptPubKey: scriptPubKey,
+			PubKey:       serializedPubKey,
+		},
+	)
 	if err != nil {
 		return err
 	}
@@ -739,33 +722,7 @@ func (w *Wallet) ImportPublicKey(_ context.Context, pubKey *btcec.PublicKey,
 }
 
 // ImportTaprootScript imports a taproot script for tracking and spending.
-//
-// This method allows the wallet to import a taproot script, which is
-// necessary for spending from or tracking a taproot address.
-//
-// How it works:
-// The method uses the BIP-0086 key scope to fetch the taproot-specific
-// scoped key manager. It then calls the underlying manager's
-// ImportTaprootScript method to store the script information.
-//
-// Logical Steps:
-//  1. Fetch the scoped key manager for the taproot key scope (BIP-0086).
-//  2. Initiate a database transaction.
-//  3. Within the transaction, get the wallet's current sync state to use as
-//     the "birthday" for the new script.
-//  4. Call the underlying address manager's ImportTaprootScript method.
-//  5. Commit the transaction.
-//
-// Database Actions:
-//   - This method performs a single database write transaction
-//     (`walletdb.Update`).
-//   - It stores the taproot script and its derived address information within
-//     the `waddrmgr` namespace.
-//
-// Time Complexity:
-//   - Similar to ImportPublicKey, this operation is dominated by a database
-//     write, making it a fast operation with a complexity of roughly O(1).
-func (w *Wallet) ImportTaprootScript(_ context.Context,
+func (w *Wallet) ImportTaprootScript(ctx context.Context,
 	tapscript waddrmgr.Tapscript) (AddressInfo, error) {
 
 	err := w.state.validateStarted()
@@ -773,34 +730,76 @@ func (w *Wallet) ImportTaprootScript(_ context.Context,
 		return AddressInfo{}, err
 	}
 
-	manager, err := w.addrStore.FetchScopedKeyManager(
-		waddrmgr.KeyScopeBIP0086,
+	taprootKey, err := tapscript.TaprootKey()
+	if err != nil {
+		return AddressInfo{}, err
+	}
+
+	addr, err := btcutil.NewAddressTaproot(
+		schnorr.SerializePubKey(taprootKey), w.cfg.ChainParams,
+	)
+	if err != nil {
+		return AddressInfo{}, fmt.Errorf("taproot address: %w", err)
+	}
+
+	scriptPubKey, err := txscript.PayToAddrScript(addr)
+	if err != nil {
+		return AddressInfo{}, fmt.Errorf("pay to addr script: %w", err)
+	}
+
+	encryptedScript, err := encryptTaprootScript(w.keyVault, &tapscript)
+	if err != nil {
+		return AddressInfo{}, err
+	}
+
+	storeInfo, err := w.store.NewImportedAddress(
+		ctx, db.NewImportedAddressParams{
+			WalletID:        w.id,
+			Scope:           db.KeyScope(waddrmgr.KeyScopeBIP0086),
+			AddressType:     db.TaprootPubKey,
+			ScriptPubKey:    scriptPubKey,
+			EncryptedScript: encryptedScript,
+		},
 	)
 	if err != nil {
 		return AddressInfo{}, err
 	}
 
-	var addr waddrmgr.ManagedAddress
+	storeInfo.HasScript = true
 
-	err = walletdb.Update(w.cfg.DB, func(tx walletdb.ReadWriteTx) error {
-		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		syncedTo := w.addrStore.SyncedTo()
-		addr, err = manager.ImportTaprootScript(
-			ns, &tapscript, &syncedTo, 1, false,
-		)
-
-		return err
-	})
+	info, err := addressInfoFromStoreAddress(storeInfo, w.cfg.ChainParams)
 	if err != nil {
 		return AddressInfo{}, err
 	}
 
-	err = w.cfg.Chain.NotifyReceived([]btcutil.Address{addr.Address()})
+	err = w.cfg.Chain.NotifyReceived([]btcutil.Address{addr})
 	if err != nil {
 		return AddressInfo{}, err
 	}
 
-	return addressInfoFromManagedAddress(addr)
+	return info, nil
+}
+
+// encryptTaprootScript encodes and encrypts taproot script data before the
+// encrypted blob is handed to the store.
+func encryptTaprootScript(vault keyvault.Vault,
+	tapscript *waddrmgr.Tapscript) ([]byte, error) {
+
+	encodedScript, err := waddrmgr.EncodeTaprootScript(tapscript)
+	if err != nil {
+		return nil, fmt.Errorf("encode tapscript: %w", err)
+	}
+
+	if vault == nil {
+		return nil, fmt.Errorf("%w: keyVault", ErrMissingParam)
+	}
+
+	encryptedScript, err := vault.Encrypt(waddrmgr.CKTPublic, encodedScript)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt tapscript: %w", err)
+	}
+
+	return encryptedScript, nil
 }
 
 // ScriptForOutput returns the address metadata and spending scripts for a given

--- a/wallet/address_manager.go
+++ b/wallet/address_manager.go
@@ -52,9 +52,6 @@ var (
 	// ErrUnableToExtractAddress is returned when an address cannot be
 	// extracted from a pkscript.
 	ErrUnableToExtractAddress = errors.New("unable to extract address")
-	// errStopIteration is a special error used to stop the iteration in
-	// ForEachAccountAddress.
-	errStopIteration = errors.New("stop iteration")
 )
 
 // addressManagerPageLimit is the transitional address iteration page size.
@@ -363,7 +360,7 @@ func storeAddressPubKeyCompressed(pubKey []byte) bool {
 //     transaction to persist the new address.
 //     This ensures that we only save an address after we are confident that
 //     it is being watched by the backend, preventing fund loss.
-func (w *Wallet) NewAddress(_ context.Context, accountName string,
+func (w *Wallet) NewAddress(ctx context.Context, accountName string,
 	addrType waddrmgr.AddressType, change bool) (btcutil.Address, error) {
 
 	err := w.state.validateStarted()
@@ -381,48 +378,26 @@ func (w *Wallet) NewAddress(_ context.Context, accountName string,
 		return nil, fmt.Errorf("%w: %v", ErrUnknownAddrType, addrType)
 	}
 
-	manager, err := w.addrStore.FetchScopedKeyManager(keyScope)
+	addrInfo, err := w.store.NewDerivedAddress(
+		ctx, db.NewDerivedAddressParams{
+			WalletID:    w.id,
+			AccountName: accountName,
+			Scope:       db.KeyScope(keyScope),
+			Change:      change,
+		},
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	addr, err := w.newAddress(manager, accountName, change)
-	if err != nil {
-		return nil, err
+	addr := extractAddrFromPKScript(addrInfo.ScriptPubKey, w.cfg.ChainParams)
+	if addr == nil {
+		return nil, fmt.Errorf("%w: from pkscript %x",
+			ErrUnableToExtractAddress, addrInfo.ScriptPubKey)
 	}
 
 	// Notify the rpc server about the newly created address.
 	err = w.cfg.Chain.NotifyReceived([]btcutil.Address{addr})
-	if err != nil {
-		return nil, err
-	}
-
-	return addr, nil
-}
-
-// newAddress returns the next external chained address for a wallet. It
-// wraps the database transaction and the call to the scoped key manager's
-// NewAddress method. The underlying address manager handles its own
-// synchronization to ensure that in-memory state remains consistent with the
-// database, preventing race conditions during address creation.
-func (w *Wallet) newAddress(manager waddrmgr.AccountStore,
-	accountName string, change bool) (btcutil.Address, error) {
-
-	var (
-		addr btcutil.Address
-		err  error
-	)
-
-	err = walletdb.Update(w.cfg.DB, func(tx walletdb.ReadWriteTx) error {
-		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-
-		addr, err = manager.NewAddress(addrmgrNs, accountName, change)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	})
 	if err != nil {
 		return nil, err
 	}
@@ -482,19 +457,35 @@ func (w *Wallet) GetUnusedAddress(ctx context.Context, accountName string,
 		return nil, fmt.Errorf("%w: %v", ErrUnknownAddrType, addrType)
 	}
 
-	manager, err := w.addrStore.FetchScopedKeyManager(keyScope)
+	req, err := addressPageRequest()
 	if err != nil {
 		return nil, err
 	}
 
-	unusedAddr, err := w.findUnusedAddress(manager, accountName, change)
-	// We'll ignore the special error that we use to stop the iteration.
-	if err != nil && !errors.Is(err, errStopIteration) {
-		return nil, err
-	}
+	addresses := w.store.IterAddresses(
+		ctx, db.ListAddressesQuery{
+			WalletID:    w.id,
+			AccountName: accountName,
+			Scope:       db.KeyScope(keyScope),
+			Page:        req,
+		},
+	)
+	for storeAddr, err := range addresses {
+		if err != nil {
+			return nil, err
+		}
 
-	// If we found an unused address, we can return it now.
-	if unusedAddr != nil {
+		unusedAddr, ok, err := nextUnusedStoreAddress(
+			storeAddr, change, w.cfg.ChainParams,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		if !ok {
+			continue
+		}
+
 		return unusedAddr, nil
 	}
 
@@ -502,50 +493,31 @@ func (w *Wallet) GetUnusedAddress(ctx context.Context, accountName string,
 	return w.NewAddress(ctx, accountName, addrType, change)
 }
 
-// findUnusedAddress scans for an unused address for the given account.
-func (w *Wallet) findUnusedAddress(manager waddrmgr.AccountStore,
-	accountName string, change bool) (btcutil.Address, error) {
+// nextUnusedStoreAddress returns the unused address candidate represented by a
+// store record, if it matches the requested branch and is not already used.
+func nextUnusedStoreAddress(storeAddr db.AddressInfo,
+	change bool,
+	chainParams *chaincfg.Params) (btcutil.Address, bool, error) {
 
-	var unusedAddr btcutil.Address
+	if storeAddr.Origin != db.DerivedAccount {
+		return nil, false, nil
+	}
 
-	err := walletdb.View(w.cfg.DB, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+	if (storeAddr.Branch == 1) != change {
+		return nil, false, nil
+	}
 
-		// First, look up the account number for the passed account
-		// name.
-		acctNum, err := manager.LookupAccount(addrmgrNs, accountName)
-		if err != nil {
-			return err
-		}
+	if storeAddr.IsUsed {
+		return nil, false, nil
+	}
 
-		// Now, iterate through all addresses for the account and
-		// return the first one that is unused.
-		return manager.ForEachAccountAddress(
-			addrmgrNs, acctNum,
-			func(maddr waddrmgr.ManagedAddress) error {
-				// We only want to consider addresses that match
-				// the change parameter.
-				if maddr.Internal() != change {
-					return nil
-				}
+	addr := extractAddrFromPKScript(storeAddr.ScriptPubKey, chainParams)
+	if addr == nil {
+		return nil, false, fmt.Errorf("%w: from pkscript %x",
+			ErrUnableToExtractAddress, storeAddr.ScriptPubKey)
+	}
 
-				if !maddr.Used(addrmgrNs) {
-					unusedAddr = maddr.Address()
-
-					// Return a special error to signal
-					// that the iteration should be
-					// stopped. This is the idiomatic way
-					// to halt a ForEach* loop in this
-					// codebase.
-					return errStopIteration
-				}
-
-				return nil
-			},
-		)
-	})
-
-	return unusedAddr, err
+	return addr, true, nil
 }
 
 // GetAddressInfo returns detailed information regarding a wallet address.

--- a/wallet/address_manager_test.go
+++ b/wallet/address_manager_test.go
@@ -96,7 +96,7 @@ func expectStoreNewAddress(t *testing.T, w *Wallet, deps *mockWalletDeps,
 			AccountName: accountName,
 			Scope:       db.KeyScope(scope),
 			Change:      change,
-		}, mock.Anything,
+		},
 	).Return(addressInfoFromAddr(t, addr), nil).Once()
 	deps.chain.On("NotifyReceived", []btcutil.Address{addr}).Return(nil).Once()
 }

--- a/wallet/address_manager_test.go
+++ b/wallet/address_manager_test.go
@@ -547,11 +547,21 @@ func TestGetDerivationInfoNoDerivationInfo(t *testing.T) {
 	require.Error(t, err)
 
 	// Arrange: Import the key as a watch-only address.
-	deps.addrStore.On("FetchScopedKeyManager", mock.Anything).
-		Return(deps.accountManager, nil).Once()
-	deps.accountManager.On("ImportPublicKey", mock.Anything, pubKey,
-		mock.Anything).Return(deps.pubKeyAddr, nil).Once()
-	deps.pubKeyAddr.On("Address").Return(addr).Twice()
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	deps.store.On(
+		"NewImportedAddress", mock.Anything,
+		db.NewImportedAddressParams{
+			WalletID:     w.id,
+			Scope:        db.KeyScope(waddrmgr.KeyScopeBIP0084),
+			AddressType:  db.WitnessPubKey,
+			ScriptPubKey: pkScript,
+			PubKey:       pubKey.SerializeCompressed(),
+		},
+	).Return(importedPubKeyAddressInfoFromAddr(
+		t, addr, waddrmgr.KeyScopeBIP0084, pubKey,
+	), nil).Once()
 	deps.chain.On("NotifyReceived", []btcutil.Address{addr}).
 		Return(nil).Once()
 
@@ -562,6 +572,7 @@ func TestGetDerivationInfoNoDerivationInfo(t *testing.T) {
 	// imported key.
 	deps.addrStore.On("Address", mock.Anything, addr).
 		Return(deps.pubKeyAddr, nil).Once()
+	deps.pubKeyAddr.On("Address").Return(addr).Once()
 	deps.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
 	deps.pubKeyAddr.On("Imported").Return(true).Once()
 	deps.pubKeyAddr.On("Internal").Return(false).Once()
@@ -678,48 +689,37 @@ func TestListAddresses(t *testing.T) {
 func TestImportPublicKey(t *testing.T) {
 	t.Parallel()
 
-	// Create a new test wallet.
 	w, deps := createStartedWalletWithMocks(t)
 
-	// Create a new public key to import.
 	privKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 
 	pubKey := privKey.PubKey()
 
-	// Import the public key.
 	addr, _ := btcutil.NewAddressWitnessPubKeyHash(
 		btcutil.Hash160(pubKey.SerializeCompressed()),
 		w.cfg.ChainParams,
 	)
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
 
-	deps.addrStore.On("FetchScopedKeyManager", mock.Anything).
-		Return(deps.accountManager, nil).Once()
-	deps.accountManager.On("ImportPublicKey", mock.Anything, pubKey,
-		mock.Anything).Return(deps.pubKeyAddr, nil).Once()
-	deps.pubKeyAddr.On("Address").Return(addr).Once()
+	deps.store.On(
+		"NewImportedAddress", mock.Anything,
+		db.NewImportedAddressParams{
+			WalletID:     w.id,
+			Scope:        db.KeyScope(waddrmgr.KeyScopeBIP0084),
+			AddressType:  db.WitnessPubKey,
+			ScriptPubKey: pkScript,
+			PubKey:       pubKey.SerializeCompressed(),
+		},
+	).Return(importedPubKeyAddressInfoFromAddr(
+		t, addr, waddrmgr.KeyScopeBIP0084, pubKey,
+	), nil).Once()
 	deps.chain.On("NotifyReceived", []btcutil.Address{addr}).
 		Return(nil).Once()
 
 	err = w.ImportPublicKey(t.Context(), pubKey, waddrmgr.WitnessPubKey)
 	require.NoError(t, err)
-
-	// Check that the address is now managed by the wallet.
-	deps.addrStore.On("Address", mock.Anything, addr).
-		Return(deps.pubKeyAddr, nil).Once()
-	deps.pubKeyAddr.On("Address").Return(addr).Once()
-	deps.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
-	deps.pubKeyAddr.On("Imported").Return(true).Once()
-	deps.pubKeyAddr.On("Internal").Return(false).Once()
-	deps.pubKeyAddr.On("Compressed").Return(true).Once()
-	deps.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-	deps.pubKeyAddr.On("DerivationInfo").Return(
-		waddrmgr.KeyScope{}, waddrmgr.DerivationPath{}, false,
-	).Once()
-
-	info, err := w.GetAddressInfo(t.Context(), addr)
-	require.NoError(t, err)
-	require.NotNil(t, info)
 }
 
 // TestImportTaprootScript tests the ImportTaprootScript method to ensure it can
@@ -727,7 +727,6 @@ func TestImportPublicKey(t *testing.T) {
 func TestImportTaprootScript(t *testing.T) {
 	t.Parallel()
 
-	// Create a new test wallet.
 	w, deps := createStartedWalletWithMocks(t)
 
 	// Create a new tapscript to import.
@@ -752,25 +751,37 @@ func TestImportTaprootScript(t *testing.T) {
 		Leaves: []txscript.TapLeaf{leaf},
 	}
 
-	// Import the tapscript.
 	addr, _ := btcutil.NewAddressTaproot(
 		schnorr.SerializePubKey(txscript.ComputeTaprootOutputKey(
 			pubKey, rootHash[:],
 		)), w.cfg.ChainParams,
 	)
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
 
-	deps.addrStore.On("FetchScopedKeyManager", waddrmgr.KeyScopeBIP0086).
-		Return(deps.accountManager, nil).Once()
+	encodedScript, err := waddrmgr.EncodeTaprootScript(&tapscript)
+	require.NoError(t, err)
 
-	// SyncedTo is mocked in createStartedWalletWithMocks (height 1).
-	deps.accountManager.On("ImportTaprootScript", mock.Anything,
-		mock.Anything, mock.Anything, uint8(1), false).
-		Return(deps.taprootAddr, nil).Once()
-	deps.taprootAddr.On("Address").Return(addr).Twice()
-	deps.taprootAddr.On("AddrType").Return(waddrmgr.TaprootScript).Once()
-	deps.taprootAddr.On("Imported").Return(true).Once()
-	deps.taprootAddr.On("Internal").Return(false).Once()
-	deps.taprootAddr.On("Compressed").Return(false).Once()
+	encryptedScript := []byte("encrypted tapscript")
+	deps.addrStore.On(
+		"Encrypt", waddrmgr.CKTPublic, encodedScript,
+	).Return(encryptedScript, nil).Once()
+	deps.store.On("NewImportedAddress", mock.Anything,
+		db.NewImportedAddressParams{
+			WalletID:        w.id,
+			Scope:           db.KeyScope(waddrmgr.KeyScopeBIP0086),
+			AddressType:     db.TaprootPubKey,
+			ScriptPubKey:    pkScript,
+			EncryptedScript: encryptedScript,
+		}).Return(&db.AddressInfo{
+		AddrType:     db.TaprootPubKey,
+		Origin:       db.ImportedAccount,
+		AccountName:  db.DefaultImportedAccountName,
+		KeyScope:     db.KeyScope(waddrmgr.KeyScopeBIP0086),
+		ScriptPubKey: pkScript,
+		HasScript:    true,
+		IsWatchOnly:  true,
+	}, nil).Once()
 	deps.chain.On("NotifyReceived", []btcutil.Address{addr}).
 		Return(nil).Once()
 

--- a/wallet/address_manager_test.go
+++ b/wallet/address_manager_test.go
@@ -5,6 +5,7 @@
 package wallet
 
 import (
+	"iter"
 	"testing"
 	"time"
 
@@ -15,11 +16,101 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+// addressInfoFromAddr builds a store address record for a test address.
+func addressInfoFromAddr(t *testing.T, addr btcutil.Address) *db.AddressInfo {
+	t.Helper()
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	return &db.AddressInfo{ScriptPubKey: pkScript}
+}
+
+// derivedAddressInfoFromAddr builds derived store address metadata for tests.
+func derivedAddressInfoFromAddr(t *testing.T, addr btcutil.Address,
+	addrType db.AddressType, accountName string, scope waddrmgr.KeyScope,
+	change bool, index uint32, fingerprint uint32,
+	pubKey *btcec.PublicKey) *db.AddressInfo {
+
+	t.Helper()
+
+	info := addressInfoFromAddr(t, addr)
+	info.AddrType = addrType
+	info.Origin = db.DerivedAccount
+	info.AccountName = accountName
+	info.AccountNumber = 0
+	info.KeyScope = db.KeyScope(scope)
+	info.MasterKeyFingerprint = fingerprint
+	info.Index = index
+
+	if change {
+		info.Branch = 1
+	}
+
+	if pubKey != nil {
+		info.PubKey = pubKey.SerializeCompressed()
+	}
+
+	return info
+}
+
+// importedPubKeyAddressInfoFromAddr builds imported public-key store metadata
+// for tests.
+func importedPubKeyAddressInfoFromAddr(t *testing.T, addr btcutil.Address,
+	scope waddrmgr.KeyScope, pubKey *btcec.PublicKey) *db.AddressInfo {
+
+	t.Helper()
+
+	info := addressInfoFromAddr(t, addr)
+	info.AddrType = db.WitnessPubKey
+	info.Origin = db.ImportedAccount
+	info.AccountName = db.DefaultImportedAccountName
+	info.KeyScope = db.KeyScope(scope)
+	info.IsWatchOnly = true
+
+	if pubKey != nil {
+		info.PubKey = pubKey.SerializeCompressed()
+	}
+
+	return info
+}
+
+// expectStoreNewAddress configures mock expectations for deriving an address.
+func expectStoreNewAddress(t *testing.T, w *Wallet, deps *mockWalletDeps,
+	accountName string, scope waddrmgr.KeyScope, change bool,
+	addr btcutil.Address) {
+
+	t.Helper()
+
+	deps.store.On(
+		"NewDerivedAddress", mock.Anything,
+		db.NewDerivedAddressParams{
+			WalletID:    w.id,
+			AccountName: accountName,
+			Scope:       db.KeyScope(scope),
+			Change:      change,
+		}, mock.Anything,
+	).Return(addressInfoFromAddr(t, addr), nil).Once()
+	deps.chain.On("NotifyReceived", []btcutil.Address{addr}).Return(nil).Once()
+}
+
+// addressIter returns an address iterator over static test records.
+func addressIter(items ...db.AddressInfo) iter.Seq2[db.AddressInfo, error] {
+	return func(yield func(db.AddressInfo, error) bool) {
+		for i := range items {
+			if !yield(items[i], nil) {
+				return
+			}
+		}
+	}
+}
 
 // TestNewAddress tests the NewAddress method, ensuring it can generate
 // various address types for different accounts and correctly handles both

--- a/wallet/address_manager_test.go
+++ b/wallet/address_manager_test.go
@@ -174,13 +174,9 @@ func TestNewAddress(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Create a new test wallet for each test case.
 			w, deps := createStartedWalletWithMocks(t)
 
-			// Setup mock expectations.
 			if tc.expectErr {
-				// Attempt to generate a new address with the specified
-				// parameters.
 				_, err := w.NewAddress(
 					t.Context(), tc.accountName,
 					tc.addrType, tc.change,
@@ -214,44 +210,21 @@ func TestNewAddress(t *testing.T) {
 				require.FailNow(t, "unknown address type", tc.addrType)
 			}
 
-			deps.addrStore.On("FetchScopedKeyManager", mock.Anything).
-				Return(deps.accountManager, nil).
-				Once()
-			deps.addrStore.On("Address", mock.Anything, addr).
-				Return(deps.addr, nil).
-				Once()
+			scope, err := tc.addrType.KeyScope()
+			require.NoError(t, err)
 
-			deps.accountManager.On(
-				"NewAddress", mock.Anything, tc.accountName, tc.change,
-			).Return(addr, nil).Once()
+			expectStoreNewAddress(
+				t, w, deps, tc.accountName, scope, tc.change, addr,
+			)
 
-			deps.chain.On("NotifyReceived", []btcutil.Address{addr}).
-				Return(nil).
-				Once()
-
-			deps.addr.On("Address").Return(addr).Once()
-			deps.addr.On("AddrType").Return(tc.addrType).Once()
-			deps.addr.On("Imported").Return(false).Once()
-			deps.addr.On("Internal").Return(tc.change).Once()
-			deps.addr.On("Compressed").Return(true).Once()
-
-			// Attempt to generate a new address with the specified
-			// parameters.
-			addr, err := w.NewAddress(
+			addr, err = w.NewAddress(
 				t.Context(), tc.accountName,
 				tc.addrType, tc.change,
 			)
 			require.NoError(t, err)
 			require.NotNil(t, addr)
 
-			// Verify that the address is of the correct type.
 			require.IsType(t, tc.expectedAddrType, addr)
-
-			// Verify that the address is correctly marked as
-			// internal or external.
-			addrInfo, err := w.GetAddressInfo(t.Context(), addr)
-			require.NoError(t, err)
-			require.Equal(t, tc.change, addrInfo.Internal)
 		})
 	}
 }
@@ -261,121 +234,48 @@ func TestNewAddress(t *testing.T) {
 func TestGetUnusedAddress(t *testing.T) {
 	t.Parallel()
 
-	// Create a new test wallet.
 	w, deps := createStartedWalletWithMocks(t)
 
-	// Get a new address to start with.
-	mockAddr, _ := btcutil.NewAddressWitnessPubKeyHash(
+	firstAddr, _ := btcutil.NewAddressWitnessPubKeyHash(
 		make([]byte, 20), w.cfg.ChainParams,
 	)
-
-	deps.addrStore.On("FetchScopedKeyManager", mock.Anything).
-		Return(deps.accountManager, nil).Once()
-	deps.accountManager.On("NewAddress", mock.Anything, "default", false).
-		Return(mockAddr, nil).Once()
-	deps.chain.On("NotifyReceived", []btcutil.Address{mockAddr}).
-		Return(nil).Once()
-
-	addr, err := w.NewAddress(
-		t.Context(), "default", waddrmgr.WitnessPubKey, false,
-	)
+	scope := waddrmgr.KeyScopeBIP0084
+	req, err := addressPageRequest()
 	require.NoError(t, err)
 
-	// The first unused address should be the one we just created.
-	// GetUnusedAddress calls:
-	// - addrType.KeyScope
-	// - w.addrStore.FetchScopedKeyManager
-	// - w.findUnusedAddress (calls manager.LookupAccount and
-	//   ForEachAccountAddress)
-	deps.addrStore.On("FetchScopedKeyManager", mock.Anything).
-		Return(deps.accountManager, nil).Once()
-
-	deps.accountManager.On("LookupAccount", mock.Anything, "default").
-		Return(uint32(0), nil).Once()
-
-	deps.accountManager.On("ForEachAccountAddress", mock.Anything, uint32(0),
-		mock.Anything).Run(func(args mock.Arguments) {
-		f, ok := args.Get(2).(func(waddrmgr.ManagedAddress) error)
-		require.True(t, ok)
-		mockAddr1 := &mockManagedAddress{}
-		mockAddr1.On("Internal").Return(false).Once()
-		mockAddr1.On("Used", mock.Anything).Return(false).Once()
-		mockAddr1.On("Address").Return(addr).Once()
-		_ = f(mockAddr1)
-	}).Return(errStopIteration).Once()
+	deps.store.On(
+		"IterAddresses", mock.Anything,
+		db.ListAddressesQuery{
+			WalletID:    w.id,
+			AccountName: "default",
+			Scope:       db.KeyScope(scope),
+			Page:        req,
+		},
+	).Return(addressIter(*derivedAddressInfoFromAddr(
+		t, firstAddr, db.WitnessPubKey, "default", scope, false, 0, 0, nil,
+	))).Once()
 
 	unusedAddr, err := w.GetUnusedAddress(
 		t.Context(), "default", waddrmgr.WitnessPubKey, false,
 	)
 	require.NoError(t, err)
-	require.Equal(t, addr.String(), unusedAddr.String())
+	require.Equal(t, firstAddr.String(), unusedAddr.String())
 
-	// "Use" the address by creating a fake UTXO for it.
-	pkScript, err := txscript.PayToAddrScript(addr)
-	require.NoError(t, err)
+	usedFirstAddr := derivedAddressInfoFromAddr(
+		t, firstAddr, db.WitnessPubKey, "default", scope, false,
+		0, 0, nil,
+	)
+	usedFirstAddr.IsUsed = true
 
-	// Setup expectations for using the address.
-	deps.txStore.On("InsertTx", mock.Anything, mock.Anything,
-		mock.Anything).Return(nil).Once()
-	deps.txStore.On("AddCredit", mock.Anything, mock.Anything,
-		mock.Anything, uint32(0), false).Return(nil).Once()
-	deps.addrStore.On("MarkUsed", mock.Anything, addr).Return(nil).Once()
-
-	// We need to create a realistic transaction that has at least one
-	// input.
-	err = walletdb.Update(w.cfg.DB, func(tx walletdb.ReadWriteTx) error {
-		txmgrNs := tx.ReadWriteBucket(wtxmgrNamespaceKey)
-
-		// Create a new transaction and set the output to the address
-		// we want to mark as used.
-		msgTx := TstTx.MsgTx()
-		msgTx.TxOut = []*wire.TxOut{{
-			PkScript: pkScript,
-			Value:    1000,
-		}}
-
-		rec, err := wtxmgr.NewTxRecordFromMsgTx(msgTx, time.Now())
-		if err != nil {
-			return err
-		}
-
-		err = w.txStore.InsertTx(txmgrNs, rec, nil)
-		if err != nil {
-			return err
-		}
-
-		err = w.txStore.AddCredit(txmgrNs, rec, nil, 0, false)
-		if err != nil {
-			return err
-		}
-
-		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-
-		return w.addrStore.MarkUsed(addrmgrNs, addr)
-	})
-	require.NoError(t, err)
-
-	// Get the next unused address.
-	// This time findUnusedAddress will find the first address as used, and
-	// then we mock it returning nil for any more existing addresses,
-	// triggering a NewAddress call.
-	deps.addrStore.On("FetchScopedKeyManager", mock.Anything).
-		Return(deps.accountManager, nil).Twice()
-
-	deps.accountManager.On("LookupAccount", mock.Anything, "default").
-		Return(uint32(0), nil).Once()
-
-	deps.accountManager.On("ForEachAccountAddress", mock.Anything, uint32(0),
-		mock.Anything).Run(func(args mock.Arguments) {
-		f, ok := args.Get(2).(func(waddrmgr.ManagedAddress) error)
-		require.True(t, ok)
-
-		// First addr is used.
-		mockAddr1 := &mockManagedAddress{}
-		mockAddr1.On("Internal").Return(false).Once()
-		mockAddr1.On("Used", mock.Anything).Return(true).Once()
-		_ = f(mockAddr1)
-	}).Return(nil).Once()
+	deps.store.On(
+		"IterAddresses", mock.Anything,
+		db.ListAddressesQuery{
+			WalletID:    w.id,
+			AccountName: "default",
+			Scope:       db.KeyScope(scope),
+			Page:        req,
+		},
+	).Return(addressIter(*usedFirstAddr)).Once()
 
 	nextAddrVal, _ := btcutil.NewAddressWitnessPubKeyHash(
 		[]byte{
@@ -383,10 +283,7 @@ func TestGetUnusedAddress(t *testing.T) {
 			11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
 		}, w.cfg.ChainParams,
 	)
-	deps.accountManager.On("NewAddress", mock.Anything, "default", false).
-		Return(nextAddrVal, nil).Once()
-	deps.chain.On("NotifyReceived", []btcutil.Address{nextAddrVal}).
-		Return(nil).Once()
+	expectStoreNewAddress(t, w, deps, "default", scope, false, nextAddrVal)
 
 	nextAddr, err := w.GetUnusedAddress(
 		t.Context(), "default", waddrmgr.WitnessPubKey, false,
@@ -394,9 +291,8 @@ func TestGetUnusedAddress(t *testing.T) {
 	require.NoError(t, err)
 
 	// The next unused address should not be the same as the first one.
-	require.NotEqual(t, addr.String(), nextAddr.String())
+	require.NotEqual(t, firstAddr.String(), nextAddr.String())
 
-	// Now, let's test the change address.
 	changeAddrVal, _ := btcutil.NewAddressWitnessPubKeyHash(
 		[]byte{
 			21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
@@ -404,47 +300,23 @@ func TestGetUnusedAddress(t *testing.T) {
 		}, w.cfg.ChainParams,
 	)
 
-	deps.addrStore.On("FetchScopedKeyManager", mock.Anything).
-		Return(deps.accountManager, nil).Once()
-	deps.accountManager.On("NewAddress", mock.Anything, "default", true).
-		Return(changeAddrVal, nil).Once()
-	deps.chain.On("NotifyReceived", []btcutil.Address{changeAddrVal}).
-		Return(nil).Once()
-
-	changeAddr, err := w.NewAddress(
-		t.Context(), "default", waddrmgr.WitnessPubKey, true,
-	)
-	require.NoError(t, err)
-
-	// The first unused change address should be the one we just created.
-	deps.addrStore.On("FetchScopedKeyManager", mock.Anything).
-		Return(deps.accountManager, nil).Once()
-
-	deps.accountManager.On("LookupAccount", mock.Anything, "default").
-		Return(uint32(0), nil).Once()
-
-	deps.accountManager.On("ForEachAccountAddress", mock.Anything, uint32(0),
-		mock.Anything).Run(func(args mock.Arguments) {
-		f, ok := args.Get(2).(func(waddrmgr.ManagedAddress) error)
-		require.True(t, ok)
-
-		// First external addr (used).
-		deps.addr.On("Internal").Return(false).Once()
-		_ = f(deps.addr)
-
-		// First internal addr (unused).
-		mockAddr2 := &mockManagedAddress{}
-		mockAddr2.On("Internal").Return(true).Once()
-		mockAddr2.On("Used", mock.Anything).Return(false).Once()
-		mockAddr2.On("Address").Return(changeAddrVal).Once()
-		_ = f(mockAddr2)
-	}).Return(errStopIteration).Once()
+	deps.store.On(
+		"IterAddresses", mock.Anything,
+		db.ListAddressesQuery{
+			WalletID:    w.id,
+			AccountName: "default",
+			Scope:       db.KeyScope(scope),
+			Page:        req,
+		},
+	).Return(addressIter(*derivedAddressInfoFromAddr(
+		t, changeAddrVal, db.WitnessPubKey, "default", scope, true, 0, 0, nil,
+	))).Once()
 
 	unusedChangeAddr, err := w.GetUnusedAddress(
 		t.Context(), "default", waddrmgr.WitnessPubKey, true,
 	)
 	require.NoError(t, err)
-	require.Equal(t, changeAddr.String(), unusedChangeAddr.String())
+	require.Equal(t, changeAddrVal.String(), unusedChangeAddr.String())
 }
 
 // TestGetAddressInfo tests the GetAddressInfo method to ensure it returns
@@ -462,12 +334,9 @@ func TestGetAddressInfo(t *testing.T) {
 		make([]byte, 20), w.cfg.ChainParams,
 	)
 
-	deps.addrStore.On("FetchScopedKeyManager", mock.Anything).
-		Return(deps.accountManager, nil).Once()
-	deps.accountManager.On("NewAddress", mock.Anything, "default", false).
-		Return(addr, nil).Once()
-	deps.chain.On("NotifyReceived", []btcutil.Address{addr}).
-		Return(nil).Once()
+	expectStoreNewAddress(
+		t, w, deps, "default", waddrmgr.KeyScopeBIP0084, false, addr,
+	)
 
 	extAddr, err := w.NewAddress(
 		t.Context(), "default", waddrmgr.WitnessPubKey, false,
@@ -498,12 +367,9 @@ func TestGetAddressInfo(t *testing.T) {
 		make([]byte, 20), w.cfg.ChainParams,
 	)
 
-	deps.addrStore.On("FetchScopedKeyManager", mock.Anything).
-		Return(deps.accountManager, nil).Once()
-	deps.accountManager.On("NewAddress", mock.Anything, "default", true).
-		Return(addr, nil).Once()
-	deps.chain.On("NotifyReceived", []btcutil.Address{addr}).
-		Return(nil).Once()
+	expectStoreNewAddress(
+		t, w, deps, "default", waddrmgr.KeyScopeBIP0084, true, addr,
+	)
 
 	intAddr, err := w.NewAddress(
 		t.Context(), "default", waddrmgr.WitnessPubKey, true,
@@ -542,12 +408,9 @@ func TestGetDerivationInfoExternalAddressSuccess(t *testing.T) {
 		make([]byte, 20), w.cfg.ChainParams,
 	)
 
-	deps.addrStore.On("FetchScopedKeyManager", mock.Anything).
-		Return(deps.accountManager, nil).Once()
-	deps.accountManager.On("NewAddress", mock.Anything, "default", false).
-		Return(mockAddr, nil).Once()
-	deps.chain.On("NotifyReceived", []btcutil.Address{mockAddr}).
-		Return(nil).Once()
+	expectStoreNewAddress(
+		t, w, deps, "default", waddrmgr.KeyScopeBIP0084, false, mockAddr,
+	)
 
 	addr, err := w.NewAddress(
 		t.Context(), "default", waddrmgr.WitnessPubKey, false,
@@ -608,12 +471,9 @@ func TestGetDerivationInfoInternalAddressSuccess(t *testing.T) {
 		make([]byte, 20), w.cfg.ChainParams,
 	)
 
-	deps.addrStore.On("FetchScopedKeyManager", mock.Anything).
-		Return(deps.accountManager, nil).Once()
-	deps.accountManager.On("NewAddress", mock.Anything, "default", true).
-		Return(mockAddr, nil).Once()
-	deps.chain.On("NotifyReceived", []btcutil.Address{mockAddr}).
-		Return(nil).Once()
+	expectStoreNewAddress(
+		t, w, deps, "default", waddrmgr.KeyScopeBIP0084, true, mockAddr,
+	)
 
 	addr, err := w.NewAddress(
 		t.Context(), "default", waddrmgr.WitnessPubKey, true,
@@ -728,12 +588,9 @@ func TestListAddresses(t *testing.T) {
 		make([]byte, 20), w.cfg.ChainParams,
 	)
 
-	deps.addrStore.On("FetchScopedKeyManager", mock.Anything).
-		Return(deps.accountManager, nil).Once()
-	deps.accountManager.On("NewAddress", mock.Anything, "default", false).
-		Return(mockAddr, nil).Once()
-	deps.chain.On("NotifyReceived", []btcutil.Address{mockAddr}).
-		Return(nil).Once()
+	expectStoreNewAddress(
+		t, w, deps, "default", waddrmgr.KeyScopeBIP0084, false, mockAddr,
+	)
 
 	addr, err := w.NewAddress(
 		t.Context(), "default", waddrmgr.WitnessPubKey, false,
@@ -938,12 +795,9 @@ func TestScriptForOutput(t *testing.T) {
 		make([]byte, 20), w.cfg.ChainParams,
 	)
 
-	deps.addrStore.On("FetchScopedKeyManager", mock.Anything).
-		Return(deps.accountManager, nil).Once()
-	deps.accountManager.On("NewAddress", mock.Anything, "default", false).
-		Return(mockAddr, nil).Once()
-	deps.chain.On("NotifyReceived", []btcutil.Address{mockAddr}).
-		Return(nil).Once()
+	expectStoreNewAddress(
+		t, w, deps, "default", waddrmgr.KeyScopeBIP0084, false, mockAddr,
+	)
 
 	addr, err := w.NewAddress(
 		t.Context(), "default", waddrmgr.WitnessPubKey, false,

--- a/wallet/internal/addresstype/addresstype.go
+++ b/wallet/internal/addresstype/addresstype.go
@@ -1,0 +1,101 @@
+// Package addresstype bridges wallet-facing and store-facing address type
+// enums.
+package addresstype
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+)
+
+// ErrUnknown is returned when an address type has no supported wallet/store
+// mapping.
+var ErrUnknown = errors.New("unknown address type")
+
+// StoreType is the store representation of a wallet-facing address type.
+type StoreType struct {
+	// Type is the database-native address type.
+	Type db.AddressType
+
+	// HasScript reports whether this address type requires script metadata in
+	// addition to Type to round-trip back to the wallet representation.
+	HasScript bool
+}
+
+// FromWallet maps one wallet-facing address type to the store representation.
+func FromWallet(addrType waddrmgr.AddressType) (StoreType, error) {
+	switch addrType {
+	case waddrmgr.RawPubKey:
+		return StoreType{Type: db.RawPubKey}, nil
+
+	case waddrmgr.PubKeyHash:
+		return StoreType{Type: db.PubKeyHash}, nil
+
+	case waddrmgr.Script:
+		return StoreType{Type: db.ScriptHash, HasScript: true}, nil
+
+	case waddrmgr.NestedWitnessPubKey:
+		return StoreType{Type: db.NestedWitnessPubKey}, nil
+
+	case waddrmgr.WitnessPubKey:
+		return StoreType{Type: db.WitnessPubKey}, nil
+
+	case waddrmgr.WitnessScript:
+		return StoreType{Type: db.WitnessScript, HasScript: true}, nil
+
+	case waddrmgr.TaprootPubKey:
+		return StoreType{Type: db.TaprootPubKey}, nil
+
+	case waddrmgr.TaprootScript:
+		return StoreType{Type: db.TaprootPubKey, HasScript: true}, nil
+
+	default:
+		return StoreType{}, fmt.Errorf("wallet address type %d: %w",
+			addrType, ErrUnknown)
+	}
+}
+
+// ToWallet maps one store address type and script marker to the wallet-facing
+// address type.
+//
+//nolint:cyclop // This switch intentionally covers every store address type.
+func ToWallet(addrType db.AddressType,
+	hasScript bool) (waddrmgr.AddressType, error) {
+
+	switch addrType {
+	case db.RawPubKey:
+		return waddrmgr.RawPubKey, nil
+
+	case db.PubKeyHash:
+		return waddrmgr.PubKeyHash, nil
+
+	case db.ScriptHash:
+		return waddrmgr.Script, nil
+
+	case db.NestedWitnessPubKey:
+		return waddrmgr.NestedWitnessPubKey, nil
+
+	case db.WitnessPubKey:
+		return waddrmgr.WitnessPubKey, nil
+
+	case db.WitnessScript:
+		return waddrmgr.WitnessScript, nil
+
+	case db.TaprootPubKey:
+		if hasScript {
+			return waddrmgr.TaprootScript, nil
+		}
+
+		return waddrmgr.TaprootPubKey, nil
+
+	case db.Anchor:
+		return 0, fmt.Errorf("store address type %d: %w", addrType,
+			ErrUnknown)
+
+	default:
+		return 0, fmt.Errorf("store address type %d: %w", addrType,
+			ErrUnknown)
+	}
+}

--- a/wallet/internal/addresstype/addresstype_test.go
+++ b/wallet/internal/addresstype/addresstype_test.go
@@ -1,0 +1,173 @@
+package addresstype
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFromWallet verifies wallet-facing address types map to store address
+// types and script metadata.
+func TestFromWallet(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		addrType   waddrmgr.AddressType
+		wantType   db.AddressType
+		wantScript bool
+		wantErr    bool
+	}{
+		{
+			name:     "raw pubkey",
+			addrType: waddrmgr.RawPubKey,
+			wantType: db.RawPubKey,
+		},
+		{
+			name:     "pubkey hash",
+			addrType: waddrmgr.PubKeyHash,
+			wantType: db.PubKeyHash,
+		},
+		{
+			name:       "script hash",
+			addrType:   waddrmgr.Script,
+			wantType:   db.ScriptHash,
+			wantScript: true,
+		},
+		{
+			name:     "nested witness pubkey",
+			addrType: waddrmgr.NestedWitnessPubKey,
+			wantType: db.NestedWitnessPubKey,
+		},
+		{
+			name:     "witness pubkey",
+			addrType: waddrmgr.WitnessPubKey,
+			wantType: db.WitnessPubKey,
+		},
+		{
+			name:       "witness script",
+			addrType:   waddrmgr.WitnessScript,
+			wantType:   db.WitnessScript,
+			wantScript: true,
+		},
+		{
+			name:     "taproot pubkey",
+			addrType: waddrmgr.TaprootPubKey,
+			wantType: db.TaprootPubKey,
+		},
+		{
+			name:       "taproot script",
+			addrType:   waddrmgr.TaprootScript,
+			wantType:   db.TaprootPubKey,
+			wantScript: true,
+		},
+		{
+			name:     "unknown",
+			addrType: waddrmgr.AddressType(255),
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := FromWallet(tc.addrType)
+			if tc.wantErr {
+				require.ErrorIs(t, err, ErrUnknown)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.wantType, got.Type)
+			require.Equal(t, tc.wantScript, got.HasScript)
+		})
+	}
+}
+
+// TestToWallet verifies store address types and script metadata map back to
+// wallet-facing address types.
+func TestToWallet(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		addrType  db.AddressType
+		hasScript bool
+		want      waddrmgr.AddressType
+		wantErr   bool
+	}{
+		{
+			name:     "raw pubkey",
+			addrType: db.RawPubKey,
+			want:     waddrmgr.RawPubKey,
+		},
+		{
+			name:     "pubkey hash",
+			addrType: db.PubKeyHash,
+			want:     waddrmgr.PubKeyHash,
+		},
+		{
+			name:      "script hash with metadata",
+			addrType:  db.ScriptHash,
+			hasScript: true,
+			want:      waddrmgr.Script,
+		},
+		{
+			name:     "nested witness pubkey",
+			addrType: db.NestedWitnessPubKey,
+			want:     waddrmgr.NestedWitnessPubKey,
+		},
+		{
+			name:     "witness pubkey",
+			addrType: db.WitnessPubKey,
+			want:     waddrmgr.WitnessPubKey,
+		},
+		{
+			name:      "witness script with metadata",
+			addrType:  db.WitnessScript,
+			hasScript: true,
+			want:      waddrmgr.WitnessScript,
+		},
+		{
+			name:     "taproot pubkey",
+			addrType: db.TaprootPubKey,
+			want:     waddrmgr.TaprootPubKey,
+		},
+		{
+			name:      "taproot script",
+			addrType:  db.TaprootPubKey,
+			hasScript: true,
+			want:      waddrmgr.TaprootScript,
+		},
+		{
+			name:     "anchor unsupported",
+			addrType: db.Anchor,
+			wantErr:  true,
+		},
+		{
+			name:     "unknown",
+			addrType: db.AddressType(255),
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ToWallet(tc.addrType, tc.hasScript)
+			if tc.wantErr {
+				require.ErrorIs(t, err, ErrUnknown)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/wallet/internal/db/kvdb/addressstore.go
+++ b/wallet/internal/db/kvdb/addressstore.go
@@ -8,6 +8,8 @@ import (
 	"iter"
 	"sort"
 
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/addresstype"
@@ -113,11 +115,89 @@ func derivedAddressInfo(ns walletdb.ReadWriteBucket,
 	return info, nil
 }
 
-// NewImportedAddress is not yet implemented for kvdb.
+// NewImportedAddress imports one address through the legacy address-manager
+// path.
 func (s *Store) NewImportedAddress(ctx context.Context,
-	_ db.NewImportedAddressParams) (*db.AddressInfo, error) {
+	params db.NewImportedAddressParams) (*db.AddressInfo, error) {
 
-	return nil, notImplemented(ctx, "NewImportedAddress")
+	err := ctx.Err()
+	if err != nil {
+		return nil, err
+	}
+
+	err = params.ValidateBasic()
+	if err != nil {
+		return nil, fmt.Errorf("validate params: %w", err)
+	}
+
+	if params.HasPrivateKey() {
+		return nil, fmt.Errorf("NewImportedAddress: private key: %w",
+			errNotImplemented)
+	}
+
+	addrMgr := s.addrStore
+
+	manager, err := addrMgr.FetchScopedKeyManager(
+		waddrmgr.KeyScope(params.Scope),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("NewImportedAddress: fetch scoped manager: "+
+			"%w", err)
+	}
+
+	var info *db.AddressInfo
+
+	err = walletdb.Update(s.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+		if ns == nil {
+			return errMissingAddrmgrNamespace
+		}
+
+		managedAddr, err := s.importAddress(ns, manager, params)
+		if err != nil {
+			return err
+		}
+
+		info, err = managedAddressInfo(
+			ns, manager, addrMgr.WatchOnly(), managedAddr,
+		)
+		if err != nil {
+			return err
+		}
+
+		err = validateImportedAddress(params, info)
+		if err != nil {
+			return err
+		}
+
+		return setAddressID(
+			ns, manager, managedAddr.InternalAccount(),
+			addrMgr.WatchOnly(), info,
+		)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("NewImportedAddress: %w", err)
+	}
+
+	return info, nil
+}
+
+// validateImportedAddress checks that the legacy import result matches the
+// store request before the write transaction commits.
+func validateImportedAddress(params db.NewImportedAddressParams,
+	info *db.AddressInfo) error {
+
+	if params.AddressType != info.AddrType {
+		return fmt.Errorf("validate imported type: got %d want %d: %w",
+			info.AddrType, params.AddressType, errImportedAddressMismatch)
+	}
+
+	if !bytes.Equal(params.ScriptPubKey, info.ScriptPubKey) {
+		return fmt.Errorf("validate imported script pubkey: %w",
+			errImportedAddressMismatch)
+	}
+
+	return nil
 }
 
 // GetAddress is not yet implemented for kvdb.
@@ -224,6 +304,173 @@ func nextAddress(ns walletdb.ReadWriteBucket,
 	}
 
 	return addrs[0], nil
+}
+
+// importAddress imports a public key or encrypted script through the legacy
+// scoped manager.
+func (s *Store) importAddress(ns walletdb.ReadWriteBucket,
+	manager waddrmgr.AccountStore,
+	params db.NewImportedAddressParams) (waddrmgr.ManagedAddress, error) {
+
+	if params.HasScript() {
+		return s.importScriptAddress(ns, manager, params)
+	}
+
+	if len(params.PubKey) == 0 {
+		return nil, fmt.Errorf("kvdb imported raw script pubkey: %w",
+			errNotImplemented)
+	}
+
+	pubKey, err := btcec.ParsePubKey(params.PubKey)
+	if err != nil {
+		return nil, fmt.Errorf("parse imported pubkey: %w", err)
+	}
+
+	err = validateImportedPubKeyRequest(
+		manager, pubKey, params, s.addrStore.ChainParams(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	managedAddr, err := manager.ImportPublicKey(ns, pubKey, nil)
+	if err != nil {
+		return nil, fmt.Errorf("import public key: %w", err)
+	}
+
+	return managedAddr, nil
+}
+
+// validateImportedPubKeyRequest checks that a public-key import request matches
+// the address type and script that legacy waddrmgr will create.
+func validateImportedPubKeyRequest(manager waddrmgr.AccountStore,
+	pubKey *btcec.PublicKey, params db.NewImportedAddressParams,
+	chainParams *chaincfg.Params) error {
+
+	legacyAddrType, err := waddrmgr.AddressTypeForScope(manager.Scope())
+	if err != nil {
+		return fmt.Errorf("legacy import address type: %w", err)
+	}
+
+	storeAddrType, err := addresstype.FromWallet(legacyAddrType)
+	if err != nil {
+		return fmt.Errorf("legacy import store address type: %w", err)
+	}
+
+	if params.AddressType != storeAddrType.Type {
+		return fmt.Errorf("validate imported type: got %d want %d: %w",
+			storeAddrType.Type, params.AddressType,
+			errImportedAddressMismatch)
+	}
+
+	addr, err := legacyAddrType.AddrFromPubKeyBytes(
+		pubKey.SerializeCompressed(), chainParams,
+	)
+	if err != nil {
+		return fmt.Errorf("derive imported pubkey address: %w", err)
+	}
+
+	scriptPubKey, err := txscript.PayToAddrScript(addr)
+	if err != nil {
+		return fmt.Errorf("pay to imported pubkey address: %w", err)
+	}
+
+	if !bytes.Equal(params.ScriptPubKey, scriptPubKey) {
+		return fmt.Errorf("validate imported script pubkey: %w",
+			errImportedAddressMismatch)
+	}
+
+	return nil
+}
+
+// importScriptAddress decrypts and imports script material through the
+// legacy scoped manager.
+func (s *Store) importScriptAddress(ns walletdb.ReadWriteBucket,
+	manager waddrmgr.AccountStore,
+	params db.NewImportedAddressParams) (waddrmgr.ManagedAddress, error) {
+
+	script, err := s.addrStore.Decrypt(
+		waddrmgr.CKTPublic, params.EncryptedScript,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt imported script: %w", err)
+	}
+
+	blockStamp := s.addrStore.SyncedTo()
+	switch params.AddressType {
+	case db.ScriptHash:
+		return importScriptHashAddress(
+			ns, manager, script, &blockStamp,
+		)
+
+	case db.WitnessScript:
+		return importWitnessScriptAddress(
+			ns, manager, script, &blockStamp,
+		)
+
+	case db.TaprootPubKey:
+		return importTaprootScriptAddress(
+			ns, manager, script, &blockStamp,
+		)
+
+	case db.RawPubKey, db.PubKeyHash, db.NestedWitnessPubKey,
+		db.WitnessPubKey, db.Anchor:
+
+		return nil, fmt.Errorf("import script address type %d: %w",
+			params.AddressType, errNotImplemented)
+
+	default:
+		return nil, fmt.Errorf("import script address type %d: %w",
+			params.AddressType, errNotImplemented)
+	}
+}
+
+// importScriptHashAddress imports legacy P2SH script material.
+func importScriptHashAddress(ns walletdb.ReadWriteBucket,
+	manager waddrmgr.AccountStore, script []byte,
+	blockStamp *waddrmgr.BlockStamp) (waddrmgr.ManagedAddress, error) {
+
+	managedAddr, err := manager.ImportScript(ns, script, blockStamp)
+	if err != nil {
+		return nil, fmt.Errorf("import script: %w", err)
+	}
+
+	return managedAddr, nil
+}
+
+// importWitnessScriptAddress imports legacy P2WSH script material.
+func importWitnessScriptAddress(ns walletdb.ReadWriteBucket,
+	manager waddrmgr.AccountStore, script []byte,
+	blockStamp *waddrmgr.BlockStamp) (waddrmgr.ManagedAddress, error) {
+
+	managedAddr, err := manager.ImportWitnessScript(
+		ns, script, blockStamp, 0, false,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("import witness script: %w", err)
+	}
+
+	return managedAddr, nil
+}
+
+// importTaprootScriptAddress imports legacy taproot script material.
+func importTaprootScriptAddress(ns walletdb.ReadWriteBucket,
+	manager waddrmgr.AccountStore, script []byte,
+	blockStamp *waddrmgr.BlockStamp) (waddrmgr.ManagedAddress, error) {
+
+	tapscript, err := waddrmgr.DecodeTaprootScript(script)
+	if err != nil {
+		return nil, fmt.Errorf("decode tapscript: %w", err)
+	}
+
+	managedAddr, err := manager.ImportTaprootScript(
+		ns, tapscript, blockStamp, 1, false,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("import tapscript: %w", err)
+	}
+
+	return managedAddr, nil
 }
 
 // setAddressID assigns target's synthetic ID from the current legacy

--- a/wallet/internal/db/kvdb/addressstore.go
+++ b/wallet/internal/db/kvdb/addressstore.go
@@ -54,16 +54,47 @@ func (s *Store) GetAddressSecret(ctx context.Context,
 	return nil, notImplemented(ctx, "GetAddressSecret")
 }
 
-// ListAddressTypes is not yet implemented for kvdb.
-func (s *Store) ListAddressTypes(ctx context.Context) (
-	[]db.AddressTypeInfo, error) {
+// ListAddressTypes returns the static set of address types supported by the
+// store contract.
+func (s *Store) ListAddressTypes(ctx context.Context) ([]db.AddressTypeInfo,
+	error) {
 
-	return nil, notImplemented(ctx, "ListAddressTypes")
+	err := ctx.Err()
+	if err != nil {
+		return nil, err
+	}
+
+	infos := make([]db.AddressTypeInfo, len(addressTypes))
+	copy(infos, addressTypes)
+
+	return infos, nil
 }
 
-// GetAddressType is not yet implemented for kvdb.
+// GetAddressType returns the static address type metadata for the given type.
 func (s *Store) GetAddressType(ctx context.Context,
-	_ db.AddressType) (db.AddressTypeInfo, error) {
+	id db.AddressType) (db.AddressTypeInfo, error) {
 
-	return db.AddressTypeInfo{}, notImplemented(ctx, "GetAddressType")
+	err := ctx.Err()
+	if err != nil {
+		return db.AddressTypeInfo{}, err
+	}
+
+	for _, info := range addressTypes {
+		if info.Type == id {
+			return info, nil
+		}
+	}
+
+	return db.AddressTypeInfo{}, db.ErrAddressTypeNotFound
+}
+
+var addressTypes = []db.AddressTypeInfo{
+	{Type: db.RawPubKey, Description: "P2PK"},
+	{Type: db.PubKeyHash, Description: "P2PKH"},
+	{Type: db.ScriptHash, Description: "P2SH"},
+	{Type: db.NestedWitnessPubKey, Description: "P2SH-P2WPKH"},
+	{Type: db.WitnessPubKey, Description: "P2WPKH"},
+	{Type: db.WitnessScript, Description: "P2WSH"},
+	{Type: db.TaprootPubKey, Description: "P2TR"},
+	{Type: db.Anchor, Description: "P2A"},
 }

--- a/wallet/internal/db/kvdb/addressstore.go
+++ b/wallet/internal/db/kvdb/addressstore.go
@@ -1,18 +1,116 @@
 package kvdb
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"iter"
+	"sort"
 
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/addresstype"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wallet/internal/db/page"
+	"github.com/btcsuite/btcwallet/walletdb"
 )
 
-// NewDerivedAddress is not yet implemented for kvdb.
-func (s *Store) NewDerivedAddress(ctx context.Context,
-	_ db.NewDerivedAddressParams) (*db.AddressInfo, error) {
+var (
+	// errUnexpectedAddressCount is returned when legacy address derivation
+	// returns a number of addresses different from the requested count.
+	errUnexpectedAddressCount = errors.New("unexpected derived address count")
 
-	return nil, notImplemented(ctx, "NewDerivedAddress")
+	// errImportedAddressMismatch is returned when a legacy imported address
+	// does not match the store request's type or script.
+	errImportedAddressMismatch = errors.New("imported address mismatch")
+
+	// errMissingAddrmgrNamespace is returned when the waddrmgr namespace
+	// bucket is absent from the database.
+	errMissingAddrmgrNamespace = errors.New(
+		"kvdb: missing waddrmgr namespace",
+	)
+)
+
+// NewDerivedAddress creates one derived address through the legacy address-
+// manager path.
+func (s *Store) NewDerivedAddress(ctx context.Context,
+	params db.NewDerivedAddressParams) (*db.AddressInfo, error) {
+
+	err := ctx.Err()
+	if err != nil {
+		return nil, err
+	}
+
+	if params.AccountName == "" {
+		return nil, db.ErrMissingAccountName
+	}
+
+	addrMgr := s.addrStore
+
+	manager, err := addrMgr.FetchScopedKeyManager(
+		waddrmgr.KeyScope(params.Scope),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("NewDerivedAddress: fetch scoped manager: "+
+			"%w", err)
+	}
+
+	var info *db.AddressInfo
+
+	err = walletdb.Update(s.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+		if ns == nil {
+			return errMissingAddrmgrNamespace
+		}
+
+		info, err = derivedAddressInfo(
+			ns, manager, addrMgr.WatchOnly(), params,
+		)
+
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("NewDerivedAddress: %w", err)
+	}
+
+	return info, nil
+}
+
+// derivedAddressInfo creates one derived address info using the legacy scoped
+// manager and assigns its synthetic address ID.
+func derivedAddressInfo(ns walletdb.ReadWriteBucket,
+	manager waddrmgr.AccountStore,
+	walletIsWatchOnly bool,
+	params db.NewDerivedAddressParams) (*db.AddressInfo, error) {
+
+	account, err := manager.LookupAccount(ns, params.AccountName)
+	if err != nil {
+		if waddrmgr.IsError(err, waddrmgr.ErrAccountNotFound) {
+			return nil, db.ErrAccountNotFound
+		}
+
+		return nil, fmt.Errorf("lookup account: %w", err)
+	}
+
+	managedAddr, err := nextAddress(ns, manager, account, params.Change)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := managedAddressInfo(
+		ns, manager, walletIsWatchOnly, managedAddr,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	err = setAddressID(ns, manager, account, walletIsWatchOnly, info)
+	if err != nil {
+		return nil, err
+	}
+
+	return info, nil
 }
 
 // NewImportedAddress is not yet implemented for kvdb.
@@ -98,4 +196,244 @@ var addressTypes = []db.AddressTypeInfo{
 	{Type: db.WitnessScript, Description: "P2WSH"},
 	{Type: db.TaprootPubKey, Description: "P2TR"},
 	{Type: db.Anchor, Description: "P2A"},
+}
+
+// nextAddress allocates the next external or internal address for an account.
+func nextAddress(ns walletdb.ReadWriteBucket,
+	manager waddrmgr.AccountStore, account uint32,
+	change bool) (waddrmgr.ManagedAddress, error) {
+
+	var (
+		addrs []waddrmgr.ManagedAddress
+		err   error
+	)
+
+	if change {
+		addrs, err = manager.NextInternalAddresses(ns, account, 1)
+	} else {
+		addrs, err = manager.NextExternalAddresses(ns, account, 1)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("derive address: %w", err)
+	}
+
+	if len(addrs) != 1 {
+		return nil, fmt.Errorf("derive address: expected 1, got %d: %w",
+			len(addrs), errUnexpectedAddressCount)
+	}
+
+	return addrs[0], nil
+}
+
+// setAddressID assigns target's synthetic ID from the current legacy
+// account view.
+func setAddressID(ns walletdb.ReadBucket, manager waddrmgr.AccountStore,
+	account uint32, walletIsWatchOnly bool, target *db.AddressInfo) error {
+
+	items, err := accountAddressInfos(
+		ns, manager, account, walletIsWatchOnly,
+	)
+	if err != nil {
+		return err
+	}
+
+	for i := range items {
+		if bytes.Equal(items[i].ScriptPubKey, target.ScriptPubKey) {
+			target.ID = items[i].ID
+
+			return nil
+		}
+	}
+
+	return db.ErrAddressNotFound
+}
+
+// accountAddressInfos loads all addresses for a legacy account and assigns
+// collision-free synthetic IDs for the current sorted account view.
+func accountAddressInfos(ns walletdb.ReadBucket,
+	manager waddrmgr.AccountStore, account uint32,
+	walletIsWatchOnly bool) ([]db.AddressInfo, error) {
+
+	var items []db.AddressInfo
+
+	err := manager.ForEachAccountAddress(
+		ns, account, func(managedAddr waddrmgr.ManagedAddress) error {
+			info, err := managedAddressInfo(
+				ns, manager, walletIsWatchOnly, managedAddr,
+			)
+			if err != nil {
+				return err
+			}
+
+			items = append(items, *info)
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("iterate account addresses: %w", err)
+	}
+
+	// NOTE: waddrmgr does not expose SQL-style cursor queries, so the
+	// transitional kvdb adapter materializes the full legacy account before
+	// slicing a page.
+	err = sortAddressInfos(items)
+	if err != nil {
+		return nil, err
+	}
+
+	return items, nil
+}
+
+// sortAddressInfos sorts address infos and assigns one-based ordinal IDs.
+func sortAddressInfos(items []db.AddressInfo) error {
+	sort.Slice(items, func(i, j int) bool {
+		return addressLess(items[i], items[j])
+	})
+
+	for i := range items {
+		id, err := db.Int64ToUint32(int64(i + 1))
+		if err != nil {
+			return fmt.Errorf("address ordinal: %w", err)
+		}
+
+		items[i].ID = id
+	}
+
+	return nil
+}
+
+// addressLess reports whether a sorts before b in the synthetic address view.
+func addressLess(a, b db.AddressInfo) bool {
+	if a.Origin != b.Origin {
+		return a.Origin < b.Origin
+	}
+
+	if a.Branch != b.Branch {
+		return a.Branch < b.Branch
+	}
+
+	if a.Index != b.Index {
+		return a.Index < b.Index
+	}
+
+	return bytes.Compare(a.ScriptPubKey, b.ScriptPubKey) < 0
+}
+
+// managedAddressInfo adapts one legacy managed address into the db address view
+// used by store callers.
+func managedAddressInfo(ns walletdb.ReadBucket,
+	manager waddrmgr.AccountStore, walletIsWatchOnly bool,
+	managedAddr waddrmgr.ManagedAddress) (*db.AddressInfo, error) {
+
+	scriptPubKey, err := txscript.PayToAddrScript(managedAddr.Address())
+	if err != nil {
+		return nil, fmt.Errorf("pay to address script: %w", err)
+	}
+
+	addrType, err := addresstype.FromWallet(managedAddr.AddrType())
+	if err != nil {
+		return nil, fmt.Errorf("legacy address type: %w", err)
+	}
+
+	accountNumber := managedAddr.InternalAccount()
+	accountName := db.DefaultImportedAccountName
+	keyScope := db.KeyScope(manager.Scope())
+	origin := db.DerivedAccount
+
+	if managedAddr.Imported() {
+		accountNumber = 0
+		origin = db.ImportedAccount
+	} else {
+		accountName, err = manager.AccountName(ns, accountNumber)
+		if err != nil {
+			return nil, fmt.Errorf("account name: %w", err)
+		}
+	}
+
+	var (
+		branch      uint32
+		index       uint32
+		fingerprint uint32
+		pubKey      []byte
+	)
+
+	pubKeyAddr, ok := managedAddr.(waddrmgr.ManagedPubKeyAddress)
+	if ok {
+		pubKey = managedAddressPubKey(pubKeyAddr)
+
+		scope, path, ok := pubKeyAddr.DerivationInfo()
+		if ok {
+			accountNumber = path.InternalAccount
+			branch = path.Branch
+			index = path.Index
+			fingerprint = path.MasterKeyFingerprint
+			keyScope = db.KeyScope(scope)
+		}
+	}
+
+	isWatchOnly, err := managedAddressIsWatchOnly(
+		walletIsWatchOnly, managedAddr,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &db.AddressInfo{
+		AccountID:            accountNumber,
+		AccountNumber:        accountNumber,
+		AccountName:          accountName,
+		KeyScope:             keyScope,
+		MasterKeyFingerprint: fingerprint,
+		AddrType:             addrType.Type,
+		Origin:               origin,
+		Branch:               branch,
+		Index:                index,
+		ScriptPubKey:         scriptPubKey,
+		PubKey:               pubKey,
+		HasScript:            addrType.HasScript,
+		IsWatchOnly:          isWatchOnly,
+		IsUsed:               managedAddr.Used(ns),
+	}, nil
+}
+
+// managedAddressPubKey returns a managed address's public key using its
+// actual legacy encoding.
+func managedAddressPubKey(
+	managedAddr waddrmgr.ManagedPubKeyAddress) []byte {
+
+	if managedAddr.Compressed() {
+		return managedAddr.PubKey().SerializeCompressed()
+	}
+
+	return managedAddr.PubKey().SerializeUncompressed()
+}
+
+// managedAddressIsWatchOnly reports whether a managed address is unable to
+// spend due to wallet-level watch-only mode or missing private key material.
+func managedAddressIsWatchOnly(walletIsWatchOnly bool,
+	managedAddr waddrmgr.ManagedAddress) (bool, error) {
+
+	if walletIsWatchOnly {
+		return true, nil
+	}
+
+	if !managedAddr.Imported() {
+		return false, nil
+	}
+
+	pubKeyAddr, ok := managedAddr.(waddrmgr.ManagedPubKeyAddress)
+	if !ok {
+		return true, nil
+	}
+
+	hasPrivateKey, err := waddrmgr.ManagedPubKeyAddressHasPrivateKey(
+		pubKeyAddr,
+	)
+	if err != nil {
+		return false, fmt.Errorf("managed pubkey private key state: %w", err)
+	}
+
+	return !hasPrivateKey, nil
 }

--- a/wallet/internal/db/kvdb/addressstore.go
+++ b/wallet/internal/db/kvdb/addressstore.go
@@ -38,13 +38,14 @@ func (s *Store) ListAddresses(ctx context.Context,
 	)
 }
 
-// IterAddresses is not yet implemented for kvdb.
+// IterAddresses returns an iterator over paginated legacy address-manager
+// results.
 func (s *Store) IterAddresses(ctx context.Context,
-	_ db.ListAddressesQuery) iter.Seq2[db.AddressInfo, error] {
+	query db.ListAddressesQuery) iter.Seq2[db.AddressInfo, error] {
 
-	return func(yield func(db.AddressInfo, error) bool) {
-		yield(db.AddressInfo{}, notImplemented(ctx, "IterAddresses"))
-	}
+	return page.Iter(
+		ctx, query, s.ListAddresses, db.NextListAddressesQuery,
+	)
 }
 
 // GetAddressSecret is not yet implemented for kvdb.

--- a/wallet/internal/db/kvdb/addressstore_test.go
+++ b/wallet/internal/db/kvdb/addressstore_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/stretchr/testify/mock"
@@ -44,6 +46,173 @@ func TestAddressStoreNewDerivedAddress(t *testing.T) {
 	require.Equal(t, props.AccountNumber, info.AccountID)
 	require.NotEmpty(t, info.ScriptPubKey)
 	require.NotEmpty(t, info.PubKey)
+}
+
+// TestAddressStoreImportedPublicKeyIsWatchOnly verifies that imported public
+// keys are marked watch-only instead of relying only on imported origin.
+func TestAddressStoreImportedPublicKeyIsWatchOnly(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	addrStore := newSpendableAddrMgr(t, dbConn)
+	store := NewStore(dbConn, nil, addrStore)
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	pubKey := privKey.PubKey()
+	pubKeyBytes := pubKey.SerializeCompressed()
+	addr, err := btcutil.NewAddressWitnessPubKeyHash(
+		btcutil.Hash160(pubKeyBytes), addrStore.ChainParams(),
+	)
+	require.NoError(t, err)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	info, err := store.NewImportedAddress(
+		t.Context(), db.NewImportedAddressParams{
+			WalletID:     0,
+			Scope:        db.KeyScope(waddrmgr.KeyScopeBIP0084),
+			AddressType:  db.WitnessPubKey,
+			ScriptPubKey: pkScript,
+			PubKey:       pubKeyBytes,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, db.ImportedAccount, info.Origin)
+	require.Equal(t, db.WitnessPubKey, info.AddrType)
+	require.Equal(t, pkScript, info.ScriptPubKey)
+	require.Equal(t, pubKeyBytes, info.PubKey)
+	require.True(t, info.IsWatchOnly)
+}
+
+// TestAddressStoreImportedPublicKeyRejectsMismatch verifies that kvdb rejects
+// imported public-key requests when legacy import output does not match the
+// requested type or script.
+func TestAddressStoreImportedPublicKeyRejectsMismatch(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		addrType   db.AddressType
+		scriptFunc func(*testing.T, []byte, *waddrmgr.Manager) []byte
+	}{
+		{
+			name:     "type mismatch",
+			addrType: db.PubKeyHash,
+			scriptFunc: func(t *testing.T, script []byte,
+				_ *waddrmgr.Manager) []byte {
+
+				t.Helper()
+
+				return script
+			},
+		},
+		{
+			name:     "script mismatch",
+			addrType: db.WitnessPubKey,
+			scriptFunc: func(t *testing.T, _ []byte,
+				addrStore *waddrmgr.Manager) []byte {
+
+				t.Helper()
+
+				otherPrivKey, err := btcec.NewPrivateKey()
+				require.NoError(t, err)
+
+				otherPubKey := otherPrivKey.PubKey().SerializeCompressed()
+				otherAddr, err := btcutil.NewAddressWitnessPubKeyHash(
+					btcutil.Hash160(otherPubKey),
+					addrStore.ChainParams(),
+				)
+				require.NoError(t, err)
+
+				otherScript, err := txscript.PayToAddrScript(
+					otherAddr,
+				)
+				require.NoError(t, err)
+
+				return otherScript
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dbConn, cleanup := newTestDB(t)
+			t.Cleanup(cleanup)
+
+			addrStore := newSpendableAddrMgr(t, dbConn)
+			store := NewStore(dbConn, nil, addrStore)
+
+			privKey, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+
+			pubKeyBytes := privKey.PubKey().SerializeCompressed()
+			addr, err := btcutil.NewAddressWitnessPubKeyHash(
+				btcutil.Hash160(pubKeyBytes), addrStore.ChainParams(),
+			)
+			require.NoError(t, err)
+
+			actualScript, err := txscript.PayToAddrScript(addr)
+			require.NoError(t, err)
+
+			_, err = store.NewImportedAddress(
+				t.Context(), db.NewImportedAddressParams{
+					WalletID: 0,
+					Scope: db.KeyScope(
+						waddrmgr.KeyScopeBIP0084,
+					),
+					AddressType: tc.addrType,
+					ScriptPubKey: tc.scriptFunc(
+						t, actualScript, addrStore,
+					),
+					PubKey: pubKeyBytes,
+				},
+			)
+			require.ErrorIs(t, err, errImportedAddressMismatch)
+		})
+	}
+}
+
+// TestAddressStoreImportTaprootScript verifies that kvdb.Store imports taproot
+// script metadata through the legacy address manager while preserving the store
+// level script marker.
+func TestAddressStoreImportTaprootScript(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	addrStore := newSpendableAddrMgr(t, dbConn)
+	store := NewStore(dbConn, nil, addrStore)
+
+	tapscript, pkScript := testTaprootScript(t, addrStore)
+	encodedScript, err := waddrmgr.EncodeTaprootScript(&tapscript)
+	require.NoError(t, err)
+	encryptedScript, err := addrStore.Encrypt(
+		waddrmgr.CKTPublic, encodedScript,
+	)
+	require.NoError(t, err)
+
+	info, err := store.NewImportedAddress(
+		t.Context(), db.NewImportedAddressParams{
+			WalletID:        0,
+			Scope:           db.KeyScope(waddrmgr.KeyScopeBIP0086),
+			AddressType:     db.TaprootPubKey,
+			ScriptPubKey:    pkScript,
+			EncryptedScript: encryptedScript,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, db.ImportedAccount, info.Origin)
+	require.Equal(t, db.TaprootPubKey, info.AddrType)
+	require.True(t, info.HasScript)
+	require.Equal(t, pkScript, info.ScriptPubKey)
 }
 
 // TestManagedAddressIsWatchOnlyUnsupportedPubKey verifies that unsupported
@@ -124,4 +293,41 @@ func (m *unsupportedManagedPubKeyAddress) DerivationInfo() (waddrmgr.KeyScope,
 	path, _ := args.Get(1).(waddrmgr.DerivationPath)
 
 	return scope, path, args.Bool(2)
+}
+
+// testTaprootScript returns a tapscript and its P2TR output script.
+func testTaprootScript(t *testing.T,
+	addrStore *waddrmgr.Manager) (waddrmgr.Tapscript, []byte) {
+
+	t.Helper()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	pubKey := privKey.PubKey()
+	script, err := txscript.NewScriptBuilder().
+		AddData(pubKey.SerializeCompressed()).
+		AddOp(txscript.OP_CHECKSIG).
+		Script()
+	require.NoError(t, err)
+
+	leaf := txscript.NewTapLeaf(txscript.BaseLeafVersion, script)
+	tree := txscript.AssembleTaprootScriptTree(leaf)
+	rootHash := tree.RootNode.TapHash()
+	taprootKey := txscript.ComputeTaprootOutputKey(pubKey, rootHash[:])
+	addr, err := btcutil.NewAddressTaproot(
+		schnorr.SerializePubKey(taprootKey), addrStore.ChainParams(),
+	)
+	require.NoError(t, err)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	return waddrmgr.Tapscript{
+		Type: waddrmgr.TapscriptTypeFullTree,
+		ControlBlock: &txscript.ControlBlock{
+			InternalKey: pubKey,
+		},
+		Leaves: []txscript.TapLeaf{leaf},
+	}, pkScript
 }

--- a/wallet/internal/db/kvdb/addressstore_test.go
+++ b/wallet/internal/db/kvdb/addressstore_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package kvdb
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAddressStoreNewDerivedAddress verifies that kvdb.Store creates derived
+// addresses through the legacy address manager.
+func TestAddressStoreNewDerivedAddress(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	addrStore := newSpendableAddrMgr(t, dbConn)
+	store := NewStore(dbConn, nil, addrStore)
+	props := createLegacyAccount(
+		t, dbConn, addrStore, waddrmgr.KeyScopeBIP0084, "addr",
+	)
+
+	info, err := store.NewDerivedAddress(
+		t.Context(), db.NewDerivedAddressParams{
+			WalletID:    0,
+			AccountName: "addr",
+			Scope:       db.KeyScope(waddrmgr.KeyScopeBIP0084),
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), info.ID)
+	require.Equal(t, db.DerivedAccount, info.Origin)
+	require.Equal(t, db.WitnessPubKey, info.AddrType)
+	require.Equal(t, "addr", info.AccountName)
+	require.Equal(t, props.AccountNumber, info.AccountID)
+	require.NotEmpty(t, info.ScriptPubKey)
+	require.NotEmpty(t, info.PubKey)
+}
+
+// TestManagedAddressIsWatchOnlyUnsupportedPubKey verifies that unsupported
+// managed public-key address implementations are reported explicitly.
+func TestManagedAddressIsWatchOnlyUnsupportedPubKey(t *testing.T) {
+	t.Parallel()
+
+	m := &unsupportedManagedPubKeyAddress{}
+	m.On("Imported").Return(true).Once()
+
+	isWatchOnly, err := managedAddressIsWatchOnly(false, m)
+	require.ErrorContains(t, err, "unsupported managed pubkey address")
+	require.False(t, isWatchOnly)
+	m.AssertExpectations(t)
+}
+
+// unsupportedManagedPubKeyAddress is a mock.Mock-based test double for
+// waddrmgr.ManagedPubKeyAddress used to exercise the unsupported pubkey path
+// in managedAddressIsWatchOnly.
+//
+// The embedded waddrmgr.ManagedAddress satisfies the base interface so the
+// type assertion to waddrmgr.ManagedPubKeyAddress succeeds; the mock.Mock
+// shim methods then drive the behavior the test exercises.
+type unsupportedManagedPubKeyAddress struct {
+	mock.Mock
+	waddrmgr.ManagedAddress
+}
+
+// Imported reports whether the managed pubkey address is imported.
+func (m *unsupportedManagedPubKeyAddress) Imported() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
+// PubKey returns the public key associated with the managed pubkey address.
+func (m *unsupportedManagedPubKeyAddress) PubKey() *btcec.PublicKey {
+	args := m.Called()
+
+	pubKey, _ := args.Get(0).(*btcec.PublicKey)
+
+	return pubKey
+}
+
+// ExportPubKey returns the hex-encoded public key.
+func (m *unsupportedManagedPubKeyAddress) ExportPubKey() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+// PrivKey returns the private key associated with the managed pubkey address.
+func (m *unsupportedManagedPubKeyAddress) PrivKey() (*btcec.PrivateKey, error) {
+	args := m.Called()
+
+	privKey, _ := args.Get(0).(*btcec.PrivateKey)
+
+	return privKey, args.Error(1)
+}
+
+// ExportPrivKey returns the wallet import format encoding of the private key.
+func (m *unsupportedManagedPubKeyAddress) ExportPrivKey() (*btcutil.WIF,
+	error) {
+
+	args := m.Called()
+
+	wif, _ := args.Get(0).(*btcutil.WIF)
+
+	return wif, args.Error(1)
+}
+
+// DerivationInfo returns the BIP-32 derivation path for the managed pubkey
+// address.
+func (m *unsupportedManagedPubKeyAddress) DerivationInfo() (waddrmgr.KeyScope,
+	waddrmgr.DerivationPath, bool) {
+
+	args := m.Called()
+
+	scope, _ := args.Get(0).(waddrmgr.KeyScope)
+	path, _ := args.Get(1).(waddrmgr.DerivationPath)
+
+	return scope, path, args.Bool(2)
+}

--- a/wallet/internal/db/kvdb/legacy_test_helpers_test.go
+++ b/wallet/internal/db/kvdb/legacy_test_helpers_test.go
@@ -1,0 +1,46 @@
+package kvdb
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/stretchr/testify/require"
+)
+
+// testPrivPass is the private passphrase used by legacy waddrmgr test
+// helpers. It must match the seed/pass setup in newSpendableAddrMgr.
+var testPrivPass = []byte("priv")
+
+// legacyAccountProps captures the subset of waddrmgr account metadata that
+// the legacy address-store tests rely on after creating an account.
+type legacyAccountProps struct {
+	AccountNumber uint32
+}
+
+// createLegacyAccount creates a new account on the given scoped manager and
+// returns the metadata the test path consults.
+func createLegacyAccount(t *testing.T, dbConn walletdb.DB,
+	addrStore *waddrmgr.Manager, scope waddrmgr.KeyScope,
+	name string) *legacyAccountProps {
+
+	t.Helper()
+
+	manager, err := addrStore.FetchScopedKeyManager(scope)
+	require.NoError(t, err)
+
+	var accountNumber uint32
+
+	err = walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+
+		require.NoError(t, addrStore.Unlock(ns, testPrivPass))
+
+		accountNumber, err = manager.NewAccount(ns, name)
+
+		return err
+	})
+	require.NoError(t, err)
+
+	return &legacyAccountProps{AccountNumber: accountNumber}
+}


### PR DESCRIPTION
## Summary
- extend the transitional `db.Store` surface with `db.AddressStore` and shared address metadata types
- add SQL/PG address-store create, get, list, type, and secret helpers, and implement the kvdb address-store adapter over legacy `waddrmgr`
- migrate the wallet address manager to create, import, get, and list addresses through `w.store` while keeping legacy fallbacks where kvdb store coverage is still transitional

## Why
- this moves address-manager callers toward the internal store abstraction without forcing the kvdb migration to implement unrelated UTXO support first
- it keeps `db.Store` persistence-focused and leaves derivation/encryption details in wallet/keyvault or legacy `waddrmgr` boundaries
- it preserves existing kvdb wallet behavior while giving SQL backends the same logical address metadata shape

## What Changed
- `db.AddressStore` now covers derived/imported address creation, address lookup/listing, address secrets, address types, and address iteration
- kvdb adapts the existing legacy address manager for derived/imported address creation, get, list, type metadata, pagination, and taproot script imports
- SQL and PostgreSQL return consistent `AddressInfo` account metadata for create/get/list paths
- `Wallet.ListAddresses` falls back to legacy UTXO balance aggregation when the transitional kvdb UTXO store returns `ErrNotImplemented`
- address tests cover create/get/list metadata consistency, kvdb pagination, watch-only semantics, public-key compression, and wallet fallback behavior

## Testing
- `GOWORK=off go test ./wallet ./wallet/internal/db/kvdb ./wallet/internal/db/sqlite ./wallet/internal/db/pg`
- `GOWORK=off go test ./waddrmgr ./wallet/internal/db`
- `make lint-check`
- `git diff --check impl-account-manager-store...HEAD`
- `gofmt -l $(git diff --name-only --diff-filter=ACMRT impl-account-manager-store...HEAD -- '*.go')`

CI is pending on the latest push.