### PR TITLE
db: populate AccountInfo balance with SkipBalance opt-out

### DIFF
--- a/wallet/internal/db/accounts_common.go
+++ b/wallet/internal/db/accounts_common.go
@@ -816,3 +816,95 @@ func CreateImportedAccount[CreateArgs any, CreateRow any, SecretArgs any](
 
 	return getProps(accountID)
 }
+
+// ProcessAccountRows converts a batch of dialect-specific account rows into
+// AccountInfo pointers (ordered as input). The convert closure produces both
+// the AccountInfo and the SQL row ID for each row; ProcessAccountRows stores
+// the row ID on the returned AccountInfo via the unexported rowID field so
+// AttachBalances can pair per-account balance rows back to their AccountInfo
+// without threading a parallel ids slice.
+func ProcessAccountRows[T any](rows []T,
+	convert func(T) (*AccountInfo, int64, error)) ([]*AccountInfo, error) {
+
+	infos := make([]*AccountInfo, len(rows))
+	for i := range rows {
+		info, id, err := convert(rows[i])
+		if err != nil {
+			return nil, err
+		}
+
+		info.rowID = id
+		infos[i] = info
+	}
+
+	return infos, nil
+}
+
+// AccountBalance is the dialect-agnostic shape of a per-account balance row.
+// Backends translate their sqlc balance rows into AccountBalance values when
+// calling AttachBalances; the wire-level AccountBalancesByIDs query lives in
+// each backend, and AccountBalance is the common contract its results land
+// in for the shared merge logic.
+type AccountBalance struct {
+	// AccountID is the SQL row ID of the account this balance belongs to;
+	// it matches the rowID populated on AccountInfo by ProcessAccountRows.
+	AccountID int64
+
+	// Confirmed is the sum of UTXO amounts (in satoshis) that are
+	// considered confirmed by the wallet's confirmation policy.
+	Confirmed int64
+
+	// Unconfirmed is the sum of UTXO amounts (in satoshis) that are
+	// unconfirmed.
+	Unconfirmed int64
+}
+
+// AttachBalances merges per-account balances into a batch of AccountInfo
+// values. The queryBalances callback executes the backend-specific
+// AccountBalancesByIDs and returns its results as []AccountBalance. The
+// merge step uses each AccountInfo's rowID (populated by ProcessAccountRows)
+// to map balance rows back to their AccountInfo in a single pass. The
+// returned slice preserves the input order of infos.
+//
+// When skipBalance is true or infos is empty, the query dispatch is skipped
+// and every returned AccountInfo keeps zero balance fields. The query
+// callback is invoked at most once per AttachBalances call.
+func AttachBalances(ctx context.Context, walletID uint32, skipBalance bool,
+	infos []*AccountInfo,
+	queryBalances func(ctx context.Context, walletID uint32,
+		ids []int64) ([]AccountBalance, error)) ([]AccountInfo, error) {
+
+	out := make([]AccountInfo, len(infos))
+	for i := range infos {
+		out[i] = *infos[i]
+	}
+
+	if skipBalance || len(infos) == 0 {
+		return out, nil
+	}
+
+	indexByID := make(map[int64]int, len(infos))
+	ids := make([]int64, len(infos))
+
+	for i := range infos {
+		indexByID[infos[i].rowID] = i
+		ids[i] = infos[i].rowID
+	}
+
+	balances, err := queryBalances(ctx, walletID, ids)
+	if err != nil {
+		return nil, fmt.Errorf("account balances: %w", err)
+	}
+
+	for _, bal := range balances {
+		idx, ok := indexByID[bal.AccountID]
+		if !ok {
+			continue
+		}
+
+		out[idx].ConfirmedBalance = btcutil.Amount(bal.Confirmed)
+		out[idx].UnconfirmedBalance = btcutil.Amount(bal.Unconfirmed)
+	}
+
+	return out, nil
+}

--- a/wallet/internal/db/accounts_common.go
+++ b/wallet/internal/db/accounts_common.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
 )
 
 var (
@@ -249,6 +251,7 @@ func CreateDerivedAccountWithOps(ctx context.Context,
 		accNumber, params.Name, DerivedAccount, 0, 0, 0,
 		walletIsWatchOnly, row.CreatedAt, params.Scope,
 		derived.PublicKey, derived.MasterKeyFingerprint,
+		0, 0,
 	), nil
 }
 
@@ -473,16 +476,17 @@ func getAddrSchemaForScope(scope KeyScope) (ScopeAddrSchema, error) {
 	return addrSchema, nil
 }
 
