### PR TITLE
wallet: enforce watch-only invariants in sql

### DIFF
--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -188,16 +188,20 @@ type AccountStore interface {
 	// CreateDerivedAccount creates a new derived account with the given name
 	// and scope.
 	//
-	// If the key scope does not exist, it will be automatically created with
-	// NULL encrypted keys using the address schema from ScopeAddrMap.
+	// If the key scope does not exist, it will be automatically created
+	// using the address schema from ScopeAddrMap. Spendable scopes may
+	// later gain a key_scope_secrets row; watch-only scopes remain absent
+	// from that table.
 	CreateDerivedAccount(ctx context.Context,
 		params CreateDerivedAccountParams) (*AccountInfo, error)
 
 	// CreateImportedAccount stores an imported account identified by an
 	// extended public key.
 	//
-	// If the key scope does not exist, it will be automatically created with
-	// NULL encrypted keys using the address schema from ScopeAddrMap.
+	// If the key scope does not exist, it will be automatically created
+	// using the address schema from ScopeAddrMap. Spendable scopes may
+	// later gain a key_scope_secrets row; watch-only scopes remain absent
+	// from that table.
 	CreateImportedAccount(ctx context.Context,
 		params CreateImportedAccountParams) (*AccountProperties, error)
 

--- a/wallet/internal/db/itest/account_store_test.go
+++ b/wallet/internal/db/itest/account_store_test.go
@@ -100,6 +100,54 @@ func TestCreateImportedAccountRejectsWalletScopeMismatch(t *testing.T) {
 	require.ErrorContains(t, err, "constraint")
 }
 
+// TestAccountWalletIDImmutable verifies that raw account reparenting updates
+// cannot change wallet ownership after insert.
+func TestAccountWalletIDImmutable(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	queries := store.Queries()
+
+	sourceWalletID := newWallet(t, store, "account-wallet-immutable-source")
+	targetWalletID := newWallet(t, store, "account-wallet-immutable-target")
+
+	CreateImportedAccount(
+		t, store, sourceWalletID, db.KeyScopeBIP0084, "source-imported",
+	)
+	createDerivedAccount(
+		t, store, targetWalletID, db.KeyScopeBIP0084, "target-derived",
+	)
+
+	sourceScopeID := GetKeyScopeID(
+		t, queries, sourceWalletID, db.KeyScopeBIP0084,
+	)
+	targetScopeID := GetKeyScopeID(
+		t, queries, targetWalletID, db.KeyScopeBIP0084,
+	)
+	sourceAccountID := GetAccountID(
+		t, queries, sourceScopeID, "source-imported",
+	)
+
+	err := reparentAccountRaw(
+		t, store.DB(), sourceAccountID, targetWalletID, targetScopeID,
+	)
+	require.Error(t, err)
+	requireDriverConstraintError(t, err)
+
+	accountInfo, err := store.GetAccount(
+		t.Context(), getAccountQueryByName(
+			sourceWalletID, db.KeyScopeBIP0084, "source-imported",
+		),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, accountInfo)
+	require.Equal(t, "source-imported", accountInfo.AccountName)
+	require.Equal(
+		t, sourceAccountID,
+		GetAccountID(t, queries, sourceScopeID, "source-imported"),
+	)
+}
+
 // TestWatchOnlyAccountSecretTriggers verifies that account_secrets rejects
 // watch-only parent accounts while still allowing inserts and updates for
 // non-watch-only parents.

--- a/wallet/internal/db/itest/account_store_test.go
+++ b/wallet/internal/db/itest/account_store_test.go
@@ -100,6 +100,116 @@ func TestCreateImportedAccountRejectsWalletScopeMismatch(t *testing.T) {
 	require.ErrorContains(t, err, "constraint")
 }
 
+// TestWatchOnlyAccountSecretTriggers verifies that account_secrets rejects
+// watch-only parent accounts while still allowing inserts and updates for
+// non-watch-only parents.
+func TestWatchOnlyAccountSecretTriggers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("watch-only insert is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		store := NewTestStore(t)
+		queries := store.Queries()
+
+		walletInfo, err := store.CreateWallet(
+			t.Context(),
+			CreateWatchOnlyWalletParams("watch-only-account-insert"),
+		)
+		require.NoError(t, err)
+
+		props, err := store.CreateImportedAccount(
+			t.Context(), db.CreateImportedAccountParams{
+				WalletID:           walletInfo.ID,
+				Name:               "watch-only-imported",
+				Scope:              db.KeyScopeBIP0084,
+				EncryptedPublicKey: RandomBytes(32),
+			},
+		)
+		require.NoError(t, err)
+		require.True(t, props.IsWatchOnly)
+
+		scopeID := GetKeyScopeID(t, queries, walletInfo.ID, db.KeyScopeBIP0084)
+		accountID := GetAccountID(t, queries, scopeID, "watch-only-imported")
+
+		err = insertAccountSecretRaw(
+			t, store.DB(), accountID, RandomBytes(32),
+		)
+		require.Error(t, err)
+		requireDriverConstraintError(t, err)
+	})
+
+	t.Run(
+		"watch-only empty-but-non-nil insert is rejected",
+		func(t *testing.T) {
+			t.Parallel()
+
+			store := NewTestStore(t)
+			queries := store.Queries()
+
+			walletInfo, err := store.CreateWallet(
+				t.Context(),
+				CreateWatchOnlyWalletParams("watch-only-account-empty"),
+			)
+			require.NoError(t, err)
+
+			props, err := store.CreateImportedAccount(
+				t.Context(), db.CreateImportedAccountParams{
+					WalletID:           walletInfo.ID,
+					Name:               "watch-only-empty",
+					Scope:              db.KeyScopeBIP0084,
+					EncryptedPublicKey: RandomBytes(32),
+				},
+			)
+			require.NoError(t, err)
+			require.True(t, props.IsWatchOnly)
+
+			scopeID := GetKeyScopeID(
+				t, queries, walletInfo.ID, db.KeyScopeBIP0084,
+			)
+			accountID := GetAccountID(
+				t, queries, scopeID, "watch-only-empty",
+			)
+
+			err = insertAccountSecretRaw(t, store.DB(), accountID, []byte{})
+			require.Error(t, err)
+			requireDriverConstraintError(t, err)
+		},
+	)
+
+	t.Run("non-watch-only insert and update succeed", func(t *testing.T) {
+		t.Parallel()
+
+		store := NewTestStore(t)
+		queries := store.Queries()
+		walletID := newWallet(t, store, "spendable-account-secret")
+
+		props, err := store.CreateImportedAccount(
+			t.Context(), db.CreateImportedAccountParams{
+				WalletID:           walletID,
+				Name:               "spendable-imported",
+				Scope:              db.KeyScopeBIP0084,
+				EncryptedPublicKey: RandomBytes(32),
+			},
+		)
+		require.NoError(t, err)
+		require.True(t, props.IsWatchOnly)
+
+		scopeID := GetKeyScopeID(t, queries, walletID, db.KeyScopeBIP0084)
+		accountID := GetAccountID(t, queries, scopeID, "spendable-imported")
+
+		err = insertAccountSecretRaw(
+			t, store.DB(), accountID, RandomBytes(32),
+		)
+		require.NoError(t, err)
+
+		err = updateAccountSecretRaw(
+			t, store.DB(), accountID, RandomBytes(32),
+		)
+		require.NoError(t, err)
+	})
+}
+
 // TestCreateDerivedAccountErrors verifies that CreateDerivedAccount returns
 // appropriate errors for invalid inputs.
 func TestCreateDerivedAccountErrors(t *testing.T) {

--- a/wallet/internal/db/itest/address_store_test.go
+++ b/wallet/internal/db/itest/address_store_test.go
@@ -1121,6 +1121,61 @@ func TestCreateDerivedAddressRejectsWalletAccountMismatch(t *testing.T) {
 	require.ErrorContains(t, err, "constraint")
 }
 
+// TestAddressWalletIDImmutable verifies that raw address reparenting updates
+// cannot change wallet ownership after insert.
+func TestAddressWalletIDImmutable(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	queries := store.Queries()
+	sourceWalletID := newWallet(t, store, "address-wallet-immutable-source")
+	targetWalletID := newWallet(t, store, "address-wallet-immutable-target")
+
+	CreateImportedAccount(
+		t, store, sourceWalletID, db.KeyScopeBIP0084,
+		db.DefaultImportedAccountName,
+	)
+	CreateImportedAccount(
+		t, store, targetWalletID, db.KeyScopeBIP0084,
+		db.DefaultImportedAccountName,
+	)
+
+	scriptPubKey := RandomBytes(32)
+	info, err := store.NewImportedAddress(
+		t.Context(), db.NewImportedAddressParams{
+			WalletID:     sourceWalletID,
+			Scope:        db.KeyScopeBIP0084,
+			AddressType:  db.WitnessPubKey,
+			PubKey:       RandomBytes(33),
+			ScriptPubKey: scriptPubKey,
+		},
+	)
+	require.NoError(t, err)
+
+	targetScopeID := GetKeyScopeID(
+		t, queries, targetWalletID, db.KeyScopeBIP0084,
+	)
+	targetAccountID := GetAccountID(
+		t, queries, targetScopeID, db.DefaultImportedAccountName,
+	)
+
+	err = reparentAddressRaw(
+		t, store.DB(), int64(info.ID), targetWalletID, targetAccountID,
+	)
+	require.Error(t, err)
+	requireDriverConstraintError(t, err)
+
+	addressInfo, err := store.GetAddress(
+		t.Context(), db.GetAddressQuery{
+			WalletID:     sourceWalletID,
+			ScriptPubKey: scriptPubKey,
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, addressInfo)
+	require.Equal(t, info.ID, addressInfo.ID)
+}
+
 // TestGetAddressSecret verifies that GetAddressSecret correctly retrieves
 // address secrets for watch-only imported addresses and returns an error for
 // spendable addresses or non-existent address IDs.

--- a/wallet/internal/db/itest/address_store_test.go
+++ b/wallet/internal/db/itest/address_store_test.go
@@ -285,9 +285,40 @@ func TestNewImportedAddressWithEncryptedScript(t *testing.T) {
 	store := NewTestStore(t)
 	queries := store.Queries()
 	walletID := newWallet(t, store, "wallet-encrypted-script")
-	CreateImportedAccount(t, store, walletID, db.KeyScopeBIP0044, "imported")
-	CreateImportedAccount(
-		t, store, walletID, db.KeyScopeBIP0049Plus, "imported",
+
+	_, err := store.CreateImportedAccount(
+		t.Context(), db.CreateImportedAccountParams{
+			WalletID:            walletID,
+			Name:                db.DefaultImportedAccountName,
+			Scope:               db.KeyScopeBIP0044,
+			EncryptedPublicKey:  RandomBytes(32),
+			EncryptedPrivateKey: RandomBytes(32),
+		},
+	)
+	require.NoError(t, err)
+
+	_, err = store.CreateImportedAccount(
+		t.Context(), db.CreateImportedAccountParams{
+			WalletID:            walletID,
+			Name:                db.DefaultImportedAccountName,
+			Scope:               db.KeyScopeBIP0049Plus,
+			EncryptedPublicKey:  RandomBytes(32),
+			EncryptedPrivateKey: RandomBytes(32),
+		},
+	)
+	require.NoError(t, err)
+
+	require.False(
+		t, getAccountByName(
+			t, store, walletID, db.KeyScopeBIP0044,
+			db.DefaultImportedAccountName,
+		).IsWatchOnly,
+	)
+	require.False(
+		t, getAccountByName(
+			t, store, walletID, db.KeyScopeBIP0049Plus,
+			db.DefaultImportedAccountName,
+		).IsWatchOnly,
 	)
 
 	redeemScript := RandomBytes(32)
@@ -366,6 +397,7 @@ func TestNewImportedAddressWithEncryptedScript(t *testing.T) {
 			require.NotNil(t, info.PubKey)
 			require.NotNil(t, info.ScriptPubKey)
 			require.Equal(t, tc.expectedAddrType, info.AddrType)
+			require.Equal(t, !tc.hasPrivateKey, info.IsWatchOnly)
 
 			addressID := getAddressID(
 				t, queries, params.ScriptPubKey, walletID,
@@ -645,6 +677,140 @@ func TestWatchOnlyHierarchyAddressRules(t *testing.T) {
 			require.Equal(t, tc.wantWatchOnly, isWatchOnly)
 		})
 	}
+}
+
+// TestWatchOnlyAddressSecretTriggers verifies that address_secrets rejects
+// private-key writes for watch-only imported addresses while still allowing
+// inserts and updates for non-watch-only parent wallets.
+func TestWatchOnlyAddressSecretTriggers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("watch-only insert is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		store := NewTestStore(t)
+
+		walletInfo, err := store.CreateWallet(
+			t.Context(),
+			CreateWatchOnlyWalletParams("watch-only-address-secret-insert"),
+		)
+		require.NoError(t, err)
+
+		CreateImportedAccount(
+			t, store, walletInfo.ID, db.KeyScopeBIP0084,
+			db.DefaultImportedAccountName,
+		)
+
+		info, err := store.NewImportedAddress(
+			t.Context(), db.NewImportedAddressParams{
+				WalletID:     walletInfo.ID,
+				Scope:        db.KeyScopeBIP0084,
+				AddressType:  db.WitnessPubKey,
+				PubKey:       RandomBytes(33),
+				ScriptPubKey: RandomBytes(32),
+			},
+		)
+		require.NoError(t, err)
+
+		err = insertAddressSecretRaw(
+			t, store.DB(), int64(info.ID), RandomBytes(32), nil,
+		)
+		require.Error(t, err)
+		requireDriverConstraintError(t, err)
+	})
+
+	t.Run("watch-only update is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		store := NewTestStore(t)
+
+		walletInfo, err := store.CreateWallet(
+			t.Context(),
+			CreateWatchOnlyWalletParams("watch-only-address-secret-update"),
+		)
+		require.NoError(t, err)
+
+		CreateImportedAccount(
+			t, store, walletInfo.ID, db.KeyScopeBIP0084,
+			db.DefaultImportedAccountName,
+		)
+
+		info, err := store.NewImportedAddress(
+			t.Context(), db.NewImportedAddressParams{
+				WalletID:        walletInfo.ID,
+				Scope:           db.KeyScopeBIP0084,
+				AddressType:     db.WitnessScript,
+				PubKey:          RandomBytes(33),
+				ScriptPubKey:    RandomBytes(32),
+				EncryptedScript: RandomBytes(48),
+			},
+		)
+		require.NoError(t, err)
+		require.True(t, info.IsWatchOnly)
+
+		err = updateAddressSecretRaw(
+			t, store.DB(), int64(info.ID), RandomBytes(32), RandomBytes(48),
+		)
+		require.Error(t, err)
+		requireDriverConstraintError(t, err)
+	})
+
+	t.Run("non-watch-only insert and update succeed", func(t *testing.T) {
+		t.Parallel()
+
+		store := NewTestStore(t)
+
+		walletID := newWallet(t, store, "spendable-address-secret-trigger")
+		CreateImportedAccount(
+			t, store, walletID, db.KeyScopeBIP0084,
+			db.DefaultImportedAccountName,
+		)
+
+		info, err := store.NewImportedAddress(
+			t.Context(), db.NewImportedAddressParams{
+				WalletID:     walletID,
+				Scope:        db.KeyScopeBIP0084,
+				AddressType:  db.WitnessPubKey,
+				PubKey:       RandomBytes(33),
+				ScriptPubKey: RandomBytes(32),
+			},
+		)
+		require.NoError(t, err)
+		require.True(t, info.IsWatchOnly)
+
+		insertedPrivKey := RandomBytes(32)
+		err = insertAddressSecretRaw(
+			t, store.DB(), int64(info.ID), insertedPrivKey, nil,
+		)
+		require.NoError(t, err)
+
+		secret, err := store.GetAddressSecret(
+			t.Context(), db.GetAddressSecretQuery{
+				WalletID:  walletID,
+				AddressID: info.ID,
+			},
+		)
+		require.NoError(t, err)
+		require.Equal(t, insertedPrivKey, secret.EncryptedPrivKey)
+		require.Empty(t, secret.EncryptedScript)
+
+		updatedPrivKey := RandomBytes(32)
+		updatedScript := RandomBytes(48)
+		err = updateAddressSecretRaw(
+			t, store.DB(), int64(info.ID), updatedPrivKey, updatedScript,
+		)
+		require.NoError(t, err)
+
+		secret, err = store.GetAddressSecret(
+			t.Context(), db.GetAddressSecretQuery{
+				WalletID:  walletID,
+				AddressID: info.ID,
+			},
+		)
+		require.NoError(t, err)
+		require.Equal(t, updatedPrivKey, secret.EncryptedPrivKey)
+		require.Equal(t, updatedScript, secret.EncryptedScript)
+	})
 }
 
 // TestImportedAddressCounterInsertDelete verifies that imported address inserts
