### PR TITLE
build: lint tagged itest variants

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -169,6 +169,19 @@ linters:
         linters:
           - staticcheck
 
+      # E2E integration tests run a long-lived backend harness and execute test
+      # cases in registration order so the suite can stop on first failure.
+      - path: itest/.*_test\.go
+        linters:
+          - paralleltest
+
+      # DB integration tests often share a backend fixture across subtests, and
+      # forcing parallel subtests makes those ordering assumptions unsafe.
+      - path: wallet/internal/db/itest/.*_test\.go
+        linters:
+          - paralleltest
+          - tparallel
+
 issues:
   # Show only new issues created after git revision `REV`.
   # Default: ""

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,29 @@ XARGS := xargs -L 1
 include make/testing_flags.mk
 
 # Linting uses a lot of memory, so keep it under control by limiting the number
-# of workers if requested.
-ifneq ($(workers),)
+# of workers. Override with `workers=<n>` when needed.
+workers ?= 4
 LINT_WORKERS = --concurrency=$(workers)
-endif
+
+GOLANGCI_LINT = golangci-lint run -v --config .golangci.yml $(LINT_WORKERS)
+LINT_DB_SQLITE_PKGS = ./wallet/internal/db/sqlite ./wallet/internal/db/itest
+LINT_DB_POSTGRES_PKGS = ./wallet/internal/db/pg ./wallet/internal/db/itest
+
+define lint_targets
+	@$(call print, "Linting source.")
+	$(DOCKER_TOOLS) $(GOLANGCI_LINT) $(LINT_FIX)
+	@$(call print, "Linting integration tests.")
+	$(DOCKER_TOOLS) $(GOLANGCI_LINT) $(LINT_FIX) \
+		--build-tags="itest $(DEV_TAGS) nolog" ./itest
+	@$(call print, "Linting SQLite DB integration tests.")
+	$(DOCKER_TOOLS) $(GOLANGCI_LINT) $(LINT_FIX) \
+		--build-tags="itest $(DEV_TAGS) $(LOG_TAGS)" \
+		$(LINT_DB_SQLITE_PKGS)
+	@$(call print, "Linting PostgreSQL DB integration tests.")
+	$(DOCKER_TOOLS) $(GOLANGCI_LINT) $(LINT_FIX) \
+		--build-tags="itest $(DEV_TAGS) $(LOG_TAGS) test_db_postgres" \
+		$(LINT_DB_POSTGRES_PKGS)
+endef
 
 # Detect if we're in a git worktree. Use git rev-parse --git-common-dir to get
 # the path to the main git directory for the linter's diff processor to work
@@ -181,13 +200,12 @@ lint-config-check: docker-tools
 
 #? lint: Lint source and check errors
 lint-check: lint-config-check
-	@$(call print, "Linting source.")
-	$(DOCKER_TOOLS) golangci-lint run -v --config .golangci.yml $(LINT_WORKERS)
+	$(call lint_targets)
 
 #? lint: Lint source and fix
+lint: LINT_FIX = --fix
 lint: lint-config-check
-	@$(call print, "Linting source.")
-	$(DOCKER_TOOLS) golangci-lint run -v --fix --config .golangci.yml $(LINT_WORKERS)
+	$(call lint_targets)
 
 #? docker-tools: Build tools docker image
 docker-tools:

--- a/itest/main_test.go
+++ b/itest/main_test.go
@@ -44,12 +44,14 @@ var (
 	)
 )
 
+// init configures rpctest to allocate unique listener ports.
 func init() {
 	// Use system-unique ports for rpctest harnesses so multiple local test runs
 	// don't collide.
 	rpctest.ListenAddressGenerator = func() (string, string) {
 		p2p := fmt.Sprintf(rpctest.ListenerFormat, port.NextAvailablePort())
 		rpc := fmt.Sprintf(rpctest.ListenerFormat, port.NextAvailablePort())
+
 		return p2p, rpc
 	}
 }
@@ -81,6 +83,7 @@ func TestBtcWallet(t *testing.T) {
 			t.Logf("failure time: %v", time.Now().Format(
 				"2006-01-02 15:04:05.000",
 			))
+
 			break
 		}
 	}