-// BuildAccountInfo creates an AccountInfo with the provided values and zeroed
-// balances while we do not yet support balance tracking.
-//
-// TODO(stingelin): Add balance tracking support after transaction management is
-// implemented.
+// BuildAccountInfo creates an AccountInfo with the provided values.
+// confirmedBalance and unconfirmedBalance are populated verbatim from
+// the caller; create paths pass zero (a fresh account has no UTXOs)
+// while the read paths feed real values from the dedicated
+// AccountBalance / AccountBalances queries.
 func BuildAccountInfo(accountNum uint32, accountName string,
 	origin AccountOrigin, externalKeyCount, internalKeyCount,
 	importedKeyCount uint32, isWatchOnly bool, createdAt time.Time,
 	scope KeyScope, publicKey []byte,
-	masterKeyFingerprint uint32) *AccountInfo {
+	masterKeyFingerprint uint32,
+	confirmedBalance, unconfirmedBalance btcutil.Amount) *AccountInfo {
 
 	return &AccountInfo{
 		AccountNumber:        accountNum,
@@ -491,8 +495,8 @@ func BuildAccountInfo(accountNum uint32, accountName string,
 		ExternalKeyCount:     externalKeyCount,
 		InternalKeyCount:     internalKeyCount,
 		ImportedKeyCount:     importedKeyCount,
-		ConfirmedBalance:     0,
-		UnconfirmedBalance:   0,
+		ConfirmedBalance:     confirmedBalance,
+		UnconfirmedBalance:   unconfirmedBalance,
 		IsWatchOnly:          isWatchOnly,
 		CreatedAt:            createdAt,
 		KeyScope:             scope,
@@ -514,19 +518,21 @@ func IDToAccountOrigin[T ~int16 | ~int64](v T) (AccountOrigin, error) {
 // AccountInfoRow represents the raw database fields needed to construct
 // AccountInfo.
 type AccountInfoRow[AccOriginId any] struct {
-	AccountNumber     sql.NullInt64
-	AccountName       string
-	OriginID          AccOriginId
-	ExternalKeyCount  int64
-	InternalKeyCount  int64
-	ImportedKeyCount  int64
-	PublicKey         []byte
-	MasterFingerprint sql.NullInt64
-	IsWatchOnly       bool
-	CreatedAt         time.Time
-	Purpose           int64
-	CoinType          int64
-	IDToOriginType    func(AccOriginId) (AccountOrigin, error)
+	AccountNumber      sql.NullInt64
+	AccountName        string
+	OriginID           AccOriginId
+	ExternalKeyCount   int64
+	InternalKeyCount   int64
+	ImportedKeyCount   int64
+	PublicKey          []byte
+	MasterFingerprint  sql.NullInt64
+	IsWatchOnly        bool
+	CreatedAt          time.Time
+	Purpose            int64
+	CoinType           int64
+	ConfirmedBalance   int64
+	UnconfirmedBalance int64
+	IDToOriginType     func(AccOriginId) (AccountOrigin, error)
 }
 
 // AccountRowToInfo converts raw database field values into an AccountInfo
@@ -579,6 +585,8 @@ func AccountRowToInfo[AccOriginId any](
 		importedKeyCount, row.IsWatchOnly, row.CreatedAt,
 		KeyScope{Purpose: purposeNum, Coin: coinTypeNum},
 		row.PublicKey, fingerprint,
+		btcutil.Amount(row.ConfirmedBalance),
+		btcutil.Amount(row.UnconfirmedBalance),
 	), nil
 }
 

--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -512,6 +512,19 @@ type GetAccountQuery struct {
 	// AccountNumber is the number of the account to query. If nil, the
 	// query will be performed using the Name.
 	AccountNumber *uint32
+
+	// SkipBalance, when true, skips the dedicated AccountBalance query
+	// that the adapter normally runs alongside the account read. The
+	// returned AccountInfo reports ConfirmedBalance and UnconfirmedBalance
+	// as zero. Default (false) issues the balance query inside the same
+	// read transaction as the account fetch and populates both fields.
+	// Set this only when balance is unnecessary (e.g. identity-only
+	// lookups, autocomplete UIs, schema audits) to avoid the UTXO scan.
+	//
+	// For filtered or locked-aware balance reads (min/max confirmations,
+	// coinbase maturity, locked-output exclusion) use Store.Balance with
+	// BalanceParams instead.
+	SkipBalance bool
 }
 
 // ListAccountsQuery holds the set of options for a ListAccounts query.

--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -410,6 +410,13 @@ type AccountInfo struct {
 	// (BIP32 m/) corresponding to this account's public key. Used by
 	// some hardware wallets for proper identification and signing.
 	MasterKeyFingerprint uint32
+
+	// rowID is the SQL backend's per-account row ID. Populated by
+	// ProcessAccountRows so AttachBalances can pair AccountBalancesByIDs
+	// results back to the originating AccountInfo without threading a
+	// parallel ids slice. Unexported because it is a backend-specific
+	// detail; kvdb backends leave it at zero.
+	rowID int64
 }
 
 // ScopeAddrSchema is the address schema of a particular KeyScope. It is
@@ -542,6 +549,20 @@ type ListAccountsQuery struct {
 	// Name is an optional filter to list accounts only with a specific
 	// name.
 	Name *string
+
+	// SkipBalance, when true, skips the dedicated AccountBalances query
+	// that the adapter normally runs alongside the list fetch. Each
+	// returned AccountInfo reports ConfirmedBalance and
+	// UnconfirmedBalance as zero. Default (false) issues a single batch
+	// balance query inside the same read transaction as the list fetch
+	// and merges the per-account totals into the result by account_id.
+	// Set this only when balance is unnecessary (e.g. identity-only
+	// lookups, autocomplete UIs, schema audits) to avoid the UTXO scan.
+	//
+	// For filtered or locked-aware balance reads (min/max confirmations,
+	// coinbase maturity, locked-output exclusion) use Store.Balance with
+	// BalanceParams instead.
+	SkipBalance bool
 }
 
 // RenameAccountParams contains the parameters for renaming an account. The

--- a/wallet/internal/db/itest/account_store_test.go
+++ b/wallet/internal/db/itest/account_store_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/stretchr/testify/require"
 )
@@ -535,9 +537,11 @@ func TestCreateDerivedAccountConcurrent(t *testing.T) {
 	require.Len(t, results, workers)
 
 	// Verify all numbers are unique and sequential.
-	sort.Slice(results, func(i, j int) bool {
-		return results[i] < results[j]
-	})
+	sort.Slice(
+		results, func(i, j int) bool {
+			return results[i] < results[j]
+		},
+	)
 
 	for i := range workers {
 		require.Equal(t, uint32(i), results[i])
@@ -856,14 +860,16 @@ func TestGetAccount(t *testing.T) {
 	for _, tc := range AllAccountCases {
 		accNumber := uint32(0)
 
-		t.Run("by name-"+tc.Name, func(t *testing.T) {
-			query := getAccountQueryByName(walletID, tc.Scope, tc.Name)
-			info, err := store.GetAccount(t.Context(), query)
-			require.NoError(t, err)
-			require.NotNil(t, info)
-			requireAccountMatches(t, info, tc)
-			accNumber = info.AccountNumber
-		})
+		t.Run(
+			"by name-"+tc.Name, func(t *testing.T) {
+				query := getAccountQueryByName(walletID, tc.Scope, tc.Name)
+				info, err := store.GetAccount(t.Context(), query)
+				require.NoError(t, err)
+				require.NotNil(t, info)
+				requireAccountMatches(t, info, tc)
+				accNumber = info.AccountNumber
+			},
+		)
 
 		if tc.Origin == db.ImportedAccount {
 			continue
@@ -876,7 +882,8 @@ func TestGetAccount(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, info)
 				requireAccountMatches(t, info, tc)
-			})
+			},
+		)
 	}
 }
 
@@ -990,6 +997,150 @@ func TestListAccountsReturnsPublicKey(t *testing.T) {
 	for _, acc := range accounts {
 		require.NotEmpty(t, acc.PublicKey, acc.AccountName)
 	}
+}
+
+// TestGetAccountPopulatesBalance verifies that GetAccount returns the
+// confirmed and unconfirmed UTXO totals on the AccountInfo, sourced from
+// the dedicated AccountBalance query that the adapter dispatches
+// alongside the account row fetch.
+func TestGetAccountPopulatesBalance(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-get-balance")
+	scope := db.KeyScopeBIP0084
+
+	queries := store.Queries()
+	syncBlock := CreateBlockFixture(t, queries, 200)
+	confirmedBlock := CreateBlockFixture(t, queries, 100)
+
+	err := store.UpdateWallet(
+		t.Context(), db.UpdateWalletParams{
+			WalletID: walletID,
+			SyncedTo: &syncBlock,
+		},
+	)
+	require.NoError(t, err)
+
+	createDerivedAccount(t, store, walletID, scope, "funded")
+	createDerivedAccount(t, store, walletID, scope, "empty")
+
+	addr := newDerivedAddress(t, store, walletID, scope, "funded", false)
+
+	confirmedTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 24000, PkScript: addr.ScriptPubKey}},
+	)
+	err = store.CreateTx(
+		t.Context(), db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       confirmedTx,
+			Received: time.Unix(1710000000, 0),
+			Block:    &confirmedBlock,
+			Status:   db.TxStatusPublished,
+			Credits:  map[uint32]btcutil.Address{0: nil},
+		},
+	)
+	require.NoError(t, err)
+
+	unconfirmedTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 26000, PkScript: addr.ScriptPubKey}},
+	)
+	err = store.CreateTx(
+		t.Context(), db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       unconfirmedTx,
+			Received: time.Unix(1710000100, 0),
+			Status:   db.TxStatusPending,
+			Credits:  map[uint32]btcutil.Address{0: nil},
+		},
+	)
+	require.NoError(t, err)
+
+	funded, err := store.GetAccount(
+		t.Context(), getAccountQueryByName(walletID, scope, "funded"),
+	)
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(24000), funded.ConfirmedBalance)
+	require.Equal(t, btcutil.Amount(26000), funded.UnconfirmedBalance)
+
+	byNumber, err := store.GetAccount(
+		t.Context(),
+		getAccountQueryByNumber(walletID, scope, funded.AccountNumber),
+	)
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(24000), byNumber.ConfirmedBalance)
+	require.Equal(t, btcutil.Amount(26000), byNumber.UnconfirmedBalance)
+
+	empty, err := store.GetAccount(
+		t.Context(), getAccountQueryByName(walletID, scope, "empty"),
+	)
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(0), empty.ConfirmedBalance)
+	require.Equal(t, btcutil.Amount(0), empty.UnconfirmedBalance)
+}
+
+// TestGetAccountSkipBalanceZerosFields verifies that GetAccount with
+// SkipBalance=true skips the dedicated AccountBalance dispatch on both
+// the by-name and by-number selectors and leaves the balance fields at
+// zero even when UTXOs exist on the account.
+func TestGetAccountSkipBalanceZerosFields(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-get-balance-skip")
+	scope := db.KeyScopeBIP0084
+
+	queries := store.Queries()
+	syncBlock := CreateBlockFixture(t, queries, 200)
+	confirmedBlock := CreateBlockFixture(t, queries, 100)
+
+	err := store.UpdateWallet(
+		t.Context(), db.UpdateWalletParams{
+			WalletID: walletID,
+			SyncedTo: &syncBlock,
+		},
+	)
+	require.NoError(t, err)
+
+	createDerivedAccount(t, store, walletID, scope, "funded")
+
+	addr := newDerivedAddress(t, store, walletID, scope, "funded", false)
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 24000, PkScript: addr.ScriptPubKey}},
+	)
+	err = store.CreateTx(
+		t.Context(), db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710000200, 0),
+			Block:    &confirmedBlock,
+			Status:   db.TxStatusPublished,
+			Credits:  map[uint32]btcutil.Address{0: nil},
+		},
+	)
+	require.NoError(t, err)
+
+	byNameQuery := getAccountQueryByName(walletID, scope, "funded")
+	byNameQuery.SkipBalance = true
+
+	infoByName, err := store.GetAccount(t.Context(), byNameQuery)
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(0), infoByName.ConfirmedBalance)
+	require.Equal(t, btcutil.Amount(0), infoByName.UnconfirmedBalance)
+
+	byNumberQuery := getAccountQueryByNumber(
+		walletID, scope, infoByName.AccountNumber,
+	)
+	byNumberQuery.SkipBalance = true
+
+	infoByNumber, err := store.GetAccount(t.Context(), byNumberQuery)
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(0), infoByNumber.ConfirmedBalance)
+	require.Equal(t, btcutil.Amount(0), infoByNumber.UnconfirmedBalance)
 }
 
 // TestGetAccountNotFound verifies that GetAccount returns ErrAccountNotFound
@@ -1227,10 +1378,12 @@ func TestAccountCreatedAtTimestamp(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		accounts = append(accounts, createdAccount{
-			info:        *info,
-			createdNear: createdNear,
-		})
+		accounts = append(
+			accounts, createdAccount{
+				info:        *info,
+				createdNear: createdNear,
+			},
+		)
 	}
 
 	// Verify all accounts have CreatedAt populated.
