### PR TITLE
db: prepare kvdb store routing

### DIFF
--- a/wallet/deprecated.go
+++ b/wallet/deprecated.go
@@ -7186,7 +7186,7 @@ func OpenWithRetry(db walletdb.DB, pubPass []byte, cbs *waddrmgr.OpenCallbacks,
 
 	w := &Wallet{
 		addrStore:        addrMgr,
-		store:            kvdb.NewStore(db, txMgr),
+		store:            kvdb.NewStore(db, txMgr, addrMgr),
 		txStore:          txMgr,
 		walletDeprecated: deprecated,
 	}

--- a/wallet/deprecated.go
+++ b/wallet/deprecated.go
@@ -7187,6 +7187,7 @@ func OpenWithRetry(db walletdb.DB, pubPass []byte, cbs *waddrmgr.OpenCallbacks,
 	w := &Wallet{
 		addrStore:        addrMgr,
 		store:            kvdb.NewStore(db, txMgr, addrMgr),
+		keyVault:         addrMgr,
 		txStore:          txMgr,
 		walletDeprecated: deprecated,
 	}

--- a/wallet/internal/db/accounts_common.go
+++ b/wallet/internal/db/accounts_common.go
@@ -43,6 +43,36 @@ func (params *CreateImportedAccountParams) Validate() error {
 	return nil
 }
 
+// Validate checks that exactly one account selector was set.
+func (query GetAccountQuery) Validate() error {
+	if query.Name == nil && query.AccountNumber == nil {
+		return ErrInvalidAccountQuery
+	}
+
+	if query.Name != nil && query.AccountNumber != nil {
+		return ErrInvalidAccountQuery
+	}
+
+	return nil
+}
+
+// Validate checks that the rename parameters identify exactly one account.
+func (params RenameAccountParams) Validate() error {
+	if params.NewName == "" {
+		return ErrMissingAccountName
+	}
+
+	if params.OldName == "" && params.AccountNumber == nil {
+		return ErrInvalidAccountQuery
+	}
+
+	if params.OldName != "" && params.AccountNumber != nil {
+		return ErrInvalidAccountQuery
+	}
+
+	return nil
+}
+
 // IsWatchOnly returns true if the account is watch-only.
 func (params *CreateImportedAccountParams) IsWatchOnly() bool {
 	return len(params.EncryptedPrivateKey) == 0
@@ -382,16 +412,16 @@ func GetAccountByQuery(ctx context.Context, query GetAccountQuery,
 	getByNumber GetAccountFunc, getByName GetAccountFunc) (*AccountInfo,
 	error) {
 
-	switch {
-	case query.AccountNumber != nil && query.Name == nil:
-		return getByNumber(ctx, query)
-
-	case query.Name != nil && query.AccountNumber == nil:
-		return getByName(ctx, query)
-
-	default:
-		return nil, ErrInvalidAccountQuery
+	err := query.Validate()
+	if err != nil {
+		return nil, err
 	}
+
+	if query.AccountNumber != nil {
+		return getByNumber(ctx, query)
+	}
+
+	return getByName(ctx, query)
 }
 
 // ListAccountsFunc defines a function signature for listing accounts.
@@ -428,20 +458,16 @@ type RenameAccountFunc func(context.Context, RenameAccountParams) error
 func RenameAccountByQuery(ctx context.Context, params RenameAccountParams,
 	renameByNumber RenameAccountFunc, renameByName RenameAccountFunc) error {
 
-	if params.NewName == "" {
-		return ErrMissingAccountName
+	err := params.Validate()
+	if err != nil {
+		return err
 	}
 
-	switch {
-	case params.AccountNumber != nil && params.OldName == "":
+	if params.AccountNumber != nil {
 		return renameByNumber(ctx, params)
-
-	case params.OldName != "" && params.AccountNumber == nil:
-		return renameByName(ctx, params)
-
-	default:
-		return ErrInvalidAccountQuery
 	}
+
+	return renameByName(ctx, params)
 }
 
 // GetAccount is a generic helper that retrieves an account using the provided

--- a/wallet/internal/db/accounts_common_test.go
+++ b/wallet/internal/db/accounts_common_test.go
@@ -1,0 +1,158 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateDerivedAccountParamsValidate verifies derived account creation
+// validation rejects missing names.
+func TestCreateDerivedAccountParamsValidate(t *testing.T) {
+	t.Parallel()
+
+	err := (&CreateDerivedAccountParams{Name: "default"}).Validate()
+	require.NoError(t, err)
+
+	err = (&CreateDerivedAccountParams{}).Validate()
+	require.ErrorIs(t, err, ErrMissingAccountName)
+}
+
+// TestCreateImportedAccountParamsValidate verifies imported account creation
+// validation rejects missing names and public keys.
+func TestCreateImportedAccountParamsValidate(t *testing.T) {
+	t.Parallel()
+
+	err := (&CreateImportedAccountParams{
+		Name:               "imported",
+		EncryptedPublicKey: []byte{1},
+	}).Validate()
+	require.NoError(t, err)
+
+	err = (&CreateImportedAccountParams{
+		EncryptedPublicKey: []byte{1},
+	}).Validate()
+	require.ErrorIs(t, err, ErrMissingAccountName)
+
+	err = (&CreateImportedAccountParams{Name: "imported"}).Validate()
+	require.ErrorIs(t, err, ErrMissingAccountPublicKey)
+}
+
+// TestGetAccountQueryValidate verifies account lookups must use exactly one
+// account selector.
+func TestGetAccountQueryValidate(t *testing.T) {
+	t.Parallel()
+
+	name := "default"
+	accountNumber := uint32(7)
+
+	tests := []struct {
+		name    string
+		query   GetAccountQuery
+		wantErr error
+	}{
+		{
+			name:  "name selector",
+			query: GetAccountQuery{Name: &name},
+		},
+		{
+			name:  "number selector",
+			query: GetAccountQuery{AccountNumber: &accountNumber},
+		},
+		{
+			name:    "no selector",
+			query:   GetAccountQuery{},
+			wantErr: ErrInvalidAccountQuery,
+		},
+		{
+			name: "both selectors",
+			query: GetAccountQuery{
+				Name:          &name,
+				AccountNumber: &accountNumber,
+			},
+			wantErr: ErrInvalidAccountQuery,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := test.query.Validate()
+			if test.wantErr != nil {
+				require.ErrorIs(t, err, test.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestRenameAccountParamsValidate verifies account renames must include a new
+// name and exactly one account selector.
+func TestRenameAccountParamsValidate(t *testing.T) {
+	t.Parallel()
+
+	accountNumber := uint32(7)
+
+	tests := []struct {
+		name    string
+		params  RenameAccountParams
+		wantErr error
+	}{
+		{
+			name: "old name selector",
+			params: RenameAccountParams{
+				OldName: "default",
+				NewName: "renamed",
+			},
+		},
+		{
+			name: "account number selector",
+			params: RenameAccountParams{
+				AccountNumber: &accountNumber,
+				NewName:       "renamed",
+			},
+		},
+		{
+			name: "missing new name",
+			params: RenameAccountParams{
+				OldName: "default",
+			},
+			wantErr: ErrMissingAccountName,
+		},
+		{
+			name: "no selector",
+			params: RenameAccountParams{
+				NewName: "renamed",
+			},
+			wantErr: ErrInvalidAccountQuery,
+		},
+		{
+			name: "both selectors",
+			params: RenameAccountParams{
+				OldName:       "default",
+				AccountNumber: &accountNumber,
+				NewName:       "renamed",
+			},
+			wantErr: ErrInvalidAccountQuery,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := test.params.Validate()
+			if test.wantErr != nil {
+				require.ErrorIs(t, err, test.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}

--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -121,13 +121,14 @@ var (
 // Until we break the wallet into independent components, we use this monolithic
 // Store abstraction as a transitional step.
 //
-// For this PR, Store includes AccountStore, UTXOStore, and TxStore. Over time
-// it is expected to grow to include WalletStore and AddressStore as those
+// For this PR, Store includes AccountStore, AddressStore, UTXOStore, and
+// TxStore. Over time it is expected to grow to include WalletStore as those
 // callers migrate to the new internal db interfaces.
 //
 // TODO(yy): Break down wallet managers into independent components.
 type Store interface {
 	AccountStore
+	AddressStore
 	UTXOStore
 	TxStore
 

--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -121,12 +121,12 @@ var (
 // Until we break the wallet into independent components, we use this monolithic
 // Store abstraction as a transitional step.
 //
-// For this PR, Store includes AccountStore, AddressStore, UTXOStore, and
-// TxStore. Over time it is expected to grow to include WalletStore as those
-// callers migrate to the new internal db interfaces.
+// For this PR, Store includes wallet, account, address, UTXO, and tx store
+// interfaces.
 //
 // TODO(yy): Break down wallet managers into independent components.
 type Store interface {
+	WalletStore
 	AccountStore
 	AddressStore
 	UTXOStore

--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -121,12 +121,13 @@ var (
 // Until we break the wallet into independent components, we use this monolithic
 // Store abstraction as a transitional step.
 //
-// For this PR, Store includes UTXOStore and TxStore. Over time it is expected
-// to grow to include WalletStore, AccountStore, and AddressStore as those
+// For this PR, Store includes AccountStore, UTXOStore, and TxStore. Over time
+// it is expected to grow to include WalletStore and AddressStore as those
 // callers migrate to the new internal db interfaces.
 //
 // TODO(yy): Break down wallet managers into independent components.
 type Store interface {
+	AccountStore
 	UTXOStore
 	TxStore
 

--- a/wallet/internal/db/kvdb/accountstore.go
+++ b/wallet/internal/db/kvdb/accountstore.go
@@ -1,0 +1,42 @@
+package kvdb
+
+import (
+	"context"
+
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+)
+
+// CreateDerivedAccount is not yet implemented for kvdb.
+func (s *Store) CreateDerivedAccount(ctx context.Context,
+	_ db.CreateDerivedAccountParams) (*db.AccountInfo, error) {
+
+	return nil, notImplemented(ctx, "CreateDerivedAccount")
+}
+
+// CreateImportedAccount is not yet implemented for kvdb.
+func (s *Store) CreateImportedAccount(ctx context.Context,
+	_ db.CreateImportedAccountParams) (*db.AccountProperties, error) {
+
+	return nil, notImplemented(ctx, "CreateImportedAccount")
+}
+
+// GetAccount is not yet implemented for kvdb.
+func (s *Store) GetAccount(ctx context.Context,
+	_ db.GetAccountQuery) (*db.AccountInfo, error) {
+
+	return nil, notImplemented(ctx, "GetAccount")
+}
+
+// ListAccounts is not yet implemented for kvdb.
+func (s *Store) ListAccounts(ctx context.Context,
+	_ db.ListAccountsQuery) ([]db.AccountInfo, error) {
+
+	return nil, notImplemented(ctx, "ListAccounts")
+}
+
+// RenameAccount is not yet implemented for kvdb.
+func (s *Store) RenameAccount(ctx context.Context,
+	_ db.RenameAccountParams) error {
+
+	return notImplemented(ctx, "RenameAccount")
+}

--- a/wallet/internal/db/kvdb/addressstore.go
+++ b/wallet/internal/db/kvdb/addressstore.go
@@ -1,0 +1,70 @@
+package kvdb
+
+import (
+	"context"
+	"iter"
+
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/db/page"
+)
+
+// NewDerivedAddress is not yet implemented for kvdb.
+func (s *Store) NewDerivedAddress(ctx context.Context,
+	_ db.NewDerivedAddressParams,
+	_ db.AddressDerivationFunc) (*db.AddressInfo, error) {
+
+	return nil, notImplemented(ctx, "NewDerivedAddress")
+}
+
+// NewImportedAddress is not yet implemented for kvdb.
+func (s *Store) NewImportedAddress(ctx context.Context,
+	_ db.NewImportedAddressParams) (*db.AddressInfo, error) {
+
+	return nil, notImplemented(ctx, "NewImportedAddress")
+}
+
+// GetAddress is not yet implemented for kvdb.
+func (s *Store) GetAddress(ctx context.Context,
+	_ db.GetAddressQuery) (*db.AddressInfo, error) {
+
+	return nil, notImplemented(ctx, "GetAddress")
+}
+
+// ListAddresses is not yet implemented for kvdb.
+func (s *Store) ListAddresses(ctx context.Context,
+	_ db.ListAddressesQuery) (page.Result[db.AddressInfo, uint32], error) {
+
+	return page.Result[db.AddressInfo, uint32]{}, notImplemented(
+		ctx, "ListAddresses",
+	)
+}
+
+// IterAddresses is not yet implemented for kvdb.
+func (s *Store) IterAddresses(ctx context.Context,
+	_ db.ListAddressesQuery) iter.Seq2[db.AddressInfo, error] {
+
+	return func(yield func(db.AddressInfo, error) bool) {
+		yield(db.AddressInfo{}, notImplemented(ctx, "IterAddresses"))
+	}
+}
+
+// GetAddressSecret is not yet implemented for kvdb.
+func (s *Store) GetAddressSecret(ctx context.Context,
+	_ db.GetAddressSecretQuery) (*db.AddressSecret, error) {
+
+	return nil, notImplemented(ctx, "GetAddressSecret")
+}
+
+// ListAddressTypes is not yet implemented for kvdb.
+func (s *Store) ListAddressTypes(ctx context.Context) (
+	[]db.AddressTypeInfo, error) {
+
+	return nil, notImplemented(ctx, "ListAddressTypes")
+}
+
+// GetAddressType is not yet implemented for kvdb.
+func (s *Store) GetAddressType(ctx context.Context,
+	_ db.AddressType) (db.AddressTypeInfo, error) {
+
+	return db.AddressTypeInfo{}, notImplemented(ctx, "GetAddressType")
+}

--- a/wallet/internal/db/kvdb/driver.go
+++ b/wallet/internal/db/kvdb/driver.go
@@ -12,19 +12,23 @@ import (
 // NOTE: This is a partial implementation that will be expanded as the wallet
 // UTXO manager migrates to the new db interfaces.
 type Store struct {
-	db      walletdb.DB
-	txStore wtxmgr.TxStore
+	db        walletdb.DB
+	txStore   wtxmgr.TxStore
+	addrStore any
 }
 
 // A compile-time assertion to ensure that Store implements the db.Store
 // interface.
 var _ db.Store = (*Store)(nil)
 
-// NewStore creates a new kvdb-backed UTXO store.
-func NewStore(dbConn walletdb.DB, txStore wtxmgr.TxStore) *Store {
+// NewStore creates a new kvdb-backed wallet store adapter.
+func NewStore(dbConn walletdb.DB, txStore wtxmgr.TxStore,
+	addrStore any) *Store {
+
 	return &Store{
-		db:      dbConn,
-		txStore: txStore,
+		db:        dbConn,
+		txStore:   txStore,
+		addrStore: addrStore,
 	}
 }
 

--- a/wallet/internal/db/kvdb/txstore_test.go
+++ b/wallet/internal/db/kvdb/txstore_test.go
@@ -22,7 +22,7 @@ func TestUpdateTxLabelOnlySuccess(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	txStore := newTxStore(t, dbConn)
-	store := NewStore(dbConn, txStore)
+	store := NewStore(dbConn, txStore, nil)
 
 	txMsg := &wire.MsgTx{Version: 1}
 	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
@@ -71,7 +71,7 @@ func TestUpdateTxLabelOnlyNotFound(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	txStore := newTxStore(t, dbConn)
-	store := NewStore(dbConn, txStore)
+	store := NewStore(dbConn, txStore, nil)
 
 	label := "missing"
 	err := store.UpdateTx(t.Context(), db.UpdateTxParams{
@@ -91,7 +91,7 @@ func TestUpdateTxRejectsUnsupportedPatches(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	txStore := newTxStore(t, dbConn)
-	store := NewStore(dbConn, txStore)
+	store := NewStore(dbConn, txStore, nil)
 
 	state := &db.UpdateTxState{Status: db.TxStatusPublished}
 	err := store.UpdateTx(t.Context(), db.UpdateTxParams{
@@ -111,7 +111,7 @@ func TestUpdateTxEmptyLabelPreservesLegacyError(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	txStore := newTxStore(t, dbConn)
-	store := NewStore(dbConn, txStore)
+	store := NewStore(dbConn, txStore, nil)
 
 	txMsg := &wire.MsgTx{Version: 1}
 	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
@@ -147,7 +147,7 @@ func TestUpdateTxLongLabelPreservesLegacyError(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	txStore := newTxStore(t, dbConn)
-	store := NewStore(dbConn, txStore)
+	store := NewStore(dbConn, txStore, nil)
 
 	txMsg := &wire.MsgTx{Version: 1}
 	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
@@ -184,7 +184,7 @@ func TestGetTxSummarySuccess(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	txStore := newTxStore(t, dbConn)
-	store := NewStore(dbConn, txStore)
+	store := NewStore(dbConn, txStore, nil)
 
 	txMsg := &wire.MsgTx{Version: 1}
 	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
@@ -223,7 +223,7 @@ func TestGetTxDetailSuccess(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	txStore := newTxStore(t, dbConn)
-	store := NewStore(dbConn, txStore)
+	store := NewStore(dbConn, txStore, nil)
 
 	funding, spend := insertSpendChain(t, dbConn, txStore)
 
@@ -254,7 +254,7 @@ func TestGetTxSummaryNotFound(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	txStore := newTxStore(t, dbConn)
-	store := NewStore(dbConn, txStore)
+	store := NewStore(dbConn, txStore, nil)
 
 	_, err := store.GetTx(t.Context(), db.GetTxQuery{
 		WalletID: 0,
@@ -272,7 +272,7 @@ func TestListTxnsSummaryUnminedOnlySuccess(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	txStore := newTxStore(t, dbConn)
-	store := NewStore(dbConn, txStore)
+	store := NewStore(dbConn, txStore, nil)
 
 	txMsg := &wire.MsgTx{Version: 1}
 	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
@@ -310,7 +310,7 @@ func TestListTxnsSummaryConfirmedRangeSuccess(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	txStore := newTxStore(t, dbConn)
-	store := NewStore(dbConn, txStore)
+	store := NewStore(dbConn, txStore, nil)
 
 	rec := insertConfirmedTx(t, dbConn, txStore, 144)
 
@@ -338,7 +338,7 @@ func TestListTxnsSummaryBoundedRange(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	txStore := newTxStore(t, dbConn)
-	store := NewStore(dbConn, txStore)
+	store := NewStore(dbConn, txStore, nil)
 
 	insideLow := insertConfirmedTxWithSeed(t, dbConn, txStore, 144, 1)
 	insideHigh := insertConfirmedTxWithSeed(t, dbConn, txStore, 145, 2)
@@ -370,7 +370,7 @@ func TestListTxDetailsCopiesMsgTx(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	txStore := newTxStore(t, dbConn)
-	store := NewStore(dbConn, txStore)
+	store := NewStore(dbConn, txStore, nil)
 
 	firstTx := &wire.MsgTx{Version: 1}
 	firstTx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{

--- a/wallet/internal/db/kvdb/utxostore_test.go
+++ b/wallet/internal/db/kvdb/utxostore_test.go
@@ -21,7 +21,7 @@ func TestReleaseOutputSuccess(t *testing.T) {
 	t.Cleanup(cleanup)
 
 	txStore := newTxStore(t, dbConn)
-	store := NewStore(dbConn, txStore)
+	store := NewStore(dbConn, txStore, nil)
 
 	lockID := wtxmgr.LockID{1}
 	op := wire.OutPoint{Hash: [32]byte{1}, Index: 0}
@@ -102,7 +102,7 @@ func TestReleaseOutputMissingNamespace(t *testing.T) {
 	dbConn, cleanup := newTestDB(t)
 	t.Cleanup(cleanup)
 
-	store := NewStore(dbConn, nil)
+	store := NewStore(dbConn, nil, nil)
 
 	err := store.ReleaseOutput(t.Context(), db.ReleaseOutputParams{
 		WalletID: 0,

--- a/wallet/internal/db/kvdb/walletstore.go
+++ b/wallet/internal/db/kvdb/walletstore.go
@@ -1,0 +1,65 @@
+package kvdb
+
+import (
+	"context"
+	"iter"
+
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/db/page"
+)
+
+// A compile-time assertion to ensure Store implements the wallet store.
+var _ db.WalletStore = (*Store)(nil)
+
+// CreateWallet is not yet implemented for kvdb.
+func (s *Store) CreateWallet(ctx context.Context,
+	_ db.CreateWalletParams) (*db.WalletInfo, error) {
+
+	return nil, notImplemented(ctx, "CreateWallet")
+}
+
+// GetWallet is not yet implemented for kvdb.
+func (s *Store) GetWallet(ctx context.Context,
+	_ string) (*db.WalletInfo, error) {
+
+	return nil, notImplemented(ctx, "GetWallet")
+}
+
+// ListWallets is not yet implemented for kvdb.
+func (s *Store) ListWallets(ctx context.Context,
+	_ db.ListWalletsQuery) (page.Result[db.WalletInfo, uint32], error) {
+
+	return page.Result[db.WalletInfo, uint32]{}, notImplemented(
+		ctx, "ListWallets",
+	)
+}
+
+// IterWallets is not yet implemented for kvdb.
+func (s *Store) IterWallets(ctx context.Context,
+	_ db.ListWalletsQuery) iter.Seq2[db.WalletInfo, error] {
+
+	return func(yield func(db.WalletInfo, error) bool) {
+		yield(db.WalletInfo{}, notImplemented(ctx, "IterWallets"))
+	}
+}
+
+// UpdateWallet is not yet implemented for kvdb.
+func (s *Store) UpdateWallet(ctx context.Context,
+	_ db.UpdateWalletParams) error {
+
+	return notImplemented(ctx, "UpdateWallet")
+}
+
+// GetEncryptedHDSeed is not yet implemented for kvdb.
+func (s *Store) GetEncryptedHDSeed(ctx context.Context,
+	_ uint32) ([]byte, error) {
+
+	return nil, notImplemented(ctx, "GetEncryptedHDSeed")
+}
+
+// UpdateWalletSecrets is not yet implemented for kvdb.
+func (s *Store) UpdateWalletSecrets(ctx context.Context,
+	_ db.UpdateWalletSecretsParams) error {
+
+	return notImplemented(ctx, "UpdateWalletSecrets")
+}

--- a/wallet/internal/keyvault/keyvault.go
+++ b/wallet/internal/keyvault/keyvault.go
@@ -1,0 +1,17 @@
+// Package keyvault defines the wallet key-material encryption boundary.
+package keyvault
+
+import "github.com/btcsuite/btcwallet/waddrmgr"
+
+// Vault provides encryption and decryption for wallet key material.
+type Vault interface {
+	// Encrypt encrypts plaintext key material with the selected key type.
+	Encrypt(keyType waddrmgr.CryptoKeyType, plaintext []byte) ([]byte, error)
+
+	// Decrypt decrypts ciphertext key material with the selected key type.
+	Decrypt(keyType waddrmgr.CryptoKeyType, ciphertext []byte) ([]byte, error)
+}
+
+// A compile-time assertion to ensure the legacy address manager satisfies the
+// keyvault boundary.
+var _ Vault = (*waddrmgr.Manager)(nil)

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -301,7 +301,7 @@ func (m *Manager) Load(cfg Config) (*Wallet, error) {
 		cfg:         cfg,
 		id:          walletID,
 		addrStore:   addrMgr,
-		store:       kvdb.NewStore(cfg.DB, txMgr),
+		store:       kvdb.NewStore(cfg.DB, txMgr, addrMgr),
 		txStore:     txMgr,
 		requestChan: make(chan any),
 		lifetimeCtx: lifetimeCtx,

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -302,6 +302,7 @@ func (m *Manager) Load(cfg Config) (*Wallet, error) {
 		id:          walletID,
 		addrStore:   addrMgr,
 		store:       kvdb.NewStore(cfg.DB, txMgr, addrMgr),
+		keyVault:    addrMgr,
 		txStore:     txMgr,
 		requestChan: make(chan any),
 		lifetimeCtx: lifetimeCtx,

--- a/wallet/mock_test.go
+++ b/wallet/mock_test.go
@@ -9,6 +9,7 @@ package wallet
 
 import (
 	"context"
+	"iter"
 	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -22,6 +23,7 @@ import (
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/db/page"
 	dbruntime "github.com/btcsuite/btcwallet/wallet/internal/db/runtime"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
@@ -104,6 +106,111 @@ func (m *mockStore) RenameAccount(ctx context.Context,
 	args := m.Called(ctx, params)
 
 	return args.Error(0)
+}
+
+// NewDerivedAddress implements the db.AddressStore interface.
+func (m *mockStore) NewDerivedAddress(ctx context.Context,
+	params db.NewDerivedAddressParams,
+	deriveFn db.AddressDerivationFunc) (*db.AddressInfo, error) {
+
+	args := m.Called(ctx, params, deriveFn)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*db.AddressInfo), args.Error(1)
+}
+
+// NewImportedAddress implements the db.AddressStore interface.
+func (m *mockStore) NewImportedAddress(ctx context.Context,
+	params db.NewImportedAddressParams) (*db.AddressInfo, error) {
+
+	args := m.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*db.AddressInfo), args.Error(1)
+}
+
+// GetAddress implements the db.AddressStore interface.
+func (m *mockStore) GetAddress(ctx context.Context,
+	query db.GetAddressQuery) (*db.AddressInfo, error) {
+
+	args := m.Called(ctx, query)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*db.AddressInfo), args.Error(1)
+}
+
+// ListAddresses implements the db.AddressStore interface.
+func (m *mockStore) ListAddresses(ctx context.Context,
+	query db.ListAddressesQuery) (page.Result[db.AddressInfo, uint32], error) {
+
+	args := m.Called(ctx, query)
+
+	result, ok := args.Get(0).(page.Result[db.AddressInfo, uint32])
+	if !ok {
+		return page.Result[db.AddressInfo, uint32]{}, args.Error(1)
+	}
+
+	return result, args.Error(1)
+}
+
+// IterAddresses implements the db.AddressStore interface.
+func (m *mockStore) IterAddresses(ctx context.Context,
+	query db.ListAddressesQuery) iter.Seq2[db.AddressInfo, error] {
+
+	args := m.Called(ctx, query)
+
+	seq, ok := args.Get(0).(iter.Seq2[db.AddressInfo, error])
+	if ok {
+		return seq
+	}
+
+	return func(yield func(db.AddressInfo, error) bool) {
+		yield(db.AddressInfo{}, args.Error(1))
+	}
+}
+
+// GetAddressSecret implements the db.AddressStore interface.
+func (m *mockStore) GetAddressSecret(ctx context.Context,
+	query db.GetAddressSecretQuery) (*db.AddressSecret, error) {
+
+	args := m.Called(ctx, query)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*db.AddressSecret), args.Error(1)
+}
+
+// ListAddressTypes implements the db.AddressStore interface.
+func (m *mockStore) ListAddressTypes(ctx context.Context) (
+	[]db.AddressTypeInfo, error) {
+
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).([]db.AddressTypeInfo), args.Error(1)
+}
+
+// GetAddressType implements the db.AddressStore interface.
+func (m *mockStore) GetAddressType(ctx context.Context,
+	id db.AddressType) (db.AddressTypeInfo, error) {
+
+	args := m.Called(ctx, id)
+
+	result, ok := args.Get(0).(db.AddressTypeInfo)
+	if !ok {
+		return db.AddressTypeInfo{}, args.Error(1)
+	}
+
+	return result, args.Error(1)
 }
 
 // GetUtxo implements the db.UTXOStore interface.

--- a/wallet/mock_test.go
+++ b/wallet/mock_test.go
@@ -49,6 +49,63 @@ func (m *mockStore) StatsSnapshot() dbruntime.StatsSnapshot {
 	return dbruntime.StatsSnapshot{}
 }
 
+// CreateDerivedAccount implements the db.AccountStore interface.
+func (m *mockStore) CreateDerivedAccount(ctx context.Context,
+	params db.CreateDerivedAccountParams) (*db.AccountInfo, error) {
+
+	args := m.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*db.AccountInfo), args.Error(1)
+}
+
+// CreateImportedAccount implements the db.AccountStore interface.
+func (m *mockStore) CreateImportedAccount(ctx context.Context,
+	params db.CreateImportedAccountParams) (*db.AccountProperties, error) {
+
+	args := m.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*db.AccountProperties), args.Error(1)
+}
+
+// GetAccount implements the db.AccountStore interface.
+func (m *mockStore) GetAccount(ctx context.Context,
+	query db.GetAccountQuery) (*db.AccountInfo, error) {
+
+	args := m.Called(ctx, query)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*db.AccountInfo), args.Error(1)
+}
+
+// ListAccounts implements the db.AccountStore interface.
+func (m *mockStore) ListAccounts(ctx context.Context,
+	query db.ListAccountsQuery) ([]db.AccountInfo, error) {
+
+	args := m.Called(ctx, query)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).([]db.AccountInfo), args.Error(1)
+}
+
+// RenameAccount implements the db.AccountStore interface.
+func (m *mockStore) RenameAccount(ctx context.Context,
+	params db.RenameAccountParams) error {
+
+	args := m.Called(ctx, params)
+
+	return args.Error(0)
+}
+
 // GetUtxo implements the db.UTXOStore interface.
 func (m *mockStore) GetUtxo(ctx context.Context,
 	query db.GetUtxoQuery) (*db.UtxoInfo, error) {

--- a/wallet/mock_test.go
+++ b/wallet/mock_test.go
@@ -51,6 +51,90 @@ func (m *mockStore) StatsSnapshot() dbruntime.StatsSnapshot {
 	return dbruntime.StatsSnapshot{}
 }
 
+// CreateWallet implements the db.WalletStore interface.
+func (m *mockStore) CreateWallet(ctx context.Context,
+	params db.CreateWalletParams) (*db.WalletInfo, error) {
+
+	args := m.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*db.WalletInfo), args.Error(1)
+}
+
+// GetWallet implements the db.WalletStore interface.
+func (m *mockStore) GetWallet(ctx context.Context,
+	name string) (*db.WalletInfo, error) {
+
+	args := m.Called(ctx, name)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*db.WalletInfo), args.Error(1)
+}
+
+// ListWallets implements the db.WalletStore interface.
+func (m *mockStore) ListWallets(ctx context.Context,
+	query db.ListWalletsQuery) (page.Result[db.WalletInfo, uint32], error) {
+
+	args := m.Called(ctx, query)
+
+	result, ok := args.Get(0).(page.Result[db.WalletInfo, uint32])
+	if !ok {
+		return page.Result[db.WalletInfo, uint32]{}, args.Error(1)
+	}
+
+	return result, args.Error(1)
+}
+
+// IterWallets implements the db.WalletStore interface.
+func (m *mockStore) IterWallets(ctx context.Context,
+	query db.ListWalletsQuery) iter.Seq2[db.WalletInfo, error] {
+
+	args := m.Called(ctx, query)
+
+	seq, ok := args.Get(0).(iter.Seq2[db.WalletInfo, error])
+	if ok {
+		return seq
+	}
+
+	return func(yield func(db.WalletInfo, error) bool) {
+		yield(db.WalletInfo{}, args.Error(1))
+	}
+}
+
+// UpdateWallet implements the db.WalletStore interface.
+func (m *mockStore) UpdateWallet(ctx context.Context,
+	params db.UpdateWalletParams) error {
+
+	args := m.Called(ctx, params)
+
+	return args.Error(0)
+}
+
+// GetEncryptedHDSeed implements the db.WalletStore interface.
+func (m *mockStore) GetEncryptedHDSeed(ctx context.Context,
+	walletID uint32) ([]byte, error) {
+
+	args := m.Called(ctx, walletID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+// UpdateWalletSecrets implements the db.WalletStore interface.
+func (m *mockStore) UpdateWalletSecrets(ctx context.Context,
+	params db.UpdateWalletSecretsParams) error {
+
+	args := m.Called(ctx, params)
+
+	return args.Error(0)
+}
+
 // CreateDerivedAccount implements the db.AccountStore interface.
 func (m *mockStore) CreateDerivedAccount(ctx context.Context,
 	params db.CreateDerivedAccountParams) (*db.AccountInfo, error) {

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -23,6 +23,7 @@ import (
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/keyvault"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 )
@@ -338,6 +339,9 @@ type Wallet struct {
 	// txStore is the transaction manager responsible for storing and
 	// querying the wallet's transaction history and unspent outputs.
 	txStore wtxmgr.TxStore
+
+	// keyVault provides encryption and decryption for wallet key material.
+	keyVault keyvault.Vault
 
 	// store provides access to database operations used by wallet managers.
 	//


### PR DESCRIPTION
## Summary
- Add shared account/address validation and embed account/address store APIs into `db.Store`.
- Thread the kvdb address store through wallet store construction.
- Add the wallet keyvault bridge and align address metadata contracts for later store routing.

## Tests
- `GOWORK=off go test ./wallet/internal/db/kvdb ./wallet/internal/db/sqlite ./wallet/internal/db/pg ./wallet`