### PR TITLE
db: add SQL tx detail reads

### DIFF
--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -834,6 +834,56 @@ type TxInfo struct {
 	Label string
 }
 
+// TxOwnedInput records one wallet-owned previous output spent by a
+// transaction.
+type TxOwnedInput struct {
+	// Index is the input index within the transaction.
+	Index uint32
+
+	// Amount is the value of the wallet-owned input being spent.
+	Amount btcutil.Amount
+}
+
+// TxOwnedOutput records one wallet-owned output created by a transaction.
+type TxOwnedOutput struct {
+	// Index is the output index within the transaction.
+	Index uint32
+
+	// Amount is the value of the wallet-owned output.
+	Amount btcutil.Amount
+}
+
+// TxDetailInfo is a db-native transaction detail model tailored for wallet tx
+// history reads.
+type TxDetailInfo struct {
+	// Hash is the transaction hash.
+	Hash chainhash.Hash
+
+	// MsgTx is the decoded wire transaction when the backend already has it.
+	MsgTx *wire.MsgTx
+
+	// SerializedTx is the serialized transaction.
+	SerializedTx []byte
+
+	// Received is the timestamp when the transaction was received.
+	Received time.Time
+
+	// Block contains metadata about the block that includes the transaction.
+	Block *Block
+
+	// Status is the wallet-relative validity state of the transaction.
+	Status TxStatus
+
+	// Label is a user-defined label for the transaction.
+	Label string
+
+	// OwnedInputs are the wallet-owned inputs spent by the transaction.
+	OwnedInputs []TxOwnedInput
+
+	// OwnedOutputs are the wallet-owned outputs created by the transaction.
+	OwnedOutputs []TxOwnedOutput
+}
+
 // CreateTxParams contains the parameters for creating a new transaction record.
 type CreateTxParams struct {
 	// WalletID is the ID of the wallet to create the transaction in.
@@ -948,6 +998,29 @@ type GetTxQuery struct {
 
 	// Txid is the hash of the transaction to query.
 	Txid chainhash.Hash
+}
+
+// GetTxDetailQuery contains the parameters for querying detailed transaction
+// data for one wallet-scoped transaction.
+type GetTxDetailQuery struct {
+	// WalletID is the ID of the wallet to query.
+	WalletID uint32
+
+	// Txid is the hash of the transaction to query.
+	Txid chainhash.Hash
+}
+
+// ListTxDetailsQuery contains the parameters for listing detailed transaction
+// data using wallet tx-reader range semantics.
+type ListTxDetailsQuery struct {
+	// WalletID is the ID of the wallet to query.
+	WalletID uint32
+
+	// StartHeight is the starting height in wallet tx-reader semantics.
+	StartHeight int32
+
+	// EndHeight is the ending height in wallet tx-reader semantics.
+	EndHeight int32
 }
 
 // ListTxnsQuery contains the parameters for listing transactions.

--- a/wallet/internal/db/itest/tx_utxo_store_test.go
+++ b/wallet/internal/db/itest/tx_utxo_store_test.go
@@ -1060,6 +1060,178 @@ func TestListTxnsReturnsConfirmedTxsByHeightRange(t *testing.T) {
 	require.Equal(t, uint32(211), infos[0].Block.Height)
 }
 
+// TestListTxnsUsesConfirmationOrder verifies that confirmed reads do not use
+// row IDs as the same-block ordering tie-breaker.
+//
+// Scenario:
+//   - One wallet sees a transaction as unmined before another transaction that
+//     appears earlier in the same block.
+//
+// Setup:
+//   - Insert the later block transaction as unmined first.
+//   - Insert the earlier block transaction directly as confirmed.
+//   - Confirm the older unmined row in the same block.
+//
+// Action:
+//   - Query summary and detail transactions for that exact block height.
+//
+// Assertions:
+//   - Both SQL reader paths return the direct confirmed transaction before the
+//     older row that was confirmed later.
+func TestListTxnsUsesConfirmationOrder(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Give laterBlockTx the smaller row ID, which used to make it sort
+	// before earlierBlockTx after both rows were attached to the same block.
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-list-txns-confirm-order")
+	queries := store.Queries()
+	const blockHeight = 222
+	block := CreateBlockFixture(t, queries, blockHeight)
+
+	laterBlockTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 17000, PkScript: []byte{0x51}}},
+	)
+	earlierBlockTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 18000, PkScript: []byte{0x52}}},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       laterBlockTx,
+		Received: time.Unix(1710000980, 0),
+		Status:   db.TxStatusPending,
+	})
+	require.NoError(t, err)
+
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       earlierBlockTx,
+		Received: time.Unix(1710000990, 0),
+		Block:    &block,
+		Status:   db.TxStatusPublished,
+	})
+	require.NoError(t, err)
+
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       laterBlockTx,
+		Received: time.Unix(1710001000, 0),
+		Block:    &block,
+		Status:   db.TxStatusPublished,
+	})
+	require.NoError(t, err)
+
+	// Act: Read the same confirmed block through summary and detail APIs.
+	infos, err := store.ListTxns(t.Context(), db.ListTxnsQuery{
+		WalletID:    walletID,
+		StartHeight: blockHeight,
+		EndHeight:   blockHeight,
+	})
+	require.NoError(t, err)
+
+	details, err := store.ListTxDetails(t.Context(), db.ListTxDetailsQuery{
+		WalletID:    walletID,
+		StartHeight: blockHeight,
+		EndHeight:   blockHeight,
+	})
+	require.NoError(t, err)
+
+	// Assert: The later-confirmed old row stays after the direct confirmed row.
+	wantOrder := []chainhash.Hash{
+		earlierBlockTx.TxHash(),
+		laterBlockTx.TxHash(),
+	}
+	require.Equal(t, wantOrder, txHashes(infos))
+	require.Equal(t, wantOrder, txDetailHashes(details))
+}
+
+// TestGetTxDetailFindsOwnedInputAfterSpendEdgeCleared verifies that detail
+// reads reconstruct historical debits after invalidation clears spent_by_tx_id.
+//
+// Scenario:
+//   - One wallet-owned parent output is spent by an unmined child transaction.
+//   - The child is invalidated, clearing the mutable spend edge while retaining
+//     the child transaction row as failed history.
+//
+// Setup:
+//   - Insert one wallet-owned parent credit and one child that spends it.
+//   - Invalidate the child transaction.
+//
+// Action:
+//   - Query the failed child through GetTxDetail.
+//
+// Assertions:
+//   - The parent output is spendable again, proving the spend edge was cleared.
+//   - The child detail still reports the wallet-owned input from its raw tx.
+func TestGetTxDetailFindsOwnedInputAfterSpendEdgeCleared(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a wallet-owned parent credit and a child that spends it.
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-detail-cleared-spend-edge")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	parentTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 5000, PkScript: addr.ScriptPubKey}},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       parentTx,
+		Received: time.Unix(1710001010, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	spentOutPoint := wire.OutPoint{Hash: parentTx.TxHash(), Index: 0}
+	childTx := newRegularTx(
+		[]wire.OutPoint{spentOutPoint},
+		[]*wire.TxOut{{Value: 4000, PkScript: []byte{0x51}}},
+	)
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       childTx,
+		Received: time.Unix(1710001020, 0),
+		Status:   db.TxStatusPending,
+	})
+	require.NoError(t, err)
+
+	err = store.InvalidateUnminedTx(t.Context(), db.InvalidateUnminedTxParams{
+		WalletID: walletID,
+		Txid:     childTx.TxHash(),
+	})
+	require.NoError(t, err)
+
+	// Act: Read the failed child detail after its spend edge has been cleared.
+	detail, err := store.GetTxDetail(t.Context(), db.GetTxDetailQuery{
+		WalletID: walletID,
+		Txid:     childTx.TxHash(),
+	})
+	require.NoError(t, err)
+
+	parentUtxo, err := store.GetUtxo(t.Context(), db.GetUtxoQuery{
+		WalletID: walletID,
+		OutPoint: spentOutPoint,
+	})
+	require.NoError(t, err)
+
+	// Assert: The current UTXO set is restored, but historical child details
+	// still report the wallet-owned debit from the serialized child transaction.
+	require.Equal(t, btcutil.Amount(5000), parentUtxo.Amount)
+	require.Equal(t, db.TxStatusFailed, detail.Status)
+	require.Len(t, detail.OwnedInputs, 1)
+	require.Equal(t, uint32(0), detail.OwnedInputs[0].Index)
+	require.Equal(t, btcutil.Amount(5000), detail.OwnedInputs[0].Amount)
+}
+
 // TestDeleteTxRemovesLeafUnminedTx verifies that DeleteTx removes a leaf
 // unmined row and restores any parent spend markers it introduced.
 //
