### PR TITLE
wallet: disambiguates watch-only

### DIFF
--- a/wallet/internal/db/accounts_common.go
+++ b/wallet/internal/db/accounts_common.go
@@ -43,6 +43,20 @@ func (params *CreateImportedAccountParams) Validate() error {
 	return nil
 }
 
+// ValidateWatchOnly validates watch-only invariants for creating an imported
+// account.
+func (params *CreateImportedAccountParams) ValidateWatchOnly(
+	walletIsWatchOnly bool) error {
+
+	hasPrivateKey := len(params.EncryptedPrivateKey) > 0
+	if walletIsWatchOnly && hasPrivateKey {
+		return fmt.Errorf("wallet %d cannot create account %q: %w",
+			params.WalletID, params.Name, ErrWatchOnlyViolation)
+	}
+
+	return nil
+}
+
 // Validate checks that exactly one account selector was set.
 func (query GetAccountQuery) Validate() error {
 	if query.Name == nil && query.AccountNumber == nil {
@@ -529,6 +543,7 @@ func RenameAccount[Args any](ctx context.Context,
 func CreateImportedAccount[CreateArgs any, CreateRow any, SecretArgs any](
 	ctx context.Context, params CreateImportedAccountParams,
 	ensureScope func() (int64, error),
+	walletWatchOnly func() (bool, error),
 	createAccount func(context.Context, CreateArgs) (CreateRow, error),
 	buildCreateArgs func(scopeID int64, isWatchOnly bool) CreateArgs,
 	rowToID func(CreateRow) int64,
@@ -542,7 +557,18 @@ func CreateImportedAccount[CreateArgs any, CreateRow any, SecretArgs any](
 		return nil, err
 	}
 
-	isWatchOnly := params.IsWatchOnly()
+	walletIsWatchOnly, err := walletWatchOnly()
+	if err != nil {
+		return nil, err
+	}
+
+	err = params.ValidateWatchOnly(walletIsWatchOnly)
+	if err != nil {
+		return nil, err
+	}
+
+	hasAccountSecret := len(params.EncryptedPrivateKey) > 0
+	isWatchOnly := walletIsWatchOnly || !hasAccountSecret
 
 	scopeID, err := ensureScope()
 	if err != nil {
@@ -558,7 +584,7 @@ func CreateImportedAccount[CreateArgs any, CreateRow any, SecretArgs any](
 
 	accountID := rowToID(row)
 
-	if isWatchOnly {
+	if !hasAccountSecret {
 		return getProps(accountID)
 	}
 

--- a/wallet/internal/db/accounts_common.go
+++ b/wallet/internal/db/accounts_common.go
@@ -30,8 +30,8 @@ func (params *CreateDerivedAccountParams) Validate() error {
 	return nil
 }
 
-// Validate validates required fields for creating an imported account.
-func (params *CreateImportedAccountParams) Validate() error {
+// ValidateBasic validates required fields for creating an imported account.
+func (params *CreateImportedAccountParams) ValidateBasic() error {
 	if params.Name == "" {
 		return ErrMissingAccountName
 	}
@@ -85,11 +85,6 @@ func (params RenameAccountParams) Validate() error {
 	}
 
 	return nil
-}
-
-// IsWatchOnly returns true if the account is watch-only.
-func (params *CreateImportedAccountParams) IsWatchOnly() bool {
-	return len(params.EncryptedPrivateKey) == 0
 }
 
 // AccountPropsRow represents the raw database fields needed to construct
@@ -538,21 +533,21 @@ func RenameAccount[Args any](ctx context.Context,
 
 // CreateImportedAccount is a generic helper that creates an imported account.
 // It handles ensuring the key scope exists, creating the account record,
-// optionally creating the account secret for non-watch-only accounts, and
-// fetching the full account properties from the database.
+// optionally creating the account secret when account private key material is
+// present, and fetching the full account properties from the database.
 func CreateImportedAccount[CreateArgs any, CreateRow any, SecretArgs any](
 	ctx context.Context, params CreateImportedAccountParams,
 	ensureScope func() (int64, error),
 	walletWatchOnly func() (bool, error),
 	createAccount func(context.Context, CreateArgs) (CreateRow, error),
-	buildCreateArgs func(scopeID int64, isWatchOnly bool) CreateArgs,
+	buildCreateArgs func(scopeID int64) CreateArgs,
 	rowToID func(CreateRow) int64,
 	createSecret func(context.Context, SecretArgs) error,
 	buildSecretArgs func(accountID int64) SecretArgs,
 	getProps func(accountID int64) (*AccountProperties, error),
 ) (*AccountProperties, error) {
 
-	err := params.Validate()
+	err := params.ValidateBasic()
 	if err != nil {
 		return nil, err
 	}
@@ -568,14 +563,13 @@ func CreateImportedAccount[CreateArgs any, CreateRow any, SecretArgs any](
 	}
 
 	hasAccountSecret := len(params.EncryptedPrivateKey) > 0
-	isWatchOnly := walletIsWatchOnly || !hasAccountSecret
 
 	scopeID, err := ensureScope()
 	if err != nil {
 		return nil, err
 	}
 
-	createArgs := buildCreateArgs(scopeID, isWatchOnly)
+	createArgs := buildCreateArgs(scopeID)
 
 	row, err := createAccount(ctx, createArgs)
 	if err != nil {

--- a/wallet/internal/db/accounts_common_test.go
+++ b/wallet/internal/db/accounts_common_test.go
@@ -26,15 +26,15 @@ func TestCreateImportedAccountParamsValidate(t *testing.T) {
 	err := (&CreateImportedAccountParams{
 		Name:               "imported",
 		EncryptedPublicKey: []byte{1},
-	}).Validate()
+	}).ValidateBasic()
 	require.NoError(t, err)
 
 	err = (&CreateImportedAccountParams{
 		EncryptedPublicKey: []byte{1},
-	}).Validate()
+	}).ValidateBasic()
 	require.ErrorIs(t, err, ErrMissingAccountName)
 
-	err = (&CreateImportedAccountParams{Name: "imported"}).Validate()
+	err = (&CreateImportedAccountParams{Name: "imported"}).ValidateBasic()
 	require.ErrorIs(t, err, ErrMissingAccountPublicKey)
 }
 

--- a/wallet/internal/db/addresses_common.go
+++ b/wallet/internal/db/addresses_common.go
@@ -13,6 +13,16 @@ import (
 // addresses.
 const DefaultImportedAccountName = "imported"
 
+// importedAddressIsWatchOnly determines whether an imported address is
+// watch-only based on wallet-level watch-only mode and address-level private
+// key presence. An imported address is watch-only if the wallet is watch-only
+// or if the address does not carry encrypted private key material.
+func importedAddressIsWatchOnly(walletIsWatchOnly bool,
+	hasPrivateKey bool) bool {
+
+	return walletIsWatchOnly || !hasPrivateKey
+}
+
 var (
 	// errNilAddressDerivationFunc is returned when derived address creation is
 	// called without a derivation callback.
@@ -89,9 +99,9 @@ func GetAddressSecret[Row any](ctx context.Context,
 	return nil, fmt.Errorf("get address secret: %w", err)
 }
 
-// Validate validates the required fields for creating an imported address.
-// Returns sentinel errors on failure.
-func (p NewImportedAddressParams) Validate() error {
+// ValidateBasic checks imported address creation parameters that do not depend
+// on external state.
+func (p NewImportedAddressParams) ValidateBasic() error {
 	if len(p.ScriptPubKey) == 0 {
 		return ErrMissingScriptPubKey
 	}
@@ -99,17 +109,32 @@ func (p NewImportedAddressParams) Validate() error {
 	return nil
 }
 
-// IsWatchOnly returns true if the params include neither a private key nor
-// a redeem or witness script.
-func (p NewImportedAddressParams) IsWatchOnly() bool {
-	noPrivKey := len(p.EncryptedPrivateKey) == 0
-	noScript := len(p.EncryptedScript) == 0
+// ValidateWatchOnly checks imported address creation parameters against the
+// parent wallet's watch-only state.
+func (p NewImportedAddressParams) ValidateWatchOnly(
+	walletIsWatchOnly bool) error {
 
-	if noPrivKey && noScript {
-		return true
+	if walletIsWatchOnly && p.HasPrivateKey() {
+		return fmt.Errorf("watch-only wallet %d cannot import private-key-"+
+			"bearing address into account %q: %w",
+			p.WalletID, DefaultImportedAccountName, ErrWatchOnlyViolation)
 	}
 
-	return false
+	return nil
+}
+
+// HasPrivateKey returns true if the params include private key material.
+// Script material is tracked separately and does not make an imported address
+// spend-capable by itself.
+func (p NewImportedAddressParams) HasPrivateKey() bool {
+	return len(p.EncryptedPrivateKey) > 0
+}
+
+// HasSecretMaterial returns true when the imported address carries any
+// encrypted secret payload that should be persisted in address_secrets.
+// Private keys and scripts are stored independently.
+func (p NewImportedAddressParams) HasSecretMaterial() bool {
+	return len(p.EncryptedPrivateKey) > 0 || len(p.EncryptedScript) > 0
 }
 
 // IDToOrigin safely converts an integer to AccountOrigin. It returns an error
@@ -138,6 +163,9 @@ type AddressInfoRow[TypeID, OriginIDType any] struct {
 	// OriginID is the database identifier for address origin (derived=0,
 	// imported=1).
 	OriginID OriginIDType
+
+	// WalletIsWatchOnly indicates whether the wallet is watch-only.
+	WalletIsWatchOnly bool
 
 	// HasPrivateKey indicates whether the address has an encrypted private key.
 	HasPrivateKey bool
@@ -222,13 +250,17 @@ func convertAddressIDs(id, accountID int64) (uint32, uint32, error) {
 }
 
 // newImportedAddressTx handles the shared transaction flow for creating an
-// imported address across database backends.
+// imported address across database backends. It creates the address row and
+// conditionally inserts the address_secrets row when any encrypted private key
+// or encrypted script material is present. Imported addresses are watch-only
+// when their parent wallet is watch-only or when the address itself does not
+// carry private key material.
 func newImportedAddressTx[QTX any, Row any, CreateArgs any, InsertArgs any](
 	ctx context.Context, create func(context.Context, CreateArgs) (Row, error),
 	createArgs CreateArgs,
 	insertFn func(QTX) func(context.Context, InsertArgs) error, qtx QTX,
 	insertArgs func(int64, NewImportedAddressParams) InsertArgs,
-	params NewImportedAddressParams, accountID int64,
+	params NewImportedAddressParams, accountID int64, walletIsWatchOnly bool,
 	rowID func(Row) int64, rowCreatedAt func(Row) time.Time) (*AddressInfo,
 	error) {
 
@@ -238,7 +270,7 @@ func newImportedAddressTx[QTX any, Row any, CreateArgs any, InsertArgs any](
 	}
 
 	addrID := rowID(addrRow)
-	if !params.IsWatchOnly() {
+	if params.HasSecretMaterial() {
 		err = insertFn(qtx)(ctx, insertArgs(addrID, params))
 		if err != nil {
 			return nil, fmt.Errorf("insert address secret: %w", err)
@@ -258,7 +290,9 @@ func newImportedAddressTx[QTX any, Row any, CreateArgs any, InsertArgs any](
 		Origin:       ImportedAccount,
 		ScriptPubKey: params.ScriptPubKey,
 		PubKey:       params.PubKey,
-		IsWatchOnly:  params.IsWatchOnly(),
+		IsWatchOnly: importedAddressIsWatchOnly(
+			walletIsWatchOnly, params.HasPrivateKey(),
+		),
 	}, nil
 }
 
@@ -314,6 +348,10 @@ func convertAddressPath(origin AccountOrigin, branch,
 
 // AddressRowToInfo converts raw database field values into an AddressInfo
 // struct. It handles type conversion and validation for each field.
+//
+// Watch-only computation: derived addresses follow wallet watch-only mode.
+// Imported addresses are watch-only when the wallet is watch-only or when the
+// imported address does not carry encrypted private key material.
 func AddressRowToInfo[TypeID, OriginIDType any](
 	row AddressInfoRow[TypeID, OriginIDType]) (*AddressInfo, error) {
 
@@ -334,8 +372,12 @@ func AddressRowToInfo[TypeID, OriginIDType any](
 		return nil, err
 	}
 
-	isWatchOnly := origin == ImportedAccount && !row.HasPrivateKey &&
-		!row.HasScript
+	isWatchOnly := row.WalletIsWatchOnly
+	if origin == ImportedAccount {
+		isWatchOnly = importedAddressIsWatchOnly(
+			row.WalletIsWatchOnly, row.HasPrivateKey,
+		)
+	}
 
 	return &AddressInfo{
 		ID:           id,
@@ -394,6 +436,10 @@ type DerivedAddressAdapters[QTX any, AccountRow any, AccountParams any,
 	// GetAccountID extracts the account ID from an account row.
 	GetAccountID func(AccountRow) int64
 
+	// GetWalletWatchOnly extracts the wallet watch-only state from an account
+	// row.
+	GetWalletWatchOnly func(AccountRow) bool
+
 	// GetExtIndex returns a function to get the external index.
 	GetExtIndex func(QTX) func(context.Context, int64) (int64, error)
 
@@ -425,6 +471,10 @@ type ImportedAddressAdapters[QTX any, AccountRow any,
 
 	// GetAccountID extracts the account ID from an account row.
 	GetAccountID func(AccountRow) int64
+
+	// GetWalletWatchOnly extracts the wallet-derived watch-only state from an
+	// account row.
+	GetWalletWatchOnly func(AccountRow) bool
 
 	// CreateAddr returns a function to create an address row.
 	CreateAddr func(QTX) func(context.Context, CreateArgs) (AddrRow, error)
@@ -465,6 +515,7 @@ func GetAddressByQuery(ctx context.Context, query GetAddressQuery,
 // inputs and then createFn to create the address.
 func createDerivedAddress[T any](ctx context.Context,
 	params NewDerivedAddressParams, walletID int64, accountID int64,
+	walletIsWatchOnly bool,
 	getExtIndex func(context.Context, int64) (int64, error),
 	getIntIndex func(context.Context, int64) (int64, error),
 	createFn func(context.Context, int64, int64, AddressType, uint32, uint32,
@@ -503,7 +554,7 @@ func createDerivedAddress[T any](ctx context.Context,
 		Branch:       branch,
 		Index:        index,
 		ScriptPubKey: scriptPubKey,
-		IsWatchOnly:  false,
+		IsWatchOnly:  walletIsWatchOnly,
 	}, nil
 }
 
@@ -588,8 +639,11 @@ func NewDerivedAddressWithTx[QTX any, AccountRow any,
 	err := executeTx(ctx, func(qtx QTX) error {
 		row, err := adapters.GetAccount(ctx, adapters.AccountParams(params))
 		if err == nil {
+			accountID := adapters.GetAccountID(row)
+
 			info, errAddr := createDerivedAddress(
-				ctx, params, int64(params.WalletID), adapters.GetAccountID(row),
+				ctx, params, int64(params.WalletID), accountID,
+				adapters.GetWalletWatchOnly(row),
 				adapters.GetExtIndex(qtx),
 				adapters.GetIntIndex(qtx),
 				adapters.CreateAddr(qtx),
@@ -630,7 +684,7 @@ func NewImportedAddressWithTx[QTX any, AccountRow any, AccountParams any,
 	adapters ImportedAddressAdapters[QTX, AccountRow, AccountParams, CreateArgs,
 		AddrRow, SecretParams]) (*AddressInfo, error) {
 
-	validationErr := params.Validate()
+	validationErr := params.ValidateBasic()
 	if validationErr != nil {
 		return nil, validationErr
 	}
@@ -640,13 +694,20 @@ func NewImportedAddressWithTx[QTX any, AccountRow any, AccountParams any,
 	err := executeTx(ctx, func(qtx QTX) error {
 		row, err := adapters.GetAccount(ctx, adapters.AccountParams(params))
 		if err == nil {
+			walletIsWatchOnly := adapters.GetWalletWatchOnly(row)
+
+			errWatchOnly := params.ValidateWatchOnly(walletIsWatchOnly)
+			if errWatchOnly != nil {
+				return errWatchOnly
+			}
+
 			acctID := adapters.GetAccountID(row)
 
 			info, errAddr := newImportedAddressTx(
 				ctx, adapters.CreateAddr(qtx),
 				adapters.CreateParams(int64(params.WalletID), acctID, params),
 				adapters.InsertSecret, qtx,
-				adapters.SecretParams, params, acctID,
+				adapters.SecretParams, params, acctID, walletIsWatchOnly,
 				adapters.RowID,
 				adapters.RowCreatedAt)
 			if errAddr != nil {

--- a/wallet/internal/db/common.go
+++ b/wallet/internal/db/common.go
@@ -1,0 +1,25 @@
+package db
+
+// NilIfEmptyBytes returns nil for nil or empty byte slices and returns
+// non-empty byte slices unchanged.
+//
+// Call this at the SQL boundary on nullable byte columns where "absent"
+// is encoded as SQL NULL. Go's []byte{} is non-nil but length-zero, and
+// database/sql sends it as an empty bytea/BLOB (not NULL), which
+// disagrees with two things:
+//
+//   - DB-side triggers and CHECK constraints that test `IS NULL` /
+//     `IS NOT NULL` (e.g. the watch-only secret triggers), and
+//   - Go-side "no value" checks that use `len(...) == 0` (e.g.
+//     HasPrivateKey).
+//
+// Normalizing empty to nil here picks one canonical storage shape —
+// empty means SQL NULL — so the two layers stay in agreement, and callers
+// can pass either nil or []byte{} without changing behavior.
+func NilIfEmptyBytes(b []byte) []byte {
+	if len(b) == 0 {
+		return nil
+	}
+
+	return b
+}

--- a/wallet/internal/db/common_test.go
+++ b/wallet/internal/db/common_test.go
@@ -1,0 +1,39 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNilIfEmptyBytes verifies that nil and empty slices normalize to nil while
+// non-empty slices are preserved.
+func TestNilIfEmptyBytes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil input", func(t *testing.T) {
+		t.Parallel()
+
+		result := NilIfEmptyBytes(nil)
+
+		require.Nil(t, result)
+	})
+
+	t.Run("empty non-nil input", func(t *testing.T) {
+		t.Parallel()
+
+		result := NilIfEmptyBytes([]byte{})
+
+		require.Nil(t, result)
+	})
+
+	t.Run("non-empty input", func(t *testing.T) {
+		t.Parallel()
+
+		input := []byte{1, 2, 3}
+		result := NilIfEmptyBytes(input)
+
+		require.NotNil(t, result)
+		require.Equal(t, input, result)
+	})
+}

--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -496,8 +496,10 @@ type AccountProperties struct {
 	// KeyScope is the key scope the account belongs to.
 	KeyScope KeyScope
 
-	// IsWatchOnly indicates whether the is set up as watch-only, i.e., it
-	// doesn't contain any private key information.
+	// IsWatchOnly indicates whether the account is in watch-only mode.
+	// Derived accounts inherit the wallet's watch-only status. Imported
+	// accounts are watch-only if the wallet is watch-only OR if the imported
+	// account has no private key material (account_secret is NULL).
 	IsWatchOnly bool
 
 	// CreatedAt is the timestamp when the account was created in the database.
@@ -620,8 +622,8 @@ type AddressInfo struct {
 	// addresses.
 	PubKey []byte
 
-	// IsWatchOnly indicates whether the wallet has the private key for this
-	// address. Convenience field.
+	// IsWatchOnly indicates whether the address belongs to a watch-only
+	// wallet or does not have private keys.
 	IsWatchOnly bool
 }
 
@@ -665,6 +667,10 @@ type NewDerivedAddressParams struct {
 // address into the wallet. All imported addresses are assigned to the
 // wallet imported account. The caller is responsible for encrypting any
 // sensitive material before populating this struct.
+//
+// Watch-only semantics: An imported address is watch-only if the parent wallet
+// is watch-only or if EncryptedPrivateKey is empty. EncryptedScript alone does
+// not make the imported address spendable.
 type NewImportedAddressParams struct {
 	// WalletID identifies the wallet that will own this address.
 	//

--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -381,6 +381,9 @@ type AccountInfo struct {
 	UnconfirmedBalance btcutil.Amount
 
 	// IsWatchOnly indicates whether the account is in watch-only mode.
+	// Derived accounts inherit the wallet's watch-only status. Imported
+	// accounts are watch-only if the wallet is watch-only OR if the imported
+	// account has no private key material (account_secret is NULL).
 	IsWatchOnly bool
 
 	// CreatedAt is the timestamp when the account was created in the database.
@@ -445,7 +448,8 @@ type CreateImportedAccountParams struct {
 
 	// EncryptedPrivateKey is the encrypted extended private key for the
 	// account. This should be encrypted by the caller before being passed
-	// to the database layer. A nil or empty slice indicates watch-only.
+	// to the database layer. A nil or empty slice means no account private
+	// key material is stored; the imported account will be watch-only.
 	EncryptedPrivateKey []byte
 }
 

--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -21,6 +21,11 @@ var (
 	// in the database.
 	ErrSecretNotFound = errors.New("secret not found")
 
+	// ErrWatchOnlyViolation is returned when an operation violates watch-only
+	// invariants. Watch-only means the wallet or address lacks private key
+	// material and cannot sign transactions.
+	ErrWatchOnlyViolation = errors.New("watch-only invariant violation")
+
 	// ErrNilDB is returned when a nil database connection pointer is
 	// provided to the wallet.
 	ErrNilDB = errors.New("wallet requires a non-nil database connection")

--- a/wallet/internal/db/itest/account_store_test.go
+++ b/wallet/internal/db/itest/account_store_test.go
@@ -366,6 +366,44 @@ func TestCreateImportedAccountErrors(t *testing.T) {
 	}
 }
 
+// TestCreateImportedAccountMissingWallet verifies that CreateImportedAccount
+// returns ErrWalletNotFound when the wallet does not exist.
+func TestCreateImportedAccountMissingWallet(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+
+	params := db.CreateImportedAccountParams{
+		WalletID:           99999,
+		Name:               "missing-wallet-imported",
+		Scope:              db.KeyScopeBIP0084,
+		EncryptedPublicKey: RandomBytes(32),
+	}
+
+	props, err := store.CreateImportedAccount(t.Context(), params)
+	require.ErrorIs(t, err, db.ErrWalletNotFound)
+	require.Nil(t, props)
+}
+
+// TestCreateImportedAccountValidationPrecedesWalletLookup verifies that basic
+// input validation still wins over wallet lookup failures.
+func TestCreateImportedAccountValidationPrecedesWalletLookup(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+
+	props, err := store.CreateImportedAccount(
+		t.Context(), db.CreateImportedAccountParams{
+			WalletID:           99999,
+			Name:               "",
+			Scope:              db.KeyScopeBIP0084,
+			EncryptedPublicKey: RandomBytes(32),
+		},
+	)
+	require.ErrorIs(t, err, db.ErrMissingAccountName)
+	require.Nil(t, props)
+}
+
 // TestCreateImportedAccountDuplicateName verifies that creating an imported
 // account with a duplicate name in the same scope fails.
 func TestCreateImportedAccountDuplicateName(t *testing.T) {

--- a/wallet/internal/db/itest/account_store_test.go
+++ b/wallet/internal/db/itest/account_store_test.go
@@ -143,6 +143,24 @@ func TestCreateDerivedAccountErrors(t *testing.T) {
 	}
 }
 
+// TestCreateDerivedAccountMissingWallet verifies that CreateDerivedAccount
+// returns ErrWalletNotFound when the wallet does not exist.
+func TestCreateDerivedAccountMissingWallet(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+
+	params := db.CreateDerivedAccountParams{
+		WalletID: 99999,
+		Scope:    db.KeyScopeBIP0084,
+		Name:     "missing-wallet-account",
+	}
+
+	info, err := store.CreateDerivedAccount(t.Context(), params)
+	require.ErrorIs(t, err, db.ErrWalletNotFound)
+	require.Nil(t, info)
+}
+
 // TestCreateDerivedAccountDuplicateName verifies that creating a derived
 // account with a duplicate name in the same scope fails.
 func TestCreateDerivedAccountDuplicateName(t *testing.T) {
@@ -404,6 +422,183 @@ func TestCreateImportedAccountValidationPrecedesWalletLookup(t *testing.T) {
 	require.Nil(t, props)
 }
 
+// TestWatchOnlyHierarchyAccountRules is the canonical wallet-to-account
+// watch-only matrix for derived and imported accounts.
+func TestWatchOnlyHierarchyAccountRules(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		walletParams    func(string) db.CreateWalletParams
+		wantWatchOnly   bool
+		wantErr         error
+		createAccountFn func(*testing.T, db.AccountStore, uint32) (bool, error)
+	}{
+		{
+			name:          "standard wallet derived account is spendable",
+			walletParams:  CreateWalletParamsFixture,
+			wantWatchOnly: false,
+			createAccountFn: func(t *testing.T, store db.AccountStore,
+				walletID uint32) (bool, error) {
+
+				t.Helper()
+				info, err := store.CreateDerivedAccount(
+					t.Context(), db.CreateDerivedAccountParams{
+						WalletID: walletID,
+						Scope:    db.KeyScopeBIP0084,
+						Name:     "drv-std",
+					},
+				)
+				if err != nil {
+					return false, err
+				}
+
+				return info.IsWatchOnly, nil
+			},
+		},
+		{
+			name:          "watch-only wallet derived account is watch-only",
+			walletParams:  CreateWatchOnlyWalletParams,
+			wantWatchOnly: true,
+			createAccountFn: func(t *testing.T, store db.AccountStore,
+				walletID uint32) (bool, error) {
+
+				t.Helper()
+				info, err := store.CreateDerivedAccount(
+					t.Context(), db.CreateDerivedAccountParams{
+						WalletID: walletID,
+						Scope:    db.KeyScopeBIP0084,
+						Name:     "drv-wo",
+					},
+				)
+				if err != nil {
+					return false, err
+				}
+
+				return info.IsWatchOnly, nil
+			},
+		},
+		{
+			name: "standard wallet imported account with " +
+				"private key is spendable",
+			walletParams:  CreateWalletParamsFixture,
+			wantWatchOnly: false,
+			createAccountFn: func(t *testing.T, store db.AccountStore,
+				walletID uint32) (bool, error) {
+
+				t.Helper()
+				props, err := store.CreateImportedAccount(
+					t.Context(), db.CreateImportedAccountParams{
+						WalletID:            walletID,
+						Name:                db.DefaultImportedAccountName,
+						Scope:               db.KeyScopeBIP0084,
+						EncryptedPublicKey:  RandomBytes(32),
+						EncryptedPrivateKey: RandomBytes(32),
+					},
+				)
+				if err != nil {
+					return false, err
+				}
+
+				return props.IsWatchOnly, nil
+			},
+		},
+		{
+			name: "standard wallet imported account without " +
+				"private key is watch-only",
+			walletParams:  CreateWalletParamsFixture,
+			wantWatchOnly: true,
+			createAccountFn: func(t *testing.T, store db.AccountStore,
+				walletID uint32) (bool, error) {
+
+				t.Helper()
+				props, err := store.CreateImportedAccount(
+					t.Context(), db.CreateImportedAccountParams{
+						WalletID:           walletID,
+						Name:               db.DefaultImportedAccountName,
+						Scope:              db.KeyScopeBIP0084,
+						EncryptedPublicKey: RandomBytes(32),
+					},
+				)
+				if err != nil {
+					return false, err
+				}
+
+				return props.IsWatchOnly, nil
+			},
+		},
+		{
+			name: "watch-only wallet imported account without " +
+				"private key is watch-only",
+			walletParams:  CreateWatchOnlyWalletParams,
+			wantWatchOnly: true,
+			createAccountFn: func(t *testing.T, store db.AccountStore,
+				walletID uint32) (bool, error) {
+
+				t.Helper()
+				props, err := store.CreateImportedAccount(
+					t.Context(), db.CreateImportedAccountParams{
+						WalletID:           walletID,
+						Name:               db.DefaultImportedAccountName,
+						Scope:              db.KeyScopeBIP0084,
+						EncryptedPublicKey: RandomBytes(32),
+					},
+				)
+				if err != nil {
+					return false, err
+				}
+
+				return props.IsWatchOnly, nil
+			},
+		},
+		{
+			name: "watch-only wallet imported account with " +
+				"private key is rejected",
+			walletParams: CreateWatchOnlyWalletParams,
+			wantErr:      db.ErrWatchOnlyViolation,
+			createAccountFn: func(t *testing.T, store db.AccountStore,
+				walletID uint32) (bool, error) {
+
+				t.Helper()
+				props, err := store.CreateImportedAccount(
+					t.Context(), db.CreateImportedAccountParams{
+						WalletID:            walletID,
+						Name:                "hardware",
+						Scope:               db.KeyScopeBIP0084,
+						EncryptedPublicKey:  RandomBytes(32),
+						EncryptedPrivateKey: RandomBytes(32),
+					},
+				)
+				if err != nil {
+					return false, err
+				}
+
+				return props.IsWatchOnly, nil
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := NewTestStore(t)
+
+			walletInfo, err := store.CreateWallet(
+				t.Context(), tc.walletParams("watch-only-account-matrix"),
+			)
+			require.NoError(t, err)
+
+			isWatchOnly, err := tc.createAccountFn(t, store, walletInfo.ID)
+			require.ErrorIs(t, err, tc.wantErr)
+
+			if tc.wantErr != nil {
+				return
+			}
+
+			require.Equal(t, tc.wantWatchOnly, isWatchOnly)
+		})
+	}
+}
+
 // TestCreateImportedAccountDuplicateName verifies that creating an imported
 // account with a duplicate name in the same scope fails.
 func TestCreateImportedAccountDuplicateName(t *testing.T) {
@@ -467,6 +662,42 @@ func TestGetAccount(t *testing.T) {
 				requireAccountMatches(t, info, tc)
 			})
 	}
+}
+
+// TestGetAccountWatchOnlyMapping verifies that GetAccount preserves
+// representative watch-only flags on read.
+func TestGetAccountWatchOnlyMapping(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-get-watch")
+	scope := db.KeyScopeBIP0084
+
+	createDerivedAccount(t, store, walletID, scope, "derived")
+
+	_, err := store.CreateImportedAccount(
+		t.Context(), db.CreateImportedAccountParams{
+			WalletID:           walletID,
+			Name:               db.DefaultImportedAccountName,
+			Scope:              scope,
+			EncryptedPublicKey: RandomBytes(32),
+		},
+	)
+	require.NoError(t, err)
+
+	derived, err := store.GetAccount(
+		t.Context(), getAccountQueryByName(walletID, scope, "derived"),
+	)
+	require.NoError(t, err)
+	require.False(t, derived.IsWatchOnly)
+
+	imported, err := store.GetAccount(
+		t.Context(), getAccountQueryByName(
+			walletID, scope, db.DefaultImportedAccountName,
+		),
+	)
+	require.NoError(t, err)
+	require.True(t, imported.IsWatchOnly)
 }
 
 // TestGetAccountNotFound verifies that GetAccount returns ErrAccountNotFound
@@ -588,6 +819,52 @@ func TestListAccounts(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, accounts)
 	})
+}
+
+// TestListAccountsWatchOnlyMapping verifies that ListAccounts preserves
+// representative watch-only flags on read.
+func TestListAccountsWatchOnlyMapping(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-list-watch")
+	scope := db.KeyScopeBIP0084
+
+	createDerivedAccount(t, store, walletID, scope, "derived")
+
+	_, err := store.CreateImportedAccount(
+		t.Context(), db.CreateImportedAccountParams{
+			WalletID:           walletID,
+			Name:               db.DefaultImportedAccountName,
+			Scope:              scope,
+			EncryptedPublicKey: RandomBytes(32),
+		},
+	)
+	require.NoError(t, err)
+
+	accounts, err := store.ListAccounts(
+		t.Context(), db.ListAccountsQuery{
+			WalletID: walletID,
+			Scope:    &scope,
+		},
+	)
+	require.NoError(t, err)
+
+	derived := findAccountInList(
+		t, accounts, AccountTestCase{
+			Name:  "derived",
+			Scope: scope,
+		},
+	)
+	imported := findAccountInList(
+		t, accounts, AccountTestCase{
+			Name:  db.DefaultImportedAccountName,
+			Scope: scope,
+		},
+	)
+
+	require.False(t, derived.IsWatchOnly)
+	require.True(t, imported.IsWatchOnly)
 }
 
 // TestListAccountsOrdering verifies that ListAccounts returns derived accounts
@@ -932,8 +1209,7 @@ func CreateImportedAccount(t *testing.T, store db.AccountStore, walletID uint32,
 }
 
 // requireAccountMatches asserts that the provided AccountInfo matches the
-// expected AccountTestCase, including name, scope, origin, watch-only status,
-// and creation timestamp.
+// expected AccountTestCase's core identity fields and creation timestamp.
 func requireAccountMatches(t *testing.T, info *db.AccountInfo,
 	tc AccountTestCase) {
 
@@ -942,7 +1218,6 @@ func requireAccountMatches(t *testing.T, info *db.AccountInfo,
 	require.Equal(t, tc.Name, info.AccountName)
 	require.Equal(t, tc.Scope, info.KeyScope)
 	require.Equal(t, tc.Origin, info.Origin)
-	require.Equal(t, tc.IsWatchOnly, info.IsWatchOnly)
 
 	// Verify CreatedAt is populated and not in the future. The account may
 	// have been created several seconds earlier in the test when parallel
@@ -954,8 +1229,8 @@ func requireAccountMatches(t *testing.T, info *db.AccountInfo,
 }
 
 // requireAccountPropertiesMatches asserts that the provided AccountProperties
-// matches the expected AccountTestCase, including name, scope, origin,
-// watch-only status, and creation timestamp.
+// matches the expected AccountTestCase's core identity fields and creation
+// timestamp.
 func requireAccountPropertiesMatches(t *testing.T, props *db.AccountProperties,
 	tc AccountTestCase) {
 
@@ -964,7 +1239,6 @@ func requireAccountPropertiesMatches(t *testing.T, props *db.AccountProperties,
 	require.Equal(t, tc.Name, props.AccountName)
 	require.Equal(t, tc.Scope, props.KeyScope)
 	require.Equal(t, tc.Origin, props.Origin)
-	require.Equal(t, tc.IsWatchOnly, props.IsWatchOnly)
 
 	// Verify CreatedAt is populated and not in the future. Imported-account
 	// test fixtures can be created well before these assertions run under

--- a/wallet/internal/db/itest/address_store_test.go
+++ b/wallet/internal/db/itest/address_store_test.go
@@ -130,7 +130,7 @@ func flattenAddressPages(
 }
 
 // TestNewImportedAddress verifies that NewImportedAddress correctly imports
-// addresses of different types, both watch-only and spendable.
+// addresses of different types, with and without private key material.
 func TestNewImportedAddress(t *testing.T) {
 	t.Parallel()
 
@@ -170,42 +170,42 @@ func TestNewImportedAddress(t *testing.T) {
 		providePrivateKey bool
 	}{
 		{
-			name:              "P2PKH watch-only",
+			name:              "P2PKH without private key",
 			addr:              p2pkhAddr,
 			scope:             db.KeyScopeBIP0044,
 			expectedAddrType:  db.PubKeyHash,
 			providePrivateKey: false,
 		},
 		{
-			name:              "P2PKH spendable",
+			name:              "P2PKH with private key",
 			addr:              p2pkhAddr,
 			scope:             db.KeyScopeBIP0044,
 			expectedAddrType:  db.PubKeyHash,
 			providePrivateKey: true,
 		},
 		{
-			name:              "P2WPKH watch-only",
+			name:              "P2WPKH without private key",
 			addr:              p2wpkhAddr,
 			scope:             db.KeyScopeBIP0084,
 			expectedAddrType:  db.WitnessPubKey,
 			providePrivateKey: false,
 		},
 		{
-			name:              "P2WPKH spendable",
+			name:              "P2WPKH with private key",
 			addr:              p2wpkhAddr,
 			scope:             db.KeyScopeBIP0084,
 			expectedAddrType:  db.WitnessPubKey,
 			providePrivateKey: true,
 		},
 		{
-			name:              "P2TR watch-only",
+			name:              "P2TR without private key",
 			addr:              p2trAddr,
 			scope:             db.KeyScopeBIP0086,
 			expectedAddrType:  db.TaprootPubKey,
 			providePrivateKey: false,
 		},
 		{
-			name:              "P2TR spendable",
+			name:              "P2TR with private key",
 			addr:              p2trAddr,
 			scope:             db.KeyScopeBIP0086,
 			expectedAddrType:  db.TaprootPubKey,
@@ -241,7 +241,6 @@ func TestNewImportedAddress(t *testing.T) {
 			require.NotNil(t, info.PubKey)
 			require.NotNil(t, info.ScriptPubKey)
 			require.Equal(t, tc.expectedAddrType, info.AddrType)
-			require.Equal(t, !tc.providePrivateKey, info.IsWatchOnly)
 
 			// Verify account imported_key_count incremented.
 			account, err := store.GetAccount(
@@ -300,16 +299,14 @@ func TestNewImportedAddressWithEncryptedScript(t *testing.T) {
 		addressType      db.AddressType
 		encryptedScript  []byte
 		hasPrivateKey    bool
-		hasScript        bool
 		expectedAddrType db.AddressType
 	}{
 		{
-			name:             "P2SH with EncryptedScript only (watch-only)",
+			name:             "P2SH with EncryptedScript only",
 			scope:            db.KeyScopeBIP0044,
 			addressType:      db.ScriptHash,
 			encryptedScript:  redeemScript,
 			hasPrivateKey:    false,
-			hasScript:        true,
 			expectedAddrType: db.ScriptHash,
 		},
 		{
@@ -319,16 +316,14 @@ func TestNewImportedAddressWithEncryptedScript(t *testing.T) {
 			addressType:      db.ScriptHash,
 			encryptedScript:  redeemScript,
 			hasPrivateKey:    true,
-			hasScript:        true,
 			expectedAddrType: db.ScriptHash,
 		},
 		{
-			name:             "P2WSH with EncryptedScript only (watch-only)",
+			name:             "P2WSH with EncryptedScript only",
 			scope:            db.KeyScopeBIP0049Plus,
 			addressType:      db.WitnessScript,
 			encryptedScript:  witnessScript,
 			hasPrivateKey:    false,
-			hasScript:        true,
 			expectedAddrType: db.WitnessScript,
 		},
 		{
@@ -338,7 +333,6 @@ func TestNewImportedAddressWithEncryptedScript(t *testing.T) {
 			addressType:      db.WitnessScript,
 			encryptedScript:  witnessScript,
 			hasPrivateKey:    true,
-			hasScript:        true,
 			expectedAddrType: db.WitnessScript,
 		},
 	}
@@ -383,25 +377,272 @@ func TestNewImportedAddressWithEncryptedScript(t *testing.T) {
 					AddressID: uint32(addressID),
 				},
 			)
+			require.NoError(t, err)
 			require.Equal(t, tc.encryptedScript, secret.EncryptedScript)
 
 			if tc.hasPrivateKey {
-				require.NoError(t, err)
 				require.Equal(
 					t, params.EncryptedPrivateKey, secret.EncryptedPrivKey,
 				)
-
-				return
+			} else {
+				require.Empty(t, secret.EncryptedPrivKey)
 			}
+		})
+	}
+}
 
-			if tc.hasScript {
+// TestNewImportedAddressNormalizesEmptyPrivateKey verifies that empty private
+// key payloads are treated as absent for validation and persisted as NULL.
+func TestNewImportedAddressNormalizesEmptyPrivateKey(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-empty-private-import")
+	CreateImportedAccount(t, store, walletID, db.KeyScopeBIP0044, "imported")
+
+	params := db.NewImportedAddressParams{
+		WalletID:            walletID,
+		Scope:               db.KeyScopeBIP0044,
+		AddressType:         db.ScriptHash,
+		PubKey:              RandomBytes(33),
+		ScriptPubKey:        RandomBytes(32),
+		EncryptedPrivateKey: []byte{},
+		EncryptedScript:     RandomBytes(48),
+	}
+
+	info, err := store.NewImportedAddress(t.Context(), params)
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	require.True(t, info.IsWatchOnly)
+
+	secret, err := store.GetAddressSecret(
+		t.Context(), db.GetAddressSecretQuery{
+			WalletID:  walletID,
+			AddressID: info.ID,
+		},
+	)
+	require.NoError(t, err)
+	require.Nil(t, secret.EncryptedPrivKey)
+	require.Equal(t, params.EncryptedScript, secret.EncryptedScript)
+}
+
+// TestWatchOnlyHierarchyAddressRules is the canonical wallet-to-account-to-
+// address watch-only matrix for derived and imported addresses.
+func TestWatchOnlyHierarchyAddressRules(t *testing.T) {
+	t.Parallel()
+
+	type watchOnlyAddressStore interface {
+		db.AddressStore
+		db.AccountStore
+	}
+
+	tests := []struct {
+		name            string
+		walletParams    func(string) db.CreateWalletParams
+		wantWatchOnly   bool
+		wantErr         error
+		createAddressFn func(*testing.T, watchOnlyAddressStore, uint32) (bool,
+			error)
+	}{
+		{
+			name: "standard wallet derived address is " +
+				"spendable",
+			walletParams:  CreateWalletParamsFixture,
+			wantWatchOnly: false,
+			createAddressFn: func(t *testing.T, store watchOnlyAddressStore,
+				walletID uint32) (bool, error) {
+
+				t.Helper()
+				createDerivedAccount(
+					t, store, walletID, db.KeyScopeBIP0084, "derived",
+				)
+
+				info := newDerivedAddress(
+					t, store, walletID, db.KeyScopeBIP0084, "derived", false,
+				)
+
+				return info.IsWatchOnly, nil
+			},
+		},
+		{
+			name: "watch-only wallet derived address is " +
+				"watch-only",
+			walletParams:  CreateWatchOnlyWalletParams,
+			wantWatchOnly: true,
+			createAddressFn: func(t *testing.T, store watchOnlyAddressStore,
+				walletID uint32) (bool, error) {
+
+				t.Helper()
+				createDerivedAccount(
+					t, store, walletID, db.KeyScopeBIP0084, "derived",
+				)
+
+				info := newDerivedAddress(
+					t, store, walletID, db.KeyScopeBIP0084, "derived", false,
+				)
+
+				return info.IsWatchOnly, nil
+			},
+		},
+		{
+			name: "standard wallet imported address with " +
+				"private key is spendable",
+			walletParams:  CreateWalletParamsFixture,
+			wantWatchOnly: false,
+			createAddressFn: func(t *testing.T, store watchOnlyAddressStore,
+				walletID uint32) (bool, error) {
+
+				t.Helper()
+				CreateImportedAccount(
+					t, store, walletID, db.KeyScopeBIP0084,
+					db.DefaultImportedAccountName,
+				)
+
+				info, err := store.NewImportedAddress(
+					t.Context(), db.NewImportedAddressParams{
+						WalletID:            walletID,
+						Scope:               db.KeyScopeBIP0084,
+						AddressType:         db.WitnessPubKey,
+						PubKey:              RandomBytes(33),
+						ScriptPubKey:        RandomBytes(32),
+						EncryptedPrivateKey: RandomBytes(32),
+					},
+				)
+				if err != nil {
+					return false, err
+				}
+
+				return info.IsWatchOnly, nil
+			},
+		},
+		{
+			name: "standard wallet imported address without " +
+				"private key is watch-only",
+			walletParams:  CreateWalletParamsFixture,
+			wantWatchOnly: true,
+			createAddressFn: func(t *testing.T, store watchOnlyAddressStore,
+				walletID uint32) (bool, error) {
+
+				t.Helper()
+				_, err := store.CreateImportedAccount(
+					t.Context(), db.CreateImportedAccountParams{
+						WalletID:            walletID,
+						Name:                db.DefaultImportedAccountName,
+						Scope:               db.KeyScopeBIP0084,
+						EncryptedPublicKey:  RandomBytes(32),
+						EncryptedPrivateKey: RandomBytes(32),
+					},
+				)
 				require.NoError(t, err)
-				require.Equal(t, params.EncryptedScript, secret.EncryptedScript)
 
+				info, err := store.NewImportedAddress(
+					t.Context(), db.NewImportedAddressParams{
+						WalletID:     walletID,
+						Scope:        db.KeyScopeBIP0084,
+						AddressType:  db.WitnessPubKey,
+						PubKey:       RandomBytes(33),
+						ScriptPubKey: RandomBytes(32),
+					},
+				)
+				if err != nil {
+					return false, err
+				}
+
+				return info.IsWatchOnly, nil
+			},
+		},
+		{
+			name: "watch-only wallet script-only imported " +
+				"address is watch-only",
+			walletParams:  CreateWatchOnlyWalletParams,
+			wantWatchOnly: true,
+			createAddressFn: func(t *testing.T, store watchOnlyAddressStore,
+				walletID uint32) (bool, error) {
+
+				t.Helper()
+				_, err := store.CreateImportedAccount(
+					t.Context(), db.CreateImportedAccountParams{
+						WalletID:           walletID,
+						Name:               db.DefaultImportedAccountName,
+						Scope:              db.KeyScopeBIP0084,
+						EncryptedPublicKey: RandomBytes(32),
+					},
+				)
+				require.NoError(t, err)
+
+				info, err := store.NewImportedAddress(
+					t.Context(), db.NewImportedAddressParams{
+						WalletID:        walletID,
+						Scope:           db.KeyScopeBIP0084,
+						AddressType:     db.WitnessScript,
+						PubKey:          RandomBytes(33),
+						ScriptPubKey:    RandomBytes(32),
+						EncryptedScript: RandomBytes(48),
+					},
+				)
+				if err != nil {
+					return false, err
+				}
+
+				return info.IsWatchOnly, nil
+			},
+		},
+		{
+			name: "watch-only wallet imported address with " +
+				"private key is rejected",
+			walletParams: CreateWatchOnlyWalletParams,
+			wantErr:      db.ErrWatchOnlyViolation,
+			createAddressFn: func(t *testing.T, store watchOnlyAddressStore,
+				walletID uint32) (bool, error) {
+
+				t.Helper()
+				_, err := store.CreateImportedAccount(
+					t.Context(), db.CreateImportedAccountParams{
+						WalletID:           walletID,
+						Name:               db.DefaultImportedAccountName,
+						Scope:              db.KeyScopeBIP0084,
+						EncryptedPublicKey: RandomBytes(32),
+					},
+				)
+				require.NoError(t, err)
+
+				info, err := store.NewImportedAddress(
+					t.Context(), db.NewImportedAddressParams{
+						WalletID:            walletID,
+						Scope:               db.KeyScopeBIP0084,
+						AddressType:         db.WitnessScript,
+						PubKey:              RandomBytes(33),
+						ScriptPubKey:        RandomBytes(32),
+						EncryptedPrivateKey: RandomBytes(32),
+						EncryptedScript:     RandomBytes(48),
+					},
+				)
+				if err != nil {
+					return false, err
+				}
+
+				return info.IsWatchOnly, nil
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := NewTestStore(t)
+
+			walletInfo, err := store.CreateWallet(
+				t.Context(), tc.walletParams("watch-only-address-matrix"),
+			)
+			require.NoError(t, err)
+
+			isWatchOnly, err := tc.createAddressFn(t, store, walletInfo.ID)
+			require.ErrorIs(t, err, tc.wantErr)
+
+			if tc.wantErr != nil {
 				return
 			}
 
-			require.ErrorIs(t, err, db.ErrSecretNotFound)
+			require.Equal(t, tc.wantWatchOnly, isWatchOnly)
 		})
 	}
 }
@@ -869,6 +1110,42 @@ func TestGetAddress(t *testing.T) {
 
 				require.NotNil(t, addr.ScriptPubKey)
 				require.Equal(t, db.ImportedAccount, addr.Origin)
+				require.True(t, addr.IsWatchOnly)
+			},
+		},
+		{
+			name: "get imported address with private key",
+			setupFunc: func(t *testing.T, addrStore db.AddressStore,
+				accountStore db.AccountStore,
+				walletID uint32) db.GetAddressQuery {
+
+				t.Helper()
+				CreateImportedAccount(
+					t, accountStore, walletID, db.KeyScopeBIP0084, "imported",
+				)
+
+				script := RandomBytes(32)
+				params := db.NewImportedAddressParams{
+					WalletID:            walletID,
+					Scope:               db.KeyScopeBIP0084,
+					AddressType:         db.WitnessPubKey,
+					PubKey:              RandomBytes(33),
+					ScriptPubKey:        script,
+					EncryptedPrivateKey: RandomBytes(32),
+				}
+				_, err := addrStore.NewImportedAddress(t.Context(), params)
+				require.NoError(t, err)
+
+				return db.GetAddressQuery{
+					WalletID:     walletID,
+					ScriptPubKey: script,
+				}
+			},
+			validate: func(t *testing.T, addr *db.AddressInfo) {
+				t.Helper()
+				require.NotNil(t, addr.ScriptPubKey)
+				require.Equal(t, db.ImportedAccount, addr.Origin)
+				require.False(t, addr.IsWatchOnly)
 			},
 		},
 		{
@@ -974,8 +1251,11 @@ func TestListAddresses(t *testing.T) {
 					require.Equal(t, uint32(0), addr.Branch)
 					require.Equal(t, db.DerivedAccount, addr.Origin)
 				}
+
+				require.False(t, addrs[0].IsWatchOnly)
 			},
 		},
+
 		{
 			name: "list addresses - empty result",
 			setupFunc: func(t *testing.T, _ db.AddressStore,
@@ -1090,6 +1370,52 @@ func TestListAddressesZeroLimit(t *testing.T) {
 	require.ErrorIs(t, err, db.ErrInvalidPageLimit)
 }
 
+// TestListAddressesWatchOnlyWallet verifies that ListAddresses preserves the
+// watch-only flag for derived addresses from a watch-only wallet.
+func TestListAddressesWatchOnlyWallet(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+
+	walletInfo, err := store.CreateWallet(
+		t.Context(), CreateWatchOnlyWalletParams("watch-only-list-wallet"),
+	)
+	require.NoError(t, err)
+
+	_, err = store.CreateDerivedAccount(
+		t.Context(), db.CreateDerivedAccountParams{
+			WalletID: walletInfo.ID,
+			Scope:    db.KeyScopeBIP0084,
+			Name:     "watch-only-account",
+		},
+	)
+	require.NoError(t, err)
+
+	createDerivedAddresses(
+		t, store, walletInfo.ID, db.KeyScopeBIP0084, "watch-only-account",
+		false, 3,
+	)
+
+	pageResult, err := store.ListAddresses(
+		t.Context(), db.ListAddressesQuery{
+			WalletID:    walletInfo.ID,
+			Scope:       db.KeyScopeBIP0084,
+			AccountName: "watch-only-account",
+			Page:        newTestReq[uint32](t, 10),
+		},
+	)
+	require.NoError(t, err)
+
+	addrs := pageResult.Items
+	require.Len(t, addrs, 3)
+
+	for _, addr := range addrs {
+		require.Equal(t, db.DerivedAccount, addr.Origin)
+	}
+
+	require.True(t, addrs[0].IsWatchOnly)
+}
+
 // TestNewDerivedAddress verifies that NewDerivedAddress correctly creates
 // derived addresses with proper AddressInfo fields for both external and
 // change addresses.
@@ -1134,7 +1460,6 @@ func TestNewDerivedAddress(t *testing.T) {
 			require.Equal(t, tc.expectedBranch, info.Branch)
 			require.NotNil(t, info.ScriptPubKey)
 			require.Nil(t, info.PubKey)
-			require.False(t, info.IsWatchOnly)
 		})
 	}
 }

--- a/wallet/internal/db/itest/fixtures_common_test.go
+++ b/wallet/internal/db/itest/fixtures_common_test.go
@@ -100,8 +100,8 @@ type AccountTestCase struct {
 	// Origin indicates whether the account is derived or imported.
 	Origin db.AccountOrigin
 
-	// IsWatchOnly indicates whether the account has no private key.
-	// Only relevant for imported accounts.
+	// IsWatchOnly indicates whether the account is watch-only (has no private
+	// key material).
 	IsWatchOnly bool
 }
 
@@ -180,45 +180,47 @@ var ImportedAccountCases = []AccountTestCase{
 	},
 }
 
-// WatchOnlyAccountCases contains watch-only imported account fixtures (no
-// private keys) across multiple key scopes.
-var WatchOnlyAccountCases = []AccountTestCase{
+// PublicOnlyImportedAccountCases contains imported account fixtures without
+// private keys across multiple key scopes. These fixtures exercise public-only
+// (xpub) account creation without accidentally generating private key material.
+var PublicOnlyImportedAccountCases = []AccountTestCase{
 	{
-		Name:        "watchonly-bip84-cold",
+		Name:        "xpub-bip84-cold",
 		Scope:       db.KeyScopeBIP0084,
 		Origin:      db.ImportedAccount,
 		IsWatchOnly: true,
 	},
 	{
-		Name:        "watchonly-bip84-monitor",
+		Name:        "xpub-bip84-monitor",
 		Scope:       db.KeyScopeBIP0084,
 		Origin:      db.ImportedAccount,
 		IsWatchOnly: true,
 	},
 	{
-		Name:        "watchonly-bip86-cold",
+		Name:        "xpub-bip86-cold",
 		Scope:       db.KeyScopeBIP0086,
 		Origin:      db.ImportedAccount,
 		IsWatchOnly: true,
 	},
 	{
-		Name:        "watchonly-bip86-monitor",
+		Name:        "xpub-bip86-monitor",
 		Scope:       db.KeyScopeBIP0086,
 		Origin:      db.ImportedAccount,
 		IsWatchOnly: true,
 	},
 }
 
-// AllAccountCases combines all account test cases (derived, imported, and
-// watch-only) into a single slice.
+// AllAccountCases combines all account test cases (derived, imported with
+// private keys, and public-only imported) into a single slice.
 var AllAccountCases = append(
 	append(DerivedAccountCases, ImportedAccountCases...),
-	WatchOnlyAccountCases...,
+	PublicOnlyImportedAccountCases...,
 )
 
-// AllImportedAccountCases combines imported and watch-only account cases.
+// AllImportedAccountCases combines imported account cases (with and without
+// private keys).
 var AllImportedAccountCases = append(
-	ImportedAccountCases, WatchOnlyAccountCases...,
+	ImportedAccountCases, PublicOnlyImportedAccountCases...,
 )
 
 // DerivedParams converts the test case to CreateDerivedAccountParams.
@@ -232,8 +234,8 @@ func (tc AccountTestCase) DerivedParams(
 	}
 }
 
-// ImportedParams converts the test case to CreateImportedAccountParams. If
-// IsWatchOnly is true, EncryptedPrivateKey will be nil.
+// ImportedParams converts the test case to CreateImportedAccountParams.
+// IsWatchOnly controls whether EncryptedPrivateKey is populated.
 func (tc AccountTestCase) ImportedParams(
 	walletID uint32) db.CreateImportedAccountParams {
 

--- a/wallet/internal/db/itest/fixtures_pg_test.go
+++ b/wallet/internal/db/itest/fixtures_pg_test.go
@@ -72,7 +72,6 @@ func CreateAccountWithNumber(t *testing.T, queries *sqlc.Queries,
 			},
 			AccountName: name,
 			OriginID:    int16(db.DerivedAccount),
-			IsWatchOnly: false,
 		},
 	)
 	require.NoError(t, err)
@@ -91,13 +90,12 @@ func createDerivedAccountRaw(t *testing.T, dbConn *sql.DB, walletID uint32,
 			scope_id,
 			account_number,
 			account_name,
-			origin_id,
-			is_watch_only
-		) VALUES ($1, $2, $3, $4, $5, $6)`
+			origin_id
+		) VALUES ($1, $2, $3, $4, $5)`
 
 	_, err := dbConn.ExecContext(
 		t.Context(), stmt, int64(walletID), scopeID, int64(accountNumber),
-		name, int16(db.DerivedAccount), false,
+		name, int16(db.DerivedAccount),
 	)
 
 	return err
@@ -117,13 +115,12 @@ func createImportedAccountRaw(t *testing.T, dbConn *sql.DB, walletID uint32,
 			account_number,
 			account_name,
 			origin_id,
-			encrypted_public_key,
-			is_watch_only
-		) VALUES ($1, $2, NULL, $3, $4, $5, $6)`
+			encrypted_public_key
+		) VALUES ($1, $2, NULL, $3, $4, $5)`
 
 	_, err := dbConn.ExecContext(
 		t.Context(), stmt, int64(walletID), scopeID, name,
-		int16(db.ImportedAccount), RandomBytes(32), true,
+		int16(db.ImportedAccount), RandomBytes(32),
 	)
 
 	return err

--- a/wallet/internal/db/itest/fixtures_sqlite_test.go
+++ b/wallet/internal/db/itest/fixtures_sqlite_test.go
@@ -72,7 +72,6 @@ func CreateAccountWithNumber(t *testing.T, queries *sqlc.Queries,
 			},
 			AccountName: name,
 			OriginID:    int64(db.DerivedAccount),
-			IsWatchOnly: false,
 		},
 	)
 	require.NoError(t, err)
@@ -91,13 +90,12 @@ func createDerivedAccountRaw(t *testing.T, dbConn *sql.DB, walletID uint32,
 			scope_id,
 			account_number,
 			account_name,
-			origin_id,
-			is_watch_only
-		) VALUES (?, ?, ?, ?, ?, ?)`
+			origin_id
+		) VALUES (?, ?, ?, ?, ?)`
 
 	_, err := dbConn.ExecContext(
 		t.Context(), stmt, int64(walletID), scopeID, int64(accountNumber),
-		name, int64(db.DerivedAccount), false,
+		name, int64(db.DerivedAccount),
 	)
 
 	return err
@@ -117,13 +115,12 @@ func createImportedAccountRaw(t *testing.T, dbConn *sql.DB, walletID uint32,
 			account_number,
 			account_name,
 			origin_id,
-			encrypted_public_key,
-			is_watch_only
-		) VALUES (?, ?, NULL, ?, ?, ?, ?)`
+			encrypted_public_key
+		) VALUES (?, ?, NULL, ?, ?, ?)`
 
 	_, err := dbConn.ExecContext(
 		t.Context(), stmt, int64(walletID), scopeID, name,
-		int64(db.ImportedAccount), RandomBytes(32), true,
+		int64(db.ImportedAccount), RandomBytes(32),
 	)
 
 	return err

--- a/wallet/internal/db/itest/pg_sanitize_test.go
+++ b/wallet/internal/db/itest/pg_sanitize_test.go
@@ -1,0 +1,90 @@
+//go:build itest && test_db_postgres
+
+package itest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSanitizedPgDBNameShort verifies that short names remain unchanged.
+func TestSanitizedPgDBNameShort(t *testing.T) {
+	t.Parallel()
+
+	shortName := "TestShort"
+	expected := "testshort"
+
+	result := sanitizePgDBNameString(shortName)
+	require.Equal(t, expected, result)
+}
+
+// TestSanitizedPgDBNameSanitization verifies special characters are replaced.
+func TestSanitizedPgDBNameSanitization(t *testing.T) {
+	t.Parallel()
+
+	nameWithSpecial := "Test/With-Special.Chars"
+	expected := "test_with_special_chars"
+
+	result := sanitizePgDBNameString(nameWithSpecial)
+	require.Equal(t, expected, result)
+}
+
+// TestSanitizedPgDBNameMaxLength verifies names at the limit are unchanged.
+func TestSanitizedPgDBNameMaxLength(t *testing.T) {
+	t.Parallel()
+
+	nameAtLimit := "abcdefghijklmnopqrstuvwxyz0123456789" +
+		"abcdefghijklmnopqrstuvwxyz0"
+	require.Len(t, nameAtLimit, 63)
+
+	result := sanitizePgDBNameString(nameAtLimit)
+	require.Equal(t, nameAtLimit, result)
+	require.Len(t, result, 63)
+}
+
+// TestSanitizedPgDBNameTruncationWithHash verifies truncation adds hash
+// suffix.
+func TestSanitizedPgDBNameTruncationWithHash(t *testing.T) {
+	t.Parallel()
+
+	longName := "TestVeryLongNameThatExceedsPostgreSQL" +
+		"IdentifierLimitOfSixtyThreeBytes"
+	require.Greater(t, len(longName), 63)
+
+	result := sanitizePgDBNameString(longName)
+
+	require.Len(t, result, 63)
+	require.Contains(t, result, "_")
+
+	suffix := result[len(result)-9:]
+	require.Len(t, suffix, 9)
+	require.Equal(t, byte('_'), suffix[0])
+
+	for _, ch := range suffix[1:] {
+		require.True(
+			t, (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f'),
+			"suffix contains non-hex character: %q", string(ch),
+		)
+	}
+}
+
+// TestSanitizedPgDBNameCollisionAvoidance verifies different long names
+// with identical prefixes produce different database names.
+func TestSanitizedPgDBNameCollisionAvoidance(t *testing.T) {
+	t.Parallel()
+
+	prefix := "testverylongnamethatsharesfirstfiftyfourcharacterswithother"
+	name1 := prefix + "suffix1"
+	name2 := prefix + "suffix2"
+
+	require.Greater(t, len(name1), 63)
+	require.Greater(t, len(name2), 63)
+
+	result1 := sanitizePgDBNameString(name1)
+	result2 := sanitizePgDBNameString(name2)
+
+	require.NotEqual(t, result1, result2)
+	require.Len(t, result1, 63)
+	require.Len(t, result2, 63)
+}

--- a/wallet/internal/db/itest/pg_test.go
+++ b/wallet/internal/db/itest/pg_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"hash/crc32"
 	"net"
 	"os"
 	"regexp"
@@ -28,6 +29,20 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const (
+	// pgMaxIdentifierLen is the PostgreSQL maximum identifier length
+	// (NAMEDATALEN - 1).
+	pgMaxIdentifierLen = 63
+
+	// pgHashSuffixLen is the length of the deterministic hash suffix
+	// appended to truncated database names (8 hex chars from CRC32).
+	pgHashSuffixLen = 8
+
+	// pgHashSeparator is the separator between the truncated prefix and
+	// the hash suffix.
+	pgHashSeparator = "_"
 )
 
 var (
@@ -171,22 +186,51 @@ func GetPostgresContainer(ctx context.Context) (*postgres.PostgresContainer,
 	return pgContainer, errPGContainer
 }
 
-// sanitizedPgDBName converts a test name to a valid PostgreSQL database name.
-// It converts to lowercase and replaces special characters with underscores.
-func sanitizedPgDBName(t *testing.T) string {
-	t.Helper()
-
+// sanitizePgDBNameString converts a database name string to a valid PostgreSQL
+// database name. It converts to lowercase and replaces special characters with
+// underscores. If the resulting name exceeds PostgreSQL's 63-byte identifier
+// limit, it is truncated with a deterministic CRC32 hash suffix to prevent
+// collisions from long subtest names that share the same prefix.
+func sanitizePgDBNameString(dbName string) string {
 	// Convert to lowercase.
-	dbName := strings.ToLower(t.Name())
+	dbName = strings.ToLower(dbName)
 
 	// Replace slashes and other special chars with underscores.
 	reg := regexp.MustCompile(`[^a-z0-9_]`)
 	dbName = reg.ReplaceAllString(dbName, "_")
 
 	// PostgreSQL database names are limited to 63 characters.
-	if len(dbName) > 63 {
-		dbName = dbName[:63]
-		t.Logf("database name truncated to %d characters: %s", 63, dbName)
+	// If truncation is needed, append a deterministic hash suffix to prevent
+	// collisions from long subtest names with identical prefixes.
+	if len(dbName) > pgMaxIdentifierLen {
+		// Reserve space for separator and hash suffix.
+		suffixLen := len(pgHashSeparator) + pgHashSuffixLen
+		prefixLen := pgMaxIdentifierLen - suffixLen
+
+		// Compute deterministic CRC32 hash of the full sanitized name.
+		checksum := crc32.ChecksumIEEE([]byte(dbName))
+		hashSuffix := fmt.Sprintf("%08x", checksum)
+
+		// Truncate prefix and append hash suffix.
+		dbName = dbName[:prefixLen] + pgHashSeparator + hashSuffix
+	}
+
+	return dbName
+}
+
+// sanitizedPgDBName converts a test name to a valid PostgreSQL database name.
+// It converts to lowercase and replaces special characters with underscores.
+// If the resulting name exceeds PostgreSQL's 63-byte identifier limit, it is
+// truncated with a deterministic CRC32 hash suffix to prevent collisions from
+// long subtest names that share the same prefix.
+func sanitizedPgDBName(t *testing.T) string {
+	t.Helper()
+
+	dbName := sanitizePgDBNameString(t.Name())
+
+	if len(t.Name()) > pgMaxIdentifierLen {
+		t.Logf("database name truncated to %d characters with hash suffix: %s",
+			pgMaxIdentifierLen, dbName)
 	}
 
 	return dbName

--- a/wallet/internal/db/itest/wallet_store_test.go
+++ b/wallet/internal/db/itest/wallet_store_test.go
@@ -842,6 +842,155 @@ func TestGetEncryptedHDSeed_WatchOnly(t *testing.T) {
 	require.ErrorIs(t, err, db.ErrSecretNotFound)
 }
 
+// TestWatchOnlyWalletRejectsWalletSecrets verifies that watch-only
+// wallets allow script-encryption material while still rejecting
+// private wallet secrets.
+func TestWatchOnlyWalletRejectsWalletSecrets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("create with no private secrets succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		store := NewTestStore(t)
+
+		params := CreateWatchOnlyWalletParams("watch-only-create-ok")
+		info, err := store.CreateWallet(t.Context(), params)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		require.True(t, info.IsWatchOnly)
+	})
+
+	t.Run(
+		"create with empty-but-non-nil private secrets succeeds",
+		func(t *testing.T) {
+			t.Parallel()
+
+			store := NewTestStore(t)
+
+			params := CreateWatchOnlyWalletParams("watch-only-create-empty")
+			params.MasterKeyPrivParams = []byte{}
+			params.EncryptedCryptoPrivKey = []byte{}
+			params.EncryptedMasterPrivKey = []byte{}
+
+			info, err := store.CreateWallet(t.Context(), params)
+			require.NoError(t, err)
+			require.NotNil(t, info)
+			require.True(t, info.IsWatchOnly)
+
+			seed, err := store.GetEncryptedHDSeed(t.Context(), info.ID)
+			require.Nil(t, seed)
+			require.ErrorIs(t, err, db.ErrSecretNotFound)
+		},
+	)
+
+	t.Run("create with script key only succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		store := NewTestStore(t)
+
+		params := CreateWatchOnlyWalletParams("watch-only-create-script")
+		params.EncryptedCryptoScriptKey = RandomBytes(32)
+
+		info, err := store.CreateWallet(t.Context(), params)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		require.True(t, info.IsWatchOnly)
+
+		seed, err := store.GetEncryptedHDSeed(t.Context(), info.ID)
+		require.Nil(t, seed)
+		require.ErrorIs(t, err, db.ErrSecretNotFound)
+	})
+
+	t.Run("create with private secrets is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		store := NewTestStore(t)
+
+		params := CreateWatchOnlyWalletParams("watch-only-create-reject")
+		params.MasterKeyPrivParams = RandomBytes(16)
+
+		_, err := store.CreateWallet(t.Context(), params)
+		require.Error(t, err)
+		require.ErrorIs(t, err, db.ErrWatchOnlyViolation)
+	})
+
+	t.Run("update with script key only succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		store := NewTestStore(t)
+
+		created, err := store.CreateWallet(
+			t.Context(),
+			CreateWatchOnlyWalletParams("watch-only-update-script"),
+		)
+		require.NoError(t, err)
+
+		err = store.UpdateWalletSecrets(
+			t.Context(), db.UpdateWalletSecretsParams{
+				WalletID:                 created.ID,
+				EncryptedCryptoScriptKey: RandomBytes(32),
+			},
+		)
+		require.NoError(t, err)
+
+		seed, err := store.GetEncryptedHDSeed(t.Context(), created.ID)
+		require.Nil(t, seed)
+		require.ErrorIs(t, err, db.ErrSecretNotFound)
+	})
+
+	t.Run(
+		"update with empty-but-non-nil private secrets succeeds",
+		func(t *testing.T) {
+			t.Parallel()
+
+			store := NewTestStore(t)
+
+			created, err := store.CreateWallet(
+				t.Context(),
+				CreateWatchOnlyWalletParams("watch-only-update-empty"),
+			)
+			require.NoError(t, err)
+
+			err = store.UpdateWalletSecrets(
+				t.Context(), db.UpdateWalletSecretsParams{
+					WalletID:                 created.ID,
+					MasterPrivParams:         []byte{},
+					EncryptedCryptoPrivKey:   []byte{},
+					EncryptedMasterHdPrivKey: []byte{},
+				},
+			)
+			require.NoError(t, err)
+
+			seed, err := store.GetEncryptedHDSeed(t.Context(), created.ID)
+			require.Nil(t, seed)
+			require.ErrorIs(t, err, db.ErrSecretNotFound)
+		},
+	)
+
+	t.Run("update with private secrets is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		store := NewTestStore(t)
+
+		created, err := store.CreateWallet(
+			t.Context(),
+			CreateWatchOnlyWalletParams("watch-only-update-reject"),
+		)
+		require.NoError(t, err)
+
+		err = store.UpdateWalletSecrets(
+			t.Context(), db.UpdateWalletSecretsParams{
+				WalletID:                 created.ID,
+				MasterPrivParams:         RandomBytes(16),
+				EncryptedCryptoPrivKey:   RandomBytes(32),
+				EncryptedMasterHdPrivKey: RandomBytes(32),
+			},
+		)
+		require.Error(t, err)
+		require.ErrorIs(t, err, db.ErrWatchOnlyViolation)
+	})
+}
+
 // TestUpdateWalletSecrets checks that updating the wallet secrets works
 // correctly.
 func TestUpdateWalletSecrets(t *testing.T) {

--- a/wallet/internal/db/pg/accounts.go
+++ b/wallet/internal/db/pg/accounts.go
@@ -92,6 +92,13 @@ func (s *Store) CreateDerivedAccount(ctx context.Context,
 	var info *db.AccountInfo
 
 	err := s.execWrite(ctx, func(qtx *sqlc.Queries) error {
+		walletIsWatchOnly, err := getWalletWatchOnly(
+			ctx, qtx, params.WalletID,
+		)
+		if err != nil {
+			return err
+		}
+
 		scopeID, err := ensureKeyScope(
 			ctx, qtx, params.WalletID, params.Scope,
 		)
@@ -114,7 +121,6 @@ func (s *Store) CreateDerivedAccount(ctx context.Context,
 				ScopeID:     scopeID,
 				AccountName: params.Name,
 				OriginID:    int16(db.DerivedAccount),
-				IsWatchOnly: false,
 			},
 		)
 		if err != nil {
@@ -135,8 +141,8 @@ func (s *Store) CreateDerivedAccount(ctx context.Context,
 		}
 
 		info = db.BuildAccountInfo(
-			accNumber, params.Name, db.DerivedAccount, 0, 0, 0, false,
-			row.CreatedAt, params.Scope,
+			accNumber, params.Name, db.DerivedAccount, 0, 0, 0,
+			walletIsWatchOnly, row.CreatedAt, params.Scope,
 		)
 
 		return nil
@@ -204,11 +210,9 @@ func getWalletWatchOnly(ctx context.Context, qtx *sqlc.Queries,
 // CreateImportedAccountParams for PostgreSQL.
 func buildCreateImportedAccountArgs(
 	params db.CreateImportedAccountParams,
-) func(int64, bool) sqlc.CreateImportedAccountParams {
+) func(int64) sqlc.CreateImportedAccountParams {
 
-	return func(scopeID int64,
-		isWatchOnly bool) sqlc.CreateImportedAccountParams {
-
+	return func(scopeID int64) sqlc.CreateImportedAccountParams {
 		return sqlc.CreateImportedAccountParams{
 			ScopeID:            scopeID,
 			AccountName:        params.Name,
@@ -218,7 +222,6 @@ func buildCreateImportedAccountArgs(
 				Int64: int64(params.MasterFingerprint),
 				Valid: true,
 			},
-			IsWatchOnly: isWatchOnly,
 		}
 	}
 }
@@ -231,8 +234,10 @@ func buildCreateAccountSecretArgs(
 
 	return func(accountID int64) sqlc.CreateAccountSecretParams {
 		return sqlc.CreateAccountSecretParams{
-			AccountID:           accountID,
-			EncryptedPrivateKey: params.EncryptedPrivateKey,
+			AccountID: accountID,
+			EncryptedPrivateKey: db.NilIfEmptyBytes(
+				params.EncryptedPrivateKey,
+			),
 		}
 	}
 }

--- a/wallet/internal/db/pg/accounts.go
+++ b/wallet/internal/db/pg/accounts.go
@@ -317,6 +317,36 @@ type accountInfoRow interface {
 		sqlc.ListAccountsByWalletAndNameRow
 }
 
+// derivedAddressGetAccountID extracts the account ID from a row.
+func derivedAddressGetAccountID(
+	row sqlc.GetAccountByWalletScopeAndNameRow) int64 {
+
+	return row.ID
+}
+
+// derivedAddressGetWalletWatchOnly extracts the wallet-level watch-only state
+// from a row.
+func derivedAddressGetWalletWatchOnly(
+	row sqlc.GetAccountByWalletScopeAndNameRow) bool {
+
+	return row.WalletIsWatchOnly
+}
+
+// importedAddressGetAccountID extracts the account ID from a row.
+func importedAddressGetAccountID(
+	row sqlc.GetAccountByWalletScopeAndNameRow) int64 {
+
+	return row.ID
+}
+
+// importedAddressGetWalletWatchOnly extracts the wallet-level watch-only state
+// from a row.
+func importedAddressGetWalletWatchOnly(
+	row sqlc.GetAccountByWalletScopeAndNameRow) bool {
+
+	return row.WalletIsWatchOnly
+}
+
 // accountRowToInfo converts a PostgreSQL account row to an AccountInfo
 // struct. It uses type conversion since all accountInfoRow types have
 // identical fields.

--- a/wallet/internal/db/pg/accounts.go
+++ b/wallet/internal/db/pg/accounts.go
@@ -3,6 +3,7 @@ package pg
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
@@ -162,6 +163,8 @@ func (s *Store) CreateImportedAccount(ctx context.Context,
 		props, err = db.CreateImportedAccount(
 			ctx, params, func() (int64, error) {
 				return ensureKeyScope(ctx, qtx, params.WalletID, params.Scope)
+			}, func() (bool, error) {
+				return getWalletWatchOnly(ctx, qtx, params.WalletID)
 			}, qtx.CreateImportedAccount,
 			buildCreateImportedAccountArgs(params),
 			func(row sqlc.CreateImportedAccountRow) int64 { return row.ID },
@@ -178,6 +181,23 @@ func (s *Store) CreateImportedAccount(ctx context.Context,
 	}
 
 	return props, nil
+}
+
+// getWalletWatchOnly returns the current watch-only mode for the wallet.
+func getWalletWatchOnly(ctx context.Context, qtx *sqlc.Queries,
+	walletID uint32) (bool, error) {
+
+	row, err := qtx.GetWalletByID(ctx, int64(walletID))
+	if err == nil {
+		return row.IsWatchOnly, nil
+	}
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, fmt.Errorf("wallet %d: %w", walletID,
+			db.ErrWalletNotFound)
+	}
+
+	return false, fmt.Errorf("get wallet: %w", err)
 }
 
 // buildCreateImportedAccountArgs returns a function that builds the

--- a/wallet/internal/db/pg/addresses.go
+++ b/wallet/internal/db/pg/addresses.go
@@ -131,14 +131,15 @@ func (s *Store) NewDerivedAddress(ctx context.Context,
 		sqlc.GetAccountByWalletScopeAndNameRow,
 		db.AccountLookupKey,
 		sqlc.CreateDerivedAddressRow]{
-		GetAccount:    getAccountFromKey(s.queries),
-		AccountParams: db.AccountKeyFromParams,
-		GetAccountID:  derivedAddressGetAccountID,
-		GetExtIndex:   derivedAddressGetExtIndex,
-		GetIntIndex:   derivedAddressGetIntIndex,
-		CreateAddr:    derivedAddressCreateAddr,
-		RowID:         derivedAddressRowID,
-		RowCreatedAt:  derivedAddressRowCreatedAt,
+		GetAccount:         getAccountFromKey(s.queries),
+		AccountParams:      db.AccountKeyFromParams,
+		GetAccountID:       derivedAddressGetAccountID,
+		GetWalletWatchOnly: derivedAddressGetWalletWatchOnly,
+		GetExtIndex:        derivedAddressGetExtIndex,
+		GetIntIndex:        derivedAddressGetIntIndex,
+		CreateAddr:         derivedAddressCreateAddr,
+		RowID:              derivedAddressRowID,
+		RowCreatedAt:       derivedAddressRowCreatedAt,
 	}
 
 	return db.NewDerivedAddressWithTx(
@@ -157,15 +158,16 @@ func (s *Store) NewImportedAddress(ctx context.Context,
 		sqlc.CreateImportedAddressParams,
 		sqlc.CreateImportedAddressRow,
 		sqlc.InsertAddressSecretParams]{
-		GetAccount:    getAccountFromKey(s.queries),
-		AccountParams: db.AccountKeyFromImportedParams,
-		GetAccountID:  importedAddressGetAccountID,
-		CreateAddr:    createImportedAddress,
-		CreateParams:  createImportedAddressParams,
-		InsertSecret:  insertAddressSecret,
-		SecretParams:  insertAddressSecretParams,
-		RowID:         importedAddressRowID,
-		RowCreatedAt:  importedAddressRowCreatedAt,
+		GetAccount:         getAccountFromKey(s.queries),
+		AccountParams:      db.AccountKeyFromImportedParams,
+		GetAccountID:       importedAddressGetAccountID,
+		GetWalletWatchOnly: importedAddressGetWalletWatchOnly,
+		CreateAddr:         createImportedAddress,
+		CreateParams:       createImportedAddressParams,
+		InsertSecret:       insertAddressSecret,
+		SecretParams:       insertAddressSecretParams,
+		RowID:              importedAddressRowID,
+		RowCreatedAt:       importedAddressRowCreatedAt,
 	}
 
 	return db.NewImportedAddressWithTx(ctx, params, s.execWrite, adapters)
@@ -188,13 +190,6 @@ func getAccountFromKey(qtx *sqlc.Queries) func(context.Context,
 			},
 		)
 	}
-}
-
-// derivedAddressGetAccountID extracts the account ID from a row.
-func derivedAddressGetAccountID(
-	row sqlc.GetAccountByWalletScopeAndNameRow) int64 {
-
-	return row.ID
 }
 
 // derivedAddressGetExtIndex returns the external index query.
@@ -259,13 +254,6 @@ func derivedAddressRowCreatedAt(
 	return row.CreatedAt
 }
 
-// importedAddressGetAccountID extracts the account ID from a row.
-func importedAddressGetAccountID(
-	row sqlc.GetAccountByWalletScopeAndNameRow) int64 {
-
-	return row.ID
-}
-
 // createImportedAddress returns the imported address insert helper.
 func createImportedAddress(qtx *sqlc.Queries) func(context.Context,
 	sqlc.CreateImportedAddressParams) (sqlc.CreateImportedAddressRow,
@@ -299,9 +287,13 @@ func insertAddressSecretParams(addressID int64,
 	params db.NewImportedAddressParams) sqlc.InsertAddressSecretParams {
 
 	return sqlc.InsertAddressSecretParams{
-		AddressID:        addressID,
-		EncryptedPrivKey: params.EncryptedPrivateKey,
-		EncryptedScript:  params.EncryptedScript,
+		AddressID: addressID,
+		EncryptedPrivKey: db.NilIfEmptyBytes(
+			params.EncryptedPrivateKey,
+		),
+		EncryptedScript: db.NilIfEmptyBytes(
+			params.EncryptedScript,
+		),
 	}
 }
 
@@ -345,13 +337,14 @@ func addressRowToInfo[T addressInfoRow](row T) (*db.AddressInfo, error) {
 	base := sqlc.GetAddressByScriptPubKeyRow(row)
 
 	info, err := db.AddressRowToInfo(db.AddressInfoRow[int16, int16]{
-		ID:            base.ID,
-		AccountID:     base.AccountID,
-		TypeID:        base.TypeID,
-		OriginID:      base.OriginID,
-		HasPrivateKey: base.HasPrivateKey,
-		HasScript:     base.HasScript,
-		CreatedAt:     base.CreatedAt,
+		ID:                base.ID,
+		AccountID:         base.AccountID,
+		TypeID:            base.TypeID,
+		OriginID:          base.OriginID,
+		WalletIsWatchOnly: base.WalletIsWatchOnly,
+		HasPrivateKey:     base.HasPrivateKey,
+		HasScript:         base.HasScript,
+		CreatedAt:         base.CreatedAt,
 		AddressBranch: sql.NullInt64{
 			Int64: int64(base.AddressBranch.Int16),
 			Valid: base.AddressBranch.Valid,

--- a/wallet/internal/db/pg/wallet.go
+++ b/wallet/internal/db/pg/wallet.go
@@ -21,9 +21,14 @@ var _ db.WalletStore = (*Store)(nil)
 func (s *Store) CreateWallet(ctx context.Context,
 	params db.CreateWalletParams) (*db.WalletInfo, error) {
 
+	err := params.Validate()
+	if err != nil {
+		return nil, err
+	}
+
 	var info *db.WalletInfo
 
-	err := s.execWrite(ctx, func(qtx *sqlc.Queries) error {
+	err = s.execWrite(ctx, func(qtx *sqlc.Queries) error {
 		walletParams := sqlc.CreateWalletParams{
 			WalletName:              params.Name,
 			IsImported:              params.IsImported,
@@ -40,12 +45,19 @@ func (s *Store) CreateWallet(ctx context.Context,
 		}
 
 		secretsParams := sqlc.InsertWalletSecretsParams{
-			WalletID:               id,
-			MasterPrivParams:       params.MasterKeyPrivParams,
-			EncryptedCryptoPrivKey: params.EncryptedCryptoPrivKey,
-			EncryptedCryptoScriptKey: params.
-				EncryptedCryptoScriptKey,
-			EncryptedMasterHdPrivKey: params.EncryptedMasterPrivKey,
+			WalletID: id,
+			MasterPrivParams: db.NilIfEmptyBytes(
+				params.MasterKeyPrivParams,
+			),
+			EncryptedCryptoPrivKey: db.NilIfEmptyBytes(
+				params.EncryptedCryptoPrivKey,
+			),
+			EncryptedCryptoScriptKey: db.NilIfEmptyBytes(
+				params.EncryptedCryptoScriptKey,
+			),
+			EncryptedMasterHdPrivKey: db.NilIfEmptyBytes(
+				params.EncryptedMasterPrivKey,
+			),
 		}
 
 		err = qtx.InsertWalletSecrets(ctx, secretsParams)
@@ -294,14 +306,37 @@ func (s *Store) UpdateWalletSecrets(ctx context.Context,
 	params db.UpdateWalletSecretsParams) error {
 
 	secretsParams := sqlc.UpdateWalletSecretsParams{
-		MasterPrivParams:         params.MasterPrivParams,
-		EncryptedCryptoPrivKey:   params.EncryptedCryptoPrivKey,
-		EncryptedCryptoScriptKey: params.EncryptedCryptoScriptKey,
-		EncryptedMasterHdPrivKey: params.EncryptedMasterHdPrivKey,
-		WalletID:                 int64(params.WalletID),
+		MasterPrivParams: db.NilIfEmptyBytes(
+			params.MasterPrivParams,
+		),
+		EncryptedCryptoPrivKey: db.NilIfEmptyBytes(
+			params.EncryptedCryptoPrivKey,
+		),
+		EncryptedCryptoScriptKey: db.NilIfEmptyBytes(
+			params.EncryptedCryptoScriptKey,
+		),
+		EncryptedMasterHdPrivKey: db.NilIfEmptyBytes(
+			params.EncryptedMasterHdPrivKey,
+		),
+		WalletID: int64(params.WalletID),
 	}
 
 	return s.execWrite(ctx, func(qtx *sqlc.Queries) error {
+		walletRow, err := qtx.GetWalletByID(ctx, int64(params.WalletID))
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("wallet %d: %w", params.WalletID,
+					db.ErrWalletNotFound)
+			}
+
+			return fmt.Errorf("get wallet: %w", err)
+		}
+
+		err = params.Validate(walletRow.IsWatchOnly)
+		if err != nil {
+			return err
+		}
+
 		rowsAffected, err := qtx.UpdateWalletSecrets(ctx, secretsParams)
 		if err != nil {
 			return fmt.Errorf("update wallet secrets: %w", err)

--- a/wallet/internal/db/sqlite/accounts.go
+++ b/wallet/internal/db/sqlite/accounts.go
@@ -92,6 +92,13 @@ func (s *Store) CreateDerivedAccount(ctx context.Context,
 	var info *db.AccountInfo
 
 	err := s.execWrite(ctx, func(qtx *sqlc.Queries) error {
+		walletIsWatchOnly, err := getWalletWatchOnly(
+			ctx, qtx, params.WalletID,
+		)
+		if err != nil {
+			return err
+		}
+
 		scopeID, err := ensureKeyScope(
 			ctx, qtx, params.WalletID, params.Scope,
 		)
@@ -104,7 +111,6 @@ func (s *Store) CreateDerivedAccount(ctx context.Context,
 				ScopeID:     scopeID,
 				AccountName: params.Name,
 				OriginID:    int64(db.DerivedAccount),
-				IsWatchOnly: false,
 			},
 		)
 		if err != nil {
@@ -125,8 +131,8 @@ func (s *Store) CreateDerivedAccount(ctx context.Context,
 		}
 
 		info = db.BuildAccountInfo(
-			accNumber, params.Name, db.DerivedAccount, 0, 0, 0, false,
-			row.CreatedAt, params.Scope,
+			accNumber, params.Name, db.DerivedAccount, 0, 0, 0,
+			walletIsWatchOnly, row.CreatedAt, params.Scope,
 		)
 
 		return nil
@@ -231,11 +237,9 @@ func getWalletWatchOnly(ctx context.Context, qtx *sqlc.Queries,
 // CreateImportedAccountParams for SQLite.
 func buildCreateImportedAccountArgs(
 	params db.CreateImportedAccountParams,
-) func(int64, bool) sqlc.CreateImportedAccountParams {
+) func(int64) sqlc.CreateImportedAccountParams {
 
-	return func(scopeID int64,
-		isWatchOnly bool) sqlc.CreateImportedAccountParams {
-
+	return func(scopeID int64) sqlc.CreateImportedAccountParams {
 		return sqlc.CreateImportedAccountParams{
 			ScopeID:            scopeID,
 			AccountName:        params.Name,
@@ -245,7 +249,6 @@ func buildCreateImportedAccountArgs(
 				Int64: int64(params.MasterFingerprint),
 				Valid: true,
 			},
-			IsWatchOnly: isWatchOnly,
 		}
 	}
 }
@@ -258,8 +261,10 @@ func buildCreateAccountSecretArgs(
 
 	return func(accountID int64) sqlc.CreateAccountSecretParams {
 		return sqlc.CreateAccountSecretParams{
-			AccountID:           accountID,
-			EncryptedPrivateKey: params.EncryptedPrivateKey,
+			AccountID: accountID,
+			EncryptedPrivateKey: db.NilIfEmptyBytes(
+				params.EncryptedPrivateKey,
+			),
 		}
 	}
 }

--- a/wallet/internal/db/sqlite/accounts.go
+++ b/wallet/internal/db/sqlite/accounts.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
@@ -186,6 +187,9 @@ func (s *Store) CreateImportedAccount(ctx context.Context,
 					ctx, qtx, params.WalletID, params.Scope,
 				)
 			},
+			func() (bool, error) {
+				return getWalletWatchOnly(ctx, qtx, params.WalletID)
+			},
 			qtx.CreateImportedAccount,
 			buildCreateImportedAccountArgs(params),
 			func(row sqlc.CreateImportedAccountRow) int64 {
@@ -204,6 +208,23 @@ func (s *Store) CreateImportedAccount(ctx context.Context,
 	}
 
 	return props, nil
+}
+
+// getWalletWatchOnly returns the current watch-only mode for the wallet.
+func getWalletWatchOnly(ctx context.Context, qtx *sqlc.Queries,
+	walletID uint32) (bool, error) {
+
+	row, err := qtx.GetWalletByID(ctx, int64(walletID))
+	if err == nil {
+		return row.IsWatchOnly, nil
+	}
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, fmt.Errorf("wallet %d: %w", walletID,
+			db.ErrWalletNotFound)
+	}
+
+	return false, fmt.Errorf("get wallet: %w", err)
 }
 
 // buildCreateImportedAccountArgs returns a function that builds the

--- a/wallet/internal/db/sqlite/accounts.go
+++ b/wallet/internal/db/sqlite/accounts.go
@@ -312,6 +312,36 @@ type accountInfoRow interface {
 		sqlc.ListAccountsByWalletAndNameRow
 }
 
+// derivedAddressGetAccountID extracts the account ID from a row.
+func derivedAddressGetAccountID(
+	row sqlc.GetAccountByWalletScopeAndNameRow) int64 {
+
+	return row.ID
+}
+
+// derivedAddressGetWalletWatchOnly extracts the wallet-level watch-only state
+// from a row.
+func derivedAddressGetWalletWatchOnly(
+	row sqlc.GetAccountByWalletScopeAndNameRow) bool {
+
+	return row.WalletIsWatchOnly
+}
+
+// importedAddressGetAccountID extracts the account ID from a row.
+func importedAddressGetAccountID(
+	row sqlc.GetAccountByWalletScopeAndNameRow) int64 {
+
+	return row.ID
+}
+
+// importedAddressGetWalletWatchOnly extracts the wallet-level watch-only state
+// from a row.
+func importedAddressGetWalletWatchOnly(
+	row sqlc.GetAccountByWalletScopeAndNameRow) bool {
+
+	return row.WalletIsWatchOnly
+}
+
 // accountRowToInfo converts a SQLite account row to an AccountInfo
 // struct. It uses type conversion since all accountInfoRow types have
 // identical fields.

--- a/wallet/internal/db/sqlite/addresses.go
+++ b/wallet/internal/db/sqlite/addresses.go
@@ -132,14 +132,15 @@ func (s *Store) NewDerivedAddress(ctx context.Context,
 		sqlc.GetAccountByWalletScopeAndNameRow,
 		db.AccountLookupKey,
 		sqlc.CreateDerivedAddressRow]{
-		GetAccount:    getAccountFromKey(s.queries),
-		AccountParams: db.AccountKeyFromParams,
-		GetAccountID:  derivedAddressGetAccountID,
-		GetExtIndex:   derivedAddressGetExtIndex,
-		GetIntIndex:   derivedAddressGetIntIndex,
-		CreateAddr:    derivedAddressCreateAddr,
-		RowID:         derivedAddressRowID,
-		RowCreatedAt:  derivedAddressRowCreatedAt,
+		GetAccount:         getAccountFromKey(s.queries),
+		AccountParams:      db.AccountKeyFromParams,
+		GetAccountID:       derivedAddressGetAccountID,
+		GetWalletWatchOnly: derivedAddressGetWalletWatchOnly,
+		GetExtIndex:        derivedAddressGetExtIndex,
+		GetIntIndex:        derivedAddressGetIntIndex,
+		CreateAddr:         derivedAddressCreateAddr,
+		RowID:              derivedAddressRowID,
+		RowCreatedAt:       derivedAddressRowCreatedAt,
 	}
 
 	return db.NewDerivedAddressWithTx(
@@ -158,15 +159,16 @@ func (s *Store) NewImportedAddress(ctx context.Context,
 		sqlc.CreateImportedAddressParams,
 		sqlc.CreateImportedAddressRow,
 		sqlc.InsertAddressSecretParams]{
-		GetAccount:    getAccountFromKey(s.queries),
-		AccountParams: db.AccountKeyFromImportedParams,
-		GetAccountID:  importedAddressGetAccountID,
-		CreateAddr:    createImportedAddress,
-		CreateParams:  createImportedAddressParams,
-		InsertSecret:  insertAddressSecret,
-		SecretParams:  insertAddressSecretParams,
-		RowID:         importedAddressRowID,
-		RowCreatedAt:  importedAddressRowCreatedAt,
+		GetAccount:         getAccountFromKey(s.queries),
+		AccountParams:      db.AccountKeyFromImportedParams,
+		GetAccountID:       importedAddressGetAccountID,
+		GetWalletWatchOnly: importedAddressGetWalletWatchOnly,
+		CreateAddr:         createImportedAddress,
+		CreateParams:       createImportedAddressParams,
+		InsertSecret:       insertAddressSecret,
+		SecretParams:       insertAddressSecretParams,
+		RowID:              importedAddressRowID,
+		RowCreatedAt:       importedAddressRowCreatedAt,
 	}
 
 	return db.NewImportedAddressWithTx(ctx, params, s.execWrite, adapters)
@@ -189,13 +191,6 @@ func getAccountFromKey(qtx *sqlc.Queries) func(context.Context,
 			},
 		)
 	}
-}
-
-// derivedAddressGetAccountID extracts the account ID from a row.
-func derivedAddressGetAccountID(
-	row sqlc.GetAccountByWalletScopeAndNameRow) int64 {
-
-	return row.ID
 }
 
 // derivedAddressGetExtIndex returns the external index query.
@@ -257,13 +252,6 @@ func derivedAddressRowCreatedAt(
 	return row.CreatedAt
 }
 
-// importedAddressGetAccountID extracts the account ID from a row.
-func importedAddressGetAccountID(
-	row sqlc.GetAccountByWalletScopeAndNameRow) int64 {
-
-	return row.ID
-}
-
 // createImportedAddress returns the imported address insert helper.
 func createImportedAddress(qtx *sqlc.Queries) func(context.Context,
 	sqlc.CreateImportedAddressParams) (
@@ -309,9 +297,13 @@ func insertAddressSecretParams(addressID int64,
 	params db.NewImportedAddressParams) sqlc.InsertAddressSecretParams {
 
 	return sqlc.InsertAddressSecretParams{
-		AddressID:        addressID,
-		EncryptedPrivKey: params.EncryptedPrivateKey,
-		EncryptedScript:  params.EncryptedScript,
+		AddressID: addressID,
+		EncryptedPrivKey: db.NilIfEmptyBytes(
+			params.EncryptedPrivateKey,
+		),
+		EncryptedScript: db.NilIfEmptyBytes(
+			params.EncryptedScript,
+		),
 	}
 }
 
@@ -344,19 +336,20 @@ func addressRowToInfo[T addressInfoRow](row T) (*db.AddressInfo,
 	base := sqlc.GetAddressByScriptPubKeyRow(row)
 
 	info, err := db.AddressRowToInfo(db.AddressInfoRow[int64, int64]{
-		ID:            base.ID,
-		AccountID:     base.AccountID,
-		TypeID:        base.TypeID,
-		OriginID:      base.OriginID,
-		HasPrivateKey: base.HasPrivateKey,
-		HasScript:     base.HasScript,
-		CreatedAt:     base.CreatedAt,
-		AddressBranch: base.AddressBranch,
-		AddressIndex:  base.AddressIndex,
-		ScriptPubKey:  base.ScriptPubKey,
-		PubKey:        base.PubKey,
-		IDToAddrType:  db.IDToAddressType[int64],
-		IDToOrigin:    db.IDToOrigin[int64],
+		ID:                base.ID,
+		AccountID:         base.AccountID,
+		TypeID:            base.TypeID,
+		OriginID:          base.OriginID,
+		WalletIsWatchOnly: base.WalletIsWatchOnly,
+		HasPrivateKey:     base.HasPrivateKey,
+		HasScript:         base.HasScript,
+		CreatedAt:         base.CreatedAt,
+		AddressBranch:     base.AddressBranch,
+		AddressIndex:      base.AddressIndex,
+		ScriptPubKey:      base.ScriptPubKey,
+		PubKey:            base.PubKey,
+		IDToAddrType:      db.IDToAddressType[int64],
+		IDToOrigin:        db.IDToOrigin[int64],
 	})
 	if err != nil {
 		return nil, err

--- a/wallet/internal/db/sqlite/wallet.go
+++ b/wallet/internal/db/sqlite/wallet.go
@@ -21,9 +21,14 @@ var _ db.WalletStore = (*Store)(nil)
 func (s *Store) CreateWallet(ctx context.Context,
 	params db.CreateWalletParams) (*db.WalletInfo, error) {
 
+	err := params.Validate()
+	if err != nil {
+		return nil, err
+	}
+
 	var info *db.WalletInfo
 
-	err := s.execWrite(ctx, func(qtx *sqlc.Queries) error {
+	err = s.execWrite(ctx, func(qtx *sqlc.Queries) error {
 		walletParams := sqlc.CreateWalletParams{
 			WalletName:              params.Name,
 			IsImported:              params.IsImported,
@@ -40,12 +45,19 @@ func (s *Store) CreateWallet(ctx context.Context,
 		}
 
 		secretsParams := sqlc.InsertWalletSecretsParams{
-			WalletID:               id,
-			MasterPrivParams:       params.MasterKeyPrivParams,
-			EncryptedCryptoPrivKey: params.EncryptedCryptoPrivKey,
-			EncryptedCryptoScriptKey: params.
-				EncryptedCryptoScriptKey,
-			EncryptedMasterHdPrivKey: params.EncryptedMasterPrivKey,
+			WalletID: id,
+			MasterPrivParams: db.NilIfEmptyBytes(
+				params.MasterKeyPrivParams,
+			),
+			EncryptedCryptoPrivKey: db.NilIfEmptyBytes(
+				params.EncryptedCryptoPrivKey,
+			),
+			EncryptedCryptoScriptKey: db.NilIfEmptyBytes(
+				params.EncryptedCryptoScriptKey,
+			),
+			EncryptedMasterHdPrivKey: db.NilIfEmptyBytes(
+				params.EncryptedMasterPrivKey,
+			),
 		}
 
 		err = qtx.InsertWalletSecrets(ctx, secretsParams)
@@ -293,14 +305,37 @@ func (s *Store) UpdateWalletSecrets(ctx context.Context,
 	params db.UpdateWalletSecretsParams) error {
 
 	secretsParams := sqlc.UpdateWalletSecretsParams{
-		MasterPrivParams:         params.MasterPrivParams,
-		EncryptedCryptoPrivKey:   params.EncryptedCryptoPrivKey,
-		EncryptedCryptoScriptKey: params.EncryptedCryptoScriptKey,
-		EncryptedMasterHdPrivKey: params.EncryptedMasterHdPrivKey,
-		WalletID:                 int64(params.WalletID),
+		MasterPrivParams: db.NilIfEmptyBytes(
+			params.MasterPrivParams,
+		),
+		EncryptedCryptoPrivKey: db.NilIfEmptyBytes(
+			params.EncryptedCryptoPrivKey,
+		),
+		EncryptedCryptoScriptKey: db.NilIfEmptyBytes(
+			params.EncryptedCryptoScriptKey,
+		),
+		EncryptedMasterHdPrivKey: db.NilIfEmptyBytes(
+			params.EncryptedMasterHdPrivKey,
+		),
+		WalletID: int64(params.WalletID),
 	}
 
 	return s.execWrite(ctx, func(qtx *sqlc.Queries) error {
+		walletRow, err := qtx.GetWalletByID(ctx, int64(params.WalletID))
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("wallet %d: %w", params.WalletID,
+					db.ErrWalletNotFound)
+			}
+
+			return fmt.Errorf("get wallet: %w", err)
+		}
+
+		err = params.Validate(walletRow.IsWatchOnly)
+		if err != nil {
+			return err
+		}
+
 		rowsAffected, err := qtx.UpdateWalletSecrets(ctx, secretsParams)
 		if err != nil {
 			return fmt.Errorf("update wallet secrets: %w", err)

--- a/wallet/internal/db/wallets_common.go
+++ b/wallet/internal/db/wallets_common.go
@@ -1,5 +1,45 @@
 package db
 
+import "fmt"
+
+// Validate checks wallet creation parameters for store-level invariants.
+// Watch-only wallets may keep the script crypto key so they can still encrypt
+// imported scripts, but they must not include private wallet secret material.
+func (p *CreateWalletParams) Validate() error {
+	if !p.IsWatchOnly {
+		return nil
+	}
+
+	if len(p.MasterKeyPrivParams) == 0 &&
+		len(p.EncryptedCryptoPrivKey) == 0 &&
+		len(p.EncryptedMasterPrivKey) == 0 {
+
+		return nil
+	}
+
+	return fmt.Errorf("watch-only wallet %q private secrets: %w", p.Name,
+		ErrWatchOnlyViolation)
+}
+
+// Validate checks wallet secret update parameters for store-level invariants.
+// Watch-only wallets may keep the script crypto key so they can still encrypt
+// imported scripts, but they must not include private wallet secret material.
+func (p *UpdateWalletSecretsParams) Validate(walletIsWatchOnly bool) error {
+	if !walletIsWatchOnly {
+		return nil
+	}
+
+	if len(p.MasterPrivParams) == 0 &&
+		len(p.EncryptedCryptoPrivKey) == 0 &&
+		len(p.EncryptedMasterHdPrivKey) == 0 {
+
+		return nil
+	}
+
+	return fmt.Errorf("watch-only wallet %d private secrets: %w", p.WalletID,
+		ErrWatchOnlyViolation)
+}
+
 // NextListWalletsQuery returns a query with its pagination cursor advanced to
 // the provided value.
 func NextListWalletsQuery(q ListWalletsQuery, cursor uint32) ListWalletsQuery {

--- a/wallet/internal/sql/pg/migrations/000002_wallets.up.sql
+++ b/wallet/internal/sql/pg/migrations/000002_wallets.up.sql
@@ -35,8 +35,8 @@ CREATE UNIQUE INDEX uidx_wallets_name ON wallets (wallet_name);
 -- Wallet Secrets table to store rarely accessed, highly sensitive encrypted
 -- material with a strict one-to-one relationship with the wallets table.
 -- Separated from the main wallets table for security and access pattern isolation.
--- Watch-only wallets may have no corresponding row in this table or have all
--- private key fields with no data.
+-- Watch-only wallets may have no corresponding row in this table or may store
+-- only script-encryption material while private wallet secret fields stay NULL.
 CREATE TABLE wallet_secrets (
     -- Reference to the wallet these secrets belong to. Also serves as the
     -- primary key, enforcing one-to-one relationship.
@@ -50,7 +50,7 @@ CREATE TABLE wallet_secrets (
     encrypted_crypto_priv_key BYTEA,
 
     -- Encrypted key used to encrypt/decrypt wallet data related to scripts.
-    -- NULL for watch-only wallets.
+    -- Watch-only wallets may still store this to protect imported scripts.
     encrypted_crypto_script_key BYTEA,
 
     -- Encrypted HD private key of the wallet. NULL for watch-only wallets.

--- a/wallet/internal/sql/pg/migrations/000005_accounts.up.sql
+++ b/wallet/internal/sql/pg/migrations/000005_accounts.up.sql
@@ -54,9 +54,6 @@ CREATE TABLE accounts (
     -- Reference to the origin of the account.
     origin_id SMALLINT NOT NULL,
 
-    -- Defines if the account is watch-only.
-    is_watch_only BOOLEAN NOT NULL,
-
     -- Master fingerprint is the fingerprint of the master pub key that created
     -- this account.
     master_fingerprint BIGINT,

--- a/wallet/internal/sql/pg/queries/accounts.sql
+++ b/wallet/internal/sql/pg/queries/accounts.sql
@@ -37,8 +37,7 @@ INSERT INTO accounts (
     account_name,
     origin_id,
     encrypted_public_key,
-    master_fingerprint,
-    is_watch_only
+    master_fingerprint
 )
 SELECT
     ks.wallet_id,
@@ -51,8 +50,7 @@ SELECT
     sqlc.arg('account_name') AS account_name,
     sqlc.arg('origin_id') AS origin_id,
     sqlc.arg('encrypted_public_key') AS encrypted_public_key,
-    sqlc.arg('master_fingerprint') AS master_fingerprint,
-    sqlc.arg('is_watch_only') AS is_watch_only
+    sqlc.arg('master_fingerprint') AS master_fingerprint
 FROM key_scopes AS ks
 WHERE ks.id = sqlc.arg('scope_id')
 RETURNING id, account_number, created_at;
@@ -68,8 +66,7 @@ INSERT INTO accounts (
     account_name,
     origin_id,
     encrypted_public_key,
-    master_fingerprint,
-    is_watch_only
+    master_fingerprint
 )
 SELECT
     ks.wallet_id,
@@ -78,8 +75,7 @@ SELECT
     sqlc.arg('account_name') AS account_name,
     sqlc.arg('origin_id') AS origin_id,
     sqlc.arg('encrypted_public_key') AS encrypted_public_key,
-    sqlc.arg('master_fingerprint') AS master_fingerprint,
-    sqlc.arg('is_watch_only') AS is_watch_only
+    sqlc.arg('master_fingerprint') AS master_fingerprint
 FROM key_scopes AS ks
 WHERE ks.id = sqlc.arg('scope_id')
 RETURNING id, created_at;
@@ -100,15 +96,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    CASE
+        WHEN w.is_watch_only THEN TRUE
+        WHEN a.origin_id = 1 AND acs.account_id IS NULL THEN TRUE
+        ELSE FALSE
+    END AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE a.scope_id = $1 AND a.account_name = $2;
 
 -- name: GetAccountByScopeAndNumber :one
@@ -118,15 +121,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    CASE
+        WHEN w.is_watch_only THEN TRUE
+        WHEN a.origin_id = 1 AND acs.account_id IS NULL THEN TRUE
+        ELSE FALSE
+    END AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE a.scope_id = $1 AND a.account_number = $2;
 
 -- name: GetAccountByWalletScopeAndName :one
@@ -136,15 +146,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    CASE
+        WHEN w.is_watch_only THEN TRUE
+        WHEN a.origin_id = 1 AND acs.account_id IS NULL THEN TRUE
+        ELSE FALSE
+    END AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE
     ks.wallet_id = $1
     AND ks.purpose = $2
@@ -158,15 +175,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    CASE
+        WHEN w.is_watch_only THEN TRUE
+        WHEN a.origin_id = 1 AND acs.account_id IS NULL THEN TRUE
+        ELSE FALSE
+    END AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE
     ks.wallet_id = $1
     AND ks.purpose = $2
@@ -181,7 +205,6 @@ SELECT
     a.origin_id,
     a.encrypted_public_key,
     a.master_fingerprint,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
@@ -189,9 +212,16 @@ SELECT
     ks.external_type_id,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    CASE
+        WHEN w.is_watch_only THEN TRUE
+        WHEN a.origin_id = 1 AND acs.account_id IS NULL THEN TRUE
+        ELSE FALSE
+    END AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE a.id = $1;
 
 -- name: ListAccountsByScope :many
@@ -202,15 +232,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    CASE
+        WHEN w.is_watch_only THEN TRUE
+        WHEN a.origin_id = 1 AND acs.account_id IS NULL THEN TRUE
+        ELSE FALSE
+    END AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE a.scope_id = $1
 ORDER BY a.account_number NULLS LAST;
 
@@ -222,15 +259,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    CASE
+        WHEN w.is_watch_only THEN TRUE
+        WHEN a.origin_id = 1 AND acs.account_id IS NULL THEN TRUE
+        ELSE FALSE
+    END AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE
     ks.wallet_id = $1
     AND ks.purpose = $2
@@ -245,15 +289,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    CASE
+        WHEN w.is_watch_only THEN TRUE
+        WHEN a.origin_id = 1 AND acs.account_id IS NULL THEN TRUE
+        ELSE FALSE
+    END AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE ks.wallet_id = $1 AND a.account_name = $2
 ORDER BY a.account_number NULLS LAST;
 
@@ -265,15 +316,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    CASE
+        WHEN w.is_watch_only THEN TRUE
+        WHEN a.origin_id = 1 AND acs.account_id IS NULL THEN TRUE
+        ELSE FALSE
+    END AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE ks.wallet_id = $1
 ORDER BY a.account_number NULLS LAST;
 
@@ -315,16 +373,14 @@ INSERT INTO accounts (
     scope_id,
     account_number,
     account_name,
-    origin_id,
-    is_watch_only
+    origin_id
 )
 SELECT
     ks.wallet_id,
     ks.id AS scope_id,
     sqlc.arg('account_number') AS account_number,
     sqlc.arg('account_name') AS account_name,
-    sqlc.arg('origin_id') AS origin_id,
-    sqlc.arg('is_watch_only') AS is_watch_only
+    sqlc.arg('origin_id') AS origin_id
 FROM key_scopes AS ks
 WHERE ks.id = sqlc.arg('scope_id')
 RETURNING id, account_number, created_at;

--- a/wallet/internal/sql/pg/queries/addresses.sql
+++ b/wallet/internal/sql/pg/queries/addresses.sql
@@ -1,5 +1,6 @@
 -- name: InsertAddressSecret :exec
--- Inserts address secret information (private key, script) for imported addresses.
+-- Inserts address secret information (private key and/or script) for imported
+-- addresses.
 -- Not used for derived addresses (their keys are derived from account key).
 INSERT INTO address_secrets (
     address_id,
@@ -21,17 +22,19 @@ SELECT
     a.pub_key,
     a.created_at,
     acc.origin_id,
+    w.is_watch_only AS wallet_is_watch_only,
     (s.encrypted_priv_key IS NOT NULL)::BOOLEAN AS has_private_key,
     (s.encrypted_script IS NOT NULL)::BOOLEAN AS has_script
 FROM addresses AS a
 INNER JOIN accounts AS acc ON a.account_id = acc.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
 LEFT JOIN address_secrets AS s ON a.id = s.address_id
 WHERE a.script_pub_key = $1 AND a.wallet_id = $2;
 
 -- name: GetAddressSecret :one
 -- Retrieves secret information for an address. Uses LEFT JOIN to distinguish:
 -- - Address exists with secret: returns full row
--- - Address exists without secret (watch-only/derived): returns row with NULL secret fields
+-- - Address exists without secret row: returns row with NULL secret fields
 -- - Address does not exist: returns no rows (sql.ErrNoRows)
 SELECT
     a.id AS address_id,
@@ -86,10 +89,12 @@ SELECT
     a.pub_key,
     a.created_at,
     acc.origin_id,
+    w.is_watch_only AS wallet_is_watch_only,
     (s.encrypted_priv_key IS NOT NULL)::BOOLEAN AS has_private_key,
     (s.encrypted_script IS NOT NULL)::BOOLEAN AS has_script
 FROM addresses AS a
 INNER JOIN accounts AS acc ON a.account_id = acc.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
 INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
 LEFT JOIN address_secrets AS s ON a.id = s.address_id
 WHERE

--- a/wallet/internal/sql/pg/sqlc/accounts.sql.go
+++ b/wallet/internal/sql/pg/sqlc/accounts.sql.go
@@ -39,8 +39,7 @@ INSERT INTO accounts (
     account_name,
     origin_id,
     encrypted_public_key,
-    master_fingerprint,
-    is_watch_only
+    master_fingerprint
 )
 SELECT
     ks.wallet_id,
@@ -53,8 +52,7 @@ SELECT
     $2 AS account_name,
     $3 AS origin_id,
     $4 AS encrypted_public_key,
-    $5 AS master_fingerprint,
-    $6 AS is_watch_only
+    $5 AS master_fingerprint
 FROM key_scopes AS ks
 WHERE ks.id = $1
 RETURNING id, account_number, created_at
@@ -66,7 +64,6 @@ type CreateDerivedAccountParams struct {
 	OriginID           int16
 	EncryptedPublicKey []byte
 	MasterFingerprint  sql.NullInt64
-	IsWatchOnly        bool
 }
 
 type CreateDerivedAccountRow struct {
@@ -86,7 +83,6 @@ func (q *Queries) CreateDerivedAccount(ctx context.Context, arg CreateDerivedAcc
 		arg.OriginID,
 		arg.EncryptedPublicKey,
 		arg.MasterFingerprint,
-		arg.IsWatchOnly,
 	)
 	var i CreateDerivedAccountRow
 	err := row.Scan(&i.ID, &i.AccountNumber, &i.CreatedAt)
@@ -99,18 +95,16 @@ INSERT INTO accounts (
     scope_id,
     account_number,
     account_name,
-    origin_id,
-    is_watch_only
+    origin_id
 )
 SELECT
     ks.wallet_id,
     ks.id AS scope_id,
     $1 AS account_number,
     $2 AS account_name,
-    $3 AS origin_id,
-    $4 AS is_watch_only
+    $3 AS origin_id
 FROM key_scopes AS ks
-WHERE ks.id = $5
+WHERE ks.id = $4
 RETURNING id, account_number, created_at
 `
 
@@ -118,7 +112,6 @@ type CreateDerivedAccountWithNumberParams struct {
 	AccountNumber sql.NullInt64
 	AccountName   string
 	OriginID      int16
-	IsWatchOnly   bool
 	ScopeID       int64
 }
 
@@ -135,7 +128,6 @@ func (q *Queries) CreateDerivedAccountWithNumber(ctx context.Context, arg Create
 		arg.AccountNumber,
 		arg.AccountName,
 		arg.OriginID,
-		arg.IsWatchOnly,
 		arg.ScopeID,
 	)
 	var i CreateDerivedAccountWithNumberRow
@@ -151,8 +143,7 @@ INSERT INTO accounts (
     account_name,
     origin_id,
     encrypted_public_key,
-    master_fingerprint,
-    is_watch_only
+    master_fingerprint
 )
 SELECT
     ks.wallet_id,
@@ -161,10 +152,9 @@ SELECT
     $1 AS account_name,
     $2 AS origin_id,
     $3 AS encrypted_public_key,
-    $4 AS master_fingerprint,
-    $5 AS is_watch_only
+    $4 AS master_fingerprint
 FROM key_scopes AS ks
-WHERE ks.id = $6
+WHERE ks.id = $5
 RETURNING id, created_at
 `
 
@@ -173,7 +163,6 @@ type CreateImportedAccountParams struct {
 	OriginID           int16
 	EncryptedPublicKey []byte
 	MasterFingerprint  sql.NullInt64
-	IsWatchOnly        bool
 	ScopeID            int64
 }
 
@@ -191,7 +180,6 @@ func (q *Queries) CreateImportedAccount(ctx context.Context, arg CreateImportedA
 		arg.OriginID,
 		arg.EncryptedPublicKey,
 		arg.MasterFingerprint,
-		arg.IsWatchOnly,
 		arg.ScopeID,
 	)
 	var i CreateImportedAccountRow
@@ -205,15 +193,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    CASE
+        WHEN w.is_watch_only THEN TRUE
+        WHEN a.origin_id = 1 AND acs.account_id IS NULL THEN TRUE
+        ELSE FALSE
+    END AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE a.scope_id = $1 AND a.account_name = $2
 `
 
@@ -223,17 +218,18 @@ type GetAccountByScopeAndNameParams struct {
 }
 
 type GetAccountByScopeAndNameRow struct {
-	ID               int64
-	AccountNumber    sql.NullInt64
-	AccountName      string
-	OriginID         int16
-	IsWatchOnly      bool
-	CreatedAt        time.Time
-	Purpose          int64
-	CoinType         int64
-	ExternalKeyCount int64
-	InternalKeyCount int64
-	ImportedKeyCount int64
+	ID                int64
+	AccountNumber     sql.NullInt64
+	AccountName       string
+	OriginID          int16
+	CreatedAt         time.Time
+	Purpose           int64
+	CoinType          int64
+	ExternalKeyCount  int64
+	InternalKeyCount  int64
+	ImportedKeyCount  int64
+	WalletIsWatchOnly bool
+	IsWatchOnly       bool
 }
 
 // Returns a single account by scope id and account name.
@@ -245,13 +241,14 @@ func (q *Queries) GetAccountByScopeAndName(ctx context.Context, arg GetAccountBy
 		&i.AccountNumber,
 		&i.AccountName,
 		&i.OriginID,
-		&i.IsWatchOnly,
 		&i.CreatedAt,
 		&i.Purpose,
 		&i.CoinType,
 		&i.ExternalKeyCount,
 		&i.InternalKeyCount,
 		&i.ImportedKeyCount,
+		&i.WalletIsWatchOnly,
+		&i.IsWatchOnly,
 	)
 	return i, err
 }
@@ -262,15 +259,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    CASE
+        WHEN w.is_watch_only THEN TRUE
+        WHEN a.origin_id = 1 AND acs.account_id IS NULL THEN TRUE
+        ELSE FALSE
+    END AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE a.scope_id = $1 AND a.account_number = $2
 `
 
@@ -280,17 +284,18 @@ type GetAccountByScopeAndNumberParams struct {
 }
 
 type GetAccountByScopeAndNumberRow struct {
-	ID               int64
-	AccountNumber    sql.NullInt64
-	AccountName      string
-	OriginID         int16
-	IsWatchOnly      bool
-	CreatedAt        time.Time
-	Purpose          int64
-	CoinType         int64
-	ExternalKeyCount int64
-	InternalKeyCount int64
-	ImportedKeyCount int64
+	ID                int64
+	AccountNumber     sql.NullInt64
+	AccountName       string
+	OriginID          int16
+	CreatedAt         time.Time
+	Purpose           int64
+	CoinType          int64
+	ExternalKeyCount  int64
+	InternalKeyCount  int64
+	ImportedKeyCount  int64
+	WalletIsWatchOnly bool
+	IsWatchOnly       bool
 }
 
 // Returns a single account by scope id and account number.
@@ -302,13 +307,14 @@ func (q *Queries) GetAccountByScopeAndNumber(ctx context.Context, arg GetAccount
 		&i.AccountNumber,
 		&i.AccountName,
 		&i.OriginID,
-		&i.IsWatchOnly,
 		&i.CreatedAt,
 		&i.Purpose,
 		&i.CoinType,
 		&i.ExternalKeyCount,
 		&i.InternalKeyCount,
 		&i.ImportedKeyCount,
+		&i.WalletIsWatchOnly,
+		&i.IsWatchOnly,
 	)
 	return i, err
 }
@@ -319,15 +325,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    CASE
+        WHEN w.is_watch_only THEN TRUE
+        WHEN a.origin_id = 1 AND acs.account_id IS NULL THEN TRUE
+        ELSE FALSE
+    END AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE
     ks.wallet_id = $1
     AND ks.purpose = $2
@@ -343,17 +356,18 @@ type GetAccountByWalletScopeAndNameParams struct {
 }
 
 type GetAccountByWalletScopeAndNameRow struct {
-	ID               int64
-	AccountNumber    sql.NullInt64
-	AccountName      string
-	OriginID         int16
-	IsWatchOnly      bool
-	CreatedAt        time.Time
-	Purpose          int64
-	CoinType         int64
-	ExternalKeyCount int64
-	InternalKeyCount int64
-	ImportedKeyCount int64
+	ID                int64
+	AccountNumber     sql.NullInt64
+	AccountName       string
+	OriginID          int16
+	CreatedAt         time.Time
+	Purpose           int64
+	CoinType          int64
+	ExternalKeyCount  int64
+	InternalKeyCount  int64
+	ImportedKeyCount  int64
+	WalletIsWatchOnly bool
+	IsWatchOnly       bool
 }
 
 // Returns a single account by wallet id, scope tuple, and account name.
@@ -370,13 +384,14 @@ func (q *Queries) GetAccountByWalletScopeAndName(ctx context.Context, arg GetAcc
 		&i.AccountNumber,
 		&i.AccountName,
 		&i.OriginID,
-		&i.IsWatchOnly,
 		&i.CreatedAt,
 		&i.Purpose,
 		&i.CoinType,
 		&i.ExternalKeyCount,
 		&i.InternalKeyCount,
 		&i.ImportedKeyCount,
+		&i.WalletIsWatchOnly,
+		&i.IsWatchOnly,
 	)
 	return i, err
 }
@@ -387,15 +402,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    CASE
+        WHEN w.is_watch_only THEN TRUE
+        WHEN a.origin_id = 1 AND acs.account_id IS NULL THEN TRUE
+        ELSE FALSE
+    END AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE
     ks.wallet_id = $1
     AND ks.purpose = $2
@@ -411,17 +433,18 @@ type GetAccountByWalletScopeAndNumberParams struct {
 }
 
 type GetAccountByWalletScopeAndNumberRow struct {
-	ID               int64
-	AccountNumber    sql.NullInt64
-	AccountName      string
-	OriginID         int16
-	IsWatchOnly      bool
-	CreatedAt        time.Time
-	Purpose          int64
-	CoinType         int64
-	ExternalKeyCount int64
-	InternalKeyCount int64
-	ImportedKeyCount int64
+	ID                int64
+	AccountNumber     sql.NullInt64
+	AccountName       string
+	OriginID          int16
+	CreatedAt         time.Time
+	Purpose           int64
+	CoinType          int64
+	ExternalKeyCount  int64
+	InternalKeyCount  int64
+	ImportedKeyCount  int64
+	WalletIsWatchOnly bool
+	IsWatchOnly       bool
 }
 
 // Returns a single account by wallet id, scope tuple, and account number.
@@ -438,13 +461,14 @@ func (q *Queries) GetAccountByWalletScopeAndNumber(ctx context.Context, arg GetA
 		&i.AccountNumber,
 		&i.AccountName,
 		&i.OriginID,
-		&i.IsWatchOnly,
 		&i.CreatedAt,
 		&i.Purpose,
 		&i.CoinType,
 		&i.ExternalKeyCount,
 		&i.InternalKeyCount,
 		&i.ImportedKeyCount,
+		&i.WalletIsWatchOnly,
+		&i.IsWatchOnly,
 	)
 	return i, err
 }
@@ -456,7 +480,6 @@ SELECT
     a.origin_id,
     a.encrypted_public_key,
     a.master_fingerprint,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
@@ -464,9 +487,16 @@ SELECT
     ks.external_type_id,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    CASE
+        WHEN w.is_watch_only THEN TRUE
+        WHEN a.origin_id = 1 AND acs.account_id IS NULL THEN TRUE
+        ELSE FALSE
+    END AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE a.id = $1
 `
 
@@ -476,7 +506,6 @@ type GetAccountPropsByIdRow struct {
 	OriginID           int16
 	EncryptedPublicKey []byte
 	MasterFingerprint  sql.NullInt64
-	IsWatchOnly        bool
 	CreatedAt          time.Time
 	Purpose            int64
 	CoinType           int64
@@ -485,6 +514,7 @@ type GetAccountPropsByIdRow struct {
 	ExternalKeyCount   int64
 	InternalKeyCount   int64
 	ImportedKeyCount   int64
+	IsWatchOnly        bool
 }
 
 // Returns full account properties by account id.
@@ -497,7 +527,6 @@ func (q *Queries) GetAccountPropsById(ctx context.Context, id int64) (GetAccount
 		&i.OriginID,
 		&i.EncryptedPublicKey,
 		&i.MasterFingerprint,
-		&i.IsWatchOnly,
 		&i.CreatedAt,
 		&i.Purpose,
 		&i.CoinType,
@@ -506,6 +535,7 @@ func (q *Queries) GetAccountPropsById(ctx context.Context, id int64) (GetAccount
 		&i.ExternalKeyCount,
 		&i.InternalKeyCount,
 		&i.ImportedKeyCount,
+		&i.IsWatchOnly,
 	)
 	return i, err
 }
@@ -548,31 +578,39 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    CASE
+        WHEN w.is_watch_only THEN TRUE
+        WHEN a.origin_id = 1 AND acs.account_id IS NULL THEN TRUE
+        ELSE FALSE
+    END AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE a.scope_id = $1
 ORDER BY a.account_number NULLS LAST
 `
 
 type ListAccountsByScopeRow struct {
-	ID               int64
-	AccountNumber    sql.NullInt64
-	AccountName      string
-	OriginID         int16
-	IsWatchOnly      bool
-	CreatedAt        time.Time
-	Purpose          int64
-	CoinType         int64
-	ExternalKeyCount int64
-	InternalKeyCount int64
-	ImportedKeyCount int64
+	ID                int64
+	AccountNumber     sql.NullInt64
+	AccountName       string
+	OriginID          int16
+	CreatedAt         time.Time
+	Purpose           int64
+	CoinType          int64
+	ExternalKeyCount  int64
+	InternalKeyCount  int64
+	ImportedKeyCount  int64
+	WalletIsWatchOnly bool
+	IsWatchOnly       bool
 }
 
 // Lists all accounts in a scope, ordered by account number. Imported accounts
@@ -591,13 +629,14 @@ func (q *Queries) ListAccountsByScope(ctx context.Context, scopeID int64) ([]Lis
 			&i.AccountNumber,
 			&i.AccountName,
 			&i.OriginID,
-			&i.IsWatchOnly,
 			&i.CreatedAt,
 			&i.Purpose,
 			&i.CoinType,
 			&i.ExternalKeyCount,
 			&i.InternalKeyCount,
 			&i.ImportedKeyCount,
+			&i.WalletIsWatchOnly,
+			&i.IsWatchOnly,
 		); err != nil {
 			return nil, err
 		}
@@ -618,31 +657,39 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    CASE
+        WHEN w.is_watch_only THEN TRUE
+        WHEN a.origin_id = 1 AND acs.account_id IS NULL THEN TRUE
+        ELSE FALSE
+    END AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE ks.wallet_id = $1
 ORDER BY a.account_number NULLS LAST
 `
 
 type ListAccountsByWalletRow struct {
-	ID               int64
-	AccountNumber    sql.NullInt64
-	AccountName      string
-	OriginID         int16
-	IsWatchOnly      bool
-	CreatedAt        time.Time
-	Purpose          int64
-	CoinType         int64
-	ExternalKeyCount int64
-	InternalKeyCount int64
-	ImportedKeyCount int64
+	ID                int64
+	AccountNumber     sql.NullInt64
+	AccountName       string
+	OriginID          int16
+	CreatedAt         time.Time
+	Purpose           int64
+	CoinType          int64
+	ExternalKeyCount  int64
+	InternalKeyCount  int64
+	ImportedKeyCount  int64
+	WalletIsWatchOnly bool
+	IsWatchOnly       bool
 }
 
 // Lists all accounts for a wallet, ordered by account number. Imported
@@ -661,13 +708,14 @@ func (q *Queries) ListAccountsByWallet(ctx context.Context, walletID int64) ([]L
 			&i.AccountNumber,
 			&i.AccountName,
 			&i.OriginID,
-			&i.IsWatchOnly,
 			&i.CreatedAt,
 			&i.Purpose,
 			&i.CoinType,
 			&i.ExternalKeyCount,
 			&i.InternalKeyCount,
 			&i.ImportedKeyCount,
+			&i.WalletIsWatchOnly,
+			&i.IsWatchOnly,
 		); err != nil {
 			return nil, err
 		}
@@ -688,15 +736,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    CASE
+        WHEN w.is_watch_only THEN TRUE
+        WHEN a.origin_id = 1 AND acs.account_id IS NULL THEN TRUE
+        ELSE FALSE
+    END AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE ks.wallet_id = $1 AND a.account_name = $2
 ORDER BY a.account_number NULLS LAST
 `
@@ -707,17 +762,18 @@ type ListAccountsByWalletAndNameParams struct {
 }
 
 type ListAccountsByWalletAndNameRow struct {
-	ID               int64
-	AccountNumber    sql.NullInt64
-	AccountName      string
-	OriginID         int16
-	IsWatchOnly      bool
-	CreatedAt        time.Time
-	Purpose          int64
-	CoinType         int64
-	ExternalKeyCount int64
-	InternalKeyCount int64
-	ImportedKeyCount int64
+	ID                int64
+	AccountNumber     sql.NullInt64
+	AccountName       string
+	OriginID          int16
+	CreatedAt         time.Time
+	Purpose           int64
+	CoinType          int64
+	ExternalKeyCount  int64
+	InternalKeyCount  int64
+	ImportedKeyCount  int64
+	WalletIsWatchOnly bool
+	IsWatchOnly       bool
 }
 
 // Lists all accounts for a wallet filtered by account name, ordered by account
@@ -736,13 +792,14 @@ func (q *Queries) ListAccountsByWalletAndName(ctx context.Context, arg ListAccou
 			&i.AccountNumber,
 			&i.AccountName,
 			&i.OriginID,
-			&i.IsWatchOnly,
 			&i.CreatedAt,
 			&i.Purpose,
 			&i.CoinType,
 			&i.ExternalKeyCount,
 			&i.InternalKeyCount,
 			&i.ImportedKeyCount,
+			&i.WalletIsWatchOnly,
+			&i.IsWatchOnly,
 		); err != nil {
 			return nil, err
 		}
@@ -763,15 +820,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    CASE
+        WHEN w.is_watch_only THEN TRUE
+        WHEN a.origin_id = 1 AND acs.account_id IS NULL THEN TRUE
+        ELSE FALSE
+    END AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE
     ks.wallet_id = $1
     AND ks.purpose = $2
@@ -786,17 +850,18 @@ type ListAccountsByWalletScopeParams struct {
 }
 
 type ListAccountsByWalletScopeRow struct {
-	ID               int64
-	AccountNumber    sql.NullInt64
-	AccountName      string
-	OriginID         int16
-	IsWatchOnly      bool
-	CreatedAt        time.Time
-	Purpose          int64
-	CoinType         int64
-	ExternalKeyCount int64
-	InternalKeyCount int64
-	ImportedKeyCount int64
+	ID                int64
+	AccountNumber     sql.NullInt64
+	AccountName       string
+	OriginID          int16
+	CreatedAt         time.Time
+	Purpose           int64
+	CoinType          int64
+	ExternalKeyCount  int64
+	InternalKeyCount  int64
+	ImportedKeyCount  int64
+	WalletIsWatchOnly bool
+	IsWatchOnly       bool
 }
 
 // Lists all accounts for a wallet and scope tuple, ordered by account number.
@@ -815,13 +880,14 @@ func (q *Queries) ListAccountsByWalletScope(ctx context.Context, arg ListAccount
 			&i.AccountNumber,
 			&i.AccountName,
 			&i.OriginID,
-			&i.IsWatchOnly,
 			&i.CreatedAt,
 			&i.Purpose,
 			&i.CoinType,
 			&i.ExternalKeyCount,
 			&i.InternalKeyCount,
 			&i.ImportedKeyCount,
+			&i.WalletIsWatchOnly,
+			&i.IsWatchOnly,
 		); err != nil {
 			return nil, err
 		}

--- a/wallet/internal/sql/pg/sqlc/addresses.sql.go
+++ b/wallet/internal/sql/pg/sqlc/addresses.sql.go
@@ -110,10 +110,12 @@ SELECT
     a.pub_key,
     a.created_at,
     acc.origin_id,
+    w.is_watch_only AS wallet_is_watch_only,
     (s.encrypted_priv_key IS NOT NULL)::BOOLEAN AS has_private_key,
     (s.encrypted_script IS NOT NULL)::BOOLEAN AS has_script
 FROM addresses AS a
 INNER JOIN accounts AS acc ON a.account_id = acc.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
 LEFT JOIN address_secrets AS s ON a.id = s.address_id
 WHERE a.script_pub_key = $1 AND a.wallet_id = $2
 `
@@ -124,17 +126,18 @@ type GetAddressByScriptPubKeyParams struct {
 }
 
 type GetAddressByScriptPubKeyRow struct {
-	ID            int64
-	AccountID     int64
-	TypeID        int16
-	AddressBranch sql.NullInt16
-	AddressIndex  sql.NullInt64
-	ScriptPubKey  []byte
-	PubKey        []byte
-	CreatedAt     time.Time
-	OriginID      int16
-	HasPrivateKey bool
-	HasScript     bool
+	ID                int64
+	AccountID         int64
+	TypeID            int16
+	AddressBranch     sql.NullInt16
+	AddressIndex      sql.NullInt64
+	ScriptPubKey      []byte
+	PubKey            []byte
+	CreatedAt         time.Time
+	OriginID          int16
+	WalletIsWatchOnly bool
+	HasPrivateKey     bool
+	HasScript         bool
 }
 
 // Retrieves an address by its script pubkey and account wallet.
@@ -151,6 +154,7 @@ func (q *Queries) GetAddressByScriptPubKey(ctx context.Context, arg GetAddressBy
 		&i.PubKey,
 		&i.CreatedAt,
 		&i.OriginID,
+		&i.WalletIsWatchOnly,
 		&i.HasPrivateKey,
 		&i.HasScript,
 	)
@@ -180,7 +184,7 @@ type GetAddressSecretRow struct {
 
 // Retrieves secret information for an address. Uses LEFT JOIN to distinguish:
 // - Address exists with secret: returns full row
-// - Address exists without secret (watch-only/derived): returns row with NULL secret fields
+// - Address exists without secret row: returns row with NULL secret fields
 // - Address does not exist: returns no rows (sql.ErrNoRows)
 func (q *Queries) GetAddressSecret(ctx context.Context, arg GetAddressSecretParams) (GetAddressSecretRow, error) {
 	row := q.queryRow(ctx, q.getAddressSecretStmt, GetAddressSecret, arg.WalletID, arg.ID)
@@ -205,7 +209,8 @@ type InsertAddressSecretParams struct {
 	EncryptedScript  []byte
 }
 
-// Inserts address secret information (private key, script) for imported addresses.
+// Inserts address secret information (private key and/or script) for imported
+// addresses.
 // Not used for derived addresses (their keys are derived from account key).
 func (q *Queries) InsertAddressSecret(ctx context.Context, arg InsertAddressSecretParams) error {
 	_, err := q.exec(ctx, q.insertAddressSecretStmt, InsertAddressSecret, arg.AddressID, arg.EncryptedPrivKey, arg.EncryptedScript)
@@ -223,10 +228,12 @@ SELECT
     a.pub_key,
     a.created_at,
     acc.origin_id,
+    w.is_watch_only AS wallet_is_watch_only,
     (s.encrypted_priv_key IS NOT NULL)::BOOLEAN AS has_private_key,
     (s.encrypted_script IS NOT NULL)::BOOLEAN AS has_script
 FROM addresses AS a
 INNER JOIN accounts AS acc ON a.account_id = acc.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
 INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
 LEFT JOIN address_secrets AS s ON a.id = s.address_id
 WHERE
@@ -256,17 +263,18 @@ type ListAddressesByAccountParams struct {
 }
 
 type ListAddressesByAccountRow struct {
-	ID            int64
-	AccountID     int64
-	TypeID        int16
-	AddressBranch sql.NullInt16
-	AddressIndex  sql.NullInt64
-	ScriptPubKey  []byte
-	PubKey        []byte
-	CreatedAt     time.Time
-	OriginID      int16
-	HasPrivateKey bool
-	HasScript     bool
+	ID                int64
+	AccountID         int64
+	TypeID            int16
+	AddressBranch     sql.NullInt16
+	AddressIndex      sql.NullInt64
+	ScriptPubKey      []byte
+	PubKey            []byte
+	CreatedAt         time.Time
+	OriginID          int16
+	WalletIsWatchOnly bool
+	HasPrivateKey     bool
+	HasScript         bool
 }
 
 // Lists addresses for an account identified by wallet_id, key scope
@@ -299,6 +307,7 @@ func (q *Queries) ListAddressesByAccount(ctx context.Context, arg ListAddressesB
 			&i.PubKey,
 			&i.CreatedAt,
 			&i.OriginID,
+			&i.WalletIsWatchOnly,
 			&i.HasPrivateKey,
 			&i.HasScript,
 		); err != nil {

--- a/wallet/internal/sql/pg/sqlc/models.go
+++ b/wallet/internal/sql/pg/sqlc/models.go
@@ -16,7 +16,6 @@ type Account struct {
 	AccountNumber      sql.NullInt64
 	AccountName        string
 	OriginID           int16
-	IsWatchOnly        bool
 	MasterFingerprint  sql.NullInt64
 	EncryptedPublicKey []byte
 	CreatedAt          time.Time

--- a/wallet/internal/sql/pg/sqlc/querier.go
+++ b/wallet/internal/sql/pg/sqlc/querier.go
@@ -154,7 +154,7 @@ type Querier interface {
 	GetAddressByScriptPubKey(ctx context.Context, arg GetAddressByScriptPubKeyParams) (GetAddressByScriptPubKeyRow, error)
 	// Retrieves secret information for an address. Uses LEFT JOIN to distinguish:
 	// - Address exists with secret: returns full row
-	// - Address exists without secret (watch-only/derived): returns row with NULL secret fields
+	// - Address exists without secret row: returns row with NULL secret fields
 	// - Address does not exist: returns no rows (sql.ErrNoRows)
 	GetAddressSecret(ctx context.Context, arg GetAddressSecretParams) (GetAddressSecretRow, error)
 	// Returns a single address type by its ID.
@@ -247,7 +247,8 @@ type Querier interface {
 	// - Targets one wallet-scoped outpoint through the parent tx lookup plus the
 	//   unique `(tx_id, output_index)` key.
 	HasInvalidWalletUtxoByOutpoint(ctx context.Context, arg HasInvalidWalletUtxoByOutpointParams) (bool, error)
-	// Inserts address secret information (private key, script) for imported addresses.
+	// Inserts address secret information (private key and/or script) for imported
+	// addresses.
 	// Not used for derived addresses (their keys are derived from account key).
 	InsertAddressSecret(ctx context.Context, arg InsertAddressSecretParams) error
 	InsertBlock(ctx context.Context, arg InsertBlockParams) error

--- a/wallet/internal/sql/sqlite/migrations/000002_wallets.up.sql
+++ b/wallet/internal/sql/sqlite/migrations/000002_wallets.up.sql
@@ -35,8 +35,8 @@ CREATE UNIQUE INDEX uidx_wallets_name ON wallets (wallet_name);
 -- Wallet Secrets table to store rarely accessed, highly sensitive encrypted
 -- material with a strict one-to-one relationship with the wallets table.
 -- Separated from the main wallets table for security and access pattern isolation.
--- Watch-only wallets may have no corresponding row in this table or have all
--- private key fields with no data.
+-- Watch-only wallets may have no corresponding row in this table or may store
+-- only script-encryption material while private wallet secret fields stay NULL.
 CREATE TABLE wallet_secrets (
     -- Reference to the wallet these secrets belong to. Also serves as the
     -- primary key, enforcing one-to-one relationship.
@@ -50,7 +50,7 @@ CREATE TABLE wallet_secrets (
     encrypted_crypto_priv_key BLOB,
 
     -- Encrypted key used to encrypt/decrypt wallet data related to scripts.
-    -- NULL for watch-only wallets.
+    -- Watch-only wallets may still store this to protect imported scripts.
     encrypted_crypto_script_key BLOB,
 
     -- Encrypted HD private key of the wallet. NULL for watch-only wallets.

--- a/wallet/internal/sql/sqlite/migrations/000005_accounts.up.sql
+++ b/wallet/internal/sql/sqlite/migrations/000005_accounts.up.sql
@@ -54,9 +54,6 @@ CREATE TABLE accounts (
     -- Reference to the origin of the account.
     origin_id INTEGER NOT NULL,
 
-    -- Defines if the account is watch-only.
-    is_watch_only BOOLEAN NOT NULL,
-
     -- Master fingerprint is the fingerprint of the master pub key that created
     -- this account.
     master_fingerprint INTEGER,

--- a/wallet/internal/sql/sqlite/queries/accounts.sql
+++ b/wallet/internal/sql/sqlite/queries/accounts.sql
@@ -9,8 +9,7 @@ INSERT INTO accounts (
     account_name,
     origin_id,
     encrypted_public_key,
-    master_fingerprint,
-    is_watch_only
+    master_fingerprint
 )
 SELECT
     ks.wallet_id,
@@ -22,8 +21,7 @@ SELECT
     sqlc.arg('account_name') AS account_name,
     sqlc.arg('origin_id') AS origin_id,
     sqlc.arg('encrypted_public_key') AS encrypted_public_key,
-    sqlc.arg('master_fingerprint') AS master_fingerprint,
-    sqlc.arg('is_watch_only') AS is_watch_only
+    sqlc.arg('master_fingerprint') AS master_fingerprint
 FROM key_scopes AS ks
 WHERE ks.id = sqlc.arg('scope_id')
 RETURNING id, account_number, created_at;
@@ -39,8 +37,7 @@ INSERT INTO accounts (
     account_name,
     origin_id,
     encrypted_public_key,
-    master_fingerprint,
-    is_watch_only
+    master_fingerprint
 )
 SELECT
     ks.wallet_id,
@@ -49,8 +46,7 @@ SELECT
     sqlc.arg('account_name') AS account_name,
     sqlc.arg('origin_id') AS origin_id,
     sqlc.arg('encrypted_public_key') AS encrypted_public_key,
-    sqlc.arg('master_fingerprint') AS master_fingerprint,
-    sqlc.arg('is_watch_only') AS is_watch_only
+    sqlc.arg('master_fingerprint') AS master_fingerprint
 FROM key_scopes AS ks
 WHERE ks.id = sqlc.arg('scope_id')
 RETURNING id, created_at;
@@ -71,15 +67,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    cast(
+        w.is_watch_only
+        OR (a.origin_id = 1 AND acs.account_id IS NULL)
+        AS BOOLEAN
+    ) AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE a.scope_id = ? AND a.account_name = ?;
 
 -- name: GetAccountByScopeAndNumber :one
@@ -89,15 +92,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    cast(
+        w.is_watch_only
+        OR (a.origin_id = 1 AND acs.account_id IS NULL)
+        AS BOOLEAN
+    ) AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE a.scope_id = ? AND a.account_number = ?;
 
 -- name: GetAccountByWalletScopeAndName :one
@@ -107,15 +117,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    cast(
+        w.is_watch_only
+        OR (a.origin_id = 1 AND acs.account_id IS NULL)
+        AS BOOLEAN
+    ) AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE
     ks.wallet_id = ?
     AND ks.purpose = ?
@@ -129,15 +146,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    cast(
+        w.is_watch_only
+        OR (a.origin_id = 1 AND acs.account_id IS NULL)
+        AS BOOLEAN
+    ) AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE
     ks.wallet_id = ?
     AND ks.purpose = ?
@@ -152,7 +176,6 @@ SELECT
     a.origin_id,
     a.encrypted_public_key,
     a.master_fingerprint,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
@@ -160,9 +183,16 @@ SELECT
     ks.external_type_id,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    cast(
+        w.is_watch_only
+        OR (a.origin_id = 1 AND acs.account_id IS NULL)
+        AS BOOLEAN
+    ) AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE a.id = ?;
 
 -- name: ListAccountsByScope :many
@@ -173,15 +203,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    cast(
+        w.is_watch_only
+        OR (a.origin_id = 1 AND acs.account_id IS NULL)
+        AS BOOLEAN
+    ) AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE a.scope_id = ?
 ORDER BY a.account_number IS NULL, a.account_number;
 
@@ -193,15 +230,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    cast(
+        w.is_watch_only
+        OR (a.origin_id = 1 AND acs.account_id IS NULL)
+        AS BOOLEAN
+    ) AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE
     ks.wallet_id = ?
     AND ks.purpose = ?
@@ -216,15 +260,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    cast(
+        w.is_watch_only
+        OR (a.origin_id = 1 AND acs.account_id IS NULL)
+        AS BOOLEAN
+    ) AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE ks.wallet_id = ? AND a.account_name = ?
 ORDER BY a.account_number IS NULL, a.account_number;
 
@@ -236,15 +287,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    cast(
+        w.is_watch_only
+        OR (a.origin_id = 1 AND acs.account_id IS NULL)
+        AS BOOLEAN
+    ) AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE ks.wallet_id = ?
 ORDER BY a.account_number IS NULL, a.account_number;
 
@@ -286,16 +344,14 @@ INSERT INTO accounts (
     scope_id,
     account_number,
     account_name,
-    origin_id,
-    is_watch_only
+    origin_id
 )
 SELECT
     ks.wallet_id,
     ks.id AS scope_id,
     sqlc.arg('account_number') AS account_number,
     sqlc.arg('account_name') AS account_name,
-    sqlc.arg('origin_id') AS origin_id,
-    sqlc.arg('is_watch_only') AS is_watch_only
+    sqlc.arg('origin_id') AS origin_id
 FROM key_scopes AS ks
 WHERE ks.id = sqlc.arg('scope_id')
 RETURNING id, account_number, created_at;

--- a/wallet/internal/sql/sqlite/queries/addresses.sql
+++ b/wallet/internal/sql/sqlite/queries/addresses.sql
@@ -1,5 +1,6 @@
 -- name: InsertAddressSecret :exec
--- Inserts address secret information (private key, script) for imported addresses.
+-- Inserts address secret information (private key and/or script) for imported
+-- addresses.
 -- Not used for derived addresses (their keys are derived from account key).
 INSERT INTO address_secrets (
     address_id,
@@ -21,17 +22,19 @@ SELECT
     a.pub_key,
     a.created_at,
     acc.origin_id,
+    w.is_watch_only AS wallet_is_watch_only,
     s.encrypted_priv_key IS NOT NULL AS has_private_key,
     s.encrypted_script IS NOT NULL AS has_script
 FROM addresses AS a
 INNER JOIN accounts AS acc ON a.account_id = acc.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
 LEFT JOIN address_secrets AS s ON a.id = s.address_id
 WHERE a.script_pub_key = ? AND a.wallet_id = ?;
 
 -- name: GetAddressSecret :one
 -- Retrieves secret information for an address. Uses LEFT JOIN to distinguish:
 -- - Address exists with secret: returns full row
--- - Address exists without secret (watch-only/derived): returns row with NULL secret fields
+-- - Address exists without secret row: returns row with NULL secret fields
 -- - Address does not exist: returns no rows (sql.ErrNoRows)
 SELECT
     a.id AS address_id,
@@ -86,10 +89,12 @@ SELECT
     a.pub_key,
     a.created_at,
     acc.origin_id,
+    w.is_watch_only AS wallet_is_watch_only,
     s.encrypted_priv_key IS NOT NULL AS has_private_key,
     s.encrypted_script IS NOT NULL AS has_script
 FROM addresses AS a
 INNER JOIN accounts AS acc ON a.account_id = acc.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
 INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
 LEFT JOIN address_secrets AS s ON a.id = s.address_id
 WHERE

--- a/wallet/internal/sql/sqlite/sqlc/accounts.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/accounts.sql.go
@@ -39,8 +39,7 @@ INSERT INTO accounts (
     account_name,
     origin_id,
     encrypted_public_key,
-    master_fingerprint,
-    is_watch_only
+    master_fingerprint
 )
 SELECT
     ks.wallet_id,
@@ -52,8 +51,7 @@ SELECT
     ?2 AS account_name,
     ?3 AS origin_id,
     ?4 AS encrypted_public_key,
-    ?5 AS master_fingerprint,
-    ?6 AS is_watch_only
+    ?5 AS master_fingerprint
 FROM key_scopes AS ks
 WHERE ks.id = ?1
 RETURNING id, account_number, created_at
@@ -65,7 +63,6 @@ type CreateDerivedAccountParams struct {
 	OriginID           int64
 	EncryptedPublicKey []byte
 	MasterFingerprint  sql.NullInt64
-	IsWatchOnly        bool
 }
 
 type CreateDerivedAccountRow struct {
@@ -84,7 +81,6 @@ func (q *Queries) CreateDerivedAccount(ctx context.Context, arg CreateDerivedAcc
 		arg.OriginID,
 		arg.EncryptedPublicKey,
 		arg.MasterFingerprint,
-		arg.IsWatchOnly,
 	)
 	var i CreateDerivedAccountRow
 	err := row.Scan(&i.ID, &i.AccountNumber, &i.CreatedAt)
@@ -97,18 +93,16 @@ INSERT INTO accounts (
     scope_id,
     account_number,
     account_name,
-    origin_id,
-    is_watch_only
+    origin_id
 )
 SELECT
     ks.wallet_id,
     ks.id AS scope_id,
     ?1 AS account_number,
     ?2 AS account_name,
-    ?3 AS origin_id,
-    ?4 AS is_watch_only
+    ?3 AS origin_id
 FROM key_scopes AS ks
-WHERE ks.id = ?5
+WHERE ks.id = ?4
 RETURNING id, account_number, created_at
 `
 
@@ -116,7 +110,6 @@ type CreateDerivedAccountWithNumberParams struct {
 	AccountNumber sql.NullInt64
 	AccountName   string
 	OriginID      int64
-	IsWatchOnly   bool
 	ScopeID       int64
 }
 
@@ -133,7 +126,6 @@ func (q *Queries) CreateDerivedAccountWithNumber(ctx context.Context, arg Create
 		arg.AccountNumber,
 		arg.AccountName,
 		arg.OriginID,
-		arg.IsWatchOnly,
 		arg.ScopeID,
 	)
 	var i CreateDerivedAccountWithNumberRow
@@ -149,8 +141,7 @@ INSERT INTO accounts (
     account_name,
     origin_id,
     encrypted_public_key,
-    master_fingerprint,
-    is_watch_only
+    master_fingerprint
 )
 SELECT
     ks.wallet_id,
@@ -159,10 +150,9 @@ SELECT
     ?1 AS account_name,
     ?2 AS origin_id,
     ?3 AS encrypted_public_key,
-    ?4 AS master_fingerprint,
-    ?5 AS is_watch_only
+    ?4 AS master_fingerprint
 FROM key_scopes AS ks
-WHERE ks.id = ?6
+WHERE ks.id = ?5
 RETURNING id, created_at
 `
 
@@ -171,7 +161,6 @@ type CreateImportedAccountParams struct {
 	OriginID           int64
 	EncryptedPublicKey []byte
 	MasterFingerprint  sql.NullInt64
-	IsWatchOnly        bool
 	ScopeID            int64
 }
 
@@ -189,7 +178,6 @@ func (q *Queries) CreateImportedAccount(ctx context.Context, arg CreateImportedA
 		arg.OriginID,
 		arg.EncryptedPublicKey,
 		arg.MasterFingerprint,
-		arg.IsWatchOnly,
 		arg.ScopeID,
 	)
 	var i CreateImportedAccountRow
@@ -203,15 +191,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    cast(
+        w.is_watch_only
+        OR (a.origin_id = 1 AND acs.account_id IS NULL)
+        AS BOOLEAN
+    ) AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE a.scope_id = ? AND a.account_name = ?
 `
 
@@ -221,17 +216,18 @@ type GetAccountByScopeAndNameParams struct {
 }
 
 type GetAccountByScopeAndNameRow struct {
-	ID               int64
-	AccountNumber    sql.NullInt64
-	AccountName      string
-	OriginID         int64
-	IsWatchOnly      bool
-	CreatedAt        time.Time
-	Purpose          int64
-	CoinType         int64
-	ExternalKeyCount int64
-	InternalKeyCount int64
-	ImportedKeyCount int64
+	ID                int64
+	AccountNumber     sql.NullInt64
+	AccountName       string
+	OriginID          int64
+	CreatedAt         time.Time
+	Purpose           int64
+	CoinType          int64
+	ExternalKeyCount  int64
+	InternalKeyCount  int64
+	ImportedKeyCount  int64
+	WalletIsWatchOnly bool
+	IsWatchOnly       bool
 }
 
 // Returns a single account by scope id and account name.
@@ -243,13 +239,14 @@ func (q *Queries) GetAccountByScopeAndName(ctx context.Context, arg GetAccountBy
 		&i.AccountNumber,
 		&i.AccountName,
 		&i.OriginID,
-		&i.IsWatchOnly,
 		&i.CreatedAt,
 		&i.Purpose,
 		&i.CoinType,
 		&i.ExternalKeyCount,
 		&i.InternalKeyCount,
 		&i.ImportedKeyCount,
+		&i.WalletIsWatchOnly,
+		&i.IsWatchOnly,
 	)
 	return i, err
 }
@@ -260,15 +257,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    cast(
+        w.is_watch_only
+        OR (a.origin_id = 1 AND acs.account_id IS NULL)
+        AS BOOLEAN
+    ) AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE a.scope_id = ? AND a.account_number = ?
 `
 
@@ -278,17 +282,18 @@ type GetAccountByScopeAndNumberParams struct {
 }
 
 type GetAccountByScopeAndNumberRow struct {
-	ID               int64
-	AccountNumber    sql.NullInt64
-	AccountName      string
-	OriginID         int64
-	IsWatchOnly      bool
-	CreatedAt        time.Time
-	Purpose          int64
-	CoinType         int64
-	ExternalKeyCount int64
-	InternalKeyCount int64
-	ImportedKeyCount int64
+	ID                int64
+	AccountNumber     sql.NullInt64
+	AccountName       string
+	OriginID          int64
+	CreatedAt         time.Time
+	Purpose           int64
+	CoinType          int64
+	ExternalKeyCount  int64
+	InternalKeyCount  int64
+	ImportedKeyCount  int64
+	WalletIsWatchOnly bool
+	IsWatchOnly       bool
 }
 
 // Returns a single account by scope id and account number.
@@ -300,13 +305,14 @@ func (q *Queries) GetAccountByScopeAndNumber(ctx context.Context, arg GetAccount
 		&i.AccountNumber,
 		&i.AccountName,
 		&i.OriginID,
-		&i.IsWatchOnly,
 		&i.CreatedAt,
 		&i.Purpose,
 		&i.CoinType,
 		&i.ExternalKeyCount,
 		&i.InternalKeyCount,
 		&i.ImportedKeyCount,
+		&i.WalletIsWatchOnly,
+		&i.IsWatchOnly,
 	)
 	return i, err
 }
@@ -317,15 +323,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    cast(
+        w.is_watch_only
+        OR (a.origin_id = 1 AND acs.account_id IS NULL)
+        AS BOOLEAN
+    ) AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE
     ks.wallet_id = ?
     AND ks.purpose = ?
@@ -341,17 +354,18 @@ type GetAccountByWalletScopeAndNameParams struct {
 }
 
 type GetAccountByWalletScopeAndNameRow struct {
-	ID               int64
-	AccountNumber    sql.NullInt64
-	AccountName      string
-	OriginID         int64
-	IsWatchOnly      bool
-	CreatedAt        time.Time
-	Purpose          int64
-	CoinType         int64
-	ExternalKeyCount int64
-	InternalKeyCount int64
-	ImportedKeyCount int64
+	ID                int64
+	AccountNumber     sql.NullInt64
+	AccountName       string
+	OriginID          int64
+	CreatedAt         time.Time
+	Purpose           int64
+	CoinType          int64
+	ExternalKeyCount  int64
+	InternalKeyCount  int64
+	ImportedKeyCount  int64
+	WalletIsWatchOnly bool
+	IsWatchOnly       bool
 }
 
 // Returns a single account by wallet id, scope tuple, and account name.
@@ -368,13 +382,14 @@ func (q *Queries) GetAccountByWalletScopeAndName(ctx context.Context, arg GetAcc
 		&i.AccountNumber,
 		&i.AccountName,
 		&i.OriginID,
-		&i.IsWatchOnly,
 		&i.CreatedAt,
 		&i.Purpose,
 		&i.CoinType,
 		&i.ExternalKeyCount,
 		&i.InternalKeyCount,
 		&i.ImportedKeyCount,
+		&i.WalletIsWatchOnly,
+		&i.IsWatchOnly,
 	)
 	return i, err
 }
@@ -385,15 +400,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    cast(
+        w.is_watch_only
+        OR (a.origin_id = 1 AND acs.account_id IS NULL)
+        AS BOOLEAN
+    ) AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE
     ks.wallet_id = ?
     AND ks.purpose = ?
@@ -409,17 +431,18 @@ type GetAccountByWalletScopeAndNumberParams struct {
 }
 
 type GetAccountByWalletScopeAndNumberRow struct {
-	ID               int64
-	AccountNumber    sql.NullInt64
-	AccountName      string
-	OriginID         int64
-	IsWatchOnly      bool
-	CreatedAt        time.Time
-	Purpose          int64
-	CoinType         int64
-	ExternalKeyCount int64
-	InternalKeyCount int64
-	ImportedKeyCount int64
+	ID                int64
+	AccountNumber     sql.NullInt64
+	AccountName       string
+	OriginID          int64
+	CreatedAt         time.Time
+	Purpose           int64
+	CoinType          int64
+	ExternalKeyCount  int64
+	InternalKeyCount  int64
+	ImportedKeyCount  int64
+	WalletIsWatchOnly bool
+	IsWatchOnly       bool
 }
 
 // Returns a single account by wallet id, scope tuple, and account number.
@@ -436,13 +459,14 @@ func (q *Queries) GetAccountByWalletScopeAndNumber(ctx context.Context, arg GetA
 		&i.AccountNumber,
 		&i.AccountName,
 		&i.OriginID,
-		&i.IsWatchOnly,
 		&i.CreatedAt,
 		&i.Purpose,
 		&i.CoinType,
 		&i.ExternalKeyCount,
 		&i.InternalKeyCount,
 		&i.ImportedKeyCount,
+		&i.WalletIsWatchOnly,
+		&i.IsWatchOnly,
 	)
 	return i, err
 }
@@ -454,7 +478,6 @@ SELECT
     a.origin_id,
     a.encrypted_public_key,
     a.master_fingerprint,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
@@ -462,9 +485,16 @@ SELECT
     ks.external_type_id,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    cast(
+        w.is_watch_only
+        OR (a.origin_id = 1 AND acs.account_id IS NULL)
+        AS BOOLEAN
+    ) AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE a.id = ?
 `
 
@@ -474,7 +504,6 @@ type GetAccountPropsByIdRow struct {
 	OriginID           int64
 	EncryptedPublicKey []byte
 	MasterFingerprint  sql.NullInt64
-	IsWatchOnly        bool
 	CreatedAt          time.Time
 	Purpose            int64
 	CoinType           int64
@@ -483,6 +512,7 @@ type GetAccountPropsByIdRow struct {
 	ExternalKeyCount   int64
 	InternalKeyCount   int64
 	ImportedKeyCount   int64
+	IsWatchOnly        bool
 }
 
 // Returns full account properties by account id.
@@ -495,7 +525,6 @@ func (q *Queries) GetAccountPropsById(ctx context.Context, id int64) (GetAccount
 		&i.OriginID,
 		&i.EncryptedPublicKey,
 		&i.MasterFingerprint,
-		&i.IsWatchOnly,
 		&i.CreatedAt,
 		&i.Purpose,
 		&i.CoinType,
@@ -504,6 +533,7 @@ func (q *Queries) GetAccountPropsById(ctx context.Context, id int64) (GetAccount
 		&i.ExternalKeyCount,
 		&i.InternalKeyCount,
 		&i.ImportedKeyCount,
+		&i.IsWatchOnly,
 	)
 	return i, err
 }
@@ -546,31 +576,39 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    cast(
+        w.is_watch_only
+        OR (a.origin_id = 1 AND acs.account_id IS NULL)
+        AS BOOLEAN
+    ) AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE a.scope_id = ?
 ORDER BY a.account_number IS NULL, a.account_number
 `
 
 type ListAccountsByScopeRow struct {
-	ID               int64
-	AccountNumber    sql.NullInt64
-	AccountName      string
-	OriginID         int64
-	IsWatchOnly      bool
-	CreatedAt        time.Time
-	Purpose          int64
-	CoinType         int64
-	ExternalKeyCount int64
-	InternalKeyCount int64
-	ImportedKeyCount int64
+	ID                int64
+	AccountNumber     sql.NullInt64
+	AccountName       string
+	OriginID          int64
+	CreatedAt         time.Time
+	Purpose           int64
+	CoinType          int64
+	ExternalKeyCount  int64
+	InternalKeyCount  int64
+	ImportedKeyCount  int64
+	WalletIsWatchOnly bool
+	IsWatchOnly       bool
 }
 
 // Lists all accounts in a scope, ordered by account number. Imported accounts
@@ -589,13 +627,14 @@ func (q *Queries) ListAccountsByScope(ctx context.Context, scopeID int64) ([]Lis
 			&i.AccountNumber,
 			&i.AccountName,
 			&i.OriginID,
-			&i.IsWatchOnly,
 			&i.CreatedAt,
 			&i.Purpose,
 			&i.CoinType,
 			&i.ExternalKeyCount,
 			&i.InternalKeyCount,
 			&i.ImportedKeyCount,
+			&i.WalletIsWatchOnly,
+			&i.IsWatchOnly,
 		); err != nil {
 			return nil, err
 		}
@@ -616,31 +655,39 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    cast(
+        w.is_watch_only
+        OR (a.origin_id = 1 AND acs.account_id IS NULL)
+        AS BOOLEAN
+    ) AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE ks.wallet_id = ?
 ORDER BY a.account_number IS NULL, a.account_number
 `
 
 type ListAccountsByWalletRow struct {
-	ID               int64
-	AccountNumber    sql.NullInt64
-	AccountName      string
-	OriginID         int64
-	IsWatchOnly      bool
-	CreatedAt        time.Time
-	Purpose          int64
-	CoinType         int64
-	ExternalKeyCount int64
-	InternalKeyCount int64
-	ImportedKeyCount int64
+	ID                int64
+	AccountNumber     sql.NullInt64
+	AccountName       string
+	OriginID          int64
+	CreatedAt         time.Time
+	Purpose           int64
+	CoinType          int64
+	ExternalKeyCount  int64
+	InternalKeyCount  int64
+	ImportedKeyCount  int64
+	WalletIsWatchOnly bool
+	IsWatchOnly       bool
 }
 
 // Lists all accounts for a wallet, ordered by account number. Imported
@@ -659,13 +706,14 @@ func (q *Queries) ListAccountsByWallet(ctx context.Context, walletID int64) ([]L
 			&i.AccountNumber,
 			&i.AccountName,
 			&i.OriginID,
-			&i.IsWatchOnly,
 			&i.CreatedAt,
 			&i.Purpose,
 			&i.CoinType,
 			&i.ExternalKeyCount,
 			&i.InternalKeyCount,
 			&i.ImportedKeyCount,
+			&i.WalletIsWatchOnly,
+			&i.IsWatchOnly,
 		); err != nil {
 			return nil, err
 		}
@@ -686,15 +734,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    cast(
+        w.is_watch_only
+        OR (a.origin_id = 1 AND acs.account_id IS NULL)
+        AS BOOLEAN
+    ) AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE ks.wallet_id = ? AND a.account_name = ?
 ORDER BY a.account_number IS NULL, a.account_number
 `
@@ -705,17 +760,18 @@ type ListAccountsByWalletAndNameParams struct {
 }
 
 type ListAccountsByWalletAndNameRow struct {
-	ID               int64
-	AccountNumber    sql.NullInt64
-	AccountName      string
-	OriginID         int64
-	IsWatchOnly      bool
-	CreatedAt        time.Time
-	Purpose          int64
-	CoinType         int64
-	ExternalKeyCount int64
-	InternalKeyCount int64
-	ImportedKeyCount int64
+	ID                int64
+	AccountNumber     sql.NullInt64
+	AccountName       string
+	OriginID          int64
+	CreatedAt         time.Time
+	Purpose           int64
+	CoinType          int64
+	ExternalKeyCount  int64
+	InternalKeyCount  int64
+	ImportedKeyCount  int64
+	WalletIsWatchOnly bool
+	IsWatchOnly       bool
 }
 
 // Lists all accounts for a wallet filtered by account name, ordered by account
@@ -734,13 +790,14 @@ func (q *Queries) ListAccountsByWalletAndName(ctx context.Context, arg ListAccou
 			&i.AccountNumber,
 			&i.AccountName,
 			&i.OriginID,
-			&i.IsWatchOnly,
 			&i.CreatedAt,
 			&i.Purpose,
 			&i.CoinType,
 			&i.ExternalKeyCount,
 			&i.InternalKeyCount,
 			&i.ImportedKeyCount,
+			&i.WalletIsWatchOnly,
+			&i.IsWatchOnly,
 		); err != nil {
 			return nil, err
 		}
@@ -761,15 +818,22 @@ SELECT
     a.account_number,
     a.account_name,
     a.origin_id,
-    a.is_watch_only,
     a.created_at,
     ks.purpose,
     ks.coin_type,
     a.next_external_index AS external_key_count,
     a.next_internal_index AS internal_key_count,
-    a.imported_key_count
+    a.imported_key_count,
+    w.is_watch_only AS wallet_is_watch_only,
+    cast(
+        w.is_watch_only
+        OR (a.origin_id = 1 AND acs.account_id IS NULL)
+        AS BOOLEAN
+    ) AS is_watch_only
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
 WHERE
     ks.wallet_id = ?
     AND ks.purpose = ?
@@ -784,17 +848,18 @@ type ListAccountsByWalletScopeParams struct {
 }
 
 type ListAccountsByWalletScopeRow struct {
-	ID               int64
-	AccountNumber    sql.NullInt64
-	AccountName      string
-	OriginID         int64
-	IsWatchOnly      bool
-	CreatedAt        time.Time
-	Purpose          int64
-	CoinType         int64
-	ExternalKeyCount int64
-	InternalKeyCount int64
-	ImportedKeyCount int64
+	ID                int64
+	AccountNumber     sql.NullInt64
+	AccountName       string
+	OriginID          int64
+	CreatedAt         time.Time
+	Purpose           int64
+	CoinType          int64
+	ExternalKeyCount  int64
+	InternalKeyCount  int64
+	ImportedKeyCount  int64
+	WalletIsWatchOnly bool
+	IsWatchOnly       bool
 }
 
 // Lists all accounts for a wallet and scope tuple, ordered by account number.
@@ -813,13 +878,14 @@ func (q *Queries) ListAccountsByWalletScope(ctx context.Context, arg ListAccount
 			&i.AccountNumber,
 			&i.AccountName,
 			&i.OriginID,
-			&i.IsWatchOnly,
 			&i.CreatedAt,
 			&i.Purpose,
 			&i.CoinType,
 			&i.ExternalKeyCount,
 			&i.InternalKeyCount,
 			&i.ImportedKeyCount,
+			&i.WalletIsWatchOnly,
+			&i.IsWatchOnly,
 		); err != nil {
 			return nil, err
 		}

--- a/wallet/internal/sql/sqlite/sqlc/addresses.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/addresses.sql.go
@@ -110,10 +110,12 @@ SELECT
     a.pub_key,
     a.created_at,
     acc.origin_id,
+    w.is_watch_only AS wallet_is_watch_only,
     s.encrypted_priv_key IS NOT NULL AS has_private_key,
     s.encrypted_script IS NOT NULL AS has_script
 FROM addresses AS a
 INNER JOIN accounts AS acc ON a.account_id = acc.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
 LEFT JOIN address_secrets AS s ON a.id = s.address_id
 WHERE a.script_pub_key = ? AND a.wallet_id = ?
 `
@@ -124,17 +126,18 @@ type GetAddressByScriptPubKeyParams struct {
 }
 
 type GetAddressByScriptPubKeyRow struct {
-	ID            int64
-	AccountID     int64
-	TypeID        int64
-	AddressBranch sql.NullInt64
-	AddressIndex  sql.NullInt64
-	ScriptPubKey  []byte
-	PubKey        []byte
-	CreatedAt     time.Time
-	OriginID      int64
-	HasPrivateKey bool
-	HasScript     bool
+	ID                int64
+	AccountID         int64
+	TypeID            int64
+	AddressBranch     sql.NullInt64
+	AddressIndex      sql.NullInt64
+	ScriptPubKey      []byte
+	PubKey            []byte
+	CreatedAt         time.Time
+	OriginID          int64
+	WalletIsWatchOnly bool
+	HasPrivateKey     bool
+	HasScript         bool
 }
 
 // Retrieves an address by its script pubkey and account wallet.
@@ -151,6 +154,7 @@ func (q *Queries) GetAddressByScriptPubKey(ctx context.Context, arg GetAddressBy
 		&i.PubKey,
 		&i.CreatedAt,
 		&i.OriginID,
+		&i.WalletIsWatchOnly,
 		&i.HasPrivateKey,
 		&i.HasScript,
 	)
@@ -180,7 +184,7 @@ type GetAddressSecretRow struct {
 
 // Retrieves secret information for an address. Uses LEFT JOIN to distinguish:
 // - Address exists with secret: returns full row
-// - Address exists without secret (watch-only/derived): returns row with NULL secret fields
+// - Address exists without secret row: returns row with NULL secret fields
 // - Address does not exist: returns no rows (sql.ErrNoRows)
 func (q *Queries) GetAddressSecret(ctx context.Context, arg GetAddressSecretParams) (GetAddressSecretRow, error) {
 	row := q.queryRow(ctx, q.getAddressSecretStmt, GetAddressSecret, arg.WalletID, arg.ID)
@@ -205,7 +209,8 @@ type InsertAddressSecretParams struct {
 	EncryptedScript  []byte
 }
 
-// Inserts address secret information (private key, script) for imported addresses.
+// Inserts address secret information (private key and/or script) for imported
+// addresses.
 // Not used for derived addresses (their keys are derived from account key).
 func (q *Queries) InsertAddressSecret(ctx context.Context, arg InsertAddressSecretParams) error {
 	_, err := q.exec(ctx, q.insertAddressSecretStmt, InsertAddressSecret, arg.AddressID, arg.EncryptedPrivKey, arg.EncryptedScript)
@@ -223,10 +228,12 @@ SELECT
     a.pub_key,
     a.created_at,
     acc.origin_id,
+    w.is_watch_only AS wallet_is_watch_only,
     s.encrypted_priv_key IS NOT NULL AS has_private_key,
     s.encrypted_script IS NOT NULL AS has_script
 FROM addresses AS a
 INNER JOIN accounts AS acc ON a.account_id = acc.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
 INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
 LEFT JOIN address_secrets AS s ON a.id = s.address_id
 WHERE
@@ -256,17 +263,18 @@ type ListAddressesByAccountParams struct {
 }
 
 type ListAddressesByAccountRow struct {
-	ID            int64
-	AccountID     int64
-	TypeID        int64
-	AddressBranch sql.NullInt64
-	AddressIndex  sql.NullInt64
-	ScriptPubKey  []byte
-	PubKey        []byte
-	CreatedAt     time.Time
-	OriginID      int64
-	HasPrivateKey bool
-	HasScript     bool
+	ID                int64
+	AccountID         int64
+	TypeID            int64
+	AddressBranch     sql.NullInt64
+	AddressIndex      sql.NullInt64
+	ScriptPubKey      []byte
+	PubKey            []byte
+	CreatedAt         time.Time
+	OriginID          int64
+	WalletIsWatchOnly bool
+	HasPrivateKey     bool
+	HasScript         bool
 }
 
 // Lists addresses for an account identified by wallet_id, key scope
@@ -299,6 +307,7 @@ func (q *Queries) ListAddressesByAccount(ctx context.Context, arg ListAddressesB
 			&i.PubKey,
 			&i.CreatedAt,
 			&i.OriginID,
+			&i.WalletIsWatchOnly,
 			&i.HasPrivateKey,
 			&i.HasScript,
 		); err != nil {

--- a/wallet/internal/sql/sqlite/sqlc/models.go
+++ b/wallet/internal/sql/sqlite/sqlc/models.go
@@ -16,7 +16,6 @@ type Account struct {
 	AccountNumber      sql.NullInt64
 	AccountName        string
 	OriginID           int64
-	IsWatchOnly        bool
 	MasterFingerprint  sql.NullInt64
 	EncryptedPublicKey []byte
 	CreatedAt          time.Time

--- a/wallet/internal/sql/sqlite/sqlc/querier.go
+++ b/wallet/internal/sql/sqlite/sqlc/querier.go
@@ -151,7 +151,7 @@ type Querier interface {
 	GetAddressByScriptPubKey(ctx context.Context, arg GetAddressByScriptPubKeyParams) (GetAddressByScriptPubKeyRow, error)
 	// Retrieves secret information for an address. Uses LEFT JOIN to distinguish:
 	// - Address exists with secret: returns full row
-	// - Address exists without secret (watch-only/derived): returns row with NULL secret fields
+	// - Address exists without secret row: returns row with NULL secret fields
 	// - Address does not exist: returns no rows (sql.ErrNoRows)
 	GetAddressSecret(ctx context.Context, arg GetAddressSecretParams) (GetAddressSecretRow, error)
 	// Returns a single address type by its ID.
@@ -244,7 +244,8 @@ type Querier interface {
 	// - Targets one wallet-scoped outpoint through the parent tx lookup plus the
 	//   unique `(tx_id, output_index)` key.
 	HasInvalidWalletUtxoByOutpoint(ctx context.Context, arg HasInvalidWalletUtxoByOutpointParams) (bool, error)
-	// Inserts address secret information (private key, script) for imported addresses.
+	// Inserts address secret information (private key and/or script) for imported
+	// addresses.
 	// Not used for derived addresses (their keys are derived from account key).
 	InsertAddressSecret(ctx context.Context, arg InsertAddressSecretParams) error
 	InsertBlock(ctx context.Context, arg InsertBlockParams) error


### PR DESCRIPTION
disambiguates watch-only
- Enforces wallet/account/address watch-only rules across PostgreSQL and SQLite.
- Treats script-only imported addresses as watch-only, while still preserving their encrypted scripts.
- Removes account-table watch-only state as an independent source of truth because account watch-only behavior is derived from wallet mode and imported-account semantics; duplicating it risks drift.
- Keeps the default imported account as a mixed container in non-watch-only wallets so it can hold both watch-only and spendable imported addresses.

The goal is to prevent SQL paths from accepting private-key-bearing data under watch-only wallets/accounts, without breaking valid script-only imports or mixed imported-address behavior in normal wallets.

Related to https://github.com/btcsuite/btcwallet/pull/1162#discussion_r2791907008

Next https://github.com/btcsuite/btcwallet/pull/1222