@@ -1250,6 +1416,7 @@ func TestListAddresses(t *testing.T) {
 					require.Equal(t, uint32(i), addr.Index)
 					require.Equal(t, uint32(0), addr.Branch)
 					require.Equal(t, db.DerivedAccount, addr.Origin)
+					require.False(t, addr.IsWatchOnly)
 				}
 
 				require.False(t, addrs[0].IsWatchOnly)

--- a/wallet/internal/db/itest/fixtures_pg_test.go
+++ b/wallet/internal/db/itest/fixtures_pg_test.go
@@ -281,6 +281,37 @@ func updateWalletSecretRaw(t *testing.T, dbConn *sql.DB, walletID uint32,
 	return nil
 }
 
+// updateWalletWatchOnlyRaw updates the watch-only flag directly through the
+// database so tests can validate its immutability trigger.
+func updateWalletWatchOnlyRaw(t *testing.T, dbConn *sql.DB, walletID uint32,
+	isWatchOnly bool) error {
+
+	t.Helper()
+
+	const stmt = `
+		UPDATE wallets
+		SET is_watch_only = $1
+		WHERE id = $2`
+
+	result, err := dbConn.ExecContext(
+		t.Context(), stmt, isWatchOnly, int64(walletID),
+	)
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rows != 1 {
+		return fmt.Errorf("%w: got %d", errUnexpectedUpdatedRows, rows)
+	}
+
+	return nil
+}
+
 // CreateAddressWithIndex creates a derived address with a specific address
 // index. Used to test address index overflow without creating billions of
 // addresses.

--- a/wallet/internal/db/itest/fixtures_pg_test.go
+++ b/wallet/internal/db/itest/fixtures_pg_test.go
@@ -391,6 +391,102 @@ func updateWalletWatchOnlyRaw(t *testing.T, dbConn *sql.DB, walletID uint32,
 	return nil
 }
 
+// updateKeyScopeWalletIDRaw updates a key scope wallet_id directly through the
+// database so tests can validate its immutability trigger.
+func updateKeyScopeWalletIDRaw(t *testing.T, dbConn *sql.DB, scopeID int64,
+	walletID uint32) error {
+
+	t.Helper()
+
+	const stmt = `
+		UPDATE key_scopes
+		SET wallet_id = $1
+		WHERE id = $2`
+
+	result, err := dbConn.ExecContext(
+		t.Context(), stmt, int64(walletID), scopeID,
+	)
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rows != 1 {
+		return fmt.Errorf("%w: got %d", errUnexpectedUpdatedRows, rows)
+	}
+
+	return nil
+}
+
+// reparentAccountRaw updates an account wallet/scope pair directly through the
+// database so tests can validate wallet ownership immutability after insert.
+func reparentAccountRaw(t *testing.T, dbConn *sql.DB, accountID int64,
+	walletID uint32, scopeID int64) error {
+
+	t.Helper()
+
+	const stmt = `
+		UPDATE accounts
+		SET wallet_id = $1,
+			scope_id = $2
+		WHERE id = $3`
+
+	result, err := dbConn.ExecContext(
+		t.Context(), stmt, int64(walletID), scopeID, accountID,
+	)
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rows != 1 {
+		return fmt.Errorf("%w: got %d", errUnexpectedUpdatedRows, rows)
+	}
+
+	return nil
+}
+
+// reparentAddressRaw updates an address wallet/account pair directly through
+// the database so tests can validate wallet ownership immutability after
+// insert.
+func reparentAddressRaw(t *testing.T, dbConn *sql.DB, addressID int64,
+	walletID uint32, accountID int64) error {
+
+	t.Helper()
+
+	const stmt = `
+		UPDATE addresses
+		SET wallet_id = $1,
+			account_id = $2
+		WHERE id = $3`
+
+	result, err := dbConn.ExecContext(
+		t.Context(), stmt, int64(walletID), accountID, addressID,
+	)
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rows != 1 {
+		return fmt.Errorf("%w: got %d", errUnexpectedUpdatedRows, rows)
+	}
+
+	return nil
+}
+
 // CreateAddressWithIndex creates a derived address with a specific address
 // index. Used to test address index overflow without creating billions of
 // addresses.

--- a/wallet/internal/db/itest/fixtures_pg_test.go
+++ b/wallet/internal/db/itest/fixtures_pg_test.go
@@ -14,10 +14,14 @@ import (
 	dberr "github.com/btcsuite/btcwallet/wallet/internal/db/err"
 	"github.com/btcsuite/btcwallet/wallet/internal/db/pg"
 	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
 )
 
-var errUnexpectedDeletedRows = errors.New("unexpected deleted row count")
+var (
+	errUnexpectedDeletedRows = errors.New("unexpected deleted row count")
+	errUnexpectedUpdatedRows = errors.New("unexpected updated row count")
+)
 
 // testBackend returns the SQL backend expected by PostgreSQL itests.
 func testBackend() dberr.Backend {
@@ -35,6 +39,16 @@ func requireConstraintSQLError(t *testing.T, err error) {
 	require.Equal(t, dberr.ReasonConstraint, sqlErr.Reason)
 	require.Equal(t, dberr.ClassPermanent, sqlErr.Class())
 	require.ErrorIs(t, err, sqlErr)
+}
+
+// requireDriverConstraintError verifies that a direct PostgreSQL driver
+// error is a constraint violation before store-level error wrapping occurs.
+func requireDriverConstraintError(t *testing.T, err error) {
+	t.Helper()
+
+	var pgErr *pgconn.PgError
+	require.ErrorAs(t, err, &pgErr)
+	require.Equal(t, "23514", pgErr.Code)
 }
 
 // CreateBlockFixture inserts a test block into the database and returns it.
@@ -124,6 +138,147 @@ func createImportedAccountRaw(t *testing.T, dbConn *sql.DB, walletID uint32,
 	)
 
 	return err
+}
+
+// insertAccountSecretRaw inserts an account secret directly through the
+// database so tests can validate watch-only triggers on account_secrets.
+func insertAccountSecretRaw(t *testing.T, dbConn *sql.DB, accountID int64,
+	encryptedPrivateKey []byte) error {
+
+	t.Helper()
+
+	const stmt = `
+		INSERT INTO account_secrets (
+			account_id,
+			encrypted_private_key
+		) VALUES ($1, $2)`
+
+	_, err := dbConn.ExecContext(
+		t.Context(), stmt, accountID, encryptedPrivateKey,
+	)
+
+	return err
+}
+
+// updateAccountSecretRaw updates an account secret directly through the
+// database so tests can validate watch-only triggers on account_secrets.
+func updateAccountSecretRaw(t *testing.T, dbConn *sql.DB, accountID int64,
+	encryptedPrivateKey []byte) error {
+
+	t.Helper()
+
+	const stmt = `
+		UPDATE account_secrets
+		SET encrypted_private_key = $1
+		WHERE account_id = $2`
+
+	result, err := dbConn.ExecContext(
+		t.Context(), stmt, encryptedPrivateKey, accountID,
+	)
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rows != 1 {
+		return fmt.Errorf("%w: got %d", errUnexpectedUpdatedRows, rows)
+	}
+
+	return nil
+}
+
+// deleteWalletSecretRaw deletes a wallet secret row directly through the
+// database so tests can re-exercise wallet_secrets insert triggers.
+func deleteWalletSecretRaw(t *testing.T, dbConn *sql.DB,
+	walletID uint32) error {
+
+	t.Helper()
+
+	const stmt = `
+		DELETE FROM wallet_secrets
+		WHERE wallet_id = $1`
+
+	result, err := dbConn.ExecContext(t.Context(), stmt, int64(walletID))
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rows != 1 {
+		return fmt.Errorf("%w: got %d", errUnexpectedDeletedRows, rows)
+	}
+
+	return nil
+}
+
+// insertWalletSecretRaw inserts a wallet secret directly through the database
+// so tests can validate watch-only triggers on wallet_secrets.
+func insertWalletSecretRaw(t *testing.T, dbConn *sql.DB, walletID uint32,
+	masterPrivParams []byte, encryptedCryptoPrivKey []byte,
+	encryptedCryptoScriptKey []byte, encryptedMasterHDPrivKey []byte) error {
+
+	t.Helper()
+
+	const stmt = `
+		INSERT INTO wallet_secrets (
+			wallet_id,
+			master_priv_params,
+			encrypted_crypto_priv_key,
+			encrypted_crypto_script_key,
+			encrypted_master_hd_priv_key
+		) VALUES ($1, $2, $3, $4, $5)`
+
+	_, err := dbConn.ExecContext(
+		t.Context(), stmt, int64(walletID), masterPrivParams,
+		encryptedCryptoPrivKey, encryptedCryptoScriptKey,
+		encryptedMasterHDPrivKey,
+	)
+
+	return err
+}
+
+// updateWalletSecretRaw updates a wallet secret directly through the database
+// so tests can validate watch-only triggers on wallet_secrets.
+func updateWalletSecretRaw(t *testing.T, dbConn *sql.DB, walletID uint32,
+	masterPrivParams []byte, encryptedCryptoPrivKey []byte,
+	encryptedCryptoScriptKey []byte, encryptedMasterHDPrivKey []byte) error {
+
+	t.Helper()
+
+	const stmt = `
+		UPDATE wallet_secrets
+		SET master_priv_params = $1,
+			encrypted_crypto_priv_key = $2,
+			encrypted_crypto_script_key = $3,
+			encrypted_master_hd_priv_key = $4
+		WHERE wallet_id = $5`
+
+	result, err := dbConn.ExecContext(
+		t.Context(), stmt, masterPrivParams, encryptedCryptoPrivKey,
+		encryptedCryptoScriptKey, encryptedMasterHDPrivKey, int64(walletID),
+	)
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rows != 1 {
+		return fmt.Errorf("%w: got %d", errUnexpectedUpdatedRows, rows)
+	}
+
+	return nil
 }
 
 // CreateAddressWithIndex creates a derived address with a specific address
