### PR TITLE
bwtest: pin bitcoind to v1 transport

### DIFF
--- a/bwtest/bitcoind.go
+++ b/bwtest/bitcoind.go
@@ -154,6 +154,12 @@ func (b *BitcoindBackend) Start() error {
 		"-regtest",
 		"-connect=" + b.minerAddr,
 
+		// bitcoind enables P2P v2 by default, but the shared btcd miner keeps
+		// v2 transport disabled by default. Pin bitcoind to v1 here so harness
+		// startup does not rely on downgrade timing during the first peer
+		// handshake.
+		"-v2transport=0",
+
 		// Enable wallet-required indexing and RPC auth.
 		"-txindex",
 		"-disablewallet",


### PR DESCRIPTION
## Summary
- Pin the bitcoind integration harness to legacy P2P transport so it does not rely on the btcd miner's default transport mode during startup.
- Stabilize the `itest bitcoind (v30)` job that failed with the backend stuck at height 0 in CI.
- Context: failed CI run https://github.com/btcsuite/btcwallet/actions/runs/24432270704

## Testing
- `GOWORK=off make itest chain=bitcoind db=kvdb`