### PR TITLE
wallet: cleanup import aliases

### DIFF
--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -8,7 +8,7 @@ sql:
     gen:
       go:
         out: "wallet/internal/sql/pg/sqlc"
-        package: "sqlcpg"
+        package: "sqlc"
 
         # This is the driver package that sqlc will use in the generated code.
         sql_package: database/sql
@@ -29,7 +29,7 @@ sql:
     gen:
       go:
         out: "wallet/internal/sql/sqlite/sqlc"
-        package: "sqlcsqlite"
+        package: "sqlc"
 
         # This is the driver package that sqlc will use in the generated code.
         sql_package: database/sql

--- a/wallet/internal/db/db_connectors_test.go
+++ b/wallet/internal/db/db_connectors_test.go
@@ -4,9 +4,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	dbpg "github.com/btcsuite/btcwallet/wallet/internal/db/pg"
-	dbsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlite"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/db/pg"
+	"github.com/btcsuite/btcwallet/wallet/internal/db/sqlite"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,19 +15,19 @@ func TestPostgresNewStoreValidateConfig(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		cfg     dbpg.Config
+		cfg     pg.Config
 		wantErr error
 	}{
 		{
 			name: "empty DSN",
-			cfg: dbpg.Config{
+			cfg: pg.Config{
 				Dsn: "",
 			},
 			wantErr: db.ErrEmptyDSN,
 		},
 		{
 			name: "negative max connections",
-			cfg: dbpg.Config{
+			cfg: pg.Config{
 				Dsn:            "postgres://test",
 				MaxConnections: -1,
 			},
@@ -39,7 +39,7 @@ func TestPostgresNewStoreValidateConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			store, err := dbpg.NewStore(t.Context(), tc.cfg)
+			store, err := pg.NewStore(t.Context(), tc.cfg)
 			require.ErrorIs(t, err, tc.wantErr)
 			require.Nil(t, store)
 		})
@@ -50,11 +50,11 @@ func TestPostgresNewStoreConnectionFailure(t *testing.T) {
 	t.Parallel()
 
 	// Valid config, but hits a connection failure.
-	cfg := dbpg.Config{
+	cfg := pg.Config{
 		Dsn: "postgres://localhost:1/testdb",
 	}
 
-	store, err := dbpg.NewStore(t.Context(), cfg)
+	store, err := pg.NewStore(t.Context(), cfg)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "ping database")
 	require.NotErrorIs(t, err, db.ErrEmptyDSN)
@@ -70,19 +70,19 @@ func TestSQLiteNewStoreValidateConfig(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		cfg     dbsqlite.Config
+		cfg     sqlite.Config
 		wantErr error
 	}{
 		{
 			name: "empty DB path",
-			cfg: dbsqlite.Config{
+			cfg: sqlite.Config{
 				DBPath: "",
 			},
 			wantErr: db.ErrEmptyDBPath,
 		},
 		{
 			name: "negative max connections",
-			cfg: dbsqlite.Config{
+			cfg: sqlite.Config{
 				DBPath:         "/tmp/test.db",
 				MaxConnections: -1,
 			},
@@ -94,7 +94,7 @@ func TestSQLiteNewStoreValidateConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			store, err := dbsqlite.NewStore(t.Context(), tc.cfg)
+			store, err := sqlite.NewStore(t.Context(), tc.cfg)
 			require.ErrorIs(t, err, tc.wantErr)
 			require.Nil(t, store)
 		})
@@ -104,11 +104,11 @@ func TestSQLiteNewStoreValidateConfig(t *testing.T) {
 func TestSQLiteNewStoreSuccess(t *testing.T) {
 	t.Parallel()
 
-	cfg := dbsqlite.Config{
+	cfg := sqlite.Config{
 		DBPath: filepath.Join(t.TempDir(), "wallet.db"),
 	}
 
-	store, err := dbsqlite.NewStore(t.Context(), cfg)
+	store, err := sqlite.NewStore(t.Context(), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, store)
 

--- a/wallet/internal/db/itest/fixtures_pg_test.go
+++ b/wallet/internal/db/itest/fixtures_pg_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
-	dbpg "github.com/btcsuite/btcwallet/wallet/internal/db/pg"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db/pg"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 	"github.com/stretchr/testify/require"
 )
 
@@ -190,9 +190,9 @@ func setupMaxAccountNumberTest(t *testing.T, store db.AccountStore,
 
 	t.Helper()
 
-	require.IsType(t, &dbpg.Store{}, store)
+	require.IsType(t, &pg.Store{}, store)
 
-	pgStore := store.(*dbpg.Store)
+	pgStore := store.(*pg.Store)
 	queries := pgStore.Queries()
 	scopeID := GetKeyScopeID(t, queries, walletID, db.KeyScopeBIP0084)
 	CreateAccountWithNumber(t, queries, scopeID, math.MaxUint32-1,

--- a/wallet/internal/db/itest/fixtures_sqlite_test.go
+++ b/wallet/internal/db/itest/fixtures_sqlite_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
-	dbsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlite"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db/sqlite"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 	"github.com/stretchr/testify/require"
 )
 
@@ -190,9 +190,9 @@ func setupMaxAccountNumberTest(t *testing.T, store db.AccountStore,
 
 	t.Helper()
 
-	require.IsType(t, &dbsqlite.Store{}, store)
+	require.IsType(t, &sqlite.Store{}, store)
 
-	sqliteStore := store.(*dbsqlite.Store)
+	sqliteStore := store.(*sqlite.Store)
 	queries := sqliteStore.Queries()
 	scopeID := GetKeyScopeID(t, queries, walletID, db.KeyScopeBIP0084)
 	CreateAccountWithNumber(t, queries, scopeID, math.MaxUint32-1,

--- a/wallet/internal/db/itest/pg_test.go
+++ b/wallet/internal/db/itest/pg_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
-	dbpg "github.com/btcsuite/btcwallet/wallet/internal/db/pg"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db/pg"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -193,7 +193,7 @@ func sanitizedPgDBName(t *testing.T) string {
 // limit allows, exhausting the PostgreSQL connection pool. Avoid this by
 // creating NewTestStore inside each parallel subtest so its lifecycle is tied
 // to the subtest's parallel slot.
-func NewTestStore(t *testing.T) *dbpg.Store {
+func NewTestStore(t *testing.T) *pg.Store {
 	t.Helper()
 	ctx := t.Context()
 
@@ -223,12 +223,12 @@ func NewTestStore(t *testing.T) *dbpg.Store {
 	// Build the connection string for the test database.
 	testConnStr := strings.Replace(connStr, "/postgres?", "/"+dbName+"?", 1)
 
-	cfg := dbpg.Config{
+	cfg := pg.Config{
 		Dsn:            testConnStr,
 		MaxConnections: 0,
 	}
 
-	store, err := dbpg.NewStore(t.Context(), cfg)
+	store, err := pg.NewStore(t.Context(), cfg)
 	require.NoError(t, err, "failed to create postgres store")
 
 	t.Cleanup(func() {
@@ -240,7 +240,7 @@ func NewTestStore(t *testing.T) *dbpg.Store {
 
 // childSpendingTxIDs returns the direct child transaction IDs recorded for the
 // provided parent transaction hash.
-func childSpendingTxIDs(t *testing.T, store *dbpg.Store,
+func childSpendingTxIDs(t *testing.T, store *pg.Store,
 	walletID uint32,
 	txHash chainhash.Hash) []int64 {
 
@@ -273,7 +273,7 @@ func childSpendingTxIDs(t *testing.T, store *dbpg.Store,
 
 // txIDByHash returns the database row ID for the given wallet-scoped
 // transaction hash and reports whether the row exists.
-func txIDByHash(t *testing.T, store *dbpg.Store, walletID uint32,
+func txIDByHash(t *testing.T, store *pg.Store, walletID uint32,
 	txHash chainhash.Hash) (int64, bool) {
 
 	t.Helper()
@@ -297,7 +297,7 @@ func txIDByHash(t *testing.T, store *dbpg.Store, walletID uint32,
 
 // rawTxByHash returns the serialized transaction bytes for the given
 // wallet-scoped transaction hash.
-func rawTxByHash(t *testing.T, store *dbpg.Store, walletID uint32,
+func rawTxByHash(t *testing.T, store *pg.Store, walletID uint32,
 	txHash chainhash.Hash) []byte {
 
 	t.Helper()
@@ -315,7 +315,7 @@ func rawTxByHash(t *testing.T, store *dbpg.Store, walletID uint32,
 
 // setTxStatus rewrites one wallet-scoped transaction row to the provided
 // status using the internal status-update query.
-func setTxStatus(t *testing.T, store *dbpg.Store, walletID uint32,
+func setTxStatus(t *testing.T, store *pg.Store, walletID uint32,
 	txHash chainhash.Hash, status db.TxStatus) {
 
 	t.Helper()
@@ -336,7 +336,7 @@ func setTxStatus(t *testing.T, store *dbpg.Store, walletID uint32,
 
 // walletUtxoExists reports whether one wallet-scoped outpoint is currently
 // present in the UTXO set.
-func walletUtxoExists(t *testing.T, store *dbpg.Store,
+func walletUtxoExists(t *testing.T, store *pg.Store,
 	walletID uint32,
 	outPoint wire.OutPoint) bool {
 

--- a/wallet/internal/db/itest/sqlite_test.go
+++ b/wallet/internal/db/itest/sqlite_test.go
@@ -11,25 +11,25 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
-	dbsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlite"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db/sqlite"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 	"github.com/stretchr/testify/require"
 )
 
 // NewTestStore creates a new SQLite database for testing with migrations
 // applied. Each test gets its own temporary database file.
-func NewTestStore(t *testing.T) *dbsqlite.Store {
+func NewTestStore(t *testing.T) *sqlite.Store {
 	t.Helper()
 
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test.db")
 
-	cfg := dbsqlite.Config{
+	cfg := sqlite.Config{
 		DBPath:         dbPath,
 		MaxConnections: 0,
 	}
 
-	store, err := dbsqlite.NewStore(t.Context(), cfg)
+	store, err := sqlite.NewStore(t.Context(), cfg)
 	require.NoError(t, err, "failed to create sqlite store")
 
 	t.Cleanup(func() {
@@ -41,7 +41,7 @@ func NewTestStore(t *testing.T) *dbsqlite.Store {
 
 // childSpendingTxIDs returns the direct child transaction IDs recorded for the
 // provided parent transaction hash.
-func childSpendingTxIDs(t *testing.T, store *dbsqlite.Store,
+func childSpendingTxIDs(t *testing.T, store *sqlite.Store,
 	walletID uint32,
 	txHash chainhash.Hash) []int64 {
 
@@ -74,7 +74,7 @@ func childSpendingTxIDs(t *testing.T, store *dbsqlite.Store,
 
 // txIDByHash returns the database row ID for the given wallet-scoped
 // transaction hash and reports whether the row exists.
-func txIDByHash(t *testing.T, store *dbsqlite.Store, walletID uint32,
+func txIDByHash(t *testing.T, store *sqlite.Store, walletID uint32,
 	txHash chainhash.Hash) (int64, bool) {
 
 	t.Helper()
@@ -98,7 +98,7 @@ func txIDByHash(t *testing.T, store *dbsqlite.Store, walletID uint32,
 
 // rawTxByHash returns the serialized transaction bytes for the given
 // wallet-scoped transaction hash.
-func rawTxByHash(t *testing.T, store *dbsqlite.Store, walletID uint32,
+func rawTxByHash(t *testing.T, store *sqlite.Store, walletID uint32,
 	txHash chainhash.Hash) []byte {
 
 	t.Helper()
@@ -116,7 +116,7 @@ func rawTxByHash(t *testing.T, store *dbsqlite.Store, walletID uint32,
 
 // setTxStatus rewrites one wallet-scoped transaction row to the provided
 // status using the internal status-update query.
-func setTxStatus(t *testing.T, store *dbsqlite.Store, walletID uint32,
+func setTxStatus(t *testing.T, store *sqlite.Store, walletID uint32,
 	txHash chainhash.Hash, status db.TxStatus) {
 
 	t.Helper()
@@ -137,7 +137,7 @@ func setTxStatus(t *testing.T, store *dbsqlite.Store, walletID uint32,
 
 // walletUtxoExists reports whether one wallet-scoped outpoint is currently
 // present in the UTXO set.
-func walletUtxoExists(t *testing.T, store *dbsqlite.Store,
+func walletUtxoExists(t *testing.T, store *sqlite.Store,
 	walletID uint32,
 	outPoint wire.OutPoint) bool {
 

--- a/wallet/internal/db/itest/tx_corruption_pg_test.go
+++ b/wallet/internal/db/itest/tx_corruption_pg_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	dbpg "github.com/btcsuite/btcwallet/wallet/internal/db/pg"
+	"github.com/btcsuite/btcwallet/wallet/internal/db/pg"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,7 +19,7 @@ import (
 // corruptTransactionStatus writes an invalid tx status after dropping the
 // validating constraints that normally reject it. The corruption itests use
 // this to verify that reads reject impossible tx states.
-func corruptTransactionStatus(t *testing.T, store *dbpg.Store,
+func corruptTransactionStatus(t *testing.T, store *pg.Store,
 	walletID uint32, txHash chainhash.Hash, status int64) {
 	t.Helper()
 
@@ -49,7 +49,7 @@ func corruptTransactionStatus(t *testing.T, store *dbpg.Store,
 // corruptTransactionHash writes malformed tx-hash bytes after dropping the
 // fixed-length hash check. The corruption itests then verify that hash
 // decoding fails with the expected error path.
-func corruptTransactionHash(t *testing.T, store *dbpg.Store,
+func corruptTransactionHash(t *testing.T, store *pg.Store,
 	walletID uint32, txHash chainhash.Hash, hash []byte) {
 	t.Helper()
 
@@ -75,7 +75,7 @@ func corruptTransactionHash(t *testing.T, store *dbpg.Store,
 // the non-negative height check and creating a matching block row. The
 // corruption itests use this to verify that reads reject impossible
 // confirmation metadata.
-func corruptTransactionBlockHeight(t *testing.T, store *dbpg.Store,
+func corruptTransactionBlockHeight(t *testing.T, store *pg.Store,
 	walletID uint32, txHash chainhash.Hash, height int64) {
 	t.Helper()
 
@@ -110,7 +110,7 @@ func corruptTransactionBlockHeight(t *testing.T, store *dbpg.Store,
 // corruptUtxoOutputIndex writes an invalid output index after dropping the
 // non-negative output-index check. The corruption itests then verify that UTXO
 // decoding rejects the malformed persisted value.
-func corruptUtxoOutputIndex(t *testing.T, store *dbpg.Store,
+func corruptUtxoOutputIndex(t *testing.T, store *pg.Store,
 	walletID uint32, txHash chainhash.Hash, oldIndex uint32, newIndex int64) {
 	t.Helper()
 
@@ -136,7 +136,7 @@ func corruptUtxoOutputIndex(t *testing.T, store *dbpg.Store,
 // corruptActiveLeaseLockID writes an invalid lease lock ID after dropping the
 // fixed-length lock-id check. The corruption itests use this to verify that
 // lease reads reject malformed lock identifiers.
-func corruptActiveLeaseLockID(t *testing.T, store *dbpg.Store,
+func corruptActiveLeaseLockID(t *testing.T, store *pg.Store,
 	walletID uint32, txHash chainhash.Hash, outputIndex uint32, lockID []byte) {
 	t.Helper()
 

--- a/wallet/internal/db/itest/tx_corruption_sqlite_test.go
+++ b/wallet/internal/db/itest/tx_corruption_sqlite_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	dbsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlite"
+	"github.com/btcsuite/btcwallet/wallet/internal/db/sqlite"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,7 +19,7 @@ import (
 // corruptTransactionStatus writes an invalid tx status into one stored row while
 // sqlite check constraints are disabled inside the surrounding transaction. The
 // corruption itests use this to verify that reads reject impossible tx states.
-func corruptTransactionStatus(t *testing.T, store *dbsqlite.Store,
+func corruptTransactionStatus(t *testing.T, store *sqlite.Store,
 	walletID uint32, txHash chainhash.Hash, status int64) {
 	t.Helper()
 
@@ -54,7 +54,7 @@ func corruptTransactionStatus(t *testing.T, store *dbsqlite.Store,
 // corruptTransactionHash writes malformed tx-hash bytes into one stored row
 // while sqlite check constraints are disabled. The corruption itests then
 // verify that hash decoding fails with the expected error path.
-func corruptTransactionHash(t *testing.T, store *dbsqlite.Store,
+func corruptTransactionHash(t *testing.T, store *sqlite.Store,
 	walletID uint32, txHash chainhash.Hash, hash []byte) {
 	t.Helper()
 
@@ -89,7 +89,7 @@ func corruptTransactionHash(t *testing.T, store *dbsqlite.Store,
 // corruptTransactionBlockHeight writes an invalid block height after first
 // creating a matching block row in sqlite. The corruption itests use this to
 // verify that reads reject impossible confirmation metadata.
-func corruptTransactionBlockHeight(t *testing.T, store *dbsqlite.Store,
+func corruptTransactionBlockHeight(t *testing.T, store *sqlite.Store,
 	walletID uint32, txHash chainhash.Hash, height int64) {
 	t.Helper()
 
@@ -134,7 +134,7 @@ func corruptTransactionBlockHeight(t *testing.T, store *dbsqlite.Store,
 // corruptUtxoOutputIndex writes an invalid output index into one stored UTXO
 // while sqlite check constraints are disabled. The corruption itests then
 // verify that UTXO decoding rejects the malformed persisted value.
-func corruptUtxoOutputIndex(t *testing.T, store *dbsqlite.Store,
+func corruptUtxoOutputIndex(t *testing.T, store *sqlite.Store,
 	walletID uint32, txHash chainhash.Hash, oldIndex uint32, newIndex int64) {
 	t.Helper()
 
@@ -170,7 +170,7 @@ func corruptUtxoOutputIndex(t *testing.T, store *dbsqlite.Store,
 // corruptActiveLeaseLockID writes an invalid lease lock ID into one active
 // lease row while sqlite check constraints are disabled. The corruption itests
 // use this to verify that lease reads reject malformed lock identifiers.
-func corruptActiveLeaseLockID(t *testing.T, store *dbsqlite.Store,
+func corruptActiveLeaseLockID(t *testing.T, store *sqlite.Store,
 	walletID uint32, txHash chainhash.Hash, outputIndex uint32, lockID []byte) {
 	t.Helper()
 

--- a/wallet/internal/db/itest/tx_store_corruption_test.go
+++ b/wallet/internal/db/itest/tx_store_corruption_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
-	dbpg "github.com/btcsuite/btcwallet/wallet/internal/db/pg"
+	"github.com/btcsuite/btcwallet/wallet/internal/db/pg"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,7 +22,7 @@ func dropTableForCorruption(t *testing.T, store interface{ DB() *sql.DB },
 	t.Helper()
 
 	stmt := fmt.Sprintf("DROP TABLE %s", table)
-	if _, ok := any(store).(*dbpg.Store); ok {
+	if _, ok := any(store).(*pg.Store); ok {
 		stmt += " CASCADE"
 	}
 
@@ -492,7 +492,7 @@ func TestRollbackToBlockReturnsQueryErrorWhenBlocksTableMissing(t *testing.T) {
 	// wallet_sync_states keeps direct block references with ON DELETE RESTRICT.
 	// PostgreSQL drops those dependent rows with CASCADE when the blocks table is
 	// removed, so rollback gets far enough to fail on the block delete instead.
-	_, ok := any(store).(*dbpg.Store)
+	_, ok := any(store).(*pg.Store)
 	if ok {
 		require.ErrorContains(t, err, "delete blocks at or above height")
 		return

--- a/wallet/internal/db/itest/utxo_store_edge_cases_test.go
+++ b/wallet/internal/db/itest/utxo_store_edge_cases_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
-	dbpg "github.com/btcsuite/btcwallet/wallet/internal/db/pg"
+	"github.com/btcsuite/btcwallet/wallet/internal/db/pg"
 	"github.com/stretchr/testify/require"
 )
 
@@ -258,7 +258,7 @@ func TestGetUtxoAndLeaseRejectLargeOutputIndex(t *testing.T) {
 		},
 	)
 
-	if _, ok := any(store).(*dbpg.Store); ok {
+	if _, ok := any(store).(*pg.Store); ok {
 		require.ErrorContains(t, err, "convert output index")
 		require.ErrorContains(t, leaseErr, "convert output index")
 		require.ErrorContains(t, releaseErr, "could not cast")

--- a/wallet/internal/db/pg/accounts.go
+++ b/wallet/internal/db/pg/accounts.go
@@ -5,8 +5,8 @@ import (
 	"database/sql"
 	"fmt"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 )
 
 // Ensure Store satisfies the AccountStore interface.

--- a/wallet/internal/db/pg/address_types.go
+++ b/wallet/internal/db/pg/address_types.go
@@ -3,8 +3,8 @@ package pg
 import (
 	"context"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 )
 
 // addressTypeRowToInfo converts a PostgreSQL address type row to an

--- a/wallet/internal/db/pg/addresses.go
+++ b/wallet/internal/db/pg/addresses.go
@@ -7,9 +7,9 @@ import (
 	"iter"
 	"time"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wallet/internal/db/page"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 )
 
 var _ db.AddressStore = (*Store)(nil)

--- a/wallet/internal/db/pg/backend_error_test.go
+++ b/wallet/internal/db/pg/backend_error_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 	"github.com/stretchr/testify/require"
 )
 

--- a/wallet/internal/db/pg/backend_rows_test.go
+++ b/wallet/internal/db/pg/backend_rows_test.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 	"github.com/stretchr/testify/require"
 	_ "modernc.org/sqlite"
 )

--- a/wallet/internal/db/pg/block.go
+++ b/wallet/internal/db/pg/block.go
@@ -7,8 +7,8 @@ import (
 	"errors"
 	"fmt"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 )
 
 // buildBlock constructs a Block from the given PostgreSQL block

--- a/wallet/internal/db/pg/config.go
+++ b/wallet/internal/db/pg/config.go
@@ -3,7 +3,7 @@ package pg
 import (
 	"fmt"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/jackc/pgx/v5"
 )
 

--- a/wallet/internal/db/pg/config_test.go
+++ b/wallet/internal/db/pg/config_test.go
@@ -3,7 +3,7 @@ package pg
 import (
 	"testing"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/stretchr/testify/require"
 )
 

--- a/wallet/internal/db/pg/itest.go
+++ b/wallet/internal/db/pg/itest.go
@@ -5,8 +5,8 @@ package pg
 import (
 	"database/sql"
 
-	sqlassetpg "github.com/btcsuite/btcwallet/wallet/internal/sql/pg"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 )
 
 // DB returns the underlying *sql.DB connection for integration testing.
@@ -21,10 +21,10 @@ func (s *Store) Queries() *sqlc.Queries {
 
 // RollbackAllMigrations rolls back all PostgreSQL migrations.
 func (s *Store) RollbackAllMigrations() error {
-	return sqlassetpg.RollbackMigrations(s.db)
+	return pg.RollbackMigrations(s.db)
 }
 
 // ApplyAllMigrations reapplies all PostgreSQL migrations.
 func (s *Store) ApplyAllMigrations() error {
-	return sqlassetpg.ApplyMigrations(s.db)
+	return pg.ApplyMigrations(s.db)
 }

--- a/wallet/internal/db/pg/store.go
+++ b/wallet/internal/db/pg/store.go
@@ -5,9 +5,9 @@ import (
 	"database/sql"
 	"fmt"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlassetpg "github.com/btcsuite/btcwallet/wallet/internal/sql/pg"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 	_ "github.com/jackc/pgx/v5/stdlib" // Import pgx driver for postgres database/sql support.
 )
 
@@ -54,7 +54,7 @@ func NewStore(ctx context.Context, cfg Config) (*Store,
 
 	queries := sqlc.New(dbConn)
 
-	err = sqlassetpg.ApplyMigrations(dbConn)
+	err = pg.ApplyMigrations(dbConn)
 	if err != nil {
 		_ = dbConn.Close()
 		return nil, fmt.Errorf("apply migrations: %w", err)

--- a/wallet/internal/db/pg/testhelpers_test.go
+++ b/wallet/internal/db/pg/testhelpers_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/stretchr/testify/require"
 )
 

--- a/wallet/internal/db/pg/txstore_createtx.go
+++ b/wallet/internal/db/pg/txstore_createtx.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 )
 
 // CreateTx atomically records a wallet-scoped transaction row, its

--- a/wallet/internal/db/pg/txstore_deletetx.go
+++ b/wallet/internal/db/pg/txstore_deletetx.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 )
 
 // DeleteTx atomically removes one unmined transaction and restores any wallet

--- a/wallet/internal/db/pg/txstore_gettx.go
+++ b/wallet/internal/db/pg/txstore_gettx.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"time"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 )
 
 // GetTx retrieves one wallet-scoped transaction snapshot by hash.

--- a/wallet/internal/db/pg/txstore_invalidateunmined.go
+++ b/wallet/internal/db/pg/txstore_invalidateunmined.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 )
 
 // InvalidateUnminedTx atomically invalidates one wallet-owned unmined

--- a/wallet/internal/db/pg/txstore_listtxns.go
+++ b/wallet/internal/db/pg/txstore_listtxns.go
@@ -5,8 +5,8 @@ import (
 	"database/sql"
 	"fmt"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 )
 
 // ListTxns lists wallet-scoped transactions using either the confirmed-range

--- a/wallet/internal/db/pg/txstore_rollback.go
+++ b/wallet/internal/db/pg/txstore_rollback.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 )
 
 // RollbackToBlock atomically removes every block at or above the provided

--- a/wallet/internal/db/pg/txstore_updatetx.go
+++ b/wallet/internal/db/pg/txstore_updatetx.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 )
 
 // UpdateTx patches the mutable metadata for one wallet-scoped transaction.

--- a/wallet/internal/db/pg/utxostore_balance.go
+++ b/wallet/internal/db/pg/utxostore_balance.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 )
 
 // Balance returns the sum of wallet-owned current UTXOs after optional filters.

--- a/wallet/internal/db/pg/utxostore_getutxo.go
+++ b/wallet/internal/db/pg/utxostore_getutxo.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"time"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 )
 
 // GetUtxo retrieves one current wallet-owned UTXO by outpoint.

--- a/wallet/internal/db/pg/utxostore_leaseoutput.go
+++ b/wallet/internal/db/pg/utxostore_leaseoutput.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"time"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 )
 
 // LeaseOutput atomically acquires or renews a lease for one current UTXO.

--- a/wallet/internal/db/pg/utxostore_listleasedoutputs.go
+++ b/wallet/internal/db/pg/utxostore_listleasedoutputs.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 )
 
 // ListLeasedOutputs lists all active leases for current wallet-owned UTXOs.

--- a/wallet/internal/db/pg/utxostore_listutxos.go
+++ b/wallet/internal/db/pg/utxostore_listutxos.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 )
 
 // ListUTXOs lists all current wallet-owned UTXOs matching the caller filters.

--- a/wallet/internal/db/pg/utxostore_releaseoutput.go
+++ b/wallet/internal/db/pg/utxostore_releaseoutput.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"time"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 )
 
 // ReleaseOutput atomically releases a lease when the caller provides the

--- a/wallet/internal/db/pg/wallet.go
+++ b/wallet/internal/db/pg/wallet.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"iter"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wallet/internal/db/page"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 )
 
 // Ensure Store satisfies the WalletStore interface.

--- a/wallet/internal/db/sqlite/accounts.go
+++ b/wallet/internal/db/sqlite/accounts.go
@@ -5,8 +5,8 @@ import (
 	"database/sql"
 	"fmt"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 )
 
 // Ensure Store satisfies the AccountStore interface.

--- a/wallet/internal/db/sqlite/address_types.go
+++ b/wallet/internal/db/sqlite/address_types.go
@@ -3,8 +3,8 @@ package sqlite
 import (
 	"context"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 )
 
 // addressTypeRowToInfo converts a SQLite address type row to an

--- a/wallet/internal/db/sqlite/addresses.go
+++ b/wallet/internal/db/sqlite/addresses.go
@@ -7,9 +7,9 @@ import (
 	"iter"
 	"time"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wallet/internal/db/page"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 )
 
 var _ db.AddressStore = (*Store)(nil)

--- a/wallet/internal/db/sqlite/backend_error_test.go
+++ b/wallet/internal/db/sqlite/backend_error_test.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 	"github.com/stretchr/testify/require"
 )
 

--- a/wallet/internal/db/sqlite/backend_rows_test.go
+++ b/wallet/internal/db/sqlite/backend_rows_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 	"github.com/stretchr/testify/require"
 )
 

--- a/wallet/internal/db/sqlite/block.go
+++ b/wallet/internal/db/sqlite/block.go
@@ -7,8 +7,8 @@ import (
 	"errors"
 	"fmt"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 )
 
 // buildBlock constructs a Block from the given SQLite block

--- a/wallet/internal/db/sqlite/config.go
+++ b/wallet/internal/db/sqlite/config.go
@@ -1,6 +1,6 @@
 package sqlite
 
-import db "github.com/btcsuite/btcwallet/wallet/internal/db"
+import "github.com/btcsuite/btcwallet/wallet/internal/db"
 
 // Config holds the configuration for the SQLite database.
 type Config struct {

--- a/wallet/internal/db/sqlite/config_test.go
+++ b/wallet/internal/db/sqlite/config_test.go
@@ -3,7 +3,7 @@ package sqlite
 import (
 	"testing"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/stretchr/testify/require"
 )
 

--- a/wallet/internal/db/sqlite/itest.go
+++ b/wallet/internal/db/sqlite/itest.go
@@ -5,8 +5,8 @@ package sqlite
 import (
 	"database/sql"
 
-	sqlassetsqlite "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 )
 
 // DB returns the underlying *sql.DB connection for integration testing.
@@ -21,10 +21,10 @@ func (s *Store) Queries() *sqlc.Queries {
 
 // RollbackAllMigrations rolls back all SQLite migrations.
 func (s *Store) RollbackAllMigrations() error {
-	return sqlassetsqlite.RollbackMigrations(s.db)
+	return sqlite.RollbackMigrations(s.db)
 }
 
 // ApplyAllMigrations reapplies all SQLite migrations.
 func (s *Store) ApplyAllMigrations() error {
-	return sqlassetsqlite.ApplyMigrations(s.db)
+	return sqlite.ApplyMigrations(s.db)
 }

--- a/wallet/internal/db/sqlite/store.go
+++ b/wallet/internal/db/sqlite/store.go
@@ -5,9 +5,9 @@ import (
 	"database/sql"
 	"fmt"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlassetsqlite "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 	_ "modernc.org/sqlite" // Import sqlite driver for sqlite database/sql support.
 )
 
@@ -60,7 +60,7 @@ func NewStore(ctx context.Context, cfg Config) (*Store,
 
 	queries := sqlc.New(dbConn)
 
-	err = sqlassetsqlite.ApplyMigrations(dbConn)
+	err = sqlite.ApplyMigrations(dbConn)
 	if err != nil {
 		_ = dbConn.Close()
 		return nil, fmt.Errorf("apply migrations: %w", err)

--- a/wallet/internal/db/sqlite/testhelpers_test.go
+++ b/wallet/internal/db/sqlite/testhelpers_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/stretchr/testify/require"
 )
 

--- a/wallet/internal/db/sqlite/txstore_createtx.go
+++ b/wallet/internal/db/sqlite/txstore_createtx.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 )
 
 // CreateTx atomically records a wallet-scoped transaction row, its wallet-owned

--- a/wallet/internal/db/sqlite/txstore_deletetx.go
+++ b/wallet/internal/db/sqlite/txstore_deletetx.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 )
 
 // DeleteTx atomically removes one unmined transaction and restores any wallet

--- a/wallet/internal/db/sqlite/txstore_gettx.go
+++ b/wallet/internal/db/sqlite/txstore_gettx.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"time"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 )
 
 // GetTx retrieves one wallet-scoped transaction snapshot by hash.

--- a/wallet/internal/db/sqlite/txstore_invalidateunmined.go
+++ b/wallet/internal/db/sqlite/txstore_invalidateunmined.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 )
 
 // InvalidateUnminedTx atomically invalidates one wallet-owned unmined

--- a/wallet/internal/db/sqlite/txstore_listtxns.go
+++ b/wallet/internal/db/sqlite/txstore_listtxns.go
@@ -5,8 +5,8 @@ import (
 	"database/sql"
 	"fmt"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 )
 
 // ListTxns lists wallet-scoped transactions using either the confirmed-range

--- a/wallet/internal/db/sqlite/txstore_rollback.go
+++ b/wallet/internal/db/sqlite/txstore_rollback.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 )
 
 // RollbackToBlock atomically removes every block at or above the provided

--- a/wallet/internal/db/sqlite/txstore_updatetx.go
+++ b/wallet/internal/db/sqlite/txstore_updatetx.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 )
 
 // UpdateTx patches the mutable metadata for one wallet-scoped transaction.

--- a/wallet/internal/db/sqlite/utxostore_balance.go
+++ b/wallet/internal/db/sqlite/utxostore_balance.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 )
 
 // Balance returns the sum of wallet-owned current UTXOs after optional filters.

--- a/wallet/internal/db/sqlite/utxostore_getutxo.go
+++ b/wallet/internal/db/sqlite/utxostore_getutxo.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"time"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 )
 
 // GetUtxo retrieves one current wallet-owned UTXO by outpoint.

--- a/wallet/internal/db/sqlite/utxostore_leaseoutput.go
+++ b/wallet/internal/db/sqlite/utxostore_leaseoutput.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"time"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 )
 
 // LeaseOutput atomically acquires or renews a lease for one current UTXO.

--- a/wallet/internal/db/sqlite/utxostore_listleasedoutputs.go
+++ b/wallet/internal/db/sqlite/utxostore_listleasedoutputs.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 )
 
 // ListLeasedOutputs lists all active leases for current wallet-owned UTXOs.

--- a/wallet/internal/db/sqlite/utxostore_listutxos.go
+++ b/wallet/internal/db/sqlite/utxostore_listutxos.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 )
 
 // ListUTXOs lists all current wallet-owned UTXOs matching the caller filters.

--- a/wallet/internal/db/sqlite/utxostore_releaseoutput.go
+++ b/wallet/internal/db/sqlite/utxostore_releaseoutput.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"time"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 )
 
 // ReleaseOutput atomically releases a lease when the caller provides the

--- a/wallet/internal/db/sqlite/wallet.go
+++ b/wallet/internal/db/sqlite/wallet.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"iter"
 
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wallet/internal/db/page"
-	sqlc "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 )
 
 // Ensure Store satisfies the WalletStore interface.

--- a/wallet/internal/sql/pg/sqlc/accounts.sql.go
+++ b/wallet/internal/sql/pg/sqlc/accounts.sql.go
@@ -3,7 +3,7 @@
 //   sqlc v1.30.0
 // source: accounts.sql
 
-package sqlcpg
+package sqlc
 
 import (
 	"context"

--- a/wallet/internal/sql/pg/sqlc/address_types.sql.go
+++ b/wallet/internal/sql/pg/sqlc/address_types.sql.go
@@ -3,7 +3,7 @@
 //   sqlc v1.30.0
 // source: address_types.sql
 
-package sqlcpg
+package sqlc
 
 import (
 	"context"

--- a/wallet/internal/sql/pg/sqlc/addresses.sql.go
+++ b/wallet/internal/sql/pg/sqlc/addresses.sql.go
@@ -3,7 +3,7 @@
 //   sqlc v1.30.0
 // source: addresses.sql
 
-package sqlcpg
+package sqlc
 
 import (
 	"context"

--- a/wallet/internal/sql/pg/sqlc/blocks.sql.go
+++ b/wallet/internal/sql/pg/sqlc/blocks.sql.go
@@ -3,7 +3,7 @@
 //   sqlc v1.30.0
 // source: blocks.sql
 
-package sqlcpg
+package sqlc
 
 import (
 	"context"

--- a/wallet/internal/sql/pg/sqlc/db.go
+++ b/wallet/internal/sql/pg/sqlc/db.go
@@ -2,7 +2,7 @@
 // versions:
 //   sqlc v1.30.0
 
-package sqlcpg
+package sqlc
 
 import (
 	"context"

--- a/wallet/internal/sql/pg/sqlc/key_scopes.sql.go
+++ b/wallet/internal/sql/pg/sqlc/key_scopes.sql.go
@@ -3,7 +3,7 @@
 //   sqlc v1.30.0
 // source: key_scopes.sql
 
-package sqlcpg
+package sqlc
 
 import (
 	"context"

--- a/wallet/internal/sql/pg/sqlc/models.go
+++ b/wallet/internal/sql/pg/sqlc/models.go
@@ -2,7 +2,7 @@
 // versions:
 //   sqlc v1.30.0
 
-package sqlcpg
+package sqlc
 
 import (
 	"database/sql"

--- a/wallet/internal/sql/pg/sqlc/querier.go
+++ b/wallet/internal/sql/pg/sqlc/querier.go
@@ -2,7 +2,7 @@
 // versions:
 //   sqlc v1.30.0
 
-package sqlcpg
+package sqlc
 
 import (
 	"context"

--- a/wallet/internal/sql/pg/sqlc/transactions.sql.go
+++ b/wallet/internal/sql/pg/sqlc/transactions.sql.go
@@ -3,7 +3,7 @@
 //   sqlc v1.30.0
 // source: transactions.sql
 
-package sqlcpg
+package sqlc
 
 import (
 	"context"

--- a/wallet/internal/sql/pg/sqlc/tx_replacements.sql.go
+++ b/wallet/internal/sql/pg/sqlc/tx_replacements.sql.go
@@ -3,7 +3,7 @@
 //   sqlc v1.30.0
 // source: tx_replacements.sql
 
-package sqlcpg
+package sqlc
 
 import (
 	"context"

--- a/wallet/internal/sql/pg/sqlc/utxo_leases.sql.go
+++ b/wallet/internal/sql/pg/sqlc/utxo_leases.sql.go
@@ -3,7 +3,7 @@
 //   sqlc v1.30.0
 // source: utxo_leases.sql
 
-package sqlcpg
+package sqlc
 
 import (
 	"context"

--- a/wallet/internal/sql/pg/sqlc/utxos.sql.go
+++ b/wallet/internal/sql/pg/sqlc/utxos.sql.go
@@ -3,7 +3,7 @@
 //   sqlc v1.30.0
 // source: utxos.sql
 
-package sqlcpg
+package sqlc
 
 import (
 	"context"

--- a/wallet/internal/sql/pg/sqlc/wallets.sql.go
+++ b/wallet/internal/sql/pg/sqlc/wallets.sql.go
@@ -3,7 +3,7 @@
 //   sqlc v1.30.0
 // source: wallets.sql
 
-package sqlcpg
+package sqlc
 
 import (
 	"context"

--- a/wallet/internal/sql/sqlite/sqlc/accounts.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/accounts.sql.go
@@ -3,7 +3,7 @@
 //   sqlc v1.30.0
 // source: accounts.sql
 
-package sqlcsqlite
+package sqlc
 
 import (
 	"context"

--- a/wallet/internal/sql/sqlite/sqlc/address_types.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/address_types.sql.go
@@ -3,7 +3,7 @@
 //   sqlc v1.30.0
 // source: address_types.sql
 
-package sqlcsqlite
+package sqlc
 
 import (
 	"context"

--- a/wallet/internal/sql/sqlite/sqlc/addresses.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/addresses.sql.go
@@ -3,7 +3,7 @@
 //   sqlc v1.30.0
 // source: addresses.sql
 
-package sqlcsqlite
+package sqlc
 
 import (
 	"context"

--- a/wallet/internal/sql/sqlite/sqlc/blocks.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/blocks.sql.go
@@ -3,7 +3,7 @@
 //   sqlc v1.30.0
 // source: blocks.sql
 
-package sqlcsqlite
+package sqlc
 
 import (
 	"context"

--- a/wallet/internal/sql/sqlite/sqlc/db.go
+++ b/wallet/internal/sql/sqlite/sqlc/db.go
@@ -2,7 +2,7 @@
 // versions:
 //   sqlc v1.30.0
 
-package sqlcsqlite
+package sqlc
 
 import (
 	"context"

--- a/wallet/internal/sql/sqlite/sqlc/key_scopes.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/key_scopes.sql.go
@@ -3,7 +3,7 @@
 //   sqlc v1.30.0
 // source: key_scopes.sql
 
-package sqlcsqlite
+package sqlc
 
 import (
 	"context"

--- a/wallet/internal/sql/sqlite/sqlc/models.go
+++ b/wallet/internal/sql/sqlite/sqlc/models.go
@@ -2,7 +2,7 @@
 // versions:
 //   sqlc v1.30.0
 
-package sqlcsqlite
+package sqlc
 
 import (
 	"database/sql"

--- a/wallet/internal/sql/sqlite/sqlc/querier.go
+++ b/wallet/internal/sql/sqlite/sqlc/querier.go
@@ -2,7 +2,7 @@
 // versions:
 //   sqlc v1.30.0
 
-package sqlcsqlite
+package sqlc
 
 import (
 	"context"

--- a/wallet/internal/sql/sqlite/sqlc/transactions.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/transactions.sql.go
@@ -3,7 +3,7 @@
 //   sqlc v1.30.0
 // source: transactions.sql
 
-package sqlcsqlite
+package sqlc
 
 import (
 	"context"

--- a/wallet/internal/sql/sqlite/sqlc/tx_replacements.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/tx_replacements.sql.go
@@ -3,7 +3,7 @@
 //   sqlc v1.30.0
 // source: tx_replacements.sql
 
-package sqlcsqlite
+package sqlc
 
 import (
 	"context"

--- a/wallet/internal/sql/sqlite/sqlc/utxo_leases.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/utxo_leases.sql.go
@@ -3,7 +3,7 @@
 //   sqlc v1.30.0
 // source: utxo_leases.sql
 
-package sqlcsqlite
+package sqlc
 
 import (
 	"context"

--- a/wallet/internal/sql/sqlite/sqlc/utxos.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/utxos.sql.go
@@ -3,7 +3,7 @@
 //   sqlc v1.30.0
 // source: utxos.sql
 
-package sqlcsqlite
+package sqlc
 
 import (
 	"context"

--- a/wallet/internal/sql/sqlite/sqlc/wallets.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/wallets.sql.go
@@ -3,7 +3,7 @@
 //   sqlc v1.30.0
 // source: wallets.sql
 
-package sqlcsqlite
+package sqlc
 
 import (
 	"context"

--- a/wallet/mock_test.go
+++ b/wallet/mock_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/btcsuite/btcwallet/waddrmgr"
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/lightninglabs/neutrino"

--- a/wallet/utxo_manager.go
+++ b/wallet/utxo_manager.go
@@ -19,7 +19,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/waddrmgr"
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 )

--- a/wallet/utxo_manager_test.go
+++ b/wallet/utxo_manager_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/waddrmgr"
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -24,7 +24,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/btcsuite/btcwallet/waddrmgr"
-	db "github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 )


### PR DESCRIPTION
I think with the new package structure, we can simplify the import aliases a bit, relying on the default names in most cases.


also related to https://github.com/btcsuite/btcwallet/pull/1210#discussion_r3077710310