@@ -291,6 +446,59 @@ func createImportedAddressRaw(ctx context.Context, queries *sqlc.Queries,
 	)
 
 	return err
+}
+
+// insertAddressSecretRaw inserts an address secret directly through the
+// database so tests can validate watch-only triggers on address_secrets.
+func insertAddressSecretRaw(t *testing.T, dbConn *sql.DB, addressID int64,
+	encryptedPrivKey []byte, encryptedScript []byte) error {
+
+	t.Helper()
+
+	const stmt = `
+		INSERT INTO address_secrets (
+			address_id,
+			encrypted_priv_key,
+			encrypted_script
+		) VALUES ($1, $2, $3)`
+
+	_, err := dbConn.ExecContext(
+		t.Context(), stmt, addressID, encryptedPrivKey, encryptedScript,
+	)
+
+	return err
+}
+
+// updateAddressSecretRaw updates an address secret directly through the
+// database so tests can validate watch-only triggers on address_secrets.
+func updateAddressSecretRaw(t *testing.T, dbConn *sql.DB, addressID int64,
+	encryptedPrivKey []byte, encryptedScript []byte) error {
+
+	t.Helper()
+
+	const stmt = `
+		UPDATE address_secrets
+		SET encrypted_priv_key = $1,
+			encrypted_script = $2
+		WHERE address_id = $3`
+
+	result, err := dbConn.ExecContext(
+		t.Context(), stmt, encryptedPrivKey, encryptedScript, addressID,
+	)
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rows != 1 {
+		return fmt.Errorf("%w: got %d", errUnexpectedUpdatedRows, rows)
+	}
+
+	return nil
 }
 
 // createDerivedAddressRaw inserts a derived address directly through

--- a/wallet/internal/db/itest/fixtures_pg_test.go
+++ b/wallet/internal/db/itest/fixtures_pg_test.go
@@ -191,6 +191,85 @@ func updateAccountSecretRaw(t *testing.T, dbConn *sql.DB, accountID int64,
 	return nil
 }
 
