### PR TITLE
wallet: replace advisory lock with persisted account counter

### DIFF
--- a/wallet/internal/db/accounts_common.go
+++ b/wallet/internal/db/accounts_common.go
@@ -30,6 +30,103 @@ func (params *CreateDerivedAccountParams) Validate() error {
 	return nil
 }
 
+// CreateDerivedAccountRow contains the backend-independent fields the shared
+// CreateDerivedAccount workflow needs from the final insert row.
+type CreateDerivedAccountRow struct {
+	AccountNumber sql.NullInt64
+	CreatedAt     time.Time
+}
+
+// CreateDerivedAccountOps is the backend adapter the shared
+// CreateDerivedAccount workflow uses.
+//
+// The shared account-creation algorithm is intentionally ordered:
+//   - validate the public request before any backend step runs
+//   - load the wallet watch-only mode so the returned AccountInfo matches the
+//     stored wallet state
+//   - ensure the requested key scope exists before allocating from its counter
+//   - allocate the next derived account number for that scope
+//   - insert the derived account row with the allocated number
+//   - normalize the inserted row into the public AccountInfo result
+//
+// The adapter methods map directly to those stages so the shared helper keeps
+// the sequencing and invariants while each backend keeps its sqlc query types,
+// binding shapes, and row conversions local.
+type CreateDerivedAccountOps interface {
+	// WalletWatchOnly returns whether the target wallet currently runs in
+	// watch-only mode.
+	WalletWatchOnly(ctx context.Context, walletID uint32) (bool, error)
+
+	// EnsureScope returns the existing or newly created key-scope row ID for
+	// the wallet/scope pair.
+	EnsureScope(ctx context.Context, walletID uint32,
+		scope KeyScope) (int64, error)
+
+	// AllocateAccountNumber advances and returns the next derived account
+	// number for the provided scope row.
+	AllocateAccountNumber(ctx context.Context, scopeID int64) (int64, error)
+
+	// CreateDerivedAccount inserts the derived account row using the provided
+	// scope ID, allocated account number, and public account name.
+	CreateDerivedAccount(ctx context.Context, scopeID int64,
+		accountNumber int64, name string) (CreateDerivedAccountRow, error)
+}
+
+// CreateDerivedAccountWithOps runs the backend-independent
+// CreateDerivedAccount workflow once the caller has opened a backend-specific
+// SQL transaction.
+//
+// The helper owns the end-to-end sequencing so postgres and sqlite both:
+// validate the public request first, allocate from the same scope counter only
+// after that scope exists, preserve the same account-number overflow mapping,
+// and build the same normalized AccountInfo result from the inserted row.
+func CreateDerivedAccountWithOps(ctx context.Context,
+	params CreateDerivedAccountParams,
+	ops CreateDerivedAccountOps) (*AccountInfo, error) {
+
+	paramsErr := params.Validate()
+	if paramsErr != nil {
+		return nil, paramsErr
+	}
+
+	walletIsWatchOnly, err := ops.WalletWatchOnly(ctx, params.WalletID)
+	if err != nil {
+		return nil, fmt.Errorf("wallet watch only: %w", err)
+	}
+
+	scopeID, err := ops.EnsureScope(ctx, params.WalletID, params.Scope)
+	if err != nil {
+		return nil, fmt.Errorf("ensure scope: %w", err)
+	}
+
+	accountNumber, err := ops.AllocateAccountNumber(ctx, scopeID)
+	if err != nil {
+		return nil, fmt.Errorf("allocate account number: %w", err)
+	}
+
+	row, err := ops.CreateDerivedAccount(
+		ctx, scopeID, accountNumber, params.Name,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create account: %w", err)
+	}
+
+	if !row.AccountNumber.Valid {
+		// This should never happen unless the query is modified incorrectly.
+		return nil, ErrNilDBAccountNumber
+	}
+
+	accNumber, err := Int64ToUint32(row.AccountNumber.Int64)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrMaxAccountNumberReached, err)
+	}
+
+	return BuildAccountInfo(
+		accNumber, params.Name, DerivedAccount, 0, 0, 0,
+		walletIsWatchOnly, row.CreatedAt, params.Scope,
+	), nil
+}
+
 // ValidateBasic validates required fields for creating an imported account.
 func (params *CreateImportedAccountParams) ValidateBasic() error {
 	if params.Name == "" {

--- a/wallet/internal/db/accounts_common_test.go
+++ b/wallet/internal/db/accounts_common_test.go
@@ -1,9 +1,20 @@
 package db
 
 import (
+	"context"
+	"database/sql"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+)
+
+var (
+	// Test errors for CreateDerivedAccount ops testing.
+	errTestWallet = errors.New("wallet")
+	errTestScope  = errors.New("scope")
+	errTestBoom   = errors.New("boom")
 )
 
 // TestCreateDerivedAccountParamsValidate verifies derived account creation
@@ -155,4 +166,309 @@ func TestRenameAccountParamsValidate(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+// TestCreateDerivedAccountWithOps verifies that the shared helper owns the
+// common derived-account workflow and returns the normalized AccountInfo.
+func TestCreateDerivedAccountWithOps(t *testing.T) {
+	t.Parallel()
+
+	params := CreateDerivedAccountParams{
+		WalletID: 7,
+		Scope: KeyScope{
+			Purpose: 49,
+			Coin:    0,
+		},
+		Name: "savings",
+	}
+	createdAt := time.Unix(123, 0)
+	ops := newValidCreateDerivedAccountOps()
+	ops.walletWatchOnly = true
+	ops.ensureScopeID = 11
+	ops.accountNumber = 12
+	ops.row = CreateDerivedAccountRow{
+		AccountNumber: sql.NullInt64{Int64: 12, Valid: true},
+		CreatedAt:     createdAt,
+	}
+
+	ctx := t.Context()
+	info, err := CreateDerivedAccountWithOps(ctx, params, ops)
+
+	require.NoError(t, err)
+	require.Equal(
+		t, []string{
+			"WalletWatchOnly",
+			"EnsureScope",
+			"AllocateAccountNumber",
+			"CreateDerivedAccount",
+		}, ops.calls,
+	)
+	require.Equal(t, params.WalletID, ops.walletID)
+	require.Equal(t, params.WalletID, ops.ensureWalletID)
+	require.Equal(t, params.Scope, ops.ensureScope)
+	require.Equal(t, int64(11), ops.allocateScopeID)
+	require.Equal(t, int64(11), ops.createScopeID)
+	require.Equal(t, int64(12), ops.createAccountNumber)
+	require.Equal(t, params.Name, ops.createName)
+	require.Equal(t, uint32(12), info.AccountNumber)
+	require.Equal(t, params.Name, info.AccountName)
+	require.Equal(t, DerivedAccount, info.Origin)
+	require.True(t, info.IsWatchOnly)
+	require.Equal(t, createdAt, info.CreatedAt)
+	require.Equal(t, params.Scope, info.KeyScope)
+}
+
+// TestCreateDerivedAccountWithOpsRejectsInvalidParams verifies that the shared
+// helper validates the public request before any backend step runs.
+func TestCreateDerivedAccountWithOpsRejectsInvalidParams(t *testing.T) {
+	t.Parallel()
+
+	ops := newValidCreateDerivedAccountOps()
+
+	info, err := CreateDerivedAccountWithOps(
+		t.Context(), CreateDerivedAccountParams{}, ops,
+	)
+
+	require.Nil(t, info)
+	require.ErrorIs(t, err, ErrMissingAccountName)
+	require.Empty(t, ops.calls)
+}
+
+// TestCreateDerivedAccountWithOpsMissingAccountNumber verifies that the shared
+// helper rejects a backend row with a nil account number.
+func TestCreateDerivedAccountWithOpsMissingAccountNumber(t *testing.T) {
+	t.Parallel()
+
+	ops := newValidCreateDerivedAccountOps()
+	ops.ensureScopeID = 8
+	ops.accountNumber = 9
+	ops.row = CreateDerivedAccountRow{
+		CreatedAt: time.Unix(456, 0),
+	}
+
+	info, err := CreateDerivedAccountWithOps(
+		t.Context(), testCreateDerivedAccountParams(), ops,
+	)
+
+	require.Nil(t, info)
+	require.ErrorIs(t, err, ErrNilDBAccountNumber)
+}
+
+// TestCreateDerivedAccountWithOpsMaxAccountNumber verifies that the shared
+// helper preserves the existing max-account-number error mapping.
+func TestCreateDerivedAccountWithOpsMaxAccountNumber(t *testing.T) {
+	t.Parallel()
+
+	ops := newValidCreateDerivedAccountOps()
+	ops.ensureScopeID = 8
+	ops.accountNumber = int64(^uint32(0)) + 1
+	ops.row = CreateDerivedAccountRow{
+		AccountNumber: sql.NullInt64{
+			Int64: int64(^uint32(0)) + 1,
+			Valid: true,
+		},
+		CreatedAt: time.Unix(789, 0),
+	}
+
+	info, err := CreateDerivedAccountWithOps(
+		t.Context(), testCreateDerivedAccountParams(), ops,
+	)
+
+	require.Nil(t, info)
+	require.ErrorIs(t, err, ErrMaxAccountNumberReached)
+	require.ErrorContains(t, err, "casting overflow")
+}
+
+// TestCreateDerivedAccountWithOpsWrapsStageErrors verifies that the shared
+// helper keeps stage-specific error context around backend failures and
+// short-circuits on early errors.
+func TestCreateDerivedAccountWithOpsWrapsStageErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		setupOps        func() *stubCreateDerivedAccountOps
+		wantErr         error
+		wantWrappedText string
+		wantCalls       []string
+	}{
+		{
+			name: "wallet watch only",
+			setupOps: func() *stubCreateDerivedAccountOps {
+				ops := newValidCreateDerivedAccountOps()
+				ops.walletErr = errTestWallet
+				return ops
+			},
+			wantErr:   errTestWallet,
+			wantCalls: []string{"WalletWatchOnly"},
+		},
+		{
+			name: "ensure scope",
+			setupOps: func() *stubCreateDerivedAccountOps {
+				ops := newValidCreateDerivedAccountOps()
+				ops.ensureScopeErr = errTestScope
+				return ops
+			},
+			wantErr:   errTestScope,
+			wantCalls: []string{"WalletWatchOnly", "EnsureScope"},
+		},
+		{
+			name: "allocate account number",
+			setupOps: func() *stubCreateDerivedAccountOps {
+				ops := newValidCreateDerivedAccountOps()
+				ops.ensureScopeID = 8
+				ops.allocateErr = errTestBoom
+
+				return ops
+			},
+			wantErr:         errTestBoom,
+			wantWrappedText: "allocate account number: boom",
+			wantCalls: []string{
+				"WalletWatchOnly",
+				"EnsureScope",
+				"AllocateAccountNumber",
+			},
+		},
+		{
+			name: "create account",
+			setupOps: func() *stubCreateDerivedAccountOps {
+				ops := newValidCreateDerivedAccountOps()
+				ops.ensureScopeID = 8
+				ops.accountNumber = 9
+				ops.createErr = errTestBoom
+
+				return ops
+			},
+			wantErr:         errTestBoom,
+			wantWrappedText: "create account: boom",
+			wantCalls: []string{
+				"WalletWatchOnly",
+				"EnsureScope",
+				"AllocateAccountNumber",
+				"CreateDerivedAccount",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ops := tc.setupOps()
+
+			info, err := CreateDerivedAccountWithOps(
+				t.Context(), testCreateDerivedAccountParams(), ops,
+			)
+
+			require.Nil(t, info)
+			require.Error(t, err)
+			require.ErrorIs(t, err, tc.wantErr)
+
+			if tc.wantWrappedText != "" {
+				require.EqualError(t, err, tc.wantWrappedText)
+			}
+
+			require.Equal(t, tc.wantCalls, ops.calls)
+		})
+	}
+}
+
+// testCreateDerivedAccountParams returns one valid derived-account request for
+// shared helper tests.
+func testCreateDerivedAccountParams() CreateDerivedAccountParams {
+	return CreateDerivedAccountParams{
+		WalletID: 7,
+		Scope: KeyScope{
+			Purpose: 49,
+			Coin:    0,
+		},
+		Name: "savings",
+	}
+}
+
+// newValidCreateDerivedAccountOps returns a stub adapter with valid defaults
+// for all backend stages so each test only overrides the fields relevant to
+// that case.
+func newValidCreateDerivedAccountOps() *stubCreateDerivedAccountOps {
+	return &stubCreateDerivedAccountOps{
+		walletWatchOnly: false,
+		ensureScopeID:   1,
+		accountNumber:   1,
+		row: CreateDerivedAccountRow{
+			AccountNumber: sql.NullInt64{Int64: 1, Valid: true},
+			CreatedAt:     time.Unix(1, 0),
+		},
+	}
+}
+
+// stubCreateDerivedAccountOps is a deterministic test adapter for the shared
+// CreateDerivedAccount helper.
+type stubCreateDerivedAccountOps struct {
+	walletWatchOnly bool
+	walletErr       error
+	ensureScopeID   int64
+	ensureScopeErr  error
+	accountNumber   int64
+	allocateErr     error
+	row             CreateDerivedAccountRow
+	createErr       error
+
+	calls               []string
+	walletID            uint32
+	ensureWalletID      uint32
+	ensureScope         KeyScope
+	allocateScopeID     int64
+	createScopeID       int64
+	createAccountNumber int64
+	createName          string
+}
+
+var _ CreateDerivedAccountOps = (*stubCreateDerivedAccountOps)(nil)
+
+// WalletWatchOnly implements CreateDerivedAccountOps.
+func (s *stubCreateDerivedAccountOps) WalletWatchOnly(ctx context.Context,
+	walletID uint32) (bool, error) {
+
+	s.calls = append(s.calls, "WalletWatchOnly")
+	s.walletID = walletID
+
+	return s.walletWatchOnly, s.walletErr
+}
+
+// EnsureScope implements CreateDerivedAccountOps.
+func (s *stubCreateDerivedAccountOps) EnsureScope(ctx context.Context,
+	walletID uint32, scope KeyScope) (int64, error) {
+
+	s.calls = append(s.calls, "EnsureScope")
+	s.ensureWalletID = walletID
+	s.ensureScope = scope
+
+	return s.ensureScopeID, s.ensureScopeErr
+}
+
+// AllocateAccountNumber implements CreateDerivedAccountOps.
+func (s *stubCreateDerivedAccountOps) AllocateAccountNumber(ctx context.Context,
+	scopeID int64) (int64, error) {
+
+	s.calls = append(s.calls, "AllocateAccountNumber")
+	s.allocateScopeID = scopeID
+
+	return s.accountNumber, s.allocateErr
+}
+
+// CreateDerivedAccount implements CreateDerivedAccountOps.
+func (s *stubCreateDerivedAccountOps) CreateDerivedAccount(ctx context.Context,
+	scopeID int64, accountNumber int64, name string) (CreateDerivedAccountRow,
+	error) {
+
+	s.calls = append(s.calls, "CreateDerivedAccount")
+	s.createScopeID = scopeID
+	s.createAccountNumber = accountNumber
+	s.createName = name
+
+	if s.createErr != nil {
+		return CreateDerivedAccountRow{}, s.createErr
+	}
+
+	return s.row, nil
 }

--- a/wallet/internal/db/itest/account_store_test.go
+++ b/wallet/internal/db/itest/account_store_test.go
@@ -420,6 +420,46 @@ func TestCreateDerivedAccountSequentialNumbers(t *testing.T) {
 	}
 }
 