--- a/itest/manager_test.go
+++ b/itest/manager_test.go
@@ -42,7 +42,9 @@ func testCreateWallet(h *bwtest.HarnessTest) {
 	h.Cleanup(func() {
 		// We use a background context here because h.Context() might be
 		// cancelled already.
-		require.NoError(h, w.Stop(context.Background()), "failed to stop wallet")
+		require.NoError(
+			h, w.Stop(context.Background()), "failed to stop wallet",
+		)
 	})
 
 	// Register the wallet so harness helpers can assert global invariants.

--- a/wallet/internal/db/itest/account_store_test.go
+++ b/wallet/internal/db/itest/account_store_test.go
@@ -54,8 +54,12 @@ func TestCreateDerivedAccountRejectsWalletScopeMismatch(t *testing.T) {
 
 	store := NewTestStore(t)
 	queries := store.Queries()
-	firstWalletID := newWallet(t, store, "wallet-raw-derived-account-mismatch-a")
-	secondWalletID := newWallet(t, store, "wallet-raw-derived-account-mismatch-b")
+	firstWalletID := newWallet(
+		t, store, "wallet-raw-derived-account-mismatch-a",
+	)
+	secondWalletID := newWallet(
+		t, store, "wallet-raw-derived-account-mismatch-b",
+	)
 	createDerivedAccount(
 		t, store, firstWalletID, db.KeyScopeBIP0084, "seed-derived-scope",
 	)
@@ -77,8 +81,12 @@ func TestCreateImportedAccountRejectsWalletScopeMismatch(t *testing.T) {
 
 	store := NewTestStore(t)
 	queries := store.Queries()
-	firstWalletID := newWallet(t, store, "wallet-raw-imported-account-mismatch-a")
-	secondWalletID := newWallet(t, store, "wallet-raw-imported-account-mismatch-b")
+	firstWalletID := newWallet(
+		t, store, "wallet-raw-imported-account-mismatch-a",
+	)
+	secondWalletID := newWallet(
+		t, store, "wallet-raw-imported-account-mismatch-b",
+	)
 	CreateImportedAccount(
 		t, store, firstWalletID, db.KeyScopeBIP0084, "seed-imported-scope",
 	)
@@ -219,6 +227,7 @@ func TestCreateDerivedAccountSequentialNumbers(t *testing.T) {
 	walletID := newWallet(t, store, "sequential-wallet")
 
 	scope := db.KeyScopeBIP0084
+
 	const numAccounts = 5
 
 	for i := range numAccounts {
@@ -254,6 +263,7 @@ func TestCreateDerivedAccountConcurrent(t *testing.T) {
 	}
 
 	resultCh := make(chan createResult, workers)
+
 	var wg sync.WaitGroup
 
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
@@ -261,6 +271,7 @@ func TestCreateDerivedAccountConcurrent(t *testing.T) {
 
 	for i := range workers {
 		wg.Add(1)
+
 		go func(i int) {
 			defer wg.Done()
 
@@ -295,6 +306,7 @@ func TestCreateDerivedAccountConcurrent(t *testing.T) {
 	sort.Slice(results, func(i, j int) bool {
 		return results[i] < results[j]
 	})
+
 	for i := range workers {
 		require.Equal(t, uint32(i), results[i])
 	}
@@ -410,7 +422,6 @@ func TestGetAccount(t *testing.T) {
 
 		t.Run(fmt.Sprintf("by number-%d-%s", accNumber, tc.Name),
 			func(t *testing.T) {
-
 				query := getAccountQueryByNumber(walletID, tc.Scope, accNumber)
 				info, err := store.GetAccount(t.Context(), query)
 				require.NoError(t, err)
@@ -473,6 +484,7 @@ func TestListAccounts(t *testing.T) {
 		accounts, err := store.ListAccounts(t.Context(), query)
 		require.NoError(t, err)
 		require.Len(t, accounts, len(AllAccountCases))
+
 		for _, tc := range AllAccountCases {
 			acc := findAccountInList(t, accounts, tc)
 			requireAccountMatches(t, &acc, tc)
@@ -497,6 +509,7 @@ func TestListAccounts(t *testing.T) {
 		cases := FilterAccountsByScope(scope)
 
 		require.Len(t, accounts, len(cases))
+
 		for _, tc := range cases {
 			acc := findAccountInList(t, accounts, tc)
 			requireAccountMatches(t, &acc, tc)
@@ -594,7 +607,7 @@ func TestAccountCreatedAtTimestamp(t *testing.T) {
 		createdNear time.Time
 	}
 
-	var accounts []createdAccount
+	accounts := make([]createdAccount, 0, 3)
 	for i := range 3 {
 		createdNear := time.Now()
 		params := db.CreateDerivedAccountParams{
@@ -604,6 +617,7 @@ func TestAccountCreatedAtTimestamp(t *testing.T) {
 		}
 		info, err := store.CreateDerivedAccount(t.Context(), params)
 		require.NoError(t, err)
+
 		accounts = append(accounts, createdAccount{
 			info:        *info,
 			createdNear: createdNear,
@@ -618,9 +632,11 @@ func TestAccountCreatedAtTimestamp(t *testing.T) {
 			5*time.Second, "account %d CreatedAt should track creation", i)
 	}
 
-	require.False(t, accounts[0].info.CreatedAt.After(accounts[1].info.CreatedAt),
+	require.False(
+		t, accounts[0].info.CreatedAt.After(accounts[1].info.CreatedAt),
 		"account 0 should not have CreatedAt after account 1")
-	require.False(t, accounts[1].info.CreatedAt.After(accounts[2].info.CreatedAt),
+	require.False(
+		t, accounts[1].info.CreatedAt.After(accounts[2].info.CreatedAt),
 		"account 1 should not have CreatedAt after account 2")
 }
 
@@ -890,10 +906,10 @@ func requireAccountMatches(t *testing.T, info *db.AccountInfo,
 	require.Equal(t, tc.Origin, info.Origin)
 	require.Equal(t, tc.IsWatchOnly, info.IsWatchOnly)
 
-	// Verify CreatedAt is populated and not in the future. The account may have
-	// been created several seconds earlier in the test when parallel database
-	// setup runs under the race detector, so a strict "recent" assertion here is
-	// unnecessarily flaky.
+	// Verify CreatedAt is populated and not in the future. The account may
+	// have been created several seconds earlier in the test when parallel
+	// database setup runs under the race detector, so a strict "recent"
+	// assertion here is unnecessarily flaky.
 	require.False(t, info.CreatedAt.IsZero(), "CreatedAt should be set")
 	require.False(t, info.CreatedAt.After(time.Now().Add(5*time.Second)),
 		"CreatedAt should not be in the future")
@@ -912,9 +928,9 @@ func requireAccountPropertiesMatches(t *testing.T, props *db.AccountProperties,
 	require.Equal(t, tc.Origin, props.Origin)
 	require.Equal(t, tc.IsWatchOnly, props.IsWatchOnly)
 
-	// Verify CreatedAt is populated and not in the future. Imported-account test
-	// fixtures can be created well before these assertions run under heavy CI
-	// contention, so only the forward-time invariant is stable here.
+	// Verify CreatedAt is populated and not in the future. Imported-account
+	// test fixtures can be created well before these assertions run under
+	// heavy CI contention, so only the forward-time invariant is stable here.
 	require.False(t, props.CreatedAt.IsZero(), "CreatedAt should be set")
 	require.False(t, props.CreatedAt.After(time.Now().Add(5*time.Second)),
 		"CreatedAt should not be in the future")

--- a/wallet/internal/db/itest/address_store_test.go
+++ b/wallet/internal/db/itest/address_store_test.go
@@ -30,6 +30,7 @@ func mockDeriveFunc() db.AddressDerivationFunc {
 		binary.BigEndian.PutUint32(scriptPubKey[0:4], accountID)
 		binary.BigEndian.PutUint32(scriptPubKey[4:8], branch)
 		binary.BigEndian.PutUint32(scriptPubKey[8:12], index)
+
 		return &db.DerivedAddressData{
 			ScriptPubKey: scriptPubKey,
 		}, nil
@@ -39,6 +40,7 @@ func mockDeriveFunc() db.AddressDerivationFunc {
 // newDerivedAddress creates and returns a derived address for testing.
 func newDerivedAddress(t *testing.T, store db.AddressStore, walletID uint32,
 	scope db.KeyScope, accountName string, change bool) *db.AddressInfo {
+
 	t.Helper()
 
 	info, err := store.NewDerivedAddress(
@@ -59,10 +61,11 @@ func newDerivedAddress(t *testing.T, store db.AddressStore, walletID uint32,
 func createDerivedAddresses(t *testing.T, store db.AddressStore,
 	walletID uint32, scope db.KeyScope, accountName string, change bool,
 	count int) []db.AddressInfo {
+
 	t.Helper()
 
 	addresses := make([]db.AddressInfo, 0, count)
-	for i := 0; i < count; i++ {
+	for range count {
 		info := newDerivedAddress(
 			t, store, walletID, scope, accountName, change,
 		)
@@ -75,6 +78,7 @@ func createDerivedAddresses(t *testing.T, store db.AddressStore,
 // getAccountByName retrieves an account by wallet, scope, and name for testing.
 func getAccountByName(t *testing.T, store db.AccountStore, walletID uint32,
 	scope db.KeyScope, accountName string) *db.AccountInfo {
+
 	t.Helper()
 
 	account, err := store.GetAccount(
@@ -89,12 +93,14 @@ func getAccountByName(t *testing.T, store db.AccountStore, walletID uint32,
 // all pages from ListAddresses until Next is nil.
 func collectAddressPages(t *testing.T, store db.AddressStore,
 	query db.ListAddressesQuery) []page.Result[db.AddressInfo, uint32] {
+
 	t.Helper()
 
 	pages := make([]page.Result[db.AddressInfo, uint32], 0)
 	for {
 		pageResult, err := store.ListAddresses(t.Context(), query)
 		require.NoError(t, err)
+
 		pages = append(pages, pageResult)
 
 		if pageResult.Next == nil {
@@ -138,6 +144,7 @@ func TestNewImportedAddress(t *testing.T) {
 
 	privKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
+
 	pubKey := privKey.PubKey()
 
 	p2pkhAddr, err := btcutil.NewAddressPubKeyHash(
@@ -208,7 +215,6 @@ func TestNewImportedAddress(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-
 			params := db.NewImportedAddressParams{
 				WalletID:     walletID,
 				Scope:        tc.scope,
@@ -244,7 +250,7 @@ func TestNewImportedAddress(t *testing.T) {
 				),
 			)
 			require.NoError(t, err)
-			require.Greater(t, account.ImportedKeyCount, uint32(0))
+			require.Positive(t, account.ImportedKeyCount)
 
 			// Verify address_secrets row for imported addresses.
 			addressID := getAddressID(
@@ -307,7 +313,8 @@ func TestNewImportedAddressWithEncryptedScript(t *testing.T) {
 			expectedAddrType: db.ScriptHash,
 		},
 		{
-			name:             "P2SH with both EncryptedPrivateKey and EncryptedScript",
+			name: "P2SH with both EncryptedPrivateKey and " +
+				"EncryptedScript",
 			scope:            db.KeyScopeBIP0044,
 			addressType:      db.ScriptHash,
 			encryptedScript:  redeemScript,
@@ -325,7 +332,8 @@ func TestNewImportedAddressWithEncryptedScript(t *testing.T) {
 			expectedAddrType: db.WitnessScript,
 		},
 		{
-			name:             "P2WSH with both EncryptedPrivateKey and EncryptedScript",
+			name: "P2WSH with both EncryptedPrivateKey and " +
+				"EncryptedScript",
 			scope:            db.KeyScopeBIP0049Plus,
 			addressType:      db.WitnessScript,
 			encryptedScript:  witnessScript,
@@ -393,7 +401,7 @@ func TestNewImportedAddressWithEncryptedScript(t *testing.T) {
 				return
 			}
 
-			require.ErrorAs(t, err, &db.ErrSecretNotFound)
+			require.ErrorIs(t, err, db.ErrSecretNotFound)
 		})
 	}
 }
@@ -409,6 +417,7 @@ func TestImportedAddressCounterInsertDelete(t *testing.T) {
 	CreateImportedAccount(t, store, walletID, db.KeyScopeBIP0084, "imported")
 
 	const importedAddrCount = 5
+
 	addressIDs := make([]uint32, 0, importedAddrCount)
 
 	account := getAccountByName(
@@ -416,7 +425,7 @@ func TestImportedAddressCounterInsertDelete(t *testing.T) {
 	)
 	require.Zero(t, account.ImportedKeyCount)
 
-	for i := 0; i < importedAddrCount; i++ {
+	for range importedAddrCount {
 		info, err := store.NewImportedAddress(
 			t.Context(), db.NewImportedAddressParams{
 				WalletID:     walletID,
@@ -457,6 +466,7 @@ func TestImportedAddressCounterConcurrentInsert(t *testing.T) {
 	CreateImportedAccount(t, store, walletID, db.KeyScopeBIP0084, "imported")
 
 	const workers = 20
+
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
@@ -466,10 +476,12 @@ func TestImportedAddressCounterConcurrentInsert(t *testing.T) {
 	}
 
 	insertResultChan := make(chan insertResult, workers)
+
 	var wg sync.WaitGroup
 
 	for range workers {
 		wg.Add(1)
+
 		go func() {
 			defer wg.Done()
 
@@ -510,8 +522,10 @@ func TestImportedAddressCounterConcurrentInsert(t *testing.T) {
 	deleteErrChan := make(chan error, workers)
 	for _, addressID := range addressIDs {
 		wg.Add(1)
+
 		go func() {
 			defer wg.Done()
+
 			deleteErrChan <- deleteAddress(ctx, dbConn, addressID)
 		}()
 	}
@@ -828,6 +842,8 @@ func TestGetAddress(t *testing.T) {
 				accountStore db.AccountStore,
 				walletID uint32) db.GetAddressQuery {
 
+				t.Helper()
+
 				CreateImportedAccount(
 					t, accountStore, walletID, db.KeyScopeBIP0084, "imported",
 				)
@@ -849,6 +865,8 @@ func TestGetAddress(t *testing.T) {
 				}
 			},
 			validate: func(t *testing.T, addr *db.AddressInfo) {
+				t.Helper()
+
 				require.NotNil(t, addr.ScriptPubKey)
 				require.Equal(t, db.ImportedAccount, addr.Origin)
 			},
@@ -892,11 +910,13 @@ func TestGetAddress(t *testing.T) {
 			if tc.wantErr != nil {
 				require.ErrorIs(t, err, tc.wantErr)
 				require.Nil(t, addr)
+
 				return
 			}
 
 			require.NoError(t, err)
 			require.NotNil(t, addr)
+
 			if tc.validate != nil {
 				tc.validate(t, addr)
 			}
@@ -924,6 +944,8 @@ func TestListAddresses(t *testing.T) {
 				accountStore db.AccountStore,
 				walletID uint32) db.ListAddressesQuery {
 
+				t.Helper()
+
 				createDerivedAccount(
 					t, accountStore, walletID, db.KeyScopeBIP0044,
 					"test-account",
@@ -944,6 +966,8 @@ func TestListAddresses(t *testing.T) {
 			},
 			wantCount: 5,
 			validate: func(t *testing.T, addrs []db.AddressInfo) {
+				t.Helper()
+
 				require.Len(t, addrs, 5)
 				for i, addr := range addrs {
 					require.Equal(t, uint32(i), addr.Index)
@@ -957,6 +981,8 @@ func TestListAddresses(t *testing.T) {
 			setupFunc: func(t *testing.T, _ db.AddressStore,
 				accountStore db.AccountStore,
 				walletID uint32) db.ListAddressesQuery {
+
+				t.Helper()
 
 				createDerivedAccount(
 					t, accountStore, walletID, db.KeyScopeBIP0084,
@@ -977,6 +1003,8 @@ func TestListAddresses(t *testing.T) {
 			setupFunc: func(t *testing.T, addrStore db.AddressStore,
 				accountStore db.AccountStore,
 				walletID uint32) db.ListAddressesQuery {
+
+				t.Helper()
 
 				// Create accounts in different scopes.
 				createDerivedAccount(
@@ -1010,6 +1038,8 @@ func TestListAddresses(t *testing.T) {
 			},
 			wantCount: 3,
 			validate: func(t *testing.T, addrs []db.AddressInfo) {
+				t.Helper()
+
 				require.Len(t, addrs, 3)
 				for _, addr := range addrs {
 					require.Equal(t, db.DerivedAccount, addr.Origin)
@@ -1034,6 +1064,7 @@ func TestListAddresses(t *testing.T) {
 			}
 
 			require.NoError(t, err)
+
 			addrs := pageResult.Items
 			require.Len(t, addrs, tc.wantCount)
 
@@ -1101,7 +1132,6 @@ func TestNewDerivedAddress(t *testing.T) {
 			require.Equal(t, db.DerivedAccount, info.Origin)
 			require.NotZero(t, info.CreatedAt)
 			require.Equal(t, tc.expectedBranch, info.Branch)
-			require.GreaterOrEqual(t, info.Index, uint32(0))
 			require.NotNil(t, info.ScriptPubKey)
 			require.Nil(t, info.PubKey)
 			require.False(t, info.IsWatchOnly)
@@ -1147,6 +1177,7 @@ func TestNewDerivedAddressDerivationGuards(t *testing.T) {
 		deriveFn := func(ctx context.Context, accountID uint32, branch uint32,
 			index uint32) (*db.DerivedAddressData, error) {
 
+			//nolint:nilnil // Intentionally exercise nil-data success guard.
 			return nil, nil
 		}
 
@@ -1227,7 +1258,8 @@ func TestNewImportedAddressWalletAccountMismatch(t *testing.T) {
 // on a derived address returns db.ErrSecretNotFound (not ErrAddressNotFound).
 // This validates the LEFT JOIN: derived addresses exist in the addresses
 // table but have no corresponding row in address_secrets. The query returns a
-// row with NULL encrypted_priv_key, and the converter returns ErrSecretNotFound.
+// row with NULL encrypted_priv_key, and the converter returns
+// ErrSecretNotFound.
 func TestGetAddressSecret_DerivedAddress(t *testing.T) {
 	t.Parallel()
 
@@ -1241,7 +1273,9 @@ func TestGetAddressSecret_DerivedAddress(t *testing.T) {
 		Scope:       db.KeyScopeBIP0084,
 		Change:      false,
 	}
-	addrInfo, err := store.NewDerivedAddress(t.Context(), params, mockDeriveFunc())
+	addrInfo, err := store.NewDerivedAddress(
+		t.Context(), params, mockDeriveFunc(),
+	)
 	require.NoError(t, err)
 
 	// Attempt to get secret for derived address.
@@ -1272,7 +1306,7 @@ func TestNewDerivedAddressSequentialIndexes(t *testing.T) {
 	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, accountName)
 
 	// Create 5 addresses in external branch and verify sequential indexes.
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		info := newDerivedAddress(
 			t, store, walletID, db.KeyScopeBIP0084, accountName, false,
 		)
@@ -1311,12 +1345,15 @@ func TestListAddressesOrdering(t *testing.T) {
 	)
 
 	require.NoError(t, err)
+
 	addresses := pageResult.Items
 	require.Len(t, addresses, 6)
 
 	// Separate addresses by branch for verification.
-	var externalAddrs []db.AddressInfo
-	var changeAddrs []db.AddressInfo
+	var (
+		externalAddrs []db.AddressInfo
+		changeAddrs   []db.AddressInfo
+	)
 
 	for _, addr := range addresses {
 		if addr.Branch == 0 {
@@ -1328,16 +1365,16 @@ func TestListAddressesOrdering(t *testing.T) {
 
 	// Verify external addresses sorted by index.
 	for i := 1; i < len(externalAddrs); i++ {
-		require.True(
-			t, externalAddrs[i-1].Index <= externalAddrs[i].Index,
+		require.LessOrEqual(
+			t, externalAddrs[i-1].Index, externalAddrs[i].Index,
 			"external addresses not in order",
 		)
 	}
 
 	// Verify change addresses sorted by index.
 	for i := 1; i < len(changeAddrs); i++ {
-		require.True(
-			t, changeAddrs[i-1].Index <= changeAddrs[i].Index,
+		require.LessOrEqual(
+			t, changeAddrs[i-1].Index, changeAddrs[i].Index,
 			"change addresses not in order",
 		)
 	}
@@ -1397,6 +1434,7 @@ func TestListAddressesPagination(t *testing.T) {
 	paged = append(paged, page2.Items...)
 	paged = append(paged, page3.Items...)
 	require.Equal(t, accountA, paged)
+
 	for i, addr := range paged {
 		require.Equal(t, uint32(i), addr.Index)
 		require.Equal(t, uint32(0), addr.Branch)
@@ -1504,6 +1542,7 @@ func TestListAddressesDeterministicPagination(t *testing.T) {
 		for j, addr := range pages[i].Items {
 			_, duplicate := seenIDs[addr.ID]
 			require.False(t, duplicate)
+
 			seenIDs[addr.ID] = struct{}{}
 
 			// Skip the first item on the first page; there's no prior cursor
@@ -1565,6 +1604,7 @@ func TestListAddressesAccountIsolation(t *testing.T) {
 	require.Len(t, addresses, len(expected))
 	require.Equal(t, expected, addresses)
 	accountAID := expected[0].AccountID
+
 	accountBID := otherAccount[0].AccountID
 	for _, addr := range addresses {
 		require.Equal(t, accountAID, addr.AccountID)
@@ -1677,6 +1717,7 @@ func TestIterAddresses(t *testing.T) {
 	iterAddrs := make([]db.AddressInfo, 0, len(expected))
 	for addr, err := range store.IterAddresses(t.Context(), query) {
 		require.NoError(t, err)
+
 		iterAddrs = append(iterAddrs, addr)
 	}
 
@@ -1717,6 +1758,7 @@ func TestIterAddressesPaginated(t *testing.T) {
 	iterAddrs := make([]db.AddressInfo, 0, len(expected))
 	for addr, err := range store.IterAddresses(t.Context(), query) {
 		require.NoError(t, err)
+
 		iterAddrs = append(iterAddrs, addr)
 	}
 
@@ -1856,15 +1898,18 @@ func TestNewDerivedAddressConcurrent(t *testing.T) {
 	}
 
 	resultCh := make(chan deriveResult, workers)
+
 	var wg sync.WaitGroup
 
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
+
 	deriveFn := mockDeriveFunc()
 
-	for i := range workers {
+	for range workers {
 		wg.Add(1)
-		go func(i int) {
+
+		go func() {
 			defer wg.Done()
 
 			info, err := store.NewDerivedAddress(
@@ -1881,7 +1926,7 @@ func TestNewDerivedAddressConcurrent(t *testing.T) {
 			}
 
 			resultCh <- deriveResult{info: *info}
-		}(i)
+		}()
 	}
 
 	wg.Wait()
@@ -1925,10 +1970,10 @@ func TestNewDerivedAddressBranchIsolation(t *testing.T) {
 
 	// Create addresses alternating between branches:
 	// external-0, change-0, external-1, change-1, external-2, change-2.
-	var externalAddrs []db.AddressInfo
-	var changeAddrs []db.AddressInfo
+	externalAddrs := make([]db.AddressInfo, 0, 3)
+	changeAddrs := make([]db.AddressInfo, 0, 3)
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		// Create external address (branch 0).
 		extInfo := newDerivedAddress(
 			t, store, walletID, db.KeyScopeBIP0084, accountName, false,

--- a/wallet/internal/db/itest/fixtures_pg_test.go
+++ b/wallet/internal/db/itest/fixtures_pg_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var errUnexpectedDeletedRows = errors.New("unexpected deleted row count")
+
 // testBackend returns the SQL backend expected by PostgreSQL itests.
 func testBackend() dberr.Backend {
 	return dberr.BackendPostgres
@@ -32,12 +34,13 @@ func requireConstraintSQLError(t *testing.T, err error) {
 	require.Equal(t, testBackend(), sqlErr.Backend)
 	require.Equal(t, dberr.ReasonConstraint, sqlErr.Reason)
 	require.Equal(t, dberr.ClassPermanent, sqlErr.Class())
-	require.True(t, errors.Is(err, sqlErr))
+	require.ErrorIs(t, err, sqlErr)
 }
 
 // CreateBlockFixture inserts a test block into the database and returns it.
 func CreateBlockFixture(t *testing.T, queries *sqlc.Queries,
 	height uint32) db.Block {
+
 	t.Helper()
 
 	block := NewBlockFixture(height)
@@ -57,15 +60,19 @@ func CreateBlockFixture(t *testing.T, queries *sqlc.Queries,
 // Used to test account number overflow without creating billions of accounts.
 func CreateAccountWithNumber(t *testing.T, queries *sqlc.Queries,
 	scopeID int64, accountNumber uint32, name string) {
+
 	t.Helper()
 
 	_, err := queries.CreateDerivedAccountWithNumber(
 		t.Context(), sqlc.CreateDerivedAccountWithNumberParams{
-			ScopeID:       scopeID,
-			AccountNumber: sql.NullInt64{Int64: int64(accountNumber), Valid: true},
-			AccountName:   name,
-			OriginID:      int16(db.DerivedAccount),
-			IsWatchOnly:   false,
+			ScopeID: scopeID,
+			AccountNumber: sql.NullInt64{
+				Int64: int64(accountNumber),
+				Valid: true,
+			},
+			AccountName: name,
+			OriginID:    int16(db.DerivedAccount),
+			IsWatchOnly: false,
 		},
 	)
 	require.NoError(t, err)
@@ -127,6 +134,7 @@ func createImportedAccountRaw(t *testing.T, dbConn *sql.DB, walletID uint32,
 // addresses.
 func CreateAddressWithIndex(t *testing.T, queries *sqlc.Queries,
 	walletID uint32, accountID int64, branch int16, index uint32) {
+
 	t.Helper()
 
 	_, err := queries.CreateDerivedAddress(
@@ -146,6 +154,7 @@ func CreateAddressWithIndex(t *testing.T, queries *sqlc.Queries,
 // UpdateAccountNextExternalIndex updates the account's external index counter.
 func UpdateAccountNextExternalIndex(t *testing.T, dbConn *sql.DB,
 	accountID int64, nextIndex uint32) {
+
 	t.Helper()
 
 	_, err := dbConn.ExecContext(
@@ -173,6 +182,7 @@ func UpdateAccountNextInternalIndex(t *testing.T, dbConn *sql.DB,
 // GetKeyScopeID retrieves the scope ID for a given wallet and key scope.
 func GetKeyScopeID(t *testing.T, queries *sqlc.Queries,
 	walletID uint32, scope db.KeyScope) int64 {
+
 	t.Helper()
 
 	row, err := queries.GetKeyScopeByWalletAndScope(
@@ -190,6 +200,7 @@ func GetKeyScopeID(t *testing.T, queries *sqlc.Queries,
 // GetAccountID retrieves the account ID for a given scope and account name.
 func GetAccountID(t *testing.T, queries *sqlc.Queries,
 	scopeID int64, accountName string) int64 {
+
 	t.Helper()
 
 	row, err := queries.GetAccountByScopeAndName(
@@ -204,8 +215,10 @@ func GetAccountID(t *testing.T, queries *sqlc.Queries,
 	return row.ID
 }
 
+// getAddressID retrieves an address ID by script and wallet.
 func getAddressID(t *testing.T, queries *sqlc.Queries, scriptPubKey []byte,
 	walletID uint32) int64 {
+
 	t.Helper()
 
 	addr, err := queries.GetAddressByScriptPubKey(
@@ -244,20 +257,21 @@ func deleteAddress(ctx context.Context, dbConn *sql.DB,
 	}
 
 	if rows != 1 {
-		return fmt.Errorf("expected 1 deleted row, got %d", rows)
+		return fmt.Errorf("%w: got %d", errUnexpectedDeletedRows, rows)
 	}
 
 	return nil
 }
 
+// setupMaxAccountNumberTest seeds state near the account-number limit.
 func setupMaxAccountNumberTest(t *testing.T, store db.AccountStore,
 	walletID uint32) {
 
 	t.Helper()
 
-	require.IsType(t, &pg.Store{}, store)
+	pgStore, ok := store.(*pg.Store)
+	require.True(t, ok)
 
-	pgStore := store.(*pg.Store)
 	queries := pgStore.Queries()
 	scopeID := GetKeyScopeID(t, queries, walletID, db.KeyScopeBIP0084)
 	CreateAccountWithNumber(t, queries, scopeID, math.MaxUint32-1,
@@ -287,6 +301,7 @@ func createImportedAddressRaw(ctx context.Context, queries *sqlc.Queries,
 func createDerivedAddressRaw(t *testing.T, queries *sqlc.Queries,
 	walletID uint32, accountID int64, branch uint32, index uint32,
 	scriptPubKey []byte) error {
+
 	t.Helper()
 
 	branchNum, err := db.Uint32ToInt16(branch)

--- a/wallet/internal/db/itest/fixtures_sqlite_test.go
+++ b/wallet/internal/db/itest/fixtures_sqlite_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var errUnexpectedDeletedRows = errors.New("unexpected deleted row count")
+
 // testBackend returns the SQL backend expected by SQLite itests.
 func testBackend() dberr.Backend {
 	return dberr.BackendSQLite
@@ -32,12 +34,13 @@ func requireConstraintSQLError(t *testing.T, err error) {
 	require.Equal(t, testBackend(), sqlErr.Backend)
 	require.Equal(t, dberr.ReasonConstraint, sqlErr.Reason)
 	require.Equal(t, dberr.ClassPermanent, sqlErr.Class())
-	require.True(t, errors.Is(err, sqlErr))
+	require.ErrorIs(t, err, sqlErr)
 }
 
 // CreateBlockFixture inserts a test block into the database and returns it.
 func CreateBlockFixture(t *testing.T, queries *sqlc.Queries,
 	height uint32) db.Block {
+
 	t.Helper()
 
 	block := NewBlockFixture(height)
@@ -57,15 +60,19 @@ func CreateBlockFixture(t *testing.T, queries *sqlc.Queries,
 // Used to test account number overflow without creating billions of accounts.
 func CreateAccountWithNumber(t *testing.T, queries *sqlc.Queries,
 	scopeID int64, accountNumber uint32, name string) {
+
 	t.Helper()
 
 	_, err := queries.CreateDerivedAccountWithNumber(
 		t.Context(), sqlc.CreateDerivedAccountWithNumberParams{
-			ScopeID:       scopeID,
-			AccountNumber: sql.NullInt64{Int64: int64(accountNumber), Valid: true},
-			AccountName:   name,
-			OriginID:      int64(db.DerivedAccount),
-			IsWatchOnly:   false,
+			ScopeID: scopeID,
+			AccountNumber: sql.NullInt64{
+				Int64: int64(accountNumber),
+				Valid: true,
+			},
+			AccountName: name,
+			OriginID:    int64(db.DerivedAccount),
+			IsWatchOnly: false,
 		},
 	)
 	require.NoError(t, err)
@@ -127,6 +134,7 @@ func createImportedAccountRaw(t *testing.T, dbConn *sql.DB, walletID uint32,
 // addresses.
 func CreateAddressWithIndex(t *testing.T, queries *sqlc.Queries,
 	walletID uint32, accountID int64, branch uint32, index uint32) {
+
 	t.Helper()
 
 	_, err := queries.CreateDerivedAddress(
@@ -146,6 +154,7 @@ func CreateAddressWithIndex(t *testing.T, queries *sqlc.Queries,
 // UpdateAccountNextExternalIndex updates the account's external index counter.
 func UpdateAccountNextExternalIndex(t *testing.T, dbConn *sql.DB,
 	accountID int64, nextIndex uint32) {
+
 	t.Helper()
 
 	_, err := dbConn.ExecContext(
@@ -173,6 +182,7 @@ func UpdateAccountNextInternalIndex(t *testing.T, dbConn *sql.DB,
 // GetKeyScopeID retrieves the scope ID for a given wallet and key scope.
 func GetKeyScopeID(t *testing.T, queries *sqlc.Queries,
 	walletID uint32, scope db.KeyScope) int64 {
+
 	t.Helper()
 
 	row, err := queries.GetKeyScopeByWalletAndScope(
@@ -190,6 +200,7 @@ func GetKeyScopeID(t *testing.T, queries *sqlc.Queries,
 // GetAccountID retrieves the account ID for a given scope and account name.
 func GetAccountID(t *testing.T, queries *sqlc.Queries,
 	scopeID int64, accountName string) int64 {
+
 	t.Helper()
 
 	row, err := queries.GetAccountByScopeAndName(
@@ -204,8 +215,10 @@ func GetAccountID(t *testing.T, queries *sqlc.Queries,
 	return row.ID
 }
 
+// getAddressID retrieves an address ID by script and wallet.
 func getAddressID(t *testing.T, queries *sqlc.Queries,
 	scriptPubKey []byte, walletID uint32) int64 {
+
 	t.Helper()
 
 	addr, err := queries.GetAddressByScriptPubKey(
@@ -244,20 +257,21 @@ func deleteAddress(ctx context.Context, dbConn *sql.DB,
 	}
 
 	if rows != 1 {
-		return fmt.Errorf("expected 1 deleted row, got %d", rows)
+		return fmt.Errorf("%w: got %d", errUnexpectedDeletedRows, rows)
 	}
 
 	return nil
 }
 
+// setupMaxAccountNumberTest seeds state near the account-number limit.
 func setupMaxAccountNumberTest(t *testing.T, store db.AccountStore,
 	walletID uint32) {
 
 	t.Helper()
 
-	require.IsType(t, &sqlite.Store{}, store)
+	sqliteStore, ok := store.(*sqlite.Store)
+	require.True(t, ok)
 
-	sqliteStore := store.(*sqlite.Store)
 	queries := sqliteStore.Queries()
 	scopeID := GetKeyScopeID(t, queries, walletID, db.KeyScopeBIP0084)
 	CreateAccountWithNumber(t, queries, scopeID, math.MaxUint32-1,
@@ -287,6 +301,9 @@ func createImportedAddressRaw(ctx context.Context, queries *sqlc.Queries,
 func createDerivedAddressRaw(t *testing.T, queries *sqlc.Queries,
 	walletID uint32, accountID int64, branch uint32, index uint32,
 	scriptPubKey []byte) error {
+
+	t.Helper()
+
 	_, err := queries.CreateDerivedAddress(
 		t.Context(), sqlc.CreateDerivedAddressParams{
 			WalletID:     int64(walletID),

--- a/wallet/internal/db/itest/pg_test.go
+++ b/wallet/internal/db/itest/pg_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"net"
 	"os"
 	"regexp"
 	"runtime"
@@ -40,7 +41,7 @@ var (
 
 	// Error returned by the container creation operation. We need to store
 	// it to return when the error already occurred during test setup.
-	pgContainerErr error
+	errPGContainer error
 
 	// Timeout for waiting for the postgres container to start. Needs to
 	// consider container image download time.
@@ -77,15 +78,19 @@ func TestMain(m *testing.M) {
 		ctx, cancel := context.WithTimeout(
 			context.Background(), pgTerminateTimeout,
 		)
-		defer cancel()
-
 		// As the tests already completed, we can stop the container
 		// immediately.
 		err := pgContainer.Terminate(
 			ctx, testcontainers.StopTimeout(0),
 		)
+
+		cancel()
+
 		if err != nil {
-			fmt.Printf("failed to terminate postgres container: %v\n", err)
+			_, _ = fmt.Fprintf(
+				os.Stderr, "failed to terminate postgres container: %v\n",
+				err,
+			)
 		}
 	}
 
@@ -121,6 +126,7 @@ func DefaultPostgresConfig() PostgresConfig {
 // The container is created once and reused across all tests for performance.
 func GetPostgresContainer(ctx context.Context) (*postgres.PostgresContainer,
 	error) {
+
 	pgContainerOnce.Do(func() {
 		cfg := DefaultPostgresConfig()
 
@@ -129,10 +135,11 @@ func GetPostgresContainer(ctx context.Context) (*postgres.PostgresContainer,
 		// trip instead of only waiting for the port to open.
 		waitForSQL := wait.ForSQL(
 			"5432/tcp", "pgx", func(host string, port nat.Port) string {
+				hostPort := net.JoinHostPort(host, port.Port())
+
 				return fmt.Sprintf(
-					"postgres://%s:%s@%s:%s/%s?sslmode=disable",
-					cfg.Username, cfg.Password, host, port.Port(),
-					cfg.Database,
+					"postgres://%s:%s@%s/%s?sslmode=disable",
+					cfg.Username, cfg.Password, hostPort, cfg.Database,
 				)
 			},
 		).WithStartupTimeout(pgInitTimeout)
@@ -147,7 +154,7 @@ func GetPostgresContainer(ctx context.Context) (*postgres.PostgresContainer,
 		// connection source separately.
 		pgMaxConns := 2 * p * m
 
-		pgContainer, pgContainerErr = postgres.Run(ctx,
+		pgContainer, errPGContainer = postgres.Run(ctx,
 			cfg.Image,
 			postgres.WithDatabase(cfg.Database),
 			postgres.WithUsername(cfg.Username),
@@ -161,12 +168,14 @@ func GetPostgresContainer(ctx context.Context) (*postgres.PostgresContainer,
 		)
 	})
 
-	return pgContainer, pgContainerErr
+	return pgContainer, errPGContainer
 }
 
 // sanitizedPgDBName converts a test name to a valid PostgreSQL database name.
 // It converts to lowercase and replaces special characters with underscores.
 func sanitizedPgDBName(t *testing.T) string {
+	t.Helper()
+
 	// Convert to lowercase.
 	dbName := strings.ToLower(t.Name())
 
@@ -212,7 +221,7 @@ func NewTestStore(t *testing.T) *pg.Store {
 	dbName := sanitizedPgDBName(t)
 
 	// Create the test database.
-	createDBStmt := fmt.Sprintf("CREATE DATABASE %s", dbName)
+	createDBStmt := "CREATE DATABASE " + dbName
 	_, err = adminDB.ExecContext(ctx, createDBStmt)
 	require.NoError(t, err, "failed to create test database")
 
@@ -293,24 +302,6 @@ func txIDByHash(t *testing.T, store *pg.Store, walletID uint32,
 	}
 
 	return meta.ID, true
-}
-
-// rawTxByHash returns the serialized transaction bytes for the given
-// wallet-scoped transaction hash.
-func rawTxByHash(t *testing.T, store *pg.Store, walletID uint32,
-	txHash chainhash.Hash) []byte {
-
-	t.Helper()
-
-	row, err := store.Queries().GetTransactionByHash(
-		t.Context(), sqlc.GetTransactionByHashParams{
-			WalletID: int64(walletID),
-			TxHash:   txHash[:],
-		},
-	)
-	require.NoError(t, err)
-
-	return row.RawTx
 }
 
 // setTxStatus rewrites one wallet-scoped transaction row to the provided

--- a/wallet/internal/db/itest/sqlite_test.go
+++ b/wallet/internal/db/itest/sqlite_test.go
@@ -96,24 +96,6 @@ func txIDByHash(t *testing.T, store *sqlite.Store, walletID uint32,
 	return meta.ID, true
 }
 
-// rawTxByHash returns the serialized transaction bytes for the given
-// wallet-scoped transaction hash.
-func rawTxByHash(t *testing.T, store *sqlite.Store, walletID uint32,
-	txHash chainhash.Hash) []byte {
-
-	t.Helper()
-
-	row, err := store.Queries().GetTransactionByHash(
-		t.Context(), sqlc.GetTransactionByHashParams{
-			WalletID: int64(walletID),
-			TxHash:   txHash[:],
-		},
-	)
-	require.NoError(t, err)
-
-	return row.RawTx
-}
-
 // setTxStatus rewrites one wallet-scoped transaction row to the provided
 // status using the internal status-update query.
 func setTxStatus(t *testing.T, store *sqlite.Store, walletID uint32,

--- a/wallet/internal/db/itest/tx_corruption_pg_test.go
+++ b/wallet/internal/db/itest/tx_corruption_pg_test.go
@@ -21,14 +21,19 @@ import (
 // this to verify that reads reject impossible tx states.
 func corruptTransactionStatus(t *testing.T, store *pg.Store,
 	walletID uint32, txHash chainhash.Hash, status int64) {
+
 	t.Helper()
 
 	for _, stmt := range []string{
 		"ALTER TABLE transactions DROP CONSTRAINT IF EXISTS valid_status",
-		"ALTER TABLE transactions DROP CONSTRAINT IF EXISTS check_orphaned_coinbase_only",
-		"ALTER TABLE transactions DROP CONSTRAINT IF EXISTS check_confirmed_published",
-		"ALTER TABLE transactions DROP CONSTRAINT IF EXISTS check_coinbase_not_pending",
-		"ALTER TABLE transactions DROP CONSTRAINT IF EXISTS check_coinbase_confirmation_state",
+		"ALTER TABLE transactions DROP CONSTRAINT IF EXISTS " +
+			"check_orphaned_coinbase_only",
+		"ALTER TABLE transactions DROP CONSTRAINT IF EXISTS " +
+			"check_confirmed_published",
+		"ALTER TABLE transactions DROP CONSTRAINT IF EXISTS " +
+			"check_coinbase_not_pending",
+		"ALTER TABLE transactions DROP CONSTRAINT IF EXISTS " +
+			"check_coinbase_confirmation_state",
 	} {
 		_, err := store.DB().ExecContext(t.Context(), stmt)
 		require.NoError(t, err)
@@ -36,7 +41,8 @@ func corruptTransactionStatus(t *testing.T, store *pg.Store,
 
 	result, err := store.DB().ExecContext(
 		t.Context(),
-		"UPDATE transactions SET tx_status = $1 WHERE wallet_id = $2 AND tx_hash = $3",
+		"UPDATE transactions SET tx_status = $1 "+
+			"WHERE wallet_id = $2 AND tx_hash = $3",
 		status, int64(walletID), txHash[:],
 	)
 	require.NoError(t, err)
@@ -51,17 +57,20 @@ func corruptTransactionStatus(t *testing.T, store *pg.Store,
 // decoding fails with the expected error path.
 func corruptTransactionHash(t *testing.T, store *pg.Store,
 	walletID uint32, txHash chainhash.Hash, hash []byte) {
+
 	t.Helper()
 
 	_, err := store.DB().ExecContext(
 		t.Context(),
-		"ALTER TABLE transactions DROP CONSTRAINT IF EXISTS transactions_tx_hash_check",
+		"ALTER TABLE transactions DROP CONSTRAINT IF EXISTS "+
+			"transactions_tx_hash_check",
 	)
 	require.NoError(t, err)
 
 	result, err := store.DB().ExecContext(
 		t.Context(),
-		"UPDATE transactions SET tx_hash = $1 WHERE wallet_id = $2 AND tx_hash = $3",
+		"UPDATE transactions SET tx_hash = $1 "+
+			"WHERE wallet_id = $2 AND tx_hash = $3",
 		hash, int64(walletID), txHash[:],
 	)
 	require.NoError(t, err)
@@ -77,19 +86,23 @@ func corruptTransactionHash(t *testing.T, store *pg.Store,
 // confirmation metadata.
 func corruptTransactionBlockHeight(t *testing.T, store *pg.Store,
 	walletID uint32, txHash chainhash.Hash, height int64) {
+
 	t.Helper()
 
 	_, err := store.DB().ExecContext(
 		t.Context(),
-		"ALTER TABLE blocks DROP CONSTRAINT IF EXISTS blocks_block_height_check",
+		"ALTER TABLE blocks DROP CONSTRAINT IF EXISTS "+
+			"blocks_block_height_check",
 	)
 	require.NoError(t, err)
 
 	blockHash := RandomHash()
 	_, err = store.DB().ExecContext(
 		t.Context(),
-		"INSERT INTO blocks (block_height, header_hash, block_timestamp) VALUES ($1, $2, $3) "+
-			"ON CONFLICT (block_height) DO UPDATE SET header_hash = EXCLUDED.header_hash, "+
+		"INSERT INTO blocks (block_height, header_hash, block_timestamp) "+
+			"VALUES ($1, $2, $3) "+
+			"ON CONFLICT (block_height) DO UPDATE SET "+
+			"header_hash = EXCLUDED.header_hash, "+
 			"block_timestamp = EXCLUDED.block_timestamp",
 		height, blockHash[:], time.Now().Unix(),
 	)
@@ -97,7 +110,8 @@ func corruptTransactionBlockHeight(t *testing.T, store *pg.Store,
 
 	result, err := store.DB().ExecContext(
 		t.Context(),
-		"UPDATE transactions SET block_height = $1 WHERE wallet_id = $2 AND tx_hash = $3",
+		"UPDATE transactions SET block_height = $1 "+
+			"WHERE wallet_id = $2 AND tx_hash = $3",
 		height, int64(walletID), txHash[:],
 	)
 	require.NoError(t, err)
@@ -112,6 +126,7 @@ func corruptTransactionBlockHeight(t *testing.T, store *pg.Store,
 // decoding rejects the malformed persisted value.
 func corruptUtxoOutputIndex(t *testing.T, store *pg.Store,
 	walletID uint32, txHash chainhash.Hash, oldIndex uint32, newIndex int64) {
+
 	t.Helper()
 
 	_, err := store.DB().ExecContext(
@@ -123,7 +138,8 @@ func corruptUtxoOutputIndex(t *testing.T, store *pg.Store,
 	result, err := store.DB().ExecContext(
 		t.Context(),
 		"UPDATE utxos SET output_index = $1 WHERE output_index = $2 "+
-			"AND tx_id = (SELECT id FROM transactions WHERE wallet_id = $3 AND tx_hash = $4)",
+			"AND tx_id = (SELECT id FROM transactions "+
+			"WHERE wallet_id = $3 AND tx_hash = $4)",
 		newIndex, int64(oldIndex), int64(walletID), txHash[:],
 	)
 	require.NoError(t, err)
@@ -138,19 +154,23 @@ func corruptUtxoOutputIndex(t *testing.T, store *pg.Store,
 // lease reads reject malformed lock identifiers.
 func corruptActiveLeaseLockID(t *testing.T, store *pg.Store,
 	walletID uint32, txHash chainhash.Hash, outputIndex uint32, lockID []byte) {
+
 	t.Helper()
 
 	_, err := store.DB().ExecContext(
 		t.Context(),
-		"ALTER TABLE utxo_leases DROP CONSTRAINT IF EXISTS utxo_leases_lock_id_check",
+		"ALTER TABLE utxo_leases DROP CONSTRAINT IF EXISTS "+
+			"utxo_leases_lock_id_check",
 	)
 	require.NoError(t, err)
 
 	result, err := store.DB().ExecContext(
 		t.Context(),
-		"UPDATE utxo_leases SET lock_id = $1 WHERE wallet_id = $2 AND utxo_id = ("+
+		"UPDATE utxo_leases SET lock_id = $1 "+
+			"WHERE wallet_id = $2 AND utxo_id = ("+
 			"SELECT u.id FROM utxos u JOIN transactions t ON t.id = u.tx_id "+
-			"WHERE t.wallet_id = $3 AND t.tx_hash = $4 AND u.output_index = $5)",
+			"WHERE t.wallet_id = $3 AND t.tx_hash = $4 "+
+			"AND u.output_index = $5)",
 		lockID, int64(walletID), int64(walletID), txHash[:], int64(outputIndex),
 	)
 	require.NoError(t, err)

--- a/wallet/internal/db/itest/tx_corruption_sqlite_test.go
+++ b/wallet/internal/db/itest/tx_corruption_sqlite_test.go
@@ -11,38 +11,47 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	ignoreCheckConstraintsOn  = "PRAGMA ignore_check_constraints = ON"
+	ignoreCheckConstraintsOff = "PRAGMA ignore_check_constraints = OFF"
+)
+
 // These sqlite-only helpers intentionally bypass CHECK constraints in the
 // isolated test database so corruption itests can persist rows that normal
 // store writes would reject. The follow-up read paths must treat those rows as
 // corruption instead of silently accepting them.
 
-// corruptTransactionStatus writes an invalid tx status into one stored row while
-// sqlite check constraints are disabled inside the surrounding transaction. The
-// corruption itests use this to verify that reads reject impossible tx states.
+// corruptTransactionStatus writes an invalid tx status into one stored row
+// while sqlite check constraints are disabled inside the surrounding
+// transaction. The corruption itests use this to verify that reads reject
+// impossible tx states.
 func corruptTransactionStatus(t *testing.T, store *sqlite.Store,
 	walletID uint32, txHash chainhash.Hash, status int64) {
+
 	t.Helper()
 
 	tx, err := store.DB().BeginTx(t.Context(), nil)
+
 	require.NoError(t, err)
 	defer func() {
 		_, _ = tx.ExecContext(
-			t.Context(), "PRAGMA ignore_check_constraints = OFF",
+			t.Context(), ignoreCheckConstraintsOff,
 		)
 		_ = tx.Rollback()
 	}()
 
-	_, err = tx.ExecContext(t.Context(), "PRAGMA ignore_check_constraints = ON")
+	_, err = tx.ExecContext(t.Context(), ignoreCheckConstraintsOn)
 	require.NoError(t, err)
 
 	result, err := tx.ExecContext(
 		t.Context(),
-		"UPDATE transactions SET tx_status = ? WHERE wallet_id = ? AND tx_hash = ?",
+		"UPDATE transactions SET tx_status = ? "+
+			"WHERE wallet_id = ? AND tx_hash = ?",
 		status, int64(walletID), txHash[:],
 	)
 	require.NoError(t, err)
 
-	_, err = tx.ExecContext(t.Context(), "PRAGMA ignore_check_constraints = OFF")
+	_, err = tx.ExecContext(t.Context(), ignoreCheckConstraintsOff)
 	require.NoError(t, err)
 
 	rows, err := result.RowsAffected()
@@ -56,28 +65,31 @@ func corruptTransactionStatus(t *testing.T, store *sqlite.Store,
 // verify that hash decoding fails with the expected error path.
 func corruptTransactionHash(t *testing.T, store *sqlite.Store,
 	walletID uint32, txHash chainhash.Hash, hash []byte) {
+
 	t.Helper()
 
 	tx, err := store.DB().BeginTx(t.Context(), nil)
+
 	require.NoError(t, err)
 	defer func() {
 		_, _ = tx.ExecContext(
-			t.Context(), "PRAGMA ignore_check_constraints = OFF",
+			t.Context(), ignoreCheckConstraintsOff,
 		)
 		_ = tx.Rollback()
 	}()
 
-	_, err = tx.ExecContext(t.Context(), "PRAGMA ignore_check_constraints = ON")
+	_, err = tx.ExecContext(t.Context(), ignoreCheckConstraintsOn)
 	require.NoError(t, err)
 
 	result, err := tx.ExecContext(
 		t.Context(),
-		"UPDATE transactions SET tx_hash = ? WHERE wallet_id = ? AND tx_hash = ?",
+		"UPDATE transactions SET tx_hash = ? "+
+			"WHERE wallet_id = ? AND tx_hash = ?",
 		hash, int64(walletID), txHash[:],
 	)
 	require.NoError(t, err)
 
-	_, err = tx.ExecContext(t.Context(), "PRAGMA ignore_check_constraints = OFF")
+	_, err = tx.ExecContext(t.Context(), ignoreCheckConstraintsOff)
 	require.NoError(t, err)
 
 	rows, err := result.RowsAffected()
@@ -91,25 +103,29 @@ func corruptTransactionHash(t *testing.T, store *sqlite.Store,
 // verify that reads reject impossible confirmation metadata.
 func corruptTransactionBlockHeight(t *testing.T, store *sqlite.Store,
 	walletID uint32, txHash chainhash.Hash, height int64) {
+
 	t.Helper()
 
 	tx, err := store.DB().BeginTx(t.Context(), nil)
+
 	require.NoError(t, err)
 	defer func() {
 		_, _ = tx.ExecContext(
-			t.Context(), "PRAGMA ignore_check_constraints = OFF",
+			t.Context(), ignoreCheckConstraintsOff,
 		)
 		_ = tx.Rollback()
 	}()
 
-	_, err = tx.ExecContext(t.Context(), "PRAGMA ignore_check_constraints = ON")
+	_, err = tx.ExecContext(t.Context(), ignoreCheckConstraintsOn)
 	require.NoError(t, err)
 
 	blockHash := RandomHash()
 	_, err = tx.ExecContext(
 		t.Context(),
-		"INSERT INTO blocks (block_height, header_hash, block_timestamp) VALUES (?, ?, ?) "+
-			"ON CONFLICT(block_height) DO UPDATE SET header_hash = excluded.header_hash, "+
+		"INSERT INTO blocks (block_height, header_hash, block_timestamp) "+
+			"VALUES (?, ?, ?) "+
+			"ON CONFLICT(block_height) DO UPDATE SET "+
+			"header_hash = excluded.header_hash, "+
 			"block_timestamp = excluded.block_timestamp",
 		height, blockHash[:], time.Now().Unix(),
 	)
@@ -117,12 +133,13 @@ func corruptTransactionBlockHeight(t *testing.T, store *sqlite.Store,
 
 	result, err := tx.ExecContext(
 		t.Context(),
-		"UPDATE transactions SET block_height = ? WHERE wallet_id = ? AND tx_hash = ?",
+		"UPDATE transactions SET block_height = ? "+
+			"WHERE wallet_id = ? AND tx_hash = ?",
 		height, int64(walletID), txHash[:],
 	)
 	require.NoError(t, err)
 
-	_, err = tx.ExecContext(t.Context(), "PRAGMA ignore_check_constraints = OFF")
+	_, err = tx.ExecContext(t.Context(), ignoreCheckConstraintsOff)
 	require.NoError(t, err)
 
 	rows, err := result.RowsAffected()
@@ -136,29 +153,32 @@ func corruptTransactionBlockHeight(t *testing.T, store *sqlite.Store,
 // verify that UTXO decoding rejects the malformed persisted value.
 func corruptUtxoOutputIndex(t *testing.T, store *sqlite.Store,
 	walletID uint32, txHash chainhash.Hash, oldIndex uint32, newIndex int64) {
+
 	t.Helper()
 
 	tx, err := store.DB().BeginTx(t.Context(), nil)
+
 	require.NoError(t, err)
 	defer func() {
 		_, _ = tx.ExecContext(
-			t.Context(), "PRAGMA ignore_check_constraints = OFF",
+			t.Context(), ignoreCheckConstraintsOff,
 		)
 		_ = tx.Rollback()
 	}()
 
-	_, err = tx.ExecContext(t.Context(), "PRAGMA ignore_check_constraints = ON")
+	_, err = tx.ExecContext(t.Context(), ignoreCheckConstraintsOn)
 	require.NoError(t, err)
 
 	result, err := tx.ExecContext(
 		t.Context(),
 		"UPDATE utxos SET output_index = ? WHERE output_index = ? "+
-			"AND tx_id = (SELECT id FROM transactions WHERE wallet_id = ? AND tx_hash = ?)",
+			"AND tx_id = (SELECT id FROM transactions "+
+			"WHERE wallet_id = ? AND tx_hash = ?)",
 		newIndex, int64(oldIndex), int64(walletID), txHash[:],
 	)
 	require.NoError(t, err)
 
-	_, err = tx.ExecContext(t.Context(), "PRAGMA ignore_check_constraints = OFF")
+	_, err = tx.ExecContext(t.Context(), ignoreCheckConstraintsOff)
 	require.NoError(t, err)
 
 	rows, err := result.RowsAffected()
@@ -172,30 +192,33 @@ func corruptUtxoOutputIndex(t *testing.T, store *sqlite.Store,
 // use this to verify that lease reads reject malformed lock identifiers.
 func corruptActiveLeaseLockID(t *testing.T, store *sqlite.Store,
 	walletID uint32, txHash chainhash.Hash, outputIndex uint32, lockID []byte) {
+
 	t.Helper()
 
 	tx, err := store.DB().BeginTx(t.Context(), nil)
+
 	require.NoError(t, err)
 	defer func() {
 		_, _ = tx.ExecContext(
-			t.Context(), "PRAGMA ignore_check_constraints = OFF",
+			t.Context(), ignoreCheckConstraintsOff,
 		)
 		_ = tx.Rollback()
 	}()
 
-	_, err = tx.ExecContext(t.Context(), "PRAGMA ignore_check_constraints = ON")
+	_, err = tx.ExecContext(t.Context(), ignoreCheckConstraintsOn)
 	require.NoError(t, err)
 
 	result, err := tx.ExecContext(
 		t.Context(),
-		"UPDATE utxo_leases SET lock_id = ? WHERE wallet_id = ? AND utxo_id = ("+
+		"UPDATE utxo_leases SET lock_id = ? "+
+			"WHERE wallet_id = ? AND utxo_id = ("+
 			"SELECT u.id FROM utxos u JOIN transactions t ON t.id = u.tx_id "+
 			"WHERE t.wallet_id = ? AND t.tx_hash = ? AND u.output_index = ?)",
 		lockID, int64(walletID), int64(walletID), txHash[:], int64(outputIndex),
 	)
 	require.NoError(t, err)
 
-	_, err = tx.ExecContext(t.Context(), "PRAGMA ignore_check_constraints = OFF")
+	_, err = tx.ExecContext(t.Context(), ignoreCheckConstraintsOff)
 	require.NoError(t, err)
 
 	rows, err := result.RowsAffected()

--- a/wallet/internal/db/itest/tx_store_corruption_test.go
+++ b/wallet/internal/db/itest/tx_store_corruption_test.go
@@ -4,7 +4,6 @@ package itest
 
 import (
 	"database/sql"
-	"fmt"
 	"testing"
 	"time"
 
@@ -19,9 +18,10 @@ import (
 // surface the backend query errors exercised by the corruption tests.
 func dropTableForCorruption(t *testing.T, store interface{ DB() *sql.DB },
 	table string) {
+
 	t.Helper()
 
-	stmt := fmt.Sprintf("DROP TABLE %s", table)
+	stmt := "DROP TABLE " + table
 	if _, ok := any(store).(*pg.Store); ok {
 		stmt += " CASCADE"
 	}
@@ -265,7 +265,8 @@ func TestListTxnsRejectsCorruptedUnminedHash(t *testing.T) {
 }
 
 // TestGetTxRejectsCorruptedConfirmedBlockHeight verifies that confirmed reads
-// fail when the joined block height cannot map back into the public block model.
+// fail when the joined block height cannot map back into the public block
+// model.
 func TestGetTxRejectsCorruptedConfirmedBlockHeight(t *testing.T) {
 	t.Parallel()
 
@@ -346,7 +347,9 @@ func TestDeleteTxRejectsCorruptedLiveChild(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	corruptTransactionHash(t, store, walletID, childTx.TxHash(), []byte{1, 2, 3})
+	corruptTransactionHash(
+		t, store, walletID, childTx.TxHash(), []byte{1, 2, 3},
+	)
 
 	err = store.DeleteTx(
 		t.Context(),
@@ -359,7 +362,8 @@ func TestDeleteTxRejectsCorruptedLiveChild(t *testing.T) {
 }
 
 // TestRollbackToBlockRejectsCorruptedCoinbaseRootHash verifies that rollback
-// fails loudly when a disconnected coinbase root carries an invalid stored hash.
+// fails loudly when a disconnected coinbase root carries an invalid stored
+// hash.
 func TestRollbackToBlockRejectsCorruptedCoinbaseRootHash(t *testing.T) {
 	t.Parallel()
 
@@ -387,7 +391,9 @@ func TestRollbackToBlockRejectsCorruptedCoinbaseRootHash(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	corruptTransactionHash(t, store, walletID, coinbaseTx.TxHash(), []byte{1, 2, 3})
+	corruptTransactionHash(
+		t, store, walletID, coinbaseTx.TxHash(), []byte{1, 2, 3},
+	)
 
 	err = store.RollbackToBlock(t.Context(), coinbaseBlock.Height)
 	require.ErrorContains(t, err, "rollback coinbase hash")
@@ -407,7 +413,13 @@ func TestCreateTxReturnsQueryErrorWhenTransactionsTableMissing(t *testing.T) {
 		t.Context(),
 		db.CreateTxParams{
 			WalletID: walletID,
-			Tx:       newRegularTx([]wire.OutPoint{randomOutPoint()}, []*wire.TxOut{{Value: 5500, PkScript: []byte{0x51}}}),
+			Tx: newRegularTx(
+				[]wire.OutPoint{randomOutPoint()},
+				[]*wire.TxOut{{
+					Value:    5500,
+					PkScript: []byte{0x51},
+				}},
+			),
 			Received: time.Unix(1710001433, 0),
 			Status:   db.TxStatusPending,
 		},
@@ -478,7 +490,8 @@ func TestCreateTxReturnsQueryErrorWhenUtxosTableMissing(t *testing.T) {
 }
 
 // TestRollbackToBlockReturnsQueryErrorWhenBlocksTableMissing verifies that the
-// backend rollback queries surface database errors when the block table is gone.
+// backend rollback queries surface database errors when the block table is
+// gone.
 func TestRollbackToBlockReturnsQueryErrorWhenBlocksTableMissing(t *testing.T) {
 	t.Parallel()
 
@@ -490,8 +503,9 @@ func TestRollbackToBlockReturnsQueryErrorWhenBlocksTableMissing(t *testing.T) {
 
 	// SQLite still fails while rewinding wallet sync-state heights because
 	// wallet_sync_states keeps direct block references with ON DELETE RESTRICT.
-	// PostgreSQL drops those dependent rows with CASCADE when the blocks table is
-	// removed, so rollback gets far enough to fail on the block delete instead.
+	// PostgreSQL drops those dependent rows with CASCADE when the blocks table
+	// is removed, so rollback gets far enough to fail on the block delete
+	// instead.
 	_, ok := any(store).(*pg.Store)
 	if ok {
 		require.ErrorContains(t, err, "delete blocks at or above height")

--- a/wallet/internal/db/itest/tx_store_create_edge_cases_test.go
+++ b/wallet/internal/db/itest/tx_store_create_edge_cases_test.go
@@ -104,7 +104,9 @@ func TestCreateTxRejectsDuplicateConfirmedTransaction(t *testing.T) {
 // TestCreateTxRejectsMissingConfirmingBlockForExistingUnminedRow verifies that
 // re-confirming an existing unmined row still requires the confirming block to
 // exist in block history.
-func TestCreateTxRejectsMissingConfirmingBlockForExistingUnminedRow(t *testing.T) {
+func TestCreateTxRejectsMissingConfirmingBlockForExistingUnminedRow(
+	t *testing.T) {
+
 	t.Parallel()
 
 	store := NewTestStore(t)

--- a/wallet/internal/db/itest/tx_store_invalidate_edge_cases_test.go
+++ b/wallet/internal/db/itest/tx_store_invalidate_edge_cases_test.go
@@ -12,8 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestInvalidateUnminedTxFailsBranch verifies that invalidating one unmined root
-// fails the whole dependent branch and restores the wallet-owned parent output.
+// TestInvalidateUnminedTxFailsBranch verifies that invalidating one unmined
+// root fails the whole dependent branch and restores the wallet-owned parent
+// output.
 func TestInvalidateUnminedTxFailsBranch(t *testing.T) {
 	t.Parallel()
 

--- a/wallet/internal/db/itest/tx_utxo_store_test.go
+++ b/wallet/internal/db/itest/tx_utxo_store_test.go
@@ -1086,7 +1086,9 @@ func TestListTxnsUsesConfirmationOrder(t *testing.T) {
 	store := NewTestStore(t)
 	walletID := newWallet(t, store, "wallet-list-txns-confirm-order")
 	queries := store.Queries()
+
 	const blockHeight = 222
+
 	block := CreateBlockFixture(t, queries, blockHeight)
 
 	laterBlockTx := newRegularTx(
@@ -1224,7 +1226,8 @@ func TestGetTxDetailFindsOwnedInputAfterSpendEdgeCleared(t *testing.T) {
 	require.NoError(t, err)
 
 	// Assert: The current UTXO set is restored, but historical child details
-	// still report the wallet-owned debit from the serialized child transaction.
+	// still report the wallet-owned debit from the serialized child
+	// transaction.
 	require.Equal(t, btcutil.Amount(5000), parentUtxo.Amount)
 	require.Equal(t, db.TxStatusFailed, detail.Status)
 	require.Len(t, detail.OwnedInputs, 1)
@@ -1534,7 +1537,9 @@ func TestRollbackToBlockFailsCoinbaseDescendants(t *testing.T) {
 	require.Equal(t, db.TxStatusFailed, grandchildInfo.Status)
 	require.Nil(t, grandchildInfo.Block)
 
-	require.Empty(t, childSpendingTxIDs(t, store, walletID, coinbaseTx.TxHash()))
+	require.Empty(
+		t, childSpendingTxIDs(t, store, walletID, coinbaseTx.TxHash()),
+	)
 	require.Empty(t, childSpendingTxIDs(t, store, walletID, childTx.TxHash()))
 }
 

--- a/wallet/internal/db/itest/utxo_store_edge_cases_test.go
+++ b/wallet/internal/db/itest/utxo_store_edge_cases_test.go
@@ -166,7 +166,9 @@ func TestListLeasedOutputsRejectsCorruptedLockID(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	corruptActiveLeaseLockID(t, store, walletID, tx.TxHash(), 0, []byte{1, 2, 3})
+	corruptActiveLeaseLockID(
+		t, store, walletID, tx.TxHash(), 0, []byte{1, 2, 3},
+	)
 
 	_, err = store.ListLeasedOutputs(t.Context(), walletID)
 	require.ErrorContains(t, err, "lock id")
@@ -262,6 +264,7 @@ func TestGetUtxoAndLeaseRejectLargeOutputIndex(t *testing.T) {
 		require.ErrorContains(t, err, "convert output index")
 		require.ErrorContains(t, leaseErr, "convert output index")
 		require.ErrorContains(t, releaseErr, "could not cast")
+
 		return
 	}
 

--- a/wallet/internal/db/itest/wallet_store_test.go
+++ b/wallet/internal/db/itest/wallet_store_test.go
@@ -38,7 +38,7 @@ func TestCreateWallet(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, info)
 
-	require.Equal(t, info.ID, uint32(1), "first wallet ID should be 1")
+	require.Equal(t, uint32(1), info.ID, "first wallet ID should be 1")
 	require.Equal(t, params.Name, info.Name)
 	require.Equal(t, params.IsImported, info.IsImported)
 	require.Equal(t, params.ManagerVersion, info.ManagerVersion)
@@ -213,6 +213,7 @@ func TestListWallets(t *testing.T) {
 	for i, w := range pageResult.Items {
 		walletsName[i] = w.Name
 	}
+
 	require.ElementsMatch(t, names, walletsName)
 }
 
@@ -274,6 +275,7 @@ func TestListWalletsPagination(t *testing.T) {
 	for i, wallet := range paged {
 		pagedNames[i] = wallet.Name
 	}
+
 	require.Equal(t, names, pagedNames)
 }
 
@@ -283,6 +285,7 @@ func TestListWalletsExactBoundary(t *testing.T) {
 	t.Parallel()
 
 	store := NewTestStore(t)
+
 	names := []string{"wallet-1", "wallet-2", "wallet-3", "wallet-4"}
 	for _, name := range names {
 		_, err := store.CreateWallet(
@@ -342,6 +345,7 @@ func TestIterWallets(t *testing.T) {
 	iterWallets := make([]db.WalletInfo, 0, len(expected))
 	for wallet, err := range store.IterWallets(t.Context(), query) {
 		require.NoError(t, err)
+
 		iterWallets = append(iterWallets, wallet)
 	}
 
@@ -376,6 +380,7 @@ func TestIterWalletsPaginated(t *testing.T) {
 	iterWallets := make([]db.WalletInfo, 0, len(expected))
 	for wallet, err := range store.IterWallets(t.Context(), query) {
 		require.NoError(t, err)
+
 		iterWallets = append(iterWallets, wallet)
 	}
 
@@ -391,11 +396,13 @@ func TestListWalletsPagedFromCursor(t *testing.T) {
 	store := NewTestStore(t)
 
 	names := []string{"wallet-1", "wallet-2", "wallet-3", "wallet-4"}
+
 	created := make([]*db.WalletInfo, 0, len(names))
 	for _, name := range names {
 		params := CreateWalletParamsFixture(name)
 		wallet, err := store.CreateWallet(t.Context(), params)
 		require.NoError(t, err)
+
 		created = append(created, wallet)
 	}
 
@@ -533,6 +540,7 @@ func TestListWalletsDeterministicPagination(t *testing.T) {
 		for j, wallet := range pages[i].Items {
 			_, duplicate := seenIDs[wallet.ID]
 			require.False(t, duplicate)
+
 			seenIDs[wallet.ID] = struct{}{}
 
 			// Skip the first item on the first page; there's no prior cursor
@@ -600,6 +608,7 @@ func TestListWalletsCursorEdges(t *testing.T) {
 	t.Parallel()
 
 	store := NewTestStore(t)
+
 	names := []string{"wallet-1", "wallet-2", "wallet-3"}
 	for _, name := range names {
 		_, err := store.CreateWallet(
@@ -635,12 +644,14 @@ func TestListWalletsCursorEdges(t *testing.T) {
 // pages from ListWallets until Next is nil.
 func collectWalletPages(t *testing.T, store db.WalletStore,
 	query db.ListWalletsQuery) []page.Result[db.WalletInfo, uint32] {
+
 	t.Helper()
 
 	pages := make([]page.Result[db.WalletInfo, uint32], 0)
 	for {
 		pageResult, err := store.ListWallets(t.Context(), query)
 		require.NoError(t, err)
+
 		pages = append(pages, pageResult)
 
 		if pageResult.Next == nil {


### PR DESCRIPTION
## Summary
- Extend `make lint` and `make lint-check` to cover default source, e2e integration tests, and both DB integration-test build-tag variants.
- Default golangci-lint concurrency to 4 workers while keeping `workers=<n>` override support.
- Clean up tagged e2e and DB integration tests so the new lint contexts pass.

## Testing
- `git diff --check`
- `make lint-check`
- `GOWORK=off go test -tags="itest dev nolog" ./itest -run '^$'`
- `GOWORK=off make itest-db db=sqlite`
- `GOWORK=off make itest-db db=postgres`