+// deleteKeyScopeSecretRaw deletes a key-scope secret row directly through the
+// database so tests can verify or reset absent-row state.
+func deleteKeyScopeSecretRaw(t *testing.T, dbConn *sql.DB,
+	scopeID int64) error {
+
+	t.Helper()
+
+	const stmt = `
+		DELETE FROM key_scope_secrets
+		WHERE scope_id = $1`
+
+	result, err := dbConn.ExecContext(t.Context(), stmt, scopeID)
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rows > 1 {
+		return fmt.Errorf("%w: got %d", errUnexpectedDeletedRows, rows)
+	}
+
+	return nil
+}
+
+// insertKeyScopeSecretRaw inserts a key-scope secret directly through the
+// database so tests can validate watch-only triggers on key_scope_secrets.
+func insertKeyScopeSecretRaw(t *testing.T, dbConn *sql.DB, scopeID int64,
+	encryptedCoinPrivKey []byte) error {
+
+	t.Helper()
+
+	const stmt = `
+		INSERT INTO key_scope_secrets (
+			scope_id,
+			encrypted_coin_priv_key
+		) VALUES ($1, $2)`
+
+	_, err := dbConn.ExecContext(
+		t.Context(), stmt, scopeID, encryptedCoinPrivKey,
+	)
+
+	return err
+}
+
+// updateKeyScopeSecretRaw updates a key-scope secret directly through the
+// database so tests can validate watch-only triggers on key_scope_secrets.
+func updateKeyScopeSecretRaw(t *testing.T, dbConn *sql.DB, scopeID int64,
+	encryptedCoinPrivKey []byte) error {
+
+	t.Helper()
+
+	const stmt = `
+		UPDATE key_scope_secrets
+		SET encrypted_coin_priv_key = $1
+		WHERE scope_id = $2`
+
+	result, err := dbConn.ExecContext(
+		t.Context(), stmt, encryptedCoinPrivKey, scopeID,
+	)
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rows != 1 {
+		return fmt.Errorf("%w: got %d", errUnexpectedUpdatedRows, rows)
+	}
+
+	return nil
+}
+
 // deleteWalletSecretRaw deletes a wallet secret row directly through the
 // database so tests can re-exercise wallet_secrets insert triggers.
 func deleteWalletSecretRaw(t *testing.T, dbConn *sql.DB,

--- a/wallet/internal/db/itest/fixtures_sqlite_test.go
+++ b/wallet/internal/db/itest/fixtures_sqlite_test.go
@@ -286,6 +286,37 @@ func updateWalletSecretRaw(t *testing.T, dbConn *sql.DB, walletID uint32,
 	return nil
 }
 
+// updateWalletWatchOnlyRaw updates the watch-only flag directly through the
+// database so tests can validate its immutability trigger.
+func updateWalletWatchOnlyRaw(t *testing.T, dbConn *sql.DB, walletID uint32,
+	isWatchOnly bool) error {
+
+	t.Helper()
+
+	const stmt = `
+		UPDATE wallets
+		SET is_watch_only = ?
+		WHERE id = ?`
+
+	result, err := dbConn.ExecContext(
+		t.Context(), stmt, isWatchOnly, int64(walletID),
+	)
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rows != 1 {
+		return fmt.Errorf("%w: got %d", errUnexpectedUpdatedRows, rows)
+	}
+
+	return nil
+}
+
 // CreateAddressWithIndex creates a derived address with a specific address
 // index. Used to test address index overflow without creating billions of
 // addresses.

--- a/wallet/internal/db/itest/fixtures_sqlite_test.go
+++ b/wallet/internal/db/itest/fixtures_sqlite_test.go
@@ -12,12 +12,17 @@ import (
 
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	dberr "github.com/btcsuite/btcwallet/wallet/internal/db/err"
-	"github.com/btcsuite/btcwallet/wallet/internal/db/sqlite"
+	dbsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlite"
 	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 	"github.com/stretchr/testify/require"
+	sqlitedriver "modernc.org/sqlite"
+	sqlite3 "modernc.org/sqlite/lib"
 )
 
-var errUnexpectedDeletedRows = errors.New("unexpected deleted row count")
+var (
+	errUnexpectedDeletedRows = errors.New("unexpected deleted row count")
+	errUnexpectedUpdatedRows = errors.New("unexpected updated row count")
+)
 
 // testBackend returns the SQL backend expected by SQLite itests.
 func testBackend() dberr.Backend {
@@ -35,6 +40,18 @@ func requireConstraintSQLError(t *testing.T, err error) {
 	require.Equal(t, dberr.ReasonConstraint, sqlErr.Reason)
 	require.Equal(t, dberr.ClassPermanent, sqlErr.Class())
 	require.ErrorIs(t, err, sqlErr)
+}
+
+// requireDriverConstraintError verifies that a direct SQLite driver error is a
+// constraint violation before store-level error wrapping occurs.
+func requireDriverConstraintError(t *testing.T, err error) {
+	t.Helper()
+
+	const mask = 0xff
+
+	var sqliteErr *sqlitedriver.Error
+	require.ErrorAs(t, err, &sqliteErr)
+	require.Equal(t, sqlite3.SQLITE_CONSTRAINT, sqliteErr.Code()&mask)
 }
 
 // CreateBlockFixture inserts a test block into the database and returns it.
@@ -124,6 +141,149 @@ func createImportedAccountRaw(t *testing.T, dbConn *sql.DB, walletID uint32,
 	)
 
 	return err
+}
+
+// insertAccountSecretRaw inserts an account secret directly through the
+// database so tests can validate watch-only triggers on account_secrets.
+func insertAccountSecretRaw(t *testing.T, dbConn *sql.DB, accountID int64,
+	encryptedPrivateKey []byte) error {
+
+	t.Helper()
+
+	const stmt = `
+		INSERT INTO account_secrets (
+			account_id,
+			encrypted_private_key
+		) VALUES (?, ?)`
+
+	_, err := dbConn.ExecContext(
+		t.Context(), stmt, accountID, encryptedPrivateKey,
+	)
+
+	return err
+}
+
+// updateAccountSecretRaw updates an account secret directly through the
+// database so tests can validate watch-only triggers on account_secrets.
+func updateAccountSecretRaw(t *testing.T, dbConn *sql.DB, accountID int64,
+	encryptedPrivateKey []byte) error {
+
+	t.Helper()
+
+	const stmt = `
+		UPDATE account_secrets
+		SET encrypted_private_key = ?
+		WHERE account_id = ?`
+
+	result, err := dbConn.ExecContext(
+		t.Context(), stmt, encryptedPrivateKey, accountID,
+	)
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rows != 1 {
+		return fmt.Errorf("%w: got %d", errUnexpectedUpdatedRows, rows)
+	}
+
+	return nil
+}
+
+// deleteWalletSecretRaw deletes a wallet secret row directly through the
+// database so tests can re-exercise wallet_secrets insert triggers.
+func deleteWalletSecretRaw(t *testing.T, dbConn *sql.DB,
+	walletID uint32) error {
+
+	t.Helper()
+
+	const stmt = `
+		DELETE FROM wallet_secrets
+		WHERE wallet_id = ?`
+
+	result, err := dbConn.ExecContext(
+		t.Context(), stmt, int64(walletID),
+	)
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rows != 1 {
+		return fmt.Errorf("%w: got %d", errUnexpectedDeletedRows, rows)
+	}
+
+	return nil
+}
+
+// insertWalletSecretRaw inserts a wallet secret directly through the database
+// so tests can validate watch-only triggers on wallet_secrets.
+func insertWalletSecretRaw(t *testing.T, dbConn *sql.DB, walletID uint32,
+	masterPrivParams []byte, encryptedCryptoPrivKey []byte,
+	encryptedCryptoScriptKey []byte, encryptedMasterHDPrivKey []byte) error {
+
+	t.Helper()
+
+	const stmt = `
+		INSERT INTO wallet_secrets (
+			wallet_id,
+			master_priv_params,
+			encrypted_crypto_priv_key,
+			encrypted_crypto_script_key,
+			encrypted_master_hd_priv_key
+		) VALUES (?, ?, ?, ?, ?)`
+
+	_, err := dbConn.ExecContext(
+		t.Context(), stmt, int64(walletID), masterPrivParams,
+		encryptedCryptoPrivKey, encryptedCryptoScriptKey,
+		encryptedMasterHDPrivKey,
+	)
+
+	return err
+}
+
+// updateWalletSecretRaw updates a wallet secret directly through the database
+// so tests can validate watch-only triggers on wallet_secrets.
+func updateWalletSecretRaw(t *testing.T, dbConn *sql.DB, walletID uint32,
+	masterPrivParams []byte, encryptedCryptoPrivKey []byte,
+	encryptedCryptoScriptKey []byte, encryptedMasterHDPrivKey []byte) error {
+
+	t.Helper()
+
+	const stmt = `
+		UPDATE wallet_secrets
+		SET master_priv_params = ?,
+			encrypted_crypto_priv_key = ?,
+			encrypted_crypto_script_key = ?,
+			encrypted_master_hd_priv_key = ?
+		WHERE wallet_id = ?`
+
+	result, err := dbConn.ExecContext(
+		t.Context(), stmt, masterPrivParams, encryptedCryptoPrivKey,
+		encryptedCryptoScriptKey, encryptedMasterHDPrivKey, int64(walletID),
+	)
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rows != 1 {
+		return fmt.Errorf("%w: got %d", errUnexpectedUpdatedRows, rows)
+	}
+
+	return nil
 }
 
 // CreateAddressWithIndex creates a derived address with a specific address
@@ -266,7 +426,7 @@ func setupMaxAccountNumberTest(t *testing.T, store db.AccountStore,
 
 	t.Helper()
 
-	sqliteStore, ok := store.(*sqlite.Store)
+	sqliteStore, ok := store.(*dbsqlite.Store)
 	require.True(t, ok)
 
 	queries := sqliteStore.Queries()
@@ -291,6 +451,59 @@ func createImportedAddressRaw(ctx context.Context, queries *sqlc.Queries,
 	)
 
 	return err
+}
+
+// insertAddressSecretRaw inserts an address secret directly through the
+// database so tests can validate watch-only triggers on address_secrets.
+func insertAddressSecretRaw(t *testing.T, dbConn *sql.DB, addressID int64,
+	encryptedPrivKey []byte, encryptedScript []byte) error {
+
+	t.Helper()
+
+	const stmt = `
+		INSERT INTO address_secrets (
+			address_id,
+			encrypted_priv_key,
+			encrypted_script
+		) VALUES (?, ?, ?)`
+
+	_, err := dbConn.ExecContext(
+		t.Context(), stmt, addressID, encryptedPrivKey, encryptedScript,
+	)
+
+	return err
+}
+
+// updateAddressSecretRaw updates an address secret directly through the
+// database so tests can validate watch-only triggers on address_secrets.
+func updateAddressSecretRaw(t *testing.T, dbConn *sql.DB, addressID int64,
+	encryptedPrivKey []byte, encryptedScript []byte) error {
+
+	t.Helper()
+
+	const stmt = `
+		UPDATE address_secrets
+		SET encrypted_priv_key = ?,
+			encrypted_script = ?
+		WHERE address_id = ?`
+
+	result, err := dbConn.ExecContext(
+		t.Context(), stmt, encryptedPrivKey, encryptedScript, addressID,
+	)
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rows != 1 {
+		return fmt.Errorf("%w: got %d", errUnexpectedUpdatedRows, rows)
+	}
+
+	return nil
 }
 
 // createDerivedAddressRaw inserts a derived address directly through the

--- a/wallet/internal/db/itest/fixtures_sqlite_test.go
+++ b/wallet/internal/db/itest/fixtures_sqlite_test.go
@@ -396,6 +396,102 @@ func updateWalletWatchOnlyRaw(t *testing.T, dbConn *sql.DB, walletID uint32,
 	return nil
 }
 
+// updateKeyScopeWalletIDRaw updates a key scope wallet_id directly through the
+// database so tests can validate its immutability trigger.
+func updateKeyScopeWalletIDRaw(t *testing.T, dbConn *sql.DB, scopeID int64,
+	walletID uint32) error {
+
+	t.Helper()
+
+	const stmt = `
+		UPDATE key_scopes
+		SET wallet_id = ?
+		WHERE id = ?`
+
+	result, err := dbConn.ExecContext(
+		t.Context(), stmt, int64(walletID), scopeID,
+	)
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rows != 1 {
+		return fmt.Errorf("%w: got %d", errUnexpectedUpdatedRows, rows)
+	}
+
+	return nil
+}
+
+// reparentAccountRaw updates an account wallet/scope pair directly through the
+// database so tests can validate wallet ownership immutability after insert.
+func reparentAccountRaw(t *testing.T, dbConn *sql.DB, accountID int64,
+	walletID uint32, scopeID int64) error {
+
+	t.Helper()
+
+	const stmt = `
+		UPDATE accounts
+		SET wallet_id = ?,
+			scope_id = ?
+		WHERE id = ?`
+
+	result, err := dbConn.ExecContext(
+		t.Context(), stmt, int64(walletID), scopeID, accountID,
+	)
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rows != 1 {
+		return fmt.Errorf("%w: got %d", errUnexpectedUpdatedRows, rows)
+	}
+
+	return nil
+}
+
+// reparentAddressRaw updates an address wallet/account pair directly through
+// the database so tests can validate wallet ownership immutability after
+// insert.
+func reparentAddressRaw(t *testing.T, dbConn *sql.DB, addressID int64,
+	walletID uint32, accountID int64) error {
+
+	t.Helper()
+
+	const stmt = `
+		UPDATE addresses
+		SET wallet_id = ?,
+			account_id = ?
+		WHERE id = ?`
+
+	result, err := dbConn.ExecContext(
+		t.Context(), stmt, int64(walletID), accountID, addressID,
+	)
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rows != 1 {
+		return fmt.Errorf("%w: got %d", errUnexpectedUpdatedRows, rows)
+	}
+
+	return nil
+}
+
 // CreateAddressWithIndex creates a derived address with a specific address
 // index. Used to test address index overflow without creating billions of
 // addresses.

--- a/wallet/internal/db/itest/fixtures_sqlite_test.go
+++ b/wallet/internal/db/itest/fixtures_sqlite_test.go
@@ -194,6 +194,85 @@ func updateAccountSecretRaw(t *testing.T, dbConn *sql.DB, accountID int64,
 	return nil
 }
 
+// deleteKeyScopeSecretRaw deletes a key-scope secret row directly through the
+// database so tests can verify or reset absent-row state.
+func deleteKeyScopeSecretRaw(t *testing.T, dbConn *sql.DB,
+	scopeID int64) error {
+
+	t.Helper()
+
+	const stmt = `
+		DELETE FROM key_scope_secrets
+		WHERE scope_id = ?`
+
+	result, err := dbConn.ExecContext(t.Context(), stmt, scopeID)
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rows > 1 {
+		return fmt.Errorf("%w: got %d", errUnexpectedDeletedRows, rows)
+	}
+
+	return nil
+}
+
+// insertKeyScopeSecretRaw inserts a key-scope secret directly through the
+// database so tests can validate watch-only triggers on key_scope_secrets.
+func insertKeyScopeSecretRaw(t *testing.T, dbConn *sql.DB, scopeID int64,
+	encryptedCoinPrivKey []byte) error {
+
+	t.Helper()
+
+	const stmt = `
+		INSERT INTO key_scope_secrets (
+			scope_id,
+			encrypted_coin_priv_key
+		) VALUES (?, ?)`
+
+	_, err := dbConn.ExecContext(
+		t.Context(), stmt, scopeID, encryptedCoinPrivKey,
+	)
+
+	return err
+}
+
+// updateKeyScopeSecretRaw updates a key-scope secret directly through the
+// database so tests can validate watch-only triggers on key_scope_secrets.
+func updateKeyScopeSecretRaw(t *testing.T, dbConn *sql.DB, scopeID int64,
+	encryptedCoinPrivKey []byte) error {
+
+	t.Helper()
+
+	const stmt = `
+		UPDATE key_scope_secrets
+		SET encrypted_coin_priv_key = ?
+		WHERE scope_id = ?`
+
+	result, err := dbConn.ExecContext(
+		t.Context(), stmt, encryptedCoinPrivKey, scopeID,
+	)
+	if err != nil {
+		return err
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rows != 1 {
+		return fmt.Errorf("%w: got %d", errUnexpectedUpdatedRows, rows)
+	}
+
+	return nil
+}
+
 // deleteWalletSecretRaw deletes a wallet secret row directly through the
 // database so tests can re-exercise wallet_secrets insert triggers.
 func deleteWalletSecretRaw(t *testing.T, dbConn *sql.DB,

--- a/wallet/internal/db/itest/key_scope_store_test.go
+++ b/wallet/internal/db/itest/key_scope_store_test.go
@@ -1,0 +1,95 @@
+//go:build itest
+
+package itest
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWatchOnlyKeyScopeSecretTriggers verifies that key_scope_secrets models
+// watch-only scopes as absent rows while still rejecting direct private-key
+// writes for watch-only parents and allowing inserts/updates for spendable
+// parents.
+func TestWatchOnlyKeyScopeSecretTriggers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("watch-only scopes keep secrets row absent", func(t *testing.T) {
+		t.Parallel()
+
+		store := NewTestStore(t)
+		queries := store.Queries()
+
+		walletInfo, err := store.CreateWallet(
+			t.Context(),
+			CreateWatchOnlyWalletParams("watch-only-key-scope-secret-insert"),
+		)
+		require.NoError(t, err)
+
+		CreateImportedAccount(
+			t, store, walletInfo.ID, db.KeyScopeBIP0084,
+			"watch-only-key-scope-scope-absent",
+		)
+
+		scopeID := GetKeyScopeID(t, queries, walletInfo.ID, db.KeyScopeBIP0084)
+
+		_, err = queries.GetKeyScopeSecrets(t.Context(), scopeID)
+		require.ErrorIs(t, err, sql.ErrNoRows)
+
+		err = deleteKeyScopeSecretRaw(t, store.DB(), scopeID)
+		require.NoError(t, err)
+	})
+
+	t.Run("watch-only insert is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		store := NewTestStore(t)
+		queries := store.Queries()
+
+		walletInfo, err := store.CreateWallet(
+			t.Context(),
+			CreateWatchOnlyWalletParams("watch-only-key-scope-secret-insert"),
+		)
+		require.NoError(t, err)
+
+		CreateImportedAccount(
+			t, store, walletInfo.ID, db.KeyScopeBIP0084,
+			"watch-only-key-scope-scope-insert",
+		)
+
+		scopeID := GetKeyScopeID(t, queries, walletInfo.ID, db.KeyScopeBIP0084)
+
+		err = insertKeyScopeSecretRaw(t, store.DB(), scopeID, RandomBytes(32))
+		require.Error(t, err)
+		requireDriverConstraintError(t, err)
+	})
+
+	t.Run("non-watch-only insert and update succeed", func(t *testing.T) {
+		t.Parallel()
+
+		store := NewTestStore(t)
+		queries := store.Queries()
+		walletID := newWallet(t, store, "spendable-key-scope-secret-trigger")
+
+		createDerivedAccount(
+			t, store, walletID, db.KeyScopeBIP0084,
+			"spendable-key-scope-account",
+		)
+
+		scopeID := GetKeyScopeID(t, queries, walletID, db.KeyScopeBIP0084)
+
+		err := deleteKeyScopeSecretRaw(t, store.DB(), scopeID)
+		require.NoError(t, err)
+
+		insertedPrivKey := RandomBytes(32)
+		err = insertKeyScopeSecretRaw(t, store.DB(), scopeID, insertedPrivKey)
+		require.NoError(t, err)
+
+		updatedPrivKey := RandomBytes(32)
+		err = updateKeyScopeSecretRaw(t, store.DB(), scopeID, updatedPrivKey)
+		require.NoError(t, err)
+	})
+}

--- a/wallet/internal/db/itest/key_scope_store_test.go
+++ b/wallet/internal/db/itest/key_scope_store_test.go
@@ -93,3 +93,29 @@ func TestWatchOnlyKeyScopeSecretTriggers(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+// TestKeyScopeWalletIDImmutable verifies that raw scope updates cannot change
+// wallet ownership after insert.
+func TestKeyScopeWalletIDImmutable(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	queries := store.Queries()
+
+	sourceWalletID := newWallet(t, store, "scope-wallet-immutable-source")
+	createDerivedAccount(
+		t, store, sourceWalletID, db.KeyScopeBIP0084, "scope-wallet-source",
+	)
+
+	scopeID := GetKeyScopeID(t, queries, sourceWalletID, db.KeyScopeBIP0084)
+	targetWalletID := newWallet(t, store, "scope-wallet-immutable-target")
+
+	err := updateKeyScopeWalletIDRaw(t, store.DB(), scopeID, targetWalletID)
+	require.Error(t, err)
+	requireDriverConstraintError(t, err)
+
+	require.Equal(
+		t, scopeID,
+		GetKeyScopeID(t, queries, sourceWalletID, db.KeyScopeBIP0084),
+	)
+}

--- a/wallet/internal/db/itest/pg_test.go
+++ b/wallet/internal/db/itest/pg_test.go
@@ -163,11 +163,11 @@ func GetPostgresContainer(ctx context.Context) (*postgres.PostgresContainer,
 		m := db.DefaultMaxConnections
 
 		// pgMaxConns is the Postgres max_connections budget for the
-		// test container. We budget 2x the steady-state pool size to
+		// test container. We budget 3x the steady-state pool size to
 		// absorb connection lifecycle overlap during parallel test
 		// teardown and startup without trying to model each transient
 		// connection source separately.
-		pgMaxConns := 2 * p * m
+		pgMaxConns := 3 * p * m
 
 		pgContainer, errPGContainer = postgres.Run(ctx,
 			cfg.Image,

--- a/wallet/internal/db/itest/wallet_store_test.go
+++ b/wallet/internal/db/itest/wallet_store_test.go
@@ -991,6 +991,144 @@ func TestWatchOnlyWalletRejectsWalletSecrets(t *testing.T) {
 	})
 }
 
+// TestWatchOnlyWalletSecretTriggers verifies that wallet_secrets rejects
+// watch-only parent wallets while still allowing inserts and updates for
+// non-watch-only parents.
+func TestWatchOnlyWalletSecretTriggers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("watch-only insert is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		store := NewTestStore(t)
+
+		walletInfo, err := store.CreateWallet(
+			t.Context(),
+			CreateWatchOnlyWalletParams("watch-only-wallet-secret-insert"),
+		)
+		require.NoError(t, err)
+
+		err = insertWalletSecretRaw(
+			t, store.DB(), walletInfo.ID, RandomBytes(16), RandomBytes(32),
+			RandomBytes(32), RandomBytes(32),
+		)
+		require.Error(t, err)
+		requireDriverConstraintError(t, err)
+	})
+
+	t.Run("watch-only script-only insert succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		store := NewTestStore(t)
+
+		walletInfo, err := store.CreateWallet(
+			t.Context(),
+			CreateWatchOnlyWalletParams("watch-only-wallet-secret-script-only"),
+		)
+		require.NoError(t, err)
+
+		err = deleteWalletSecretRaw(t, store.DB(), walletInfo.ID)
+		require.NoError(t, err)
+
+		err = insertWalletSecretRaw(
+			t, store.DB(), walletInfo.ID, nil, nil, RandomBytes(32), nil,
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run(
+		"watch-only empty-but-non-nil insert is rejected",
+		func(t *testing.T) {
+			t.Parallel()
+
+			store := NewTestStore(t)
+
+			walletInfo, err := store.CreateWallet(
+				t.Context(),
+				CreateWatchOnlyWalletParams(
+					"watch-only-wallet-secret-empty-insert",
+				),
+			)
+			require.NoError(t, err)
+
+			err = insertWalletSecretRaw(
+				t, store.DB(), walletInfo.ID, []byte{}, nil, RandomBytes(32),
+				nil,
+			)
+			require.Error(t, err)
+			requireDriverConstraintError(t, err)
+		},
+	)
+
+	t.Run("watch-only update is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		store := NewTestStore(t)
+
+		params := CreateWatchOnlyWalletParams("watch-only-wallet-secret-update")
+		params.EncryptedCryptoScriptKey = RandomBytes(32)
+
+		walletInfo, err := store.CreateWallet(t.Context(), params)
+		require.NoError(t, err)
+
+		seed, err := store.GetEncryptedHDSeed(t.Context(), walletInfo.ID)
+		require.Nil(t, seed)
+		require.ErrorIs(t, err, db.ErrSecretNotFound)
+
+		err = updateWalletSecretRaw(
+			t, store.DB(), walletInfo.ID, nil, nil, RandomBytes(32), nil,
+		)
+		require.NoError(t, err)
+
+		err = updateWalletSecretRaw(
+			t, store.DB(), walletInfo.ID, RandomBytes(16), RandomBytes(32),
+			RandomBytes(32), RandomBytes(32),
+		)
+		require.Error(t, err)
+		requireDriverConstraintError(t, err)
+
+		err = updateWalletSecretRaw(
+			t, store.DB(), walletInfo.ID, []byte{}, nil, RandomBytes(32),
+			nil,
+		)
+		require.Error(t, err)
+		requireDriverConstraintError(t, err)
+	})
+
+	t.Run("non-watch-only insert and update succeed", func(t *testing.T) {
+		t.Parallel()
+
+		store := NewTestStore(t)
+
+		walletID := newWallet(t, store, "spendable-wallet-secret-trigger")
+
+		err := deleteWalletSecretRaw(t, store.DB(), walletID)
+		require.NoError(t, err)
+
+		insertedSeed := RandomBytes(32)
+		err = insertWalletSecretRaw(
+			t, store.DB(), walletID, RandomBytes(16), RandomBytes(32),
+			RandomBytes(32), insertedSeed,
+		)
+		require.NoError(t, err)
+
+		seed, err := store.GetEncryptedHDSeed(t.Context(), walletID)
+		require.NoError(t, err)
+		require.Equal(t, insertedSeed, seed)
+
+		updatedSeed := RandomBytes(32)
+		err = updateWalletSecretRaw(
+			t, store.DB(), walletID, RandomBytes(16), RandomBytes(32),
+			RandomBytes(32), updatedSeed,
+		)
+		require.NoError(t, err)
+
+		seed, err = store.GetEncryptedHDSeed(t.Context(), walletID)
+		require.NoError(t, err)
+		require.Equal(t, updatedSeed, seed)
+	})
+}
+
 // TestUpdateWalletSecrets checks that updating the wallet secrets works
 // correctly.
 func TestUpdateWalletSecrets(t *testing.T) {

--- a/wallet/internal/db/itest/wallet_store_test.go
+++ b/wallet/internal/db/itest/wallet_store_test.go
@@ -1129,6 +1129,56 @@ func TestWatchOnlyWalletSecretTriggers(t *testing.T) {
 	})
 }
 
