### PR TITLE
wallet: guard nil derived address callbacks

### DIFF
--- a/wallet/internal/db/addresses_common.go
+++ b/wallet/internal/db/addresses_common.go
@@ -14,6 +14,16 @@ import (
 const DefaultImportedAccountName = "imported"
 
 var (
+	// errNilAddressDerivationFunc is returned when derived address creation is
+	// called without a derivation callback.
+	errNilAddressDerivationFunc = errors.New(
+		"address derivation callback is nil",
+	)
+
+	// errNilDerivedAddressData is returned when the derivation callback reports
+	// success but does not return any derived address data.
+	errNilDerivedAddressData = errors.New("derived address data is nil")
+
 	// errInvalidOriginID is returned when an origin ID from the database is
 	// outside the valid range [DerivedAccount, ImportedAccount]. In practice,
 	// this should never happen, but it's possible if the database is modified
@@ -529,8 +539,7 @@ func derivedAddressInput(ctx context.Context,
 
 	indexValue, err := getIdx(ctx, accountID)
 	if err != nil {
-		return 0, 0, 0, nil, fmt.Errorf(
-			"get next address index: %w", err)
+		return 0, 0, 0, nil, fmt.Errorf("get next address index: %w", err)
 	}
 
 	if indexValue > math.MaxUint32 {
@@ -539,20 +548,22 @@ func derivedAddressInput(ctx context.Context,
 
 	index, err := Int64ToUint32(indexValue)
 	if err != nil {
-		return 0, 0, 0, nil, fmt.Errorf(
-			"address index: %w", err)
+		return 0, 0, 0, nil, fmt.Errorf("address index: %w", err)
 	}
 
 	acctID, err := Int64ToUint32(accountID)
 	if err != nil {
-		return 0, 0, 0, nil, fmt.Errorf(
-			"account ID: %w", err)
+		return 0, 0, 0, nil, fmt.Errorf("account ID: %w", err)
 	}
 
 	derivedData, err := deriveFn(ctx, acctID, branch, index)
 	if err != nil {
-		return 0, 0, 0, nil, fmt.Errorf(
-			"derive address: %w", err)
+		return 0, 0, 0, nil, fmt.Errorf("derive address: %w", err)
+	}
+
+	if derivedData == nil {
+		return 0, 0, 0, nil, fmt.Errorf("derive address: %w",
+			errNilDerivedAddressData)
 	}
 
 	return addrType, branch, index, derivedData.ScriptPubKey, nil
@@ -566,6 +577,11 @@ func NewDerivedAddressWithTx[QTX any, AccountRow any,
 	executeTx func(context.Context, func(QTX) error) error,
 	adapters DerivedAddressAdapters[QTX, AccountRow, AccountParams, AddrRow],
 	deriveFn AddressDerivationFunc) (*AddressInfo, error) {
+
+	if deriveFn == nil {
+		return nil, fmt.Errorf("derive address: %w",
+			errNilAddressDerivationFunc)
+	}
 
 	var result *AddressInfo
 

--- a/wallet/internal/db/addresses_common_test.go
+++ b/wallet/internal/db/addresses_common_test.go
@@ -1,0 +1,63 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewDerivedAddressWithTxNilDeriveFn verifies that the shared helper
+// rejects a missing derivation callback before opening a transaction.
+func TestNewDerivedAddressWithTxNilDeriveFn(t *testing.T) {
+	t.Parallel()
+
+	executed := false
+
+	_, err := NewDerivedAddressWithTx(
+		t.Context(), NewDerivedAddressParams{},
+		func(context.Context, func(struct{}) error) error {
+			executed = true
+
+			return nil
+		},
+		DerivedAddressAdapters[struct{}, struct{}, struct{}, struct{}]{}, nil,
+	)
+
+	require.False(t, executed)
+	require.ErrorIs(t, err, errNilAddressDerivationFunc)
+}
+
+// TestDerivedAddressInputNilDerivedData verifies that the shared derivation
+// path rejects a nil callback result before dereferencing it.
+func TestDerivedAddressInputNilDerivedData(t *testing.T) {
+	t.Parallel()
+
+	params := NewDerivedAddressParams{
+		Scope: KeyScopeBIP0084,
+	}
+
+	deriveFn := func(context.Context, uint32, uint32,
+		uint32) (*DerivedAddressData, error) {
+
+		var derivedData *DerivedAddressData
+
+		return derivedData, nil
+	}
+
+	addrType, branch, index, scriptPubKey, err := derivedAddressInput(
+		t.Context(), params, 1,
+		func(context.Context, int64) (int64, error) {
+			return 7, nil
+		},
+		func(context.Context, int64) (int64, error) {
+			return 11, nil
+		}, deriveFn,
+	)
+
+	require.Zero(t, addrType)
+	require.Zero(t, branch)
+	require.Zero(t, index)
+	require.Nil(t, scriptPubKey)
+	require.ErrorIs(t, err, errNilDerivedAddressData)
+}

--- a/wallet/internal/db/itest/address_store_test.go
+++ b/wallet/internal/db/itest/address_store_test.go
@@ -1109,6 +1109,65 @@ func TestNewDerivedAddress(t *testing.T) {
 	}
 }
 
+// TestNewDerivedAddressDerivationGuards verifies that NewDerivedAddress returns
+// errors instead of panicking when the derivation callback is nil or returns
+// nil derived data.
+func TestNewDerivedAddressDerivationGuards(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-derived-guards")
+	accountName := "derived-guard-test"
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, accountName)
+
+	params := db.NewDerivedAddressParams{
+		WalletID:    walletID,
+		Scope:       db.KeyScopeBIP0084,
+		AccountName: accountName,
+		Change:      false,
+	}
+
+	t.Run("nil derive callback", func(t *testing.T) {
+		var (
+			info *db.AddressInfo
+			err  error
+		)
+
+		require.NotPanics(
+			t, func() {
+				info, err = store.NewDerivedAddress(t.Context(), params, nil)
+			},
+		)
+
+		require.Nil(t, info)
+		require.Error(t, err)
+	})
+
+	t.Run("nil derived data", func(t *testing.T) {
+		deriveFn := func(ctx context.Context, accountID uint32, branch uint32,
+			index uint32) (*db.DerivedAddressData, error) {
+
+			return nil, nil
+		}
+
+		var (
+			info *db.AddressInfo
+			err  error
+		)
+
+		require.NotPanics(
+			t, func() {
+				info, err = store.NewDerivedAddress(
+					t.Context(), params, deriveFn,
+				)
+			},
+		)
+
+		require.Nil(t, info)
+		require.Error(t, err)
+	})
+}
+
 // TestNewImportedAddress_NonExistentImportedAccount verifies that calling
 // NewImportedAddress when the implicit "imported" account doesn't exist
 // returns db.ErrAccountNotFound. This validates that the implicit account


### PR DESCRIPTION
Prevent panics in derived address creation by rejecting a nil derivation callback and nil derived data return. Keep these guard errors internal and add focused regression tests.