### PR TITLE
wallet: migrate wallet metadata to db.Store

### DIFF
--- a/bwtest/mock/account_store.go
+++ b/bwtest/mock/account_store.go
@@ -29,6 +29,12 @@ func (m *AccountStore) Scope() waddrmgr.KeyScope {
 	return args.Get(0).(waddrmgr.KeyScope)
 }
 
+// AddrSchema implements the waddrmgr.AccountStore interface.
+func (m *AccountStore) AddrSchema() waddrmgr.ScopeAddrSchema {
+	args := m.Called()
+	return args.Get(0).(waddrmgr.ScopeAddrSchema)
+}
+
 // AccountProperties implements the waddrmgr.AccountStore interface.
 func (m *AccountStore) AccountProperties(ns walletdb.ReadBucket,
 	account uint32) (*waddrmgr.AccountProperties, error) {

--- a/waddrmgr/interface.go
+++ b/waddrmgr/interface.go
@@ -204,6 +204,13 @@ type AccountStore interface {
 	// Scope returns the key scope of the manager.
 	Scope() KeyScope
 
+	// AddrSchema returns the persisted address schema for this scope. The
+	// returned value matches what was passed to the underlying
+	// ScopedKeyManager at creation time, so callers building public
+	// AccountInfo rows can use it instead of recomputing from the global
+	// default map.
+	AddrSchema() ScopeAddrSchema
+
 	// AccountProperties returns the properties of an account, including
 	// address indexes and name.
 	AccountProperties(ns walletdb.ReadBucket,

--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -242,6 +242,20 @@ func propertiesToAccountInfo(props *waddrmgr.AccountProperties,
 		fingerprint = props.MasterKeyFingerprint
 	}
 
+	scope := db.KeyScope(props.KeyScope)
+	addrSchema := db.ScopeAddrMap[scope]
+
+	if props.AddrSchema != nil {
+		override, err := db.ScopeAddrSchemaFromWaddrmgr(*props.AddrSchema)
+		if err != nil {
+			log.Errorf("propertiesToAccountInfo: skipping invalid "+
+				"AddrSchema override (%v); falling back to scope "+
+				"default", err)
+		} else {
+			addrSchema = override
+		}
+	}
+
 	return db.AccountInfo{
 		AccountNumber:        accountNumber,
 		AccountName:          props.AccountName,
@@ -250,7 +264,8 @@ func propertiesToAccountInfo(props *waddrmgr.AccountProperties,
 		InternalKeyCount:     props.InternalKeyCount,
 		ImportedKeyCount:     props.ImportedKeyCount,
 		IsWatchOnly:          isWatchOnly,
-		KeyScope:             db.KeyScope(props.KeyScope),
+		KeyScope:             scope,
+		AddrSchema:           addrSchema,
 		PublicKey:            pubKey,
 		MasterKeyFingerprint: fingerprint,
 		ConfirmedBalance:     total,

--- a/wallet/common_test.go
+++ b/wallet/common_test.go
@@ -11,6 +11,7 @@ import (
 	bwmock "github.com/btcsuite/btcwallet/bwtest/mock"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	walletmock "github.com/btcsuite/btcwallet/wallet/internal/bwtest/mock"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
 	"github.com/stretchr/testify/mock"
@@ -197,9 +198,14 @@ func createStartedWalletWithID(t *testing.T, walletID uint32) (*Wallet,
 	w, deps := createTestWalletWithMocks(t)
 	w.id = walletID
 
-	// Mock the birthday block to be present.
-	deps.addrStore.On("BirthdayBlock", mock.Anything).
-		Return(waddrmgr.BlockStamp{}, true, nil).
+	// Mock the wallet metadata read — verifyBirthday calls
+	// store.GetWallet on startup. Returning a non-nil
+	// BirthdayBlock makes verifyBirthday take the verified
+	// short-circuit branch.
+	deps.store.On("GetWallet", mock.Anything, mock.Anything).
+		Return(&db.WalletInfo{
+			BirthdayBlock: &db.Block{},
+		}, nil).
 		Once()
 
 	// Allow SyncedTo to be called any number of times (background sync).

--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -603,12 +603,26 @@ func (w *Wallet) verifyBirthday(ctx context.Context) error {
 		return fmt.Errorf("locate birthday block: %w", err)
 	}
 
-	err = w.DBPutBirthdayBlock(ctx, *newBirthdayBlock)
+	storeBlock, err := db.BlockFromBlockStamp(*newBirthdayBlock)
+	if err != nil {
+		return fmt.Errorf("block from stamp: %w", err)
+	}
+
+	// Use walletInfo.ID instead of w.cfg's cached value: Manager.Load
+	// currently initializes the in-memory id to zero, but the store row
+	// we just read carries the authoritative wallet ID.
+	err = w.store.UpdateWallet(
+		ctx, db.UpdateWalletParams{
+			WalletID:      walletInfo.ID,
+			BirthdayBlock: storeBlock,
+			SyncedTo:      storeBlock,
+		},
+	)
 	if err != nil {
 		log.Errorf("Unable to sanity check wallet birthday "+
 			"block: %v", err)
 
-		return err
+		return fmt.Errorf("update birthday block: %w", err)
 	}
 
 	w.birthdayBlock = *newBirthdayBlock

--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 )
 
 const (
@@ -567,24 +568,23 @@ func (w *Wallet) mainLoop() {
 //     wallet's sync tip to this point to ensure a clean rescan range.
 //  6. Update the memory cache.
 func (w *Wallet) verifyBirthday(ctx context.Context) error {
-	// We'll start by fetching our wallet's birthday block.
-	birthdayBlock, verified, err := w.DBGetBirthdayBlock(ctx)
+	walletInfo, err := w.store.GetWallet(ctx, w.cfg.Name)
 	if err != nil {
-		var mgrErr waddrmgr.ManagerError
-		if !errors.As(err, &mgrErr) ||
-			mgrErr.ErrorCode != waddrmgr.ErrBirthdayBlockNotSet {
+		log.Errorf("Unable to sanity check wallet birthday block: %v", err)
 
-			log.Errorf("Unable to sanity check wallet birthday "+
-				"block: %v", err)
-
-			return err
-		}
-		// If not set, we proceed to locate it.
+		return fmt.Errorf("get wallet birthday: %w", err)
 	}
 
 	// If the birthday block has already been verified, we initialize the
 	// cache and exit our sanity check to avoid redundant lookups.
-	if verified {
+	if walletInfo.BirthdayBlock != nil {
+		birthdayBlock, err := db.BlockStampFromBlock(
+			walletInfo.BirthdayBlock,
+		)
+		if err != nil {
+			return fmt.Errorf("decode birthday block: %w", err)
+		}
+
 		log.Infof("Birthday block verified: height=%d, hash=%v",
 			birthdayBlock.Height, birthdayBlock.Hash)
 		w.birthdayBlock = birthdayBlock
@@ -593,14 +593,14 @@ func (w *Wallet) verifyBirthday(ctx context.Context) error {
 	}
 	// Otherwise, we'll attempt to locate a better one now that we have
 	// access to the chain.
-	timestamp := w.addrStore.Birthday()
+	timestamp := walletInfo.Birthday
 
 	newBirthdayBlock, err := locateBirthdayBlock(w.cfg.Chain, timestamp)
 	if err != nil {
 		log.Errorf("Unable to sanity check wallet birthday "+
 			"block: %v", err)
 
-		return err
+		return fmt.Errorf("locate birthday block: %w", err)
 	}
 
 	err = w.DBPutBirthdayBlock(ctx, *newBirthdayBlock)

--- a/wallet/controller_test.go
+++ b/wallet/controller_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	bwmock "github.com/btcsuite/btcwallet/bwtest/mock"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -248,10 +249,9 @@ func TestControllerStart(t *testing.T) {
 
 	// 1. Mock verifyBirthday: Expect a call to retrieve the birthday
 	//    block.
-	bs := waddrmgr.BlockStamp{Height: 100}
-	deps.addrStore.On(
-		"BirthdayBlock", mock.Anything,
-	).Return(bs, true, nil).Once()
+	deps.store.On("GetWallet", mock.Anything, mock.Anything).Return(
+		&db.WalletInfo{BirthdayBlock: &db.Block{Height: 100}}, nil,
+	).Once()
 
 	// 2. Mock DBGetAllAccounts: Expect a call to load active account
 	//    managers.
@@ -425,8 +425,13 @@ func TestControllerVerifyBirthday_Verified(t *testing.T) {
 	// Arrange: Setup a wallet where the birthday block is already verified.
 	w, deps := createTestWalletWithMocks(t)
 	bs := waddrmgr.BlockStamp{Height: 123, Hash: chainhash.Hash{0x01}}
-	deps.addrStore.On("BirthdayBlock", mock.Anything).Return(
-		bs, true, nil).Once()
+	deps.store.On("GetWallet", mock.Anything, mock.Anything).Return(
+		&db.WalletInfo{
+			BirthdayBlock: &db.Block{
+				Height: 123,
+				Hash:   chainhash.Hash{0x01},
+			},
+		}, nil).Once()
 
 	// Act: Verify birthday.
 	err := w.verifyBirthday(t.Context())
@@ -445,11 +450,8 @@ func TestControllerVerifyBirthday_LocateFail(t *testing.T) {
 	// and chain lookup fails.
 	w, deps := createTestWalletWithMocks(t)
 
-	deps.addrStore.On("BirthdayBlock", mock.Anything).Return(
-		waddrmgr.BlockStamp{}, false, waddrmgr.ManagerError{
-			ErrorCode: waddrmgr.ErrBirthdayBlockNotSet,
-		}).Once()
-	deps.addrStore.On("Birthday").Return(time.Now()).Once()
+	deps.store.On("GetWallet", mock.Anything, mock.Anything).Return(
+		&db.WalletInfo{Birthday: time.Now()}, nil).Once()
 	deps.chain.On("GetBestBlock").Return(nil, int32(0), errChainMock).Once()
 
 	// Act: Attempt to verify birthday.
@@ -468,11 +470,8 @@ func TestControllerVerifyBirthday_PutFail(t *testing.T) {
 	// persisting the birthday block fails.
 	w, deps := createTestWalletWithMocks(t)
 
-	deps.addrStore.On("BirthdayBlock", mock.Anything).Return(
-		waddrmgr.BlockStamp{}, false, waddrmgr.ManagerError{
-			ErrorCode: waddrmgr.ErrBirthdayBlockNotSet,
-		}).Once()
-	deps.addrStore.On("Birthday").Return(time.Now()).Once()
+	deps.store.On("GetWallet", mock.Anything, mock.Anything).Return(
+		&db.WalletInfo{Birthday: time.Now()}, nil).Once()
 	deps.chain.On("GetBestBlock").Return(
 		&chainhash.Hash{}, int32(100), nil).Once()
 	deps.chain.On("GetBlockHash", mock.Anything).Return(
@@ -536,9 +535,8 @@ func TestControllerStop(t *testing.T) {
 	w, deps := createTestWalletWithMocks(t)
 
 	// Setup mocks for the startup sequence.
-	deps.addrStore.On(
-		"BirthdayBlock", mock.Anything,
-	).Return(waddrmgr.BlockStamp{}, true, nil).Once()
+	deps.store.On("GetWallet", mock.Anything, mock.Anything).Return(
+		&db.WalletInfo{BirthdayBlock: &db.Block{}}, nil).Once()
 	deps.addrStore.On(
 		"ActiveScopedKeyManagers",
 	).Return([]waddrmgr.AccountStore(nil)).Once()
@@ -584,9 +582,8 @@ func TestControllerLock(t *testing.T) {
 	w, deps := createTestWalletWithMocks(t)
 
 	// Setup mocks for startup.
-	deps.addrStore.On(
-		"BirthdayBlock", mock.Anything,
-	).Return(waddrmgr.BlockStamp{}, true, nil).Once()
+	deps.store.On("GetWallet", mock.Anything, mock.Anything).Return(
+		&db.WalletInfo{BirthdayBlock: &db.Block{}}, nil).Once()
 	deps.addrStore.On(
 		"ActiveScopedKeyManagers",
 	).Return([]waddrmgr.AccountStore(nil)).Once()
@@ -626,9 +623,8 @@ func TestControllerUnlock(t *testing.T) {
 	w, deps := createTestWalletWithMocks(t)
 
 	// Setup mocks for startup.
-	deps.addrStore.On(
-		"BirthdayBlock", mock.Anything,
-	).Return(waddrmgr.BlockStamp{}, true, nil).Once()
+	deps.store.On("GetWallet", mock.Anything, mock.Anything).Return(
+		&db.WalletInfo{BirthdayBlock: &db.Block{}}, nil).Once()
 	deps.addrStore.On(
 		"ActiveScopedKeyManagers",
 	).Return([]waddrmgr.AccountStore(nil)).Once()
@@ -668,9 +664,8 @@ func TestControllerChangePassphrase(t *testing.T) {
 	w, deps := createTestWalletWithMocks(t)
 
 	// Setup mocks for startup.
-	deps.addrStore.On(
-		"BirthdayBlock", mock.Anything,
-	).Return(waddrmgr.BlockStamp{}, true, nil).Once()
+	deps.store.On("GetWallet", mock.Anything, mock.Anything).Return(
+		&db.WalletInfo{BirthdayBlock: &db.Block{}}, nil).Once()
 	deps.addrStore.On(
 		"ActiveScopedKeyManagers",
 	).Return([]waddrmgr.AccountStore(nil)).Once()
@@ -797,10 +792,9 @@ func TestControllerStart_WithAccounts(t *testing.T) {
 	// Arrange: Setup a wallet with existing accounts in the address store.
 	w, deps := createTestWalletWithMocks(t)
 
-	bs := waddrmgr.BlockStamp{Height: 100}
-	deps.addrStore.On(
-		"BirthdayBlock", mock.Anything,
-	).Return(bs, true, nil).Once()
+	deps.store.On("GetWallet", mock.Anything, mock.Anything).Return(
+		&db.WalletInfo{BirthdayBlock: &db.Block{Height: 100}}, nil,
+	).Once()
 
 	scopedMgr := &bwmock.AccountStore{}
 	deps.addrStore.On(
@@ -1187,9 +1181,10 @@ func TestControllerInfo(t *testing.T) {
 	w, deps := createTestWalletWithMocks(t)
 
 	bs := waddrmgr.BlockStamp{Height: 100}
-	deps.addrStore.On(
-		"BirthdayBlock", mock.Anything,
-	).Return(bs, true, nil).Once()
+	deps.store.On("GetWallet", mock.Anything, mock.Anything).Return(
+		&db.WalletInfo{
+			BirthdayBlock: &db.Block{Height: 100},
+		}, nil).Once()
 	deps.addrStore.On(
 		"ActiveScopedKeyManagers",
 	).Return([]waddrmgr.AccountStore(nil)).Once()
@@ -1316,12 +1311,12 @@ func TestControllerRescan(t *testing.T) {
 func TestControllerStart_VerifyBirthdayFail(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Setup mock expectations where birthday block lookup fails.
+	// Arrange: Setup mock expectations where GetWallet fails.
 	w, deps := createTestWalletWithMocks(t)
 
-	deps.addrStore.On(
-		"BirthdayBlock", mock.Anything,
-	).Return(waddrmgr.BlockStamp{}, false, errDBMock).Once()
+	deps.store.On(
+		"GetWallet", mock.Anything, mock.Anything,
+	).Return(nil, errDBMock).Once()
 
 	// Act: Attempt to start the wallet.
 	err := w.Start(t.Context())
@@ -1340,10 +1335,9 @@ func TestControllerStart_DBGetAllAccountsFail(t *testing.T) {
 	// startup.
 	w, deps := createTestWalletWithMocks(t)
 
-	bs := waddrmgr.BlockStamp{Height: 100}
-	deps.addrStore.On(
-		"BirthdayBlock", mock.Anything,
-	).Return(bs, true, nil).Once()
+	deps.store.On(
+		"GetWallet", mock.Anything, mock.Anything,
+	).Return(&db.WalletInfo{BirthdayBlock: &db.Block{}}, nil).Once()
 
 	mockScopedMgr := &bwmock.AccountStore{}
 	deps.addrStore.On(
@@ -1371,14 +1365,9 @@ func TestControllerStart_BirthdayNotSet(t *testing.T) {
 	// and must be located from the chain.
 	w, deps := createTestWalletWithMocks(t)
 
-	deps.addrStore.On(
-		"BirthdayBlock", mock.Anything,
-	).Return(waddrmgr.BlockStamp{}, false, waddrmgr.ManagerError{
-		ErrorCode: waddrmgr.ErrBirthdayBlockNotSet,
-	}).Once()
-
 	birthday := time.Now()
-	deps.addrStore.On("Birthday").Return(birthday).Once()
+	deps.store.On("GetWallet", mock.Anything, mock.Anything).Return(
+		&db.WalletInfo{Birthday: birthday}, nil).Once()
 
 	deps.chain.On(
 		"GetBestBlock",
@@ -1466,9 +1455,8 @@ func TestControllerStart_DeleteExpiredFail(t *testing.T) {
 	// fails.
 	w, deps := createTestWalletWithMocks(t)
 
-	bs := waddrmgr.BlockStamp{Height: 100}
-	deps.addrStore.On("BirthdayBlock", mock.Anything).Return(
-		bs, true, nil).Once()
+	deps.store.On("GetWallet", mock.Anything, mock.Anything).Return(
+		&db.WalletInfo{BirthdayBlock: &db.Block{}}, nil).Once()
 	deps.addrStore.On("ActiveScopedKeyManagers").Return(
 		[]waddrmgr.AccountStore(nil)).Once()
 

--- a/wallet/controller_test.go
+++ b/wallet/controller_test.go
@@ -478,8 +478,8 @@ func TestControllerVerifyBirthday_PutFail(t *testing.T) {
 		&chainhash.Hash{}, nil).Maybe()
 	deps.chain.On("GetBlockHeader", mock.Anything).Return(
 		&wire.BlockHeader{}, nil).Maybe()
-	deps.addrStore.On("SetBirthdayBlock", mock.Anything, mock.Anything,
-		true).Return(errPutMock).Once()
+	deps.store.On("UpdateWallet", mock.Anything, mock.Anything).Return(
+		errPutMock).Once()
 
 	// Act: Attempt to verify birthday.
 	err := w.verifyBirthday(t.Context())
@@ -1381,14 +1381,12 @@ func TestControllerStart_BirthdayNotSet(t *testing.T) {
 		"GetBlockHeader", mock.Anything,
 	).Return(header, nil).Once()
 
-	deps.addrStore.On(
-		"SetBirthdayBlock", mock.Anything,
-		mock.MatchedBy(func(bs waddrmgr.BlockStamp) bool {
-			return bs.Height == 50
-		}), true,
-	).Return(nil).Once()
-	deps.addrStore.On(
-		"SetSyncedTo", mock.Anything, mock.Anything,
+	deps.store.On(
+		"UpdateWallet", mock.Anything,
+		mock.MatchedBy(func(p db.UpdateWalletParams) bool {
+			return p.BirthdayBlock != nil &&
+				p.BirthdayBlock.Height == 50
+		}),
 	).Return(nil).Once()
 
 	deps.addrStore.On(

--- a/wallet/internal/db/accounts_common.go
+++ b/wallet/internal/db/accounts_common.go
@@ -314,7 +314,7 @@ func (params RenameAccountParams) Validate() error {
 
 // AccountPropsRow represents the raw database fields needed to construct
 // AccountInfo.
-type AccountPropsRow[AddrTypeId, AccOriginId any] struct {
+type AccountPropsRow[AddrTypeId ~int16 | ~int64, AccOriginId any] struct {
 	AccountNumber     sql.NullInt64
 	AccountName       string
 	OriginID          AccOriginId
@@ -329,7 +329,6 @@ type AccountPropsRow[AddrTypeId, AccOriginId any] struct {
 	CoinType          int64
 	InternalTypeID    AddrTypeId
 	ExternalTypeID    AddrTypeId
-	IDToAddrType      func(AddrTypeId) (AddressType, error)
 	IDToOriginType    func(AccOriginId) (AccountOrigin, error)
 }
 
@@ -402,10 +401,8 @@ func DerivedAddressAccountSchema[AddrTypeID ~int16 | ~int64](
 }
 
 // AccountPropsRowToInfo converts a database row containing full account
-// properties into an AccountInfo struct. The idToAddrType function is
-// used to convert the internal and external address type IDs to AddressType
-// values.
-func AccountPropsRowToInfo[AddrTypeId, AccOriginId any](
+// properties into an AccountInfo struct.
+func AccountPropsRowToInfo[AddrTypeId ~int16 | ~int64, AccOriginId any](
 	row AccountPropsRow[AddrTypeId, AccOriginId]) (*AccountInfo, error) {
 
 	var accountNum uint32
@@ -551,7 +548,7 @@ func IDToAccountOrigin[T ~int16 | ~int64](v T) (AccountOrigin, error) {
 
 // AccountInfoRow represents the raw database fields needed to construct
 // AccountInfo.
-type AccountInfoRow[AccOriginId any] struct {
+type AccountInfoRow[AccOriginId ~int16 | ~int64] struct {
 	AccountNumber      sql.NullInt64
 	AccountName        string
 	OriginID           AccOriginId
@@ -571,7 +568,7 @@ type AccountInfoRow[AccOriginId any] struct {
 
 // AccountRowToInfo converts raw database field values into an AccountInfo
 // struct. It handles type conversion and validation for each field.
-func AccountRowToInfo[AccOriginId any](
+func AccountRowToInfo[AccOriginId ~int16 | ~int64](
 	row AccountInfoRow[AccOriginId]) (*AccountInfo, error) {
 
 	var accountNum uint32

--- a/wallet/internal/db/accounts_common.go
+++ b/wallet/internal/db/accounts_common.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcwallet/waddrmgr"
 )
 
 var (
@@ -89,10 +90,14 @@ type CreateDerivedAccountOps interface {
 	// watch-only mode.
 	WalletWatchOnly(ctx context.Context, walletID uint32) (bool, error)
 
-	// EnsureScope returns the existing or newly created key-scope row ID for
-	// the wallet/scope pair.
+	// EnsureScope returns the existing or newly created key-scope row ID
+	// for the wallet/scope pair together with the schema persisted for that
+	// scope. The persisted schema may differ from ScopeAddrMap when the
+	// scope was originally created with a non-default override (e.g. an
+	// imported account that overrode the BIP44 / BIP49 / BIP84 / BIP86
+	// defaults).
 	EnsureScope(ctx context.Context, walletID uint32,
-		scope KeyScope) (int64, error)
+		scope KeyScope) (int64, ScopeAddrSchema, error)
 
 	// AllocateAccountNumber advances and returns the next derived account
 	// number for the provided scope row.
@@ -211,7 +216,9 @@ func CreateDerivedAccountWithOps(ctx context.Context,
 		return nil, fmt.Errorf("wallet watch only: %w", err)
 	}
 
-	scopeID, err := ops.EnsureScope(ctx, params.WalletID, params.Scope)
+	scopeID, addrSchema, err := ops.EnsureScope(
+		ctx, params.WalletID, params.Scope,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("ensure scope: %w", err)
 	}
@@ -249,7 +256,7 @@ func CreateDerivedAccountWithOps(ctx context.Context,
 
 	return BuildAccountInfo(
 		accNumber, params.Name, DerivedAccount, 0, 0, 0,
-		walletIsWatchOnly, row.CreatedAt, params.Scope,
+		walletIsWatchOnly, row.CreatedAt, params.Scope, addrSchema,
 		derived.PublicKey, derived.MasterKeyFingerprint,
 		0, 0,
 	), nil
@@ -445,6 +452,13 @@ func AccountPropsRowToInfo[AddrTypeId ~int16 | ~int64, AccOriginId any](
 		return nil, err
 	}
 
+	addrSchema, err := DerivedAddressAccountSchema(
+		row.InternalTypeID, row.ExternalTypeID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("address schema: %w", err)
+	}
+
 	return &AccountInfo{
 		AccountNumber:        accountNum,
 		AccountName:          row.AccountName,
@@ -458,6 +472,7 @@ func AccountPropsRowToInfo[AddrTypeId ~int16 | ~int64, AccOriginId any](
 			Purpose: purposeNum,
 			Coin:    coinTypeNum,
 		},
+		AddrSchema:  addrSchema,
 		IsWatchOnly: row.IsWatchOnly,
 		CreatedAt:   row.CreatedAt,
 	}, nil
@@ -495,6 +510,68 @@ func ListAccounts[T any, Args any](ctx context.Context,
 	return accountInfosFromRows(rows, toInfo)
 }
 
+// addrTypeFromWaddrmgr maps a legacy waddrmgr.AddressType to the database
+// AddressType. The two enums share names but not ordinal values, so a direct
+// cast would corrupt the schema (e.g. waddrmgr.PubKeyHash=0 collides with
+// db.RawPubKey=0). Script-bearing variants are folded into their hashing
+// counterparts because ScopeAddrSchema does not carry script metadata.
+func addrTypeFromWaddrmgr(t waddrmgr.AddressType) (AddressType, error) {
+	switch t {
+	case waddrmgr.RawPubKey:
+		return RawPubKey, nil
+
+	case waddrmgr.PubKeyHash:
+		return PubKeyHash, nil
+
+	case waddrmgr.Script:
+		return ScriptHash, nil
+
+	case waddrmgr.NestedWitnessPubKey:
+		return NestedWitnessPubKey, nil
+
+	case waddrmgr.WitnessPubKey:
+		return WitnessPubKey, nil
+
+	case waddrmgr.WitnessScript:
+		return WitnessScript, nil
+
+	case waddrmgr.TaprootPubKey:
+		return TaprootPubKey, nil
+
+	case waddrmgr.TaprootScript:
+		// ScopeAddrSchema does not carry script metadata; collapse the
+		// script-bearing taproot type onto its pubkey-hash counterpart
+		// so the schema round-trip stays lossless for the type axis.
+		return TaprootPubKey, nil
+
+	default:
+		return 0, fmt.Errorf("%w: waddrmgr address type %d",
+			ErrInvalidParam, t)
+	}
+}
+
+// ScopeAddrSchemaFromWaddrmgr converts a legacy address-manager schema into
+// the database account schema shape. An unknown address type is surfaced as
+// ErrInvalidParam rather than coerced to a different enum value.
+func ScopeAddrSchemaFromWaddrmgr(
+	schema waddrmgr.ScopeAddrSchema) (ScopeAddrSchema, error) {
+
+	external, err := addrTypeFromWaddrmgr(schema.ExternalAddrType)
+	if err != nil {
+		return ScopeAddrSchema{}, fmt.Errorf("external: %w", err)
+	}
+
+	internal, err := addrTypeFromWaddrmgr(schema.InternalAddrType)
+	if err != nil {
+		return ScopeAddrSchema{}, fmt.Errorf("internal: %w", err)
+	}
+
+	return ScopeAddrSchema{
+		ExternalAddrType: external,
+		InternalAddrType: internal,
+	}, nil
+}
+
 // getAddrSchemaForScope returns the address schema for a given key scope or
 // returns an error if the scope is not in ScopeAddrMap.
 func getAddrSchemaForScope(scope KeyScope) (ScopeAddrSchema, error) {
@@ -515,7 +592,7 @@ func getAddrSchemaForScope(scope KeyScope) (ScopeAddrSchema, error) {
 func BuildAccountInfo(accountNum uint32, accountName string,
 	origin AccountOrigin, externalKeyCount, internalKeyCount,
 	importedKeyCount uint32, isWatchOnly bool, createdAt time.Time,
-	scope KeyScope, publicKey []byte,
+	scope KeyScope, addrSchema ScopeAddrSchema, publicKey []byte,
 	masterKeyFingerprint uint32,
 	confirmedBalance, unconfirmedBalance btcutil.Amount) *AccountInfo {
 
@@ -531,6 +608,7 @@ func BuildAccountInfo(accountNum uint32, accountName string,
 		IsWatchOnly:          isWatchOnly,
 		CreatedAt:            createdAt,
 		KeyScope:             scope,
+		AddrSchema:           addrSchema,
 		PublicKey:            publicKey,
 		MasterKeyFingerprint: masterKeyFingerprint,
 	}
@@ -561,6 +639,8 @@ type AccountInfoRow[AccOriginId ~int16 | ~int64] struct {
 	CreatedAt          time.Time
 	Purpose            int64
 	CoinType           int64
+	InternalTypeID     AccOriginId
+	ExternalTypeID     AccOriginId
 	ConfirmedBalance   int64
 	UnconfirmedBalance int64
 	IDToOriginType     func(AccOriginId) (AccountOrigin, error)
@@ -611,10 +691,17 @@ func AccountRowToInfo[AccOriginId ~int16 | ~int64](
 		}
 	}
 
+	addrSchema, err := DerivedAddressAccountSchema(
+		row.InternalTypeID, row.ExternalTypeID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("address schema: %w", err)
+	}
+
 	return BuildAccountInfo(
 		accountNum, row.AccountName, origin, externalKeyCount, internalKeyCount,
 		importedKeyCount, row.IsWatchOnly, row.CreatedAt,
-		KeyScope{Purpose: purposeNum, Coin: coinTypeNum},
+		KeyScope{Purpose: purposeNum, Coin: coinTypeNum}, addrSchema,
 		row.PublicKey, fingerprint,
 		btcutil.Amount(row.ConfirmedBalance),
 		btcutil.Amount(row.UnconfirmedBalance),
@@ -627,16 +714,26 @@ func EnsureKeyScope[Row any, GetArgs any, CreateArgs any](
 	ctx context.Context, getter func(context.Context, GetArgs) (Row, error),
 	getArgs GetArgs, creator func(context.Context, CreateArgs) (int64, error),
 	createArgs func(ScopeAddrSchema) CreateArgs, rowToID func(Row) int64,
-	scope KeyScope, schemaOverride *ScopeAddrSchema) (int64, error) {
+	rowToSchema func(Row) (ScopeAddrSchema, error),
+	scope KeyScope, schemaOverride *ScopeAddrSchema,
+) (int64, ScopeAddrSchema, error) {
 
 	scopeInfo, err := getter(ctx, getArgs)
 	if err == nil {
-		// Fast path: when the scope already exists.
-		return rowToID(scopeInfo), nil
+		// Fast path: when the scope already exists. Use the persisted
+		// schema so callers see whatever was originally stored, not the
+		// caller's override or the ScopeAddrMap default.
+		persisted, err := rowToSchema(scopeInfo)
+		if err != nil {
+			return 0, ScopeAddrSchema{}, fmt.Errorf("scope "+
+				"schema: %w", err)
+		}
+
+		return rowToID(scopeInfo), persisted, nil
 	}
 
 	if !errors.Is(err, sql.ErrNoRows) {
-		return 0, fmt.Errorf("check key scope: %w", err)
+		return 0, ScopeAddrSchema{}, fmt.Errorf("check key scope: %w", err)
 	}
 
 	var addrSchema ScopeAddrSchema
@@ -645,7 +742,7 @@ func EnsureKeyScope[Row any, GetArgs any, CreateArgs any](
 	} else {
 		defaultAddrSchema, err := getAddrSchemaForScope(scope)
 		if err != nil {
-			return 0, err
+			return 0, ScopeAddrSchema{}, err
 		}
 
 		addrSchema = defaultAddrSchema
@@ -658,23 +755,31 @@ func EnsureKeyScope[Row any, GetArgs any, CreateArgs any](
 	// return sql.ErrNoRows.
 	id, err := creator(ctx, createArgs(addrSchema))
 	if err == nil {
-		return id, nil
+		return id, addrSchema, nil
 	}
 
 	if !errors.Is(err, sql.ErrNoRows) {
 		// A real database error occurred (not a conflict).
-		return 0, fmt.Errorf("create key scope: %w", err)
+		return 0, ScopeAddrSchema{}, fmt.Errorf("create key scope: %w", err)
 	}
 
 	// ErrNoRows means the scope was created concurrently by another process
 	// (the INSERT hit DO NOTHING due to conflict). Re-fetch the scope that
-	// now exists.
+	// now exists so we return the schema that actually landed in the DB,
+	// not the one we tried to insert.
 	scopeInfo, err = getter(ctx, getArgs)
 	if err != nil {
-		return 0, fmt.Errorf("get scope after create: %w", err)
+		return 0, ScopeAddrSchema{}, fmt.Errorf("get scope after "+
+			"create: %w", err)
 	}
 
-	return rowToID(scopeInfo), nil
+	persisted, err := rowToSchema(scopeInfo)
+	if err != nil {
+		return 0, ScopeAddrSchema{}, fmt.Errorf("scope schema after "+
+			"create: %w", err)
+	}
+
+	return rowToID(scopeInfo), persisted, nil
 }
 
 // GetAccountFunc defines a function signature for retrieving a single account.

--- a/wallet/internal/db/accounts_common_test.go
+++ b/wallet/internal/db/accounts_common_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -194,7 +195,7 @@ func TestCreateDerivedAccountWithOps(t *testing.T) {
 	).Once()
 	ensureScopeCall := ops.On(
 		"EnsureScope", mock.Anything, uint32(7), params.Scope,
-	).Return(int64(11), nil).Once()
+	).Return(int64(11), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
 	allocateCall := ops.On(
 		"AllocateAccountNumber", mock.Anything, int64(11),
 	).Return(int64(12), nil).Once()
@@ -217,6 +218,63 @@ func TestCreateDerivedAccountWithOps(t *testing.T) {
 	require.True(t, info.IsWatchOnly)
 	require.Equal(t, createdAt, info.CreatedAt)
 	require.Equal(t, params.Scope, info.KeyScope)
+	require.Equal(t, ScopeAddrMap[params.Scope], info.AddrSchema)
+}
+
+// TestAccountRowToInfoPopulatesAddrSchema verifies SQL account rows expose the
+// effective key-scope address schema on AccountInfo.
+func TestAccountRowToInfoPopulatesAddrSchema(t *testing.T) {
+	t.Parallel()
+
+	row := AccountInfoRow[int16]{
+		AccountNumber:    sql.NullInt64{Int64: 7, Valid: true},
+		AccountName:      "strict",
+		OriginID:         int16(ImportedAccount),
+		ExternalKeyCount: 1,
+		InternalKeyCount: 2,
+		ImportedKeyCount: 3,
+		CreatedAt:        time.Unix(123, 0).UTC(),
+		Purpose:          49,
+		CoinType:         0,
+		InternalTypeID:   int16(NestedWitnessPubKey),
+		ExternalTypeID:   int16(NestedWitnessPubKey),
+		IDToOriginType:   IDToAccountOrigin[int16],
+	}
+
+	info, err := AccountRowToInfo(row)
+	require.NoError(t, err)
+	require.Equal(t, ScopeAddrSchema{
+		ExternalAddrType: NestedWitnessPubKey,
+		InternalAddrType: NestedWitnessPubKey,
+	}, info.AddrSchema)
+}
+
+// TestScopeAddrSchemaFromWaddrmgr verifies legacy address-manager schemas are
+// converted into the database account schema shape.
+func TestScopeAddrSchemaFromWaddrmgr(t *testing.T) {
+	t.Parallel()
+
+	schema, err := ScopeAddrSchemaFromWaddrmgr(waddrmgr.ScopeAddrSchema{
+		ExternalAddrType: waddrmgr.NestedWitnessPubKey,
+		InternalAddrType: waddrmgr.WitnessPubKey,
+	})
+	require.NoError(t, err)
+	require.Equal(t, ScopeAddrSchema{
+		ExternalAddrType: NestedWitnessPubKey,
+		InternalAddrType: WitnessPubKey,
+	}, schema)
+
+	// BIP44 schemas (waddrmgr.PubKeyHash external + waddrmgr.PubKeyHash
+	// internal) regression test for the enum-ordinal mismatch.
+	schema, err = ScopeAddrSchemaFromWaddrmgr(waddrmgr.ScopeAddrSchema{
+		ExternalAddrType: waddrmgr.PubKeyHash,
+		InternalAddrType: waddrmgr.PubKeyHash,
+	})
+	require.NoError(t, err)
+	require.Equal(t, ScopeAddrSchema{
+		ExternalAddrType: PubKeyHash,
+		InternalAddrType: PubKeyHash,
+	}, schema)
 }
 
 // TestCreateDerivedAccountWithOpsRejectsInvalidParams verifies that the shared
@@ -262,7 +320,7 @@ func TestCreateDerivedAccountWithOpsNilAccountNumber(t *testing.T) {
 			Purpose: 49,
 			Coin:    0,
 		},
-	).Return(int64(8), nil).Once()
+	).Return(int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
 	ops.On("AllocateAccountNumber", mock.Anything, int64(8)).Return(
 		int64(9), nil,
 	).Once()
@@ -302,7 +360,7 @@ func TestCreateDerivedAccountWithOpsMaxAccountNumber(t *testing.T) {
 			Purpose: 49,
 			Coin:    0,
 		},
-	).Return(int64(8), nil).Once()
+	).Return(int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
 	ops.On("AllocateAccountNumber", mock.Anything, int64(8)).Return(
 		int64(^uint32(0))+1, nil,
 	).Once()
@@ -354,7 +412,7 @@ func TestCreateDerivedAccountWithOpsWrapsStageErrors(t *testing.T) {
 						Purpose: 49,
 						Coin:    0,
 					},
-				).Return(int64(0), errTestScope).Once()
+				).Return(int64(0), ScopeAddrSchema{}, errTestScope).Once()
 
 				return ops
 			},
@@ -372,7 +430,9 @@ func TestCreateDerivedAccountWithOpsWrapsStageErrors(t *testing.T) {
 						Purpose: 49,
 						Coin:    0,
 					},
-				).Return(int64(8), nil).Once()
+				).Return(
+					int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil,
+				).Once()
 				ops.On("AllocateAccountNumber", mock.Anything, int64(8)).Return(
 					int64(0), errTestBoom,
 				).Once()
@@ -392,7 +452,9 @@ func TestCreateDerivedAccountWithOpsWrapsStageErrors(t *testing.T) {
 				ops.On("EnsureScope", mock.Anything, uint32(7), KeyScope{
 					Purpose: 49,
 					Coin:    0,
-				}).Return(int64(8), nil).Once()
+				}).Return(
+					int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil,
+				).Once()
 				ops.On("AllocateAccountNumber", mock.Anything, int64(8)).Return(
 					int64(9), nil,
 				).Once()
@@ -457,7 +519,7 @@ func TestCreateDerivedAccountWithOpsDeriveFnInvokedOnce(t *testing.T) {
 			Purpose: 49,
 			Coin:    0,
 		},
-	).Return(int64(8), nil).Once()
+	).Return(int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
 	ops.On("AllocateAccountNumber", mock.Anything, int64(8)).Return(
 		int64(9), nil,
 	).Once()
@@ -504,7 +566,7 @@ func TestCreateDerivedAccountWithOpsRollsBackOnDeriveFnError(t *testing.T) {
 			Purpose: 49,
 			Coin:    0,
 		},
-	).Return(int64(8), nil).Once()
+	).Return(int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
 	ops.On("AllocateAccountNumber", mock.Anything, int64(8)).Return(
 		int64(9), nil,
 	).Once()
@@ -564,7 +626,7 @@ func TestCreateDerivedAccountWithOpsRejectsInvalidDerivedDataNil(t *testing.T) {
 			Purpose: 49,
 			Coin:    0,
 		},
-	).Return(int64(8), nil).Once()
+	).Return(int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
 	ops.On("AllocateAccountNumber", mock.Anything, int64(8)).Return(
 		int64(9), nil,
 	).Once()
@@ -603,7 +665,7 @@ func TestCreateDerivedAccountWithOpsRejectsInvalidDerivedDataMissingPublicKey(
 			Purpose: 49,
 			Coin:    0,
 		},
-	).Return(int64(8), nil).Once()
+	).Return(int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
 	ops.On("AllocateAccountNumber", mock.Anything, int64(8)).Return(
 		int64(9), nil,
 	).Once()
@@ -642,7 +704,7 @@ func TestCreateDerivedAccountWithOpsRejectsInvalidDerivedDataMissingPrivateKey(
 			Purpose: 49,
 			Coin:    0,
 		},
-	).Return(int64(8), nil).Once()
+	).Return(int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
 	ops.On("AllocateAccountNumber", mock.Anything, int64(8)).Return(
 		int64(9), nil,
 	).Once()
@@ -681,7 +743,7 @@ func TestCreateDerivedAccountWithOpsRejectsInvalidDerivedDataWatchOnlyHasPriv(
 			Purpose: 49,
 			Coin:    0,
 		},
-	).Return(int64(8), nil).Once()
+	).Return(int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
 	ops.On("AllocateAccountNumber", mock.Anything, int64(8)).Return(
 		int64(9), nil,
 	).Once()
@@ -732,16 +794,24 @@ func (m *mockCreateDerivedAccountOps) WalletWatchOnly(ctx context.Context,
 
 // EnsureScope implements CreateDerivedAccountOps.
 func (m *mockCreateDerivedAccountOps) EnsureScope(ctx context.Context,
-	walletID uint32, scope KeyScope) (int64, error) {
+	walletID uint32,
+	scope KeyScope) (int64, ScopeAddrSchema, error) {
 
 	args := m.Called(ctx, walletID, scope)
 
 	scopeID, ok := args.Get(0).(int64)
 	if !ok {
-		return 0, mockTypeError("EnsureScope result")
+		return 0, ScopeAddrSchema{}, mockTypeError("EnsureScope result")
 	}
 
-	return scopeID, args.Error(1)
+	schema, ok := args.Get(1).(ScopeAddrSchema)
+	if !ok {
+		return 0, ScopeAddrSchema{}, mockTypeError(
+			"EnsureScope schema result",
+		)
+	}
+
+	return scopeID, schema, args.Error(2)
 }
 
 // AllocateAccountNumber implements CreateDerivedAccountOps.

--- a/wallet/internal/db/block_common.go
+++ b/wallet/internal/db/block_common.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcwallet/waddrmgr"
 )
 
 // BuildBlock constructs a Block from the provided components that are common
@@ -20,4 +21,49 @@ func BuildBlock(hash []byte, height uint32, timestamp int64) (*Block, error) {
 		Height:    height,
 		Timestamp: time.Unix(timestamp, 0),
 	}, nil
+}
+
+// BlockStampFromBlock converts database block metadata into the legacy
+// block-stamp shape used by wallet runtime state.
+func BlockStampFromBlock(block *Block) (waddrmgr.BlockStamp, error) {
+	height, err := Uint32ToInt32(block.Height)
+	if err != nil {
+		return waddrmgr.BlockStamp{}, fmt.Errorf("%w: store block "+
+			"height %d exceeds max int32", ErrInvalidParam,
+			block.Height)
+	}
+
+	return waddrmgr.BlockStamp{
+		Height:    height,
+		Hash:      block.Hash,
+		Timestamp: block.Timestamp,
+	}, nil
+}
+
+// BlockFromBlockStamp converts a legacy block-stamp into the database store
+// block shape. The timestamp is normalized to UTC.
+func BlockFromBlockStamp(block waddrmgr.BlockStamp) (*Block, error) {
+	height, err := Int64ToUint32(int64(block.Height))
+	if err != nil {
+		return nil, fmt.Errorf("%w: block height %d cannot "+
+			"convert to uint32", ErrInvalidParam, block.Height)
+	}
+
+	return &Block{
+		Hash:      block.Hash,
+		Height:    height,
+		Timestamp: block.Timestamp.UTC(),
+	}, nil
+}
+
+// OptionalBlockFromBlockStamp converts a legacy block-stamp into the database
+// store block shape, treating negative heights as missing metadata.
+func OptionalBlockFromBlockStamp(
+	block waddrmgr.BlockStamp) (*Block, error) {
+
+	if block.Height < 0 {
+		return nil, ErrBlockNotFound
+	}
+
+	return BlockFromBlockStamp(block)
 }

--- a/wallet/internal/db/block_common.go
+++ b/wallet/internal/db/block_common.go
@@ -57,13 +57,15 @@ func BlockFromBlockStamp(block waddrmgr.BlockStamp) (*Block, error) {
 }
 
 // OptionalBlockFromBlockStamp converts a legacy block-stamp into the database
-// store block shape, treating negative heights as missing metadata.
-func OptionalBlockFromBlockStamp(
-	block waddrmgr.BlockStamp) (*Block, error) {
-
+// store block shape, returning nil for missing metadata.
+func OptionalBlockFromBlockStamp(block waddrmgr.BlockStamp) *Block {
 	if block.Height < 0 {
-		return nil, ErrBlockNotFound
+		return nil
 	}
 
-	return BlockFromBlockStamp(block)
+	return &Block{
+		Hash:      block.Hash,
+		Height:    uint32(block.Height),
+		Timestamp: block.Timestamp.UTC(),
+	}
 }

--- a/wallet/internal/db/block_common_test.go
+++ b/wallet/internal/db/block_common_test.go
@@ -1,0 +1,78 @@
+package db
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBlockStampFromBlock verifies that store block metadata converts to the
+// legacy block-stamp shape and rejects heights that do not fit int32.
+func TestBlockStampFromBlock(t *testing.T) {
+	t.Parallel()
+
+	var hash chainhash.Hash
+
+	hash[0] = 1
+
+	timestamp := time.Unix(123, 0).UTC()
+	block := &Block{
+		Hash:      hash,
+		Height:    42,
+		Timestamp: timestamp,
+	}
+
+	stamp, err := BlockStampFromBlock(block)
+	require.NoError(t, err)
+	require.Equal(t, int32(42), stamp.Height)
+	require.Equal(t, hash, stamp.Hash)
+	require.Equal(t, timestamp, stamp.Timestamp)
+
+	block.Height = uint32(math.MaxInt32) + 1
+	_, err = BlockStampFromBlock(block)
+	require.ErrorIs(t, err, ErrInvalidParam)
+}
+
+// TestBlockFromBlockStamp verifies that legacy block-stamps convert to the
+// store block shape with UTC timestamps.
+func TestBlockFromBlockStamp(t *testing.T) {
+	t.Parallel()
+
+	var hash chainhash.Hash
+
+	hash[0] = 2
+
+	zone := time.FixedZone("offset", 3600)
+	timestamp := time.Date(2024, 1, 2, 3, 4, 5, 0, zone)
+	stamp := waddrmgr.BlockStamp{
+		Hash:      hash,
+		Height:    42,
+		Timestamp: timestamp,
+	}
+
+	block, err := BlockFromBlockStamp(stamp)
+	require.NoError(t, err)
+	require.Equal(t, hash, block.Hash)
+	require.Equal(t, uint32(42), block.Height)
+	require.Equal(t, timestamp.UTC(), block.Timestamp)
+
+	stamp.Height = -1
+	_, err = BlockFromBlockStamp(stamp)
+	require.ErrorIs(t, err, ErrInvalidParam)
+}
+
+// TestOptionalBlockFromBlockStamp verifies that optional legacy block-stamps
+// map negative heights to missing block metadata.
+func TestOptionalBlockFromBlockStamp(t *testing.T) {
+	t.Parallel()
+
+	block, err := OptionalBlockFromBlockStamp(waddrmgr.BlockStamp{
+		Height: -1,
+	})
+	require.ErrorIs(t, err, ErrBlockNotFound)
+	require.Nil(t, block)
+}

--- a/wallet/internal/db/block_common_test.go
+++ b/wallet/internal/db/block_common_test.go
@@ -66,13 +66,12 @@ func TestBlockFromBlockStamp(t *testing.T) {
 }
 
 // TestOptionalBlockFromBlockStamp verifies that optional legacy block-stamps
-// map negative heights to missing block metadata.
+// map negative heights to nil block metadata.
 func TestOptionalBlockFromBlockStamp(t *testing.T) {
 	t.Parallel()
 
-	block, err := OptionalBlockFromBlockStamp(waddrmgr.BlockStamp{
+	block := OptionalBlockFromBlockStamp(waddrmgr.BlockStamp{
 		Height: -1,
 	})
-	require.ErrorIs(t, err, ErrBlockNotFound)
 	require.Nil(t, block)
 }

--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -419,6 +419,12 @@ type AccountInfo struct {
 	// derivation path and the default address schema.
 	KeyScope KeyScope
 
+	// AddrSchema is the effective address schema for the account. SQL backends
+	// expose the key-scope schema because they do not currently model legacy
+	// per-account schema overrides; kvdb uses the waddrmgr account override
+	// when one is present.
+	AddrSchema ScopeAddrSchema
+
 	// PublicKey is the account-level extended public key in plaintext.
 	// It is set for both derived and imported accounts where the wallet
 	// knows the account public material.

--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -251,8 +251,8 @@ type Block struct {
 	// Height is the height of the block in the blockchain.
 	Height uint32
 
-	// Timestamp is the timestamp of the block, which is used for wallet
-	// synchronization and rescan operations.
+	// Timestamp is the UTC timestamp of the block, which is used for
+	// wallet synchronization and rescan operations.
 	Timestamp time.Time
 }
 

--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -168,9 +168,9 @@ type WalletStore interface {
 		query ListWalletsQuery) iter.Seq2[WalletInfo, error]
 
 	// UpdateWallet updates various properties of a wallet, such as its
-	// birthday, birthday block, or sync state. The specific fields to
-	// update are provided in the UpdateWalletParams struct. It returns an
-	// error if the update fails.
+	// birthday, birthday block, or sync state. SQL multi-wallet backends
+	// return ErrWalletNotFound when the wallet ID is unknown. The legacy kvdb
+	// backend is a single-wallet adapter and ignores WalletID.
 	UpdateWallet(ctx context.Context, params UpdateWalletParams) error
 
 	// GetEncryptedHDSeed retrieves the encrypted Hierarchical

--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -151,9 +151,10 @@ type WalletStore interface {
 	CreateWallet(ctx context.Context, params CreateWalletParams) (
 		*WalletInfo, error)
 
-	// GetWallet retrieves information about a wallet given its name. It
-	// returns a WalletInfo struct containing the wallet's properties or an
-	// error if the wallet is not found.
+	// GetWallet retrieves information about a wallet given its name. SQL
+	// multi-wallet backends return ErrWalletNotFound when the wallet name is
+	// unknown. The legacy kvdb backend is a single-wallet adapter and echoes
+	// the requested name without validating it.
 	GetWallet(ctx context.Context, name string) (*WalletInfo, error)
 
 	// ListWallets returns one page of wallets for the given query, including a

--- a/wallet/internal/db/kvdb/accountstore.go
+++ b/wallet/internal/db/kvdb/accountstore.go
@@ -108,8 +108,8 @@ func (o *createDerivedAccountOps) WalletWatchOnly(
 
 // EnsureScope implements db.CreateDerivedAccountOps. waddrmgr scopes are
 // pre-registered; the call only fetches and caches the scoped manager.
-func (o *createDerivedAccountOps) EnsureScope(_ context.Context,
-	_ uint32, scope db.KeyScope) (int64, error) {
+func (o *createDerivedAccountOps) EnsureScope(_ context.Context, _ uint32,
+	scope db.KeyScope) (int64, db.ScopeAddrSchema, error) {
 
 	waddrScope := waddrmgr.KeyScope{
 		Purpose: scope.Purpose,
@@ -118,13 +118,28 @@ func (o *createDerivedAccountOps) EnsureScope(_ context.Context,
 
 	scopedMgr, err := o.mgr.FetchScopedKeyManager(waddrScope)
 	if err != nil {
-		return 0, translateAccountErr(err, db.ErrAccountNotFound)
+		return 0, db.ScopeAddrSchema{}, translateAccountErr(
+			err, db.ErrAccountNotFound,
+		)
 	}
 
 	o.scope = waddrScope
 	o.scopedMgr = scopedMgr
 
-	return 0, nil
+	// Read the persisted scope schema from the waddrmgr scoped manager
+	// instead of the global ScopeAddrMap default. A scope that was
+	// created with a non-default schema (e.g. a custom BIP49 variant)
+	// surfaces its actual schema here rather than getting recomputed.
+	// per-account overrides ride on props.AddrSchema at load time.
+	waddrSchema := scopedMgr.AddrSchema()
+
+	addrSchema, err := db.ScopeAddrSchemaFromWaddrmgr(waddrSchema)
+	if err != nil {
+		return 0, db.ScopeAddrSchema{}, fmt.Errorf("scope schema: %w",
+			err)
+	}
+
+	return 0, addrSchema, nil
 }
 
 // AllocateAccountNumber implements db.CreateDerivedAccountOps.
@@ -593,6 +608,56 @@ func sanitizeAccountNumber(acctNum uint32) (uint32, error) {
 	return acctNum, nil
 }
 
+// effectiveAddrSchema resolves the per-account schema from the legacy
+// waddrmgr override when present, otherwise falls back to the
+// scope-level persisted schema the scoped manager reports. The
+// persisted schema covers custom (non-default) scopes that
+// db.ScopeAddrMap does not enumerate, so derived accounts under a
+// custom scope still get the correct address types instead of
+// failing with ErrUnknownKeyScope or silently picking the default
+// BIP49-plus shape.
+func effectiveAddrSchema(scopeSchema waddrmgr.ScopeAddrSchema,
+	override *waddrmgr.ScopeAddrSchema) (db.ScopeAddrSchema, error) {
+
+	source := scopeSchema
+	if override != nil {
+		source = *override
+	}
+
+	schema, err := db.ScopeAddrSchemaFromWaddrmgr(source)
+	if err != nil {
+		return db.ScopeAddrSchema{}, fmt.Errorf("convert "+
+			"scope schema: %w", err)
+	}
+
+	return schema, nil
+}
+
+// resolveMasterFingerprintForAccount returns the master-key fingerprint
+// for the account at props.AccountNumber. For imported accounts the value
+// lives on the waddrmgr watch-only row in props.MasterKeyFingerprint. For
+// derived accounts waddrmgr's default-account row has no fingerprint
+// column, so kvdb stores it in a side bucket; legacy derived rows have
+// no side-bucket entry and the wallet layer fills in the cached value
+// at the public boundary.
+func resolveMasterFingerprintForAccount(ns walletdb.ReadBucket,
+	scope waddrmgr.KeyScope,
+	props *waddrmgr.AccountProperties) (uint32, error) {
+
+	persisted, ok, err := getAccountMasterFingerprint(
+		ns, scope, props.AccountNumber,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("read master fingerprint: %w", err)
+	}
+
+	if ok {
+		return persisted, nil
+	}
+
+	return props.MasterKeyFingerprint, nil
+}
+
 // loadAccountInfo materializes a db.AccountInfo from waddrmgr's
 // AccountProperties + IsImportedAccount classifier.
 func loadAccountInfo(ns walletdb.ReadBucket,
@@ -632,26 +697,11 @@ func loadAccountInfo(ns walletdb.ReadBucket,
 		return nil, fmt.Errorf("read created-at: %w", err)
 	}
 
-	// For imported accounts the per-row master_fingerprint is the
-	// parent xpub fingerprint persisted on the watch-only row. For
-	// derived accounts waddrmgr's default-account row has no
-	// fingerprint column; the kvdb side bucket
-	// (accountMasterFingerprintBucketKey) holds it for new rows
-	// written through this adapter. Legacy derived rows have no
-	// side-bucket entry and props.MasterKeyFingerprint is 0; the
-	// wallet-layer override fills in the cached value at the public
-	// boundary for the legacy case.
-	fingerprint := props.MasterKeyFingerprint
-
-	persisted, ok, fpErr := getAccountMasterFingerprint(
-		ns, scope, props.AccountNumber,
+	fingerprint, err := resolveMasterFingerprintForAccount(
+		ns, scope, props,
 	)
-	if fpErr != nil {
-		return nil, fmt.Errorf("read master fingerprint: %w", fpErr)
-	}
-
-	if ok {
-		fingerprint = persisted
+	if err != nil {
+		return nil, err
 	}
 
 	// Imported accounts in kvdb share waddrmgr's per-scope counter
@@ -662,6 +712,13 @@ func loadAccountInfo(ns walletdb.ReadBucket,
 	accountNumberForContract := props.AccountNumber
 	if origin == db.ImportedAccount {
 		accountNumberForContract = 0
+	}
+
+	addrSchema, err := effectiveAddrSchema(
+		scopedMgr.AddrSchema(), props.AddrSchema,
+	)
+	if err != nil {
+		return nil, err
 	}
 
 	return &db.AccountInfo{
@@ -676,6 +733,7 @@ func loadAccountInfo(ns walletdb.ReadBucket,
 			Purpose: scope.Purpose,
 			Coin:    scope.Coin,
 		},
+		AddrSchema:           addrSchema,
 		PublicKey:            pubKey,
 		MasterKeyFingerprint: fingerprint,
 		CreatedAt:            createdAt,

--- a/wallet/internal/db/kvdb/accountstore_test.go
+++ b/wallet/internal/db/kvdb/accountstore_test.go
@@ -287,8 +287,8 @@ func TestRenameAccountRejectsImported(t *testing.T) {
 	}
 	name := "imported-rename"
 
-	_, err = store.CreateImportedAccount(t.Context(),
-		db.CreateImportedAccountParams{
+	_, err = store.CreateImportedAccount(
+		t.Context(), db.CreateImportedAccountParams{
 			Scope:             scope,
 			Name:              name,
 			MasterFingerprint: 0xDEADBEEF,
@@ -328,10 +328,12 @@ func TestRenameAccountRejectsImported(t *testing.T) {
 	})
 	require.ErrorIs(t, err, db.ErrAccountNotFound)
 
-	info, err := store.GetAccount(t.Context(), db.GetAccountQuery{
-		Scope: scope,
-		Name:  &name,
-	})
+	info, err := store.GetAccount(
+		t.Context(), db.GetAccountQuery{
+			Scope: scope,
+			Name:  &name,
+		},
+	)
 	require.NoError(t, err)
 	require.Equal(t, name, info.AccountName)
 }
@@ -722,7 +724,7 @@ func TestCreateImportedAccountUsesAddrSchema(t *testing.T) {
 	}
 
 	name := "imported-schema"
-	_, err = store.CreateImportedAccount(t.Context(),
+	info, err := store.CreateImportedAccount(t.Context(),
 		db.CreateImportedAccountParams{
 			Scope:             scope,
 			Name:              name,
@@ -732,6 +734,16 @@ func TestCreateImportedAccountUsesAddrSchema(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
+	require.Equal(t, addrSchema, info.AddrSchema)
+
+	info, err = store.GetAccount(
+		t.Context(), db.GetAccountQuery{
+			Scope: scope,
+			Name:  &name,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, addrSchema, info.AddrSchema)
 
 	scopedMgr, err := store.addrStore.FetchScopedKeyManager(
 		waddrmgr.KeyScope(scope),

--- a/wallet/internal/db/kvdb/log.go
+++ b/wallet/internal/db/kvdb/log.go
@@ -1,0 +1,22 @@
+package kvdb
+
+import (
+	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btcwallet/build"
+)
+
+// log is a logger that is initialized with no output filters. This means the
+// package will not perform any logging by default until the caller requests it.
+var log btclog.Logger
+
+// init sets the default kvdb package logger.
+func init() {
+	UseLogger(build.NewSubLogger("KVDB", nil))
+}
+
+// UseLogger uses a specified Logger to output package logging info. This
+// should be used in preference to SetLogWriter if the caller is also using
+// btclog.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/wallet/internal/db/kvdb/walletstore.go
+++ b/wallet/internal/db/kvdb/walletstore.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"time"
 
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
@@ -27,6 +28,11 @@ func (s *Store) CreateWallet(ctx context.Context,
 }
 
 // GetWallet reads wallet runtime metadata from the legacy address manager.
+//
+// NOTE: kvdb is a single-wallet legacy backend. The supplied name is not
+// validated against the underlying wallet; the returned WalletInfo echoes the
+// requested name. SQL backends honor the Store contract and return
+// db.ErrWalletNotFound for unknown names; kvdb does not.
 func (s *Store) GetWallet(_ context.Context,
 	name string) (*db.WalletInfo, error) {
 
@@ -103,11 +109,210 @@ func (s *Store) IterWallets(ctx context.Context,
 	}
 }
 
-// UpdateWallet is not yet implemented for kvdb.
-func (s *Store) UpdateWallet(ctx context.Context,
-	_ db.UpdateWalletParams) error {
+// UpdateWallet writes wallet runtime metadata through the legacy address
+// manager.
+//
+// NOTE: kvdb is a single-wallet legacy backend. params.WalletID is ignored;
+// the call always targets the single underlying wallet. SQL backends honor the
+// Store contract and return db.ErrWalletNotFound for unknown WalletIDs; kvdb
+// does not.
+func (s *Store) UpdateWallet(_ context.Context,
+	params db.UpdateWalletParams) error {
 
-	return notImplemented(ctx, "UpdateWallet")
+	if s.addrStore == nil {
+		return fmt.Errorf("kvdb.Store.UpdateWallet: %w",
+			errMissingAddrStore)
+	}
+
+	addrStore := s.addrStore
+
+	err := walletdb.Update(s.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+		if ns == nil {
+			return errMissingAddrmgrNamespace
+		}
+
+		return updateWallet(ns, addrStore, params)
+	})
+	if err != nil {
+		return fmt.Errorf("kvdb.Store.UpdateWallet: %w", err)
+	}
+
+	return nil
+}
+
+// walletStateSnapshot captures the wallet metadata that updateWallet may
+// mutate inside a single walletdb transaction. It is consumed by the
+// deferred restoreWalletStateOnError so a failed mutation does not leave
+// the in-memory waddrmgr cache out of sync with the rolled-back walletdb
+// transaction.
+type walletStateSnapshot struct {
+	birthday         time.Time
+	syncedTo         waddrmgr.BlockStamp
+	birthdayBlock    waddrmgr.BlockStamp
+	birthdayBlockSet bool
+}
+
+// snapshotWalletState captures the current wallet metadata from the address
+// manager so updateWallet can restore it on rollback. A missing birthday
+// block is normal before initial sync finishes and is signalled via the
+// birthdayBlockSet flag rather than returned as an error.
+func snapshotWalletState(ns walletdb.ReadWriteBucket,
+	addrStore waddrmgr.AddrStore) (walletStateSnapshot, error) {
+
+	snap := walletStateSnapshot{
+		birthday: addrStore.Birthday(),
+		syncedTo: addrStore.SyncedTo(),
+	}
+
+	prior, _, err := addrStore.BirthdayBlock(ns)
+	switch {
+	case err == nil:
+		snap.birthdayBlock = prior
+		snap.birthdayBlockSet = true
+
+	case waddrmgr.IsError(err, waddrmgr.ErrBirthdayBlockNotSet):
+		// A missing birthday block is normal before initial sync finishes.
+
+	default:
+		return walletStateSnapshot{}, fmt.Errorf("snapshot birthday "+
+			"block: %w", err)
+	}
+
+	return snap, nil
+}
+
+// restoreWalletStateOnError reverts the in-memory waddrmgr cache (Birthday,
+// SyncedTo) and the birthday-block bucket back to the pre-update snapshot
+// when the enclosing walletdb transaction returns an error. The birthday-
+// block bucket is restored first so a follow-up SetSyncedTo cache rollback
+// does not enforce predecessor-hash continuity against a block this
+// transaction is rolling back.
+func restoreWalletStateOnError(ns walletdb.ReadWriteBucket,
+	addrStore waddrmgr.AddrStore, snap walletStateSnapshot,
+	birthdayMayMutate, syncedToMutated bool, retErr error) {
+
+	if retErr == nil {
+		return
+	}
+
+	if !snap.birthdayBlockSet {
+		rerr := waddrmgr.DeleteBirthdayBlock(ns)
+		if rerr != nil {
+			log.Errorf("UpdateWallet rollback: "+
+				"DeleteBirthdayBlock: %v (orig: %v)",
+				rerr, retErr)
+		}
+	} else {
+		rerr := waddrmgr.PutBirthdayBlock(ns, snap.birthdayBlock)
+		if rerr != nil {
+			log.Errorf("UpdateWallet rollback: "+
+				"PutBirthdayBlock prior: %v (orig: %v)",
+				rerr, retErr)
+		}
+	}
+
+	if birthdayMayMutate {
+		rerr := addrStore.SetBirthday(ns, snap.birthday)
+		if rerr != nil {
+			log.Errorf("UpdateWallet rollback: restore "+
+				"SetBirthday: %v (orig: %v)", rerr, retErr)
+		}
+	}
+
+	if !syncedToMutated {
+		return
+	}
+
+	rerr := addrStore.SetSyncedTo(ns, &snap.syncedTo)
+	if rerr != nil {
+		log.Errorf("UpdateWallet rollback: restore SetSyncedTo: "+
+			"%v (orig: %v)", rerr, retErr)
+	}
+}
+
+// updateWallet applies wallet metadata updates through the legacy address
+// manager while preserving in-memory cache consistency on rollback.
+func updateWallet(ns walletdb.ReadWriteBucket,
+	addrStore waddrmgr.AddrStore,
+	params db.UpdateWalletParams) error {
+
+	if params.Birthday == nil && params.BirthdayBlock == nil &&
+		params.SyncedTo == nil {
+
+		return nil
+	}
+
+	snap, err := snapshotWalletState(ns, addrStore)
+	if err != nil {
+		return err
+	}
+
+	birthdayMayMutate := params.Birthday != nil
+	syncedToMutated := false
+
+	// applyWalletMutations mutates the in-memory waddrmgr cache
+	// (Birthday, SyncedTo) and the birthday-block bucket inline. If
+	// it returns an error after one of those mutations has been
+	// applied, restoreWalletStateOnError reverts the cache back to
+	// the snapshot so the next read does not see a half-applied
+	// update.
+	err = applyWalletMutations(ns, addrStore, params, &syncedToMutated)
+	if err != nil {
+		restoreWalletStateOnError(
+			ns, addrStore, snap, birthdayMayMutate,
+			syncedToMutated, err,
+		)
+	}
+
+	return err
+}
+
+// applyWalletMutations applies the requested birthday, synced-to and
+// birthday-block changes through the address manager in the order the
+// legacy waddrmgr expects: birthday timestamp first, then synced-to
+// (so SetSyncedTo's predecessor-hash check still runs against the prior
+// birthday block bucket), and birthday-block bucket last.
+func applyWalletMutations(ns walletdb.ReadWriteBucket,
+	addrStore waddrmgr.AddrStore, params db.UpdateWalletParams,
+	syncedToMutated *bool) error {
+
+	if params.Birthday != nil {
+		err := addrStore.SetBirthday(ns, params.Birthday.UTC())
+		if err != nil {
+			return fmt.Errorf("set birthday: %w", err)
+		}
+	}
+
+	if params.SyncedTo != nil {
+		syncedTo, err := db.BlockStampFromBlock(params.SyncedTo)
+		if err != nil {
+			return err
+		}
+
+		err = addrStore.SetSyncedTo(ns, &syncedTo)
+		if err != nil {
+			return fmt.Errorf("set synced to: %w", err)
+		}
+
+		*syncedToMutated = true
+	}
+
+	if params.BirthdayBlock != nil {
+		birthdayBlock, err := db.BlockStampFromBlock(
+			params.BirthdayBlock,
+		)
+		if err != nil {
+			return err
+		}
+
+		err = addrStore.SetBirthdayBlock(ns, birthdayBlock, true)
+		if err != nil {
+			return fmt.Errorf("set birthday block: %w", err)
+		}
+	}
+
+	return nil
 }
 
 // GetEncryptedHDSeed reads the encrypted master HD private key from the
@@ -157,5 +362,3 @@ func (s *Store) UpdateWalletSecrets(ctx context.Context,
 
 	return notImplemented(ctx, "UpdateWalletSecrets")
 }
-
-

--- a/wallet/internal/db/kvdb/walletstore.go
+++ b/wallet/internal/db/kvdb/walletstore.go
@@ -75,12 +75,7 @@ func (s *Store) GetWallet(_ context.Context,
 		return nil, fmt.Errorf("kvdb.Store.GetWallet: %w", err)
 	}
 
-	syncedTo, err := db.OptionalBlockFromBlockStamp(addrStore.SyncedTo())
-	if errors.Is(err, db.ErrBlockNotFound) {
-		syncedTo = nil
-	} else if err != nil {
-		return nil, fmt.Errorf("kvdb.Store.GetWallet: %w", err)
-	}
+	syncedTo := db.OptionalBlockFromBlockStamp(addrStore.SyncedTo())
 
 	return &db.WalletInfo{
 		ID:            0,

--- a/wallet/internal/db/kvdb/walletstore.go
+++ b/wallet/internal/db/kvdb/walletstore.go
@@ -2,6 +2,8 @@ package kvdb
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"iter"
 
 	"github.com/btcsuite/btcwallet/waddrmgr"
@@ -13,6 +15,10 @@ import (
 // A compile-time assertion to ensure Store implements the wallet store.
 var _ db.WalletStore = (*Store)(nil)
 
+// errMissingAddrStore is returned when a legacy address-manager backed store
+// operation has no address manager wired.
+var errMissingAddrStore = errors.New("missing legacy addr store")
+
 // CreateWallet is not yet implemented for kvdb.
 func (s *Store) CreateWallet(ctx context.Context,
 	_ db.CreateWalletParams) (*db.WalletInfo, error) {
@@ -20,11 +26,63 @@ func (s *Store) CreateWallet(ctx context.Context,
 	return nil, notImplemented(ctx, "CreateWallet")
 }
 
-// GetWallet is not yet implemented for kvdb.
-func (s *Store) GetWallet(ctx context.Context,
-	_ string) (*db.WalletInfo, error) {
+// GetWallet reads wallet runtime metadata from the legacy address manager.
+func (s *Store) GetWallet(_ context.Context,
+	name string) (*db.WalletInfo, error) {
 
-	return nil, notImplemented(ctx, "GetWallet")
+	if s.addrStore == nil {
+		return nil, fmt.Errorf("kvdb.Store.GetWallet: %w",
+			errMissingAddrStore)
+	}
+
+	addrStore := s.addrStore
+
+	var birthdayBlock *db.Block
+
+	err := walletdb.View(s.db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgr.NamespaceKey)
+		if ns == nil {
+			return errMissingAddrmgrNamespace
+		}
+
+		block, verified, err := addrStore.BirthdayBlock(ns)
+		if err != nil {
+			if waddrmgr.IsError(err, waddrmgr.ErrBirthdayBlockNotSet) {
+				return nil
+			}
+
+			return fmt.Errorf("get birthday block: %w", err)
+		}
+
+		if !verified {
+			return nil
+		}
+
+		birthdayBlock, err = db.BlockFromBlockStamp(block)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("kvdb.Store.GetWallet: %w", err)
+	}
+
+	syncedTo, err := db.OptionalBlockFromBlockStamp(addrStore.SyncedTo())
+	if errors.Is(err, db.ErrBlockNotFound) {
+		syncedTo = nil
+	} else if err != nil {
+		return nil, fmt.Errorf("kvdb.Store.GetWallet: %w", err)
+	}
+
+	return &db.WalletInfo{
+		ID:            0,
+		Name:          name,
+		Birthday:      addrStore.Birthday().UTC(),
+		BirthdayBlock: birthdayBlock,
+		SyncedTo:      syncedTo,
+	}, nil
 }
 
 // ListWallets is not yet implemented for kvdb.
@@ -41,7 +99,7 @@ func (s *Store) IterWallets(ctx context.Context,
 	_ db.ListWalletsQuery) iter.Seq2[db.WalletInfo, error] {
 
 	return func(yield func(db.WalletInfo, error) bool) {
-		yield(db.WalletInfo{}, notImplemented(ctx, "IterWallets"))
+		_ = yield(db.WalletInfo{}, notImplemented(ctx, "IterWallets"))
 	}
 }
 
@@ -99,3 +157,5 @@ func (s *Store) UpdateWalletSecrets(ctx context.Context,
 
 	return notImplemented(ctx, "UpdateWalletSecrets")
 }
+
+

--- a/wallet/internal/db/kvdb/walletstore_test.go
+++ b/wallet/internal/db/kvdb/walletstore_test.go
@@ -60,6 +60,13 @@ func newSpendableAddrMgr(t *testing.T,
 	return mgr
 }
 
+// newAddrStore creates a spendable legacy address store for kvdb tests.
+func newAddrStore(t *testing.T, dbConn walletdb.DB) *waddrmgr.Manager {
+	t.Helper()
+
+	return newSpendableAddrMgr(t, dbConn)
+}
+
 // newWalletStoreTestSetup builds a kvdb.Store hooked up to a freshly
 // created spendable waddrmgr wallet for the wallet-store master-key tests.
 func newWalletStoreTestSetup(t *testing.T) (*Store, func()) {
@@ -88,4 +95,59 @@ func TestGetEncryptedHDSeed(t *testing.T) {
 	encrypted, err := store.GetEncryptedHDSeed(t.Context(), 0)
 	require.NoError(t, err)
 	require.NotEmpty(t, encrypted)
+}
+
+// TestGetWalletReadsLegacyMetadata verifies that kvdb.Store adapts legacy
+// wallet metadata into the db-native wallet view.
+func TestGetWalletReadsLegacyMetadata(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	addrStore := newAddrStore(t, dbConn)
+	store := NewStore(dbConn, nil, addrStore)
+
+	info, err := store.GetWallet(t.Context(), "default")
+	require.NoError(t, err)
+	require.Equal(t, uint32(0), info.ID)
+	require.Equal(t, "default", info.Name)
+	require.Equal(t, addrStore.Birthday().UTC(), info.Birthday)
+	require.Nil(t, info.BirthdayBlock)
+}
+
+// TestGetWalletMissingAddrStore verifies that GetWallet reports a helpful
+// error when the legacy address manager is unavailable.
+func TestGetWalletMissingAddrStore(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	store := NewStore(dbConn, nil, nil)
+
+	_, err := store.GetWallet(t.Context(), "default")
+	require.ErrorContains(t, err, "missing legacy addr store")
+}
+
+// TestGetWalletKvdbIgnoresName verifies that the kvdb single-wallet adapter
+// echoes any requested wallet name without validating it. Unlike SQL backends
+// which enforce wallet-name lookup, kvdb is a single-wallet adapter and
+// returns the same legacy wallet regardless of name.
+func TestGetWalletKvdbIgnoresName(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	addrStore := newAddrStore(t, dbConn)
+	store := NewStore(dbConn, nil, addrStore)
+
+	info, err := store.GetWallet(t.Context(), "any-name")
+	require.NoError(t, err)
+	require.Equal(t, "any-name", info.Name)
+
+	info, err = store.GetWallet(t.Context(), "different-name")
+	require.NoError(t, err)
+	require.Equal(t, "different-name", info.Name)
 }

--- a/wallet/internal/db/kvdb/walletstore_test.go
+++ b/wallet/internal/db/kvdb/walletstore_test.go
@@ -2,15 +2,24 @@ package kvdb
 
 import (
 	"bytes"
+	"errors"
+	"math"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
 	"github.com/stretchr/testify/require"
+)
+
+var (
+	errInducedFailure          = errors.New("induced failure")
+	errInducedVerificationStep = errors.New("induced verification-step failure")
 )
 
 // newSpendableAddrMgr creates a fresh waddrmgr-backed wallet on top of a new
@@ -67,6 +76,49 @@ func newAddrStore(t *testing.T, dbConn walletdb.DB) *waddrmgr.Manager {
 	return newSpendableAddrMgr(t, dbConn)
 }
 
+// someBlock returns deterministic block metadata for wallet-store tests.
+func someBlock(t *testing.T, height uint32) *db.Block {
+	t.Helper()
+
+	var hash chainhash.Hash
+
+	hash[0] = byte(height)
+	hash[1] = byte(height >> 8)
+	hash[2] = byte(height >> 16)
+	hash[3] = byte(height >> 24)
+	hash[4] = 0x42
+
+	return &db.Block{
+		Hash:      hash,
+		Height:    height,
+		Timestamp: time.Unix(int64(height)*600, 0).UTC(),
+	}
+}
+
+// failingAddrStore injects SetBirthdayBlock failures after allowing other
+// address-manager mutations to use the embedded real manager.
+type failingAddrStore struct {
+	*waddrmgr.Manager
+
+	failBeforePut bool
+}
+
+// SetBirthdayBlock injects a clean or partial birthday-block write failure.
+func (f *failingAddrStore) SetBirthdayBlock(ns walletdb.ReadWriteBucket,
+	block waddrmgr.BlockStamp, _ bool) error {
+
+	if f.failBeforePut {
+		return errInducedFailure
+	}
+
+	err := waddrmgr.PutBirthdayBlock(ns, block)
+	if err != nil {
+		return err
+	}
+
+	return errInducedVerificationStep
+}
+
 // newWalletStoreTestSetup builds a kvdb.Store hooked up to a freshly
 // created spendable waddrmgr wallet for the wallet-store master-key tests.
 func newWalletStoreTestSetup(t *testing.T) (*Store, func()) {
@@ -116,24 +168,8 @@ func TestGetWalletReadsLegacyMetadata(t *testing.T) {
 	require.Nil(t, info.BirthdayBlock)
 }
 
-// TestGetWalletMissingAddrStore verifies that GetWallet reports a helpful
-// error when the legacy address manager is unavailable.
-func TestGetWalletMissingAddrStore(t *testing.T) {
-	t.Parallel()
-
-	dbConn, cleanup := newTestDB(t)
-	t.Cleanup(cleanup)
-
-	store := NewStore(dbConn, nil, nil)
-
-	_, err := store.GetWallet(t.Context(), "default")
-	require.ErrorContains(t, err, "missing legacy addr store")
-}
-
-// TestGetWalletKvdbIgnoresName verifies that the kvdb single-wallet adapter
-// echoes any requested wallet name without validating it. Unlike SQL backends
-// which enforce wallet-name lookup, kvdb is a single-wallet adapter and
-// returns the same legacy wallet regardless of name.
+// TestGetWalletKvdbIgnoresName documents that kvdb echoes the requested
+// wallet name because it is a single-wallet legacy backend.
 func TestGetWalletKvdbIgnoresName(t *testing.T) {
 	t.Parallel()
 
@@ -150,4 +186,212 @@ func TestGetWalletKvdbIgnoresName(t *testing.T) {
 	info, err = store.GetWallet(t.Context(), "different-name")
 	require.NoError(t, err)
 	require.Equal(t, "different-name", info.Name)
+}
+
+// TestGetWalletMissingAddrStore verifies that GetWallet reports a helpful
+// error when the legacy address manager is unavailable.
+func TestGetWalletMissingAddrStore(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	store := NewStore(dbConn, nil, nil)
+
+	_, err := store.GetWallet(t.Context(), "default")
+	require.ErrorContains(t, err, "missing legacy addr store")
+}
+
+// TestUpdateWalletWritesLegacyMetadata verifies that kvdb.Store writes wallet
+// metadata through the legacy address manager.
+func TestUpdateWalletWritesLegacyMetadata(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	addrStore := newAddrStore(t, dbConn)
+	store := NewStore(dbConn, nil, addrStore)
+
+	birthday := time.Unix(123, 0).UTC()
+	birthdayBlock := &db.Block{
+		Hash:      chainhash.Hash{1},
+		Height:    0,
+		Timestamp: time.Unix(456, 0).UTC(),
+	}
+	err := store.UpdateWallet(t.Context(), db.UpdateWalletParams{
+		WalletID:      0,
+		Birthday:      &birthday,
+		BirthdayBlock: birthdayBlock,
+		SyncedTo:      birthdayBlock,
+	})
+	require.NoError(t, err)
+
+	info, err := store.GetWallet(t.Context(), "default")
+	require.NoError(t, err)
+	require.Equal(t, birthday, info.Birthday)
+	require.Equal(t, birthdayBlock, info.BirthdayBlock)
+	require.Equal(t, birthdayBlock, info.SyncedTo)
+}
+
+// TestUpdateWalletBirthdayBlockAndSyncedToTogether verifies non-zero initial
+// birthday block and synced-to writes can land in one kvdb update.
+func TestUpdateWalletBirthdayBlockAndSyncedToTogether(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	addrStore := newAddrStore(t, dbConn)
+	store := NewStore(dbConn, nil, addrStore)
+
+	birthdayBlock := someBlock(t, 100)
+	syncedTo := someBlock(t, 101)
+	err := store.UpdateWallet(t.Context(), db.UpdateWalletParams{
+		BirthdayBlock: birthdayBlock,
+		SyncedTo:      syncedTo,
+	})
+	require.NoError(t, err)
+
+	info, err := store.GetWallet(t.Context(), "default")
+	require.NoError(t, err)
+	require.Equal(t, birthdayBlock, info.BirthdayBlock)
+	require.Equal(t, syncedTo, info.SyncedTo)
+}
+
+// TestUpdateWalletKvdbIgnoresWalletID documents that kvdb applies updates to
+// the single legacy wallet regardless of the requested WalletID.
+func TestUpdateWalletKvdbIgnoresWalletID(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	addrStore := newAddrStore(t, dbConn)
+	store := NewStore(dbConn, nil, addrStore)
+
+	birthday := time.Date(2021, 6, 15, 0, 0, 0, 0, time.UTC)
+	err := store.UpdateWallet(t.Context(), db.UpdateWalletParams{
+		WalletID: 99999,
+		Birthday: &birthday,
+	})
+	require.NoError(t, err)
+
+	info, err := store.GetWallet(t.Context(), "default")
+	require.NoError(t, err)
+	require.Equal(t, birthday, info.Birthday)
+}
+
+// TestUpdateWalletRollsBackInMemoryBirthdayOnError verifies validation errors
+// do not leave the legacy manager's birthday cache ahead of the transaction.
+func TestUpdateWalletRollsBackInMemoryBirthdayOnError(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	addrStore := newAddrStore(t, dbConn)
+	store := NewStore(dbConn, nil, addrStore)
+
+	initial := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	err := store.UpdateWallet(t.Context(), db.UpdateWalletParams{
+		Birthday: &initial,
+	})
+	require.NoError(t, err)
+
+	newBirthday := time.Date(2021, 6, 15, 0, 0, 0, 0, time.UTC)
+	badBlock := &db.Block{
+		Height:    uint32(math.MaxInt32) + 1,
+		Hash:      chainhash.Hash{},
+		Timestamp: time.Now(),
+	}
+	err = store.UpdateWallet(t.Context(), db.UpdateWalletParams{
+		Birthday:      &newBirthday,
+		BirthdayBlock: badBlock,
+	})
+	require.Error(t, err)
+	require.Equal(t, initial, addrStore.Birthday())
+}
+
+// TestUpdateWalletRollsBackAfterPartialMutation verifies in-memory birthday
+// and synced-to caches are restored when a later birthday-block write fails.
+func TestUpdateWalletRollsBackAfterPartialMutation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		failBeforePut bool
+	}{
+		{name: "clean failure", failBeforePut: true},
+		{name: "partial write", failBeforePut: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			runPartialMutationRollback(t, tc.failBeforePut, 0)
+		})
+	}
+}
+
+// TestUpdateWalletRollsBackAfterPartialMutationNonZeroSync verifies rollback
+// clears transient birthday-block state before restoring a non-zero sync tip.
+func TestUpdateWalletRollsBackAfterPartialMutationNonZeroSync(t *testing.T) {
+	t.Parallel()
+
+	runPartialMutationRollback(t, false, 50)
+}
+
+// runPartialMutationRollback drives the injected birthday-block failure flow
+// and asserts that in-memory manager caches return to their original values.
+func runPartialMutationRollback(t *testing.T, failBeforePut bool,
+	initialHeight uint32) {
+
+	t.Helper()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	realMgr := newSpendableAddrMgr(t, dbConn)
+	addrStore := &failingAddrStore{
+		Manager:       realMgr,
+		failBeforePut: failBeforePut,
+	}
+	store := NewStore(dbConn, nil, addrStore)
+
+	initial := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	initialSync := someBlock(t, initialHeight)
+	err := store.UpdateWallet(t.Context(), db.UpdateWalletParams{
+		Birthday: &initial,
+		SyncedTo: initialSync,
+	})
+	require.NoError(t, err)
+
+	newBirthday := time.Date(2021, 6, 15, 0, 0, 0, 0, time.UTC)
+	newSync := someBlock(t, initialHeight+100)
+	err = store.UpdateWallet(t.Context(), db.UpdateWalletParams{
+		Birthday:      &newBirthday,
+		SyncedTo:      newSync,
+		BirthdayBlock: newSync,
+	})
+	require.Error(t, err)
+
+	require.Equal(t, initial, realMgr.Birthday())
+	require.Equal(t, initialSync.Hash, realMgr.SyncedTo().Hash)
+	require.Equal(t, initialSync.Height, uint32(realMgr.SyncedTo().Height))
+}
+
+// TestUpdateWalletMissingAddrStore verifies that UpdateWallet reports a
+// helpful error when the legacy address manager is unavailable.
+func TestUpdateWalletMissingAddrStore(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	store := NewStore(dbConn, nil, nil)
+
+	err := store.UpdateWallet(t.Context(), db.UpdateWalletParams{})
+	require.ErrorContains(t, err, "missing legacy addr store")
 }

--- a/wallet/internal/db/pg/accounts.go
+++ b/wallet/internal/db/pg/accounts.go
@@ -127,7 +127,8 @@ func (o createDerivedAccountOps) WalletWatchOnly(ctx context.Context,
 
 // EnsureScope implements db.CreateDerivedAccountOps.
 func (o createDerivedAccountOps) EnsureScope(ctx context.Context,
-	walletID uint32, scope db.KeyScope) (int64, error) {
+	walletID uint32,
+	scope db.KeyScope) (int64, db.ScopeAddrSchema, error) {
 
 	return ensureKeyScope(ctx, o.q, walletID, scope, nil)
 }
@@ -205,10 +206,12 @@ func (s *Store) CreateImportedAccount(ctx context.Context,
 
 		props, err = db.CreateImportedAccount(
 			ctx, params, func() (int64, error) {
-				return ensureKeyScope(
+				id, _, err := ensureKeyScope(
 					ctx, qtx, params.WalletID, params.Scope,
 					params.AddrSchema,
 				)
+
+				return id, err
 			}, func() (bool, error) {
 				return getWalletWatchOnly(ctx, qtx, params.WalletID)
 			}, qtx.CreateImportedAccount,
@@ -322,15 +325,20 @@ func getAccountProps(ctx context.Context, qtx *sqlc.Queries,
 			CreatedAt:         row.CreatedAt,
 			Purpose:           row.Purpose,
 			CoinType:          row.CoinType,
+			InternalTypeID:    row.InternalTypeID,
+			ExternalTypeID:    row.ExternalTypeID,
 			IDToOriginType:    db.IDToAccountOrigin[int16],
 		},
 	)
 }
 
-// ensureKeyScope retrieves an existing key scope or creates it if missing for
-// PostgreSQL. It returns the scope ID once available.
+// ensureKeyScope retrieves an existing key scope or creates it if missing
+// for PostgreSQL. It returns the scope ID together with the schema that is
+// now persisted for the scope so callers can build AccountInfo from
+// authoritative state instead of recomputing from ScopeAddrMap.
 func ensureKeyScope(ctx context.Context, qtx *sqlc.Queries, walletID uint32,
-	scope db.KeyScope, addrSchema *db.ScopeAddrSchema) (int64, error) {
+	scope db.KeyScope,
+	addrSchema *db.ScopeAddrSchema) (int64, db.ScopeAddrSchema, error) {
 
 	return db.EnsureKeyScope(
 		ctx, qtx.GetKeyScopeByWalletAndScope,
@@ -355,7 +363,15 @@ func ensureKeyScope(ctx context.Context, qtx *sqlc.Queries, walletID uint32,
 		},
 		func(row sqlc.GetKeyScopeByWalletAndScopeRow) int64 {
 			return row.ID
-		}, scope, addrSchema,
+		},
+		func(row sqlc.GetKeyScopeByWalletAndScopeRow) (
+			db.ScopeAddrSchema, error) {
+
+			return db.DerivedAddressAccountSchema(
+				row.InternalTypeID, row.ExternalTypeID,
+			)
+		},
+		scope, addrSchema,
 	)
 }
 
@@ -450,6 +466,8 @@ func accountRowToInfo[T accountInfoRow](row T) (*db.AccountInfo, error) {
 			CreatedAt:         base.CreatedAt,
 			Purpose:           base.Purpose,
 			CoinType:          base.CoinType,
+			InternalTypeID:    base.InternalTypeID,
+			ExternalTypeID:    base.ExternalTypeID,
 			IDToOriginType:    db.IDToAccountOrigin[int16],
 		},
 	)

--- a/wallet/internal/db/sqlite/accounts.go
+++ b/wallet/internal/db/sqlite/accounts.go
@@ -127,7 +127,8 @@ func (o createDerivedAccountOps) WalletWatchOnly(ctx context.Context,
 
 // EnsureScope implements db.CreateDerivedAccountOps.
 func (o createDerivedAccountOps) EnsureScope(ctx context.Context,
-	walletID uint32, scope db.KeyScope) (int64, error) {
+	walletID uint32,
+	scope db.KeyScope) (int64, db.ScopeAddrSchema, error) {
 
 	return ensureKeyScope(ctx, o.q, walletID, scope, nil)
 }
@@ -195,7 +196,7 @@ func (o createDerivedAccountOps) CreateDerivedAccount(ctx context.Context,
 // for SQLite. It returns the scope ID once available.
 func ensureKeyScope(ctx context.Context, qtx *sqlc.Queries,
 	walletID uint32, scope db.KeyScope,
-	addrSchema *db.ScopeAddrSchema) (int64, error) {
+	addrSchema *db.ScopeAddrSchema) (int64, db.ScopeAddrSchema, error) {
 
 	return db.EnsureKeyScope(
 		ctx, qtx.GetKeyScopeByWalletAndScope,
@@ -220,7 +221,15 @@ func ensureKeyScope(ctx context.Context, qtx *sqlc.Queries,
 		},
 		func(row sqlc.GetKeyScopeByWalletAndScopeRow) int64 {
 			return row.ID
-		}, scope, addrSchema,
+		},
+		func(row sqlc.GetKeyScopeByWalletAndScopeRow) (
+			db.ScopeAddrSchema, error) {
+
+			return db.DerivedAddressAccountSchema(
+				row.InternalTypeID, row.ExternalTypeID,
+			)
+		},
+		scope, addrSchema,
 	)
 }
 
@@ -240,10 +249,12 @@ func (s *Store) CreateImportedAccount(ctx context.Context,
 		props, err = db.CreateImportedAccount(
 			ctx, params,
 			func() (int64, error) {
-				return ensureKeyScope(
+				id, _, err := ensureKeyScope(
 					ctx, qtx, params.WalletID, params.Scope,
 					params.AddrSchema,
 				)
+
+				return id, err
 			},
 			func() (bool, error) {
 				return getWalletWatchOnly(ctx, qtx, params.WalletID)
@@ -360,6 +371,8 @@ func getAccountProps(ctx context.Context, qtx *sqlc.Queries,
 		CreatedAt:         row.CreatedAt,
 		Purpose:           row.Purpose,
 		CoinType:          row.CoinType,
+		InternalTypeID:    row.InternalTypeID,
+		ExternalTypeID:    row.ExternalTypeID,
 		IDToOriginType:    db.IDToAccountOrigin[int64],
 	})
 }
@@ -456,6 +469,8 @@ func accountRowToInfo[T accountInfoRow](row T) (*db.AccountInfo,
 		CreatedAt:         base.CreatedAt,
 		Purpose:           base.Purpose,
 		CoinType:          base.CoinType,
+		InternalTypeID:    base.InternalTypeID,
+		ExternalTypeID:    base.ExternalTypeID,
 		IDToOriginType:    db.IDToAccountOrigin[int64],
 	})
 }

--- a/wallet/log.go
+++ b/wallet/log.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btclog"
 	"github.com/btcsuite/btcwallet/build"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/db/kvdb"
 	"github.com/btcsuite/btcwallet/walletdb/migration"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 )
@@ -36,6 +37,7 @@ func UseLogger(logger btclog.Logger) {
 
 	migration.UseLogger(logger)
 	waddrmgr.UseLogger(logger)
+	kvdb.UseLogger(logger)
 	wtxmgr.UseLogger(logger)
 }
 


### PR DESCRIPTION
## Summary
- add kvdb implementations for the wallet metadata store methods
- route wallet metadata reads and updates through `w.store`
- update wallet mocks and tests for the store-backed metadata flow

## Why
- wallet metadata still used direct legacy wallet database access
- routing it through `db.Store` continues the incremental kvdb migration after the address manager
- keeping this in its own stacked PR makes the following UTXO-manager PR reviewable on top of a wallet metadata boundary

## What Changed
- implement kvdb `GetWallet` and `UpdateWallet`
- route wallet controller metadata paths through the store abstraction
- update mocks and add kvdb wallet-store coverage for metadata reads and updates

## Testing
- Not run in this step; draft PR opened to expose the stack.