+// TestWalletWatchOnlyImmutable verifies that raw wallet updates cannot change
+// the watch-only flag after wallet creation.
+func TestWalletWatchOnlyImmutable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		walletName       string
+		params           func(string) db.CreateWalletParams
+		updatedWatchOnly bool
+	}{
+		{
+			name:             "spendable wallet cannot become watch-only",
+			walletName:       "wallet-watch-only-immutable-spendable",
+			params:           CreateWalletParamsFixture,
+			updatedWatchOnly: true,
+		},
+		{
+			name:             "watch-only wallet cannot become spendable",
+			walletName:       "wallet-watch-only-immutable-watch-only",
+			params:           CreateWatchOnlyWalletParams,
+			updatedWatchOnly: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := NewTestStore(t)
+
+			created, err := store.CreateWallet(
+				t.Context(), tc.params(tc.walletName),
+			)
+			require.NoError(t, err)
+
+			err = updateWalletWatchOnlyRaw(
+				t, store.DB(), created.ID, tc.updatedWatchOnly,
+			)
+			require.Error(t, err)
+			requireDriverConstraintError(t, err)
+
+			walletInfo, err := store.GetWallet(t.Context(), tc.walletName)
+			require.NoError(t, err)
+			require.NotNil(t, walletInfo)
+			require.Equal(t, created.IsWatchOnly, walletInfo.IsWatchOnly)
+		})
+	}
+}
+
 // TestUpdateWalletSecrets checks that updating the wallet secrets works
 // correctly.
 func TestUpdateWalletSecrets(t *testing.T) {

--- a/wallet/internal/db/pg/accounts.go
+++ b/wallet/internal/db/pg/accounts.go
@@ -79,8 +79,8 @@ func (s *Store) RenameAccount(ctx context.Context,
 }
 
 // CreateDerivedAccount creates a new derived account with the given name and
-// scope. If the key scope does not exist, it is created with NULL encrypted
-// keys using the address schema provided by the caller.
+// scope. If the key scope does not exist, it is created using the address
+// schema provided by the caller.
 func (s *Store) CreateDerivedAccount(ctx context.Context,
 	params db.CreateDerivedAccountParams) (*db.AccountInfo, error) {
 
@@ -155,9 +155,9 @@ func (s *Store) CreateDerivedAccount(ctx context.Context,
 }
 
 // CreateImportedAccount stores an imported account identified by an extended
-// public key. If the key scope does not exist, it is created with NULL
-// encrypted keys using the address schema provided by the caller. Imported
-// accounts have NULL account_number since they don't follow BIP44 derivation.
+// public key. If the key scope does not exist, it is created using the address
+// schema provided by the caller. Imported accounts have NULL account_number
+// since they don't follow BIP44 derivation.
 func (s *Store) CreateImportedAccount(ctx context.Context,
 	params db.CreateImportedAccountParams) (*db.AccountProperties, error) {
 

--- a/wallet/internal/db/sqlite/accounts.go
+++ b/wallet/internal/db/sqlite/accounts.go
@@ -79,8 +79,8 @@ func (s *Store) RenameAccount(ctx context.Context,
 }
 
 // CreateDerivedAccount creates a new derived account with the given name and
-// scope. If the key scope does not exist, it is created with NULL encrypted
-// keys using the address schema provided by the caller.
+// scope. If the key scope does not exist, it is created using the address
+// schema provided by the caller.
 func (s *Store) CreateDerivedAccount(ctx context.Context,
 	params db.CreateDerivedAccountParams) (*db.AccountInfo, error) {
 
@@ -175,9 +175,9 @@ func ensureKeyScope(ctx context.Context, qtx *sqlc.Queries,
 }
 
 // CreateImportedAccount stores an imported account identified by an extended
-// public key. If the key scope does not exist, it is created with NULL
-// encrypted keys using the address schema provided by the caller. Imported
-// accounts have NULL account_number since they don't follow BIP44 derivation.
+// public key. If the key scope does not exist, it is created using the address
+// schema provided by the caller. Imported accounts have NULL account_number
+// since they don't follow BIP44 derivation.
 func (s *Store) CreateImportedAccount(ctx context.Context,
 	params db.CreateImportedAccountParams) (*db.AccountProperties, error) {
 

--- a/wallet/internal/sql/pg/migrations/000002_wallets.down.sql
+++ b/wallet/internal/sql/pg/migrations/000002_wallets.down.sql
@@ -1,5 +1,8 @@
 -- Rollback note: Idempotent by design (using "IF EXISTS").
 -- Must succeed even if tables are already dropped or database in unexpected state.
+DROP TRIGGER IF EXISTS trg_assert_watch_only_wallet_secrets_insert ON wallet_secrets;
+DROP TRIGGER IF EXISTS trg_assert_watch_only_wallet_secrets_update ON wallet_secrets;
+DROP FUNCTION IF EXISTS assert_watch_only_wallet_secrets();
 DROP TABLE IF EXISTS wallet_sync_states;
 DROP TABLE IF EXISTS wallet_secrets;
 DROP TABLE IF EXISTS wallets;

--- a/wallet/internal/sql/pg/migrations/000002_wallets.down.sql
+++ b/wallet/internal/sql/pg/migrations/000002_wallets.down.sql
@@ -1,5 +1,7 @@
 -- Rollback note: Idempotent by design (using "IF EXISTS").
 -- Must succeed even if tables are already dropped or database in unexpected state.
+DROP TRIGGER IF EXISTS trg_assert_wallet_is_watch_only_immutable ON wallets;
+DROP FUNCTION IF EXISTS assert_wallet_is_watch_only_immutable();
 DROP TRIGGER IF EXISTS trg_assert_watch_only_wallet_secrets_insert ON wallet_secrets;
 DROP TRIGGER IF EXISTS trg_assert_watch_only_wallet_secrets_update ON wallet_secrets;
 DROP FUNCTION IF EXISTS assert_watch_only_wallet_secrets();

--- a/wallet/internal/sql/pg/migrations/000002_wallets.up.sql
+++ b/wallet/internal/sql/pg/migrations/000002_wallets.up.sql
@@ -32,6 +32,26 @@ CREATE TABLE wallets (
 -- Unique index to prevent duplicate wallet names.
 CREATE UNIQUE INDEX uidx_wallets_name ON wallets (wallet_name);
 
+-- Enforce that the watch-only status chosen at wallet creation time remains
+-- immutable. This closes the database-boundary hole where a raw wallet update
+-- could silently bypass the secret-table triggers by flipping the parent
+-- wallet between watch-only and spendable after insert.
+CREATE FUNCTION assert_wallet_is_watch_only_immutable() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.is_watch_only IS DISTINCT FROM OLD.is_watch_only THEN
+        RAISE EXCEPTION 'wallet is_watch_only cannot be changed after creation'
+            USING ERRCODE = '23514'; -- check_violation
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_assert_wallet_is_watch_only_immutable
+BEFORE UPDATE OF is_watch_only ON wallets
+FOR EACH ROW
+EXECUTE FUNCTION assert_wallet_is_watch_only_immutable();
+
 -- Wallet Secrets table to store rarely accessed, highly sensitive encrypted
 -- material with a strict one-to-one relationship with the wallets table.
 -- Separated from the main wallets table for security and access pattern isolation.

--- a/wallet/internal/sql/pg/migrations/000002_wallets.up.sql
+++ b/wallet/internal/sql/pg/migrations/000002_wallets.up.sql
@@ -61,6 +61,42 @@ CREATE TABLE wallet_secrets (
     FOREIGN KEY (wallet_id) REFERENCES wallets (id) ON DELETE RESTRICT
 );
 
+-- Enforce the watch-only wallet secret invariant at the database boundary.
+-- Watch-only wallets may retain script-encryption material for imported
+-- scripts, but must never store private key material; keeping these columns
+-- NULL prevents an insert or update from silently turning a watch-only wallet
+-- into a spend-capable wallet.
+CREATE FUNCTION assert_watch_only_wallet_secrets() RETURNS TRIGGER AS $$
+DECLARE
+    wallet_is_watch_only BOOLEAN;
+BEGIN
+    SELECT w.is_watch_only INTO wallet_is_watch_only
+    FROM wallets AS w
+    WHERE w.id = NEW.wallet_id;
+
+    IF wallet_is_watch_only AND (
+        NEW.master_priv_params IS NOT NULL
+        OR NEW.encrypted_crypto_priv_key IS NOT NULL
+        OR NEW.encrypted_master_hd_priv_key IS NOT NULL
+    ) THEN
+        RAISE EXCEPTION 'watch-only wallet private secret columns must be null'
+            USING ERRCODE = '23514'; -- check_violation
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_assert_watch_only_wallet_secrets_insert
+BEFORE INSERT ON wallet_secrets
+FOR EACH ROW
+EXECUTE FUNCTION assert_watch_only_wallet_secrets();
+
+CREATE TRIGGER trg_assert_watch_only_wallet_secrets_update
+BEFORE UPDATE ON wallet_secrets
+FOR EACH ROW
+EXECUTE FUNCTION assert_watch_only_wallet_secrets();
+
 -- Wallet Sync States table to store the synchronization state of each wallet.
 -- This is kept separate from the wallets table to avoid write amplification on
 -- frequently updated sync data. Each wallet has exactly one sync state record.

--- a/wallet/internal/sql/pg/migrations/000004_key_scopes.down.sql
+++ b/wallet/internal/sql/pg/migrations/000004_key_scopes.down.sql
@@ -2,6 +2,8 @@
 -- Must succeed even if tables are already dropped or database in unexpected state.
 DROP TRIGGER IF EXISTS trg_assert_watch_only_key_scope_secrets_insert ON key_scope_secrets;
 DROP TRIGGER IF EXISTS trg_assert_watch_only_key_scope_secrets_update ON key_scope_secrets;
+DROP TRIGGER IF EXISTS trg_assert_key_scope_wallet_id_immutable ON key_scopes;
 DROP FUNCTION IF EXISTS assert_watch_only_key_scope_secrets();
+DROP FUNCTION IF EXISTS assert_key_scope_wallet_id_immutable();
 DROP TABLE IF EXISTS key_scope_secrets;
 DROP TABLE IF EXISTS key_scopes;

--- a/wallet/internal/sql/pg/migrations/000004_key_scopes.down.sql
+++ b/wallet/internal/sql/pg/migrations/000004_key_scopes.down.sql
@@ -1,4 +1,7 @@
 -- Rollback note: Idempotent by design (using "IF EXISTS").
 -- Must succeed even if tables are already dropped or database in unexpected state.
+DROP TRIGGER IF EXISTS trg_assert_watch_only_key_scope_secrets_insert ON key_scope_secrets;
+DROP TRIGGER IF EXISTS trg_assert_watch_only_key_scope_secrets_update ON key_scope_secrets;
+DROP FUNCTION IF EXISTS assert_watch_only_key_scope_secrets();
 DROP TABLE IF EXISTS key_scope_secrets;
 DROP TABLE IF EXISTS key_scopes;

--- a/wallet/internal/sql/pg/migrations/000004_key_scopes.up.sql
+++ b/wallet/internal/sql/pg/migrations/000004_key_scopes.up.sql
@@ -61,3 +61,34 @@ CREATE TABLE key_scope_secrets (
     -- that the key scope cannot be deleted if secrets still exist.
     FOREIGN KEY (scope_id) REFERENCES key_scopes (id) ON DELETE RESTRICT
 );
+
+-- Enforce the watch-only key-scope secret invariant at the database boundary.
+-- Watch-only wallets may keep a scope row for public derivation metadata, but
+-- the matching key_scope_secrets row must not carry coin private key material.
+CREATE FUNCTION assert_watch_only_key_scope_secrets() RETURNS TRIGGER AS $$
+DECLARE
+    wallet_is_watch_only BOOLEAN;
+BEGIN
+    SELECT w.is_watch_only INTO wallet_is_watch_only
+    FROM key_scopes AS ks
+    INNER JOIN wallets AS w ON w.id = ks.wallet_id
+    WHERE ks.id = NEW.scope_id;
+
+    IF wallet_is_watch_only THEN
+        RAISE EXCEPTION 'watch-only key scopes cannot store coin private keys'
+            USING ERRCODE = '23514'; -- check_violation
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_assert_watch_only_key_scope_secrets_insert
+BEFORE INSERT ON key_scope_secrets
+FOR EACH ROW
+EXECUTE FUNCTION assert_watch_only_key_scope_secrets();
+
+CREATE TRIGGER trg_assert_watch_only_key_scope_secrets_update
+BEFORE UPDATE ON key_scope_secrets
+FOR EACH ROW
+EXECUTE FUNCTION assert_watch_only_key_scope_secrets();

--- a/wallet/internal/sql/pg/migrations/000004_key_scopes.up.sql
+++ b/wallet/internal/sql/pg/migrations/000004_key_scopes.up.sql
@@ -44,6 +44,25 @@ ON key_scopes (wallet_id, purpose, coin_type);
 -- Unique index to support composite foreign keys scoped by wallet ownership.
 CREATE UNIQUE INDEX uidx_key_scopes_wallet_id_id ON key_scopes (wallet_id, id);
 
+-- Enforce that wallet ownership chosen at key-scope creation time remains
+-- immutable. This closes the database-boundary hole where a raw update could
+-- reparent an existing scope into another wallet after insert.
+CREATE FUNCTION assert_key_scope_wallet_id_immutable() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.wallet_id IS DISTINCT FROM OLD.wallet_id THEN
+        RAISE EXCEPTION 'key scope wallet_id cannot be changed after creation'
+            USING ERRCODE = '23514'; -- check_violation
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_assert_key_scope_wallet_id_immutable
+BEFORE UPDATE OF wallet_id ON key_scopes
+FOR EACH ROW
+EXECUTE FUNCTION assert_key_scope_wallet_id_immutable();
+
 -- Key Scope Secrets table to hold encrypted coin-type secrets for spendable
 -- scopes.
 -- Separated from the main key_scopes table for security and access pattern

--- a/wallet/internal/sql/pg/migrations/000004_key_scopes.up.sql
+++ b/wallet/internal/sql/pg/migrations/000004_key_scopes.up.sql
@@ -44,18 +44,18 @@ ON key_scopes (wallet_id, purpose, coin_type);
 -- Unique index to support composite foreign keys scoped by wallet ownership.
 CREATE UNIQUE INDEX uidx_key_scopes_wallet_id_id ON key_scopes (wallet_id, id);
 
--- Key Scope Secrets table to hold encrypted coin-type secrets for each scope.
--- Separated from the main key_scopes table for security and access pattern isolation.
--- Watch-only scopes may have no corresponding row in this table or have NULL
--- encrypted_coin_priv_key.
+-- Key Scope Secrets table to hold encrypted coin-type secrets for spendable
+-- scopes.
+-- Separated from the main key_scopes table for security and access pattern
+-- isolation. Watch-only scopes are represented by having no row in this table.
 CREATE TABLE key_scope_secrets (
     -- Reference to the key scope these keys belong to. Also serves as the
     -- primary key, enforcing one-to-one relationship.
     scope_id BIGINT PRIMARY KEY,
 
     -- Encrypted key used to derive private keys for this scope.
-    -- NULL for watch-only key scopes.
-    encrypted_coin_priv_key BYTEA,
+    -- NOT NULL enforces that only spendable scopes have a row in this table.
+    encrypted_coin_priv_key BYTEA NOT NULL,
 
     -- Foreign key constraint to key_scopes. Using ON DELETE RESTRICT to ensure
     -- that the key scope cannot be deleted if secrets still exist.

--- a/wallet/internal/sql/pg/migrations/000005_accounts.down.sql
+++ b/wallet/internal/sql/pg/migrations/000005_accounts.down.sql
@@ -1,5 +1,8 @@
 -- Rollback note: Idempotent by design (using "IF EXISTS").
 -- Must succeed even if tables are already dropped or database is in unexpected state.
+DROP TRIGGER IF EXISTS trg_assert_watch_only_account_secrets_insert ON account_secrets;
+DROP TRIGGER IF EXISTS trg_assert_watch_only_account_secrets_update ON account_secrets;
+DROP FUNCTION IF EXISTS assert_watch_only_account_secrets();
 DROP TABLE IF EXISTS account_secrets;
 DROP TABLE IF EXISTS accounts;
 DROP TABLE IF EXISTS account_origins;

--- a/wallet/internal/sql/pg/migrations/000005_accounts.down.sql
+++ b/wallet/internal/sql/pg/migrations/000005_accounts.down.sql
@@ -2,7 +2,9 @@
 -- Must succeed even if tables are already dropped or database is in unexpected state.
 DROP TRIGGER IF EXISTS trg_assert_watch_only_account_secrets_insert ON account_secrets;
 DROP TRIGGER IF EXISTS trg_assert_watch_only_account_secrets_update ON account_secrets;
+DROP TRIGGER IF EXISTS trg_assert_account_wallet_id_immutable ON accounts;
 DROP FUNCTION IF EXISTS assert_watch_only_account_secrets();
+DROP FUNCTION IF EXISTS assert_account_wallet_id_immutable();
 DROP TABLE IF EXISTS account_secrets;
 DROP TABLE IF EXISTS accounts;
 DROP TABLE IF EXISTS account_origins;

--- a/wallet/internal/sql/pg/migrations/000005_accounts.up.sql
+++ b/wallet/internal/sql/pg/migrations/000005_accounts.up.sql
@@ -114,6 +114,25 @@ WHERE account_number IS NOT NULL;
 CREATE UNIQUE INDEX uidx_accounts_scope_account_name
 ON accounts (scope_id, account_name);
 
+-- Enforce that wallet ownership chosen at account creation time remains
+-- immutable. This closes the database-boundary hole where a raw update could
+-- reparent an existing account into another wallet after insert.
+CREATE FUNCTION assert_account_wallet_id_immutable() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.wallet_id IS DISTINCT FROM OLD.wallet_id THEN
+        RAISE EXCEPTION 'account wallet_id cannot be changed after creation'
+            USING ERRCODE = '23514'; -- check_violation
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_assert_account_wallet_id_immutable
+BEFORE UPDATE OF wallet_id ON accounts
+FOR EACH ROW
+EXECUTE FUNCTION assert_account_wallet_id_immutable();
+
 -- Account Secrets table to hold encrypted account-level secrets.
 CREATE TABLE account_secrets (
     -- Reference to the account these keys belong to. Also serves as the

--- a/wallet/internal/sql/pg/migrations/000005_accounts.up.sql
+++ b/wallet/internal/sql/pg/migrations/000005_accounts.up.sql
@@ -128,3 +128,40 @@ CREATE TABLE account_secrets (
     -- that the account cannot be deleted if secrets still exist.
     FOREIGN KEY (account_id) REFERENCES accounts (id) ON DELETE RESTRICT
 );
+
+-- Enforce the watch-only account secret invariant at the database boundary.
+-- Accounts in watch-only wallets must not store account-level private key
+-- material.
+--
+-- Note: Unlike address_secrets.encrypted_priv_key (which is nullable for
+-- HD-derived addresses), account_secrets.encrypted_private_key is NOT NULL.
+-- This means any row in account_secrets necessarily represents private key
+-- material, so we reject all inserts/updates for watch-only parents without
+-- needing to check column nullability first.
+CREATE FUNCTION assert_watch_only_account_secrets() RETURNS TRIGGER AS $$
+DECLARE
+    wallet_is_watch_only BOOLEAN;
+BEGIN
+    SELECT w.is_watch_only INTO wallet_is_watch_only
+    FROM accounts AS a
+    INNER JOIN wallets AS w ON w.id = a.wallet_id
+    WHERE a.id = NEW.account_id;
+
+    IF wallet_is_watch_only THEN
+        RAISE EXCEPTION 'watch-only wallet accounts cannot store account secrets'
+            USING ERRCODE = '23514'; -- check_violation
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_assert_watch_only_account_secrets_insert
+BEFORE INSERT ON account_secrets
+FOR EACH ROW
+EXECUTE FUNCTION assert_watch_only_account_secrets();
+
+CREATE TRIGGER trg_assert_watch_only_account_secrets_update
+BEFORE UPDATE ON account_secrets
+FOR EACH ROW
+EXECUTE FUNCTION assert_watch_only_account_secrets();

--- a/wallet/internal/sql/pg/migrations/000006_addresses.down.sql
+++ b/wallet/internal/sql/pg/migrations/000006_addresses.down.sql
@@ -2,9 +2,11 @@
 -- Must succeed even if tables are already dropped or database is in unexpected state.
 DROP TRIGGER IF EXISTS trg_assert_watch_only_address_secrets_insert ON address_secrets;
 DROP TRIGGER IF EXISTS trg_assert_watch_only_address_secrets_update ON address_secrets;
+DROP TRIGGER IF EXISTS trg_assert_address_wallet_id_immutable ON addresses;
 DROP TRIGGER IF EXISTS trg_addresses_imported_key_count_insert ON addresses;
 DROP TRIGGER IF EXISTS trg_addresses_imported_key_count_delete ON addresses;
 DROP FUNCTION IF EXISTS assert_watch_only_address_secrets();
+DROP FUNCTION IF EXISTS assert_address_wallet_id_immutable();
 DROP FUNCTION IF EXISTS sync_account_imported_key_count_insert();
 DROP FUNCTION IF EXISTS sync_account_imported_key_count_delete();
 DROP INDEX IF EXISTS idx_addresses_account_id;

--- a/wallet/internal/sql/pg/migrations/000006_addresses.down.sql
+++ b/wallet/internal/sql/pg/migrations/000006_addresses.down.sql
@@ -1,7 +1,10 @@
 -- Rollback note: Idempotent by design (using "IF EXISTS").
 -- Must succeed even if tables are already dropped or database is in unexpected state.
+DROP TRIGGER IF EXISTS trg_assert_watch_only_address_secrets_insert ON address_secrets;
+DROP TRIGGER IF EXISTS trg_assert_watch_only_address_secrets_update ON address_secrets;
 DROP TRIGGER IF EXISTS trg_addresses_imported_key_count_insert ON addresses;
 DROP TRIGGER IF EXISTS trg_addresses_imported_key_count_delete ON addresses;
+DROP FUNCTION IF EXISTS assert_watch_only_address_secrets();
 DROP FUNCTION IF EXISTS sync_account_imported_key_count_insert();
 DROP FUNCTION IF EXISTS sync_account_imported_key_count_delete();
 DROP INDEX IF EXISTS idx_addresses_account_id;

--- a/wallet/internal/sql/pg/migrations/000006_addresses.up.sql
+++ b/wallet/internal/sql/pg/migrations/000006_addresses.up.sql
@@ -104,6 +104,42 @@ CREATE TABLE address_secrets (
     FOREIGN KEY (address_id) REFERENCES addresses (id) ON DELETE RESTRICT
 );
 
+-- Enforce the watch-only address secret invariant at the database boundary.
+-- Watch-only parent wallets may track imported scripts, but addresses
+-- beneath them must not store private keys; otherwise a watch-only parent could
+-- silently gain spend authority through an address secret row.
+CREATE FUNCTION assert_watch_only_address_secrets() RETURNS TRIGGER AS $$
+DECLARE
+    wallet_is_watch_only BOOLEAN;
+BEGIN
+    IF NEW.encrypted_priv_key IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    SELECT w.is_watch_only INTO wallet_is_watch_only
+    FROM addresses AS addr
+    INNER JOIN wallets AS w ON w.id = addr.wallet_id
+    WHERE addr.id = NEW.address_id;
+
+    IF wallet_is_watch_only THEN
+        RAISE EXCEPTION 'watch-only address parents cannot store private keys'
+            USING ERRCODE = '23514'; -- check_violation
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_assert_watch_only_address_secrets_insert
+BEFORE INSERT ON address_secrets
+FOR EACH ROW
+EXECUTE FUNCTION assert_watch_only_address_secrets();
+
+CREATE TRIGGER trg_assert_watch_only_address_secrets_update
+BEFORE UPDATE ON address_secrets
+FOR EACH ROW
+EXECUTE FUNCTION assert_watch_only_address_secrets();
+
 -- Increments imported_key_count for imported address inserts.
 CREATE FUNCTION sync_account_imported_key_count_insert() RETURNS TRIGGER AS $$
 BEGIN

--- a/wallet/internal/sql/pg/migrations/000006_addresses.up.sql
+++ b/wallet/internal/sql/pg/migrations/000006_addresses.up.sql
@@ -83,6 +83,25 @@ ON addresses (wallet_id, script_pub_key);
 -- Used by ListAddressesByAccount for cursor-based pagination.
 CREATE INDEX idx_addresses_account_id ON addresses (account_id, id);
 
+-- Enforce that wallet ownership chosen at address creation time remains
+-- immutable. This closes the database-boundary hole where a raw update could
+-- reparent an existing address into another wallet after insert.
+CREATE FUNCTION assert_address_wallet_id_immutable() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.wallet_id IS DISTINCT FROM OLD.wallet_id THEN
+        RAISE EXCEPTION 'address wallet_id cannot be changed after creation'
+            USING ERRCODE = '23514'; -- check_violation
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_assert_address_wallet_id_immutable
+BEFORE UPDATE OF wallet_id ON addresses
+FOR EACH ROW
+EXECUTE FUNCTION assert_address_wallet_id_immutable();
+
 -- Address Secrets table stores sensitive encrypted material needed to spend
 -- from an address. This table has a one-to-one relationship with addresses.
 -- Watch-only addresses may have no row in this table.

--- a/wallet/internal/sql/pg/queries/key_scopes.sql
+++ b/wallet/internal/sql/pg/queries/key_scopes.sql
@@ -14,8 +14,8 @@ ON CONFLICT (wallet_id, purpose, coin_type) DO NOTHING
 RETURNING id;
 
 -- name: InsertKeyScopeSecrets :exec
--- Inserts secrets for a key scope. encrypted_coin_priv_key may be NULL for
--- watch-only scopes.
+-- Inserts secrets for a spendable key scope. Watch-only scopes are represented
+-- by an absent key_scope_secrets row.
 INSERT INTO key_scope_secrets (
     scope_id,
     encrypted_coin_priv_key

--- a/wallet/internal/sql/pg/sqlc/key_scopes.sql.go
+++ b/wallet/internal/sql/pg/sqlc/key_scopes.sql.go
@@ -170,8 +170,8 @@ type InsertKeyScopeSecretsParams struct {
 	EncryptedCoinPrivKey []byte
 }
 
-// Inserts secrets for a key scope. encrypted_coin_priv_key may be NULL for
-// watch-only scopes.
+// Inserts secrets for a spendable key scope. Watch-only scopes are represented
+// by an absent key_scope_secrets row.
 func (q *Queries) InsertKeyScopeSecrets(ctx context.Context, arg InsertKeyScopeSecretsParams) error {
 	_, err := q.exec(ctx, q.insertKeyScopeSecretsStmt, InsertKeyScopeSecrets, arg.ScopeID, arg.EncryptedCoinPrivKey)
 	return err

--- a/wallet/internal/sql/pg/sqlc/querier.go
+++ b/wallet/internal/sql/pg/sqlc/querier.go
@@ -252,8 +252,8 @@ type Querier interface {
 	// Not used for derived addresses (their keys are derived from account key).
 	InsertAddressSecret(ctx context.Context, arg InsertAddressSecretParams) error
 	InsertBlock(ctx context.Context, arg InsertBlockParams) error
-	// Inserts secrets for a key scope. encrypted_coin_priv_key may be NULL for
-	// watch-only scopes.
+	// Inserts secrets for a spendable key scope. Watch-only scopes are represented
+	// by an absent key_scope_secrets row.
 	InsertKeyScopeSecrets(ctx context.Context, arg InsertKeyScopeSecretsParams) error
 	// Inserts a wallet-scoped transaction row and returns its database ID.
 	//

--- a/wallet/internal/sql/sqlite/migrations/000002_wallets.down.sql
+++ b/wallet/internal/sql/sqlite/migrations/000002_wallets.down.sql
@@ -1,5 +1,7 @@
 -- Rollback note: Idempotent by design (using "IF EXISTS").
 -- Must succeed even if tables are already dropped or database in unexpected state.
+DROP TRIGGER IF EXISTS trg_assert_watch_only_wallet_secrets_insert;
+DROP TRIGGER IF EXISTS trg_assert_watch_only_wallet_secrets_update;
 DROP TABLE IF EXISTS wallet_sync_states;
 DROP TABLE IF EXISTS wallet_secrets;
 DROP TABLE IF EXISTS wallets;

--- a/wallet/internal/sql/sqlite/migrations/000002_wallets.down.sql
+++ b/wallet/internal/sql/sqlite/migrations/000002_wallets.down.sql
@@ -1,5 +1,6 @@
 -- Rollback note: Idempotent by design (using "IF EXISTS").
 -- Must succeed even if tables are already dropped or database in unexpected state.
+DROP TRIGGER IF EXISTS trg_assert_wallet_is_watch_only_immutable;
 DROP TRIGGER IF EXISTS trg_assert_watch_only_wallet_secrets_insert;
 DROP TRIGGER IF EXISTS trg_assert_watch_only_wallet_secrets_update;
 DROP TABLE IF EXISTS wallet_sync_states;

--- a/wallet/internal/sql/sqlite/migrations/000002_wallets.up.sql
+++ b/wallet/internal/sql/sqlite/migrations/000002_wallets.up.sql
@@ -61,6 +61,43 @@ CREATE TABLE wallet_secrets (
     FOREIGN KEY (wallet_id) REFERENCES wallets (id) ON DELETE RESTRICT
 );
 
+-- Enforce the watch-only wallet secret invariant at the database boundary.
+-- Watch-only wallets may retain script-encryption material for imported
+-- scripts, but must never store private key material; keeping these columns
+-- NULL prevents an insert or update from silently turning a watch-only wallet
+-- into a spend-capable wallet.
+CREATE TRIGGER trg_assert_watch_only_wallet_secrets_insert
+BEFORE INSERT ON wallet_secrets
+FOR EACH ROW
+BEGIN
+    SELECT raise(ABORT, 'watch-only wallet private secret columns must be null')
+    WHERE (
+        SELECT w.is_watch_only
+        FROM wallets AS w
+        WHERE w.id = new.wallet_id
+    ) AND (
+        new.master_priv_params IS NOT NULL
+        OR new.encrypted_crypto_priv_key IS NOT NULL
+        OR new.encrypted_master_hd_priv_key IS NOT NULL
+    );
+END;
+
+CREATE TRIGGER trg_assert_watch_only_wallet_secrets_update
+BEFORE UPDATE ON wallet_secrets
+FOR EACH ROW
+BEGIN
+    SELECT raise(ABORT, 'watch-only wallet private secret columns must be null')
+    WHERE (
+        SELECT w.is_watch_only
+        FROM wallets AS w
+        WHERE w.id = new.wallet_id
+    ) AND (
+        new.master_priv_params IS NOT NULL
+        OR new.encrypted_crypto_priv_key IS NOT NULL
+        OR new.encrypted_master_hd_priv_key IS NOT NULL
+    );
+END;
+
 -- Wallet Sync States table to store the synchronization state of each wallet.
 -- This is kept separate from the wallets table to avoid write amplification on
 -- frequently updated sync data. Each wallet has exactly one sync state record.

--- a/wallet/internal/sql/sqlite/migrations/000002_wallets.up.sql
+++ b/wallet/internal/sql/sqlite/migrations/000002_wallets.up.sql
@@ -32,6 +32,18 @@ CREATE TABLE wallets (
 -- Unique index to prevent duplicate wallet names.
 CREATE UNIQUE INDEX uidx_wallets_name ON wallets (wallet_name);
 
+-- Enforce that the watch-only status chosen at wallet creation time remains
+-- immutable. This closes the database-boundary hole where a raw wallet update
+-- could silently bypass the secret-table triggers by flipping the parent
+-- wallet between watch-only and spendable after insert.
+CREATE TRIGGER trg_assert_wallet_is_watch_only_immutable
+BEFORE UPDATE OF is_watch_only ON wallets
+FOR EACH ROW
+WHEN new.is_watch_only != old.is_watch_only
+BEGIN
+    SELECT raise(ABORT, 'wallet is_watch_only cannot be changed after creation');
+END;
+
 -- Wallet Secrets table to store rarely accessed, highly sensitive encrypted
 -- material with a strict one-to-one relationship with the wallets table.
 -- Separated from the main wallets table for security and access pattern isolation.

--- a/wallet/internal/sql/sqlite/migrations/000004_key_scopes.down.sql
+++ b/wallet/internal/sql/sqlite/migrations/000004_key_scopes.down.sql
@@ -1,4 +1,6 @@
 -- Rollback note: Idempotent by design (using "IF EXISTS").
 -- Must succeed even if tables are already dropped or database in unexpected state.
+DROP TRIGGER IF EXISTS trg_assert_watch_only_key_scope_secrets_insert;
+DROP TRIGGER IF EXISTS trg_assert_watch_only_key_scope_secrets_update;
 DROP TABLE IF EXISTS key_scope_secrets;
 DROP TABLE IF EXISTS key_scopes;

--- a/wallet/internal/sql/sqlite/migrations/000004_key_scopes.down.sql
+++ b/wallet/internal/sql/sqlite/migrations/000004_key_scopes.down.sql
@@ -2,5 +2,6 @@
 -- Must succeed even if tables are already dropped or database in unexpected state.
 DROP TRIGGER IF EXISTS trg_assert_watch_only_key_scope_secrets_insert;
 DROP TRIGGER IF EXISTS trg_assert_watch_only_key_scope_secrets_update;
+DROP TRIGGER IF EXISTS trg_assert_key_scope_wallet_id_immutable;
 DROP TABLE IF EXISTS key_scope_secrets;
 DROP TABLE IF EXISTS key_scopes;

--- a/wallet/internal/sql/sqlite/migrations/000004_key_scopes.up.sql
+++ b/wallet/internal/sql/sqlite/migrations/000004_key_scopes.up.sql
@@ -44,18 +44,18 @@ ON key_scopes (wallet_id, purpose, coin_type);
 -- Unique index to support composite foreign keys scoped by wallet ownership.
 CREATE UNIQUE INDEX uidx_key_scopes_wallet_id_id ON key_scopes (wallet_id, id);
 
--- Key Scope Secrets table to hold encrypted coin-type secrets for each scope.
--- Separated from the main key_scopes table for security and access pattern isolation.
--- Watch-only scopes may have no corresponding row in this table or have NULL
--- encrypted_coin_priv_key.
+-- Key Scope Secrets table to hold encrypted coin-type secrets for spendable
+-- scopes.
+-- Separated from the main key_scopes table for security and access pattern
+-- isolation. Watch-only scopes are represented by having no row in this table.
 CREATE TABLE key_scope_secrets (
     -- Reference to the key scope these keys belong to. Also serves as the
     -- primary key, enforcing one-to-one relationship.
     scope_id INTEGER PRIMARY KEY,
 
     -- Encrypted key used to derive private keys for this scope.
-    -- NULL for watch-only key scopes.
-    encrypted_coin_priv_key BLOB,
+    -- NOT NULL enforces that only spendable scopes have a row in this table.
+    encrypted_coin_priv_key BLOB NOT NULL,
 
     -- Foreign key constraint to key_scopes. Using ON DELETE RESTRICT to ensure
     -- that the key scope cannot be deleted if secrets still exist.

--- a/wallet/internal/sql/sqlite/migrations/000004_key_scopes.up.sql
+++ b/wallet/internal/sql/sqlite/migrations/000004_key_scopes.up.sql
@@ -61,3 +61,38 @@ CREATE TABLE key_scope_secrets (
     -- that the key scope cannot be deleted if secrets still exist.
     FOREIGN KEY (scope_id) REFERENCES key_scopes (id) ON DELETE RESTRICT
 );
+
+-- Enforce the watch-only key-scope secret invariant at the database boundary.
+-- Watch-only wallets may keep a scope row for public derivation metadata, but
+-- the matching key_scope_secrets row must not carry coin private key material.
+CREATE TRIGGER trg_assert_watch_only_key_scope_secrets_insert
+BEFORE INSERT ON key_scope_secrets
+FOR EACH ROW
+BEGIN
+    SELECT raise(ABORT, 'watch-only key scopes cannot store coin private keys')
+    WHERE
+        EXISTS (
+            SELECT 1
+            FROM key_scopes AS ks
+            INNER JOIN wallets AS w ON ks.wallet_id = w.id
+            WHERE
+                ks.id = new.scope_id
+                AND w.is_watch_only
+        );
+END;
+
+CREATE TRIGGER trg_assert_watch_only_key_scope_secrets_update
+BEFORE UPDATE ON key_scope_secrets
+FOR EACH ROW
+BEGIN
+    SELECT raise(ABORT, 'watch-only key scopes cannot store coin private keys')
+    WHERE
+        EXISTS (
+            SELECT 1
+            FROM key_scopes AS ks
+            INNER JOIN wallets AS w ON ks.wallet_id = w.id
+            WHERE
+                ks.id = new.scope_id
+                AND w.is_watch_only
+        );
+END;

--- a/wallet/internal/sql/sqlite/migrations/000004_key_scopes.up.sql
+++ b/wallet/internal/sql/sqlite/migrations/000004_key_scopes.up.sql
@@ -44,6 +44,17 @@ ON key_scopes (wallet_id, purpose, coin_type);
 -- Unique index to support composite foreign keys scoped by wallet ownership.
 CREATE UNIQUE INDEX uidx_key_scopes_wallet_id_id ON key_scopes (wallet_id, id);
 
+-- Enforce that wallet ownership chosen at key-scope creation time remains
+-- immutable. This closes the database-boundary hole where a raw update could
+-- reparent an existing scope into another wallet after insert.
+CREATE TRIGGER trg_assert_key_scope_wallet_id_immutable
+BEFORE UPDATE OF wallet_id ON key_scopes
+FOR EACH ROW
+WHEN new.wallet_id != old.wallet_id
+BEGIN
+    SELECT raise(ABORT, 'key scope wallet_id cannot be changed after creation');
+END;
+
 -- Key Scope Secrets table to hold encrypted coin-type secrets for spendable
 -- scopes.
 -- Separated from the main key_scopes table for security and access pattern

--- a/wallet/internal/sql/sqlite/migrations/000005_accounts.down.sql
+++ b/wallet/internal/sql/sqlite/migrations/000005_accounts.down.sql
@@ -2,6 +2,7 @@
 -- Must succeed even if tables are already dropped or database is in unexpected state.
 DROP TRIGGER IF EXISTS trg_assert_watch_only_account_secrets_insert;
 DROP TRIGGER IF EXISTS trg_assert_watch_only_account_secrets_update;
+DROP TRIGGER IF EXISTS trg_assert_account_wallet_id_immutable;
 DROP TABLE IF EXISTS account_secrets;
 DROP TABLE IF EXISTS accounts;
 DROP TABLE IF EXISTS account_origins;

--- a/wallet/internal/sql/sqlite/migrations/000005_accounts.down.sql
+++ b/wallet/internal/sql/sqlite/migrations/000005_accounts.down.sql
@@ -1,5 +1,7 @@
 -- Rollback note: Idempotent by design (using "IF EXISTS").
 -- Must succeed even if tables are already dropped or database is in unexpected state.
+DROP TRIGGER IF EXISTS trg_assert_watch_only_account_secrets_insert;
+DROP TRIGGER IF EXISTS trg_assert_watch_only_account_secrets_update;
 DROP TABLE IF EXISTS account_secrets;
 DROP TABLE IF EXISTS accounts;
 DROP TABLE IF EXISTS account_origins;

--- a/wallet/internal/sql/sqlite/migrations/000005_accounts.up.sql
+++ b/wallet/internal/sql/sqlite/migrations/000005_accounts.up.sql
@@ -127,3 +127,38 @@ CREATE TABLE account_secrets (
     -- that the account cannot be deleted if secrets still exist.
     FOREIGN KEY (account_id) REFERENCES accounts (id) ON DELETE RESTRICT
 );
+
+-- Enforce the watch-only account secret invariant at the database boundary.
+-- Accounts in watch-only wallets must not store account-level private key
+-- material.
+--
+-- Note: Unlike address_secrets.encrypted_priv_key (which is nullable for
+-- HD-derived addresses), account_secrets.encrypted_private_key is NOT NULL.
+-- This means any row in account_secrets necessarily represents private key
+-- material, so we reject all inserts/updates for watch-only parents without
+-- needing to check column nullability first.
+CREATE TRIGGER trg_assert_watch_only_account_secrets_insert
+BEFORE INSERT ON account_secrets
+FOR EACH ROW
+BEGIN
+    SELECT raise(ABORT, 'watch-only accounts cannot store account secrets')
+    WHERE (
+        SELECT w.is_watch_only
+        FROM accounts AS a
+        INNER JOIN wallets AS w ON a.wallet_id = w.id
+        WHERE a.id = new.account_id
+    );
+END;
+
+CREATE TRIGGER trg_assert_watch_only_account_secrets_update
+BEFORE UPDATE ON account_secrets
+FOR EACH ROW
+BEGIN
+    SELECT raise(ABORT, 'watch-only accounts cannot store account secrets')
+    WHERE (
+        SELECT w.is_watch_only
+        FROM accounts AS a
+        INNER JOIN wallets AS w ON a.wallet_id = w.id
+        WHERE a.id = new.account_id
+    );
+END;

--- a/wallet/internal/sql/sqlite/migrations/000005_accounts.up.sql
+++ b/wallet/internal/sql/sqlite/migrations/000005_accounts.up.sql
@@ -113,6 +113,17 @@ WHERE account_number IS NOT NULL;
 CREATE UNIQUE INDEX uidx_accounts_scope_account_name
 ON accounts (scope_id, account_name);
 
+-- Enforce that wallet ownership chosen at account creation time remains
+-- immutable. This closes the database-boundary hole where a raw update could
+-- reparent an existing account into another wallet after insert.
+CREATE TRIGGER trg_assert_account_wallet_id_immutable
+BEFORE UPDATE OF wallet_id ON accounts
+FOR EACH ROW
+WHEN new.wallet_id != old.wallet_id
+BEGIN
+    SELECT raise(ABORT, 'account wallet_id cannot be changed after creation');
+END;
+
 -- Account Secrets table to hold encrypted account-level secrets.
 CREATE TABLE account_secrets (
     -- Reference to the account these keys belong to. Also serves as the

--- a/wallet/internal/sql/sqlite/migrations/000006_addresses.down.sql
+++ b/wallet/internal/sql/sqlite/migrations/000006_addresses.down.sql
@@ -2,6 +2,7 @@
 -- Must succeed even if tables are already dropped or database is in unexpected state.
 DROP TRIGGER IF EXISTS trg_assert_watch_only_address_secrets_insert;
 DROP TRIGGER IF EXISTS trg_assert_watch_only_address_secrets_update;
+DROP TRIGGER IF EXISTS trg_assert_address_wallet_id_immutable;
 DROP TRIGGER IF EXISTS trg_addresses_imported_key_count_insert;
 DROP TRIGGER IF EXISTS trg_addresses_imported_key_count_delete;
 DROP INDEX IF EXISTS idx_addresses_account_id;

--- a/wallet/internal/sql/sqlite/migrations/000006_addresses.down.sql
+++ b/wallet/internal/sql/sqlite/migrations/000006_addresses.down.sql
@@ -1,5 +1,9 @@
 -- Rollback note: Idempotent by design (using "IF EXISTS").
 -- Must succeed even if tables are already dropped or database is in unexpected state.
+DROP TRIGGER IF EXISTS trg_assert_watch_only_address_secrets_insert;
+DROP TRIGGER IF EXISTS trg_assert_watch_only_address_secrets_update;
+DROP TRIGGER IF EXISTS trg_addresses_imported_key_count_insert;
+DROP TRIGGER IF EXISTS trg_addresses_imported_key_count_delete;
 DROP INDEX IF EXISTS idx_addresses_account_id;
 DROP TABLE IF EXISTS address_secrets;
 DROP TABLE IF EXISTS addresses;

--- a/wallet/internal/sql/sqlite/migrations/000006_addresses.up.sql
+++ b/wallet/internal/sql/sqlite/migrations/000006_addresses.up.sql
@@ -102,6 +102,44 @@ CREATE TABLE address_secrets (
     FOREIGN KEY (address_id) REFERENCES addresses (id) ON DELETE RESTRICT
 );
 
+-- Enforce the watch-only address secret invariant at the database boundary.
+-- Watch-only parent wallets may track imported scripts, but addresses
+-- beneath them must not store private keys; otherwise a watch-only parent could
+-- silently gain spend authority through an address secret row.
+CREATE TRIGGER trg_assert_watch_only_address_secrets_insert
+BEFORE INSERT ON address_secrets
+FOR EACH ROW
+BEGIN
+    SELECT raise(ABORT, 'watch-only address parents cannot store private keys')
+    WHERE
+        new.encrypted_priv_key IS NOT NULL
+        AND EXISTS (
+            SELECT 1
+            FROM addresses AS addr
+            INNER JOIN wallets AS w ON addr.wallet_id = w.id
+            WHERE
+                addr.id = new.address_id
+                AND w.is_watch_only
+        );
+END;
+
+CREATE TRIGGER trg_assert_watch_only_address_secrets_update
+BEFORE UPDATE ON address_secrets
+FOR EACH ROW
+BEGIN
+    SELECT raise(ABORT, 'watch-only address parents cannot store private keys')
+    WHERE
+        new.encrypted_priv_key IS NOT NULL
+        AND EXISTS (
+            SELECT 1
+            FROM addresses AS addr
+            INNER JOIN wallets AS w ON addr.wallet_id = w.id
+            WHERE
+                addr.id = new.address_id
+                AND w.is_watch_only
+        );
+END;
+
 -- Increments imported_key_count when a new imported address is inserted.
 CREATE TRIGGER trg_addresses_imported_key_count_insert
 AFTER INSERT ON addresses

--- a/wallet/internal/sql/sqlite/migrations/000006_addresses.up.sql
+++ b/wallet/internal/sql/sqlite/migrations/000006_addresses.up.sql
@@ -81,6 +81,17 @@ ON addresses (wallet_id, script_pub_key);
 -- Used by ListAddressesByAccount for cursor-based pagination.
 CREATE INDEX idx_addresses_account_id ON addresses (account_id, id);
 
+-- Enforce that wallet ownership chosen at address creation time remains
+-- immutable. This closes the database-boundary hole where a raw update could
+-- reparent an existing address into another wallet after insert.
+CREATE TRIGGER trg_assert_address_wallet_id_immutable
+BEFORE UPDATE OF wallet_id ON addresses
+FOR EACH ROW
+WHEN new.wallet_id != old.wallet_id
+BEGIN
+    SELECT raise(ABORT, 'address wallet_id cannot be changed after creation');
+END;
+
 -- Address Secrets table stores sensitive encrypted material needed to spend
 -- from an address. This table has a one-to-one relationship with addresses.
 -- Watch-only addresses may have no row in this table.

--- a/wallet/internal/sql/sqlite/queries/key_scopes.sql
+++ b/wallet/internal/sql/sqlite/queries/key_scopes.sql
@@ -14,8 +14,8 @@ ON CONFLICT (wallet_id, purpose, coin_type) DO NOTHING
 RETURNING id;
 
 -- name: InsertKeyScopeSecrets :exec
--- Inserts secrets for a key scope. encrypted_coin_priv_key may be NULL for
--- watch-only scopes.
+-- Inserts secrets for a spendable key scope. Watch-only scopes are represented
+-- by an absent key_scope_secrets row.
 INSERT INTO key_scope_secrets (
     scope_id,
     encrypted_coin_priv_key

--- a/wallet/internal/sql/sqlite/sqlc/key_scopes.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/key_scopes.sql.go
@@ -170,8 +170,8 @@ type InsertKeyScopeSecretsParams struct {
 	EncryptedCoinPrivKey []byte
 }
 
-// Inserts secrets for a key scope. encrypted_coin_priv_key may be NULL for
-// watch-only scopes.
+// Inserts secrets for a spendable key scope. Watch-only scopes are represented
+// by an absent key_scope_secrets row.
 func (q *Queries) InsertKeyScopeSecrets(ctx context.Context, arg InsertKeyScopeSecretsParams) error {
 	_, err := q.exec(ctx, q.insertKeyScopeSecretsStmt, InsertKeyScopeSecrets, arg.ScopeID, arg.EncryptedCoinPrivKey)
 	return err

--- a/wallet/internal/sql/sqlite/sqlc/querier.go
+++ b/wallet/internal/sql/sqlite/sqlc/querier.go
@@ -249,8 +249,8 @@ type Querier interface {
 	// Not used for derived addresses (their keys are derived from account key).
 	InsertAddressSecret(ctx context.Context, arg InsertAddressSecretParams) error
 	InsertBlock(ctx context.Context, arg InsertBlockParams) error
-	// Inserts secrets for a key scope. encrypted_coin_priv_key may be NULL for
-	// watch-only scopes.
+	// Inserts secrets for a spendable key scope. Watch-only scopes are represented
+	// by an absent key_scope_secrets row.
 	InsertKeyScopeSecrets(ctx context.Context, arg InsertKeyScopeSecretsParams) error
 	// Inserts a wallet-scoped transaction row and returns its database ID.
 	//


### PR DESCRIPTION
Strengthen the database-boundary enforcement for watch-only data by adding trigger coverage and regression itests. This also prevents key scopes, accounts, and addresses from being reparented to a different wallet after insert, closing a bypass around existing secret invariants.