+// TestCreateDerivedAccountIgnoresImportedAccounts verifies that imported
+// accounts do not consume the persisted next derived-account number.
+func TestCreateDerivedAccountIgnoresImportedAccounts(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "mixed-account-number-wallet")
+
+	first, err := store.CreateDerivedAccount(
+		t.Context(), db.CreateDerivedAccountParams{
+			WalletID: walletID,
+			Scope:    db.KeyScopeBIP0084,
+			Name:     "derived-0",
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint32(0), first.AccountNumber)
+
+	props, err := store.CreateImportedAccount(
+		t.Context(), db.CreateImportedAccountParams{
+			WalletID:  walletID,
+			Scope:     db.KeyScopeBIP0084,
+			Name:      "imported-account",
+			PublicKey: RandomBytes(32),
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint32(0), props.AccountNumber)
+
+	second, err := store.CreateDerivedAccount(
+		t.Context(), db.CreateDerivedAccountParams{
+			WalletID: walletID,
+			Scope:    db.KeyScopeBIP0084,
+			Name:     "derived-1",
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), second.AccountNumber)
+}
+
 // TestCreateDerivedAccountConcurrent verifies that concurrent account creation
 // yields unique, sequential account numbers without errors.
 func TestCreateDerivedAccountConcurrent(t *testing.T) {
@@ -1240,16 +1280,25 @@ func TestRenameAccountErrors(t *testing.T) {
 	}
 }
 
-// TestCreateDerivedAccountMaxAccountNumber verifies that CreateDerivedAccount
-// returns ErrMaxAccountNumberReached when the account number counter exceeds
-// the maximum uint32 value.
+// TestCreateDerivedAccountMaxAccountNumber verifies that accounts can be
+// created up to the maximum account number (math.MaxUint32), but the next
+// account creation fails due to overflow.
 func TestCreateDerivedAccountMaxAccountNumber(t *testing.T) {
 	t.Parallel()
 
 	store := NewTestStore(t)
+	queries := store.Queries()
+	dbConn := store.DB()
 	walletID := newWallet(t, store, "wallet-max-account")
 	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "account-0")
-	setupMaxAccountNumberTest(t, store, walletID)
+
+	scopeID := GetKeyScopeID(t, queries, walletID, db.KeyScopeBIP0084)
+
+	CreateAccountWithNumber(t, queries, scopeID, math.MaxUint32-1,
+		"account-near-max")
+
+	// Set the counter to MaxUint32 so the next allocation gives us MaxUint32
+	UpdateKeyScopeNextAccountNumber(t, dbConn, scopeID, math.MaxUint32)
 
 	// This should succeed with account_number = MaxUint32.
 	info, err := store.CreateDerivedAccount(

--- a/wallet/internal/db/itest/fixtures_pg_test.go
+++ b/wallet/internal/db/itest/fixtures_pg_test.go
@@ -7,12 +7,10 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"math"
 	"testing"
 
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	dberr "github.com/btcsuite/btcwallet/wallet/internal/db/err"
-	"github.com/btcsuite/btcwallet/wallet/internal/db/pg"
 	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
@@ -537,6 +535,21 @@ func UpdateAccountNextInternalIndex(t *testing.T, dbConn *sql.DB,
 	require.NoError(t, err)
 }
 
+// UpdateKeyScopeNextAccountNumber updates the key scope's next account number
+// counter.
+func UpdateKeyScopeNextAccountNumber(t *testing.T, dbConn *sql.DB,
+	scopeID int64, nextAccountNumber uint32) {
+
+	t.Helper()
+
+	_, err := dbConn.ExecContext(
+		t.Context(),
+		"UPDATE key_scopes SET next_account_number = $1 WHERE id = $2",
+		int64(nextAccountNumber), scopeID,
+	)
+	require.NoError(t, err)
+}
+
 // GetKeyScopeID retrieves the scope ID for a given wallet and key scope.
 func GetKeyScopeID(t *testing.T, queries *sqlc.Queries,
 	walletID uint32, scope db.KeyScope) int64 {
@@ -619,21 +632,6 @@ func deleteAddress(ctx context.Context, dbConn *sql.DB,
 	}
 
 	return nil
-}
-
-// setupMaxAccountNumberTest seeds state near the account-number limit.
-func setupMaxAccountNumberTest(t *testing.T, store db.AccountStore,
-	walletID uint32) {
-
-	t.Helper()
-
-	pgStore, ok := store.(*pg.Store)
-	require.True(t, ok)
-
-	queries := pgStore.Queries()
-	scopeID := GetKeyScopeID(t, queries, walletID, db.KeyScopeBIP0084)
-	CreateAccountWithNumber(t, queries, scopeID, math.MaxUint32-1,
-		"account-near-max")
 }
 
 // createImportedAddressRaw inserts an imported address directly through the

--- a/wallet/internal/db/itest/fixtures_sqlite_test.go
+++ b/wallet/internal/db/itest/fixtures_sqlite_test.go
@@ -7,12 +7,10 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"math"
 	"testing"
 
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	dberr "github.com/btcsuite/btcwallet/wallet/internal/db/err"
-	dbsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlite"
 	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 	"github.com/stretchr/testify/require"
 	sqlitedriver "modernc.org/sqlite"
@@ -542,6 +540,21 @@ func UpdateAccountNextInternalIndex(t *testing.T, dbConn *sql.DB,
 	require.NoError(t, err)
 }
 
+// UpdateKeyScopeNextAccountNumber updates the key scope's next account number
+// counter.
+func UpdateKeyScopeNextAccountNumber(t *testing.T, dbConn *sql.DB,
+	scopeID int64, nextAccountNumber uint32) {
+
+	t.Helper()
+
+	_, err := dbConn.ExecContext(
+		t.Context(),
+		"UPDATE key_scopes SET next_account_number = ? WHERE id = ?",
+		int64(nextAccountNumber), scopeID,
+	)
+	require.NoError(t, err)
+}
+
 // GetKeyScopeID retrieves the scope ID for a given wallet and key scope.
 func GetKeyScopeID(t *testing.T, queries *sqlc.Queries,
 	walletID uint32, scope db.KeyScope) int64 {
@@ -624,21 +637,6 @@ func deleteAddress(ctx context.Context, dbConn *sql.DB,
 	}
 
 	return nil
-}
-
-// setupMaxAccountNumberTest seeds state near the account-number limit.
-func setupMaxAccountNumberTest(t *testing.T, store db.AccountStore,
-	walletID uint32) {
-
-	t.Helper()
-
-	sqliteStore, ok := store.(*dbsqlite.Store)
-	require.True(t, ok)
-
-	queries := sqliteStore.Queries()
-	scopeID := GetKeyScopeID(t, queries, walletID, db.KeyScopeBIP0084)
-	CreateAccountWithNumber(t, queries, scopeID, math.MaxUint32-1,
-		"account-near-max")
 }
 
 // createImportedAddressRaw inserts an imported address directly through the

--- a/wallet/internal/db/pg/accounts.go
+++ b/wallet/internal/db/pg/accounts.go
@@ -84,75 +84,75 @@ func (s *Store) RenameAccount(ctx context.Context,
 func (s *Store) CreateDerivedAccount(ctx context.Context,
 	params db.CreateDerivedAccountParams) (*db.AccountInfo, error) {
 
-	paramsErr := params.Validate()
-	if paramsErr != nil {
-		return nil, paramsErr
-	}
-
 	var info *db.AccountInfo
 
 	err := s.execWrite(ctx, func(qtx *sqlc.Queries) error {
-		walletIsWatchOnly, err := getWalletWatchOnly(
-			ctx, qtx, params.WalletID,
-		)
-		if err != nil {
-			return err
-		}
+		var err error
 
-		scopeID, err := ensureKeyScope(
-			ctx, qtx, params.WalletID, params.Scope,
-		)
-		if err != nil {
-			return err
-		}
-
-		accountNumber, err := qtx.GetAndIncrementNextAccountNumber(
-			ctx, scopeID,
-		)
-		if err != nil {
-			return fmt.Errorf("allocate account number: %w", err)
-		}
-
-		row, err := qtx.CreateDerivedAccount(
-			ctx, sqlc.CreateDerivedAccountParams{
-				ScopeID: scopeID,
-				AccountNumber: sql.NullInt64{
-					Int64: accountNumber,
-					Valid: true,
-				},
-				AccountName: params.Name,
-				OriginID:    int16(db.DerivedAccount),
-			},
-		)
-		if err != nil {
-			return fmt.Errorf("create account: %w", err)
-		}
-
-		if !row.AccountNumber.Valid {
-			// This should never happen unless the query is modified
-			// incorrectly.
-			return db.ErrNilDBAccountNumber
-		}
-
-		accNumber, err := db.Int64ToUint32(row.AccountNumber.Int64)
-		if err != nil {
-			return fmt.Errorf("%w: %w",
-				db.ErrMaxAccountNumberReached, err,
-			)
-		}
-
-		info = db.BuildAccountInfo(
-			accNumber, params.Name, db.DerivedAccount, 0, 0, 0,
-			walletIsWatchOnly, row.CreatedAt, params.Scope,
+		info, err = db.CreateDerivedAccountWithOps(
+			ctx, params, createDerivedAccountOps{q: qtx},
 		)
 
-		return nil
+		return err
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	return info, nil
+}
+
+// createDerivedAccountOps adapts PostgreSQL sqlc queries to the shared
+// CreateDerivedAccount workflow.
+type createDerivedAccountOps struct {
+	q *sqlc.Queries
+}
+
+// WalletWatchOnly implements db.CreateDerivedAccountOps.
+func (o createDerivedAccountOps) WalletWatchOnly(ctx context.Context,
+	walletID uint32) (bool, error) {
+
+	return getWalletWatchOnly(ctx, o.q, walletID)
+}
+
+// EnsureScope implements db.CreateDerivedAccountOps.
+func (o createDerivedAccountOps) EnsureScope(ctx context.Context,
+	walletID uint32, scope db.KeyScope) (int64, error) {
+
+	return ensureKeyScope(ctx, o.q, walletID, scope)
+}
+
+// AllocateAccountNumber implements db.CreateDerivedAccountOps.
+func (o createDerivedAccountOps) AllocateAccountNumber(ctx context.Context,
+	scopeID int64) (int64, error) {
+
+	return o.q.GetAndIncrementNextAccountNumber(ctx, scopeID)
+}
+
+// CreateDerivedAccount implements db.CreateDerivedAccountOps.
+func (o createDerivedAccountOps) CreateDerivedAccount(ctx context.Context,
+	scopeID int64, accountNumber int64,
+	name string) (db.CreateDerivedAccountRow, error) {
+
+	row, err := o.q.CreateDerivedAccount(
+		ctx, sqlc.CreateDerivedAccountParams{
+			ScopeID: scopeID,
+			AccountNumber: sql.NullInt64{
+				Int64: accountNumber,
+				Valid: true,
+			},
+			AccountName: name,
+			OriginID:    int16(db.DerivedAccount),
+		},
+	)
+	if err != nil {
+		return db.CreateDerivedAccountRow{}, err
+	}
+
+	return db.CreateDerivedAccountRow{
+		AccountNumber: row.AccountNumber,
+		CreatedAt:     row.CreatedAt,
+	}, nil
 }
 
 // CreateImportedAccount stores an imported account identified by an extended

--- a/wallet/internal/db/pg/accounts.go
+++ b/wallet/internal/db/pg/accounts.go
@@ -106,19 +106,20 @@ func (s *Store) CreateDerivedAccount(ctx context.Context,
 			return err
 		}
 
-		// Acquire an advisory lock for this scope to serialize account creation
-		// and prevent race conditions when computing MAX(account_number). This
-		// MUST be a separate statement that completes before
-		// qtx.CreateDerivedAccount runs. See the LockAccountScope comments for
-		// why single-statement approaches don't work.
-		err = qtx.LockAccountScope(ctx, scopeID)
+		accountNumber, err := qtx.GetAndIncrementNextAccountNumber(
+			ctx, scopeID,
+		)
 		if err != nil {
-			return fmt.Errorf("lock account scope: %w", err)
+			return fmt.Errorf("allocate account number: %w", err)
 		}
 
 		row, err := qtx.CreateDerivedAccount(
 			ctx, sqlc.CreateDerivedAccountParams{
-				ScopeID:     scopeID,
+				ScopeID: scopeID,
+				AccountNumber: sql.NullInt64{
+					Int64: accountNumber,
+					Valid: true,
+				},
 				AccountName: params.Name,
 				OriginID:    int16(db.DerivedAccount),
 			},
@@ -299,7 +300,7 @@ func ensureKeyScope(ctx context.Context, qtx *sqlc.Queries, walletID uint32,
 				),
 			}
 		},
-		func(row sqlc.KeyScope) int64 {
+		func(row sqlc.GetKeyScopeByWalletAndScopeRow) int64 {
 			return row.ID
 		}, scope,
 	)

--- a/wallet/internal/db/sqlite/accounts.go
+++ b/wallet/internal/db/sqlite/accounts.go
@@ -106,9 +106,20 @@ func (s *Store) CreateDerivedAccount(ctx context.Context,
 			return err
 		}
 
+		accountNumber, err := qtx.GetAndIncrementNextAccountNumber(
+			ctx, scopeID,
+		)
+		if err != nil {
+			return fmt.Errorf("allocate account number: %w", err)
+		}
+
 		row, err := qtx.CreateDerivedAccount(
 			ctx, sqlc.CreateDerivedAccountParams{
-				ScopeID:     scopeID,
+				ScopeID: scopeID,
+				AccountNumber: sql.NullInt64{
+					Int64: accountNumber,
+					Valid: true,
+				},
 				AccountName: params.Name,
 				OriginID:    int64(db.DerivedAccount),
 			},
@@ -170,7 +181,9 @@ func ensureKeyScope(ctx context.Context, qtx *sqlc.Queries,
 				),
 			}
 		},
-		func(row sqlc.KeyScope) int64 { return row.ID }, scope,
+		func(row sqlc.GetKeyScopeByWalletAndScopeRow) int64 {
+			return row.ID
+		}, scope,
 	)
 }
 

--- a/wallet/internal/db/sqlite/accounts.go
+++ b/wallet/internal/db/sqlite/accounts.go
@@ -84,75 +84,75 @@ func (s *Store) RenameAccount(ctx context.Context,
 func (s *Store) CreateDerivedAccount(ctx context.Context,
 	params db.CreateDerivedAccountParams) (*db.AccountInfo, error) {
 
-	paramsErr := params.Validate()
-	if paramsErr != nil {
-		return nil, paramsErr
-	}
-
 	var info *db.AccountInfo
 
 	err := s.execWrite(ctx, func(qtx *sqlc.Queries) error {
-		walletIsWatchOnly, err := getWalletWatchOnly(
-			ctx, qtx, params.WalletID,
-		)
-		if err != nil {
-			return err
-		}
+		var err error
 
-		scopeID, err := ensureKeyScope(
-			ctx, qtx, params.WalletID, params.Scope,
-		)
-		if err != nil {
-			return err
-		}
-
-		accountNumber, err := qtx.GetAndIncrementNextAccountNumber(
-			ctx, scopeID,
-		)
-		if err != nil {
-			return fmt.Errorf("allocate account number: %w", err)
-		}
-
-		row, err := qtx.CreateDerivedAccount(
-			ctx, sqlc.CreateDerivedAccountParams{
-				ScopeID: scopeID,
-				AccountNumber: sql.NullInt64{
-					Int64: accountNumber,
-					Valid: true,
-				},
-				AccountName: params.Name,
-				OriginID:    int64(db.DerivedAccount),
-			},
-		)
-		if err != nil {
-			return fmt.Errorf("create account: %w", err)
-		}
-
-		if !row.AccountNumber.Valid {
-			// This should never happen unless the query is modified
-			// incorrectly.
-			return db.ErrNilDBAccountNumber
-		}
-
-		accNumber, err := db.Int64ToUint32(row.AccountNumber.Int64)
-		if err != nil {
-			return fmt.Errorf("%w: %w",
-				db.ErrMaxAccountNumberReached, err,
-			)
-		}
-
-		info = db.BuildAccountInfo(
-			accNumber, params.Name, db.DerivedAccount, 0, 0, 0,
-			walletIsWatchOnly, row.CreatedAt, params.Scope,
+		info, err = db.CreateDerivedAccountWithOps(
+			ctx, params, createDerivedAccountOps{q: qtx},
 		)
 
-		return nil
+		return err
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	return info, nil
+}
+
+// createDerivedAccountOps adapts SQLite sqlc queries to the shared
+// CreateDerivedAccount workflow.
+type createDerivedAccountOps struct {
+	q *sqlc.Queries
+}
+
+// WalletWatchOnly implements db.CreateDerivedAccountOps.
+func (o createDerivedAccountOps) WalletWatchOnly(ctx context.Context,
+	walletID uint32) (bool, error) {
+
+	return getWalletWatchOnly(ctx, o.q, walletID)
+}
+
+// EnsureScope implements db.CreateDerivedAccountOps.
+func (o createDerivedAccountOps) EnsureScope(ctx context.Context,
+	walletID uint32, scope db.KeyScope) (int64, error) {
+
+	return ensureKeyScope(ctx, o.q, walletID, scope)
+}
+
+// AllocateAccountNumber implements db.CreateDerivedAccountOps.
+func (o createDerivedAccountOps) AllocateAccountNumber(ctx context.Context,
+	scopeID int64) (int64, error) {
+
+	return o.q.GetAndIncrementNextAccountNumber(ctx, scopeID)
+}
+
+// CreateDerivedAccount implements db.CreateDerivedAccountOps.
+func (o createDerivedAccountOps) CreateDerivedAccount(ctx context.Context,
+	scopeID int64, accountNumber int64,
+	name string) (db.CreateDerivedAccountRow, error) {
+
+	row, err := o.q.CreateDerivedAccount(
+		ctx, sqlc.CreateDerivedAccountParams{
+			ScopeID: scopeID,
+			AccountNumber: sql.NullInt64{
+				Int64: accountNumber,
+				Valid: true,
+			},
+			AccountName: name,
+			OriginID:    int64(db.DerivedAccount),
+		},
+	)
+	if err != nil {
+		return db.CreateDerivedAccountRow{}, err
+	}
+
+	return db.CreateDerivedAccountRow{
+		AccountNumber: row.AccountNumber,
+		CreatedAt:     row.CreatedAt,
+	}, nil
 }
 
 // ensureKeyScope retrieves an existing key scope or creates it if missing

--- a/wallet/internal/sql/pg/migrations/000004_key_scopes.up.sql
+++ b/wallet/internal/sql/pg/migrations/000004_key_scopes.up.sql
@@ -21,6 +21,9 @@ CREATE TABLE key_scopes (
     -- ADR 0009 (docs/developer/adr/0009-single-passphrase-encryption.md).
     coin_pub_key BYTEA,
 
+    -- Next derived account number to allocate within this key scope.
+    next_account_number BIGINT NOT NULL DEFAULT 0,
+
     -- Reference to the address type used for internal/change addresses.
     internal_type_id SMALLINT NOT NULL,
 
@@ -30,6 +33,9 @@ CREATE TABLE key_scopes (
     -- Foreign key constraint to wallet. Using ON DELETE RESTRICT to ensure
     -- that the wallet cannot be deleted if key scopes still exist.
     FOREIGN KEY (wallet_id) REFERENCES wallets (id) ON DELETE RESTRICT,
+
+    -- Derived account counter must be non-negative.
+    CHECK (next_account_number >= 0),
 
     -- Foreign key constraints to address types. Using ON DELETE RESTRICT to ensure
     -- that the address types cannot be deleted if key scopes still exist.

--- a/wallet/internal/sql/pg/queries/accounts.sql
+++ b/wallet/internal/sql/pg/queries/accounts.sql
@@ -1,35 +1,6 @@
--- name: LockAccountScope :exec
--- Acquires a transaction-level advisory lock to serialize account creation within a scope.
--- The lock is automatically released upon transaction commit or rollback.
--- This MUST be called immediately before 'CreateDerivedAccount' within the same transaction.
---
--- We explicitly use a two-statement pattern because single-statement CTE/Join
--- approaches failed to prevent race conditions during concurrent account generation.
--- The following "one-query" strategies were tested and proven unreliable:
---
--- 1. CTE with CROSS/INNER JOIN: The PostgreSQL optimizer may evaluate the
---    MAX(account_number) subquery using a snapshot taken before the lock CTE
---    is fully processed, leading to duplicate account numbers.
---
--- 2. CTE with OFFSET 0: Designed to force materialization, this still fails to
---    guarantee that the lock is held before the aggregate subquery begins its
---    read operation.
---
--- 3. FOR UPDATE in Subqueries: Since FOR UPDATE targets existing rows, it fails
---    to "lock the gap" for new inserts or handle empty tables, allowing
---    concurrent processes to calculate identical MAX() values.
---
--- Using two separate calls ensures the application pauses until
--- LockAccountScope returns, guaranteeing that the subsequent SELECT MAX()
--- operates inside a strictly serialized execution window for that scope.
-SELECT pg_advisory_xact_lock(hashtextextended('account_scope', $1::BIGINT));
-
-
 -- name: CreateDerivedAccount :one
--- Creates a new derived account under the given scope, computing the next
--- account number atomically. The caller MUST call LockAccountScope first
--- to acquire the advisory lock and prevent race conditions.
--- See LockAccountScope comments for why this is a separate statement.
+-- Creates a new derived account under the given scope using a separately
+-- allocated account number.
 INSERT INTO accounts (
     wallet_id,
     scope_id,
@@ -42,11 +13,7 @@ INSERT INTO accounts (
 SELECT
     ks.wallet_id,
     ks.id AS scope_id,
-    (
-        SELECT coalesce(max(a.account_number), -1) + 1
-        FROM accounts AS a
-        WHERE a.scope_id = sqlc.arg('scope_id')
-    ) AS account_number,
+    sqlc.arg('account_number') AS account_number,
     sqlc.arg('account_name') AS account_name,
     sqlc.arg('origin_id') AS origin_id,
     sqlc.arg('public_key') AS public_key,

--- a/wallet/internal/sql/pg/queries/key_scopes.sql
+++ b/wallet/internal/sql/pg/queries/key_scopes.sql
@@ -49,6 +49,15 @@ SELECT
 FROM key_scopes
 WHERE wallet_id = $1 AND purpose = $2 AND coin_type = $3;
 
+-- name: GetAndIncrementNextAccountNumber :one
+-- Atomically gets the next derived account number for a key scope and
+-- increments the persisted counter. Returns the current value before
+-- incrementing.
+UPDATE key_scopes
+SET next_account_number = next_account_number + 1
+WHERE id = $1
+RETURNING (next_account_number - 1)::BIGINT AS account_number;
+
 -- name: ListKeyScopesByWallet :many
 -- Lists all key scopes for a wallet, ordered by ID.
 SELECT

--- a/wallet/internal/sql/pg/sqlc/accounts.sql.go
+++ b/wallet/internal/sql/pg/sqlc/accounts.sql.go
@@ -44,26 +44,23 @@ INSERT INTO accounts (
 SELECT
     ks.wallet_id,
     ks.id AS scope_id,
-    (
-        SELECT coalesce(max(a.account_number), -1) + 1
-        FROM accounts AS a
-        WHERE a.scope_id = $1
-    ) AS account_number,
+    $1 AS account_number,
     $2 AS account_name,
     $3 AS origin_id,
     $4 AS public_key,
     $5 AS master_fingerprint
 FROM key_scopes AS ks
-WHERE ks.id = $1
+WHERE ks.id = $6
 RETURNING id, account_number, created_at
 `
 
 type CreateDerivedAccountParams struct {
-	ScopeID           int64
+	AccountNumber     sql.NullInt64
 	AccountName       string
 	OriginID          int16
 	PublicKey         []byte
 	MasterFingerprint sql.NullInt64
+	ScopeID           int64
 }
 
 type CreateDerivedAccountRow struct {
@@ -72,17 +69,16 @@ type CreateDerivedAccountRow struct {
 	CreatedAt     time.Time
 }
 
-// Creates a new derived account under the given scope, computing the next
-// account number atomically. The caller MUST call LockAccountScope first
-// to acquire the advisory lock and prevent race conditions.
-// See LockAccountScope comments for why this is a separate statement.
+// Creates a new derived account under the given scope using a separately
+// allocated account number.
 func (q *Queries) CreateDerivedAccount(ctx context.Context, arg CreateDerivedAccountParams) (CreateDerivedAccountRow, error) {
 	row := q.queryRow(ctx, q.createDerivedAccountStmt, CreateDerivedAccount,
-		arg.ScopeID,
+		arg.AccountNumber,
 		arg.AccountName,
 		arg.OriginID,
 		arg.PublicKey,
 		arg.MasterFingerprint,
+		arg.ScopeID,
 	)
 	var i CreateDerivedAccountRow
 	err := row.Scan(&i.ID, &i.AccountNumber, &i.CreatedAt)
@@ -900,38 +896,6 @@ func (q *Queries) ListAccountsByWalletScope(ctx context.Context, arg ListAccount
 		return nil, err
 	}
 	return items, nil
-}
-
-const LockAccountScope = `-- name: LockAccountScope :exec
-SELECT pg_advisory_xact_lock(hashtextextended('account_scope', $1::BIGINT))
-`
-
-// Acquires a transaction-level advisory lock to serialize account creation within a scope.
-// The lock is automatically released upon transaction commit or rollback.
-// This MUST be called immediately before 'CreateDerivedAccount' within the same transaction.
-//
-// We explicitly use a two-statement pattern because single-statement CTE/Join
-// approaches failed to prevent race conditions during concurrent account generation.
-// The following "one-query" strategies were tested and proven unreliable:
-//
-//  1. CTE with CROSS/INNER JOIN: The PostgreSQL optimizer may evaluate the
-//     MAX(account_number) subquery using a snapshot taken before the lock CTE
-//     is fully processed, leading to duplicate account numbers.
-//
-//  2. CTE with OFFSET 0: Designed to force materialization, this still fails to
-//     guarantee that the lock is held before the aggregate subquery begins its
-//     read operation.
-//
-//  3. FOR UPDATE in Subqueries: Since FOR UPDATE targets existing rows, it fails
-//     to "lock the gap" for new inserts or handle empty tables, allowing
-//     concurrent processes to calculate identical MAX() values.
-//
-// Using two separate calls ensures the application pauses until
-// LockAccountScope returns, guaranteeing that the subsequent SELECT MAX()
-// operates inside a strictly serialized execution window for that scope.
-func (q *Queries) LockAccountScope(ctx context.Context, dollar_1 int64) error {
-	_, err := q.exec(ctx, q.lockAccountScopeStmt, LockAccountScope, dollar_1)
-	return err
 }
 
 const UpdateAccountNameByWalletScopeAndName = `-- name: UpdateAccountNameByWalletScopeAndName :execrows

--- a/wallet/internal/sql/pg/sqlc/db.go
+++ b/wallet/internal/sql/pg/sqlc/db.go
@@ -105,6 +105,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getAddressTypeByIDStmt, err = db.PrepareContext(ctx, GetAddressTypeByID); err != nil {
 		return nil, fmt.Errorf("error preparing query GetAddressTypeByID: %w", err)
 	}
+	if q.getAndIncrementNextAccountNumberStmt, err = db.PrepareContext(ctx, GetAndIncrementNextAccountNumber); err != nil {
+		return nil, fmt.Errorf("error preparing query GetAndIncrementNextAccountNumber: %w", err)
+	}
 	if q.getAndIncrementNextExternalIndexStmt, err = db.PrepareContext(ctx, GetAndIncrementNextExternalIndex); err != nil {
 		return nil, fmt.Errorf("error preparing query GetAndIncrementNextExternalIndex: %w", err)
 	}
@@ -239,9 +242,6 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	}
 	if q.listWalletsStmt, err = db.PrepareContext(ctx, ListWallets); err != nil {
 		return nil, fmt.Errorf("error preparing query ListWallets: %w", err)
-	}
-	if q.lockAccountScopeStmt, err = db.PrepareContext(ctx, LockAccountScope); err != nil {
-		return nil, fmt.Errorf("error preparing query LockAccountScope: %w", err)
 	}
 	if q.markUtxoSpentStmt, err = db.PrepareContext(ctx, MarkUtxoSpent); err != nil {
 		return nil, fmt.Errorf("error preparing query MarkUtxoSpent: %w", err)
@@ -411,6 +411,11 @@ func (q *Queries) Close() error {
 	if q.getAddressTypeByIDStmt != nil {
 		if cerr := q.getAddressTypeByIDStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getAddressTypeByIDStmt: %w", cerr)
+		}
+	}
+	if q.getAndIncrementNextAccountNumberStmt != nil {
+		if cerr := q.getAndIncrementNextAccountNumberStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getAndIncrementNextAccountNumberStmt: %w", cerr)
 		}
 	}
 	if q.getAndIncrementNextExternalIndexStmt != nil {
@@ -638,11 +643,6 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing listWalletsStmt: %w", cerr)
 		}
 	}
-	if q.lockAccountScopeStmt != nil {
-		if cerr := q.lockAccountScopeStmt.Close(); cerr != nil {
-			err = fmt.Errorf("error closing lockAccountScopeStmt: %w", cerr)
-		}
-	}
 	if q.markUtxoSpentStmt != nil {
 		if cerr := q.markUtxoSpentStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing markUtxoSpentStmt: %w", cerr)
@@ -759,6 +759,7 @@ type Queries struct {
 	getAddressByScriptPubKeyStmt                *sql.Stmt
 	getAddressSecretStmt                        *sql.Stmt
 	getAddressTypeByIDStmt                      *sql.Stmt
+	getAndIncrementNextAccountNumberStmt        *sql.Stmt
 	getAndIncrementNextExternalIndexStmt        *sql.Stmt
 	getAndIncrementNextInternalIndexStmt        *sql.Stmt
 	getBlockByHeightStmt                        *sql.Stmt
@@ -804,7 +805,6 @@ type Queries struct {
 	listUnminedTransactionsStmt                 *sql.Stmt
 	listUtxosStmt                               *sql.Stmt
 	listWalletsStmt                             *sql.Stmt
-	lockAccountScopeStmt                        *sql.Stmt
 	markUtxoSpentStmt                           *sql.Stmt
 	releaseUtxoLeaseStmt                        *sql.Stmt
 	rewindWalletSyncStateHeightsForRollbackStmt *sql.Stmt
@@ -848,6 +848,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getAddressByScriptPubKeyStmt:                q.getAddressByScriptPubKeyStmt,
 		getAddressSecretStmt:                        q.getAddressSecretStmt,
 		getAddressTypeByIDStmt:                      q.getAddressTypeByIDStmt,
+		getAndIncrementNextAccountNumberStmt:        q.getAndIncrementNextAccountNumberStmt,
 		getAndIncrementNextExternalIndexStmt:        q.getAndIncrementNextExternalIndexStmt,
 		getAndIncrementNextInternalIndexStmt:        q.getAndIncrementNextInternalIndexStmt,
 		getBlockByHeightStmt:                        q.getBlockByHeightStmt,
@@ -893,7 +894,6 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		listUnminedTransactionsStmt:                 q.listUnminedTransactionsStmt,
 		listUtxosStmt:                               q.listUtxosStmt,
 		listWalletsStmt:                             q.listWalletsStmt,
-		lockAccountScopeStmt:                        q.lockAccountScopeStmt,
 		markUtxoSpentStmt:                           q.markUtxoSpentStmt,
 		releaseUtxoLeaseStmt:                        q.releaseUtxoLeaseStmt,
 		rewindWalletSyncStateHeightsForRollbackStmt: q.rewindWalletSyncStateHeightsForRollbackStmt,

--- a/wallet/internal/sql/pg/sqlc/key_scopes.sql.go
+++ b/wallet/internal/sql/pg/sqlc/key_scopes.sql.go
@@ -76,6 +76,23 @@ func (q *Queries) DeleteKeyScopeSecrets(ctx context.Context, scopeID int64) (int
 	return result.RowsAffected()
 }
 
+const GetAndIncrementNextAccountNumber = `-- name: GetAndIncrementNextAccountNumber :one
+UPDATE key_scopes
+SET next_account_number = next_account_number + 1
+WHERE id = $1
+RETURNING (next_account_number - 1)::BIGINT AS account_number
+`
+
+// Atomically gets the next derived account number for a key scope and
+// increments the persisted counter. Returns the current value before
+// incrementing.
+func (q *Queries) GetAndIncrementNextAccountNumber(ctx context.Context, id int64) (int64, error) {
+	row := q.queryRow(ctx, q.getAndIncrementNextAccountNumberStmt, GetAndIncrementNextAccountNumber, id)
+	var account_number int64
+	err := row.Scan(&account_number)
+	return account_number, err
+}
+
 const GetKeyScopeByID = `-- name: GetKeyScopeByID :one
 SELECT
     id,
@@ -89,10 +106,20 @@ FROM key_scopes
 WHERE id = $1
 `
 
+type GetKeyScopeByIDRow struct {
+	ID             int64
+	WalletID       int64
+	Purpose        int64
+	CoinType       int64
+	CoinPubKey     []byte
+	InternalTypeID int16
+	ExternalTypeID int16
+}
+
 // Retrieves a key scope by its ID.
-func (q *Queries) GetKeyScopeByID(ctx context.Context, id int64) (KeyScope, error) {
+func (q *Queries) GetKeyScopeByID(ctx context.Context, id int64) (GetKeyScopeByIDRow, error) {
 	row := q.queryRow(ctx, q.getKeyScopeByIDStmt, GetKeyScopeByID, id)
-	var i KeyScope
+	var i GetKeyScopeByIDRow
 	err := row.Scan(
 		&i.ID,
 		&i.WalletID,
@@ -124,10 +151,20 @@ type GetKeyScopeByWalletAndScopeParams struct {
 	CoinType int64
 }
 
+type GetKeyScopeByWalletAndScopeRow struct {
+	ID             int64
+	WalletID       int64
+	Purpose        int64
+	CoinType       int64
+	CoinPubKey     []byte
+	InternalTypeID int16
+	ExternalTypeID int16
+}
+
 // Retrieves a key scope by wallet ID, purpose, and coin type.
-func (q *Queries) GetKeyScopeByWalletAndScope(ctx context.Context, arg GetKeyScopeByWalletAndScopeParams) (KeyScope, error) {
+func (q *Queries) GetKeyScopeByWalletAndScope(ctx context.Context, arg GetKeyScopeByWalletAndScopeParams) (GetKeyScopeByWalletAndScopeRow, error) {
 	row := q.queryRow(ctx, q.getKeyScopeByWalletAndScopeStmt, GetKeyScopeByWalletAndScope, arg.WalletID, arg.Purpose, arg.CoinType)
-	var i KeyScope
+	var i GetKeyScopeByWalletAndScopeRow
 	err := row.Scan(
 		&i.ID,
 		&i.WalletID,
@@ -191,16 +228,26 @@ WHERE wallet_id = $1
 ORDER BY id
 `
 
+type ListKeyScopesByWalletRow struct {
+	ID             int64
+	WalletID       int64
+	Purpose        int64
+	CoinType       int64
+	CoinPubKey     []byte
+	InternalTypeID int16
+	ExternalTypeID int16
+}
+
 // Lists all key scopes for a wallet, ordered by ID.
-func (q *Queries) ListKeyScopesByWallet(ctx context.Context, walletID int64) ([]KeyScope, error) {
+func (q *Queries) ListKeyScopesByWallet(ctx context.Context, walletID int64) ([]ListKeyScopesByWalletRow, error) {
 	rows, err := q.query(ctx, q.listKeyScopesByWalletStmt, ListKeyScopesByWallet, walletID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []KeyScope
+	var items []ListKeyScopesByWalletRow
 	for rows.Next() {
-		var i KeyScope
+		var i ListKeyScopesByWalletRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.WalletID,

--- a/wallet/internal/sql/pg/sqlc/models.go
+++ b/wallet/internal/sql/pg/sqlc/models.go
@@ -64,13 +64,14 @@ type Block struct {
 }
 
 type KeyScope struct {
-	ID             int64
-	WalletID       int64
-	Purpose        int64
-	CoinType       int64
-	CoinPubKey     []byte
-	InternalTypeID int16
-	ExternalTypeID int16
+	ID                int64
+	WalletID          int64
+	Purpose           int64
+	CoinType          int64
+	CoinPubKey        []byte
+	NextAccountNumber int64
+	InternalTypeID    int16
+	ExternalTypeID    int16
 }
 
 type KeyScopeSecret struct {

--- a/wallet/internal/sql/pg/sqlc/querier.go
+++ b/wallet/internal/sql/pg/sqlc/querier.go
@@ -66,10 +66,8 @@ type Querier interface {
 	ClearUtxosSpentByTxID(ctx context.Context, arg ClearUtxosSpentByTxIDParams) (int64, error)
 	// Inserts the encrypted private key material for an account.
 	CreateAccountSecret(ctx context.Context, arg CreateAccountSecretParams) error
-	// Creates a new derived account under the given scope, computing the next
-	// account number atomically. The caller MUST call LockAccountScope first
-	// to acquire the advisory lock and prevent race conditions.
-	// See LockAccountScope comments for why this is a separate statement.
+	// Creates a new derived account under the given scope using a separately
+	// allocated account number.
 	CreateDerivedAccount(ctx context.Context, arg CreateDerivedAccountParams) (CreateDerivedAccountRow, error)
 	// Test-only: Creates a derived account with a specific account number.
 	// Used for testing account number overflow without creating billions of accounts.
@@ -159,6 +157,10 @@ type Querier interface {
 	GetAddressSecret(ctx context.Context, arg GetAddressSecretParams) (GetAddressSecretRow, error)
 	// Returns a single address type by its ID.
 	GetAddressTypeByID(ctx context.Context, id int16) (AddressType, error)
+	// Atomically gets the next derived account number for a key scope and
+	// increments the persisted counter. Returns the current value before
+	// incrementing.
+	GetAndIncrementNextAccountNumber(ctx context.Context, id int64) (int64, error)
 	// Atomically gets the next external address index and increments the counter.
 	// Returns the current index value (before incrementing) for the address derivation.
 	GetAndIncrementNextExternalIndex(ctx context.Context, id int64) (int64, error)
@@ -167,9 +169,9 @@ type Querier interface {
 	GetAndIncrementNextInternalIndex(ctx context.Context, id int64) (int64, error)
 	GetBlockByHeight(ctx context.Context, blockHeight int32) (Block, error)
 	// Retrieves a key scope by its ID.
-	GetKeyScopeByID(ctx context.Context, id int64) (KeyScope, error)
+	GetKeyScopeByID(ctx context.Context, id int64) (GetKeyScopeByIDRow, error)
 	// Retrieves a key scope by wallet ID, purpose, and coin type.
-	GetKeyScopeByWalletAndScope(ctx context.Context, arg GetKeyScopeByWalletAndScopeParams) (KeyScope, error)
+	GetKeyScopeByWalletAndScope(ctx context.Context, arg GetKeyScopeByWalletAndScopeParams) (GetKeyScopeByWalletAndScopeRow, error)
 	// Retrieves the secrets for a key scope.
 	GetKeyScopeSecrets(ctx context.Context, scopeID int64) (KeyScopeSecret, error)
 	// Retrieves the full transaction row along with optional block metadata.
@@ -335,7 +337,7 @@ type Querier interface {
 	// returned. Returns up to page_limit rows.
 	ListAddressesByAccount(ctx context.Context, arg ListAddressesByAccountParams) ([]ListAddressesByAccountRow, error)
 	// Lists all key scopes for a wallet, ordered by ID.
-	ListKeyScopesByWallet(ctx context.Context, walletID int64) ([]KeyScope, error)
+	ListKeyScopesByWallet(ctx context.Context, walletID int64) ([]ListKeyScopesByWalletRow, error)
 	// ListOwnedInputPrevOutputsByTxHashes lists wallet-owned previous outputs that
 	// may be spent by selected transaction inputs.
 	//
@@ -487,30 +489,6 @@ type Querier interface {
 	// from the beginning; otherwise returns wallets with id > cursor_id. Returns up
 	// to page_limit rows.
 	ListWallets(ctx context.Context, arg ListWalletsParams) ([]ListWalletsRow, error)
-	// Acquires a transaction-level advisory lock to serialize account creation within a scope.
-	// The lock is automatically released upon transaction commit or rollback.
-	// This MUST be called immediately before 'CreateDerivedAccount' within the same transaction.
-	//
-	// We explicitly use a two-statement pattern because single-statement CTE/Join
-	// approaches failed to prevent race conditions during concurrent account generation.
-	// The following "one-query" strategies were tested and proven unreliable:
-	//
-	// 1. CTE with CROSS/INNER JOIN: The PostgreSQL optimizer may evaluate the
-	//    MAX(account_number) subquery using a snapshot taken before the lock CTE
-	//    is fully processed, leading to duplicate account numbers.
-	//
-	// 2. CTE with OFFSET 0: Designed to force materialization, this still fails to
-	//    guarantee that the lock is held before the aggregate subquery begins its
-	//    read operation.
-	//
-	// 3. FOR UPDATE in Subqueries: Since FOR UPDATE targets existing rows, it fails
-	//    to "lock the gap" for new inserts or handle empty tables, allowing
-	//    concurrent processes to calculate identical MAX() values.
-	//
-	// Using two separate calls ensures the application pauses until
-	// LockAccountScope returns, guaranteeing that the subsequent SELECT MAX()
-	// operates inside a strictly serialized execution window for that scope.
-	LockAccountScope(ctx context.Context, dollar_1 int64) error
 	// Marks a wallet-owned UTXO as spent by a transaction.
 	//
 	// How:

--- a/wallet/internal/sql/sqlite/migrations/000004_key_scopes.up.sql
+++ b/wallet/internal/sql/sqlite/migrations/000004_key_scopes.up.sql
@@ -21,6 +21,9 @@ CREATE TABLE key_scopes (
     -- ADR 0009 (docs/developer/adr/0009-single-passphrase-encryption.md).
     coin_pub_key BLOB,
 
+    -- Next derived account number to allocate within this key scope.
+    next_account_number INTEGER NOT NULL DEFAULT 0,
+
     -- Reference to the address type used for internal/change addresses.
     internal_type_id INTEGER NOT NULL,
 
@@ -30,6 +33,9 @@ CREATE TABLE key_scopes (
     -- Foreign key constraint to wallet. Using ON DELETE RESTRICT to ensure
     -- that the wallet cannot be deleted if key scopes still exist.
     FOREIGN KEY (wallet_id) REFERENCES wallets (id) ON DELETE RESTRICT,
+
+    -- Derived account counter must be non-negative.
+    CHECK (next_account_number >= 0),
 
     -- Foreign key constraints to address types. Using ON DELETE RESTRICT to ensure
     -- that the address types cannot be deleted if key scopes still exist.

--- a/wallet/internal/sql/sqlite/queries/accounts.sql
+++ b/wallet/internal/sql/sqlite/queries/accounts.sql
@@ -1,7 +1,6 @@
 -- name: CreateDerivedAccount :one
--- Creates a new derived account under the given scope, computing the next
--- account number from existing accounts. SQLite's _txlock=immediate ensures
--- only one writer at a time, preventing concurrent allocation conflicts.
+-- Creates a new derived account under the given scope using a separately
+-- allocated account number.
 INSERT INTO accounts (
     wallet_id,
     scope_id,
@@ -14,10 +13,7 @@ INSERT INTO accounts (
 SELECT
     ks.wallet_id,
     ks.id AS scope_id,
-    (
-        SELECT coalesce(max(a.account_number), -1) + 1 FROM accounts AS a
-        WHERE a.scope_id = sqlc.arg('scope_id')
-    ) AS account_number,
+    sqlc.arg('account_number') AS account_number,
     sqlc.arg('account_name') AS account_name,
     sqlc.arg('origin_id') AS origin_id,
     sqlc.arg('public_key') AS public_key,

--- a/wallet/internal/sql/sqlite/queries/key_scopes.sql
+++ b/wallet/internal/sql/sqlite/queries/key_scopes.sql
@@ -49,6 +49,15 @@ SELECT
 FROM key_scopes
 WHERE wallet_id = ? AND purpose = ? AND coin_type = ?;
 
+-- name: GetAndIncrementNextAccountNumber :one
+-- Atomically gets the next derived account number for a key scope and
+-- increments the persisted counter. Returns the current value before
+-- incrementing.
+UPDATE key_scopes
+SET next_account_number = next_account_number + 1
+WHERE id = ?
+RETURNING next_account_number - 1 AS account_number;
+
 -- name: ListKeyScopesByWallet :many
 -- Lists all key scopes for a wallet, ordered by ID.
 SELECT

--- a/wallet/internal/sql/sqlite/sqlc/accounts.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/accounts.sql.go
@@ -44,25 +44,23 @@ INSERT INTO accounts (
 SELECT
     ks.wallet_id,
     ks.id AS scope_id,
-    (
-        SELECT coalesce(max(a.account_number), -1) + 1 FROM accounts AS a
-        WHERE a.scope_id = ?1
-    ) AS account_number,
+    ?1 AS account_number,
     ?2 AS account_name,
     ?3 AS origin_id,
     ?4 AS public_key,
     ?5 AS master_fingerprint
 FROM key_scopes AS ks
-WHERE ks.id = ?1
+WHERE ks.id = ?6
 RETURNING id, account_number, created_at
 `
 
 type CreateDerivedAccountParams struct {
-	ScopeID           int64
+	AccountNumber     sql.NullInt64
 	AccountName       string
 	OriginID          int64
 	PublicKey         []byte
 	MasterFingerprint sql.NullInt64
+	ScopeID           int64
 }
 
 type CreateDerivedAccountRow struct {
@@ -71,16 +69,16 @@ type CreateDerivedAccountRow struct {
 	CreatedAt     time.Time
 }
 
-// Creates a new derived account under the given scope, computing the next
-// account number from existing accounts. SQLite's _txlock=immediate ensures
-// only one writer at a time, preventing concurrent allocation conflicts.
+// Creates a new derived account under the given scope using a separately
+// allocated account number.
 func (q *Queries) CreateDerivedAccount(ctx context.Context, arg CreateDerivedAccountParams) (CreateDerivedAccountRow, error) {
 	row := q.queryRow(ctx, q.createDerivedAccountStmt, CreateDerivedAccount,
-		arg.ScopeID,
+		arg.AccountNumber,
 		arg.AccountName,
 		arg.OriginID,
 		arg.PublicKey,
 		arg.MasterFingerprint,
+		arg.ScopeID,
 	)
 	var i CreateDerivedAccountRow
 	err := row.Scan(&i.ID, &i.AccountNumber, &i.CreatedAt)

--- a/wallet/internal/sql/sqlite/sqlc/db.go
+++ b/wallet/internal/sql/sqlite/sqlc/db.go
@@ -105,6 +105,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getAddressTypeByIDStmt, err = db.PrepareContext(ctx, GetAddressTypeByID); err != nil {
 		return nil, fmt.Errorf("error preparing query GetAddressTypeByID: %w", err)
 	}
+	if q.getAndIncrementNextAccountNumberStmt, err = db.PrepareContext(ctx, GetAndIncrementNextAccountNumber); err != nil {
+		return nil, fmt.Errorf("error preparing query GetAndIncrementNextAccountNumber: %w", err)
+	}
 	if q.getAndIncrementNextExternalIndexStmt, err = db.PrepareContext(ctx, GetAndIncrementNextExternalIndex); err != nil {
 		return nil, fmt.Errorf("error preparing query GetAndIncrementNextExternalIndex: %w", err)
 	}
@@ -408,6 +411,11 @@ func (q *Queries) Close() error {
 	if q.getAddressTypeByIDStmt != nil {
 		if cerr := q.getAddressTypeByIDStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getAddressTypeByIDStmt: %w", cerr)
+		}
+	}
+	if q.getAndIncrementNextAccountNumberStmt != nil {
+		if cerr := q.getAndIncrementNextAccountNumberStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getAndIncrementNextAccountNumberStmt: %w", cerr)
 		}
 	}
 	if q.getAndIncrementNextExternalIndexStmt != nil {
@@ -751,6 +759,7 @@ type Queries struct {
 	getAddressByScriptPubKeyStmt                *sql.Stmt
 	getAddressSecretStmt                        *sql.Stmt
 	getAddressTypeByIDStmt                      *sql.Stmt
+	getAndIncrementNextAccountNumberStmt        *sql.Stmt
 	getAndIncrementNextExternalIndexStmt        *sql.Stmt
 	getAndIncrementNextInternalIndexStmt        *sql.Stmt
 	getBlockByHeightStmt                        *sql.Stmt
@@ -839,6 +848,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getAddressByScriptPubKeyStmt:                q.getAddressByScriptPubKeyStmt,
 		getAddressSecretStmt:                        q.getAddressSecretStmt,
 		getAddressTypeByIDStmt:                      q.getAddressTypeByIDStmt,
+		getAndIncrementNextAccountNumberStmt:        q.getAndIncrementNextAccountNumberStmt,
 		getAndIncrementNextExternalIndexStmt:        q.getAndIncrementNextExternalIndexStmt,
 		getAndIncrementNextInternalIndexStmt:        q.getAndIncrementNextInternalIndexStmt,
 		getBlockByHeightStmt:                        q.getBlockByHeightStmt,

--- a/wallet/internal/sql/sqlite/sqlc/key_scopes.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/key_scopes.sql.go
@@ -76,6 +76,23 @@ func (q *Queries) DeleteKeyScopeSecrets(ctx context.Context, scopeID int64) (int
 	return result.RowsAffected()
 }
 
+const GetAndIncrementNextAccountNumber = `-- name: GetAndIncrementNextAccountNumber :one
+UPDATE key_scopes
+SET next_account_number = next_account_number + 1
+WHERE id = ?
+RETURNING next_account_number - 1 AS account_number
+`
+
+// Atomically gets the next derived account number for a key scope and
+// increments the persisted counter. Returns the current value before
+// incrementing.
+func (q *Queries) GetAndIncrementNextAccountNumber(ctx context.Context, id int64) (int64, error) {
+	row := q.queryRow(ctx, q.getAndIncrementNextAccountNumberStmt, GetAndIncrementNextAccountNumber, id)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
 const GetKeyScopeByID = `-- name: GetKeyScopeByID :one
 SELECT
     id,
@@ -89,10 +106,20 @@ FROM key_scopes
 WHERE id = ?
 `
 
+type GetKeyScopeByIDRow struct {
+	ID             int64
+	WalletID       int64
+	Purpose        int64
+	CoinType       int64
+	CoinPubKey     []byte
+	InternalTypeID int64
+	ExternalTypeID int64
+}
+
 // Retrieves a key scope by its ID.
-func (q *Queries) GetKeyScopeByID(ctx context.Context, id int64) (KeyScope, error) {
+func (q *Queries) GetKeyScopeByID(ctx context.Context, id int64) (GetKeyScopeByIDRow, error) {
 	row := q.queryRow(ctx, q.getKeyScopeByIDStmt, GetKeyScopeByID, id)
-	var i KeyScope
+	var i GetKeyScopeByIDRow
 	err := row.Scan(
 		&i.ID,
 		&i.WalletID,
@@ -124,10 +151,20 @@ type GetKeyScopeByWalletAndScopeParams struct {
 	CoinType int64
 }
 
+type GetKeyScopeByWalletAndScopeRow struct {
+	ID             int64
+	WalletID       int64
+	Purpose        int64
+	CoinType       int64
+	CoinPubKey     []byte
+	InternalTypeID int64
+	ExternalTypeID int64
+}
+
 // Retrieves a key scope by wallet ID, purpose, and coin type.
-func (q *Queries) GetKeyScopeByWalletAndScope(ctx context.Context, arg GetKeyScopeByWalletAndScopeParams) (KeyScope, error) {
+func (q *Queries) GetKeyScopeByWalletAndScope(ctx context.Context, arg GetKeyScopeByWalletAndScopeParams) (GetKeyScopeByWalletAndScopeRow, error) {
 	row := q.queryRow(ctx, q.getKeyScopeByWalletAndScopeStmt, GetKeyScopeByWalletAndScope, arg.WalletID, arg.Purpose, arg.CoinType)
-	var i KeyScope
+	var i GetKeyScopeByWalletAndScopeRow
 	err := row.Scan(
 		&i.ID,
 		&i.WalletID,
@@ -191,16 +228,26 @@ WHERE wallet_id = ?
 ORDER BY id
 `
 
+type ListKeyScopesByWalletRow struct {
+	ID             int64
+	WalletID       int64
+	Purpose        int64
+	CoinType       int64
+	CoinPubKey     []byte
+	InternalTypeID int64
+	ExternalTypeID int64
+}
+
 // Lists all key scopes for a wallet, ordered by ID.
-func (q *Queries) ListKeyScopesByWallet(ctx context.Context, walletID int64) ([]KeyScope, error) {
+func (q *Queries) ListKeyScopesByWallet(ctx context.Context, walletID int64) ([]ListKeyScopesByWalletRow, error) {
 	rows, err := q.query(ctx, q.listKeyScopesByWalletStmt, ListKeyScopesByWallet, walletID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []KeyScope
+	var items []ListKeyScopesByWalletRow
 	for rows.Next() {
-		var i KeyScope
+		var i ListKeyScopesByWalletRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.WalletID,

--- a/wallet/internal/sql/sqlite/sqlc/models.go
+++ b/wallet/internal/sql/sqlite/sqlc/models.go
@@ -64,13 +64,14 @@ type Block struct {
 }
 
 type KeyScope struct {
-	ID             int64
-	WalletID       int64
-	Purpose        int64
-	CoinType       int64
-	CoinPubKey     []byte
-	InternalTypeID int64
-	ExternalTypeID int64
+	ID                int64
+	WalletID          int64
+	Purpose           int64
+	CoinType          int64
+	CoinPubKey        []byte
+	NextAccountNumber int64
+	InternalTypeID    int64
+	ExternalTypeID    int64
 }
 
 type KeyScopeSecret struct {

--- a/wallet/internal/sql/sqlite/sqlc/querier.go
+++ b/wallet/internal/sql/sqlite/sqlc/querier.go
@@ -66,9 +66,8 @@ type Querier interface {
 	ClearUtxosSpentByTxID(ctx context.Context, arg ClearUtxosSpentByTxIDParams) (int64, error)
 	// Inserts the encrypted private key material for an account.
 	CreateAccountSecret(ctx context.Context, arg CreateAccountSecretParams) error
-	// Creates a new derived account under the given scope, computing the next
-	// account number from existing accounts. SQLite's _txlock=immediate ensures
-	// only one writer at a time, preventing concurrent allocation conflicts.
+	// Creates a new derived account under the given scope using a separately
+	// allocated account number.
 	CreateDerivedAccount(ctx context.Context, arg CreateDerivedAccountParams) (CreateDerivedAccountRow, error)
 	// Test-only: Creates a derived account with a specific account number.
 	// Used for testing account number overflow without creating billions of accounts.
@@ -156,6 +155,10 @@ type Querier interface {
 	GetAddressSecret(ctx context.Context, arg GetAddressSecretParams) (GetAddressSecretRow, error)
 	// Returns a single address type by its ID.
 	GetAddressTypeByID(ctx context.Context, id int64) (AddressType, error)
+	// Atomically gets the next derived account number for a key scope and
+	// increments the persisted counter. Returns the current value before
+	// incrementing.
+	GetAndIncrementNextAccountNumber(ctx context.Context, id int64) (int64, error)
 	// Atomically gets the next external address index and increments the counter.
 	// Returns the current index value (before incrementing) for the address derivation.
 	GetAndIncrementNextExternalIndex(ctx context.Context, id int64) (int64, error)
@@ -164,9 +167,9 @@ type Querier interface {
 	GetAndIncrementNextInternalIndex(ctx context.Context, id int64) (int64, error)
 	GetBlockByHeight(ctx context.Context, blockHeight int64) (Block, error)
 	// Retrieves a key scope by its ID.
-	GetKeyScopeByID(ctx context.Context, id int64) (KeyScope, error)
+	GetKeyScopeByID(ctx context.Context, id int64) (GetKeyScopeByIDRow, error)
 	// Retrieves a key scope by wallet ID, purpose, and coin type.
-	GetKeyScopeByWalletAndScope(ctx context.Context, arg GetKeyScopeByWalletAndScopeParams) (KeyScope, error)
+	GetKeyScopeByWalletAndScope(ctx context.Context, arg GetKeyScopeByWalletAndScopeParams) (GetKeyScopeByWalletAndScopeRow, error)
 	// Retrieves the secrets for a key scope.
 	GetKeyScopeSecrets(ctx context.Context, scopeID int64) (KeyScopeSecret, error)
 	// Retrieves the full transaction row along with optional block metadata.
@@ -331,7 +334,7 @@ type Querier interface {
 	// returned. Returns up to page_limit rows.
 	ListAddressesByAccount(ctx context.Context, arg ListAddressesByAccountParams) ([]ListAddressesByAccountRow, error)
 	// Lists all key scopes for a wallet, ordered by ID.
-	ListKeyScopesByWallet(ctx context.Context, walletID int64) ([]KeyScope, error)
+	ListKeyScopesByWallet(ctx context.Context, walletID int64) ([]ListKeyScopesByWalletRow, error)
 	// ListOwnedInputPrevOutputsByTxHashes lists wallet-owned previous outputs that
 	// may be spent by selected transaction inputs.
 	//


### PR DESCRIPTION
### What we’re doing

This replaces advisory lock based account allocation with a persisted account counter, and refactors the new derived address flow to use the ops pattern.

The main idea is to stop reconstructing allocation state at runtime, and instead keep the next account number in the database, updated transactionally.

This follows the same direction raised [there](https://github.com/btcsuite/btcwallet/pull/1162#discussion_r2755247118): avoid putting hot path counting and allocation logic on top of growing table scans, and move that state into the database.

### Why

The motivation came from the PR discussion around address counts.

Deriving counts from the addresses table makes the cost grow with the number of addresses in the wallet. That is not ideal for a path that can become hot over time.

The same concern applies to account allocation. Instead of relying on a transient coordination mechanism like advisory locks, we can model the allocation state directly in the database.

By persisting the next account number and updating it in the same transaction as the account creation, correctness comes from durable database state rather than from a lock plus a value reconstructed at runtime.

### Benefits

This makes the concurrency model simpler and more explicit.

It also removes Postgres specific advisory lock logic from this path, which keeps the SQLite and Postgres implementations closer.

The ops pattern refactor should make the derived address workflow easier to maintain. Shared sequencing and invariants live in one place, while each backend keeps only the query details it needs.

That should make future changes easier to reason about, reduce backend drift, and avoid spreading the same workflow rules across multiple implementations.

### Caveats

The tradeoff is that persisted counters move more responsibility to the write path.

We need to make sure the counter is always updated in the same transaction as the row creation, and that every code path creating the relevant rows preserves that invariant.

I think this tradeoff is worth it, because it makes the allocation state explicit and durable instead of relying on a backend specific locking scheme.