@@ -1268,12 +1421,14 @@ func TestRenameAccount(t *testing.T) {
 		oldName := "original-name-1"
 		newName := "renamed-by-name"
 
-		err := store.RenameAccount(t.Context(), db.RenameAccountParams{
-			WalletID: walletID,
-			Scope:    scope,
-			OldName:  oldName,
-			NewName:  newName,
-		})
+		err := store.RenameAccount(
+			t.Context(), db.RenameAccountParams{
+				WalletID: walletID,
+				Scope:    scope,
+				OldName:  oldName,
+				NewName:  newName,
+			},
+		)
 		require.NoError(t, err)
 
 		// Verify the rename worked.
@@ -1294,12 +1449,14 @@ func TestRenameAccount(t *testing.T) {
 		accNum := uint32(0)
 		newName := "renamed-by-number"
 
-		err := store.RenameAccount(t.Context(), db.RenameAccountParams{
-			WalletID:      walletID,
-			Scope:         scope,
-			AccountNumber: &accNum,
-			NewName:       newName,
-		})
+		err := store.RenameAccount(
+			t.Context(), db.RenameAccountParams{
+				WalletID:      walletID,
+				Scope:         scope,
+				AccountNumber: &accNum,
+				NewName:       newName,
+			},
+		)
 		require.NoError(t, err)
 
 		// Verify the rename worked.
@@ -1565,9 +1722,11 @@ func findAccountInList(t *testing.T, accounts []db.AccountInfo,
 
 	t.Helper()
 
-	i := slices.IndexFunc(accounts, func(acc db.AccountInfo) bool {
-		return acc.AccountName == tc.Name && acc.KeyScope == tc.Scope
-	})
+	i := slices.IndexFunc(
+		accounts, func(acc db.AccountInfo) bool {
+			return acc.AccountName == tc.Name && acc.KeyScope == tc.Scope
+		},
+	)
 	require.GreaterOrEqual(t, i, 0, "expected account %s in list", tc.Name)
 
 	return accounts[i]

--- a/wallet/internal/db/itest/account_store_test.go
+++ b/wallet/internal/db/itest/account_store_test.go
@@ -1143,6 +1143,215 @@ func TestGetAccountSkipBalanceZerosFields(t *testing.T) {
 	require.Equal(t, btcutil.Amount(0), infoByNumber.UnconfirmedBalance)
 }
 
+// TestListAccountsPopulatesBalance verifies that ListAccounts returns
+// confirmed/unconfirmed totals on every returned AccountInfo, sourced
+// from the AccountBalances batch query dispatched alongside the row
+// fetch.
+func TestListAccountsPopulatesBalance(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-list-balance")
+	scope := db.KeyScopeBIP0084
+
+	queries := store.Queries()
+	syncBlock := CreateBlockFixture(t, queries, 200)
+	confirmedBlock := CreateBlockFixture(t, queries, 100)
+
+	err := store.UpdateWallet(
+		t.Context(), db.UpdateWalletParams{
+			WalletID: walletID,
+			SyncedTo: &syncBlock,
+		},
+	)
+	require.NoError(t, err)
+
+	createDerivedAccount(t, store, walletID, scope, "first")
+	createDerivedAccount(t, store, walletID, scope, "second")
+	createDerivedAccount(t, store, walletID, scope, "empty")
+
+	firstAddr := newDerivedAddress(t, store, walletID, scope, "first", false)
+	secondAddr := newDerivedAddress(
+		t, store, walletID, scope, "second", false,
+	)
+
+	firstTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 12000, PkScript: firstAddr.ScriptPubKey}},
+	)
+	err = store.CreateTx(
+		t.Context(), db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       firstTx,
+			Received: time.Unix(1710000200, 0),
+			Block:    &confirmedBlock,
+			Status:   db.TxStatusPublished,
+			Credits:  map[uint32]btcutil.Address{0: nil},
+		},
+	)
+	require.NoError(t, err)
+
+	secondTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 7000, PkScript: secondAddr.ScriptPubKey}},
+	)
+	err = store.CreateTx(
+		t.Context(), db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       secondTx,
+			Received: time.Unix(1710000300, 0),
+			Status:   db.TxStatusPending,
+			Credits:  map[uint32]btcutil.Address{0: nil},
+		},
+	)
+	require.NoError(t, err)
+
+	verify := func(t *testing.T,
+		accounts []db.AccountInfo, label string) {
+
+		t.Helper()
+
+		byName := make(map[string]db.AccountInfo, len(accounts))
+		for _, acc := range accounts {
+			byName[acc.AccountName] = acc
+		}
+
+		require.Contains(t, byName, "first", label)
+		require.Equal(t, btcutil.Amount(12000),
+			byName["first"].ConfirmedBalance, label+": first")
+		require.Equal(t, btcutil.Amount(0),
+			byName["first"].UnconfirmedBalance, label+": first")
+
+		require.Contains(t, byName, "second", label)
+		require.Equal(t, btcutil.Amount(0),
+			byName["second"].ConfirmedBalance, label+": second")
+		require.Equal(t, btcutil.Amount(7000),
+			byName["second"].UnconfirmedBalance, label+": second")
+
+		require.Contains(t, byName, "empty", label)
+		require.Equal(t, btcutil.Amount(0),
+			byName["empty"].ConfirmedBalance, label+": empty")
+		require.Equal(t, btcutil.Amount(0),
+			byName["empty"].UnconfirmedBalance, label+": empty")
+	}
+
+	byScope, err := store.ListAccounts(
+		t.Context(), db.ListAccountsQuery{
+			WalletID: walletID,
+			Scope:    &scope,
+		},
+	)
+	require.NoError(t, err)
+	verify(t, byScope, "by scope")
+
+	all, err := store.ListAccounts(
+		t.Context(), db.ListAccountsQuery{
+			WalletID: walletID,
+		},
+	)
+	require.NoError(t, err)
+	verify(t, all, "all")
+}
+
+// TestListAccountsSkipBalanceZerosFields verifies that ListAccounts with
+// SkipBalance=true skips the AccountBalances dispatch on each of the
+// three list selectors (scope-filtered, name-filtered, unfiltered) and
+// returns zero balance fields even when UTXOs exist.
+func TestListAccountsSkipBalanceZerosFields(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-list-skip-balance")
+	scope := db.KeyScopeBIP0084
+
+	queries := store.Queries()
+	syncBlock := CreateBlockFixture(t, queries, 200)
+	confirmedBlock := CreateBlockFixture(t, queries, 100)
+
+	err := store.UpdateWallet(
+		t.Context(), db.UpdateWalletParams{
+			WalletID: walletID,
+			SyncedTo: &syncBlock,
+		},
+	)
+	require.NoError(t, err)
+
+	createDerivedAccount(t, store, walletID, scope, "funded")
+
+	addr := newDerivedAddress(t, store, walletID, scope, "funded", false)
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 9000, PkScript: addr.ScriptPubKey}},
+	)
+	err = store.CreateTx(
+		t.Context(), db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710000400, 0),
+			Block:    &confirmedBlock,
+			Status:   db.TxStatusPublished,
+			Credits:  map[uint32]btcutil.Address{0: nil},
+		},
+	)
+	require.NoError(t, err)
+
+	verify := func(t *testing.T,
+		accounts []db.AccountInfo, label string) {
+
+		t.Helper()
+
+		require.NotEmpty(t, accounts, label)
+
+		found := false
+		for _, acc := range accounts {
+			if acc.AccountName == "funded" {
+				found = true
+			}
+
+			require.Equal(t, btcutil.Amount(0),
+				acc.ConfirmedBalance,
+				label+": "+acc.AccountName)
+			require.Equal(t, btcutil.Amount(0),
+				acc.UnconfirmedBalance,
+				label+": "+acc.AccountName)
+		}
+
+		require.True(t, found,
+			label+": funded account missing from result")
+	}
+
+	byScope, err := store.ListAccounts(
+		t.Context(), db.ListAccountsQuery{
+			WalletID:    walletID,
+			Scope:       &scope,
+			SkipBalance: true,
+		},
+	)
+	require.NoError(t, err)
+	verify(t, byScope, "by scope")
+
+	name := "funded"
+	byName, err := store.ListAccounts(
+		t.Context(), db.ListAccountsQuery{
+			WalletID:    walletID,
+			Name:        &name,
+			SkipBalance: true,
+		},
+	)
+	require.NoError(t, err)
+	verify(t, byName, "by name")
+
+	all, err := store.ListAccounts(
+		t.Context(), db.ListAccountsQuery{
+			WalletID:    walletID,
+			SkipBalance: true,
+		},
+	)
+	require.NoError(t, err)
+	verify(t, all, "all")
+}
+
 // TestGetAccountNotFound verifies that GetAccount returns ErrAccountNotFound
 // when querying a non-existent account.
 func TestGetAccountNotFound(t *testing.T) {

--- a/wallet/internal/db/pg/accounts.go
+++ b/wallet/internal/db/pg/accounts.go
@@ -411,40 +411,130 @@ type accountListQueries struct {
 	q *sqlc.Queries
 }
 
-// byScope lists accounts filtered by wallet ID and key scope.
+// byScope lists accounts filtered by wallet ID and key scope, then
+// attaches each account's balance via AccountBalancesByIDs unless
+// query.SkipBalance is set.
 func (p accountListQueries) byScope(ctx context.Context,
 	query db.ListAccountsQuery) ([]db.AccountInfo, error) {
 
-	return db.ListAccounts(
-		ctx, p.q.ListAccountsByWalletScope,
-		sqlc.ListAccountsByWalletScopeParams{
+	rows, err := p.q.ListAccountsByWalletScope(
+		ctx, sqlc.ListAccountsByWalletScopeParams{
 			WalletID: int64(query.WalletID),
 			Purpose:  int64(query.Scope.Purpose),
 			CoinType: int64(query.Scope.Coin),
-		}, accountRowToInfo,
+		},
 	)
+	if err != nil {
+		return nil, fmt.Errorf("list accounts: %w", err)
+	}
+
+	infos, err := db.ProcessAccountRows(
+		rows,
+		func(r sqlc.ListAccountsByWalletScopeRow) (*db.AccountInfo, int64,
+			error) {
+
+			info, err := accountRowToInfo(r)
+			return info, r.ID, err
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.attachBalances(ctx, query, infos)
 }
 
-// byName lists accounts filtered by wallet ID and account name.
+// byName lists accounts filtered by wallet ID and account name, then
+// attaches each account's balance via AccountBalancesByIDs unless
+// query.SkipBalance is set.
 func (p accountListQueries) byName(ctx context.Context,
 	query db.ListAccountsQuery) ([]db.AccountInfo, error) {
 
-	return db.ListAccounts(
-		ctx, p.q.ListAccountsByWalletAndName,
-		sqlc.ListAccountsByWalletAndNameParams{
+	rows, err := p.q.ListAccountsByWalletAndName(
+		ctx, sqlc.ListAccountsByWalletAndNameParams{
 			WalletID:    int64(query.WalletID),
 			AccountName: *query.Name,
-		}, accountRowToInfo,
+		},
 	)
+	if err != nil {
+		return nil, fmt.Errorf("list accounts: %w", err)
+	}
+
+	infos, err := db.ProcessAccountRows(
+		rows,
+		func(r sqlc.ListAccountsByWalletAndNameRow) (*db.AccountInfo, int64,
+			error) {
+
+			info, err := accountRowToInfo(r)
+			return info, r.ID, err
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.attachBalances(ctx, query, infos)
 }
 
-// all lists all accounts for a wallet.
+// all lists every account for a wallet, then attaches each account's
+// balance via AccountBalancesByIDs unless query.SkipBalance is set.
 func (p accountListQueries) all(ctx context.Context,
 	query db.ListAccountsQuery) ([]db.AccountInfo, error) {
 
-	return db.ListAccounts(
-		ctx, p.q.ListAccountsByWallet, int64(query.WalletID),
-		accountRowToInfo,
+	rows, err := p.q.ListAccountsByWallet(ctx, int64(query.WalletID))
+	if err != nil {
+		return nil, fmt.Errorf("list accounts: %w", err)
+	}
+
+	infos, err := db.ProcessAccountRows(
+		rows,
+		func(r sqlc.ListAccountsByWalletRow) (*db.AccountInfo, int64,
+			error) {
+
+			info, err := accountRowToInfo(r)
+			return info, r.ID, err
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.attachBalances(ctx, query, infos)
+}
+
+// attachBalances forwards to db.AttachBalances with a backend-specific
+// closure that runs AccountBalancesByIDs and converts the sqlc rows into
+// the dialect-agnostic db.AccountBalance shape.
+func (p accountListQueries) attachBalances(ctx context.Context,
+	query db.ListAccountsQuery,
+	infos []*db.AccountInfo) ([]db.AccountInfo, error) {
+
+	return db.AttachBalances(
+		ctx, query.WalletID, query.SkipBalance, infos,
+		func(ctx context.Context, walletID uint32,
+			ids []int64) ([]db.AccountBalance, error) {
+
+			rows, err := p.q.AccountBalancesByIDs(
+				ctx, sqlc.AccountBalancesByIDsParams{
+					WalletID:   int64(walletID),
+					AccountIds: ids,
+				},
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			balances := make([]db.AccountBalance, len(rows))
+			for i := range rows {
+				balances[i] = db.AccountBalance{
+					AccountID:   rows[i].AccountID,
+					Confirmed:   rows[i].ConfirmedBalance,
+					Unconfirmed: rows[i].UnconfirmedBalance,
+				}
+			}
+
+			return balances, nil
+		},
 	)
 }
 

--- a/wallet/internal/db/pg/accounts.go
+++ b/wallet/internal/db/pg/accounts.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 )
@@ -284,21 +285,23 @@ func getAccountProps(ctx context.Context, qtx *sqlc.Queries,
 		return nil, fmt.Errorf("get account props: %w", err)
 	}
 
-	return db.AccountPropsRowToInfo(db.AccountPropsRow[int16, int16]{
-		AccountNumber:     row.AccountNumber,
-		AccountName:       row.AccountName,
-		OriginID:          row.OriginID,
-		ExternalKeyCount:  row.ExternalKeyCount,
-		InternalKeyCount:  row.InternalKeyCount,
-		ImportedKeyCount:  row.ImportedKeyCount,
-		PublicKey:         row.PublicKey,
-		MasterFingerprint: row.MasterFingerprint,
-		IsWatchOnly:       row.IsWatchOnly,
-		CreatedAt:         row.CreatedAt,
-		Purpose:           row.Purpose,
-		CoinType:          row.CoinType,
-		IDToOriginType:    db.IDToAccountOrigin[int16],
-	})
+	return db.AccountPropsRowToInfo(
+		db.AccountPropsRow[int16, int16]{
+			AccountNumber:     row.AccountNumber,
+			AccountName:       row.AccountName,
+			OriginID:          row.OriginID,
+			ExternalKeyCount:  row.ExternalKeyCount,
+			InternalKeyCount:  row.InternalKeyCount,
+			ImportedKeyCount:  row.ImportedKeyCount,
+			PublicKey:         row.PublicKey,
+			MasterFingerprint: row.MasterFingerprint,
+			IsWatchOnly:       row.IsWatchOnly,
+			CreatedAt:         row.CreatedAt,
+			Purpose:           row.Purpose,
+			CoinType:          row.CoinType,
+			IDToOriginType:    db.IDToAccountOrigin[int16],
+		},
+	)
 }
 
 // ensureKeyScope retrieves an existing key scope or creates it if missing for
@@ -384,21 +387,23 @@ func accountRowToInfo[T accountInfoRow](row T) (*db.AccountInfo, error) {
 	// identical fields. If sqlc types diverge, compilation will fail.
 	base := sqlc.GetAccountByScopeAndNameRow(row)
 
-	return db.AccountRowToInfo(db.AccountInfoRow[int16]{
-		AccountNumber:     base.AccountNumber,
-		AccountName:       base.AccountName,
-		OriginID:          base.OriginID,
-		ExternalKeyCount:  base.ExternalKeyCount,
-		InternalKeyCount:  base.InternalKeyCount,
-		ImportedKeyCount:  base.ImportedKeyCount,
-		PublicKey:         base.PublicKey,
-		MasterFingerprint: base.MasterFingerprint,
-		IsWatchOnly:       base.IsWatchOnly,
-		CreatedAt:         base.CreatedAt,
-		Purpose:           base.Purpose,
-		CoinType:          base.CoinType,
-		IDToOriginType:    db.IDToAccountOrigin[int16],
-	})
+	return db.AccountRowToInfo(
+		db.AccountInfoRow[int16]{
+			AccountNumber:     base.AccountNumber,
+			AccountName:       base.AccountName,
+			OriginID:          base.OriginID,
+			ExternalKeyCount:  base.ExternalKeyCount,
+			InternalKeyCount:  base.InternalKeyCount,
+			ImportedKeyCount:  base.ImportedKeyCount,
+			PublicKey:         base.PublicKey,
+			MasterFingerprint: base.MasterFingerprint,
+			IsWatchOnly:       base.IsWatchOnly,
+			CreatedAt:         base.CreatedAt,
+			Purpose:           base.Purpose,
+			CoinType:          base.CoinType,
+			IDToOriginType:    db.IDToAccountOrigin[int16],
+		},
+	)
 }
 
 // accountListQueries groups PostgreSQL account listing query methods.
@@ -448,34 +453,102 @@ type accountGetQueries struct {
 	q *sqlc.Queries
 }
 
-// byNumber retrieves an account by wallet ID, scope, and account number.
+// byNumber retrieves an account by wallet ID, scope, and account number,
+// then attaches its balance via AccountBalance unless query.SkipBalance
+// is set.
 func (p accountGetQueries) byNumber(ctx context.Context,
 	query db.GetAccountQuery) (*db.AccountInfo, error) {
 
-	return db.GetAccount(
-		ctx, p.q.GetAccountByWalletScopeAndNumber,
-		sqlc.GetAccountByWalletScopeAndNumberParams{
+	row, err := p.q.GetAccountByWalletScopeAndNumber(
+		ctx, sqlc.GetAccountByWalletScopeAndNumberParams{
 			WalletID:      int64(query.WalletID),
 			Purpose:       int64(query.Scope.Purpose),
 			CoinType:      int64(query.Scope.Coin),
 			AccountNumber: db.NullableUint32ToSQLInt64(query.AccountNumber),
-		}, query, accountRowToInfo,
+		},
 	)
+	if err != nil {
+		return nil, mapGetAccountErr(err, query)
+	}
+
+	info, err := accountRowToInfo(row)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.attachBalance(ctx, query, info, row.ID)
 }
 
-// byName retrieves an account by wallet ID, scope, and account name.
+// byName retrieves an account by wallet ID, scope, and account name, then
+// attaches its balance via AccountBalance unless query.SkipBalance is set.
 func (p accountGetQueries) byName(ctx context.Context,
 	query db.GetAccountQuery) (*db.AccountInfo, error) {
 
-	return db.GetAccount(
-		ctx, p.q.GetAccountByWalletScopeAndName,
-		sqlc.GetAccountByWalletScopeAndNameParams{
+	row, err := p.q.GetAccountByWalletScopeAndName(
+		ctx, sqlc.GetAccountByWalletScopeAndNameParams{
 			WalletID:    int64(query.WalletID),
 			Purpose:     int64(query.Scope.Purpose),
 			CoinType:    int64(query.Scope.Coin),
 			AccountName: *query.Name,
-		}, query, accountRowToInfo,
+		},
 	)
+	if err != nil {
+		return nil, mapGetAccountErr(err, query)
+	}
+
+	info, err := accountRowToInfo(row)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.attachBalance(ctx, query, info, row.ID)
+}
+
+// attachBalance fills ConfirmedBalance and UnconfirmedBalance on info via
+// the dedicated AccountBalance query, unless the caller opted out via
+// query.SkipBalance. The query runs inside the caller's read transaction.
+func (p accountGetQueries) attachBalance(ctx context.Context,
+	query db.GetAccountQuery, info *db.AccountInfo,
+	accountID int64) (*db.AccountInfo, error) {
+
+	if query.SkipBalance {
+		return info, nil
+	}
+
+	bal, err := p.q.AccountBalance(
+		ctx, sqlc.AccountBalanceParams{
+			WalletID:  int64(query.WalletID),
+			AccountID: accountID,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("account balance: %w", err)
+	}
+
+	info.ConfirmedBalance = btcutil.Amount(bal.ConfirmedBalance)
+	info.UnconfirmedBalance = btcutil.Amount(bal.UnconfirmedBalance)
+
+	return info, nil
+}
+
+// mapGetAccountErr returns the typed ErrAccountNotFound when err is
+// sql.ErrNoRows, falling back to a wrapped form otherwise. The caller
+// names the queried account in the error using whichever selector
+// (Name or AccountNumber) was set.
+func mapGetAccountErr(err error, query db.GetAccountQuery) error {
+	if !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("get account: %w", err)
+	}
+
+	if query.Name != nil {
+		return fmt.Errorf("account %q in scope %d/%d: %w", *query.Name,
+			query.Scope.Purpose, query.Scope.Coin,
+			db.ErrAccountNotFound)
+	}
+
+	return fmt.Errorf("account %d in scope %d/%d: %w",
+		*query.AccountNumber, query.Scope.Purpose, query.Scope.Coin,
+		db.ErrAccountNotFound)
 }
 
 // accountRenameQueries groups PostgreSQL account rename query methods.

--- a/wallet/internal/db/sqlite/accounts.go
+++ b/wallet/internal/db/sqlite/accounts.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 )
@@ -458,33 +459,102 @@ type accountGetQueries struct {
 	q *sqlc.Queries
 }
 
-// byNumber retrieves an account by wallet ID, scope, and account number.
+// byNumber retrieves an account by wallet ID, scope, and account number,
+// then attaches its balance via AccountBalance unless query.SkipBalance
+// is set.
 func (s accountGetQueries) byNumber(ctx context.Context,
 	query db.GetAccountQuery) (*db.AccountInfo, error) {
 
-	return db.GetAccount(
-		ctx, s.q.GetAccountByWalletScopeAndNumber,
-		sqlc.GetAccountByWalletScopeAndNumberParams{
+	row, err := s.q.GetAccountByWalletScopeAndNumber(
+		ctx, sqlc.GetAccountByWalletScopeAndNumberParams{
 			WalletID:      int64(query.WalletID),
 			Purpose:       int64(query.Scope.Purpose),
 			CoinType:      int64(query.Scope.Coin),
 			AccountNumber: db.NullableUint32ToSQLInt64(query.AccountNumber),
-		}, query, accountRowToInfo,
+		},
 	)
+	if err != nil {
+		return nil, mapGetAccountErr(err, query)
+	}
+
+	info, err := accountRowToInfo(row)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.attachBalance(ctx, query, info, row.ID)
 }
 
-// byName retrieves an account by wallet ID, scope, and account name.
+// byName retrieves an account by wallet ID, scope, and account name, then
+// attaches its balance via AccountBalance unless query.SkipBalance is set.
 func (s accountGetQueries) byName(ctx context.Context,
 	query db.GetAccountQuery) (*db.AccountInfo, error) {
 
-	return db.GetAccount(ctx, s.q.GetAccountByWalletScopeAndName,
-		sqlc.GetAccountByWalletScopeAndNameParams{
+	row, err := s.q.GetAccountByWalletScopeAndName(
+		ctx, sqlc.GetAccountByWalletScopeAndNameParams{
 			WalletID:    int64(query.WalletID),
 			Purpose:     int64(query.Scope.Purpose),
 			CoinType:    int64(query.Scope.Coin),
 			AccountName: *query.Name,
-		}, query, accountRowToInfo,
+		},
 	)
+	if err != nil {
+		return nil, mapGetAccountErr(err, query)
+	}
+
+	info, err := accountRowToInfo(row)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.attachBalance(ctx, query, info, row.ID)
+}
+
+// attachBalance fills ConfirmedBalance and UnconfirmedBalance on info via
+// the dedicated AccountBalance query, unless the caller opted out via
+// query.SkipBalance. The query runs inside the caller's read transaction.
+func (s accountGetQueries) attachBalance(ctx context.Context,
+	query db.GetAccountQuery, info *db.AccountInfo,
+	accountID int64) (*db.AccountInfo, error) {
+
+	if query.SkipBalance {
+		return info, nil
+	}
+
+	bal, err := s.q.AccountBalance(
+		ctx, sqlc.AccountBalanceParams{
+			WalletID:  int64(query.WalletID),
+			AccountID: accountID,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("account balance: %w", err)
+	}
+
+	info.ConfirmedBalance = btcutil.Amount(bal.ConfirmedBalance)
+	info.UnconfirmedBalance = btcutil.Amount(bal.UnconfirmedBalance)
+
+	return info, nil
+}
+
+// mapGetAccountErr returns the typed ErrAccountNotFound when err is
+// sql.ErrNoRows, falling back to a wrapped form otherwise. The caller
+// names the queried account in the error using whichever selector
+// (Name or AccountNumber) was set.
+func mapGetAccountErr(err error, query db.GetAccountQuery) error {
+	if !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("get account: %w", err)
+	}
+
+	if query.Name != nil {
+		return fmt.Errorf("account %q in scope %d/%d: %w", *query.Name,
+			query.Scope.Purpose, query.Scope.Coin,
+			db.ErrAccountNotFound)
+	}
+
+	return fmt.Errorf("account %d in scope %d/%d: %w",
+		*query.AccountNumber, query.Scope.Purpose, query.Scope.Coin,
+		db.ErrAccountNotFound)
 }
 
 // accountRenameQueries groups SQLite account rename query methods.

--- a/wallet/internal/db/sqlite/accounts.go
+++ b/wallet/internal/db/sqlite/accounts.go
@@ -417,40 +417,130 @@ type accountListQueries struct {
 	q *sqlc.Queries
 }
 
-// byScope lists accounts filtered by wallet ID and key scope.
+// byScope lists accounts filtered by wallet ID and key scope, then
+// attaches each account's balance via AccountBalancesByIDs unless
+// query.SkipBalance is set.
 func (s accountListQueries) byScope(ctx context.Context,
 	query db.ListAccountsQuery) ([]db.AccountInfo, error) {
 
-	return db.ListAccounts(
-		ctx, s.q.ListAccountsByWalletScope,
-		sqlc.ListAccountsByWalletScopeParams{
+	rows, err := s.q.ListAccountsByWalletScope(
+		ctx, sqlc.ListAccountsByWalletScopeParams{
 			WalletID: int64(query.WalletID),
 			Purpose:  int64(query.Scope.Purpose),
 			CoinType: int64(query.Scope.Coin),
-		}, accountRowToInfo,
+		},
 	)
+	if err != nil {
+		return nil, fmt.Errorf("list accounts: %w", err)
+	}
+
+	infos, err := db.ProcessAccountRows(
+		rows,
+		func(r sqlc.ListAccountsByWalletScopeRow) (*db.AccountInfo, int64,
+			error) {
+
+			info, err := accountRowToInfo(r)
+			return info, r.ID, err
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.attachBalances(ctx, query, infos)
 }
 
-// byName lists accounts filtered by wallet ID and account name.
+// byName lists accounts filtered by wallet ID and account name, then
+// attaches each account's balance via AccountBalancesByIDs unless
+// query.SkipBalance is set.
 func (s accountListQueries) byName(ctx context.Context,
 	query db.ListAccountsQuery) ([]db.AccountInfo, error) {
 
-	return db.ListAccounts(
-		ctx, s.q.ListAccountsByWalletAndName,
-		sqlc.ListAccountsByWalletAndNameParams{
+	rows, err := s.q.ListAccountsByWalletAndName(
+		ctx, sqlc.ListAccountsByWalletAndNameParams{
 			WalletID:    int64(query.WalletID),
 			AccountName: *query.Name,
-		}, accountRowToInfo,
+		},
 	)
+	if err != nil {
+		return nil, fmt.Errorf("list accounts: %w", err)
+	}
+
+	infos, err := db.ProcessAccountRows(
+		rows,
+		func(r sqlc.ListAccountsByWalletAndNameRow) (*db.AccountInfo, int64,
+			error) {
+
+			info, err := accountRowToInfo(r)
+			return info, r.ID, err
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.attachBalances(ctx, query, infos)
 }
 
-// all lists all accounts for a wallet.
+// all lists every account for a wallet, then attaches each account's
+// balance via AccountBalancesByIDs unless query.SkipBalance is set.
 func (s accountListQueries) all(ctx context.Context,
 	query db.ListAccountsQuery) ([]db.AccountInfo, error) {
 
-	return db.ListAccounts(
-		ctx, s.q.ListAccountsByWallet, int64(query.WalletID),
-		accountRowToInfo,
+	rows, err := s.q.ListAccountsByWallet(ctx, int64(query.WalletID))
+	if err != nil {
+		return nil, fmt.Errorf("list accounts: %w", err)
+	}
+
+	infos, err := db.ProcessAccountRows(
+		rows,
+		func(r sqlc.ListAccountsByWalletRow) (*db.AccountInfo, int64,
+			error) {
+
+			info, err := accountRowToInfo(r)
+			return info, r.ID, err
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.attachBalances(ctx, query, infos)
+}
+
+// attachBalances forwards to db.AttachBalances with a backend-specific
+// closure that runs AccountBalancesByIDs and converts the sqlc rows into
+// the dialect-agnostic db.AccountBalance shape.
+func (s accountListQueries) attachBalances(ctx context.Context,
+	query db.ListAccountsQuery,
+	infos []*db.AccountInfo) ([]db.AccountInfo, error) {
+
+	return db.AttachBalances(
+		ctx, query.WalletID, query.SkipBalance, infos,
+		func(ctx context.Context, walletID uint32,
+			ids []int64) ([]db.AccountBalance, error) {
+
+			rows, err := s.q.AccountBalancesByIDs(
+				ctx, sqlc.AccountBalancesByIDsParams{
+					WalletID:   int64(walletID),
+					AccountIds: ids,
+				},
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			balances := make([]db.AccountBalance, len(rows))
+			for i := range rows {
+				balances[i] = db.AccountBalance{
+					AccountID:   rows[i].AccountID,
+					Confirmed:   rows[i].ConfirmedBalance,
+					Unconfirmed: rows[i].UnconfirmedBalance,
+				}
+			}
+
+			return balances, nil
+		},
 	)
 }
 

--- a/wallet/internal/sql/pg/queries/accounts.sql
+++ b/wallet/internal/sql/pg/queries/accounts.sql
@@ -381,3 +381,40 @@ UPDATE accounts
 SET next_internal_index = next_internal_index + 1
 WHERE id = $1
 RETURNING (next_internal_index - 1)::BIGINT AS address_index;
+
+-- name: AccountBalance :one
+-- AccountBalance returns the confirmed/unconfirmed balance for one
+-- account, summed from the wallet's UTXO set at read time. Confirmed
+-- means the funding tx is in a block at or below the wallet's synced
+-- height; unconfirmed covers unmined and above-synced-tip outputs.
+-- Spent outputs (`u.spent_by_tx_id IS NOT NULL`) are excluded.
+SELECT
+    coalesce(sum(
+        CASE
+            WHEN
+                t.block_height IS NOT NULL
+                AND s.synced_height IS NOT NULL
+                AND t.block_height <= s.synced_height
+                THEN u.amount
+            ELSE 0
+        END
+    ), 0)::BIGINT AS confirmed_balance,
+    coalesce(sum(
+        CASE
+            WHEN
+                t.block_height IS NULL
+                OR s.synced_height IS NULL
+                OR t.block_height > s.synced_height
+                THEN u.amount
+            ELSE 0
+        END
+    ), 0)::BIGINT AS unconfirmed_balance
+FROM utxos AS u
+INNER JOIN transactions AS t ON u.tx_id = t.id
+INNER JOIN addresses AS addr ON u.address_id = addr.id
+LEFT JOIN wallet_sync_states AS s ON t.wallet_id = s.wallet_id
+WHERE
+    addr.wallet_id = $1
+    AND addr.account_id = $2
+    AND u.spent_by_tx_id IS NULL
+    AND t.tx_status IN (0, 1);

--- a/wallet/internal/sql/pg/queries/accounts.sql
+++ b/wallet/internal/sql/pg/queries/accounts.sql
@@ -418,3 +418,42 @@ WHERE
     AND addr.account_id = $2
     AND u.spent_by_tx_id IS NULL
     AND t.tx_status IN (0, 1);
+
+-- name: AccountBalancesByIDs :many
+-- AccountBalancesByIDs returns the confirmed/unconfirmed balance for each
+-- account in account_ids that has funded UTXOs, grouped by account_id. Accounts with no
+-- spendable outputs do not appear in the result; the Go caller defaults
+-- missing entries to zero. The confirmation predicate matches
+-- AccountBalance.
+SELECT
+    addr.account_id,
+    coalesce(sum(
+        CASE
+            WHEN
+                t.block_height IS NOT NULL
+                AND s.synced_height IS NOT NULL
+                AND t.block_height <= s.synced_height
+                THEN u.amount
+            ELSE 0
+        END
+    ), 0)::BIGINT AS confirmed_balance,
+    coalesce(sum(
+        CASE
+            WHEN
+                t.block_height IS NULL
+                OR s.synced_height IS NULL
+                OR t.block_height > s.synced_height
+                THEN u.amount
+            ELSE 0
+        END
+    ), 0)::BIGINT AS unconfirmed_balance
+FROM utxos AS u
+INNER JOIN transactions AS t ON u.tx_id = t.id
+INNER JOIN addresses AS addr ON u.address_id = addr.id
+LEFT JOIN wallet_sync_states AS s ON t.wallet_id = s.wallet_id
+WHERE
+    addr.wallet_id = sqlc.arg('wallet_id')
+    AND addr.account_id = any(sqlc.arg('account_ids')::BIGINT [])
+    AND u.spent_by_tx_id IS NULL
+    AND t.tx_status IN (0, 1)
+GROUP BY addr.account_id;

--- a/wallet/internal/sql/pg/sqlc/accounts.sql.go
+++ b/wallet/internal/sql/pg/sqlc/accounts.sql.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"database/sql"
 	"time"
+
+	"github.com/lib/pq"
 )
 
 const AccountBalance = `-- name: AccountBalance :one
@@ -64,6 +66,80 @@ func (q *Queries) AccountBalance(ctx context.Context, arg AccountBalanceParams) 
 	var i AccountBalanceRow
 	err := row.Scan(&i.ConfirmedBalance, &i.UnconfirmedBalance)
 	return i, err
+}
+
+const AccountBalancesByIDs = `-- name: AccountBalancesByIDs :many
+SELECT
+    addr.account_id,
+    coalesce(sum(
+        CASE
+            WHEN
+                t.block_height IS NOT NULL
+                AND s.synced_height IS NOT NULL
+                AND t.block_height <= s.synced_height
+                THEN u.amount
+            ELSE 0
+        END
+    ), 0)::BIGINT AS confirmed_balance,
+    coalesce(sum(
+        CASE
+            WHEN
+                t.block_height IS NULL
+                OR s.synced_height IS NULL
+                OR t.block_height > s.synced_height
+                THEN u.amount
+            ELSE 0
+        END
+    ), 0)::BIGINT AS unconfirmed_balance
+FROM utxos AS u
+INNER JOIN transactions AS t ON u.tx_id = t.id
+INNER JOIN addresses AS addr ON u.address_id = addr.id
+LEFT JOIN wallet_sync_states AS s ON t.wallet_id = s.wallet_id
+WHERE
+    addr.wallet_id = $1
+    AND addr.account_id = any($2::BIGINT [])
+    AND u.spent_by_tx_id IS NULL
+    AND t.tx_status IN (0, 1)
+GROUP BY addr.account_id
+`
+
+type AccountBalancesByIDsParams struct {
+	WalletID   int64
+	AccountIds []int64
+}
+
+type AccountBalancesByIDsRow struct {
+	AccountID          int64
+	ConfirmedBalance   int64
+	UnconfirmedBalance int64
+}
+
+// AccountBalancesByIDs returns the confirmed/unconfirmed balance for each
+// account in account_ids that has funded UTXOs, grouped by account_id. Accounts with no
+// spendable outputs do not appear in the result; the Go caller defaults
+// missing entries to zero. The confirmation predicate matches
+// AccountBalance.
+func (q *Queries) AccountBalancesByIDs(ctx context.Context, arg AccountBalancesByIDsParams) ([]AccountBalancesByIDsRow, error) {
+	rows, err := q.query(ctx, q.accountBalancesByIDsStmt, AccountBalancesByIDs, arg.WalletID, pq.Array(arg.AccountIds))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []AccountBalancesByIDsRow
+	for rows.Next() {
+		var i AccountBalancesByIDsRow
+		if err := rows.Scan(&i.AccountID, &i.ConfirmedBalance, &i.UnconfirmedBalance); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const CreateAccountSecret = `-- name: CreateAccountSecret :exec

--- a/wallet/internal/sql/pg/sqlc/accounts.sql.go
+++ b/wallet/internal/sql/pg/sqlc/accounts.sql.go
@@ -11,6 +11,61 @@ import (
 	"time"
 )
 
+const AccountBalance = `-- name: AccountBalance :one
+SELECT
+    coalesce(sum(
+        CASE
+            WHEN
+                t.block_height IS NOT NULL
+                AND s.synced_height IS NOT NULL
+                AND t.block_height <= s.synced_height
+                THEN u.amount
+            ELSE 0
+        END
+    ), 0)::BIGINT AS confirmed_balance,
+    coalesce(sum(
+        CASE
+            WHEN
+                t.block_height IS NULL
+                OR s.synced_height IS NULL
+                OR t.block_height > s.synced_height
+                THEN u.amount
+            ELSE 0
+        END
+    ), 0)::BIGINT AS unconfirmed_balance
+FROM utxos AS u
+INNER JOIN transactions AS t ON u.tx_id = t.id
+INNER JOIN addresses AS addr ON u.address_id = addr.id
+LEFT JOIN wallet_sync_states AS s ON t.wallet_id = s.wallet_id
+WHERE
+    addr.wallet_id = $1
+    AND addr.account_id = $2
+    AND u.spent_by_tx_id IS NULL
+    AND t.tx_status IN (0, 1)
+`
+
+type AccountBalanceParams struct {
+	WalletID  int64
+	AccountID int64
+}
+
+type AccountBalanceRow struct {
+	ConfirmedBalance   int64
+	UnconfirmedBalance int64
+}
+
+// AccountBalance returns the confirmed/unconfirmed balance for one
+// account, summed from the wallet's UTXO set at read time. Confirmed
+// means the funding tx is in a block at or below the wallet's synced
+// height; unconfirmed covers unmined and above-synced-tip outputs.
+// Spent outputs (`u.spent_by_tx_id IS NOT NULL`) are excluded.
+func (q *Queries) AccountBalance(ctx context.Context, arg AccountBalanceParams) (AccountBalanceRow, error) {
+	row := q.queryRow(ctx, q.accountBalanceStmt, AccountBalance, arg.WalletID, arg.AccountID)
+	var i AccountBalanceRow
+	err := row.Scan(&i.ConfirmedBalance, &i.UnconfirmedBalance)
+	return i, err
+}
+
 const CreateAccountSecret = `-- name: CreateAccountSecret :exec
 INSERT INTO account_secrets (
     account_id,

--- a/wallet/internal/sql/pg/sqlc/db.go
+++ b/wallet/internal/sql/pg/sqlc/db.go
@@ -27,6 +27,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.accountBalanceStmt, err = db.PrepareContext(ctx, AccountBalance); err != nil {
 		return nil, fmt.Errorf("error preparing query AccountBalance: %w", err)
 	}
+	if q.accountBalancesByIDsStmt, err = db.PrepareContext(ctx, AccountBalancesByIDs); err != nil {
+		return nil, fmt.Errorf("error preparing query AccountBalancesByIDs: %w", err)
+	}
 	if q.acquireUtxoLeaseStmt, err = db.PrepareContext(ctx, AcquireUtxoLease); err != nil {
 		return nil, fmt.Errorf("error preparing query AcquireUtxoLease: %w", err)
 	}
@@ -284,6 +287,11 @@ func (q *Queries) Close() error {
 	if q.accountBalanceStmt != nil {
 		if cerr := q.accountBalanceStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing accountBalanceStmt: %w", cerr)
+		}
+	}
+	if q.accountBalancesByIDsStmt != nil {
+		if cerr := q.accountBalancesByIDsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing accountBalancesByIDsStmt: %w", cerr)
 		}
 	}
 	if q.acquireUtxoLeaseStmt != nil {
@@ -741,6 +749,7 @@ type Queries struct {
 	db                                          DBTX
 	tx                                          *sql.Tx
 	accountBalanceStmt                          *sql.Stmt
+	accountBalancesByIDsStmt                    *sql.Stmt
 	acquireUtxoLeaseStmt                        *sql.Stmt
 	balanceStmt                                 *sql.Stmt
 	clearUtxosSpentByTxIDStmt                   *sql.Stmt
@@ -831,6 +840,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db:                                          tx,
 		tx:                                          tx,
 		accountBalanceStmt:                          q.accountBalanceStmt,
+		accountBalancesByIDsStmt:                    q.accountBalancesByIDsStmt,
 		acquireUtxoLeaseStmt:                        q.acquireUtxoLeaseStmt,
 		balanceStmt:                                 q.balanceStmt,
 		clearUtxosSpentByTxIDStmt:                   q.clearUtxosSpentByTxIDStmt,

--- a/wallet/internal/sql/pg/sqlc/db.go
+++ b/wallet/internal/sql/pg/sqlc/db.go
@@ -24,6 +24,9 @@ func New(db DBTX) *Queries {
 func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	q := Queries{db: db}
 	var err error
+	if q.accountBalanceStmt, err = db.PrepareContext(ctx, AccountBalance); err != nil {
+		return nil, fmt.Errorf("error preparing query AccountBalance: %w", err)
+	}
 	if q.acquireUtxoLeaseStmt, err = db.PrepareContext(ctx, AcquireUtxoLease); err != nil {
 		return nil, fmt.Errorf("error preparing query AcquireUtxoLease: %w", err)
 	}
@@ -278,6 +281,11 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 
 func (q *Queries) Close() error {
 	var err error
+	if q.accountBalanceStmt != nil {
+		if cerr := q.accountBalanceStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing accountBalanceStmt: %w", cerr)
+		}
+	}
 	if q.acquireUtxoLeaseStmt != nil {
 		if cerr := q.acquireUtxoLeaseStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing acquireUtxoLeaseStmt: %w", cerr)
@@ -732,6 +740,7 @@ func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, ar
 type Queries struct {
 	db                                          DBTX
 	tx                                          *sql.Tx
+	accountBalanceStmt                          *sql.Stmt
 	acquireUtxoLeaseStmt                        *sql.Stmt
 	balanceStmt                                 *sql.Stmt
 	clearUtxosSpentByTxIDStmt                   *sql.Stmt
@@ -821,6 +830,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 	return &Queries{
 		db:                                          tx,
 		tx:                                          tx,
+		accountBalanceStmt:                          q.accountBalanceStmt,
 		acquireUtxoLeaseStmt:                        q.acquireUtxoLeaseStmt,
 		balanceStmt:                                 q.balanceStmt,
 		clearUtxosSpentByTxIDStmt:                   q.clearUtxosSpentByTxIDStmt,

--- a/wallet/internal/sql/pg/sqlc/querier.go
+++ b/wallet/internal/sql/pg/sqlc/querier.go
@@ -11,6 +11,12 @@ import (
 )
 
 type Querier interface {
+	// AccountBalance returns the confirmed/unconfirmed balance for one
+	// account, summed from the wallet's UTXO set at read time. Confirmed
+	// means the funding tx is in a block at or below the wallet's synced
+	// height; unconfirmed covers unmined and above-synced-tip outputs.
+	// Spent outputs (`u.spent_by_tx_id IS NOT NULL`) are excluded.
+	AccountBalance(ctx context.Context, arg AccountBalanceParams) (AccountBalanceRow, error)
 	// Acquires or renews a lease for an outpoint and returns the resulting
 	// expiration time.
 	//

--- a/wallet/internal/sql/pg/sqlc/querier.go
+++ b/wallet/internal/sql/pg/sqlc/querier.go
@@ -17,6 +17,12 @@ type Querier interface {
 	// height; unconfirmed covers unmined and above-synced-tip outputs.
 	// Spent outputs (`u.spent_by_tx_id IS NOT NULL`) are excluded.
 	AccountBalance(ctx context.Context, arg AccountBalanceParams) (AccountBalanceRow, error)
+	// AccountBalancesByIDs returns the confirmed/unconfirmed balance for each
+	// account in account_ids that has funded UTXOs, grouped by account_id. Accounts with no
+	// spendable outputs do not appear in the result; the Go caller defaults
+	// missing entries to zero. The confirmation predicate matches
+	// AccountBalance.
+	AccountBalancesByIDs(ctx context.Context, arg AccountBalancesByIDsParams) ([]AccountBalancesByIDsRow, error)
 	// Acquires or renews a lease for an outpoint and returns the resulting
 	// expiration time.
 	//

--- a/wallet/internal/sql/sqlite/queries/accounts.sql
+++ b/wallet/internal/sql/sqlite/queries/accounts.sql
@@ -418,3 +418,42 @@ WHERE
     AND addr.account_id = sqlc.arg('account_id')
     AND u.spent_by_tx_id IS NULL
     AND t.tx_status IN (0, 1);
+
+-- name: AccountBalancesByIDs :many
+-- AccountBalancesByIDs returns the confirmed/unconfirmed balance for each
+-- account in account_ids that has funded UTXOs, grouped by account_id. Accounts with no
+-- spendable outputs do not appear in the result; the Go caller defaults
+-- missing entries to zero. The confirmation predicate matches
+-- AccountBalance.
+SELECT
+    addr.account_id,
+    cast(coalesce(sum(
+        CASE
+            WHEN
+                t.block_height IS NOT NULL
+                AND s.synced_height IS NOT NULL
+                AND t.block_height <= s.synced_height
+                THEN u.amount
+            ELSE 0
+        END
+    ), 0) AS INTEGER) AS confirmed_balance,
+    cast(coalesce(sum(
+        CASE
+            WHEN
+                t.block_height IS NULL
+                OR s.synced_height IS NULL
+                OR t.block_height > s.synced_height
+                THEN u.amount
+            ELSE 0
+        END
+    ), 0) AS INTEGER) AS unconfirmed_balance
+FROM utxos AS u
+INNER JOIN transactions AS t ON u.tx_id = t.id
+INNER JOIN addresses AS addr ON u.address_id = addr.id
+LEFT JOIN wallet_sync_states AS s ON t.wallet_id = s.wallet_id
+WHERE
+    addr.wallet_id = sqlc.arg('wallet_id')
+    AND addr.account_id IN (sqlc.slice('account_ids'))
+    AND u.spent_by_tx_id IS NULL
+    AND t.tx_status IN (0, 1)
+GROUP BY addr.account_id;

--- a/wallet/internal/sql/sqlite/queries/accounts.sql
+++ b/wallet/internal/sql/sqlite/queries/accounts.sql
@@ -381,3 +381,40 @@ UPDATE accounts
 SET next_internal_index = next_internal_index + 1
 WHERE id = ?
 RETURNING next_internal_index - 1 AS address_index;
+
+-- name: AccountBalance :one
+-- AccountBalance returns the confirmed/unconfirmed balance for one
+-- account, summed from the wallet's UTXO set at read time. Confirmed
+-- means the funding tx is in a block at or below the wallet's synced
+-- height; unconfirmed covers unmined and above-synced-tip outputs.
+-- Spent outputs (`u.spent_by_tx_id IS NOT NULL`) are excluded.
+SELECT
+    cast(coalesce(sum(
+        CASE
+            WHEN
+                t.block_height IS NOT NULL
+                AND s.synced_height IS NOT NULL
+                AND t.block_height <= s.synced_height
+                THEN u.amount
+            ELSE 0
+        END
+    ), 0) AS INTEGER) AS confirmed_balance,
+    cast(coalesce(sum(
+        CASE
+            WHEN
+                t.block_height IS NULL
+                OR s.synced_height IS NULL
+                OR t.block_height > s.synced_height
+                THEN u.amount
+            ELSE 0
+        END
+    ), 0) AS INTEGER) AS unconfirmed_balance
+FROM utxos AS u
+INNER JOIN transactions AS t ON u.tx_id = t.id
+INNER JOIN addresses AS addr ON u.address_id = addr.id
+LEFT JOIN wallet_sync_states AS s ON t.wallet_id = s.wallet_id
+WHERE
+    addr.wallet_id = sqlc.arg('wallet_id')
+    AND addr.account_id = sqlc.arg('account_id')
+    AND u.spent_by_tx_id IS NULL
+    AND t.tx_status IN (0, 1);

--- a/wallet/internal/sql/sqlite/sqlc/accounts.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/accounts.sql.go
@@ -8,6 +8,7 @@ package sqlc
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"time"
 )
 
@@ -64,6 +65,91 @@ func (q *Queries) AccountBalance(ctx context.Context, arg AccountBalanceParams) 
 	var i AccountBalanceRow
 	err := row.Scan(&i.ConfirmedBalance, &i.UnconfirmedBalance)
 	return i, err
+}
+
+const AccountBalancesByIDs = `-- name: AccountBalancesByIDs :many
+SELECT
+    addr.account_id,
+    cast(coalesce(sum(
+        CASE
+            WHEN
+                t.block_height IS NOT NULL
+                AND s.synced_height IS NOT NULL
+                AND t.block_height <= s.synced_height
+                THEN u.amount
+            ELSE 0
+        END
+    ), 0) AS INTEGER) AS confirmed_balance,
+    cast(coalesce(sum(
+        CASE
+            WHEN
+                t.block_height IS NULL
+                OR s.synced_height IS NULL
+                OR t.block_height > s.synced_height
+                THEN u.amount
+            ELSE 0
+        END
+    ), 0) AS INTEGER) AS unconfirmed_balance
+FROM utxos AS u
+INNER JOIN transactions AS t ON u.tx_id = t.id
+INNER JOIN addresses AS addr ON u.address_id = addr.id
+LEFT JOIN wallet_sync_states AS s ON t.wallet_id = s.wallet_id
+WHERE
+    addr.wallet_id = ?1
+    AND addr.account_id IN (/*SLICE:account_ids*/?)
+    AND u.spent_by_tx_id IS NULL
+    AND t.tx_status IN (0, 1)
+GROUP BY addr.account_id
+`
+
+type AccountBalancesByIDsParams struct {
+	WalletID   int64
+	AccountIds []int64
+}
+
+type AccountBalancesByIDsRow struct {
+	AccountID          int64
+	ConfirmedBalance   int64
+	UnconfirmedBalance int64
+}
+
+// AccountBalancesByIDs returns the confirmed/unconfirmed balance for each
+// account in account_ids that has funded UTXOs, grouped by account_id. Accounts with no
+// spendable outputs do not appear in the result; the Go caller defaults
+// missing entries to zero. The confirmation predicate matches
+// AccountBalance.
+func (q *Queries) AccountBalancesByIDs(ctx context.Context, arg AccountBalancesByIDsParams) ([]AccountBalancesByIDsRow, error) {
+	query := AccountBalancesByIDs
+	var queryParams []interface{}
+	queryParams = append(queryParams, arg.WalletID)
+	if len(arg.AccountIds) > 0 {
+		for _, v := range arg.AccountIds {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:account_ids*/?", strings.Repeat(",?", len(arg.AccountIds))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:account_ids*/?", "NULL", 1)
+	}
+	rows, err := q.query(ctx, nil, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []AccountBalancesByIDsRow
+	for rows.Next() {
+		var i AccountBalancesByIDsRow
+		if err := rows.Scan(&i.AccountID, &i.ConfirmedBalance, &i.UnconfirmedBalance); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const CreateAccountSecret = `-- name: CreateAccountSecret :exec

--- a/wallet/internal/sql/sqlite/sqlc/accounts.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/accounts.sql.go
@@ -11,6 +11,61 @@ import (
 	"time"
 )
 
+const AccountBalance = `-- name: AccountBalance :one
+SELECT
+    cast(coalesce(sum(
+        CASE
+            WHEN
+                t.block_height IS NOT NULL
+                AND s.synced_height IS NOT NULL
+                AND t.block_height <= s.synced_height
+                THEN u.amount
+            ELSE 0
+        END
+    ), 0) AS INTEGER) AS confirmed_balance,
+    cast(coalesce(sum(
+        CASE
+            WHEN
+                t.block_height IS NULL
+                OR s.synced_height IS NULL
+                OR t.block_height > s.synced_height
+                THEN u.amount
+            ELSE 0
+        END
+    ), 0) AS INTEGER) AS unconfirmed_balance
+FROM utxos AS u
+INNER JOIN transactions AS t ON u.tx_id = t.id
+INNER JOIN addresses AS addr ON u.address_id = addr.id
+LEFT JOIN wallet_sync_states AS s ON t.wallet_id = s.wallet_id
+WHERE
+    addr.wallet_id = ?1
+    AND addr.account_id = ?2
+    AND u.spent_by_tx_id IS NULL
+    AND t.tx_status IN (0, 1)
+`
+
+type AccountBalanceParams struct {
+	WalletID  int64
+	AccountID int64
+}
+
+type AccountBalanceRow struct {
+	ConfirmedBalance   int64
+	UnconfirmedBalance int64
+}
+
+// AccountBalance returns the confirmed/unconfirmed balance for one
+// account, summed from the wallet's UTXO set at read time. Confirmed
+// means the funding tx is in a block at or below the wallet's synced
+// height; unconfirmed covers unmined and above-synced-tip outputs.
+// Spent outputs (`u.spent_by_tx_id IS NOT NULL`) are excluded.
+func (q *Queries) AccountBalance(ctx context.Context, arg AccountBalanceParams) (AccountBalanceRow, error) {
+	row := q.queryRow(ctx, q.accountBalanceStmt, AccountBalance, arg.WalletID, arg.AccountID)
+	var i AccountBalanceRow
+	err := row.Scan(&i.ConfirmedBalance, &i.UnconfirmedBalance)
+	return i, err
+}
+
 const CreateAccountSecret = `-- name: CreateAccountSecret :exec
 INSERT INTO account_secrets (
     account_id,

--- a/wallet/internal/sql/sqlite/sqlc/db.go
+++ b/wallet/internal/sql/sqlite/sqlc/db.go
@@ -27,6 +27,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.accountBalanceStmt, err = db.PrepareContext(ctx, AccountBalance); err != nil {
 		return nil, fmt.Errorf("error preparing query AccountBalance: %w", err)
 	}
+	if q.accountBalancesByIDsStmt, err = db.PrepareContext(ctx, AccountBalancesByIDs); err != nil {
+		return nil, fmt.Errorf("error preparing query AccountBalancesByIDs: %w", err)
+	}
 	if q.acquireUtxoLeaseStmt, err = db.PrepareContext(ctx, AcquireUtxoLease); err != nil {
 		return nil, fmt.Errorf("error preparing query AcquireUtxoLease: %w", err)
 	}
@@ -284,6 +287,11 @@ func (q *Queries) Close() error {
 	if q.accountBalanceStmt != nil {
 		if cerr := q.accountBalanceStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing accountBalanceStmt: %w", cerr)
+		}
+	}
+	if q.accountBalancesByIDsStmt != nil {
+		if cerr := q.accountBalancesByIDsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing accountBalancesByIDsStmt: %w", cerr)
 		}
 	}
 	if q.acquireUtxoLeaseStmt != nil {
@@ -741,6 +749,7 @@ type Queries struct {
 	db                                          DBTX
 	tx                                          *sql.Tx
 	accountBalanceStmt                          *sql.Stmt
+	accountBalancesByIDsStmt                    *sql.Stmt
 	acquireUtxoLeaseStmt                        *sql.Stmt
 	balanceStmt                                 *sql.Stmt
 	clearUtxosSpentByTxIDStmt                   *sql.Stmt
@@ -831,6 +840,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		db:                                          tx,
 		tx:                                          tx,
 		accountBalanceStmt:                          q.accountBalanceStmt,
+		accountBalancesByIDsStmt:                    q.accountBalancesByIDsStmt,
 		acquireUtxoLeaseStmt:                        q.acquireUtxoLeaseStmt,
 		balanceStmt:                                 q.balanceStmt,
 		clearUtxosSpentByTxIDStmt:                   q.clearUtxosSpentByTxIDStmt,

--- a/wallet/internal/sql/sqlite/sqlc/db.go
+++ b/wallet/internal/sql/sqlite/sqlc/db.go
@@ -24,6 +24,9 @@ func New(db DBTX) *Queries {
 func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	q := Queries{db: db}
 	var err error
+	if q.accountBalanceStmt, err = db.PrepareContext(ctx, AccountBalance); err != nil {
+		return nil, fmt.Errorf("error preparing query AccountBalance: %w", err)
+	}
 	if q.acquireUtxoLeaseStmt, err = db.PrepareContext(ctx, AcquireUtxoLease); err != nil {
 		return nil, fmt.Errorf("error preparing query AcquireUtxoLease: %w", err)
 	}
@@ -278,6 +281,11 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 
 func (q *Queries) Close() error {
 	var err error
+	if q.accountBalanceStmt != nil {
+		if cerr := q.accountBalanceStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing accountBalanceStmt: %w", cerr)
+		}
+	}
 	if q.acquireUtxoLeaseStmt != nil {
 		if cerr := q.acquireUtxoLeaseStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing acquireUtxoLeaseStmt: %w", cerr)
@@ -732,6 +740,7 @@ func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, ar
 type Queries struct {
 	db                                          DBTX
 	tx                                          *sql.Tx
+	accountBalanceStmt                          *sql.Stmt
 	acquireUtxoLeaseStmt                        *sql.Stmt
 	balanceStmt                                 *sql.Stmt
 	clearUtxosSpentByTxIDStmt                   *sql.Stmt
@@ -821,6 +830,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 	return &Queries{
 		db:                                          tx,
 		tx:                                          tx,
+		accountBalanceStmt:                          q.accountBalanceStmt,
 		acquireUtxoLeaseStmt:                        q.acquireUtxoLeaseStmt,
 		balanceStmt:                                 q.balanceStmt,
 		clearUtxosSpentByTxIDStmt:                   q.clearUtxosSpentByTxIDStmt,

--- a/wallet/internal/sql/sqlite/sqlc/querier.go
+++ b/wallet/internal/sql/sqlite/sqlc/querier.go
@@ -11,6 +11,12 @@ import (
 )
 
 type Querier interface {
+	// AccountBalance returns the confirmed/unconfirmed balance for one
+	// account, summed from the wallet's UTXO set at read time. Confirmed
+	// means the funding tx is in a block at or below the wallet's synced
+	// height; unconfirmed covers unmined and above-synced-tip outputs.
+	// Spent outputs (`u.spent_by_tx_id IS NOT NULL`) are excluded.
+	AccountBalance(ctx context.Context, arg AccountBalanceParams) (AccountBalanceRow, error)
 	// Acquires or renews a lease for an outpoint and returns the resulting
 	// expiration time.
 	//

--- a/wallet/internal/sql/sqlite/sqlc/querier.go
+++ b/wallet/internal/sql/sqlite/sqlc/querier.go
@@ -17,6 +17,12 @@ type Querier interface {
 	// height; unconfirmed covers unmined and above-synced-tip outputs.
 	// Spent outputs (`u.spent_by_tx_id IS NOT NULL`) are excluded.
 	AccountBalance(ctx context.Context, arg AccountBalanceParams) (AccountBalanceRow, error)
+	// AccountBalancesByIDs returns the confirmed/unconfirmed balance for each
+	// account in account_ids that has funded UTXOs, grouped by account_id. Accounts with no
+	// spendable outputs do not appear in the result; the Go caller defaults
+	// missing entries to zero. The confirmation predicate matches
+	// AccountBalance.
+	AccountBalancesByIDs(ctx context.Context, arg AccountBalancesByIDsParams) ([]AccountBalancesByIDsRow, error)
 	// Acquires or renews a lease for an outpoint and returns the resulting
 	// expiration time.
 	//


### PR DESCRIPTION
## Summary

Wires confirmed/unconfirmed balance through every account read by joining each account-returning SELECT against a per-account UTXO aggregation subquery. Adds a `SkipBalance` opt-out that dispatches to a query variant which omits the LEFT JOIN entirely so the database never scans the UTXO tables when the caller does not need balance.

## Commits

1. `db: thread balance fields through AccountInfoRow plumbing` — pure type widening. `AccountInfoRow` gains `ConfirmedBalance` / `UnconfirmedBalance int64`; `BuildAccountInfo` takes two `btcutil.Amount` params; `AccountRowToInfo` converts at the boundary. No SQL change, no behavior change.

2. `db: populate AccountInfo balance from SQL aggregation` — extends the 8 account-returning SELECTs (pg + sqlite) with a LEFT JOIN to a per-account UTXO sum, split into confirmed/unconfirmed by the wallet's synced height. Honors the same status filter and `u.spent_by_tx_id IS NULL` semantics as the rest of the balance code. pg + sqlite adapters thread the new sqlc fields into `AccountInfoRow`. `GetAccountPropsById` is intentionally not joined (its only caller is the post-create read where balance is always zero). New itests verify populated balance against mixed confirmed/unconfirmed UTXOs.

3. `db: dispatch account reads to NoBalance variants on SkipBalance` — adds `SkipBalance bool` on `GetAccountQuery` and `ListAccountsQuery`. Introduces 5 `NoBalance` sqlc query variants per use case that omit the balance subquery entirely; identical Row shape with hardcoded `0` balance columns. `accountListQueries` / `accountGetQueries` dispatch via a one-line `if query.SkipBalance`. New itests verify the opt-out path returns zero balance.

## Why this PR is split from #1231

The balance work was originally bundled into prep-account-manager-store. It's split out so the perf-sensitive aggregation lands on its own reviewable surface; the parent PR stays narrow.

## Test plan
- [x] `GOWORK=off go build ./...` clean across all 3 commits
- [x] `make lint-check` clean
- [x] Unit tests pass on `wallet/internal/db/...`
- [x] sqlite + pg itests (`TestGetAccount{,SkipBalance}*`, `TestListAccounts{,SkipBalance}*`) pass