@@ -1986,4 +2158,24 @@ func newRegularTx(inputs []wire.OutPoint, outputs []*wire.TxOut) *wire.MsgTx {
 // randomOutPoint returns one fixture outpoint backed by a random hash.
 func randomOutPoint() wire.OutPoint {
 	return wire.OutPoint{Hash: RandomHash(), Index: 0}
+}
+
+// txHashes returns transaction hashes in result order.
+func txHashes(infos []db.TxInfo) []chainhash.Hash {
+	hashes := make([]chainhash.Hash, 0, len(infos))
+	for _, info := range infos {
+		hashes = append(hashes, info.Hash)
+	}
+
+	return hashes
+}
+
+// txDetailHashes returns transaction-detail hashes in result order.
+func txDetailHashes(infos []db.TxDetailInfo) []chainhash.Hash {
+	hashes := make([]chainhash.Hash, 0, len(infos))
+	for _, info := range infos {
+		hashes = append(hashes, info.Hash)
+	}
+
+	return hashes
 }

--- a/wallet/internal/db/pg/txstore_gettxdetail.go
+++ b/wallet/internal/db/pg/txstore_gettxdetail.go
@@ -1,0 +1,214 @@
+package pg
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+)
+
+// txDetailEdgesOps adapts postgres owned-edge queries to the shared tx-detail
+// read workflows.
+type txDetailEdgesOps struct {
+	q *sqlc.Queries
+}
+
+// getTxDetailOps adapts postgres sqlc queries to the shared GetTxDetail flow.
+type getTxDetailOps struct {
+	txDetailEdgesOps
+}
+
+var _ db.GetTxDetailOps = (*getTxDetailOps)(nil)
+
+// ownedInputOutpointKey keys wallet-owned previous output amounts by outpoint.
+type ownedInputOutpointKey struct {
+	hash  chainhash.Hash
+	index uint32
+}
+
+// GetTxDetail retrieves one detailed wallet-scoped transaction view by hash.
+func (s *Store) GetTxDetail(ctx context.Context, query db.GetTxDetailQuery) (
+	*db.TxDetailInfo, error) {
+
+	var detail *db.TxDetailInfo
+
+	err := s.execRead(ctx, func(q *sqlc.Queries) error {
+		var err error
+
+		detail, err = db.GetTxDetailWithOps(ctx, query, &getTxDetailOps{
+			txDetailEdgesOps: txDetailEdgesOps{q: q},
+		})
+
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return detail, nil
+}
+
+// LoadBase loads the normalized base transaction row for one wallet-scoped
+// hash lookup.
+func (o *getTxDetailOps) LoadBase(ctx context.Context,
+	query db.GetTxDetailQuery) (db.TxDetailBase, error) {
+
+	row, err := o.q.GetTransactionByHash(
+		ctx, sqlc.GetTransactionByHashParams{
+			WalletID: int64(query.WalletID),
+			TxHash:   query.Txid[:],
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return db.TxDetailBase{}, fmt.Errorf("tx %s: %w",
+				query.Txid, db.ErrTxNotFound)
+		}
+
+		return db.TxDetailBase{}, fmt.Errorf("get tx detail: %w", err)
+	}
+
+	return txDetailBaseFromHashRow(row)
+}
+
+// txDetailBaseFromHashRow converts one postgres GetTransactionByHash row into
+// the normalized tx-detail base shape.
+func txDetailBaseFromHashRow(row sqlc.GetTransactionByHashRow) (
+	db.TxDetailBase, error) {
+
+	var (
+		block *db.Block
+		err   error
+	)
+
+	if row.BlockHeight.Valid {
+		block, err = buildBlock(
+			row.BlockHeight, row.BlockHash, row.BlockTimestamp,
+		)
+		if err != nil {
+			return db.TxDetailBase{}, err
+		}
+	}
+
+	return db.TxDetailBase{
+		ID:       row.ID,
+		Hash:     row.TxHash,
+		RawTx:    row.RawTx,
+		Received: row.ReceivedTime,
+		Block:    block,
+		Status:   int64(row.TxStatus),
+		Label:    row.TxLabel,
+	}, nil
+}
+
+// LoadOwnedOutputs loads all wallet-owned outputs created by the
+// selected transaction rows and groups them by tx id.
+func (o *txDetailEdgesOps) LoadOwnedOutputs(ctx context.Context,
+	walletID uint32, txIDs []int64) (
+	map[int64][]db.TxOwnedOutput, error) {
+
+	rows, err := o.q.ListOwnedOutputsByTxIDs(
+		ctx, sqlc.ListOwnedOutputsByTxIDsParams{
+			WalletID: int64(walletID),
+			TxIds:    txIDs,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list owned outputs by tx ids: %w", err)
+	}
+
+	result := make(map[int64][]db.TxOwnedOutput)
+	for _, row := range rows {
+		index, err := db.Int64ToUint32(int64(row.OutputIndex))
+		if err != nil {
+			return nil, fmt.Errorf("owned output index: %w", err)
+		}
+
+		result[row.TxID] = append(result[row.TxID], db.TxOwnedOutput{
+			Index:  index,
+			Amount: btcutil.Amount(row.Amount),
+		})
+	}
+
+	return result, nil
+}
+
+// LoadOwnedInputs loads all wallet-owned inputs referenced by the selected
+// transaction input outpoints and groups them by spender tx id.
+func (o *txDetailEdgesOps) LoadOwnedInputs(ctx context.Context,
+	walletID uint32, inputOutpoints []db.TxInputOutpoint) (
+	map[int64][]db.TxOwnedInput, error) {
+
+	result := make(map[int64][]db.TxOwnedInput)
+	if len(inputOutpoints) == 0 {
+		return result, nil
+	}
+
+	prevHashes := make(map[chainhash.Hash]struct{})
+
+	prevHashBytes := make([][]byte, 0, len(inputOutpoints))
+	for _, inputOutpoint := range inputOutpoints {
+		if _, ok := prevHashes[inputOutpoint.PrevTxHash]; ok {
+			continue
+		}
+
+		prevHashes[inputOutpoint.PrevTxHash] = struct{}{}
+		prevHash := inputOutpoint.PrevTxHash
+		prevHashBytes = append(prevHashBytes, prevHash[:])
+	}
+
+	rows, err := o.q.ListOwnedInputPrevOutputsByTxHashes(
+		ctx, sqlc.ListOwnedInputPrevOutputsByTxHashesParams{
+			WalletID: int64(walletID),
+			TxHashes: prevHashBytes,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"list owned input prev outputs by tx hashes: %w", err,
+		)
+	}
+
+	prevAmounts := make(map[ownedInputOutpointKey]btcutil.Amount)
+	for _, row := range rows {
+		prevHash, err := chainhash.NewHash(row.TxHash)
+		if err != nil {
+			return nil, fmt.Errorf("owned input prev tx hash: %w", err)
+		}
+
+		index, err := db.Int64ToUint32(int64(row.OutputIndex))
+		if err != nil {
+			return nil, fmt.Errorf("owned input prev output index: %w",
+				err)
+		}
+
+		prevAmounts[ownedInputOutpointKey{
+			hash:  *prevHash,
+			index: index,
+		}] = btcutil.Amount(row.Amount)
+	}
+
+	for _, inputOutpoint := range inputOutpoints {
+		amount, ok := prevAmounts[ownedInputOutpointKey{
+			hash:  inputOutpoint.PrevTxHash,
+			index: inputOutpoint.PrevOutputIndex,
+		}]
+		if !ok {
+			continue
+		}
+
+		result[inputOutpoint.TxID] = append(
+			result[inputOutpoint.TxID], db.TxOwnedInput{
+				Index:  inputOutpoint.InputIndex,
+				Amount: amount,
+			},
+		)
+	}
+
+	return result, nil
+}

--- a/wallet/internal/db/pg/txstore_listtxdetails.go
+++ b/wallet/internal/db/pg/txstore_listtxdetails.go
@@ -1,0 +1,112 @@
+package pg
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+)
+
+// ListTxDetails lists detailed wallet-scoped transaction views using wallet
+// tx-reader range semantics.
+func (s *Store) ListTxDetails(ctx context.Context,
+	query db.ListTxDetailsQuery) ([]db.TxDetailInfo, error) {
+
+	var details []db.TxDetailInfo
+
+	err := s.execRead(ctx, func(q *sqlc.Queries) error {
+		var err error
+
+		details, err = db.ListTxDetailsWithOps(ctx, query, &listTxDetailsOps{
+			txDetailEdgesOps: txDetailEdgesOps{q: q},
+		})
+
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return details, nil
+}
+
+// listTxDetailsOps adapts postgres sqlc queries to the shared ListTxDetails
+// flow.
+type listTxDetailsOps struct {
+	txDetailEdgesOps
+}
+
+var _ db.ListTxDetailsOps = (*listTxDetailsOps)(nil)
+
+// ListUnmined loads every transaction row that currently has no confirming
+// block. This includes the active unmined set together with any retained
+// invalid history that rollback or invalidation flows left without a confirming
+// block.
+func (o *listTxDetailsOps) ListUnmined(ctx context.Context,
+	walletID uint32) ([]db.TxDetailBase, error) {
+
+	rows, err := o.q.ListTransactionsWithoutBlock(ctx, int64(walletID))
+	if err != nil {
+		return nil, fmt.Errorf("list tx details without block: %w", err)
+	}
+
+	bases := make([]db.TxDetailBase, len(rows))
+	for i, row := range rows {
+		bases[i] = db.TxDetailBase{
+			ID:       row.ID,
+			Hash:     row.TxHash,
+			RawTx:    row.RawTx,
+			Received: row.ReceivedTime,
+			Status:   int64(row.TxStatus),
+			Label:    row.TxLabel,
+		}
+	}
+
+	return bases, nil
+}
+
+// ListConfirmed loads the confirmed height-range view used by ListTxDetails
+// when callers query mined history.
+func (o *listTxDetailsOps) ListConfirmed(ctx context.Context, walletID uint32,
+	startHeight, endHeight int32, reverse bool) ([]db.TxDetailBase, error) {
+
+	rows, err := o.q.ListTransactionsByHeightRange(
+		ctx, sqlc.ListTransactionsByHeightRangeParams{
+			WalletID:    int64(walletID),
+			StartHeight: startHeight,
+			EndHeight:   endHeight,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list confirmed tx details: %w", err)
+	}
+
+	bases := make([]db.TxDetailBase, len(rows))
+	for i, row := range rows {
+		block, err := buildBlock(
+			row.BlockHeight, row.BlockHash,
+			sql.NullInt64{Int64: row.BlockTimestamp, Valid: true},
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		bases[i] = db.TxDetailBase{
+			ID:       row.ID,
+			Hash:     row.TxHash,
+			RawTx:    row.RawTx,
+			Received: row.ReceivedTime,
+			Block:    block,
+			Status:   int64(row.TxStatus),
+			Label:    row.TxLabel,
+		}
+	}
+
+	if reverse {
+		db.ReverseTxDetailBasesByBlock(bases)
+	}
+
+	return bases, nil
+}

--- a/wallet/internal/db/sqlite/block.go
+++ b/wallet/internal/db/sqlite/block.go
@@ -16,6 +16,10 @@ import (
 func buildBlock(height sql.NullInt64, hash []byte,
 	timestamp sql.NullInt64) (*db.Block, error) {
 
+	if !height.Valid {
+		return nil, fmt.Errorf("block height: %w", db.ErrInvalidNullInt)
+	}
+
 	height32, err := db.Int64ToUint32(height.Int64)
 	if err != nil {
 		return nil, fmt.Errorf("block height: %w", err)

--- a/wallet/internal/db/sqlite/txstore_gettxdetail.go
+++ b/wallet/internal/db/sqlite/txstore_gettxdetail.go
@@ -1,0 +1,214 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+)
+
+// txDetailEdgesOps adapts sqlite owned-edge queries to the shared tx-detail
+// read workflows.
+type txDetailEdgesOps struct {
+	q *sqlc.Queries
+}
+
+// getTxDetailOps adapts sqlite sqlc queries to the shared GetTxDetail flow.
+type getTxDetailOps struct {
+	txDetailEdgesOps
+}
+
+var _ db.GetTxDetailOps = (*getTxDetailOps)(nil)
+
+// ownedInputOutpointKey keys wallet-owned previous output amounts by outpoint.
+type ownedInputOutpointKey struct {
+	hash  chainhash.Hash
+	index uint32
+}
+
+// GetTxDetail retrieves one detailed wallet-scoped transaction view by hash.
+func (s *Store) GetTxDetail(ctx context.Context, query db.GetTxDetailQuery) (
+	*db.TxDetailInfo, error) {
+
+	var detail *db.TxDetailInfo
+
+	err := s.execRead(ctx, func(q *sqlc.Queries) error {
+		var err error
+
+		detail, err = db.GetTxDetailWithOps(ctx, query, &getTxDetailOps{
+			txDetailEdgesOps: txDetailEdgesOps{q: q},
+		})
+
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return detail, nil
+}
+
+// LoadBase loads the normalized base transaction row for one wallet-scoped
+// hash lookup.
+func (o *getTxDetailOps) LoadBase(ctx context.Context,
+	query db.GetTxDetailQuery) (db.TxDetailBase, error) {
+
+	row, err := o.q.GetTransactionByHash(
+		ctx, sqlc.GetTransactionByHashParams{
+			WalletID: int64(query.WalletID),
+			TxHash:   query.Txid[:],
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return db.TxDetailBase{}, fmt.Errorf("tx %s: %w",
+				query.Txid, db.ErrTxNotFound)
+		}
+
+		return db.TxDetailBase{}, fmt.Errorf("get tx detail: %w", err)
+	}
+
+	return txDetailBaseFromHashRow(row)
+}
+
+// txDetailBaseFromHashRow converts one sqlite GetTransactionByHash row into the
+// normalized tx-detail base shape.
+func txDetailBaseFromHashRow(row sqlc.GetTransactionByHashRow) (
+	db.TxDetailBase, error) {
+
+	var (
+		block *db.Block
+		err   error
+	)
+
+	if row.BlockHeight.Valid {
+		block, err = buildBlock(
+			row.BlockHeight, row.BlockHash, row.BlockTimestamp,
+		)
+		if err != nil {
+			return db.TxDetailBase{}, err
+		}
+	}
+
+	return db.TxDetailBase{
+		ID:       row.ID,
+		Hash:     row.TxHash,
+		RawTx:    row.RawTx,
+		Received: row.ReceivedTime,
+		Block:    block,
+		Status:   row.TxStatus,
+		Label:    row.TxLabel,
+	}, nil
+}
+
+// LoadOwnedOutputs loads all wallet-owned outputs created by the
+// selected transaction rows and groups them by tx id.
+func (o *txDetailEdgesOps) LoadOwnedOutputs(ctx context.Context,
+	walletID uint32, txIDs []int64) (
+	map[int64][]db.TxOwnedOutput, error) {
+
+	rows, err := o.q.ListOwnedOutputsByTxIDs(
+		ctx, sqlc.ListOwnedOutputsByTxIDsParams{
+			WalletID: int64(walletID),
+			TxIds:    txIDs,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list owned outputs by tx ids: %w", err)
+	}
+
+	result := make(map[int64][]db.TxOwnedOutput)
+	for _, row := range rows {
+		index, err := db.Int64ToUint32(row.OutputIndex)
+		if err != nil {
+			return nil, fmt.Errorf("owned output index: %w", err)
+		}
+
+		result[row.TxID] = append(result[row.TxID], db.TxOwnedOutput{
+			Index:  index,
+			Amount: btcutil.Amount(row.Amount),
+		})
+	}
+
+	return result, nil
+}
+
+// LoadOwnedInputs loads all wallet-owned inputs referenced by the selected
+// transaction input outpoints and groups them by spender tx id.
+func (o *txDetailEdgesOps) LoadOwnedInputs(ctx context.Context,
+	walletID uint32, inputOutpoints []db.TxInputOutpoint) (
+	map[int64][]db.TxOwnedInput, error) {
+
+	result := make(map[int64][]db.TxOwnedInput)
+	if len(inputOutpoints) == 0 {
+		return result, nil
+	}
+
+	prevHashes := make(map[chainhash.Hash]struct{})
+
+	prevHashBytes := make([][]byte, 0, len(inputOutpoints))
+	for _, inputOutpoint := range inputOutpoints {
+		if _, ok := prevHashes[inputOutpoint.PrevTxHash]; ok {
+			continue
+		}
+
+		prevHashes[inputOutpoint.PrevTxHash] = struct{}{}
+		prevHash := inputOutpoint.PrevTxHash
+		prevHashBytes = append(prevHashBytes, prevHash[:])
+	}
+
+	rows, err := o.q.ListOwnedInputPrevOutputsByTxHashes(
+		ctx, sqlc.ListOwnedInputPrevOutputsByTxHashesParams{
+			WalletID: int64(walletID),
+			TxHashes: prevHashBytes,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"list owned input prev outputs by tx hashes: %w", err,
+		)
+	}
+
+	prevAmounts := make(map[ownedInputOutpointKey]btcutil.Amount)
+	for _, row := range rows {
+		prevHash, err := chainhash.NewHash(row.TxHash)
+		if err != nil {
+			return nil, fmt.Errorf("owned input prev tx hash: %w", err)
+		}
+
+		index, err := db.Int64ToUint32(row.OutputIndex)
+		if err != nil {
+			return nil, fmt.Errorf("owned input prev output index: %w",
+				err)
+		}
+
+		prevAmounts[ownedInputOutpointKey{
+			hash:  *prevHash,
+			index: index,
+		}] = btcutil.Amount(row.Amount)
+	}
+
+	for _, inputOutpoint := range inputOutpoints {
+		amount, ok := prevAmounts[ownedInputOutpointKey{
+			hash:  inputOutpoint.PrevTxHash,
+			index: inputOutpoint.PrevOutputIndex,
+		}]
+		if !ok {
+			continue
+		}
+
+		result[inputOutpoint.TxID] = append(
+			result[inputOutpoint.TxID], db.TxOwnedInput{
+				Index:  inputOutpoint.InputIndex,
+				Amount: amount,
+			},
+		)
+	}
+
+	return result, nil
+}

--- a/wallet/internal/db/sqlite/txstore_listtxdetails.go
+++ b/wallet/internal/db/sqlite/txstore_listtxdetails.go
@@ -1,0 +1,111 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+)
+
+// ListTxDetails lists detailed wallet-scoped transaction views using wallet
+// tx-reader range semantics.
+func (s *Store) ListTxDetails(ctx context.Context,
+	query db.ListTxDetailsQuery) ([]db.TxDetailInfo, error) {
+
+	var details []db.TxDetailInfo
+
+	err := s.execRead(ctx, func(q *sqlc.Queries) error {
+		var err error
+
+		details, err = db.ListTxDetailsWithOps(ctx, query, &listTxDetailsOps{
+			txDetailEdgesOps: txDetailEdgesOps{q: q},
+		})
+
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return details, nil
+}
+
+// listTxDetailsOps adapts sqlite sqlc queries to the shared ListTxDetails flow.
+type listTxDetailsOps struct {
+	txDetailEdgesOps
+}
+
+var _ db.ListTxDetailsOps = (*listTxDetailsOps)(nil)
+
+// ListUnmined loads every transaction row that currently has no confirming
+// block. This includes the active unmined set together with any retained
+// invalid history that rollback or invalidation flows left without a confirming
+// block.
+func (o *listTxDetailsOps) ListUnmined(ctx context.Context,
+	walletID uint32) ([]db.TxDetailBase, error) {
+
+	rows, err := o.q.ListTransactionsWithoutBlock(ctx, int64(walletID))
+	if err != nil {
+		return nil, fmt.Errorf("list tx details without block: %w", err)
+	}
+
+	bases := make([]db.TxDetailBase, len(rows))
+	for i, row := range rows {
+		bases[i] = db.TxDetailBase{
+			ID:       row.ID,
+			Hash:     row.TxHash,
+			RawTx:    row.RawTx,
+			Received: row.ReceivedTime,
+			Status:   row.TxStatus,
+			Label:    row.TxLabel,
+		}
+	}
+
+	return bases, nil
+}
+
+// ListConfirmed loads the confirmed height-range view used by ListTxDetails
+// when callers query mined history.
+func (o *listTxDetailsOps) ListConfirmed(ctx context.Context, walletID uint32,
+	startHeight, endHeight int32, reverse bool) ([]db.TxDetailBase, error) {
+
+	rows, err := o.q.ListTransactionsByHeightRange(
+		ctx, sqlc.ListTransactionsByHeightRangeParams{
+			WalletID:    int64(walletID),
+			StartHeight: int64(startHeight),
+			EndHeight:   int64(endHeight),
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list confirmed tx details: %w", err)
+	}
+
+	bases := make([]db.TxDetailBase, len(rows))
+	for i, row := range rows {
+		block, err := buildBlock(
+			row.BlockHeight, row.BlockHash,
+			sql.NullInt64{Int64: row.BlockTimestamp, Valid: true},
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		bases[i] = db.TxDetailBase{
+			ID:       row.ID,
+			Hash:     row.TxHash,
+			RawTx:    row.RawTx,
+			Received: row.ReceivedTime,
+			Block:    block,
+			Status:   row.TxStatus,
+			Label:    row.TxLabel,
+		}
+	}
+
+	if reverse {
+		db.ReverseTxDetailBasesByBlock(bases)
+	}
+
+	return bases, nil
+}

--- a/wallet/internal/db/sqlite/txstore_listtxdetails_test.go
+++ b/wallet/internal/db/sqlite/txstore_listtxdetails_test.go
@@ -1,0 +1,160 @@
+package sqlite
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestListTxDetailsReturnsRowsWithoutBlock verifies that the detail
+// path returns the same no-confirming-block history as the summary
+// path, including retained failed rows.
+func TestListTxDetailsReturnsRowsWithoutBlock(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create one confirmed transaction plus two rows
+	// without confirming blocks, one still pending and one
+	// retained as failed history.
+	store, cleanup := newTestStore(t)
+	t.Cleanup(cleanup)
+
+	wallet, err := store.CreateWallet(
+		t.Context(), testWalletParams("wallet-list-tx-details-without-block"),
+	)
+	require.NoError(t, err)
+
+	confirmedBlock := &db.Block{
+		Hash:      chainhash.Hash{90},
+		Height:    200,
+		Timestamp: time.Unix(1710000790, 0),
+	}
+
+	err = store.execWrite(t.Context(), func(qtx *sqlc.Queries) error {
+		return ensureBlockExists(t.Context(), qtx, confirmedBlock)
+	})
+	require.NoError(t, err)
+
+	confirmedTx := newListTxDetailsTestTx(1, 7_000, 0x51)
+	unminedTx := newListTxDetailsTestTx(2, 8_000, 0x52)
+	failedTx := newListTxDetailsTestTx(3, 8_100, 0x53)
+
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: wallet.ID,
+		Tx:       confirmedTx,
+		Received: time.Unix(1710000800, 0),
+		Block:    confirmedBlock,
+		Status:   db.TxStatusPublished,
+	})
+	require.NoError(t, err)
+
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: wallet.ID,
+		Tx:       unminedTx,
+		Received: time.Unix(1710000810, 0),
+		Status:   db.TxStatusPending,
+	})
+	require.NoError(t, err)
+
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: wallet.ID,
+		Tx:       failedTx,
+		Received: time.Unix(1710000815, 0),
+		Status:   db.TxStatusPending,
+	})
+	require.NoError(t, err)
+
+	err = store.execWrite(t.Context(), func(qtx *sqlc.Queries) error {
+		failedHash := failedTx.TxHash()
+
+		meta, err := qtx.GetTransactionMetaByHash(
+			t.Context(), sqlc.GetTransactionMetaByHashParams{
+				WalletID: int64(wallet.ID),
+				TxHash:   failedHash[:],
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		_, err = qtx.UpdateTransactionStatusByIDs(
+			t.Context(), sqlc.UpdateTransactionStatusByIDsParams{
+				Status:   int64(db.TxStatusFailed),
+				WalletID: int64(wallet.ID),
+				TxIds:    []int64{meta.ID},
+			},
+		)
+
+		return err
+	})
+	require.NoError(t, err)
+
+	// Act: Query the wallet tx-reader unmined range through the detail path.
+	details, err := store.ListTxDetails(t.Context(), db.ListTxDetailsQuery{
+		WalletID:    wallet.ID,
+		StartHeight: -1,
+		EndHeight:   -1,
+	})
+
+	// Assert: The detail path returns the same rows without
+	// confirming blocks as the summary path, including retained
+	// failed history.
+	require.NoError(t, err)
+	require.Len(t, details, 2)
+
+	statusesByHash := make(map[chainhash.Hash]db.TxStatus, len(details))
+	for _, detail := range details {
+		require.Nil(t, detail.Block)
+		statusesByHash[detail.Hash] = detail.Status
+	}
+
+	require.Equal(t, db.TxStatusPending, statusesByHash[unminedTx.TxHash()])
+	require.Equal(t, db.TxStatusFailed, statusesByHash[failedTx.TxHash()])
+}
+
+// newTestStore creates one SQLite store backed by a temporary database file.
+func newTestStore(t *testing.T) (*Store, func()) {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	store, err := NewStore(t.Context(), Config{DBPath: dbPath})
+	require.NoError(t, err)
+
+	return store, func() {
+		_ = store.Close()
+	}
+}
+
+// testWalletParams builds one minimal wallet creation request for SQLite tx
+// detail tests.
+func testWalletParams(name string) db.CreateWalletParams {
+	return db.CreateWalletParams{
+		Name:                     name,
+		ManagerVersion:           1,
+		EncryptedMasterPrivKey:   []byte{1},
+		EncryptedMasterPubKey:    []byte{2},
+		MasterKeyPubParams:       []byte{3},
+		MasterKeyPrivParams:      []byte{4},
+		EncryptedCryptoPrivKey:   []byte{5},
+		EncryptedCryptoPubKey:    []byte{6},
+		EncryptedCryptoScriptKey: []byte{7},
+	}
+}
+
+// newListTxDetailsTestTx builds one deterministic non-coinbase transaction
+// fixture with a unique previous outpoint and one output.
+func newListTxDetailsTestTx(seed byte, value int64, script byte) *wire.MsgTx {
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{seed},
+	}})
+	tx.AddTxOut(&wire.TxOut{Value: value, PkScript: []byte{script}})
+
+	return tx
+}

--- a/wallet/internal/db/tx_store_common.go
+++ b/wallet/internal/db/tx_store_common.go
@@ -118,6 +118,108 @@ func BuildTxInfo(hash []byte, rawTx []byte, received time.Time, block *Block,
 	}, nil
 }
 
+// TxDetailBase is the normalized transaction-row metadata the shared detail
+// read workflows need from one SQL backend.
+type TxDetailBase struct {
+	// ID is the backend row identifier for the transaction.
+	ID int64
+
+	// Hash is the serialized transaction hash bytes.
+	Hash []byte
+
+	// RawTx is the serialized wire transaction payload.
+	RawTx []byte
+
+	// Received is when the wallet observed the transaction.
+	Received time.Time
+
+	// Block is the normalized confirming block metadata, or nil when
+	// the row has no confirming block.
+	Block *Block
+
+	// Status is the stored wallet-relative transaction status code.
+	Status int64
+
+	// Label is the optional user-supplied transaction label.
+	Label string
+}
+
+// GetTxDetailOps is the small semantic adapter GetTxDetail needs from one SQL
+// backend.
+//
+// The shared GetTxDetail algorithm is intentionally ordered:
+//   - load the wallet-scoped base transaction row first
+//   - load wallet-owned outputs for that exact row ID next
+//   - load wallet-owned inputs spent by that same row ID after that
+//   - build the final TxDetailInfo from the normalized row plus those edge sets
+//
+// Each backend implements those steps with its own sqlc-generated query types,
+// nullable field shapes, and row conversion helpers while GetTxDetailWithOps
+// keeps the visible sequencing in one place.
+type GetTxDetailOps interface {
+	// LoadBase loads the normalized base transaction row for one wallet-scoped
+	// hash lookup.
+	LoadBase(ctx context.Context, query GetTxDetailQuery) (TxDetailBase, error)
+
+	// LoadOwnedOutputs loads every wallet-owned output created by
+	// the provided tx row IDs and groups them by creating tx ID.
+	LoadOwnedOutputs(ctx context.Context, walletID uint32,
+		txIDs []int64) (map[int64][]TxOwnedOutput, error)
+
+	// LoadOwnedInputs loads every wallet-owned input spent by the
+	// provided tx row IDs and groups them by spender tx ID.
+	LoadOwnedInputs(ctx context.Context, walletID uint32,
+		txIDs []int64) (map[int64][]TxOwnedInput, error)
+}
+
+// normalizedListTxDetailsQuery captures wallet tx-reader range semantics in one
+// simpler shape that the shared ListTxDetails workflow can execute directly.
+type normalizedListTxDetailsQuery struct {
+	confirmedStart int32
+	confirmedEnd   int32
+	reverse        bool
+	includeUnmined bool
+	unminedFirst   bool
+	hasConfirmed   bool
+}
+
+// ListTxDetailsOps is the small semantic adapter ListTxDetails needs from one
+// SQL backend.
+//
+// The shared ListTxDetails algorithm is intentionally ordered:
+//   - normalize the wallet tx-reader range semantics first
+//   - load the rows visible to the unmined leg before or after confirmed rows
+//     as required by that normalized view
+//   - collect the selected tx row IDs in the final output order next
+//   - load wallet-owned outputs for that exact ID set
+//   - load wallet-owned inputs for that same ID set
+//   - rebuild the final TxDetailInfo values in the original base-row order
+//
+// Each backend implements those stages with its own sqlc-generated query types,
+// nullable field shapes, and binding helpers while ListTxDetailsWithOps keeps
+// the shared sequencing and tx-reader semantics in one place.
+type ListTxDetailsOps interface {
+	// ListUnmined loads the rows visible to the tx-reader unmined leg. This
+	// includes current unmined rows together with any retained history
+	// rows that no longer have a confirming block.
+	ListUnmined(ctx context.Context, walletID uint32) ([]TxDetailBase, error)
+
+	// ListConfirmed loads the confirmed height-range rows for the normalized
+	// query.
+	ListConfirmed(ctx context.Context, walletID uint32, startHeight,
+		endHeight int32, reverse bool) ([]TxDetailBase, error)
+
+	// LoadOwnedOutputs loads every wallet-owned output created by
+	// the provided tx row IDs and groups them by creating tx ID.
+	LoadOwnedOutputs(ctx context.Context, walletID uint32,
+		txIDs []int64) (map[int64][]TxOwnedOutput, error)
+
+	// LoadOwnedInputs loads every wallet-owned input spent by the
+	// provided tx row IDs and groups them by spender tx ID.
+	LoadOwnedInputs(ctx context.Context, walletID uint32,
+		txIDs []int64) (map[int64][]TxOwnedInput, error)
+}
+
 // validateCreateTxParams enforces the CreateTx invariants shared by both SQL
 // backends after serializeMsgTx has already verified that params.Tx is non-nil.
 func validateCreateTxParams(params CreateTxParams) error {

--- a/wallet/internal/db/tx_store_common.go
+++ b/wallet/internal/db/tx_store_common.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
+	"slices"
 	"time"
 
 	"github.com/btcsuite/btcd/blockchain"
@@ -144,13 +146,31 @@ type TxDetailBase struct {
 	Label string
 }
 
+// TxInputOutpoint identifies one transaction input and the previous outpoint it
+// spends.
+type TxInputOutpoint struct {
+	// TxID is the backend row ID of the spending transaction.
+	TxID int64
+
+	// InputIndex is the input position within the spending transaction.
+	InputIndex uint32
+
+	// PrevTxHash is the hash of the transaction that created the previous
+	// output.
+	PrevTxHash chainhash.Hash
+
+	// PrevOutputIndex is the output index in the previous transaction.
+	PrevOutputIndex uint32
+}
+
 // GetTxDetailOps is the small semantic adapter GetTxDetail needs from one SQL
 // backend.
 //
 // The shared GetTxDetail algorithm is intentionally ordered:
 //   - load the wallet-scoped base transaction row first
 //   - load wallet-owned outputs for that exact row ID next
-//   - load wallet-owned inputs spent by that same row ID after that
+//   - derive previous outpoints from the raw transaction and load the
+//     wallet-owned inputs referenced by those outpoints after that
 //   - build the final TxDetailInfo from the normalized row plus those edge sets
 //
 // Each backend implements those steps with its own sqlc-generated query types,
@@ -166,10 +186,47 @@ type GetTxDetailOps interface {
 	LoadOwnedOutputs(ctx context.Context, walletID uint32,
 		txIDs []int64) (map[int64][]TxOwnedOutput, error)
 
-	// LoadOwnedInputs loads every wallet-owned input spent by the
-	// provided tx row IDs and groups them by spender tx ID.
+	// LoadOwnedInputs loads every wallet-owned input referenced by the provided
+	// transaction input outpoints and groups them by spender tx ID.
 	LoadOwnedInputs(ctx context.Context, walletID uint32,
-		txIDs []int64) (map[int64][]TxOwnedInput, error)
+		inputOutpoints []TxInputOutpoint) (map[int64][]TxOwnedInput, error)
+}
+
+// GetTxDetailWithOps runs the shared GetTxDetail read workflow.
+//
+// The helper owns the ordering between the base-row load and the owned-edge
+// loads so both SQL backends expose the same detailed transaction shape and the
+// same wallet-scoped not-found behavior.
+func GetTxDetailWithOps(ctx context.Context, query GetTxDetailQuery,
+	ops GetTxDetailOps) (*TxDetailInfo, error) {
+
+	base, err := ops.LoadBase(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("load tx detail base: %w", err)
+	}
+
+	txIDs := []int64{base.ID}
+
+	ownedOutputs, err := ops.LoadOwnedOutputs(ctx, query.WalletID, txIDs)
+	if err != nil {
+		return nil, fmt.Errorf("load tx detail outputs: %w", err)
+	}
+
+	inputOutpoints, err := txInputOutpointsFromBases([]TxDetailBase{base})
+	if err != nil {
+		return nil, fmt.Errorf("build tx detail input outpoints: %w", err)
+	}
+
+	ownedInputs, err := ops.LoadOwnedInputs(
+		ctx, query.WalletID, inputOutpoints,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load tx detail inputs: %w", err)
+	}
+
+	return buildTxDetailInfo(
+		base, ownedInputs[base.ID], ownedOutputs[base.ID],
+	)
 }
 
 // normalizedListTxDetailsQuery captures wallet tx-reader range semantics in one
@@ -192,7 +249,8 @@ type normalizedListTxDetailsQuery struct {
 //     as required by that normalized view
 //   - collect the selected tx row IDs in the final output order next
 //   - load wallet-owned outputs for that exact ID set
-//   - load wallet-owned inputs for that same ID set
+//   - derive previous outpoints from those raw transactions and load any
+//     wallet-owned inputs referenced by those outpoints
 //   - rebuild the final TxDetailInfo values in the original base-row order
 //
 // Each backend implements those stages with its own sqlc-generated query types,
@@ -214,10 +272,273 @@ type ListTxDetailsOps interface {
 	LoadOwnedOutputs(ctx context.Context, walletID uint32,
 		txIDs []int64) (map[int64][]TxOwnedOutput, error)
 
-	// LoadOwnedInputs loads every wallet-owned input spent by the
-	// provided tx row IDs and groups them by spender tx ID.
+	// LoadOwnedInputs loads every wallet-owned input referenced by the provided
+	// transaction input outpoints and groups them by spender tx ID.
 	LoadOwnedInputs(ctx context.Context, walletID uint32,
-		txIDs []int64) (map[int64][]TxOwnedInput, error)
+		inputOutpoints []TxInputOutpoint) (map[int64][]TxOwnedInput, error)
+}
+
+// ListTxDetailsWithOps runs the shared ListTxDetails read workflow.
+//
+// The helper owns the range normalization, row-order preservation, and owned-
+// edge loading order so both SQL backends expose identical tx-reader behavior.
+func ListTxDetailsWithOps(ctx context.Context, query ListTxDetailsQuery,
+	ops ListTxDetailsOps) ([]TxDetailInfo, error) {
+
+	normalized := normalizeListTxDetailsQuery(query)
+
+	bases, err := listTxDetailBases(ctx, query.WalletID, normalized, ops)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(bases) == 0 {
+		return []TxDetailInfo{}, nil
+	}
+
+	txIDs := make([]int64, 0, len(bases))
+	for _, base := range bases {
+		txIDs = append(txIDs, base.ID)
+	}
+
+	ownedOutputs, err := ops.LoadOwnedOutputs(ctx, query.WalletID, txIDs)
+	if err != nil {
+		return nil, fmt.Errorf("load tx detail outputs: %w", err)
+	}
+
+	inputOutpoints, err := txInputOutpointsFromBases(bases)
+	if err != nil {
+		return nil, fmt.Errorf("build tx detail input outpoints: %w", err)
+	}
+
+	ownedInputs, err := ops.LoadOwnedInputs(
+		ctx, query.WalletID, inputOutpoints,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load tx detail inputs: %w", err)
+	}
+
+	return buildTxDetailsFromBases(bases, ownedInputs, ownedOutputs)
+}
+
+// txInputOutpointsFromBases extracts every previous outpoint referenced by the
+// selected transaction rows.
+func txInputOutpointsFromBases(bases []TxDetailBase) (
+	[]TxInputOutpoint, error) {
+
+	var inputOutpoints []TxInputOutpoint
+
+	for _, base := range bases {
+		msgTx, err := deserializeMsgTx(base.RawTx)
+		if err != nil {
+			return nil, err
+		}
+
+		if blockchain.IsCoinBaseTx(msgTx) {
+			continue
+		}
+
+		for inputIndex, txIn := range msgTx.TxIn {
+			index, err := Int64ToUint32(int64(inputIndex))
+			if err != nil {
+				return nil, fmt.Errorf("input index %d: %w",
+					inputIndex, err)
+			}
+
+			inputOutpoints = append(inputOutpoints, TxInputOutpoint{
+				TxID:            base.ID,
+				InputIndex:      index,
+				PrevTxHash:      txIn.PreviousOutPoint.Hash,
+				PrevOutputIndex: txIn.PreviousOutPoint.Index,
+			})
+		}
+	}
+
+	return inputOutpoints, nil
+}
+
+// buildTxDetailInfo rebuilds one TxDetailInfo from one normalized base row and
+// its owned input and output edge sets.
+func buildTxDetailInfo(base TxDetailBase, ownedInputs []TxOwnedInput,
+	ownedOutputs []TxOwnedOutput) (*TxDetailInfo, error) {
+
+	msgTx, err := deserializeMsgTx(base.RawTx)
+	if err != nil {
+		return nil, err
+	}
+
+	txInfo, err := BuildTxInfo(
+		base.Hash, base.RawTx, base.Received, base.Block, base.Status,
+		base.Label,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TxDetailInfo{
+		Hash:         txInfo.Hash,
+		MsgTx:        msgTx,
+		SerializedTx: txInfo.SerializedTx,
+		Received:     txInfo.Received,
+		Block:        txInfo.Block,
+		Status:       txInfo.Status,
+		Label:        txInfo.Label,
+		OwnedInputs:  ownedInputs,
+		OwnedOutputs: ownedOutputs,
+	}, nil
+}
+
+// ReverseTxInfosByBlock reverses confirmed block order while preserving the
+// transaction order within each block.
+func ReverseTxInfosByBlock(infos []TxInfo) {
+	reverseByBlock(infos, func(info TxInfo) uint32 {
+		if info.Block == nil {
+			return 0
+		}
+
+		return info.Block.Height
+	})
+}
+
+// ReverseTxDetailBasesByBlock reverses confirmed block order while preserving
+// the transaction order within each block.
+func ReverseTxDetailBasesByBlock(bases []TxDetailBase) {
+	reverseByBlock(bases, func(base TxDetailBase) uint32 {
+		if base.Block == nil {
+			return 0
+		}
+
+		return base.Block.Height
+	})
+}
+
+// reverseByBlock reverses contiguous block groups while preserving the original
+// order inside each group.
+func reverseByBlock[T any](items []T, blockHeight func(T) uint32) {
+	slices.Reverse(items)
+
+	for start := 0; start < len(items); {
+		end := start + 1
+
+		height := blockHeight(items[start])
+		for end < len(items) && blockHeight(items[end]) == height {
+			end++
+		}
+
+		slices.Reverse(items[start:end])
+		start = end
+	}
+}
+
+// normalizeListTxDetailsQuery converts wallet tx-reader range semantics into
+// the internal form used by the shared ListTxDetails workflow.
+func normalizeListTxDetailsQuery(
+	query ListTxDetailsQuery,
+) normalizedListTxDetailsQuery {
+
+	switch {
+	case query.StartHeight < 0 && query.EndHeight < 0:
+		return normalizedListTxDetailsQuery{
+			includeUnmined: true,
+			unminedFirst:   true,
+		}
+
+	case query.StartHeight < 0:
+		return normalizedListTxDetailsQuery{
+			confirmedStart: query.EndHeight,
+			confirmedEnd:   math.MaxInt32,
+			reverse:        true,
+			includeUnmined: true,
+			unminedFirst:   true,
+			hasConfirmed:   true,
+		}
+
+	case query.EndHeight < 0:
+		return normalizedListTxDetailsQuery{
+			confirmedStart: query.StartHeight,
+			confirmedEnd:   math.MaxInt32,
+			includeUnmined: true,
+			hasConfirmed:   true,
+		}
+
+	default:
+		start := query.StartHeight
+		end := query.EndHeight
+
+		reverse := start > end
+		if reverse {
+			start, end = end, start
+		}
+
+		return normalizedListTxDetailsQuery{
+			confirmedStart: start,
+			confirmedEnd:   end,
+			reverse:        reverse,
+			hasConfirmed:   true,
+		}
+	}
+}
+
+// listTxDetailBases loads the normalized base rows for one ListTxDetails call
+// in the final output order required by the wallet tx reader.
+func listTxDetailBases(ctx context.Context, walletID uint32,
+	normalized normalizedListTxDetailsQuery,
+	ops ListTxDetailsOps) ([]TxDetailBase, error) {
+
+	var bases []TxDetailBase
+
+	if normalized.includeUnmined && normalized.unminedFirst {
+		unmined, err := ops.ListUnmined(ctx, walletID)
+		if err != nil {
+			return nil, fmt.Errorf("list unmined tx details: %w", err)
+		}
+
+		bases = append(bases, unmined...)
+	}
+
+	if normalized.hasConfirmed {
+		confirmed, err := ops.ListConfirmed(
+			ctx, walletID, normalized.confirmedStart, normalized.confirmedEnd,
+			normalized.reverse,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("list confirmed tx details: %w", err)
+		}
+
+		bases = append(bases, confirmed...)
+	}
+
+	if normalized.includeUnmined && !normalized.unminedFirst {
+		unmined, err := ops.ListUnmined(ctx, walletID)
+		if err != nil {
+			return nil, fmt.Errorf("list unmined tx details: %w", err)
+		}
+
+		bases = append(bases, unmined...)
+	}
+
+	return bases, nil
+}
+
+// buildTxDetailsFromBases rebuilds the final detail rows in base-row order
+// after the owned input and output edges have been grouped by tx id.
+func buildTxDetailsFromBases(bases []TxDetailBase,
+	ownedInputs map[int64][]TxOwnedInput,
+	ownedOutputs map[int64][]TxOwnedOutput) ([]TxDetailInfo, error) {
+
+	details := make([]TxDetailInfo, 0, len(bases))
+	for _, base := range bases {
+		detail, err := buildTxDetailInfo(
+			base, ownedInputs[base.ID], ownedOutputs[base.ID],
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		details = append(details, *detail)
+	}
+
+	return details, nil
 }
 
 // validateCreateTxParams enforces the CreateTx invariants shared by both SQL

--- a/wallet/internal/db/tx_store_common_test.go
+++ b/wallet/internal/db/tx_store_common_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"math"
 	"testing"
 	"time"
 
@@ -36,6 +37,341 @@ func TestSerializeDeserializeMsgTx(t *testing.T) {
 
 	// Assert: The decoded transaction serializes back to the same bytes.
 	require.Equal(t, rawTx, got.Bytes())
+}
+
+// TestReverseTxInfosByBlockPreservesBlockLocalOrder verifies that reversing a
+// summary range reverses block groups without reversing transactions inside the
+// same block.
+func TestReverseTxInfosByBlockPreservesBlockLocalOrder(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Build confirmed summaries ordered by ascending block height and
+	// block-local transaction order.
+	infos := []TxInfo{
+		{Hash: chainhash.Hash{1}, Block: testBlock(1)},
+		{Hash: chainhash.Hash{2}, Block: testBlock(1)},
+		{Hash: chainhash.Hash{3}, Block: testBlock(2)},
+		{Hash: chainhash.Hash{4}, Block: testBlock(3)},
+		{Hash: chainhash.Hash{5}, Block: testBlock(3)},
+	}
+
+	// Act: Reverse the summaries by block group.
+	ReverseTxInfosByBlock(infos)
+
+	// Assert: Block order is reversed, while each block's local tx order is
+	// preserved.
+	require.Equal(t, chainhash.Hash{4}, infos[0].Hash)
+	require.Equal(t, chainhash.Hash{5}, infos[1].Hash)
+	require.Equal(t, chainhash.Hash{3}, infos[2].Hash)
+	require.Equal(t, chainhash.Hash{1}, infos[3].Hash)
+	require.Equal(t, chainhash.Hash{2}, infos[4].Hash)
+}
+
+// TestReverseTxDetailBasesByBlockPreservesBlockLocalOrder verifies that
+// reversing detail base rows preserves transaction order inside each block.
+func TestReverseTxDetailBasesByBlockPreservesBlockLocalOrder(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Build confirmed detail bases ordered by ascending block
+	// height and block-local transaction order.
+	bases := []TxDetailBase{
+		{ID: 1, Block: testBlock(1)},
+		{ID: 2, Block: testBlock(1)},
+		{ID: 3, Block: testBlock(2)},
+		{ID: 4, Block: testBlock(3)},
+		{ID: 5, Block: testBlock(3)},
+	}
+
+	// Act: Reverse the base rows by block group.
+	ReverseTxDetailBasesByBlock(bases)
+
+	// Assert: Block order is reversed, while each block's local tx order is
+	// preserved.
+	require.Equal(t, int64(4), bases[0].ID)
+	require.Equal(t, int64(5), bases[1].ID)
+	require.Equal(t, int64(3), bases[2].ID)
+	require.Equal(t, int64(1), bases[3].ID)
+	require.Equal(t, int64(2), bases[4].ID)
+}
+
+// TestGetTxDetailWithOpsSuccess verifies that the shared GetTxDetail workflow
+// loads the base row first, then the owned edges, before rebuilding the final
+// detail shape.
+func TestGetTxDetailWithOpsSuccess(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Build one detail query, one normalized base row,
+	// and one mock ops adapter that records the shared call order.
+	tx := testRegularMsgTxWithSeed(11)
+	base := testTxDetailBase(t, 41, tx, testBlock(144), TxStatusPublished,
+		"detail-label")
+	query := GetTxDetailQuery{WalletID: 7, Txid: tx.TxHash()}
+	wantInputOutpoints := []TxInputOutpoint{testInputOutpoint(41, tx)}
+
+	var callOrder []string
+
+	baseHash := query.Txid
+	ops := &mockGetTxDetailOps{}
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
+
+	ops.On("LoadBase", mock.Anything, query).Return(base, nil).Run(
+		func(mock.Arguments) {
+			callOrder = append(callOrder, "base")
+		},
+	).Once()
+
+	ops.On("LoadOwnedOutputs", mock.Anything, uint32(7), []int64{41}).Return(
+		map[int64][]TxOwnedOutput{41: {{Index: 1, Amount: 12}}}, nil,
+	).Run(func(mock.Arguments) {
+		callOrder = append(callOrder, "outputs")
+	}).Once()
+
+	ops.On(
+		"LoadOwnedInputs", mock.Anything, uint32(7), wantInputOutpoints,
+	).Return(
+		map[int64][]TxOwnedInput{41: {{Index: 0, Amount: 21}}}, nil,
+	).Run(func(mock.Arguments) {
+		callOrder = append(callOrder, "inputs")
+	}).Once()
+
+	// Act: Run the shared detail workflow.
+	detail, err := GetTxDetailWithOps(context.Background(), query, ops)
+
+	// Assert: The helper preserves the staged ordering and rebuilds the final
+	// detail shape from the normalized base row plus owned edges.
+	require.NoError(t, err)
+	require.Equal(t, []string{"base", "outputs", "inputs"}, callOrder)
+	require.Equal(t, baseHash, detail.Hash)
+	require.Equal(t, "detail-label", detail.Label)
+	require.Equal(t, time.UTC, detail.Received.Location())
+	require.NotNil(t, detail.MsgTx)
+	require.Len(t, detail.OwnedInputs, 1)
+	require.Len(t, detail.OwnedOutputs, 1)
+	require.NotNil(t, detail.Block)
+	require.Equal(t, uint32(144), detail.Block.Height)
+}
+
+// TestGetTxDetailWithOpsLoadOutputsError verifies that the shared GetTxDetail
+// helper stops after an owned-output load failure and wraps that error with the
+// workflow stage context.
+func TestGetTxDetailWithOpsLoadOutputsError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Return one valid base row and one owned-output load failure.
+	tx := testRegularMsgTxWithSeed(12)
+	query := GetTxDetailQuery{WalletID: 8, Txid: tx.TxHash()}
+	base := testTxDetailBase(t, 55, tx, nil, TxStatusPending, "")
+	ops := &mockGetTxDetailOps{}
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
+
+	ops.On("LoadBase", mock.Anything, query).Return(base, nil).Once()
+	ops.On("LoadOwnedOutputs", mock.Anything, uint32(8), []int64{55}).Return(
+		nil, errCreateTxTest,
+	).Once()
+
+	// Act: Run the shared detail workflow.
+	_, err := GetTxDetailWithOps(context.Background(), query, ops)
+
+	// Assert: The helper reports the stage-local error and does not
+	// continue on to the later input load.
+	require.ErrorIs(t, err, errCreateTxTest)
+	require.ErrorContains(t, err, "load tx detail outputs")
+}
+
+// TestListTxDetailsWithOpsUnminedFirst verifies that the shared ListTxDetails
+// workflow prepends unmined rows when the wallet tx-reader range starts at the
+// unmined leg.
+func TestListTxDetailsWithOpsUnminedFirst(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Build one unmined row, one confirmed row, and one
+	// mock ops adapter that records both call order and the final
+	// tx-id batch.
+	unminedTx := testRegularMsgTxWithSeed(21)
+	confirmedTx := testRegularMsgTxWithSeed(22)
+	query := ListTxDetailsQuery{WalletID: 9, StartHeight: -1, EndHeight: 100}
+	wantInputOutpoints := []TxInputOutpoint{
+		testInputOutpoint(71, unminedTx),
+		testInputOutpoint(72, confirmedTx),
+	}
+
+	var (
+		callOrder  []string
+		batchedIDs []int64
+	)
+
+	ops := &mockListTxDetailsOps{}
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
+
+	ops.On("ListUnmined", mock.Anything, uint32(9)).Return(
+		[]TxDetailBase{
+			testTxDetailBase(t, 71, unminedTx, nil, TxStatusPending, "u"),
+		}, nil,
+	).Run(func(mock.Arguments) {
+		callOrder = append(callOrder, "unmined")
+	}).Once()
+
+	ops.On("ListConfirmed", mock.Anything, uint32(9), int32(100),
+		int32(math.MaxInt32), true).Return(
+		[]TxDetailBase{
+			testTxDetailBase(
+				t, 72, confirmedTx, testBlock(100), TxStatusPublished, "c",
+			),
+		}, nil,
+	).Run(func(mock.Arguments) {
+		callOrder = append(callOrder, "confirmed")
+	}).Once()
+
+	ops.On(
+		"LoadOwnedOutputs", mock.Anything, uint32(9), []int64{71, 72},
+	).Return(
+		map[int64][]TxOwnedOutput{
+			71: {{Index: 0, Amount: 7}},
+			72: {{Index: 0, Amount: 8}},
+		}, nil,
+	).Run(func(args mock.Arguments) {
+		callOrder = append(callOrder, "outputs")
+		ids, ok := args.Get(2).([]int64)
+		require.True(t, ok)
+		batchedIDs = append([]int64(nil), ids...)
+	}).Once()
+
+	ops.On(
+		"LoadOwnedInputs", mock.Anything, uint32(9), wantInputOutpoints,
+	).Return(
+		map[int64][]TxOwnedInput{
+			71: {{Index: 0, Amount: 3}},
+			72: {{Index: 0, Amount: 4}},
+		}, nil,
+	).Run(func(mock.Arguments) {
+		callOrder = append(callOrder, "inputs")
+	}).Once()
+
+	// Act: Run the shared list-detail workflow.
+	details, err := ListTxDetailsWithOps(context.Background(), query, ops)
+
+	// Assert: The helper preserves the unmined-first ordering and batches owned
+	// edge loads using that final tx-id order.
+	require.NoError(t, err)
+	require.Equal(t,
+		[]string{"unmined", "confirmed", "outputs", "inputs"}, callOrder,
+	)
+	require.Equal(t, []int64{71, 72}, batchedIDs)
+	require.Len(t, details, 2)
+	require.Equal(t, unminedTx.TxHash(), details[0].Hash)
+	require.Equal(t, confirmedTx.TxHash(), details[1].Hash)
+	require.Nil(t, details[0].Block)
+	require.NotNil(t, details[1].Block)
+}
+
+// TestListTxDetailsWithOpsUnminedLast verifies that the shared ListTxDetails
+// workflow appends unmined rows when the wallet tx-reader range ends at the
+// unmined leg.
+func TestListTxDetailsWithOpsUnminedLast(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Build one confirmed row, one unmined row, and one mock adapter
+	// that records the workflow ordering.
+	confirmedTx := testRegularMsgTxWithSeed(31)
+	unminedTx := testRegularMsgTxWithSeed(32)
+	query := ListTxDetailsQuery{WalletID: 10, StartHeight: 5, EndHeight: -1}
+	wantInputOutpoints := []TxInputOutpoint{
+		testInputOutpoint(81, confirmedTx),
+		testInputOutpoint(82, unminedTx),
+	}
+
+	var callOrder []string
+
+	ops := &mockListTxDetailsOps{}
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
+
+	ops.On("ListConfirmed", mock.Anything, uint32(10), int32(5),
+		int32(math.MaxInt32), false).Return(
+		[]TxDetailBase{
+			testTxDetailBase(
+				t, 81, confirmedTx, testBlock(5), TxStatusPublished, "c",
+			),
+		}, nil,
+	).Run(func(mock.Arguments) {
+		callOrder = append(callOrder, "confirmed")
+	}).Once()
+
+	ops.On("ListUnmined", mock.Anything, uint32(10)).Return(
+		[]TxDetailBase{
+			testTxDetailBase(t, 82, unminedTx, nil, TxStatusPending, "u"),
+		}, nil,
+	).Run(func(mock.Arguments) {
+		callOrder = append(callOrder, "unmined")
+	}).Once()
+
+	ops.On(
+		"LoadOwnedOutputs", mock.Anything, uint32(10), []int64{81, 82},
+	).Return(
+		map[int64][]TxOwnedOutput{
+			81: {{Index: 0, Amount: 5}},
+			82: {{Index: 0, Amount: 6}},
+		}, nil,
+	).Run(func(mock.Arguments) {
+		callOrder = append(callOrder, "outputs")
+	}).Once()
+
+	ops.On(
+		"LoadOwnedInputs", mock.Anything, uint32(10), wantInputOutpoints,
+	).Return(
+		map[int64][]TxOwnedInput{
+			81: {{Index: 0, Amount: 2}},
+			82: {{Index: 0, Amount: 1}},
+		}, nil,
+	).Run(func(mock.Arguments) {
+		callOrder = append(callOrder, "inputs")
+	}).Once()
+
+	// Act: Run the shared list-detail workflow.
+	details, err := ListTxDetailsWithOps(context.Background(), query, ops)
+
+	// Assert: The helper keeps the confirmed rows first and appends the unmined
+	// rows before loading owned edges.
+	require.NoError(t, err)
+	require.Equal(t,
+		[]string{"confirmed", "unmined", "outputs", "inputs"}, callOrder,
+	)
+	require.Len(t, details, 2)
+	require.Equal(t, confirmedTx.TxHash(), details[0].Hash)
+	require.Equal(t, unminedTx.TxHash(), details[1].Hash)
+}
+
+// TestListTxDetailsWithOpsEmptyResult verifies that the shared ListTxDetails
+// workflow returns a non-nil empty result when no rows match the range.
+func TestListTxDetailsWithOpsEmptyResult(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Build one confirmed-only query whose backend range returns no
+	// matching base rows.
+	query := ListTxDetailsQuery{WalletID: 11, StartHeight: 50, EndHeight: 50}
+	ops := &mockListTxDetailsOps{}
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
+
+	ops.On("ListConfirmed", mock.Anything, uint32(11), int32(50), int32(50),
+		false).Return([]TxDetailBase{}, nil).Once()
+
+	// Act: Run the shared list-detail workflow.
+	details, err := ListTxDetailsWithOps(context.Background(), query, ops)
+
+	// Assert: Empty results are represented as an allocated empty slice, and
+	// the helper does not attempt owned-edge loads for an empty base set.
+	require.NoError(t, err)
+	require.NotNil(t, details)
+	require.Empty(t, details)
 }
 
 // TestSerializeMsgTxNil verifies that serializeMsgTx rejects a missing
@@ -547,6 +883,56 @@ func testCoinbaseMsgTx() *wire.MsgTx {
 	return tx
 }
 
+// testRegularMsgTxWithSeed builds one deterministic non-coinbase transaction
+// fixture whose hash differs across seed values.
+func testRegularMsgTxWithSeed(seed byte) *wire.MsgTx {
+	tx := wire.NewMsgTx(wire.TxVersion)
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{seed}},
+	})
+	tx.AddTxOut(&wire.TxOut{Value: int64(seed) + 1, PkScript: []byte{0x51}})
+
+	return tx
+}
+
+// testTxDetailBase builds one normalized tx-detail base fixture for the shared
+// detail workflow tests.
+func testTxDetailBase(t *testing.T, id int64, tx *wire.MsgTx, block *Block,
+	status TxStatus, label string) TxDetailBase {
+
+	t.Helper()
+
+	rawTx, err := serializeMsgTx(tx)
+	require.NoError(t, err)
+
+	hash := tx.TxHash()
+
+	return TxDetailBase{
+		ID:       id,
+		Hash:     append([]byte(nil), hash[:]...),
+		RawTx:    rawTx,
+		Received: time.Unix(id, 0).In(time.FixedZone("X", 3600)),
+		Block:    block,
+		Status:   int64(status),
+		Label:    label,
+	}
+}
+
+// testInputOutpoint builds the expected previous-outpoint fixture for a test
+// transaction input.
+func testInputOutpoint(txID int64, tx *wire.MsgTx) TxInputOutpoint {
+	const inputIndex uint32 = 0
+
+	txIn := tx.TxIn[inputIndex]
+
+	return TxInputOutpoint{
+		TxID:            txID,
+		InputIndex:      inputIndex,
+		PrevTxHash:      txIn.PreviousOutPoint.Hash,
+		PrevOutputIndex: txIn.PreviousOutPoint.Index,
+	}
+}
+
 // mockCreateTxOps is a mock implementation of CreateTxOps.
 type mockCreateTxOps struct {
 	mock.Mock
@@ -714,6 +1100,139 @@ func (m *mockCreateTxOps) MarkInputsSpent(ctx context.Context,
 	args := m.Called(ctx, req, txID)
 
 	return args.Error(0)
+}
+
+// mockGetTxDetailOps is a mock implementation of GetTxDetailOps.
+type mockGetTxDetailOps struct {
+	mock.Mock
+}
+
+var _ GetTxDetailOps = (*mockGetTxDetailOps)(nil)
+
+// LoadBase implements GetTxDetailOps.
+func (m *mockGetTxDetailOps) LoadBase(ctx context.Context,
+	query GetTxDetailQuery) (TxDetailBase, error) {
+
+	args := m.Called(ctx, query)
+
+	base, ok := args.Get(0).(TxDetailBase)
+	if !ok {
+		return TxDetailBase{}, mockTypeError("LoadBase result")
+	}
+
+	return base, args.Error(1)
+}
+
+// LoadOwnedOutputs implements GetTxDetailOps.
+func (m *mockGetTxDetailOps) LoadOwnedOutputs(ctx context.Context,
+	walletID uint32, txIDs []int64) (map[int64][]TxOwnedOutput, error) {
+
+	args := m.Called(ctx, walletID, txIDs)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	outputs, ok := args.Get(0).(map[int64][]TxOwnedOutput)
+	if !ok {
+		return nil, mockTypeError("LoadOwnedOutputs result")
+	}
+
+	return outputs, args.Error(1)
+}
+
+// LoadOwnedInputs implements GetTxDetailOps.
+func (m *mockGetTxDetailOps) LoadOwnedInputs(ctx context.Context,
+	walletID uint32, inputOutpoints []TxInputOutpoint) (
+	map[int64][]TxOwnedInput, error) {
+
+	args := m.Called(ctx, walletID, inputOutpoints)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	inputs, ok := args.Get(0).(map[int64][]TxOwnedInput)
+	if !ok {
+		return nil, mockTypeError("LoadOwnedInputs result")
+	}
+
+	return inputs, args.Error(1)
+}
+
+// mockListTxDetailsOps is a mock implementation of ListTxDetailsOps.
+type mockListTxDetailsOps struct {
+	mock.Mock
+}
+
+var _ ListTxDetailsOps = (*mockListTxDetailsOps)(nil)
+
+// ListUnmined implements ListTxDetailsOps.
+func (m *mockListTxDetailsOps) ListUnmined(ctx context.Context,
+	walletID uint32) ([]TxDetailBase, error) {
+
+	args := m.Called(ctx, walletID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	bases, ok := args.Get(0).([]TxDetailBase)
+	if !ok {
+		return nil, mockTypeError("ListUnmined result")
+	}
+
+	return bases, args.Error(1)
+}
+
+// ListConfirmed implements ListTxDetailsOps.
+func (m *mockListTxDetailsOps) ListConfirmed(ctx context.Context,
+	walletID uint32, startHeight, endHeight int32,
+	reverse bool) ([]TxDetailBase, error) {
+
+	args := m.Called(ctx, walletID, startHeight, endHeight, reverse)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	bases, ok := args.Get(0).([]TxDetailBase)
+	if !ok {
+		return nil, mockTypeError("ListConfirmed result")
+	}
+
+	return bases, args.Error(1)
+}
+
+// LoadOwnedOutputs implements ListTxDetailsOps.
+func (m *mockListTxDetailsOps) LoadOwnedOutputs(ctx context.Context,
+	walletID uint32, txIDs []int64) (map[int64][]TxOwnedOutput, error) {
+
+	args := m.Called(ctx, walletID, txIDs)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	outputs, ok := args.Get(0).(map[int64][]TxOwnedOutput)
+	if !ok {
+		return nil, mockTypeError("LoadOwnedOutputs result")
+	}
+
+	return outputs, args.Error(1)
+}
+
+// LoadOwnedInputs implements ListTxDetailsOps.
+func (m *mockListTxDetailsOps) LoadOwnedInputs(ctx context.Context,
+	walletID uint32, inputOutpoints []TxInputOutpoint) (
+	map[int64][]TxOwnedInput, error) {
+
+	args := m.Called(ctx, walletID, inputOutpoints)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	inputs, ok := args.Get(0).(map[int64][]TxOwnedInput)
+	if !ok {
+		return nil, mockTypeError("LoadOwnedInputs result")
+	}
+
+	return inputs, args.Error(1)
 }
 
 // mockUpdateTxOps is a mock implementation of UpdateTxOps.

--- a/wallet/internal/sql/pg/migrations/000007_transactions.down.sql
+++ b/wallet/internal/sql/pg/migrations/000007_transactions.down.sql
@@ -4,3 +4,4 @@
 DROP TRIGGER IF EXISTS trg_set_coinbase_orphaned_on_disconnect ON transactions;
 DROP FUNCTION IF EXISTS set_coinbase_orphaned_on_disconnect();
 DROP TABLE IF EXISTS transactions;
+DROP SEQUENCE IF EXISTS transactions_confirmed_order_seq;

--- a/wallet/internal/sql/pg/migrations/000007_transactions.up.sql
+++ b/wallet/internal/sql/pg/migrations/000007_transactions.up.sql
@@ -1,6 +1,10 @@
 -- Migration note: Intentionally NOT idempotent (no "IF NOT EXISTS").
 -- This ensures migration tracking stays accurate and fails loudly if run twice.
 
+-- Monotonic sequence used to preserve the order in which wallet transactions
+-- enter confirmed block history, independent of their original row IDs.
+CREATE SEQUENCE transactions_confirmed_order_seq;
+
 -- Transactions table stores wallet-scoped blockchain transactions and their
 -- wallet-relative validity/confirmation state.
 CREATE TABLE transactions (
@@ -35,6 +39,11 @@ CREATE TABLE transactions (
     -- ON DELETE SET NULL: If a block is reorged, the transaction becomes
     -- unconfirmed.
     block_height INTEGER REFERENCES blocks (block_height) ON DELETE SET NULL,
+
+    -- Monotonic token assigned when a row becomes confirmed. Confirmed range
+    -- reads use it as the block-local tie-breaker so rows first seen as
+    -- unmined do not sort ahead of earlier transactions in the same block.
+    confirmed_order BIGINT,
 
     -- Validity state (soft deletion).
     --
@@ -88,6 +97,13 @@ CREATE TABLE transactions (
         block_height IS NULL OR tx_status = 1
     ),
 
+    -- The confirmation-order token is meaningful only while a transaction has
+    -- a confirming block.
+    CONSTRAINT check_confirmed_order_matches_block CHECK (
+        (block_height IS NULL AND confirmed_order IS NULL)
+        OR (block_height IS NOT NULL AND confirmed_order IS NOT NULL)
+    ),
+
     -- Coinbase transactions cannot exist in the local-only pre-broadcast state
     -- because they are created by mining, not by wallet authorship.
     CONSTRAINT check_coinbase_not_pending CHECK (
@@ -102,6 +118,9 @@ CREATE TABLE transactions (
         OR (block_height IS NULL AND tx_status = 4)
     )
 );
+
+ALTER SEQUENCE transactions_confirmed_order_seq OWNED BY
+transactions.confirmed_order;
 
 -- Optimization for unmined pending/published transaction lookups.
 CREATE INDEX idx_transactions_unconfirmed
@@ -121,13 +140,13 @@ WHERE block_height IS NULL;
 
 -- Optimization for "all transactions in block X" queries.
 CREATE INDEX idx_transactions_by_block
-ON transactions (wallet_id, block_height)
+ON transactions (wallet_id, block_height, confirmed_order)
 WHERE block_height IS NOT NULL;
 
 -- Optimization for rollback/disconnect paths that only know the confirmed block
 -- height and then fan out to affected wallet rows.
 CREATE INDEX idx_transactions_by_confirmed_height
-ON transactions (block_height, wallet_id, id)
+ON transactions (block_height, wallet_id, confirmed_order)
 WHERE block_height IS NOT NULL;
 
 -- Optimization for "latest transactions" queries.
@@ -151,10 +170,16 @@ CREATE FUNCTION set_coinbase_orphaned_on_disconnect() RETURNS TRIGGER AS $$
 BEGIN
     -- Detect the disconnect transition caused by the FK action on block delete.
     IF NEW.block_height IS NULL AND OLD.block_height IS NOT NULL
-        AND NEW.is_coinbase THEN
-        -- Only coinbase rows need rewriting here. Ordinary transactions may
-        -- become unconfirmed while keeping their existing non-orphaned status.
-        NEW.tx_status := 4;
+        THEN
+        -- The confirmation-order token belongs to the disconnected block edge.
+        NEW.confirmed_order := NULL;
+
+        IF NEW.is_coinbase THEN
+            -- Only coinbase rows need status rewriting here. Ordinary
+            -- transactions may become unconfirmed while keeping their existing
+            -- non-orphaned status.
+            NEW.tx_status := 4;
+        END IF;
     END IF;
 
     RETURN NEW;

--- a/wallet/internal/sql/pg/queries/transactions.sql
+++ b/wallet/internal/sql/pg/queries/transactions.sql
@@ -15,12 +15,24 @@ INSERT INTO transactions (
     tx_hash,
     raw_tx,
     block_height,
+    confirmed_order,
     tx_status,
     received_time,
     is_coinbase,
     tx_label
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8
+    sqlc.arg('wallet_id'),
+    sqlc.arg('tx_hash'),
+    sqlc.arg('raw_tx'),
+    sqlc.narg('block_height')::INTEGER,
+    CASE
+        WHEN sqlc.narg('block_height')::INTEGER IS NULL THEN NULL
+        ELSE nextval('transactions_confirmed_order_seq')
+    END,
+    sqlc.arg('tx_status'),
+    sqlc.arg('received_time'),
+    sqlc.arg('is_coinbase'),
+    sqlc.arg('tx_label')
 )
 RETURNING id;
 
@@ -136,7 +148,8 @@ ORDER BY t.received_time DESC, t.id DESC;
 -- - INNER JOINs blocks on the natural `block_height` key to hydrate block hash
 --   and timestamp for confirmed rows.
 -- Performance:
--- - The `(wallet_id, block_height)` index bounds the scan before the single-row
+-- - The `(wallet_id, block_height, confirmed_order)` index bounds the scan and
+--   preserves wallet-observed order within each block before the single-row
 --   block join.
 SELECT
     t.id,
@@ -156,7 +169,61 @@ WHERE
     AND t.block_height BETWEEN
     sqlc.arg('start_height')::INTEGER
     AND sqlc.arg('end_height')::INTEGER
-ORDER BY t.block_height, t.id;
+ORDER BY t.block_height, t.confirmed_order, t.id;
+
+-- name: ListOwnedOutputsByTxIDs :many
+-- ListOwnedOutputsByTxIDs lists wallet-owned outputs created by the selected
+-- transaction rows.
+--
+-- How:
+-- - Reads directly from utxos by `tx_id` after the caller has already selected
+--   the wallet-scoped transaction rows.
+-- - Returns only the output indexes and amounts needed by the tx detail read
+--   model.
+-- Performance:
+-- - Uses the provided tx-id array to bound the scan to the selected rows.
+SELECT
+    u.tx_id,
+    u.output_index,
+    u.amount
+FROM utxos AS u
+INNER JOIN transactions AS t ON u.tx_id = t.id
+INNER JOIN addresses AS a ON u.address_id = a.id
+INNER JOIN accounts AS acc ON a.account_id = acc.id
+INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
+WHERE
+    t.wallet_id = sqlc.arg('wallet_id')
+    AND ks.wallet_id = sqlc.arg('wallet_id')
+    AND u.tx_id = any(sqlc.arg('tx_ids')::BIGINT [])
+ORDER BY u.tx_id, u.output_index;
+
+-- name: ListOwnedInputPrevOutputsByTxHashes :many
+-- ListOwnedInputPrevOutputsByTxHashes lists wallet-owned previous outputs that
+-- may be spent by selected transaction inputs.
+--
+-- How:
+-- - Resolves previous transaction hashes to this wallet's tracked UTXO rows.
+-- - Rejoins addresses -> accounts -> key_scopes so debit reconstruction does
+--   not depend only on transaction wallet scope.
+-- - Does not read `spent_by_tx_id` because invalidation and rollback can clear
+--   that mutable edge while the historical spending transaction still exists.
+-- Performance:
+-- - Uses one batched transaction-hash lookup, then the UTXO tx-id index for the
+--   previous transactions' wallet-owned outputs.
+SELECT
+    t.tx_hash,
+    u.output_index,
+    u.amount
+FROM transactions AS t
+INNER JOIN utxos AS u ON t.id = u.tx_id
+INNER JOIN addresses AS a ON u.address_id = a.id
+INNER JOIN accounts AS acc ON a.account_id = acc.id
+INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
+WHERE
+    t.wallet_id = sqlc.arg('wallet_id')
+    AND ks.wallet_id = sqlc.arg('wallet_id')
+    AND t.tx_hash = any(sqlc.arg('tx_hashes')::BYTEA [])
+ORDER BY t.tx_hash, u.output_index;
 
 -- name: UpdateTransactionLabelByHash :execrows
 -- Updates only the user-visible transaction label.
@@ -188,6 +255,14 @@ WHERE
 -- - Updates at most one row through the wallet-scoped unique tx-hash lookup.
 UPDATE transactions
 SET
+    confirmed_order = CASE
+        WHEN sqlc.narg('block_height')::INTEGER IS NULL THEN NULL
+        WHEN
+            block_height = sqlc.narg('block_height')::INTEGER
+            AND confirmed_order IS NOT NULL
+            THEN confirmed_order
+        ELSE nextval('transactions_confirmed_order_seq')
+    END,
     block_height = sqlc.narg('block_height')::INTEGER,
     tx_status = sqlc.arg('status')
 WHERE

--- a/wallet/internal/sql/pg/sqlc/db.go
+++ b/wallet/internal/sql/pg/sqlc/db.go
@@ -201,6 +201,12 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.listKeyScopesByWalletStmt, err = db.PrepareContext(ctx, ListKeyScopesByWallet); err != nil {
 		return nil, fmt.Errorf("error preparing query ListKeyScopesByWallet: %w", err)
 	}
+	if q.listOwnedInputPrevOutputsByTxHashesStmt, err = db.PrepareContext(ctx, ListOwnedInputPrevOutputsByTxHashes); err != nil {
+		return nil, fmt.Errorf("error preparing query ListOwnedInputPrevOutputsByTxHashes: %w", err)
+	}
+	if q.listOwnedOutputsByTxIDsStmt, err = db.PrepareContext(ctx, ListOwnedOutputsByTxIDs); err != nil {
+		return nil, fmt.Errorf("error preparing query ListOwnedOutputsByTxIDs: %w", err)
+	}
 	if q.listReplacedTxHashesByReplacementTxHashStmt, err = db.PrepareContext(ctx, ListReplacedTxHashesByReplacementTxHash); err != nil {
 		return nil, fmt.Errorf("error preparing query ListReplacedTxHashesByReplacementTxHash: %w", err)
 	}
@@ -567,6 +573,16 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing listKeyScopesByWalletStmt: %w", cerr)
 		}
 	}
+	if q.listOwnedInputPrevOutputsByTxHashesStmt != nil {
+		if cerr := q.listOwnedInputPrevOutputsByTxHashesStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listOwnedInputPrevOutputsByTxHashesStmt: %w", cerr)
+		}
+	}
+	if q.listOwnedOutputsByTxIDsStmt != nil {
+		if cerr := q.listOwnedOutputsByTxIDsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listOwnedOutputsByTxIDsStmt: %w", cerr)
+		}
+	}
 	if q.listReplacedTxHashesByReplacementTxHashStmt != nil {
 		if cerr := q.listReplacedTxHashesByReplacementTxHashStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing listReplacedTxHashesByReplacementTxHashStmt: %w", cerr)
@@ -775,6 +791,8 @@ type Queries struct {
 	listAddressTypesStmt                        *sql.Stmt
 	listAddressesByAccountStmt                  *sql.Stmt
 	listKeyScopesByWalletStmt                   *sql.Stmt
+	listOwnedInputPrevOutputsByTxHashesStmt     *sql.Stmt
+	listOwnedOutputsByTxIDsStmt                 *sql.Stmt
 	listReplacedTxHashesByReplacementTxHashStmt *sql.Stmt
 	listReplacedTxIDsByReplacementTxIDStmt      *sql.Stmt
 	listReplacementTxHashesByReplacedTxHashStmt *sql.Stmt
@@ -862,6 +880,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		listAddressTypesStmt:                        q.listAddressTypesStmt,
 		listAddressesByAccountStmt:                  q.listAddressesByAccountStmt,
 		listKeyScopesByWalletStmt:                   q.listKeyScopesByWalletStmt,
+		listOwnedInputPrevOutputsByTxHashesStmt:     q.listOwnedInputPrevOutputsByTxHashesStmt,
+		listOwnedOutputsByTxIDsStmt:                 q.listOwnedOutputsByTxIDsStmt,
 		listReplacedTxHashesByReplacementTxHashStmt: q.listReplacedTxHashesByReplacementTxHashStmt,
 		listReplacedTxIDsByReplacementTxIDStmt:      q.listReplacedTxIDsByReplacementTxIDStmt,
 		listReplacementTxHashesByReplacedTxHashStmt: q.listReplacementTxHashesByReplacedTxHashStmt,

--- a/wallet/internal/sql/pg/sqlc/models.go
+++ b/wallet/internal/sql/pg/sqlc/models.go
@@ -80,15 +80,16 @@ type KeyScopeSecret struct {
 }
 
 type Transaction struct {
-	WalletID     int64
-	ID           int64
-	TxHash       []byte
-	RawTx        []byte
-	BlockHeight  sql.NullInt32
-	TxStatus     int16
-	ReceivedTime time.Time
-	IsCoinbase   bool
-	TxLabel      string
+	WalletID       int64
+	ID             int64
+	TxHash         []byte
+	RawTx          []byte
+	BlockHeight    sql.NullInt32
+	ConfirmedOrder sql.NullInt64
+	TxStatus       int16
+	ReceivedTime   time.Time
+	IsCoinbase     bool
+	TxLabel        string
 }
 
 type TxReplacement struct {

--- a/wallet/internal/sql/pg/sqlc/querier.go
+++ b/wallet/internal/sql/pg/sqlc/querier.go
@@ -335,6 +335,30 @@ type Querier interface {
 	ListAddressesByAccount(ctx context.Context, arg ListAddressesByAccountParams) ([]ListAddressesByAccountRow, error)
 	// Lists all key scopes for a wallet, ordered by ID.
 	ListKeyScopesByWallet(ctx context.Context, walletID int64) ([]KeyScope, error)
+	// ListOwnedInputPrevOutputsByTxHashes lists wallet-owned previous outputs that
+	// may be spent by selected transaction inputs.
+	//
+	// How:
+	// - Resolves previous transaction hashes to this wallet's tracked UTXO rows.
+	// - Rejoins addresses -> accounts -> key_scopes so debit reconstruction does
+	//   not depend only on transaction wallet scope.
+	// - Does not read `spent_by_tx_id` because invalidation and rollback can clear
+	//   that mutable edge while the historical spending transaction still exists.
+	// Performance:
+	// - Uses one batched transaction-hash lookup, then the UTXO tx-id index for the
+	//   previous transactions' wallet-owned outputs.
+	ListOwnedInputPrevOutputsByTxHashes(ctx context.Context, arg ListOwnedInputPrevOutputsByTxHashesParams) ([]ListOwnedInputPrevOutputsByTxHashesRow, error)
+	// ListOwnedOutputsByTxIDs lists wallet-owned outputs created by the selected
+	// transaction rows.
+	//
+	// How:
+	// - Reads directly from utxos by `tx_id` after the caller has already selected
+	//   the wallet-scoped transaction rows.
+	// - Returns only the output indexes and amounts needed by the tx detail read
+	//   model.
+	// Performance:
+	// - Uses the provided tx-id array to bound the scan to the selected rows.
+	ListOwnedOutputsByTxIDs(ctx context.Context, arg ListOwnedOutputsByTxIDsParams) ([]ListOwnedOutputsByTxIDsRow, error)
 	// Lists victim txids for a given replacement txid.
 	//
 	// How:
@@ -406,7 +430,8 @@ type Querier interface {
 	// - INNER JOINs blocks on the natural `block_height` key to hydrate block hash
 	//   and timestamp for confirmed rows.
 	// Performance:
-	// - The `(wallet_id, block_height)` index bounds the scan before the single-row
+	// - The `(wallet_id, block_height, confirmed_order)` index bounds the scan and
+	//   preserves wallet-observed order within each block before the single-row
 	//   block join.
 	ListTransactionsByHeightRange(ctx context.Context, arg ListTransactionsByHeightRangeParams) ([]ListTransactionsByHeightRangeRow, error)
 	// Lists every wallet transaction row that currently has no confirming block.

--- a/wallet/internal/sql/pg/sqlc/transactions.sql.go
+++ b/wallet/internal/sql/pg/sqlc/transactions.sql.go
@@ -182,12 +182,24 @@ INSERT INTO transactions (
     tx_hash,
     raw_tx,
     block_height,
+    confirmed_order,
     tx_status,
     received_time,
     is_coinbase,
     tx_label
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8
+    $1,
+    $2,
+    $3,
+    $4::INTEGER,
+    CASE
+        WHEN $4::INTEGER IS NULL THEN NULL
+        ELSE nextval('transactions_confirmed_order_seq')
+    END,
+    $5,
+    $6,
+    $7,
+    $8
 )
 RETURNING id
 `
@@ -229,6 +241,132 @@ func (q *Queries) InsertTransaction(ctx context.Context, arg InsertTransactionPa
 	var id int64
 	err := row.Scan(&id)
 	return id, err
+}
+
+const ListOwnedInputPrevOutputsByTxHashes = `-- name: ListOwnedInputPrevOutputsByTxHashes :many
+SELECT
+    t.tx_hash,
+    u.output_index,
+    u.amount
+FROM transactions AS t
+INNER JOIN utxos AS u ON t.id = u.tx_id
+INNER JOIN addresses AS a ON u.address_id = a.id
+INNER JOIN accounts AS acc ON a.account_id = acc.id
+INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
+WHERE
+    t.wallet_id = $1
+    AND ks.wallet_id = $1
+    AND t.tx_hash = any($2::BYTEA [])
+ORDER BY t.tx_hash, u.output_index
+`
+
+type ListOwnedInputPrevOutputsByTxHashesParams struct {
+	WalletID int64
+	TxHashes [][]byte
+}
+
+type ListOwnedInputPrevOutputsByTxHashesRow struct {
+	TxHash      []byte
+	OutputIndex int32
+	Amount      int64
+}
+
+// ListOwnedInputPrevOutputsByTxHashes lists wallet-owned previous outputs that
+// may be spent by selected transaction inputs.
+//
+// How:
+//   - Resolves previous transaction hashes to this wallet's tracked UTXO rows.
+//   - Rejoins addresses -> accounts -> key_scopes so debit reconstruction does
+//     not depend only on transaction wallet scope.
+//   - Does not read `spent_by_tx_id` because invalidation and rollback can clear
+//     that mutable edge while the historical spending transaction still exists.
+//
+// Performance:
+//   - Uses one batched transaction-hash lookup, then the UTXO tx-id index for the
+//     previous transactions' wallet-owned outputs.
+func (q *Queries) ListOwnedInputPrevOutputsByTxHashes(ctx context.Context, arg ListOwnedInputPrevOutputsByTxHashesParams) ([]ListOwnedInputPrevOutputsByTxHashesRow, error) {
+	rows, err := q.query(ctx, q.listOwnedInputPrevOutputsByTxHashesStmt, ListOwnedInputPrevOutputsByTxHashes, arg.WalletID, pq.Array(arg.TxHashes))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListOwnedInputPrevOutputsByTxHashesRow
+	for rows.Next() {
+		var i ListOwnedInputPrevOutputsByTxHashesRow
+		if err := rows.Scan(&i.TxHash, &i.OutputIndex, &i.Amount); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const ListOwnedOutputsByTxIDs = `-- name: ListOwnedOutputsByTxIDs :many
+SELECT
+    u.tx_id,
+    u.output_index,
+    u.amount
+FROM utxos AS u
+INNER JOIN transactions AS t ON u.tx_id = t.id
+INNER JOIN addresses AS a ON u.address_id = a.id
+INNER JOIN accounts AS acc ON a.account_id = acc.id
+INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
+WHERE
+    t.wallet_id = $1
+    AND ks.wallet_id = $1
+    AND u.tx_id = any($2::BIGINT [])
+ORDER BY u.tx_id, u.output_index
+`
+
+type ListOwnedOutputsByTxIDsParams struct {
+	WalletID int64
+	TxIds    []int64
+}
+
+type ListOwnedOutputsByTxIDsRow struct {
+	TxID        int64
+	OutputIndex int32
+	Amount      int64
+}
+
+// ListOwnedOutputsByTxIDs lists wallet-owned outputs created by the selected
+// transaction rows.
+//
+// How:
+//   - Reads directly from utxos by `tx_id` after the caller has already selected
+//     the wallet-scoped transaction rows.
+//   - Returns only the output indexes and amounts needed by the tx detail read
+//     model.
+//
+// Performance:
+// - Uses the provided tx-id array to bound the scan to the selected rows.
+func (q *Queries) ListOwnedOutputsByTxIDs(ctx context.Context, arg ListOwnedOutputsByTxIDsParams) ([]ListOwnedOutputsByTxIDsRow, error) {
+	rows, err := q.query(ctx, q.listOwnedOutputsByTxIDsStmt, ListOwnedOutputsByTxIDs, arg.WalletID, pq.Array(arg.TxIds))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListOwnedOutputsByTxIDsRow
+	for rows.Next() {
+		var i ListOwnedOutputsByTxIDsRow
+		if err := rows.Scan(&i.TxID, &i.OutputIndex, &i.Amount); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const ListRollbackCoinbaseRoots = `-- name: ListRollbackCoinbaseRoots :many
@@ -302,7 +440,7 @@ WHERE
     AND t.block_height BETWEEN
     $2::INTEGER
     AND $3::INTEGER
-ORDER BY t.block_height, t.id
+ORDER BY t.block_height, t.confirmed_order, t.id
 `
 
 type ListTransactionsByHeightRangeParams struct {
@@ -332,7 +470,8 @@ type ListTransactionsByHeightRangeRow struct {
 //     and timestamp for confirmed rows.
 //
 // Performance:
-//   - The `(wallet_id, block_height)` index bounds the scan before the single-row
+//   - The `(wallet_id, block_height, confirmed_order)` index bounds the scan and
+//     preserves wallet-observed order within each block before the single-row
 //     block join.
 func (q *Queries) ListTransactionsByHeightRange(ctx context.Context, arg ListTransactionsByHeightRangeParams) ([]ListTransactionsByHeightRangeRow, error) {
 	rows, err := q.query(ctx, q.listTransactionsByHeightRangeStmt, ListTransactionsByHeightRange, arg.WalletID, arg.StartHeight, arg.EndHeight)
@@ -619,6 +758,14 @@ func (q *Queries) UpdateTransactionLabelByHash(ctx context.Context, arg UpdateTr
 const UpdateTransactionStateByHash = `-- name: UpdateTransactionStateByHash :execrows
 UPDATE transactions
 SET
+    confirmed_order = CASE
+        WHEN $1::INTEGER IS NULL THEN NULL
+        WHEN
+            block_height = $1::INTEGER
+            AND confirmed_order IS NOT NULL
+            THEN confirmed_order
+        ELSE nextval('transactions_confirmed_order_seq')
+    END,
     block_height = $1::INTEGER,
     tx_status = $2
 WHERE

--- a/wallet/internal/sql/sqlite/migrations/000007_transactions.up.sql
+++ b/wallet/internal/sql/sqlite/migrations/000007_transactions.up.sql
@@ -27,6 +27,11 @@ CREATE TABLE transactions (
     -- unconfirmed.
     block_height INTEGER REFERENCES blocks (block_height) ON DELETE SET NULL,
 
+    -- Monotonic token assigned when a row becomes confirmed. Confirmed range
+    -- reads use it as the block-local tie-breaker so rows first seen as
+    -- unmined do not sort ahead of earlier transactions in the same block.
+    confirmed_order INTEGER,
+
     -- Validity state (soft deletion).
     --
     -- Store the status code inline instead of via a lookup table because this
@@ -85,6 +90,13 @@ CREATE TABLE transactions (
         block_height IS NULL OR tx_status = 1
     ),
 
+    -- The confirmation-order token is meaningful only while a transaction has
+    -- a confirming block.
+    CONSTRAINT check_confirmed_order_matches_block CHECK (
+        (block_height IS NULL AND confirmed_order IS NULL)
+        OR (block_height IS NOT NULL AND confirmed_order IS NOT NULL)
+    ),
+
     -- Coinbase transactions cannot exist in the local-only pre-broadcast state
     -- because they are created by mining, not by wallet authorship.
     CONSTRAINT check_coinbase_not_pending CHECK (
@@ -118,13 +130,13 @@ WHERE block_height IS NULL;
 
 -- Optimization for "all transactions in block X" queries.
 CREATE INDEX idx_transactions_by_block
-ON transactions (wallet_id, block_height)
+ON transactions (wallet_id, block_height, confirmed_order)
 WHERE block_height IS NOT NULL;
 
 -- Optimization for rollback/disconnect paths that only know the confirmed block
 -- height and then fan out to affected wallet rows.
 CREATE INDEX idx_transactions_by_confirmed_height
-ON transactions (block_height, wallet_id, id)
+ON transactions (block_height, wallet_id, confirmed_order)
 WHERE block_height IS NOT NULL;
 
 -- Optimization for "latest transactions" queries.
@@ -165,6 +177,7 @@ BEGIN
             -- status is preserved for later rollback/invalidation handling.
             ELSE tx_status
         END,
-        block_height = NULL
+        block_height = NULL,
+        confirmed_order = NULL
     WHERE block_height = old.block_height;
 END;

--- a/wallet/internal/sql/sqlite/queries/transactions.sql
+++ b/wallet/internal/sql/sqlite/queries/transactions.sql
@@ -15,12 +15,27 @@ INSERT INTO transactions (
     tx_hash,
     raw_tx,
     block_height,
+    confirmed_order,
     tx_status,
     received_time,
     is_coinbase,
     tx_label
 ) VALUES (
-    ?, ?, ?, ?, ?, ?, ?, ?
+    sqlc.arg('wallet_id'),
+    sqlc.arg('tx_hash'),
+    sqlc.arg('raw_tx'),
+    cast(sqlc.narg('block_height') AS INTEGER),
+    CASE
+        WHEN cast(sqlc.narg('block_height') AS INTEGER) IS NULL THEN NULL
+        ELSE (
+            SELECT coalesce(max(confirmed_order), 0) + 1
+            FROM transactions
+        )
+    END,
+    sqlc.arg('tx_status'),
+    sqlc.arg('received_time'),
+    sqlc.arg('is_coinbase'),
+    sqlc.arg('tx_label')
 )
 RETURNING id;
 
@@ -138,7 +153,8 @@ ORDER BY t.received_time DESC, t.id DESC;
 -- - INNER JOINs blocks on the natural `block_height` key to hydrate block hash
 --   and timestamp for confirmed rows.
 -- Performance:
--- - The `(wallet_id, block_height)` index bounds the scan before the single-row
+-- - The `(wallet_id, block_height, confirmed_order)` index bounds the scan and
+--   preserves wallet-observed order within each block before the single-row
 --   block join.
 SELECT
     t.id,
@@ -157,7 +173,61 @@ WHERE
     t.wallet_id = sqlc.arg('wallet_id')
     AND t.block_height >= cast(sqlc.arg('start_height') AS INTEGER)
     AND t.block_height <= cast(sqlc.arg('end_height') AS INTEGER)
-ORDER BY t.block_height, t.id;
+ORDER BY t.block_height, t.confirmed_order, t.id;
+
+-- name: ListOwnedOutputsByTxIDs :many
+-- ListOwnedOutputsByTxIDs lists wallet-owned outputs created by the selected
+-- transaction rows.
+--
+-- How:
+-- - Reads directly from utxos by `tx_id` after the caller has already selected
+--   the wallet-scoped transaction rows.
+-- - Returns only the output indexes and amounts needed by the tx detail read
+--   model.
+-- Performance:
+-- - Uses the provided tx-id slice to bound the scan to the selected rows.
+SELECT
+    u.tx_id,
+    u.output_index,
+    u.amount
+FROM utxos AS u
+INNER JOIN transactions AS t ON u.tx_id = t.id
+INNER JOIN addresses AS a ON u.address_id = a.id
+INNER JOIN accounts AS acc ON a.account_id = acc.id
+INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
+WHERE
+    t.wallet_id = sqlc.arg('wallet_id')
+    AND ks.wallet_id = sqlc.arg('wallet_id')
+    AND u.tx_id IN (sqlc.slice('tx_ids'))
+ORDER BY u.tx_id, u.output_index;
+
+-- name: ListOwnedInputPrevOutputsByTxHashes :many
+-- ListOwnedInputPrevOutputsByTxHashes lists wallet-owned previous outputs that
+-- may be spent by selected transaction inputs.
+--
+-- How:
+-- - Resolves previous transaction hashes to this wallet's tracked UTXO rows.
+-- - Rejoins addresses -> accounts -> key_scopes so debit reconstruction does
+--   not depend only on transaction wallet scope.
+-- - Does not read `spent_by_tx_id` because invalidation and rollback can clear
+--   that mutable edge while the historical spending transaction still exists.
+-- Performance:
+-- - Uses one batched transaction-hash lookup, then the UTXO tx-id index for the
+--   previous transactions' wallet-owned outputs.
+SELECT
+    t.tx_hash,
+    u.output_index,
+    u.amount
+FROM transactions AS t
+INNER JOIN utxos AS u ON t.id = u.tx_id
+INNER JOIN addresses AS a ON u.address_id = a.id
+INNER JOIN accounts AS acc ON a.account_id = acc.id
+INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
+WHERE
+    t.wallet_id = sqlc.arg('wallet_id')
+    AND ks.wallet_id = sqlc.arg('wallet_id')
+    AND t.tx_hash IN (sqlc.slice('tx_hashes'))
+ORDER BY t.tx_hash, u.output_index;
 
 -- name: UpdateTransactionLabelByHash :execrows
 -- Updates only the user-visible transaction label.
@@ -189,11 +259,22 @@ WHERE
 -- - Updates at most one row through the wallet-scoped unique tx-hash lookup.
 UPDATE transactions
 SET
+    confirmed_order = CASE
+        WHEN cast(sqlc.narg('block_height') AS INTEGER) IS NULL THEN NULL
+        WHEN
+            transactions.block_height = cast(sqlc.narg('block_height') AS INTEGER)
+            AND transactions.confirmed_order IS NOT NULL
+            THEN transactions.confirmed_order
+        ELSE (
+            SELECT coalesce(max(confirmed_order), 0) + 1
+            FROM transactions
+        )
+    END,
     block_height = cast(sqlc.narg('block_height') AS INTEGER),
     tx_status = sqlc.arg('status')
 WHERE
-    wallet_id = sqlc.arg('wallet_id')
-    AND tx_hash = sqlc.arg('tx_hash');
+    transactions.wallet_id = sqlc.arg('wallet_id')
+    AND transactions.tx_hash = sqlc.arg('tx_hash');
 
 -- name: UpdateTransactionStatusByIDs :execrows
 -- Updates the wallet-relative status for a set of transaction row IDs.

--- a/wallet/internal/sql/sqlite/sqlc/db.go
+++ b/wallet/internal/sql/sqlite/sqlc/db.go
@@ -201,6 +201,12 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.listKeyScopesByWalletStmt, err = db.PrepareContext(ctx, ListKeyScopesByWallet); err != nil {
 		return nil, fmt.Errorf("error preparing query ListKeyScopesByWallet: %w", err)
 	}
+	if q.listOwnedInputPrevOutputsByTxHashesStmt, err = db.PrepareContext(ctx, ListOwnedInputPrevOutputsByTxHashes); err != nil {
+		return nil, fmt.Errorf("error preparing query ListOwnedInputPrevOutputsByTxHashes: %w", err)
+	}
+	if q.listOwnedOutputsByTxIDsStmt, err = db.PrepareContext(ctx, ListOwnedOutputsByTxIDs); err != nil {
+		return nil, fmt.Errorf("error preparing query ListOwnedOutputsByTxIDs: %w", err)
+	}
 	if q.listReplacedTxHashesByReplacementTxHashStmt, err = db.PrepareContext(ctx, ListReplacedTxHashesByReplacementTxHash); err != nil {
 		return nil, fmt.Errorf("error preparing query ListReplacedTxHashesByReplacementTxHash: %w", err)
 	}
@@ -564,6 +570,16 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing listKeyScopesByWalletStmt: %w", cerr)
 		}
 	}
+	if q.listOwnedInputPrevOutputsByTxHashesStmt != nil {
+		if cerr := q.listOwnedInputPrevOutputsByTxHashesStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listOwnedInputPrevOutputsByTxHashesStmt: %w", cerr)
+		}
+	}
+	if q.listOwnedOutputsByTxIDsStmt != nil {
+		if cerr := q.listOwnedOutputsByTxIDsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listOwnedOutputsByTxIDsStmt: %w", cerr)
+		}
+	}
 	if q.listReplacedTxHashesByReplacementTxHashStmt != nil {
 		if cerr := q.listReplacedTxHashesByReplacementTxHashStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing listReplacedTxHashesByReplacementTxHashStmt: %w", cerr)
@@ -767,6 +783,8 @@ type Queries struct {
 	listAddressTypesStmt                        *sql.Stmt
 	listAddressesByAccountStmt                  *sql.Stmt
 	listKeyScopesByWalletStmt                   *sql.Stmt
+	listOwnedInputPrevOutputsByTxHashesStmt     *sql.Stmt
+	listOwnedOutputsByTxIDsStmt                 *sql.Stmt
 	listReplacedTxHashesByReplacementTxHashStmt *sql.Stmt
 	listReplacedTxIDsByReplacementTxIDStmt      *sql.Stmt
 	listReplacementTxHashesByReplacedTxHashStmt *sql.Stmt
@@ -853,6 +871,8 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		listAddressTypesStmt:                        q.listAddressTypesStmt,
 		listAddressesByAccountStmt:                  q.listAddressesByAccountStmt,
 		listKeyScopesByWalletStmt:                   q.listKeyScopesByWalletStmt,
+		listOwnedInputPrevOutputsByTxHashesStmt:     q.listOwnedInputPrevOutputsByTxHashesStmt,
+		listOwnedOutputsByTxIDsStmt:                 q.listOwnedOutputsByTxIDsStmt,
 		listReplacedTxHashesByReplacementTxHashStmt: q.listReplacedTxHashesByReplacementTxHashStmt,
 		listReplacedTxIDsByReplacementTxIDStmt:      q.listReplacedTxIDsByReplacementTxIDStmt,
 		listReplacementTxHashesByReplacedTxHashStmt: q.listReplacementTxHashesByReplacedTxHashStmt,

--- a/wallet/internal/sql/sqlite/sqlc/models.go
+++ b/wallet/internal/sql/sqlite/sqlc/models.go
@@ -80,15 +80,16 @@ type KeyScopeSecret struct {
 }
 
 type Transaction struct {
-	WalletID     int64
-	ID           int64
-	TxHash       []byte
-	RawTx        []byte
-	BlockHeight  sql.NullInt64
-	TxStatus     int64
-	ReceivedTime time.Time
-	IsCoinbase   bool
-	TxLabel      string
+	WalletID       int64
+	ID             int64
+	TxHash         []byte
+	RawTx          []byte
+	BlockHeight    sql.NullInt64
+	ConfirmedOrder sql.NullInt64
+	TxStatus       int64
+	ReceivedTime   time.Time
+	IsCoinbase     bool
+	TxLabel        string
 }
 
 type TxReplacement struct {

--- a/wallet/internal/sql/sqlite/sqlc/querier.go
+++ b/wallet/internal/sql/sqlite/sqlc/querier.go
@@ -331,6 +331,30 @@ type Querier interface {
 	ListAddressesByAccount(ctx context.Context, arg ListAddressesByAccountParams) ([]ListAddressesByAccountRow, error)
 	// Lists all key scopes for a wallet, ordered by ID.
 	ListKeyScopesByWallet(ctx context.Context, walletID int64) ([]KeyScope, error)
+	// ListOwnedInputPrevOutputsByTxHashes lists wallet-owned previous outputs that
+	// may be spent by selected transaction inputs.
+	//
+	// How:
+	// - Resolves previous transaction hashes to this wallet's tracked UTXO rows.
+	// - Rejoins addresses -> accounts -> key_scopes so debit reconstruction does
+	//   not depend only on transaction wallet scope.
+	// - Does not read `spent_by_tx_id` because invalidation and rollback can clear
+	//   that mutable edge while the historical spending transaction still exists.
+	// Performance:
+	// - Uses one batched transaction-hash lookup, then the UTXO tx-id index for the
+	//   previous transactions' wallet-owned outputs.
+	ListOwnedInputPrevOutputsByTxHashes(ctx context.Context, arg ListOwnedInputPrevOutputsByTxHashesParams) ([]ListOwnedInputPrevOutputsByTxHashesRow, error)
+	// ListOwnedOutputsByTxIDs lists wallet-owned outputs created by the selected
+	// transaction rows.
+	//
+	// How:
+	// - Reads directly from utxos by `tx_id` after the caller has already selected
+	//   the wallet-scoped transaction rows.
+	// - Returns only the output indexes and amounts needed by the tx detail read
+	//   model.
+	// Performance:
+	// - Uses the provided tx-id slice to bound the scan to the selected rows.
+	ListOwnedOutputsByTxIDs(ctx context.Context, arg ListOwnedOutputsByTxIDsParams) ([]ListOwnedOutputsByTxIDsRow, error)
 	// Lists victim txids for a given replacement txid.
 	//
 	// How:
@@ -402,7 +426,8 @@ type Querier interface {
 	// - INNER JOINs blocks on the natural `block_height` key to hydrate block hash
 	//   and timestamp for confirmed rows.
 	// Performance:
-	// - The `(wallet_id, block_height)` index bounds the scan before the single-row
+	// - The `(wallet_id, block_height, confirmed_order)` index bounds the scan and
+	//   preserves wallet-observed order within each block before the single-row
 	//   block join.
 	ListTransactionsByHeightRange(ctx context.Context, arg ListTransactionsByHeightRangeParams) ([]ListTransactionsByHeightRangeRow, error)
 	// Lists every wallet transaction row that currently has no confirming block.

--- a/wallet/internal/sql/sqlite/sqlc/transactions.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/transactions.sql.go
@@ -181,12 +181,27 @@ INSERT INTO transactions (
     tx_hash,
     raw_tx,
     block_height,
+    confirmed_order,
     tx_status,
     received_time,
     is_coinbase,
     tx_label
 ) VALUES (
-    ?, ?, ?, ?, ?, ?, ?, ?
+    ?1,
+    ?2,
+    ?3,
+    cast(?4 AS INTEGER),
+    CASE
+        WHEN cast(?4 AS INTEGER) IS NULL THEN NULL
+        ELSE (
+            SELECT coalesce(max(confirmed_order), 0) + 1
+            FROM transactions
+        )
+    END,
+    ?5,
+    ?6,
+    ?7,
+    ?8
 )
 RETURNING id
 `
@@ -228,6 +243,154 @@ func (q *Queries) InsertTransaction(ctx context.Context, arg InsertTransactionPa
 	var id int64
 	err := row.Scan(&id)
 	return id, err
+}
+
+const ListOwnedInputPrevOutputsByTxHashes = `-- name: ListOwnedInputPrevOutputsByTxHashes :many
+SELECT
+    t.tx_hash,
+    u.output_index,
+    u.amount
+FROM transactions AS t
+INNER JOIN utxos AS u ON t.id = u.tx_id
+INNER JOIN addresses AS a ON u.address_id = a.id
+INNER JOIN accounts AS acc ON a.account_id = acc.id
+INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
+WHERE
+    t.wallet_id = ?1
+    AND ks.wallet_id = ?1
+    AND t.tx_hash IN (/*SLICE:tx_hashes*/?)
+ORDER BY t.tx_hash, u.output_index
+`
+
+type ListOwnedInputPrevOutputsByTxHashesParams struct {
+	WalletID int64
+	TxHashes [][]byte
+}
+
+type ListOwnedInputPrevOutputsByTxHashesRow struct {
+	TxHash      []byte
+	OutputIndex int64
+	Amount      int64
+}
+
+// ListOwnedInputPrevOutputsByTxHashes lists wallet-owned previous outputs that
+// may be spent by selected transaction inputs.
+//
+// How:
+//   - Resolves previous transaction hashes to this wallet's tracked UTXO rows.
+//   - Rejoins addresses -> accounts -> key_scopes so debit reconstruction does
+//     not depend only on transaction wallet scope.
+//   - Does not read `spent_by_tx_id` because invalidation and rollback can clear
+//     that mutable edge while the historical spending transaction still exists.
+//
+// Performance:
+//   - Uses one batched transaction-hash lookup, then the UTXO tx-id index for the
+//     previous transactions' wallet-owned outputs.
+func (q *Queries) ListOwnedInputPrevOutputsByTxHashes(ctx context.Context, arg ListOwnedInputPrevOutputsByTxHashesParams) ([]ListOwnedInputPrevOutputsByTxHashesRow, error) {
+	query := ListOwnedInputPrevOutputsByTxHashes
+	var queryParams []interface{}
+	queryParams = append(queryParams, arg.WalletID)
+	if len(arg.TxHashes) > 0 {
+		for _, v := range arg.TxHashes {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:tx_hashes*/?", strings.Repeat(",?", len(arg.TxHashes))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:tx_hashes*/?", "NULL", 1)
+	}
+	rows, err := q.query(ctx, nil, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListOwnedInputPrevOutputsByTxHashesRow
+	for rows.Next() {
+		var i ListOwnedInputPrevOutputsByTxHashesRow
+		if err := rows.Scan(&i.TxHash, &i.OutputIndex, &i.Amount); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const ListOwnedOutputsByTxIDs = `-- name: ListOwnedOutputsByTxIDs :many
+SELECT
+    u.tx_id,
+    u.output_index,
+    u.amount
+FROM utxos AS u
+INNER JOIN transactions AS t ON u.tx_id = t.id
+INNER JOIN addresses AS a ON u.address_id = a.id
+INNER JOIN accounts AS acc ON a.account_id = acc.id
+INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
+WHERE
+    t.wallet_id = ?1
+    AND ks.wallet_id = ?1
+    AND u.tx_id IN (/*SLICE:tx_ids*/?)
+ORDER BY u.tx_id, u.output_index
+`
+
+type ListOwnedOutputsByTxIDsParams struct {
+	WalletID int64
+	TxIds    []int64
+}
+
+type ListOwnedOutputsByTxIDsRow struct {
+	TxID        int64
+	OutputIndex int64
+	Amount      int64
+}
+
+// ListOwnedOutputsByTxIDs lists wallet-owned outputs created by the selected
+// transaction rows.
+//
+// How:
+//   - Reads directly from utxos by `tx_id` after the caller has already selected
+//     the wallet-scoped transaction rows.
+//   - Returns only the output indexes and amounts needed by the tx detail read
+//     model.
+//
+// Performance:
+// - Uses the provided tx-id slice to bound the scan to the selected rows.
+func (q *Queries) ListOwnedOutputsByTxIDs(ctx context.Context, arg ListOwnedOutputsByTxIDsParams) ([]ListOwnedOutputsByTxIDsRow, error) {
+	query := ListOwnedOutputsByTxIDs
+	var queryParams []interface{}
+	queryParams = append(queryParams, arg.WalletID)
+	if len(arg.TxIds) > 0 {
+		for _, v := range arg.TxIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:tx_ids*/?", strings.Repeat(",?", len(arg.TxIds))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:tx_ids*/?", "NULL", 1)
+	}
+	rows, err := q.query(ctx, nil, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListOwnedOutputsByTxIDsRow
+	for rows.Next() {
+		var i ListOwnedOutputsByTxIDsRow
+		if err := rows.Scan(&i.TxID, &i.OutputIndex, &i.Amount); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const ListRollbackCoinbaseRoots = `-- name: ListRollbackCoinbaseRoots :many
@@ -300,7 +463,7 @@ WHERE
     t.wallet_id = ?1
     AND t.block_height >= cast(?2 AS INTEGER)
     AND t.block_height <= cast(?3 AS INTEGER)
-ORDER BY t.block_height, t.id
+ORDER BY t.block_height, t.confirmed_order, t.id
 `
 
 type ListTransactionsByHeightRangeParams struct {
@@ -330,7 +493,8 @@ type ListTransactionsByHeightRangeRow struct {
 //     and timestamp for confirmed rows.
 //
 // Performance:
-//   - The `(wallet_id, block_height)` index bounds the scan before the single-row
+//   - The `(wallet_id, block_height, confirmed_order)` index bounds the scan and
+//     preserves wallet-observed order within each block before the single-row
 //     block join.
 func (q *Queries) ListTransactionsByHeightRange(ctx context.Context, arg ListTransactionsByHeightRangeParams) ([]ListTransactionsByHeightRangeRow, error) {
 	rows, err := q.query(ctx, q.listTransactionsByHeightRangeStmt, ListTransactionsByHeightRange, arg.WalletID, arg.StartHeight, arg.EndHeight)
@@ -619,11 +783,22 @@ func (q *Queries) UpdateTransactionLabelByHash(ctx context.Context, arg UpdateTr
 const UpdateTransactionStateByHash = `-- name: UpdateTransactionStateByHash :execrows
 UPDATE transactions
 SET
+    confirmed_order = CASE
+        WHEN cast(?1 AS INTEGER) IS NULL THEN NULL
+        WHEN
+            transactions.block_height = cast(?1 AS INTEGER)
+            AND transactions.confirmed_order IS NOT NULL
+            THEN transactions.confirmed_order
+        ELSE (
+            SELECT coalesce(max(confirmed_order), 0) + 1
+            FROM transactions
+        )
+    END,
     block_height = cast(?1 AS INTEGER),
     tx_status = ?2
 WHERE
-    wallet_id = ?3
-    AND tx_hash = ?4
+    transactions.wallet_id = ?3
+    AND transactions.tx_hash = ?4
 `
 
 type UpdateTransactionStateByHashParams struct {

--- a/wallet/tx_reader.go
+++ b/wallet/tx_reader.go
@@ -232,40 +232,6 @@ func (w *Wallet) ListTxns(_ context.Context, startHeight,
 	return details, nil
 }
 
-// fetchTxDetails fetches the tx details for the given tx hash
-// from the wallet's tx store.
-func (w *Wallet) fetchTxDetails(txHash *chainhash.Hash) (
-	*wtxmgr.TxDetails, error) {
-
-	var txDetails *wtxmgr.TxDetails
-
-	err := walletdb.View(w.cfg.DB, func(dbtx walletdb.ReadTx) error {
-		txmgrNs := dbtx.ReadBucket(wtxmgrNamespaceKey)
-
-		var err error
-
-		txDetails, err = w.txStore.TxDetails(txmgrNs, txHash)
-		if err != nil {
-			return fmt.Errorf("failed to fetch tx details: %w", err)
-		}
-
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to view wallet db: %w", err)
-	}
-
-	// TxDetails will return nil when the tx is not found.
-	//
-	// TODO(yy): We should instead return an error when the tx cannot be
-	// found in the db.
-	if txDetails == nil {
-		return nil, ErrTxNotFound
-	}
-
-	return txDetails, nil
-}
-
 // buildTxDetail builds a TxDetail from the given wtxmgr.TxDetails.
 func (w *Wallet) buildTxDetail(txDetails *wtxmgr.TxDetails,
 	currentHeight int32) *TxDetail {

--- a/wallet/txdetails_legacy.go
+++ b/wallet/txdetails_legacy.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2025 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+)
+
+// fetchTxDetails fetches the tx details for the given tx hash from the wallet's
+// legacy tx store.
+//
+// NOTE: This helper remains for callers outside tx_reader.go, such as the PSBT
+// manager, while tx_reader itself migrates to db.Store-backed detail reads.
+// TODO(yy): Remove this helper once the remaining legacy callers, including the
+// PSBT manager, no longer depend on wtxmgr.TxDetails.
+func (w *Wallet) fetchTxDetails(txHash *chainhash.Hash) (*wtxmgr.TxDetails,
+	error) {
+
+	var txDetails *wtxmgr.TxDetails
+
+	err := walletdb.View(w.cfg.DB, func(dbtx walletdb.ReadTx) error {
+		txmgrNs := dbtx.ReadBucket(wtxmgrNamespaceKey)
+
+		var err error
+
+		txDetails, err = w.txStore.TxDetails(txmgrNs, txHash)
+		if err != nil {
+			return fmt.Errorf("failed to fetch tx details: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to view wallet db: %w", err)
+	}
+
+	if txDetails == nil {
+		return nil, ErrTxNotFound
+	}
+
+	return txDetails, nil
+}


### PR DESCRIPTION
Move the first 8 commits from #1202 so it's easier to review.

## Summary
- Add db-native transaction detail read models and shared ops workflows.
- Implement SQL-backed GetTxDetail/ListTxDetails adapters for postgres and sqlite.
- Move the remaining legacy TxDetails helper out of tx_reader.go for follow-up wallet routing.

## Tests
- GOWORK=off make unit pkg=wallet/internal/db verbose=1
- GOWORK=off make unit pkg=wallet/internal/db/sqlite verbose=1
- GOWORK=off make unit pkg=wallet/internal/db/pg verbose=1
- make sqlc-check