### PR TITLE
wallet: migrate UTXO store + lease ops to db.Store

### DIFF
--- a/bwtest/mock/addr_store.go
+++ b/bwtest/mock/addr_store.go
@@ -98,6 +98,10 @@ func (m *AddrStore) AddrAccount(ns walletdb.ReadBucket,
 
 	args := m.Called(ns, address)
 
+	if args.Get(0) == nil {
+		return nil, args.Get(1).(uint32), args.Error(2)
+	}
+
 	return args.Get(0).(waddrmgr.AccountStore),
 		args.Get(1).(uint32), args.Error(2)
 }

--- a/wallet/address_manager.go
+++ b/wallet/address_manager.go
@@ -26,7 +26,6 @@ import (
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wallet/internal/db/page"
 	"github.com/btcsuite/btcwallet/wallet/internal/keyvault"
-	"github.com/btcsuite/btcwallet/walletdb"
 )
 
 var (
@@ -375,6 +374,33 @@ func storeAddressPubKeyCompressed(pubKey []byte) bool {
 	return len(pubKey) == btcec.PubKeyBytesLenCompressed
 }
 
+// addrBalances returns wallet address balances from store UTXO rows.
+func (w *Wallet) addrBalances(ctx context.Context) (map[string]btcutil.Amount,
+	error) {
+
+	balances := make(map[string]btcutil.Amount)
+
+	utxos, err := w.store.ListUTXOs(ctx, db.ListUtxosQuery{
+		WalletID: w.id,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list utxos: %w", err)
+	}
+
+	for i := range utxos {
+		addr := extractAddrFromPKScript(
+			utxos[i].PkScript, w.cfg.ChainParams,
+		)
+		if addr == nil {
+			continue
+		}
+
+		balances[addr.String()] += utxos[i].Amount
+	}
+
+	return balances, nil
+}
+
 // NewAddress returns a new address for the given account and address type.
 // This method is a low-level primitive that will always derive a new, unused
 // address from the end of the address chain.
@@ -618,43 +644,6 @@ func (w *Wallet) GetAddressInfo(ctx context.Context, a btcutil.Address) (
 	return addressInfoFromStoreAddress(storeAddr, w.cfg.ChainParams)
 }
 
-// legacyAddressBalances returns wallet address balances from the legacy
-// transaction store.
-//
-// TODO(yy): remove this helper once the UTXO store implementation is
-// finished — Wallet.ListAddresses will source balances via
-// Store.ListUTXOs instead.
-func (w *Wallet) legacyAddressBalances() (map[string]btcutil.Amount, error) {
-	balances := make(map[string]btcutil.Amount)
-
-	err := walletdb.View(w.cfg.DB, func(tx walletdb.ReadTx) error {
-		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
-
-		utxos, err := w.txStore.UnspentOutputs(txmgrNs)
-		if err != nil {
-			return err
-		}
-
-		for i := range utxos {
-			addr := extractAddrFromPKScript(
-				utxos[i].PkScript, w.cfg.ChainParams,
-			)
-			if addr == nil {
-				continue
-			}
-
-			balances[addr.String()] += utxos[i].Amount
-		}
-
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return balances, nil
-}
-
 // ListAddresses lists all addresses for a given account, including their
 // balances.
 func (w *Wallet) ListAddresses(ctx context.Context, accountName string,
@@ -675,9 +664,7 @@ func (w *Wallet) ListAddresses(ctx context.Context, accountName string,
 		return nil, err
 	}
 
-	// TODO(yy): switch to Store.ListUTXOs once the kvdb backend
-	// implements it.
-	balances, err := w.legacyAddressBalances()
+	balances, err := w.addrBalances(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/wallet/address_manager_test.go
+++ b/wallet/address_manager_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/addresstype"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
-	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -664,9 +663,14 @@ func TestListAddresses(t *testing.T) {
 			Page:        req,
 		},
 	).Return(addressIter(db.AddressInfo{ScriptPubKey: pkScript})).Once()
-	deps.txStore.On(
-		"UnspentOutputs", mock.Anything,
-	).Return([]wtxmgr.Credit{{Amount: 1000, PkScript: pkScript}}, nil).Once()
+	deps.store.On(
+		"ListUTXOs", mock.Anything, db.ListUtxosQuery{
+			WalletID: w.id,
+		},
+	).Return([]db.UtxoInfo{{
+		Amount:   1000,
+		PkScript: pkScript,
+	}}, nil).Once()
 
 	addrs, err := w.ListAddresses(
 		t.Context(), "default", waddrmgr.WitnessPubKey,

--- a/wallet/internal/db/kvdb/addressstore.go
+++ b/wallet/internal/db/kvdb/addressstore.go
@@ -36,6 +36,10 @@ var (
 	errMissingAddrmgrNamespace = errors.New(
 		"kvdb: missing waddrmgr namespace",
 	)
+
+	// errNoAddressInPkScript is returned when a script contains no standard
+	// address.
+	errNoAddressInPkScript = errors.New("pkScript has no address")
 )
 
 // NewDerivedAddress creates one derived address through the legacy address-
@@ -863,4 +867,25 @@ func addressFromScript(pkScript []byte,
 	}
 
 	return addrs[0]
+}
+
+// addressFromPkScript extracts the first standard address from one script.
+//
+// This lets the legacy address manager resolve wallet metadata from a
+// script-pubkey-only store lookup.
+func addressFromPkScript(pkScript []byte,
+	chainParams *chaincfg.Params) (btcutil.Address, error) {
+
+	_, addrs, _, err := txscript.ExtractPkScriptAddrs(pkScript, chainParams)
+	if err != nil {
+		return nil, fmt.Errorf("extract address from pkScript: %w", err)
+	}
+
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf(
+			"extract address from pkScript: %w", errNoAddressInPkScript,
+		)
+	}
+
+	return addrs[0], nil
 }

--- a/wallet/internal/db/kvdb/utxostore.go
+++ b/wallet/internal/db/kvdb/utxostore.go
@@ -18,6 +18,9 @@ import (
 	"github.com/btcsuite/btcwallet/wtxmgr"
 )
 
+// A compile-time assertion to ensure Store implements the UTXO store.
+var _ db.UTXOStore = (*Store)(nil)
+
 var (
 	// errNotImplemented is returned for unimplemented kvdb store methods.
 	errNotImplemented = errors.New("not implemented")
@@ -38,15 +41,117 @@ var (
 	wtxmgrNamespaceKey = []byte("wtxmgr")
 )
 
+// notImplemented returns a consistent error for kvdb methods that still need a
+// legacy-backed implementation.
 func notImplemented(_ context.Context, method string) error {
 	return fmt.Errorf("kvdb.Store.%s: %w", method, errNotImplemented)
 }
 
-// GetUtxo is not yet implemented for kvdb.
-func (s *Store) GetUtxo(ctx context.Context,
-	_ db.GetUtxoQuery) (*db.UtxoInfo, error) {
+// GetUtxo retrieves one current wallet-owned UTXO through the legacy wtxmgr
+// query path.
+func (s *Store) GetUtxo(_ context.Context,
+	query db.GetUtxoQuery) (*db.UtxoInfo, error) {
 
-	return nil, notImplemented(ctx, "GetUtxo")
+	var utxo *db.UtxoInfo
+
+	err := walletdb.View(s.db, func(tx walletdb.ReadTx) error {
+		got, err := s.getUtxoInView(tx, query.OutPoint)
+		if err != nil {
+			return err
+		}
+
+		utxo = got
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("kvdb.Store.GetUtxo: %w", err)
+	}
+
+	return utxo, nil
+}
+
+// getUtxoInView resolves one current wallet-owned UTXO inside an open
+// walletdb read transaction. It gates the outpoint through the current
+// UTXO set first, then emits the enriched wallet-owned row.
+func (s *Store) getUtxoInView(tx walletdb.ReadTx,
+	outPoint wire.OutPoint) (*db.UtxoInfo, error) {
+
+	txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
+	if txmgrNs == nil {
+		return nil, errMissingTxmgrNamespace
+	}
+
+	credit, leaseSet, err := s.loadCurrentCredit(txmgrNs, outPoint)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.enrichOwnedCredit(tx, credit, leaseSet)
+}
+
+// loadCurrentCredit fetches one credit by outpoint and gates it through the
+// current UTXO set, returning db.ErrUtxoNotFound for unknown or non-current
+// (spent-by-unmined) outputs. The active lease set is returned alongside so
+// the caller can mark IsLocked without re-reading the lease bucket.
+func (s *Store) loadCurrentCredit(txmgrNs walletdb.ReadBucket,
+	outPoint wire.OutPoint) (*wtxmgr.Credit, map[wire.OutPoint]struct{},
+	error) {
+
+	credit, err := s.txStore.GetUtxo(txmgrNs, outPoint)
+	if err != nil {
+		if errors.Is(err, wtxmgr.ErrUtxoNotFound) {
+			return nil, nil, db.ErrUtxoNotFound
+		}
+
+		return nil, nil, fmt.Errorf("get utxo: %w", err)
+	}
+
+	current, err := s.currentUTXOSet(txmgrNs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if _, ok := current[outPoint]; !ok {
+		return nil, nil, db.ErrUtxoNotFound
+	}
+
+	leaseSet, err := s.activeLeaseSet(txmgrNs, current)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return credit, leaseSet, nil
+}
+
+// enrichOwnedCredit resolves the owning account for one current credit and
+// produces its enriched db.UtxoInfo. A credit whose script does not join to a
+// wallet address is reported as not found, matching the SQL backends which
+// inner-join UTXO rows against owned addresses rather than surfacing an
+// unenriched row.
+func (s *Store) enrichOwnedCredit(tx walletdb.ReadTx,
+	credit *wtxmgr.Credit,
+	leaseSet map[wire.OutPoint]struct{}) (*db.UtxoInfo, error) {
+
+	addrmgrNs := tx.ReadBucket(waddrmgr.NamespaceKey)
+	if addrmgrNs == nil {
+		return nil, errMissingAddrmgrNamespace
+	}
+
+	chainParams := s.addrStore.ChainParams()
+
+	binding, addr, err := s.resolveAccountForCredit(
+		addrmgrNs, credit, chainParams,
+	)
+	if err != nil {
+		if errors.Is(err, errUnownedScript) {
+			return nil, db.ErrUtxoNotFound
+		}
+
+		return nil, err
+	}
+
+	return s.enrichCredit(addrmgrNs, credit, addr, binding, leaseSet)
 }
 
 // ListUTXOs is not yet implemented for kvdb.

--- a/wallet/internal/db/kvdb/utxostore.go
+++ b/wallet/internal/db/kvdb/utxostore.go
@@ -155,11 +155,35 @@ func (s *Store) enrichOwnedCredit(tx walletdb.ReadTx,
 	return s.enrichCredit(addrmgrNs, credit, addr, binding, leaseSet)
 }
 
-// ListUTXOs is not yet implemented for kvdb.
-func (s *Store) ListUTXOs(ctx context.Context,
-	_ db.ListUtxosQuery) ([]db.UtxoInfo, error) {
+// ListUTXOs lists current wallet-owned UTXOs through the legacy wtxmgr query
+// path.
+func (s *Store) ListUTXOs(_ context.Context,
+	query db.ListUtxosQuery) ([]db.UtxoInfo, error) {
 
-	return nil, notImplemented(ctx, "ListUTXOs")
+	if s.addrStore == nil {
+		return nil, fmt.Errorf("kvdb.Store.ListUTXOs: %w",
+			errMissingAddrStore)
+	}
+
+	err := query.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	var utxos []db.UtxoInfo
+
+	err = walletdb.View(s.db, func(tx walletdb.ReadTx) error {
+		return s.listUTXOsInView(tx, query, &utxos)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("kvdb.Store.ListUTXOs: %w", err)
+	}
+
+	if len(utxos) == 0 {
+		return []db.UtxoInfo{}, nil
+	}
+
+	return utxos, nil
 }
 
 // LeaseOutput locks one known wallet UTXO through the legacy wtxmgr lease
@@ -656,6 +680,117 @@ func (s *Store) enrichCredit(addrmgrNs walletdb.ReadBucket,
 	}
 
 	return info, nil
+}
+
+// listUTXOsInView performs the legacy UTXO scan using one walletdb view
+// and populates the enriched per-row metadata (AccountName, Origin,
+// AddrType, HasScript, IsLocked).
+func (s *Store) listUTXOsInView(tx walletdb.ReadTx,
+	query db.ListUtxosQuery, utxos *[]db.UtxoInfo) error {
+
+	txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
+	if txmgrNs == nil {
+		return errMissingTxmgrNamespace
+	}
+
+	addrmgrNs := tx.ReadBucket(waddrmgr.NamespaceKey)
+	if addrmgrNs == nil {
+		return errMissingAddrmgrNamespace
+	}
+
+	credits, err := s.txStore.UnspentOutputsIncludingLocked(txmgrNs)
+	if err != nil {
+		return fmt.Errorf("list unspent outputs: %w", err)
+	}
+
+	// The credits slice already enumerates the current UTXO set, so build
+	// the lease-intersection set directly from it rather than re-scanning
+	// the unspent bucket via currentUTXOSet.
+	current := make(map[wire.OutPoint]struct{}, len(credits))
+	for i := range credits {
+		current[credits[i].OutPoint] = struct{}{}
+	}
+
+	leaseSet, err := s.activeLeaseSet(txmgrNs, current)
+	if err != nil {
+		return err
+	}
+
+	currentHeight := s.addrStore.SyncedTo().Height
+	chainParams := s.addrStore.ChainParams()
+
+	for i := range credits {
+		enriched, ok, err := s.buildListedUTXO(
+			addrmgrNs, &credits[i], query, leaseSet, currentHeight,
+			chainParams,
+		)
+		if err != nil {
+			return err
+		}
+
+		if !ok {
+			continue
+		}
+
+		*utxos = append(*utxos, *enriched)
+	}
+
+	return nil
+}
+
+// buildListedUTXO converts one current credit into an enriched db.UtxoInfo,
+// applying the confirmation, owned-address, and account filters along the
+// way. It returns ok=false for a credit that does not pass a filter so the
+// caller can skip it without treating the omission as an error.
+func (s *Store) buildListedUTXO(addrmgrNs walletdb.ReadBucket,
+	credit *wtxmgr.Credit, query db.ListUtxosQuery,
+	leaseSet map[wire.OutPoint]struct{}, currentHeight int32,
+	chainParams *chaincfg.Params) (*db.UtxoInfo, bool, error) {
+
+	if !utxoMatchesConfirmations(credit.Height, currentHeight, query) {
+		return nil, false, nil
+	}
+
+	binding, addr, err := s.resolveAccountForCredit(
+		addrmgrNs, credit, chainParams,
+	)
+	if err != nil {
+		if !errors.Is(err, errUnownedScript) {
+			return nil, false, err
+		}
+
+		// A credit whose script does not join to a wallet address is
+		// dropped, matching the SQL backends which inner-join UTXO rows
+		// against owned addresses. Such rows never surface (even with no
+		// account filter).
+		return nil, false, nil
+	}
+
+	accountOK, err := accountMatchesQuery(addrmgrNs, query, binding)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if !accountOK {
+		return nil, false, nil
+	}
+
+	enriched, err := s.enrichCredit(
+		addrmgrNs, credit, addr, binding, leaseSet,
+	)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// The AccountName filter is applied after enrichment because resolving
+	// the name requires the account-properties read that enrichCredit does.
+	if query.AccountName != nil &&
+		enriched.AccountName != *query.AccountName {
+
+		return nil, false, nil
+	}
+
+	return enriched, true, nil
 }
 
 // utxoMatchesConfirmations applies the optional db.ListUtxosQuery confirmation

--- a/wallet/internal/db/kvdb/utxostore.go
+++ b/wallet/internal/db/kvdb/utxostore.go
@@ -424,8 +424,8 @@ func (s *Store) walkBalanceUTXOs(addrmgrNs, txmgrNs walletdb.ReadBucket,
 		return 0, 0, nil
 	}
 
-	nameFound, err := s.resolveBalanceNameFilter(
-		addrmgrNs, &params, scopeFilter,
+	nameAcct, nameFound, err := s.resolveBalanceNameFilter(
+		addrmgrNs, params, scopeFilter,
 	)
 	if err != nil {
 		return 0, 0, err
@@ -447,31 +447,51 @@ func (s *Store) walkBalanceUTXOs(addrmgrNs, txmgrNs walletdb.ReadBucket,
 	for i := range unspent {
 		output := &unspent[i]
 
-		owner, account, ok := s.classifyBalanceUTXO(
-			addrmgrNs, output, chainParams,
+		accepted, err := s.balanceOutputAccepted(
+			addrmgrNs, output, scopeFilter, params, nameAcct,
+			syncBlock.Height, chainParams,
 		)
-		if !ok {
-			continue
+		if err != nil {
+			return 0, 0, err
 		}
 
-		if !balanceFilterAllows(
-			scopeFilter, owner, params, account,
-		) {
-
-			continue
+		if accepted {
+			total, locked = addBalanceOutput(total, locked, output)
 		}
-
-		if !confsAllowed(
-			output, syncBlock.Height, params,
-		) {
-
-			continue
-		}
-
-		total, locked = addBalanceOutput(total, locked, output)
 	}
 
 	return total, locked, nil
+}
+
+// balanceOutputAccepted reports whether one unspent output counts toward the
+// balance under the BalanceParams filters. It resolves the owning account,
+// applies the Scope/account filters (via balanceFilterAllows) and the
+// confirmation filters (via confsAllowed), and returns false for outputs that
+// are unowned or filtered out so the caller skips them without error.
+func (s *Store) balanceOutputAccepted(addrmgrNs walletdb.ReadBucket,
+	output *wtxmgr.Credit, scopeFilter *waddrmgr.KeyScope,
+	params db.BalanceParams, nameAcct *uint32, syncHeight int32,
+	chainParams *chaincfg.Params) (bool, error) {
+
+	owner, account, ok := s.classifyBalanceUTXO(
+		addrmgrNs, output, chainParams,
+	)
+	if !ok {
+		return false, nil
+	}
+
+	allowed, err := balanceFilterAllows(
+		addrmgrNs, scopeFilter, owner, params, nameAcct, account,
+	)
+	if err != nil {
+		return false, err
+	}
+
+	if !allowed {
+		return false, nil
+	}
+
+	return confsAllowed(output, syncHeight, params), nil
 }
 
 // addBalanceOutput adds an accepted output to the total balance and, when the
@@ -488,34 +508,40 @@ func addBalanceOutput(total, locked btcutil.Amount,
 }
 
 // resolveBalanceNameFilter resolves BalanceParams.Name into the real waddrmgr
-// account number before the UTXO walk. A missing name means no UTXOs match,
-// so the caller should return a zero balance without an error.
+// account number used for the UTXO walk. It returns (nil, true, nil) when no
+// Name filter is set, the resolved account number when one is, and
+// (nil, false, nil) when the name does not exist so the caller returns a zero
+// balance without an error.
+//
+// The resolved number is returned separately rather than folded into
+// params.Account: a Name filter is the public handle that selects an account
+// by name regardless of origin (including imported accounts), whereas a
+// numeric params.Account filter must never match imported accounts. Keeping
+// the two distinct lets balanceFilterAllows apply the imported exclusion only
+// to the numeric path.
 func (s *Store) resolveBalanceNameFilter(addrmgrNs walletdb.ReadBucket,
-	params *db.BalanceParams, scopeFilter *waddrmgr.KeyScope) (bool, error) {
+	params db.BalanceParams,
+	scopeFilter *waddrmgr.KeyScope) (*uint32, bool, error) {
 
 	if params.Name == nil {
-		return true, nil
+		return nil, true, nil
 	}
 
 	scopedMgr, err := s.addrStore.FetchScopedKeyManager(*scopeFilter)
 	if err != nil {
-		return false, fmt.Errorf("fetch scoped manager: %w", err)
+		return nil, false, fmt.Errorf("fetch scoped manager: %w", err)
 	}
 
 	acctNum, err := scopedMgr.LookupAccount(addrmgrNs, *params.Name)
 	if err != nil {
 		if waddrmgr.IsError(err, waddrmgr.ErrAccountNotFound) {
-			return false, nil
+			return nil, false, nil
 		}
 
-		return false, fmt.Errorf("lookup account: %w", err)
+		return nil, false, fmt.Errorf("lookup account: %w", err)
 	}
 
-	// Internal filtering stays on the real account number; the public
-	// AccountInfo.AccountNumber masking only applies at the read API boundary.
-	params.Account = &acctNum
-
-	return true, nil
+	return &acctNum, true, nil
 }
 
 // classifyBalanceUTXO maps an unspent output to its owning address and
@@ -541,21 +567,39 @@ func (s *Store) classifyBalanceUTXO(addrmgrNs walletdb.ReadBucket,
 	return owner, account, true
 }
 
-// balanceFilterAllows reports whether an output's owning address and
-// account survive the Scope and Account filters from BalanceParams.
-func balanceFilterAllows(scopeFilter *waddrmgr.KeyScope,
-	owner waddrmgr.AccountStore, params db.BalanceParams,
-	account uint32) bool {
+// balanceFilterAllows reports whether an output's owning address and account
+// survive the Scope and account filters from BalanceParams. nameAcct is the
+// account number resolved from a Name filter, if any; it selects that account
+// by exact number regardless of origin. A numeric params.Account filter, by
+// contrast, never matches an imported account (see numericAccountMatches).
+// Account and Name are mutually exclusive, so at most one of the two account
+// filters applies.
+func balanceFilterAllows(addrmgrNs walletdb.ReadBucket,
+	scopeFilter *waddrmgr.KeyScope, owner waddrmgr.AccountStore,
+	params db.BalanceParams, nameAcct *uint32, account uint32) (bool, error) {
 
 	if scopeFilter != nil && *scopeFilter != owner.Scope() {
-		return false
+		return false, nil
 	}
 
-	if params.Account != nil && *params.Account != account {
-		return false
+	// A Name filter resolves to a concrete account number and matches it
+	// exactly; imported accounts are reachable this way by design.
+	if nameAcct != nil {
+		return account == *nameAcct, nil
 	}
 
-	return true
+	if params.Account == nil {
+		return true, nil
+	}
+
+	imported, err := accountIsImported(addrmgrNs, owner, account)
+	if err != nil {
+		return false, err
+	}
+
+	return numericAccountMatches(
+		account, *params.Account, imported,
+	), nil
 }
 
 // confsAllowed reports whether an unspent output's confirmation depth

--- a/wallet/internal/db/kvdb/utxostore.go
+++ b/wallet/internal/db/kvdb/utxostore.go
@@ -283,11 +283,52 @@ func (s *Store) ReleaseOutput(_ context.Context,
 	return nil
 }
 
-// ListLeasedOutputs is not yet implemented for kvdb.
-func (s *Store) ListLeasedOutputs(ctx context.Context,
+// ListLeasedOutputs lists the currently active legacy output leases.
+func (s *Store) ListLeasedOutputs(_ context.Context,
 	_ uint32) ([]db.LeasedOutput, error) {
 
-	return nil, notImplemented(ctx, "ListLeasedOutputs")
+	var leases []db.LeasedOutput
+
+	err := walletdb.View(s.db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(wtxmgrNamespaceKey)
+		if ns == nil {
+			return errMissingTxmgrNamespace
+		}
+
+		locked, err := s.txStore.ListLockedOutputs(ns)
+		if err != nil {
+			return fmt.Errorf("list locked outputs: %w", err)
+		}
+
+		current, err := s.currentUTXOSet(ns)
+		if err != nil {
+			return err
+		}
+
+		leases = make([]db.LeasedOutput, 0, len(locked))
+		for _, lease := range locked {
+			if _, ok := current[lease.Outpoint]; !ok {
+				continue
+			}
+
+			leases = append(leases, db.LeasedOutput{
+				OutPoint:   lease.Outpoint,
+				LockID:     db.LockID(lease.LockID),
+				Expiration: lease.Expiration.UTC(),
+			})
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("kvdb.Store.ListLeasedOutputs: %w", err)
+	}
+
+	if len(leases) == 0 {
+		return []db.LeasedOutput{}, nil
+	}
+
+	return leases, nil
 }
 
 // Balance sums the wallet's unspent outputs that satisfy the supplied

--- a/wallet/internal/db/kvdb/utxostore.go
+++ b/wallet/internal/db/kvdb/utxostore.go
@@ -657,3 +657,95 @@ func (s *Store) enrichCredit(addrmgrNs walletdb.ReadBucket,
 
 	return info, nil
 }
+
+// utxoMatchesConfirmations applies the optional db.ListUtxosQuery confirmation
+// filters using legacy current-height state.
+func utxoMatchesConfirmations(txHeight int32, currentHeight int32,
+	query db.ListUtxosQuery) bool {
+
+	confs := calcConfs(txHeight, currentHeight)
+
+	if query.MinConfs != nil && confs < *query.MinConfs {
+		return false
+	}
+
+	if query.MaxConfs != nil && confs > *query.MaxConfs {
+		return false
+	}
+
+	return true
+}
+
+// accountMatchesQuery reports whether the owning account satisfies
+// the numeric Account and Scope filters in the query. The
+// AccountName filter is applied separately after enrichment because
+// resolving the name requires an additional account-properties read.
+func accountMatchesQuery(addrmgrNs walletdb.ReadBucket,
+	query db.ListUtxosQuery, binding *utxoAccountBinding) (bool, error) {
+
+	if query.Scope != nil && binding.scope != *query.Scope {
+		return false, nil
+	}
+
+	if query.Account == nil {
+		return true, nil
+	}
+
+	imported, err := accountIsImported(
+		addrmgrNs, binding.acctStore, binding.acctNum,
+	)
+	if err != nil {
+		return false, err
+	}
+
+	return numericAccountMatches(
+		binding.acctNum, *query.Account, imported,
+	), nil
+}
+
+// accountIsImported reports whether the owning account is imported,
+// using the same on-disk classifier (AccountStore.IsImportedAccount)
+// that the enrichment path uses for db.UtxoInfo.Origin. This keeps the
+// numeric Account filter aligned with the SQL backends, where imported
+// accounts have a NULL account_number and so are never numerically
+// selectable, including imported xpub/watch-only accounts that carry
+// ordinary kvdb account numbers.
+//
+// A nil acctStore only occurs for narrow test doubles that pre-date the
+// enrichment contract; production AddrStore always resolves a non-nil
+// AccountStore. In that case the legacy ImportedAddrAccount
+// pseudo-account is the only recognizable imported form.
+func accountIsImported(addrmgrNs walletdb.ReadBucket,
+	acctStore waddrmgr.AccountStore, acctNum uint32) (bool, error) {
+
+	if acctStore == nil {
+		return acctNum == waddrmgr.ImportedAddrAccount, nil
+	}
+
+	imported, err := acctStore.IsImportedAccount(addrmgrNs, acctNum)
+	if err != nil {
+		return false, fmt.Errorf("classify account origin: %w", err)
+	}
+
+	return imported, nil
+}
+
+// numericAccountMatches reports whether a row owned by ownerAcct
+// satisfies a numeric Account filter set to wantAcct, given whether the
+// owning account is imported.
+//
+// Imported accounts have no numeric counterpart on the SQL backends
+// (their account_number column is NULL), so an imported row never
+// matches a numeric filter on either backend regardless of its kvdb
+// account number; such rows are selectable only via (Scope,
+// AccountName). This covers both the legacy ImportedAddrAccount
+// pseudo-account and imported xpub/watch-only accounts created through
+// NewAccountWatchingOnly, which carry ordinary kvdb account numbers. A
+// derived row matches iff its account number equals the filter.
+func numericAccountMatches(ownerAcct, wantAcct uint32, imported bool) bool {
+	if imported {
+		return false
+	}
+
+	return ownerAcct == wantAcct
+}

--- a/wallet/internal/db/kvdb/utxostore.go
+++ b/wallet/internal/db/kvdb/utxostore.go
@@ -10,7 +10,9 @@ import (
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/addresstype"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
@@ -19,6 +21,15 @@ import (
 var (
 	// errNotImplemented is returned for unimplemented kvdb store methods.
 	errNotImplemented = errors.New("not implemented")
+
+	// errMissingTxmgrNamespace is returned when the legacy transaction manager
+	// bucket is not available in the kvdb wallet database.
+	errMissingTxmgrNamespace = errors.New("missing wtxmgr namespace")
+
+	// errUnownedScript is returned when a legacy credit's pkScript cannot
+	// be resolved to a wallet-owned account. The iteration skips the row
+	// rather than propagating; wallet-owned outputs should always resolve.
+	errUnownedScript = errors.New("pkScript not owned by any account")
 
 	// wtxmgrNamespaceKey is the walletdb top-level bucket key used by the
 	// transaction manager.
@@ -329,4 +340,164 @@ func calcConfs(outputHeight, curHeight int32) int32 {
 	}
 
 	return curHeight - outputHeight + 1
+}
+
+// currentUTXOSet returns the set of current UTXOs, including leased outputs
+// but excluding outputs already spent by unmined wallet transactions.
+func (s *Store) currentUTXOSet(
+	txmgrNs walletdb.ReadBucket) (map[wire.OutPoint]struct{}, error) {
+
+	credits, err := s.txStore.UnspentOutputsIncludingLocked(txmgrNs)
+	if err != nil {
+		return nil, fmt.Errorf("list current utxos: %w", err)
+	}
+
+	current := make(map[wire.OutPoint]struct{}, len(credits))
+	for i := range credits {
+		current[credits[i].OutPoint] = struct{}{}
+	}
+
+	return current, nil
+}
+
+// utxoInfoBase maps one legacy wtxmgr credit into the bare db UTXO
+// shape, without resolving the wallet-derived enrichment fields. It is
+// used by the enrichment path below as the starting point before
+// account / address-type / lease metadata is layered on.
+func utxoInfoBase(credit *wtxmgr.Credit) *db.UtxoInfo {
+	height := db.UnminedHeight
+	if credit.Height >= 0 {
+		height = nonNegativeInt32ToUint32(credit.Height)
+	}
+
+	return &db.UtxoInfo{
+		OutPoint:     credit.OutPoint,
+		Amount:       credit.Amount,
+		PkScript:     credit.PkScript,
+		Received:     credit.Received.UTC(),
+		FromCoinBase: credit.FromCoinBase,
+		Height:       height,
+	}
+}
+
+// activeLeaseSet returns the set of currently leased outpoints that
+// intersect the current UTXO set so callers can mark IsLocked on each
+// row without re-reading the lease bucket per UTXO.
+func (s *Store) activeLeaseSet(txmgrNs walletdb.ReadBucket,
+	current map[wire.OutPoint]struct{}) (
+	map[wire.OutPoint]struct{}, error) {
+
+	locked, err := s.txStore.ListLockedOutputs(txmgrNs)
+	if err != nil {
+		return nil, fmt.Errorf("list locked outputs: %w", err)
+	}
+
+	leaseSet := make(map[wire.OutPoint]struct{}, len(locked))
+	for _, lease := range locked {
+		if _, ok := current[lease.Outpoint]; !ok {
+			continue
+		}
+
+		leaseSet[lease.Outpoint] = struct{}{}
+	}
+
+	return leaseSet, nil
+}
+
+// utxoAccountBinding captures the per-row account resolution shared
+// between filter checks and enrichment population. The owning account
+// store and number are computed once and reused so callers do not
+// re-resolve the same address twice per UTXO row.
+type utxoAccountBinding struct {
+	acctStore waddrmgr.AccountStore
+	acctNum   uint32
+	scope     db.KeyScope
+}
+
+// resolveAccountForCredit maps one legacy credit's pkScript to its
+// owning account store and number. Outputs whose script cannot be
+// resolved to a wallet-owned account surface as errUnownedScript so
+// callers can skip them defensively.
+func (s *Store) resolveAccountForCredit(addrmgrNs walletdb.ReadBucket,
+	credit *wtxmgr.Credit, chainParams *chaincfg.Params) (
+	*utxoAccountBinding, btcutil.Address, error) {
+
+	addr, err := addressFromPkScript(credit.PkScript, chainParams)
+	if err != nil {
+		if errors.Is(err, errNoAddressInPkScript) {
+			return nil, nil, errUnownedScript
+		}
+
+		return nil, nil, fmt.Errorf("extract address: %w", err)
+	}
+
+	acctStore, acctNum, err := s.addrStore.AddrAccount(addrmgrNs, addr)
+	if err != nil {
+		if waddrmgr.IsError(err, waddrmgr.ErrAddressNotFound) {
+			return nil, nil, errUnownedScript
+		}
+
+		return nil, nil, fmt.Errorf("lookup account: %w", err)
+	}
+
+	binding := &utxoAccountBinding{
+		acctStore: acctStore,
+		acctNum:   acctNum,
+		scope:     db.KeyScope(acctStore.Scope()),
+	}
+
+	return binding, addr, nil
+}
+
+// enrichCredit produces an enriched db.UtxoInfo from one legacy credit
+// plus its already-resolved account binding. The lease-set lookup is
+// the only step that touches per-UTXO state outside the binding so the
+// caller can compute the set once for the whole listing.
+func (s *Store) enrichCredit(addrmgrNs walletdb.ReadBucket,
+	credit *wtxmgr.Credit, addr btcutil.Address,
+	binding *utxoAccountBinding,
+	leaseSet map[wire.OutPoint]struct{}) (*db.UtxoInfo, error) {
+
+	info := utxoInfoBase(credit)
+
+	props, err := binding.acctStore.AccountProperties(
+		addrmgrNs, binding.acctNum,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("account properties: %w", err)
+	}
+
+	imported, err := binding.acctStore.IsImportedAccount(
+		addrmgrNs, binding.acctNum,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("classify account origin: %w", err)
+	}
+
+	origin := db.DerivedAccount
+	if imported {
+		origin = db.ImportedAccount
+	}
+
+	managedAddr, err := s.addrStore.Address(addrmgrNs, addr)
+	if err != nil {
+		return nil, fmt.Errorf("managed address: %w", err)
+	}
+
+	storeType, err := addresstype.FromWallet(managedAddr.AddrType())
+	if err != nil {
+		return nil, fmt.Errorf("address type: %w", err)
+	}
+
+	info.AccountName = props.AccountName
+	info.Origin = origin
+	info.AddrType = storeType.Type
+	info.HasScript = storeType.HasScript
+	info.KeyScope = binding.scope
+
+	if _, ok := leaseSet[credit.OutPoint]; ok {
+		info.IsLocked = true
+	}
+
+	return info, nil
 }

--- a/wallet/internal/db/kvdb/utxostore.go
+++ b/wallet/internal/db/kvdb/utxostore.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -161,11 +162,61 @@ func (s *Store) ListUTXOs(ctx context.Context,
 	return nil, notImplemented(ctx, "ListUTXOs")
 }
 
-// LeaseOutput is not yet implemented for kvdb.
-func (s *Store) LeaseOutput(ctx context.Context,
-	_ db.LeaseOutputParams) (*db.LeasedOutput, error) {
+// LeaseOutput locks one known wallet UTXO through the legacy wtxmgr lease
+// path.
+func (s *Store) LeaseOutput(_ context.Context,
+	params db.LeaseOutputParams) (*db.LeasedOutput, error) {
 
-	return nil, notImplemented(ctx, "LeaseOutput")
+	if params.Duration <= 0 {
+		return nil, fmt.Errorf(
+			"%w: lease duration must be positive", db.ErrInvalidParam,
+		)
+	}
+
+	var expiration time.Time
+
+	err := walletdb.Update(s.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+		if ns == nil {
+			return errMissingTxmgrNamespace
+		}
+
+		current, err := s.currentUTXOSet(ns)
+		if err != nil {
+			return err
+		}
+
+		if _, ok := current[params.OutPoint]; !ok {
+			return db.ErrUtxoNotFound
+		}
+
+		expiration, err = s.txStore.LockOutput(
+			ns, wtxmgr.LockID(params.ID), params.OutPoint, params.Duration,
+		)
+		if err != nil {
+			switch {
+			case errors.Is(err, wtxmgr.ErrUtxoNotFound),
+				errors.Is(err, wtxmgr.ErrUnknownOutput):
+				return db.ErrUtxoNotFound
+
+			case errors.Is(err, wtxmgr.ErrOutputAlreadyLocked):
+				return db.ErrOutputAlreadyLeased
+			}
+
+			return fmt.Errorf("lock output: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("kvdb.Store.LeaseOutput: %w", err)
+	}
+
+	return &db.LeasedOutput{
+		OutPoint:   params.OutPoint,
+		LockID:     db.LockID(params.ID),
+		Expiration: expiration.UTC(),
+	}, nil
 }
 
 // ReleaseOutput releases a previously leased output.

--- a/wallet/internal/db/kvdb/utxostore.go
+++ b/wallet/internal/db/kvdb/utxostore.go
@@ -243,11 +243,17 @@ func (s *Store) LeaseOutput(_ context.Context,
 	}, nil
 }
 
-// ReleaseOutput releases a previously leased output.
+// ReleaseOutput releases a previously leased output, aligning the kvdb
+// backend with the shared db.UTXOStore release contract (see
+// db.ReleaseOutputWithOps).
 //
-// How it works:
-// The method executes a single walletdb update transaction that deletes the
-// lock record associated with the specified outpoint.
+// The outpoint is first gated through the current wallet UTXO set: a missing
+// or non-current (spent-by-unmined) outpoint maps to db.ErrUtxoNotFound, the
+// same sentinel the SQL backends return. The legacy unlock is then translated
+// onto the shared sentinels: a wrong active lock ID becomes
+// db.ErrOutputUnlockNotAllowed, while an already-unlocked or expired lease is
+// a no-op. The translation mirrors the wtxmgr.Err* -> db.Err* mapping already
+// used by GetUtxo and LeaseOutput in this file.
 //
 // Database Actions:
 //   - Performs exactly one write transaction (walletdb.Update).
@@ -269,8 +275,34 @@ func (s *Store) ReleaseOutput(_ context.Context,
 			)
 		}
 
-		err := s.txStore.UnlockOutput(ns, lockID, op)
+		// Gate the outpoint through the current UTXO set first so a
+		// missing or non-current output reports db.ErrUtxoNotFound,
+		// matching the SQL backends which resolve the wallet-owned row
+		// before attempting the release.
+		current, err := s.currentUTXOSet(ns)
 		if err != nil {
+			return err
+		}
+
+		if _, ok := current[op]; !ok {
+			return db.ErrUtxoNotFound
+		}
+
+		err = s.txStore.UnlockOutput(ns, lockID, op)
+		if err != nil {
+			switch {
+			// wtxmgr only knows the output through the lock bucket,
+			// so an unknown output here means it left the current
+			// set between the gate above and the unlock; report it
+			// as not found for parity with the SQL backends.
+			case errors.Is(err, wtxmgr.ErrUnknownOutput),
+				errors.Is(err, wtxmgr.ErrUtxoNotFound):
+				return db.ErrUtxoNotFound
+
+			case errors.Is(err, wtxmgr.ErrOutputUnlockNotAllowed):
+				return db.ErrOutputUnlockNotAllowed
+			}
+
 			return fmt.Errorf("unlock output: %w", err)
 		}
 

--- a/wallet/internal/db/kvdb/utxostore_balance_test.go
+++ b/wallet/internal/db/kvdb/utxostore_balance_test.go
@@ -518,3 +518,118 @@ func creditImportedKeyAtHeight(t *testing.T, dbConn walletdb.DB,
 		t, dbConn, mgr, txStore, pkScript, amount, height, false,
 	)
 }
+
+// TestBalanceExcludesImportedFromNumericAccountFilter verifies that the
+// Balance Account filter matches SQL semantics: a numeric Account filter
+// never counts imported UTXOs (the legacy ImportedAddrAccount pseudo-account
+// has no numeric counterpart on SQL backends), while derived accounts are
+// still summed by number. Imported balances remain reachable via
+// (Scope, Name), exercised separately by TestBalanceNameFilter.
+func TestBalanceExcludesImportedFromNumericAccountFilter(t *testing.T) {
+	t.Parallel()
+
+	store, mgr, txStore, cleanup := newCreditedFixture(t)
+	t.Cleanup(cleanup)
+
+	scope := waddrmgr.KeyScopeBIP0084
+	dbScope := db.KeyScopeBIP0084
+
+	// Arrange: a derived-account (account 0) UTXO and an imported-key UTXO.
+	creditAccountAddressAtHeight(
+		t, store.db, mgr, txStore, scope, 0, btcutil.Amount(100),
+		balanceTestTipHeight, false,
+	)
+	creditImportedKeyAtHeight(
+		t, store.db, mgr, txStore, scope, btcutil.Amount(300),
+		balanceTestTipHeight,
+	)
+
+	// A numeric Account filter set to the imported pseudo-account number
+	// sums nothing: imported outputs are not numerically addressable.
+	importedAcct := uint32(waddrmgr.ImportedAddrAccount)
+	res, err := store.Balance(
+		t.Context(), db.BalanceParams{
+			Scope:   &dbScope,
+			Account: &importedAcct,
+		},
+	)
+	require.NoError(t, err)
+	require.Zero(t, res.Total)
+
+	// The derived account is still summed by its account number, and the
+	// imported output does not leak into the result.
+	derivedAcct := uint32(0)
+	res, err = store.Balance(
+		t.Context(), db.BalanceParams{
+			Scope:   &dbScope,
+			Account: &derivedAcct,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(100), res.Total)
+}
+
+// TestBalanceExcludesWatchOnlyAccountFromNumericAccountFilter verifies that an
+// imported xpub (watch-only) account is excluded from the numeric Account
+// balance filter even though it carries an ordinary kvdb account number. SQL
+// backends store NULL account_number for imported accounts, so they can never
+// be summed numerically; kvdb must match that, while the account stays
+// reachable through (Scope, Name).
+func TestBalanceExcludesWatchOnlyAccountFromNumericAccountFilter(t *testing.T) {
+	t.Parallel()
+
+	store, mgr, txStore, cleanup := newCreditedFixture(t)
+	t.Cleanup(cleanup)
+
+	scope := waddrmgr.KeyScopeBIP0084
+	dbScope := db.KeyScopeBIP0084
+
+	// Arrange: a derived account-0 UTXO and an imported xpub-account UTXO
+	// whose account carries an ordinary (non-pseudo) account number.
+	importedName := "imported-xpub-balance"
+	importedAcct := createImportedXpubAccount(
+		t, store, scope, importedName, 0xBE,
+	)
+
+	creditAccountAddressAtHeight(
+		t, store.db, mgr, txStore, scope, 0, btcutil.Amount(100),
+		balanceTestTipHeight, false,
+	)
+	creditAccountAddressAtHeight(
+		t, store.db, mgr, txStore, scope, importedAcct,
+		btcutil.Amount(300), balanceTestTipHeight, false,
+	)
+
+	// A numeric Account filter on the imported account's ordinary number
+	// must sum nothing: imported accounts are not numerically addressable.
+	res, err := store.Balance(
+		t.Context(), db.BalanceParams{
+			Scope:   &dbScope,
+			Account: &importedAcct,
+		},
+	)
+	require.NoError(t, err)
+	require.Zero(t, res.Total)
+
+	// The derived account is still summed by its number, with no leakage
+	// from the imported account.
+	derivedAcct := uint32(0)
+	res, err = store.Balance(
+		t.Context(), db.BalanceParams{
+			Scope:   &dbScope,
+			Account: &derivedAcct,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(100), res.Total)
+
+	// The imported account remains summable through its (Scope, Name).
+	res, err = store.Balance(
+		t.Context(), db.BalanceParams{
+			Scope: &dbScope,
+			Name:  &importedName,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(300), res.Total)
+}

--- a/wallet/internal/db/kvdb/utxostore_balance_test.go
+++ b/wallet/internal/db/kvdb/utxostore_balance_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -474,4 +475,46 @@ func insertBalanceCredit(t *testing.T, dbConn walletdb.DB,
 	require.NoError(t, err)
 
 	return wire.OutPoint{Hash: rec.Hash, Index: 0}
+}
+
+// creditImportedKeyAtHeight imports a fresh private key into the legacy
+// ImportedAddrAccount pseudo-account, inserts a credit paying to its address
+// at height, and returns the credited outpoint. Imported keys are the kvdb
+// analogue of SQL imported rows (NULL account_number), so the resulting UTXO
+// must be selectable only via (Scope, AccountName), never by numeric Account.
+func creditImportedKeyAtHeight(t *testing.T, dbConn walletdb.DB,
+	mgr *waddrmgr.Manager, txStore *wtxmgr.Store,
+	scope waddrmgr.KeyScope, amount btcutil.Amount,
+	height int32) wire.OutPoint {
+
+	t.Helper()
+
+	scopedMgr, err := mgr.FetchScopedKeyManager(scope)
+	require.NoError(t, err)
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	wif, err := btcutil.NewWIF(privKey, mgr.ChainParams(), true)
+	require.NoError(t, err)
+
+	var pkScript []byte
+
+	err = walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+
+		managedAddr, err := scopedMgr.ImportPrivateKey(ns, wif, nil)
+		if err != nil {
+			return err
+		}
+
+		pkScript, err = txscript.PayToAddrScript(managedAddr.Address())
+
+		return err
+	})
+	require.NoError(t, err)
+
+	return insertBalanceCredit(
+		t, dbConn, mgr, txStore, pkScript, amount, height, false,
+	)
 }

--- a/wallet/internal/db/kvdb/utxostore_test.go
+++ b/wallet/internal/db/kvdb/utxostore_test.go
@@ -254,6 +254,178 @@ func TestLeaseOutputRejectsSpentByUnminedTx(t *testing.T) {
 	require.ErrorIs(t, err, db.ErrUtxoNotFound)
 }
 
+// TestListUTXOsIncludesLockedOutputs verifies kvdb returns current UTXOs even
+// when they are actively leased.
+func TestListUTXOsIncludesLockedOutputs(t *testing.T) {
+	t.Parallel()
+
+	store, mgr, txStore, cleanup := newCreditedFixture(t)
+	t.Cleanup(cleanup)
+
+	// Credit two wallet-owned outputs so they resolve to an account and
+	// surface through the enriched listing path (unowned scripts are
+	// dropped, matching the SQL backends).
+	scope := waddrmgr.KeyScopeBIP0084
+	lockedPoint := creditAccountAddressAtHeight(
+		t, store.db, mgr, txStore, scope, 0, btcutil.Amount(3000),
+		balanceTestTipHeight, false,
+	)
+	unlockedPoint := creditAccountAddressAtHeight(
+		t, store.db, mgr, txStore, scope, 0, btcutil.Amount(4000),
+		balanceTestTipHeight, false,
+	)
+
+	_, err := store.LeaseOutput(
+		t.Context(), db.LeaseOutputParams{
+			WalletID: 0,
+			ID:       db.LockID{3},
+			OutPoint: lockedPoint,
+			Duration: time.Hour,
+		},
+	)
+	require.NoError(t, err)
+
+	utxos, err := store.ListUTXOs(
+		t.Context(), db.ListUtxosQuery{
+			WalletID: 0,
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, utxos, 2)
+	require.ElementsMatch(t, []wire.OutPoint{
+		lockedPoint, unlockedPoint,
+	}, []wire.OutPoint{
+		utxos[0].OutPoint, utxos[1].OutPoint,
+	})
+
+	// The leased output reports IsLocked; the other does not. This is the
+	// original intent of the test: a leased UTXO still appears in the
+	// listing, now distinguished by the enriched IsLocked flag.
+	byOutPoint := make(map[wire.OutPoint]db.UtxoInfo, len(utxos))
+	for _, u := range utxos {
+		byOutPoint[u.OutPoint] = u
+	}
+
+	require.True(t, byOutPoint[lockedPoint].IsLocked)
+	require.False(t, byOutPoint[unlockedPoint].IsLocked)
+}
+
+func TestUTXOEnrichmentFields(t *testing.T) {
+	t.Parallel()
+
+	store, mgr, txStore, cleanup := newCreditedFixture(t)
+	t.Cleanup(cleanup)
+
+	scope := waddrmgr.KeyScopeBIP0084
+	wantScope := db.KeyScopeBIP0084
+
+	lockedPoint := creditAccountAddressAtHeight(
+		t, store.db, mgr, txStore, scope, 0, btcutil.Amount(20000),
+		balanceTestTipHeight, false,
+	)
+	unlockedPoint := creditAccountAddressAtHeight(
+		t, store.db, mgr, txStore, scope, 0, btcutil.Amount(30000),
+		balanceTestTipHeight, false,
+	)
+
+	// Lease only one output so IsLocked separates the two rows.
+	_, err := store.LeaseOutput(
+		t.Context(), db.LeaseOutputParams{
+			WalletID: 0,
+			OutPoint: lockedPoint,
+			ID:       db.LockID{1},
+			Duration: 30 * time.Minute,
+		},
+	)
+	require.NoError(t, err)
+
+	// ListUTXOs returns both rows with the derived-account enrichment.
+	utxos, err := store.ListUTXOs(
+		t.Context(), db.ListUtxosQuery{
+			WalletID: 0,
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, utxos, 2)
+
+	byOutPoint := make(map[wire.OutPoint]db.UtxoInfo, len(utxos))
+	for _, u := range utxos {
+		byOutPoint[u.OutPoint] = u
+	}
+
+	locked, ok := byOutPoint[lockedPoint]
+	require.True(t, ok, "locked UTXO missing from ListUTXOs")
+	require.Equal(t, waddrmgr.DefaultAccountName, locked.AccountName)
+	require.Equal(t, db.DerivedAccount, locked.Origin)
+	require.Equal(t, db.WitnessPubKey, locked.AddrType)
+	require.False(t, locked.HasScript)
+	require.True(t, locked.IsLocked)
+	require.Equal(t, wantScope, locked.KeyScope)
+
+	unlocked, ok := byOutPoint[unlockedPoint]
+	require.True(t, ok, "unlocked UTXO missing from ListUTXOs")
+	require.Equal(t, waddrmgr.DefaultAccountName, unlocked.AccountName)
+	require.Equal(t, db.DerivedAccount, unlocked.Origin)
+	require.Equal(t, db.WitnessPubKey, unlocked.AddrType)
+	require.False(t, unlocked.HasScript)
+	require.False(t, unlocked.IsLocked)
+	require.Equal(t, wantScope, unlocked.KeyScope)
+
+	// GetUtxo surfaces the same enriched view as ListUTXOs, including the
+	// active-lease IsLocked flag and the owning account's KeyScope.
+	got, err := store.GetUtxo(
+		t.Context(), db.GetUtxoQuery{
+			WalletID: 0,
+			OutPoint: lockedPoint,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, waddrmgr.DefaultAccountName, got.AccountName)
+	require.Equal(t, db.DerivedAccount, got.Origin)
+	require.Equal(t, db.WitnessPubKey, got.AddrType)
+	require.False(t, got.HasScript)
+	require.True(t, got.IsLocked)
+	require.Equal(t, wantScope, got.KeyScope)
+}
+
+// TestListUTXOsFiltersByConfirms verifies that kvdb.Store applies the
+// confirmation filters before returning db-native UTXO rows. The
+// account / scope / name filters are exercised end-to-end by the
+// cross-backend itests under wallet/internal/db/itest, where real
+// addrmgr fixtures populate the enrichment fields and the filter
+// semantics can be asserted across pg, sqlite, and kvdb together.
+func TestListUTXOsFiltersByConfirms(t *testing.T) {
+	t.Parallel()
+
+	store, mgr, txStore, cleanup := newCreditedFixture(t)
+	t.Cleanup(cleanup)
+
+	scope := waddrmgr.KeyScopeBIP0084
+	creditAccountAddressAtHeight(
+		t, store.db, mgr, txStore, scope, 0, btcutil.Amount(4000), 4,
+		false,
+	)
+	creditAccountAddressAtHeight(
+		t, store.db, mgr, txStore, scope, 0, btcutil.Amount(5000), 5,
+		false,
+	)
+	creditAccountAddressAtHeight(
+		t, store.db, mgr, txStore, scope, 0, btcutil.Amount(6000), 0,
+		false,
+	)
+
+	minConfs := int32(1)
+
+	utxos, err := store.ListUTXOs(
+		t.Context(), db.ListUtxosQuery{
+			WalletID: 0,
+			MinConfs: &minConfs,
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, utxos, 2)
+}
+
 // insertKnownCredit inserts one test credit and returns its outpoint.
 func insertKnownCredit(t *testing.T, dbConn walletdb.DB, txStore *wtxmgr.Store,
 	pkScript []byte, value int64, height int32) wire.OutPoint {

--- a/wallet/internal/db/kvdb/utxostore_test.go
+++ b/wallet/internal/db/kvdb/utxostore_test.go
@@ -1,11 +1,14 @@
 package kvdb
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/hdkeychain"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
@@ -528,4 +531,196 @@ func TestBalanceEmptyWallet(t *testing.T) {
 	result, err := store.Balance(t.Context(), db.BalanceParams{})
 	require.NoError(t, err)
 	require.Zero(t, result.Total)
+}
+
+// TestListUTXOsExcludesImportedFromNumericAccountFilter verifies that kvdb
+// matches SQL semantics for the db.ListUtxosQuery.Account filter: a numeric
+// Account filter never selects imported UTXOs (those carry the legacy
+// ImportedAddrAccount pseudo-account number, which has no numeric counterpart
+// on SQL backends), while derived accounts remain selectable by number.
+// Imported UTXOs stay reachable through (Scope, AccountName).
+func TestListUTXOsExcludesImportedFromNumericAccountFilter(t *testing.T) {
+	t.Parallel()
+
+	store, mgr, txStore, cleanup := newCreditedFixture(t)
+	t.Cleanup(cleanup)
+
+	scope := waddrmgr.KeyScopeBIP0084
+	dbScope := db.KeyScopeBIP0084
+
+	// Arrange: one derived-account (account 0) UTXO and one imported-key
+	// UTXO under the legacy ImportedAddrAccount pseudo-account.
+	derivedPoint := creditAccountAddressAtHeight(
+		t, store.db, mgr, txStore, scope, 0, btcutil.Amount(1000),
+		balanceTestTipHeight, false,
+	)
+	importedPoint := creditImportedKeyAtHeight(
+		t, store.db, mgr, txStore, scope, btcutil.Amount(2000),
+		balanceTestTipHeight,
+	)
+
+	// A numeric Account filter set to the imported pseudo-account number
+	// must select nothing: imported rows are not numerically addressable,
+	// matching SQL's NULL account_number.
+	importedAcct := uint32(waddrmgr.ImportedAddrAccount)
+	utxos, err := store.ListUTXOs(
+		t.Context(), db.ListUtxosQuery{
+			WalletID: 0,
+			Scope:    &dbScope,
+			Account:  &importedAcct,
+		},
+	)
+	require.NoError(t, err)
+	require.Empty(t, utxos)
+
+	// A numeric Account filter for the derived account returns only the
+	// derived UTXO; the imported UTXO is excluded.
+	derivedAcct := uint32(0)
+	utxos, err = store.ListUTXOs(
+		t.Context(), db.ListUtxosQuery{
+			WalletID: 0,
+			Scope:    &dbScope,
+			Account:  &derivedAcct,
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, utxos, 1)
+	require.Equal(t, derivedPoint, utxos[0].OutPoint)
+	require.Equal(t, db.DerivedAccount, utxos[0].Origin)
+
+	// The imported UTXO remains selectable via (Scope, AccountName).
+	importedName := waddrmgr.ImportedAddrAccountName
+	utxos, err = store.ListUTXOs(
+		t.Context(), db.ListUtxosQuery{
+			WalletID:    0,
+			Scope:       &dbScope,
+			AccountName: &importedName,
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, utxos, 1)
+	require.Equal(t, importedPoint, utxos[0].OutPoint)
+	require.Equal(t, db.ImportedAccount, utxos[0].Origin)
+}
+
+// TestListUTXOsExcludesWatchOnlyAccountFromNumericAccountFilter verifies that
+// kvdb excludes an imported xpub (watch-only) account from the numeric
+// db.ListUtxosQuery.Account filter even though the account carries an ordinary
+// kvdb account number. SQL backends store NULL account_number for imported
+// accounts, so they are never selectable by number; kvdb must match that. The
+// imported UTXO stays reachable through (Scope, AccountName).
+func TestListUTXOsExcludesWatchOnlyAccountFromNumericAccountFilter(
+	t *testing.T) {
+
+	t.Parallel()
+
+	store, mgr, txStore, cleanup := newCreditedFixture(t)
+	t.Cleanup(cleanup)
+
+	scope := waddrmgr.KeyScopeBIP0084
+	dbScope := db.KeyScopeBIP0084
+
+	// Arrange: a derived account-0 UTXO and an imported xpub-account UTXO
+	// whose account carries an ordinary (non-pseudo) account number.
+	importedName := "imported-xpub-list"
+	importedAcct := createImportedXpubAccount(
+		t, store, scope, importedName, 0xBE,
+	)
+
+	derivedPoint := creditAccountAddressAtHeight(
+		t, store.db, mgr, txStore, scope, 0, btcutil.Amount(1000),
+		balanceTestTipHeight, false,
+	)
+	importedPoint := creditAccountAddressAtHeight(
+		t, store.db, mgr, txStore, scope, importedAcct,
+		btcutil.Amount(2000), balanceTestTipHeight, false,
+	)
+
+	// A numeric Account filter on the imported account's ordinary number
+	// must select nothing: imported rows are not numerically addressable.
+	utxos, err := store.ListUTXOs(t.Context(), db.ListUtxosQuery{
+		WalletID: 0,
+		Scope:    &dbScope,
+		Account:  &importedAcct,
+	})
+	require.NoError(t, err)
+	require.Empty(t, utxos)
+
+	// The derived account is still selectable by number, with no leakage
+	// from the imported account.
+	derivedAcct := uint32(0)
+	utxos, err = store.ListUTXOs(t.Context(), db.ListUtxosQuery{
+		WalletID: 0,
+		Scope:    &dbScope,
+		Account:  &derivedAcct,
+	})
+	require.NoError(t, err)
+	require.Len(t, utxos, 1)
+	require.Equal(t, derivedPoint, utxos[0].OutPoint)
+	require.Equal(t, db.DerivedAccount, utxos[0].Origin)
+
+	// The imported account remains selectable through (Scope, AccountName).
+	utxos, err = store.ListUTXOs(t.Context(), db.ListUtxosQuery{
+		WalletID:    0,
+		Scope:       &dbScope,
+		AccountName: &importedName,
+	})
+	require.NoError(t, err)
+	require.Len(t, utxos, 1)
+	require.Equal(t, importedPoint, utxos[0].OutPoint)
+	require.Equal(t, db.ImportedAccount, utxos[0].Origin)
+}
+
+// createImportedXpubAccount creates an imported (watch-only) xpub account via
+// CreateImportedAccount, which allocates an ordinary kvdb account number
+// (NewAccountWatchingOnly) rather than the legacy ImportedAddrAccount
+// pseudo-account. It returns that account number so callers can confirm a
+// numeric Account filter still excludes the account despite the ordinary
+// number. The xpub-derived seed byte keeps successive accounts distinct.
+func createImportedXpubAccount(t *testing.T, store *Store,
+	scope waddrmgr.KeyScope, name string, seedByte byte) uint32 {
+
+	t.Helper()
+
+	seed := bytes.Repeat([]byte{seedByte}, hdkeychain.RecommendedSeedLen)
+	master, err := hdkeychain.NewMaster(seed, &chaincfg.SimNetParams)
+	require.NoError(t, err)
+
+	masterPub, err := master.Neuter()
+	require.NoError(t, err)
+
+	dbScope := db.KeyScope{Purpose: scope.Purpose, Coin: scope.Coin}
+
+	_, err = store.CreateImportedAccount(t.Context(),
+		db.CreateImportedAccountParams{
+			Scope:             dbScope,
+			Name:              name,
+			MasterFingerprint: 0xDEADBEEF,
+			PublicKey:         []byte(masterPub.String()),
+		},
+	)
+	require.NoError(t, err)
+
+	scopedMgr, err := store.addrStore.FetchScopedKeyManager(scope)
+	require.NoError(t, err)
+
+	var account uint32
+
+	err = walletdb.View(store.db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgr.NamespaceKey)
+
+		var inner error
+
+		account, inner = scopedMgr.LookupAccount(ns, name)
+
+		return inner
+	})
+	require.NoError(t, err)
+
+	// The imported account must receive an ordinary account number, not the
+	// legacy pseudo-account: that is the exact case the numeric filter has to
+	// guard against.
+	require.NotEqual(t, uint32(waddrmgr.ImportedAddrAccount), account)
+
+	return account
 }

--- a/wallet/internal/db/kvdb/utxostore_test.go
+++ b/wallet/internal/db/kvdb/utxostore_test.go
@@ -257,6 +257,38 @@ func TestLeaseOutputRejectsSpentByUnminedTx(t *testing.T) {
 	require.ErrorIs(t, err, db.ErrUtxoNotFound)
 }
 
+// TestListLeasedOutputsSuccess verifies that kvdb.Store exposes the active
+// legacy lease set through the db-native shape.
+func TestListLeasedOutputsSuccess(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore, nil)
+
+	outPoint := insertKnownCredit(
+		t, dbConn, txStore, []byte{0x51}, 3000, 3,
+	)
+
+	_, err := store.LeaseOutput(
+		t.Context(), db.LeaseOutputParams{
+			WalletID: 0,
+			ID:       db.LockID{2},
+			OutPoint: outPoint,
+			Duration: time.Hour,
+		},
+	)
+	require.NoError(t, err)
+
+	leases, err := store.ListLeasedOutputs(t.Context(), 0)
+	require.NoError(t, err)
+	require.Len(t, leases, 1)
+	require.Equal(t, outPoint, leases[0].OutPoint)
+	require.Equal(t, db.LockID{2}, leases[0].LockID)
+}
+
 // TestListUTXOsIncludesLockedOutputs verifies kvdb returns current UTXOs even
 // when they are actively leased.
 func TestListUTXOsIncludesLockedOutputs(t *testing.T) {
@@ -389,6 +421,37 @@ func TestUTXOEnrichmentFields(t *testing.T) {
 	require.False(t, got.HasScript)
 	require.True(t, got.IsLocked)
 	require.Equal(t, wantScope, got.KeyScope)
+}
+
+// TestListLeasedOutputsDropsSpentLeases verifies kvdb omits active leases once
+// the leased outpoint is spent by an unmined wallet transaction.
+func TestListLeasedOutputsDropsSpentLeases(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore, nil)
+	outPoint := insertKnownCredit(
+		t, dbConn, txStore, []byte{0x51}, 3000, 3,
+	)
+
+	_, err := store.LeaseOutput(
+		t.Context(), db.LeaseOutputParams{
+			WalletID: 0,
+			ID:       db.LockID{4},
+			OutPoint: outPoint,
+			Duration: time.Hour,
+		},
+	)
+	require.NoError(t, err)
+
+	insertUnminedSpend(t, dbConn, txStore, outPoint)
+
+	leases, err := store.ListLeasedOutputs(t.Context(), 0)
+	require.NoError(t, err)
+	require.Empty(t, leases)
 }
 
 // TestListUTXOsFiltersByConfirms verifies that kvdb.Store applies the

--- a/wallet/internal/db/kvdb/utxostore_test.go
+++ b/wallet/internal/db/kvdb/utxostore_test.go
@@ -28,64 +28,33 @@ func TestReleaseOutputSuccess(t *testing.T) {
 	txStore := newTxStore(t, dbConn)
 	store := NewStore(dbConn, txStore, nil)
 
-	lockID := wtxmgr.LockID{1}
-	op := wire.OutPoint{Hash: [32]byte{1}, Index: 0}
+	// Arrange: insert a current credit and lease it so there is something
+	// to release.
+	outPoint := insertKnownCredit(
+		t, dbConn, txStore, []byte{0x51}, 1000, 1,
+	)
 
-	// Arrange: Create a lease so there is something to release.
-	err := walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
-		ns := tx.ReadWriteBucket(wtxmgrNamespaceKey)
-		require.NotNil(t, ns)
-
-		// Create a mock transaction to satisfy the "known output" check in
-		// wtxmgr.
-		txMsg := &wire.MsgTx{
-			Version: 1,
-			TxOut: []*wire.TxOut{{
-				Value:    1000,
-				PkScript: []byte{0x00}, // OP_0
-			}},
-		}
-
-		rec, err := wtxmgr.NewTxRecordFromMsgTx(txMsg, time.Now())
-		if err != nil {
-			return fmt.Errorf("create tx record: %w", err)
-		}
-
-		// Insert the transaction as mined.
-		block := &wtxmgr.BlockMeta{
-			Block: wtxmgr.Block{Height: 1},
-			Time:  time.Now(),
-		}
-
-		err = txStore.InsertTx(ns, rec, block)
-		if err != nil {
-			return fmt.Errorf("insert tx: %w", err)
-		}
-
-		// Add the output as a credit so wtxmgr knows about it.
-		err = txStore.AddCredit(ns, rec, block, 0, false)
-		if err != nil {
-			return fmt.Errorf("add credit: %w", err)
-		}
-
-		// Use the inserted transaction's hash for the outpoint.
-		op.Hash = rec.Hash
-
-		_, err = txStore.LockOutput(ns, lockID, op, time.Hour)
-
-		return err
-	})
+	_, err := store.LeaseOutput(
+		t.Context(), db.LeaseOutputParams{
+			WalletID: 0,
+			ID:       db.LockID{1},
+			OutPoint: outPoint,
+			Duration: time.Hour,
+		},
+	)
 	require.NoError(t, err)
 
-	// Act: Release the lease through the kvdb store implementation.
-	err = store.ReleaseOutput(t.Context(), db.ReleaseOutputParams{
-		WalletID: 1,
-		ID:       [32]byte(lockID),
-		OutPoint: op,
-	})
+	// Act: release the lease through the kvdb store implementation.
+	err = store.ReleaseOutput(
+		t.Context(), db.ReleaseOutputParams{
+			WalletID: 0,
+			ID:       db.LockID{1},
+			OutPoint: outPoint,
+		},
+	)
 	require.NoError(t, err)
 
-	// Assert: The lock set is now empty.
+	// Assert: the lock set is now empty.
 	err = walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
 		ns := tx.ReadBucket(wtxmgrNamespaceKey)
 		require.NotNil(t, ns)
@@ -116,6 +85,143 @@ func TestReleaseOutputMissingNamespace(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.ErrorIs(t, err, walletdb.ErrBucketNotFound)
+}
+
+// TestReleaseOutputWrongLockID verifies that releasing a current output with
+// a lock ID other than the active one reports db.ErrOutputUnlockNotAllowed,
+// matching the shared db.UTXOStore release contract.
+func TestReleaseOutputWrongLockID(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore, nil)
+
+	// Arrange: insert a current credit and lease it under lock ID 1.
+	outPoint := insertKnownCredit(
+		t, dbConn, txStore, []byte{0x51}, 2500, 2,
+	)
+
+	_, err := store.LeaseOutput(
+		t.Context(), db.LeaseOutputParams{
+			WalletID: 0,
+			ID:       db.LockID{1},
+			OutPoint: outPoint,
+			Duration: time.Hour,
+		},
+	)
+	require.NoError(t, err)
+
+	// Act: attempt to release using a different lock ID.
+	err = store.ReleaseOutput(
+		t.Context(), db.ReleaseOutputParams{
+			WalletID: 0,
+			ID:       db.LockID{2},
+			OutPoint: outPoint,
+		},
+	)
+
+	// Assert: the mismatched lock ID is rejected with the db sentinel.
+	require.ErrorIs(t, err, db.ErrOutputUnlockNotAllowed)
+}
+
+// TestReleaseOutputMissingUtxo verifies that releasing an outpoint that is not
+// in the current wallet UTXO set reports db.ErrUtxoNotFound.
+func TestReleaseOutputMissingUtxo(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore, nil)
+
+	// Act: release an outpoint that was never inserted as a credit.
+	err := store.ReleaseOutput(
+		t.Context(), db.ReleaseOutputParams{
+			WalletID: 0,
+			ID:       db.LockID{1},
+			OutPoint: wire.OutPoint{Hash: [32]byte{9}, Index: 0},
+		},
+	)
+
+	// Assert: the unknown outpoint maps to the db sentinel.
+	require.ErrorIs(t, err, db.ErrUtxoNotFound)
+}
+
+// TestReleaseOutputRejectsSpentByUnminedTx verifies that an output already
+// spent by an unmined wallet transaction is no longer current and therefore
+// reports db.ErrUtxoNotFound on release, even when it still carries a lease.
+func TestReleaseOutputRejectsSpentByUnminedTx(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore, nil)
+
+	// Arrange: insert a current credit, lease it, then spend it with an
+	// unmined transaction so it drops out of the current UTXO set.
+	outPoint := insertKnownCredit(
+		t, dbConn, txStore, []byte{0x51}, 1500, 1,
+	)
+
+	_, err := store.LeaseOutput(
+		t.Context(), db.LeaseOutputParams{
+			WalletID: 0,
+			ID:       db.LockID{1},
+			OutPoint: outPoint,
+			Duration: time.Hour,
+		},
+	)
+	require.NoError(t, err)
+
+	insertUnminedSpend(t, dbConn, txStore, outPoint)
+
+	// Act: release the now non-current output.
+	err = store.ReleaseOutput(
+		t.Context(), db.ReleaseOutputParams{
+			WalletID: 0,
+			ID:       db.LockID{1},
+			OutPoint: outPoint,
+		},
+	)
+
+	// Assert: the non-current output maps to the db sentinel.
+	require.ErrorIs(t, err, db.ErrUtxoNotFound)
+}
+
+// TestReleaseOutputAlreadyUnlocked verifies that releasing a current output
+// that carries no active lease is a no-op rather than an error, matching the
+// expired/already-released behavior of the shared release contract.
+func TestReleaseOutputAlreadyUnlocked(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore, nil)
+
+	// Arrange: insert a current credit that was never leased.
+	outPoint := insertKnownCredit(
+		t, dbConn, txStore, []byte{0x51}, 2500, 2,
+	)
+
+	// Act: release the unleased output.
+	err := store.ReleaseOutput(
+		t.Context(), db.ReleaseOutputParams{
+			WalletID: 0,
+			ID:       db.LockID{1},
+			OutPoint: outPoint,
+		},
+	)
+
+	// Assert: an output with no active lease releases as a no-op.
+	require.NoError(t, err)
 }
 
 // TestGetUtxoSuccess verifies that kvdb.Store adapts one wallet-owned legacy

--- a/wallet/internal/db/kvdb/utxostore_test.go
+++ b/wallet/internal/db/kvdb/utxostore_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
@@ -111,6 +113,161 @@ func TestReleaseOutputMissingNamespace(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.ErrorIs(t, err, walletdb.ErrBucketNotFound)
+}
+
+// TestGetUtxoSuccess verifies that kvdb.Store adapts one wallet-owned legacy
+// credit into the db-native UTXO shape.
+func TestGetUtxoSuccess(t *testing.T) {
+	t.Parallel()
+
+	store, mgr, txStore, cleanup := newCreditedFixture(t)
+	t.Cleanup(cleanup)
+
+	scope := waddrmgr.KeyScopeBIP0084
+	outPoint := creditAccountAddressAtHeight(
+		t, store.db, mgr, txStore, scope, 0, btcutil.Amount(1500), 1,
+		false,
+	)
+
+	utxo, err := store.GetUtxo(
+		t.Context(), db.GetUtxoQuery{
+			WalletID: 0,
+			OutPoint: outPoint,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, outPoint, utxo.OutPoint)
+	require.Equal(t, btcutil.Amount(1500), utxo.Amount)
+	require.NotEmpty(t, utxo.PkScript)
+	require.Equal(t, uint32(1), utxo.Height)
+	require.Equal(t, waddrmgr.DefaultAccountName, utxo.AccountName)
+	require.Equal(t, db.DerivedAccount, utxo.Origin)
+	require.Equal(t, db.WitnessPubKey, utxo.AddrType)
+	require.False(t, utxo.HasScript)
+	require.Equal(t, db.KeyScopeBIP0084, utxo.KeyScope)
+}
+
+// TestGetUtxoNotFound verifies that kvdb.Store maps the legacy missing-UTXO
+// error onto db.ErrUtxoNotFound.
+func TestGetUtxoNotFound(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore, nil)
+
+	_, err := store.GetUtxo(
+		t.Context(), db.GetUtxoQuery{
+			WalletID: 0,
+			OutPoint: wire.OutPoint{Hash: [32]byte{9}, Index: 0},
+		},
+	)
+	require.ErrorIs(t, err, db.ErrUtxoNotFound)
+}
+
+// TestGetUtxoRejectsSpentByUnminedTx verifies GetUtxo only returns outputs
+// that remain current after unmined wallet spends are considered.
+func TestGetUtxoRejectsSpentByUnminedTx(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore, nil)
+	outPoint := insertKnownCredit(
+		t, dbConn, txStore, []byte{0x51}, 1500, 1,
+	)
+	insertUnminedSpend(t, dbConn, txStore, outPoint)
+
+	_, err := store.GetUtxo(
+		t.Context(), db.GetUtxoQuery{
+			WalletID: 0,
+			OutPoint: outPoint,
+		},
+	)
+	require.ErrorIs(t, err, db.ErrUtxoNotFound)
+}
+
+// TestCalcConfsGenesisHeight verifies the shared kvdb confirmation helper
+// treats height zero as unconfirmed.
+func TestCalcConfsGenesisHeight(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, int32(0), calcConfs(0, 100))
+}
+
+// insertKnownCredit inserts one test credit and returns its outpoint.
+func insertKnownCredit(t *testing.T, dbConn walletdb.DB, txStore *wtxmgr.Store,
+	pkScript []byte, value int64, height int32) wire.OutPoint {
+
+	t.Helper()
+
+	txMsg := &wire.MsgTx{Version: 1}
+	txMsg.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{Hash: [32]byte{1}},
+	})
+	txMsg.AddTxOut(&wire.TxOut{Value: value, PkScript: pkScript})
+
+	received := time.Now().UTC()
+	rec, err := wtxmgr.NewTxRecordFromMsgTx(txMsg, received)
+	require.NoError(t, err)
+
+	var block *wtxmgr.BlockMeta
+	if height >= 0 {
+		block = &wtxmgr.BlockMeta{
+			Block: wtxmgr.Block{Height: height},
+			Time:  received,
+		}
+	}
+
+	err = walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+		if ns == nil {
+			return walletdb.ErrBucketNotFound
+		}
+
+		err := txStore.InsertTx(ns, rec, block)
+		if err != nil {
+			return fmt.Errorf("insert tx: %w", err)
+		}
+
+		err = txStore.AddCredit(ns, rec, block, 0, false)
+		if err != nil {
+			return fmt.Errorf("add credit: %w", err)
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	return wire.OutPoint{Hash: rec.Hash, Index: 0}
+}
+
+// insertUnminedSpend records an unmined wallet transaction that spends the
+// given outpoint.
+func insertUnminedSpend(t *testing.T, dbConn walletdb.DB,
+	txStore *wtxmgr.Store, outPoint wire.OutPoint) {
+
+	t.Helper()
+
+	spendTx := &wire.MsgTx{Version: 1}
+	spendTx.AddTxIn(&wire.TxIn{PreviousOutPoint: outPoint})
+	spendTx.AddTxOut(&wire.TxOut{Value: 1, PkScript: []byte{0x51}})
+	spendRec, err := wtxmgr.NewTxRecordFromMsgTx(spendTx, time.Now())
+	require.NoError(t, err)
+
+	err = walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+		if ns == nil {
+			return walletdb.ErrBucketNotFound
+		}
+
+		return txStore.InsertTx(ns, spendRec, nil)
+	})
+	require.NoError(t, err)
 }
 
 // TestBalanceRejectsAccountWithoutScope verifies that Balance enforces

--- a/wallet/internal/db/kvdb/utxostore_test.go
+++ b/wallet/internal/db/kvdb/utxostore_test.go
@@ -199,6 +199,61 @@ func TestCalcConfsGenesisHeight(t *testing.T) {
 	require.Equal(t, int32(0), calcConfs(0, 100))
 }
 
+// TestLeaseOutputSuccess verifies that kvdb.Store adapts one legacy lease write
+// into the db-native leased-output view.
+func TestLeaseOutputSuccess(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore, nil)
+
+	outPoint := insertKnownCredit(
+		t, dbConn, txStore, []byte{0x51}, 2500, 2,
+	)
+
+	lease, err := store.LeaseOutput(
+		t.Context(), db.LeaseOutputParams{
+			WalletID: 0,
+			ID:       db.LockID{1},
+			OutPoint: outPoint,
+			Duration: time.Hour,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, outPoint, lease.OutPoint)
+	require.Equal(t, db.LockID{1}, lease.LockID)
+	require.True(t, lease.Expiration.After(time.Now().UTC()))
+}
+
+// TestLeaseOutputRejectsSpentByUnminedTx verifies leases cannot be acquired for
+// outputs already spent by an unmined wallet transaction.
+func TestLeaseOutputRejectsSpentByUnminedTx(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore, nil)
+	outPoint := insertKnownCredit(
+		t, dbConn, txStore, []byte{0x51}, 2500, 2,
+	)
+	insertUnminedSpend(t, dbConn, txStore, outPoint)
+
+	_, err := store.LeaseOutput(
+		t.Context(), db.LeaseOutputParams{
+			WalletID: 0,
+			ID:       db.LockID{1},
+			OutPoint: outPoint,
+			Duration: time.Hour,
+		},
+	)
+	require.ErrorIs(t, err, db.ErrUtxoNotFound)
+}
+
 // insertKnownCredit inserts one test credit and returns its outpoint.
 func insertKnownCredit(t *testing.T, dbConn walletdb.DB, txStore *wtxmgr.Store,
 	pkScript []byte, value int64, height int32) wire.OutPoint {

--- a/wallet/utxo_manager.go
+++ b/wallet/utxo_manager.go
@@ -6,22 +6,30 @@
 // around the concept of a UtxoManager, which is responsible for managing the
 // wallet's UTXO set.
 //
-// TODO(yy): bring wrapcheck back when implementing the `Store` interface.
-//
 //nolint:wrapcheck
 package wallet
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sort"
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/addresstype"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
+)
+
+var (
+	errUtxoHeightOverflow  = errors.New("utxo height overflows int32")
+	errUtxoScriptNoAddress = errors.New(
+		"utxo pkScript has no extractable address",
+	)
 )
 
 // Utxo provides a detailed overview of an unspent transaction output.
@@ -278,50 +286,87 @@ func (w *Wallet) processUnspentOutput(addrmgrNs walletdb.ReadBucket,
 	}
 }
 
-// GetUtxo returns the output information for a given outpoint.
+// buildWalletUtxoFromStore converts one store-level UTXO row into the
+// wallet's public Utxo view. The enrichment fields populated by the
+// store (AccountName, Origin, AddrType, HasScript, IsLocked) supersede
+// the prior per-UTXO follow-up calls to GetAddress / ListLeasedOutputs.
 //
-// This method provides a detailed view of a single UTXO, identified by its
-// outpoint. The result is enriched with detailed information about the UTXO,
-// such as its address, account, and spendability.
+// This is a pure mapper: the store only returns wallet-owned, enrichable
+// rows, so a row whose script cannot be converted to an address is an
+// unexpected store/wallet disagreement and surfaces as an error rather
+// than a silent skip. Account filtering is the caller's responsibility
+// and is applied before this conversion.
 //
-// How it works:
-// The method performs a direct lookup of the UTXO in the wallet's transaction
-// store (`wtxmgr`). If the UTXO is found, it then performs an additional
-// lookup in the address manager (`waddrmgr`) to enrich the UTXO data with
-// details like the owning account name, address type, and spendability.
-//
-// Logical Steps:
-//  1. Initiate a single, read-only database transaction to ensure a
-//     consistent view of the data.
-//  2. Fetch the unspent transaction output from the `wtxmgr` namespace using
-//     the provided outpoint.
-//  3. If the UTXO is not found, return a `wtxmgr.ErrUtxoNotFound` error.
-//  4. Calculate its current confirmation status based on the wallet's
-//     synced block height.
-//  5. Extract the address from the UTXO's public key script. For
-//     multi-address scripts, the first address is used.
-//  6. Call `waddrmgr.AddressDetails` to get the spendability status,
-//     account name, and address type in a single, efficient lookup.
-//  7. Construct the final `Utxo` struct with all the combined data.
-//  8. Return the final `Utxo` struct.
-//
-// Database Actions:
-//   - This method performs a single read-only database transaction
-//     (`walletdb.View`).
-//   - It reads from both the `wtxmgr` (for the UTXO) and `waddrmgr` (for
-//     address details) namespaces.
-//
-// Time Complexity:
-//   - The complexity is O(A_l), where A_l is the average cost of the
-//     address and account lookups (`AddressDetails`).
-//
-// TODO(yy): The current implementation of GetUtxo performs separate database
-// lookups for the UTXO and its details. The upcoming SQL schema redesign should
-// address this issue by denormalizing the data, which would turn the multiple
-// lookups into a single, efficient query.
+// Spendability follows ADR 0012 (wallet-level watch-only invariant):
+// a UTXO is spendable when the wallet is not watch-only AND the owning
+// account is not imported. Imported-account outputs are unspendable
+// even when the wallet holds private-key material for them — matching
+// the legacy waddrmgr.AddressDetails policy that this routing path
+// replaces.
+func (w *Wallet) buildWalletUtxoFromStore(info *db.UtxoInfo,
+	currentHeight int32) (*Utxo, error) {
+
+	addr := extractAddrFromPKScript(info.PkScript, w.cfg.ChainParams)
+	if addr == nil {
+		return nil, fmt.Errorf("%w: outpoint %v", errUtxoScriptNoAddress,
+			info.OutPoint)
+	}
+
+	walletAddrType, err := addresstype.ToWallet(
+		info.AddrType, info.HasScript,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	confirmations, err := utxoConfirmations(info.Height, currentHeight)
+	if err != nil {
+		return nil, err
+	}
+
+	spendable := !w.IsWatchOnly() &&
+		info.Origin != db.ImportedAccount
+
+	if info.FromCoinBase {
+		maturity := w.cfg.ChainParams.CoinbaseMaturity
+		if confirmations < int32(maturity) {
+			spendable = false
+		}
+	}
+
+	return &Utxo{
+		OutPoint:      info.OutPoint,
+		Amount:        info.Amount,
+		PkScript:      info.PkScript,
+		Confirmations: confirmations,
+		Spendable:     spendable,
+		Address:       addr,
+		Account:       info.AccountName,
+		AddressType:   walletAddrType,
+		Locked:        info.IsLocked,
+	}, nil
+}
+
+// utxoConfirmations converts one db-native UTXO height into wallet confirmation
+// semantics.
+func utxoConfirmations(height uint32, currentHeight int32) (int32, error) {
+	if height == db.UnminedHeight {
+		return 0, nil
+	}
+
+	txHeight, ok := safeUint32ToInt32(height)
+	if !ok {
+		return 0, fmt.Errorf("%w: %d", errUtxoHeightOverflow, height)
+	}
+
+	return calcConf(txHeight, currentHeight), nil
+}
+
+// GetUtxo returns one wallet-owned UTXO together with its wallet-facing
+// metadata.
 //
 // NOTE: This is part of the UtxoManager interface implementation.
-func (w *Wallet) GetUtxo(_ context.Context,
+func (w *Wallet) GetUtxo(ctx context.Context,
 	prevOut wire.OutPoint) (*Utxo, error) {
 
 	err := w.state.validateStarted()
@@ -329,65 +374,22 @@ func (w *Wallet) GetUtxo(_ context.Context,
 		return nil, err
 	}
 
-	// Calculate the current confirmation status based on the wallet's
-	// synced block height.
-	syncBlock := w.addrStore.SyncedTo()
-	currentHeight := syncBlock.Height
+	currentHeight := w.addrStore.SyncedTo().Height
 
-	var utxo *Utxo
-
-	err = walletdb.View(w.cfg.DB, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
-
-		// First, fetch the unspent transaction output from the UTXO
-		// set.
-		output, err := w.txStore.GetUtxo(txmgrNs, prevOut)
-		if err != nil {
-			return err
-		}
-
-		// If the output is not found, return an error.
-		if output == nil {
-			return wtxmgr.ErrUtxoNotFound
-		}
-
-		confs := calcConf(output.Height, currentHeight)
-
-		// Extract the address from the UTXO's public key script.
-		// For multi-address scripts, the first address is used.
-		addr := extractAddrFromPKScript(
-			output.PkScript, w.cfg.ChainParams,
-		)
-		if addr == nil {
-			return wtxmgr.ErrUtxoNotFound
-		}
-
-		// In a single lookup, get all the required
-		// address-related details: spendability, account name,
-		// and address type. This avoids the N+1 query problem.
-		spendable, account, addrType := w.addrStore.AddressDetails(
-			addrmgrNs, addr,
-		)
-
-		// If all filters pass, construct the final Utxo struct
-		// with all the combined data.
-		utxo = &Utxo{
-			OutPoint:      output.OutPoint,
-			Amount:        output.Amount,
-			PkScript:      output.PkScript,
-			Confirmations: confs,
-			Spendable:     spendable,
-			Address:       addr,
-			Account:       account,
-			AddressType:   addrType,
-			Locked:        output.Locked,
-		}
-
-		return nil
+	info, err := w.store.GetUtxo(ctx, db.GetUtxoQuery{
+		WalletID: w.id,
+		OutPoint: prevOut,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("get utxo: %w", err)
+	}
 
-	return utxo, err
+	utxo, err := w.buildWalletUtxoFromStore(info, currentHeight)
+	if err != nil {
+		return nil, err
+	}
+
+	return utxo, nil
 }
 
 // LeaseOutput locks an output for a given duration, preventing it from being

--- a/wallet/utxo_manager.go
+++ b/wallet/utxo_manager.go
@@ -21,7 +21,6 @@ import (
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/addresstype"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
-	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 )
 
@@ -62,6 +61,18 @@ type Utxo struct {
 	Locked bool
 }
 
+// LeasedOutput describes one currently leased wallet output.
+type LeasedOutput struct {
+	// OutPoint is the leased transaction output identifier.
+	OutPoint wire.OutPoint
+
+	// LockID is the lease owner identifier.
+	LockID wtxmgr.LockID
+
+	// Expiration is when the current lease expires.
+	Expiration time.Time
+}
+
 // UtxoQuery holds the set of options for a ListUnspent query.
 type UtxoQuery struct {
 	// Account specifies the account to query UTXOs for. If empty,
@@ -97,7 +108,7 @@ type UtxoManager interface {
 		op wire.OutPoint) error
 
 	// ListLeasedOutputs returns a list of all currently leased outputs.
-	ListLeasedOutputs(ctx context.Context) ([]*wtxmgr.LockedOutput, error)
+	ListLeasedOutputs(ctx context.Context) ([]*LeasedOutput, error)
 }
 
 // ListUnspent returns the wallet-owned UTXOs that match the provided query.
@@ -320,54 +331,31 @@ func (w *Wallet) ReleaseOutput(ctx context.Context, id wtxmgr.LockID,
 	return w.store.ReleaseOutput(ctx, params)
 }
 
-// ListLeasedOutputs returns a list of all currently leased outputs.
-//
-// This method provides a way to inspect which UTXOs are currently locked and
-// when their leases expire. This can be useful for debugging and for managing
-// long-lived locks.
-//
-// How it works:
-// The method delegates the listing operation to the underlying transaction
-// store (`wtxmgr`), which scans its record of all leased outputs.
-//
-// Logical Steps:
-//  1. Initiate a read-only database transaction.
-//  2. Call the `wtxmgr.ListLeasedOutputs` method.
-//  3. The `wtxmgr` iterates through all the recorded locks and returns them
-//     as a slice.
-//
-// Database Actions:
-//   - This method performs a single read-only database transaction
-//     (`walletdb.View`).
-//   - It reads from the `wtxmgr` namespace to get the list of leased
-//     outputs.
-//
-// Time Complexity:
-//   - The complexity is O(L), where L is the number of leased outputs, as it
-//     involves a full scan of the leased outputs bucket.
-//
-// TODO(yy): The current `wtxmgr.ListLeasedOutputs` implementation returns a
-// struct from the `wtxmgr` package. This is a leaky abstraction. The method
-// should return a struct defined in the `wallet` package to maintain a clean
-// separation of concerns.
+// ListLeasedOutputs returns the wallet-owned outputs that currently have active
+// leases.
 //
 // NOTE: This is part of the UtxoManager interface implementation.
 func (w *Wallet) ListLeasedOutputs(
-	_ context.Context) ([]*wtxmgr.LockedOutput, error) {
+	ctx context.Context) ([]*LeasedOutput, error) {
 
 	err := w.state.validateStarted()
 	if err != nil {
 		return nil, err
 	}
 
-	var leasedOutputs []*wtxmgr.LockedOutput
+	leases, err := w.store.ListLeasedOutputs(ctx, w.id)
+	if err != nil {
+		return nil, fmt.Errorf("list leased outputs: %w", err)
+	}
 
-	err = walletdb.View(w.cfg.DB, func(tx walletdb.ReadTx) error {
-		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
-		leasedOutputs, err = w.txStore.ListLockedOutputs(txmgrNs)
+	outputs := make([]*LeasedOutput, len(leases))
+	for i := range leases {
+		outputs[i] = &LeasedOutput{
+			OutPoint:   leases[i].OutPoint,
+			LockID:     wtxmgr.LockID(leases[i].LockID),
+			Expiration: leases[i].Expiration,
+		}
+	}
 
-		return err
-	})
-
-	return leasedOutputs, err
+	return outputs, nil
 }

--- a/wallet/utxo_manager.go
+++ b/wallet/utxo_manager.go
@@ -100,73 +100,10 @@ type UtxoManager interface {
 	ListLeasedOutputs(ctx context.Context) ([]*wtxmgr.LockedOutput, error)
 }
 
-// ListUnspent returns a slice of unspent transaction outputs that match the
-// query.
-//
-// This method provides a comprehensive view of the wallet's UTXO set, allowing
-// for filtering by account and confirmation status. The results are enriched
-// with detailed information about each UTXO, such as its address, account,
-// and spendability.
-//
-// How it works:
-// The method performs a full scan of all UTXOs in the wallet's transaction
-// store (`wtxmgr`). For each UTXO, it applies the specified filters (account,
-// confirmations). If a UTXO matches, the method then performs an additional
-// lookup in the address manager (`waddrmgr`) to enrich the UTXO data with
-// details like the owning account name, address type, and spendability. This
-// process of fetching a list and then performing a lookup for each item is
-// known as the "N+1 query problem" and is a known inefficiency (see TODO).
-//
-// Logical Steps:
-//  1. Initiate a single, read-only database transaction to ensure a
-//     consistent view of the data.
-//  2. Fetch all unspent transaction outputs from the `wtxmgr` namespace.
-//  3. Sort the outputs in ascending order of value. This is a convention to
-//     make the list more predictable and potentially useful for coin
-//     selection algorithms that prefer larger UTXOs.
-//  4. Iterate through each UTXO:
-//     a. Calculate its current confirmation status based on the wallet's
-//     synced block height.
-//     b. Apply the `MinConfs` and `MaxConfs` filters from the query.
-//     c. Extract the address from the UTXO's public key script. For
-//     multi-address scripts, the first address is used.
-//     d. Call `waddrmgr.AddressDetails` to get the spendability status,
-//     account name, and address type in a single, efficient lookup.
-//     e. Apply the `Account` filter from the query.
-//     f. If all filters pass, construct the final `Utxo` struct with all
-//     the combined data.
-//  5. Append the `Utxo` to the result slice.
-//  6. After iterating through all UTXOs, return the final slice.
-//
-// Database Actions:
-//   - This method performs a single read-only database transaction
-//     (`walletdb.View`).
-//   - It reads from both the `wtxmgr` (for UTXOs) and `waddrmgr` (for
-//     address details) namespaces.
-//
-// Time Complexity:
-//   - The complexity is O(U * A_l), where U is the total number of unspent
-//     transaction outputs in the wallet and A_l is the average cost of the
-//     address and account lookups (`AddressDetails`). This is due to the N+1
-//     query problem where each UTXO requires additional lookups.
-//
-// TODO(yy): The current implementation of ListUnspent fetches all UTXOs
-// from the database and then filters them in memory. This is inefficient for
-// wallets with a large number of UTXOs. The upcoming SQL schema redesign should
-// address the following issues:
-//
-//  1. **N+1 Query Problem:** The function iterates through all unspent outputs
-//     and performs separate database lookups for each one to retrieve its full
-//     details. The database schema should be denormalized to include this data
-//     directly in the `unspent` value, which would turn the N+1 query into a
-//     single, efficient bucket scan.
-//
-//  2. **Lack of Pagination:** The function loads all results into a single
-//     in-memory slice, which can be memory-intensive for wallets with a large
-//     UTXO set. A more scalable approach would use an iterator pattern.
+// ListUnspent returns the wallet-owned UTXOs that match the provided query.
 //
 // NOTE: This is part of the UtxoManager interface implementation.
-func (w *Wallet) ListUnspent(_ context.Context,
+func (w *Wallet) ListUnspent(ctx context.Context,
 	query UtxoQuery) ([]*Utxo, error) {
 
 	err := w.state.validateStarted()
@@ -176,35 +113,41 @@ func (w *Wallet) ListUnspent(_ context.Context,
 
 	log.Debugf("ListUnspent using query: %v", query)
 
-	syncBlock := w.addrStore.SyncedTo()
-	currentHeight := syncBlock.Height
+	currentHeight := w.addrStore.SyncedTo().Height
+	minConfs := query.MinConfs
+	maxConfs := query.MaxConfs
 
-	var utxos []*Utxo
+	infos, err := w.store.ListUTXOs(
+		ctx, db.ListUtxosQuery{
+			WalletID: w.id,
+			MinConfs: &minConfs,
+			MaxConfs: &maxConfs,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list utxos: %w", err)
+	}
 
-	err = walletdb.View(w.cfg.DB, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
+	utxos := make([]*Utxo, 0, len(infos))
+	for i := range infos {
+		// The store has no scope to disambiguate a bare account name,
+		// so the wallet applies the account-name filter here rather
+		// than in the ListUTXOs query.
+		if query.Account != "" &&
+			infos[i].AccountName != query.Account {
 
-		// First, fetch all unspent transaction outputs from the UTXO
-		// set.
-		unspent, err := w.txStore.UnspentOutputs(txmgrNs)
+			continue
+		}
+
+		utxo, err := w.buildWalletUtxoFromStore(
+			&infos[i], currentHeight,
+		)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
-		// Iterate through each UTXO to apply filters and enrich it with
-		// address-specific details.
-		for _, output := range unspent {
-			utxo := w.processUnspentOutput(
-				addrmgrNs, output, currentHeight, query,
-			)
-			if utxo != nil {
-				utxos = append(utxos, utxo)
-			}
-		}
-
-		return nil
-	})
+		utxos = append(utxos, utxo)
+	}
 
 	// Sort the outputs in ascending order of value. This is a convention
 	// to make the list more predictable and potentially useful for coin
@@ -213,77 +156,7 @@ func (w *Wallet) ListUnspent(_ context.Context,
 		return utxos[i].Amount < utxos[j].Amount
 	})
 
-	return utxos, err
-}
-
-// processUnspentOutput processes a single unspent output, applying filters and
-// enriching it with address details. Returns nil if the output should be
-// skipped.
-func (w *Wallet) processUnspentOutput(addrmgrNs walletdb.ReadBucket,
-	output wtxmgr.Credit, currentHeight int32, query UtxoQuery) *Utxo {
-
-	confs := calcConf(output.Height, currentHeight)
-
-	log.Tracef("Checking utxo[%v]: current height=%v, "+
-		"confirm height=%v, conf=%v", output.OutPoint,
-		currentHeight, output.Height, confs)
-
-	// Apply the MinConfs and MaxConfs filters from the query.
-	if confs < query.MinConfs || confs > query.MaxConfs {
-		return nil
-	}
-
-	// Extract the address from the UTXO's public key script.
-	// For multi-address scripts, the first address is used.
-	addr := extractAddrFromPKScript(
-		output.PkScript, w.cfg.ChainParams,
-	)
-	if addr == nil {
-		return nil
-	}
-
-	// Get all the required address-related details.
-	//
-	// NOTE: This lookup is the source of the N+1 query problem.
-	spendable, account, addrType := w.addrStore.AddressDetails(
-		addrmgrNs, addr,
-	)
-
-	log.Debugf("Found address: %s from account: %s",
-		addr.String(), account)
-
-	// Apply the Account filter from the query.
-	if query.Account != "" && account != query.Account {
-		return nil
-	}
-
-	// A UTXO is also unspendable if it is an immature coinbase output.
-	if output.FromCoinBase {
-		maturity := w.cfg.ChainParams.CoinbaseMaturity
-		if confs < int32(maturity) {
-			spendable = false
-		}
-	}
-
-	// TODO(yy): This should be a column in the new utxo SQL table. Note
-	// that currently UnspentOutputs only returns unlocked outputs, so this
-	// field will always be false. This will be fixed in the upcoming
-	// sqlization PRs.
-	locked := output.Locked
-
-	// If all filters pass, construct the final Utxo struct with all the
-	// combined data.
-	return &Utxo{
-		OutPoint:      output.OutPoint,
-		Amount:        output.Amount,
-		PkScript:      output.PkScript,
-		Confirmations: confs,
-		Spendable:     spendable,
-		Address:       addr,
-		Account:       account,
-		AddressType:   addrType,
-		Locked:        locked,
-	}
+	return utxos, nil
 }
 
 // buildWalletUtxoFromStore converts one store-level UTXO row into the

--- a/wallet/utxo_manager.go
+++ b/wallet/utxo_manager.go
@@ -24,6 +24,29 @@ import (
 	"github.com/btcsuite/btcwallet/wtxmgr"
 )
 
+// The following are the public, wallet-owned sentinel errors returned by the
+// UTXO and lease methods (GetUtxo, LeaseOutput, ReleaseOutput). They are
+// intentionally decoupled from the wallet's internal storage layers: callers
+// match on these values with errors.Is and must not reach for the internal
+// db.Err* sentinels (which live in an internal package) or the legacy
+// wtxmgr.Err* sentinels (whose package is slated to become internal). The
+// names mirror the historical wtxmgr sentinels so that downstream callers can
+// migrate mechanically.
+var (
+	// ErrUnknownOutput is returned when the requested output is not known
+	// to the wallet's UTXO set.
+	ErrUnknownOutput = errors.New("unknown output")
+
+	// ErrOutputAlreadyLocked is returned when an output is already leased
+	// under a different lock ID and therefore cannot be leased again.
+	ErrOutputAlreadyLocked = errors.New("output already locked")
+
+	// ErrOutputUnlockNotAllowed is returned when an output cannot be
+	// unlocked, for example because it is held under a different lock ID
+	// than the one supplied.
+	ErrOutputUnlockNotAllowed = errors.New("output unlock not allowed")
+)
+
 var (
 	errUtxoHeightOverflow  = errors.New("utxo height overflows int32")
 	errUtxoScriptNoAddress = errors.New(
@@ -265,6 +288,13 @@ func (w *Wallet) GetUtxo(ctx context.Context,
 		OutPoint: prevOut,
 	})
 	if err != nil {
+		// Translate the internal store sentinel into the public,
+		// wallet-owned error so callers do not couple to the internal
+		// db package.
+		if errors.Is(err, db.ErrUtxoNotFound) {
+			return nil, ErrUnknownOutput
+		}
+
 		return nil, fmt.Errorf("get utxo: %w", err)
 	}
 
@@ -281,10 +311,10 @@ func (w *Wallet) GetUtxo(ctx context.Context,
 //
 // The lock is acquired by delegating to the wallet's db.Store implementation,
 // which records the lease under the supplied LockID and returns its expiration
-// time. The store gates the outpoint against the current UTXO set first, so an
-// unknown or already-spent output yields db.ErrUtxoNotFound and an output held
-// under a different lock ID yields db.ErrOutputAlreadyLeased; any other store
-// error is wrapped for context.
+// time. The store's internal sentinels are translated into the public,
+// wallet-owned errors: an unknown or already-spent output becomes
+// ErrUnknownOutput and an output held under a different lock ID becomes
+// ErrOutputAlreadyLocked; any other store error is wrapped for context.
 //
 // NOTE: This is part of the UtxoManager interface implementation.
 func (w *Wallet) LeaseOutput(ctx context.Context, id wtxmgr.LockID,
@@ -304,6 +334,17 @@ func (w *Wallet) LeaseOutput(ctx context.Context, id wtxmgr.LockID,
 		},
 	)
 	if err != nil {
+		// Translate the internal store sentinels into the public,
+		// wallet-owned errors so callers do not couple to the internal
+		// db package.
+		switch {
+		case errors.Is(err, db.ErrUtxoNotFound):
+			return time.Time{}, ErrUnknownOutput
+
+		case errors.Is(err, db.ErrOutputAlreadyLeased):
+			return time.Time{}, ErrOutputAlreadyLocked
+		}
+
 		return time.Time{}, fmt.Errorf("lease output: %w", err)
 	}
 
@@ -313,7 +354,9 @@ func (w *Wallet) LeaseOutput(ctx context.Context, id wtxmgr.LockID,
 // ReleaseOutput unlocks a previously leased output, making it available for
 // coin selection again.
 //
-// The lock is released by delegating to the wallet's db.Store implementation.
+// The lock is released by delegating to the wallet's db.Store implementation;
+// the store's internal sentinels are translated into the public, wallet-owned
+// ErrUnknownOutput / ErrOutputUnlockNotAllowed errors.
 func (w *Wallet) ReleaseOutput(ctx context.Context, id wtxmgr.LockID,
 	op wire.OutPoint) error {
 
@@ -328,7 +371,23 @@ func (w *Wallet) ReleaseOutput(ctx context.Context, id wtxmgr.LockID,
 		OutPoint: op,
 	}
 
-	return w.store.ReleaseOutput(ctx, params)
+	err = w.store.ReleaseOutput(ctx, params)
+	if err != nil {
+		// Translate the internal store sentinels into the public,
+		// wallet-owned errors so callers do not couple to the internal
+		// db package.
+		switch {
+		case errors.Is(err, db.ErrUtxoNotFound):
+			return ErrUnknownOutput
+
+		case errors.Is(err, db.ErrOutputUnlockNotAllowed):
+			return ErrOutputUnlockNotAllowed
+		}
+
+		return fmt.Errorf("release output: %w", err)
+	}
+
+	return nil
 }
 
 // ListLeasedOutputs returns the wallet-owned outputs that currently have active

--- a/wallet/utxo_manager.go
+++ b/wallet/utxo_manager.go
@@ -265,44 +265,18 @@ func (w *Wallet) GetUtxo(ctx context.Context,
 	return utxo, nil
 }
 
-// LeaseOutput locks an output for a given duration, preventing it from being
-// used in transactions.
+// LeaseOutput locks an output for a given duration, reserving it so that it is
+// not selected for other transactions until the lease expires.
 //
-// This method allows a caller to reserve a specific UTXO for a certain period,
-// making it unavailable for other operations like coin selection. This is
-// useful in scenarios where a transaction is being built and its inputs need to
-// be protected from being used by other concurrent operations.
-//
-// How it works:
-// The method delegates the locking operation to the underlying transaction
-// store (`wtxmgr`), which maintains a record of all leased outputs. The lease
-// is identified by a unique `LockID` and has a specific `duration`.
-//
-// Logical Steps:
-//  1. Initiate a read-write database transaction.
-//  2. Call the `wtxmgr.LockOutput` method with the provided `LockID`,
-//     outpoint, and `duration`.
-//  3. The `wtxmgr` checks if the output is known and not already locked by a
-//     different ID.
-//  4. If the checks pass, it records the lock with an expiration time.
-//  5. The expiration time is returned to the caller.
-//
-// Database Actions:
-//   - This method performs a single read-write database transaction
-//     (`walletdb.Update`).
-//   - It writes to the `wtxmgr` namespace to record the output lock.
-//
-// Time Complexity:
-//   - The complexity is O(1) as it involves a direct lookup and write in the
-//     database.
-//
-// TODO(yy): The current `wtxmgr.LockOutput` implementation does not check if
-// the output is already spent by an unmined transaction. This could lead to a
-// scenario where a spent output is leased. The implementation should be
-// improved to perform this check.
+// The lock is acquired by delegating to the wallet's db.Store implementation,
+// which records the lease under the supplied LockID and returns its expiration
+// time. The store gates the outpoint against the current UTXO set first, so an
+// unknown or already-spent output yields db.ErrUtxoNotFound and an output held
+// under a different lock ID yields db.ErrOutputAlreadyLeased; any other store
+// error is wrapped for context.
 //
 // NOTE: This is part of the UtxoManager interface implementation.
-func (w *Wallet) LeaseOutput(_ context.Context, id wtxmgr.LockID,
+func (w *Wallet) LeaseOutput(ctx context.Context, id wtxmgr.LockID,
 	op wire.OutPoint, duration time.Duration) (time.Time, error) {
 
 	err := w.state.validateStarted()
@@ -310,19 +284,19 @@ func (w *Wallet) LeaseOutput(_ context.Context, id wtxmgr.LockID,
 		return time.Time{}, err
 	}
 
-	var expiration time.Time
+	lease, err := w.store.LeaseOutput(
+		ctx, db.LeaseOutputParams{
+			WalletID: w.id,
+			ID:       db.LockID(id),
+			OutPoint: op,
+			Duration: duration,
+		},
+	)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("lease output: %w", err)
+	}
 
-	err = walletdb.Update(w.cfg.DB, func(tx walletdb.ReadWriteTx) error {
-		txmgrNs := tx.ReadWriteBucket(wtxmgrNamespaceKey)
-
-		expiration, err = w.txStore.LockOutput(
-			txmgrNs, id, op, duration,
-		)
-
-		return err
-	})
-
-	return expiration, err
+	return lease.Expiration, nil
 }
 
 // ReleaseOutput unlocks a previously leased output, making it available for

--- a/wallet/utxo_manager_test.go
+++ b/wallet/utxo_manager_test.go
@@ -220,25 +220,24 @@ func TestGetUtxoErr(t *testing.T) {
 func TestLeaseOutput(t *testing.T) {
 	t.Parallel()
 
-	// Create a new test wallet with mocks.
 	w, mocks := createStartedWalletWithMocks(t)
 
-	// Create a UTXO.
-	utxo := wire.OutPoint{
-		Hash:  [32]byte{1},
-		Index: 0,
-	}
+	outPoint := wire.OutPoint{Hash: [32]byte{1}, Index: 0}
+	expiration := time.Now().Add(time.Hour).UTC()
 
-	// Mock the LockOutput method to return a fixed expiration time.
-	expiration := time.Now().Add(time.Hour)
-	mocks.txStore.On("LockOutput", mock.Anything, mock.Anything, utxo,
-		mock.Anything).Return(expiration, nil)
+	mocks.store.On("LeaseOutput", mock.Anything, db.LeaseOutputParams{
+		WalletID: w.id,
+		ID:       db.LockID{1},
+		OutPoint: outPoint,
+		Duration: time.Hour,
+	}).Return(&db.LeasedOutput{
+		OutPoint:   outPoint,
+		LockID:     db.LockID{1},
+		Expiration: expiration,
+	}, nil).Once()
 
-	// Now, try to lease the output.
-	leaseID := wtxmgr.LockID{1}
-	leaseDuration := time.Hour
 	actualExpiration, err := w.LeaseOutput(
-		t.Context(), leaseID, utxo, leaseDuration,
+		t.Context(), wtxmgr.LockID{1}, outPoint, time.Hour,
 	)
 	require.NoError(t, err)
 	require.Equal(t, expiration, actualExpiration)

--- a/wallet/utxo_manager_test.go
+++ b/wallet/utxo_manager_test.go
@@ -19,18 +19,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestListUnspent tests the ListUnspent method with various filters.
+// TestListUnspent tests that ListUnspent composes store UTXO, lease, and
+// address reads into sorted wallet-facing results.
 func TestListUnspent(t *testing.T) {
 	t.Parallel()
 
-	// Create a new test wallet with mocks.
 	w, mocks := createStartedWalletWithMocks(t)
 
-	// Define account names.
-	account1 := defaultAccountName
-	account2 := "test"
-
-	// Create the addresses that our mocks will return.
 	privKeyDefault, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 	addrDefault, err := btcutil.NewAddressPubKey(
@@ -45,151 +40,115 @@ func TestListUnspent(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// Set the current block height to match the default mock (1).
-	currentHeight := int32(1)
-
-	mocks.addrStore.On("AddressDetails", mock.Anything, addrDefault).Return(
-		false, account1, waddrmgr.WitnessPubKey,
-	)
-	mocks.addrStore.On("AddressDetails", mock.Anything, addrTest).Return(
-		false, account2, waddrmgr.NestedWitnessPubKey,
-	)
-
-	// Now that the mocks are set up, we can create the pkScripts.
 	pkScriptDefault, err := txscript.PayToAddrScript(addrDefault)
 	require.NoError(t, err)
 	pkScriptTest, err := txscript.PayToAddrScript(addrTest)
 	require.NoError(t, err)
 
-	const (
-		minConf = 2
-		maxConf = 6
+	utxoDefault := db.UtxoInfo{
+		OutPoint:    wire.OutPoint{Hash: [32]byte{1}, Index: 0},
+		Amount:      200000,
+		PkScript:    pkScriptDefault,
+		Height:      1,
+		AccountName: defaultAccountName,
+		Origin:      db.DerivedAccount,
+		AddrType:    db.WitnessPubKey,
+	}
+	utxoTest := db.UtxoInfo{
+		OutPoint:    wire.OutPoint{Hash: [32]byte{2}, Index: 0},
+		Amount:      100000,
+		PkScript:    pkScriptTest,
+		Height:      1,
+		AccountName: "test",
+		Origin:      db.DerivedAccount,
+		AddrType:    db.NestedWitnessPubKey,
+		IsLocked:    true,
+	}
+
+	query := UtxoQuery{MinConfs: 0, MaxConfs: 999999}
+	minConfs := query.MinConfs
+	maxConfs := query.MaxConfs
+
+	mocks.store.On("ListUTXOs", mock.Anything, db.ListUtxosQuery{
+		WalletID: w.id,
+		MinConfs: &minConfs,
+		MaxConfs: &maxConfs,
+	}).Return([]db.UtxoInfo{utxoDefault, utxoTest}, nil).Once()
+
+	utxos, err := w.ListUnspent(t.Context(), query)
+	require.NoError(t, err)
+	require.Len(t, utxos, 2)
+	require.Equal(t, addrTest.String(), utxos[0].Address.String())
+	require.Equal(t, btcutil.Amount(100000), utxos[0].Amount)
+	require.True(t, utxos[0].Locked)
+	require.Equal(t, addrDefault.String(), utxos[1].Address.String())
+	require.False(t, utxos[1].Locked)
+}
+
+// TestListUnspentFiltersByAccount tests that ListUnspent applies the
+// wallet-facing account-name filter after reading store UTXO rows.
+func TestListUnspentFiltersByAccount(t *testing.T) {
+	t.Parallel()
+
+	w, mocks := createStartedWalletWithMocks(t)
+
+	privKeyDefault, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	addrDefault, err := btcutil.NewAddressPubKey(
+		privKeyDefault.PubKey().SerializeCompressed(), &chainParams,
 	)
+	require.NoError(t, err)
 
-	// Create two UTXOs, one for each address.
-	utxo1 := wtxmgr.Credit{
-		OutPoint: wire.OutPoint{
-			Hash:  [32]byte{1},
-			Index: 0,
-		},
-		Amount:   100000,
-		PkScript: pkScriptDefault,
-		BlockMeta: wtxmgr.BlockMeta{
-			Block: wtxmgr.Block{
-				Height: currentHeight - minConf + 1,
-			},
-		},
-	}
-	utxo2 := wtxmgr.Credit{
-		OutPoint: wire.OutPoint{
-			Hash:  [32]byte{2},
-			Index: 0,
-		},
-		Amount:   200000,
-		PkScript: pkScriptTest,
-		BlockMeta: wtxmgr.BlockMeta{
-			Block: wtxmgr.Block{
-				Height: currentHeight - maxConf + 1,
-			},
-		},
-	}
-
-	// Mock the UnspentOutputs method to return the two UTXOs.
-	mocks.txStore.On("UnspentOutputs", mock.Anything).Return(
-		[]wtxmgr.Credit{utxo1, utxo2}, nil,
+	privKeyTest, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	addrTest, err := btcutil.NewAddressPubKey(
+		privKeyTest.PubKey().SerializeCompressed(), &chainParams,
 	)
+	require.NoError(t, err)
 
-	testCases := []struct {
-		name          string
-		query         UtxoQuery
-		expectedCount int
-		expectedAddrs map[string]bool
-	}{
-		{
-			name:          "no filter",
-			query:         UtxoQuery{MinConfs: 0, MaxConfs: 999999},
-			expectedCount: 2,
-			expectedAddrs: map[string]bool{
-				addrDefault.String(): true,
-				addrTest.String():    true,
-			},
-		},
-		{
-			name: "filter by default account",
-			query: UtxoQuery{
-				Account:  account1,
-				MinConfs: 0,
-				MaxConfs: 999999,
-			},
-			expectedCount: 1,
-			expectedAddrs: map[string]bool{
-				addrDefault.String(): true,
-			},
-		},
-		{
-			name: "filter by test account",
-			query: UtxoQuery{
-				Account:  account2,
-				MinConfs: 0,
-				MaxConfs: 999999,
-			},
-			expectedCount: 1,
-			expectedAddrs: map[string]bool{
-				addrTest.String(): true,
-			},
-		},
-		{
-			name: "filter by min confs",
-			query: UtxoQuery{
-				MinConfs: minConf + 1,
-				MaxConfs: 999999,
-			},
-			expectedCount: 1,
-			expectedAddrs: map[string]bool{
-				addrTest.String(): true,
-			},
-		},
-		{
-			name: "filter by max confs",
-			query: UtxoQuery{
-				MinConfs: 0,
-				MaxConfs: maxConf - 1,
-			},
-			expectedCount: 1,
-			expectedAddrs: map[string]bool{
-				addrDefault.String(): true,
-			},
-		},
+	pkScriptDefault, err := txscript.PayToAddrScript(addrDefault)
+	require.NoError(t, err)
+	pkScriptTest, err := txscript.PayToAddrScript(addrTest)
+	require.NoError(t, err)
+
+	utxoDefault := db.UtxoInfo{
+		OutPoint:    wire.OutPoint{Hash: [32]byte{1}, Index: 0},
+		Amount:      100000,
+		PkScript:    pkScriptDefault,
+		Height:      1,
+		AccountName: defaultAccountName,
+		Origin:      db.DerivedAccount,
+		AddrType:    db.WitnessPubKey,
+	}
+	utxoTest := db.UtxoInfo{
+		OutPoint:    wire.OutPoint{Hash: [32]byte{2}, Index: 0},
+		Amount:      200000,
+		PkScript:    pkScriptTest,
+		Height:      1,
+		AccountName: "test",
+		Origin:      db.DerivedAccount,
+		AddrType:    db.NestedWitnessPubKey,
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			utxos, err := w.ListUnspent(t.Context(), tc.query)
-			require.NoError(t, err)
-			require.Len(t, utxos, tc.expectedCount)
-
-			// Check that the correct addresses are returned. We do
-			// this by creating a map of the returned addresses and
-			// comparing it to the expected map. This ensures that
-			// all expected addresses are present and there are no
-			// duplicates.
-			returnedAddrs := make(map[string]bool)
-			for _, utxo := range utxos {
-				returnedAddrs[utxo.Address.String()] = true
-			}
-
-			require.Equal(t, tc.expectedAddrs, returnedAddrs)
-
-			// Check that the UTXOs are sorted by amount in
-			// ascending order.
-			for i := range len(utxos) - 1 {
-				require.LessOrEqual(
-					t, utxos[i].Amount, utxos[i+1].Amount,
-				)
-			}
-		})
+	query := UtxoQuery{
+		Account:  "test",
+		MinConfs: 0,
+		MaxConfs: 999999,
 	}
+	minConfs := query.MinConfs
+	maxConfs := query.MaxConfs
+
+	mocks.store.On("ListUTXOs", mock.Anything, db.ListUtxosQuery{
+		WalletID: w.id,
+		MinConfs: &minConfs,
+		MaxConfs: &maxConfs,
+	}).Return([]db.UtxoInfo{utxoDefault, utxoTest}, nil).Once()
+
+	utxos, err := w.ListUnspent(t.Context(), query)
+	require.NoError(t, err)
+	require.Len(t, utxos, 1)
+	require.Equal(t, addrTest.String(), utxos[0].Address.String())
+	require.Equal(t, btcutil.Amount(200000), utxos[0].Amount)
 }
 
 // TestGetUtxo tests that the GetUtxo method can successfully retrieve a UTXO.

--- a/wallet/utxo_manager_test.go
+++ b/wallet/utxo_manager_test.go
@@ -196,13 +196,8 @@ func TestListUnspent(t *testing.T) {
 func TestGetUtxo(t *testing.T) {
 	t.Parallel()
 
-	// Create a new test wallet with mocks.
 	w, mocks := createStartedWalletWithMocks(t)
 
-	// Define account names.
-	account1 := "default"
-
-	// Create the addresses that our mocks will return.
 	privKeyDefault, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 	addrDefault, err := btcutil.NewAddressPubKey(
@@ -210,72 +205,55 @@ func TestGetUtxo(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// Set the current block height to match the default mock (1).
-	currentHeight := int32(1)
-
-	mocks.addrStore.On("AddressDetails", mock.Anything, addrDefault).Return(
-		false, account1, waddrmgr.WitnessPubKey,
-	)
-
-	// Now that the mocks are set up, we can create the pkScripts.
 	pkScriptDefault, err := txscript.PayToAddrScript(addrDefault)
 	require.NoError(t, err)
 
-	// Create a UTXO.
-	utxo1 := wtxmgr.Credit{
-		OutPoint: wire.OutPoint{
-			Hash:  [32]byte{1},
-			Index: 0,
-		},
-		Amount:   100000,
-		PkScript: pkScriptDefault,
-		BlockMeta: wtxmgr.BlockMeta{
-			Block: wtxmgr.Block{
-				Height: currentHeight,
-			},
-		},
+	utxoInfo := &db.UtxoInfo{
+		OutPoint:    wire.OutPoint{Hash: [32]byte{1}, Index: 0},
+		Amount:      100000,
+		PkScript:    pkScriptDefault,
+		Height:      1,
+		AccountName: defaultAccountName,
+		Origin:      db.DerivedAccount,
+		AddrType:    db.WitnessPubKey,
 	}
 
-	// Mock the GetUtxo method to return the UTXO.
-	mocks.txStore.On("GetUtxo", mock.Anything, utxo1.OutPoint).Return(
-		&utxo1, nil,
-	)
+	mocks.store.On("GetUtxo", mock.Anything, db.GetUtxoQuery{
+		WalletID: w.id,
+		OutPoint: utxoInfo.OutPoint,
+	}).Return(utxoInfo, nil).Once()
 
-	// Construct the expected Utxo.
 	expectedUtxo := &Utxo{
-		OutPoint:      utxo1.OutPoint,
-		Amount:        utxo1.Amount,
-		PkScript:      utxo1.PkScript,
+		OutPoint:      utxoInfo.OutPoint,
+		Amount:        utxoInfo.Amount,
+		PkScript:      utxoInfo.PkScript,
 		Confirmations: 1,
-		Spendable:     false,
+		Spendable:     true,
 		Address:       addrDefault,
-		Account:       account1,
+		Account:       defaultAccountName,
 		AddressType:   waddrmgr.WitnessPubKey,
+		Locked:        false,
 	}
 
-	// Now, try to get the UTXO and compare it to our expected result.
-	utxo, err := w.GetUtxo(t.Context(), utxo1.OutPoint)
+	utxo, err := w.GetUtxo(t.Context(), utxoInfo.OutPoint)
 	require.NoError(t, err)
 	require.Equal(t, expectedUtxo, utxo)
 }
 
-// TestGetUtxo_Err tests the error conditions of the GetUtxo method.
-func TestGetUtxo_Err(t *testing.T) {
+// TestGetUtxoErr tests the error conditions of the GetUtxo method.
+func TestGetUtxoErr(t *testing.T) {
 	t.Parallel()
 
-	// Create a new test wallet with mocks.
 	w, mocks := createStartedWalletWithMocks(t)
 
-	// Test the case where the UTXO is not found.
-	utxoNotFound := wire.OutPoint{
-		Hash:  [32]byte{2},
-		Index: 0,
-	}
-	mocks.txStore.On("GetUtxo", mock.Anything, utxoNotFound).Return(
-		nil, wtxmgr.ErrUtxoNotFound,
-	)
+	utxoNotFound := wire.OutPoint{Hash: [32]byte{2}, Index: 0}
+	mocks.store.On("GetUtxo", mock.Anything, db.GetUtxoQuery{
+		WalletID: w.id,
+		OutPoint: utxoNotFound,
+	}).Return((*db.UtxoInfo)(nil), db.ErrUtxoNotFound).Once()
+
 	utxo, err := w.GetUtxo(t.Context(), utxoNotFound)
-	require.ErrorIs(t, err, wtxmgr.ErrUtxoNotFound)
+	require.ErrorIs(t, err, db.ErrUtxoNotFound)
 	require.Nil(t, utxo)
 }
 

--- a/wallet/utxo_manager_test.go
+++ b/wallet/utxo_manager_test.go
@@ -212,7 +212,7 @@ func TestGetUtxoErr(t *testing.T) {
 	}).Return((*db.UtxoInfo)(nil), db.ErrUtxoNotFound).Once()
 
 	utxo, err := w.GetUtxo(t.Context(), utxoNotFound)
-	require.ErrorIs(t, err, db.ErrUtxoNotFound)
+	require.ErrorIs(t, err, ErrUnknownOutput)
 	require.Nil(t, utxo)
 }
 
@@ -243,6 +243,56 @@ func TestLeaseOutput(t *testing.T) {
 	require.Equal(t, expiration, actualExpiration)
 }
 
+// TestLeaseOutputErr tests that LeaseOutput translates the store's db-native
+// sentinels into the public, wallet-owned errors.
+func TestLeaseOutputErr(t *testing.T) {
+	t.Parallel()
+
+	outPoint := wire.OutPoint{Hash: [32]byte{1}, Index: 0}
+
+	tests := []struct {
+		name        string
+		storeErr    error
+		expectedErr error
+	}{
+		{
+			name:        "missing output",
+			storeErr:    db.ErrUtxoNotFound,
+			expectedErr: ErrUnknownOutput,
+		},
+		{
+			name:        "already leased",
+			storeErr:    db.ErrOutputAlreadyLeased,
+			expectedErr: ErrOutputAlreadyLocked,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			w, mocks := createStartedWalletWithMocks(t)
+
+			mocks.store.On(
+				"LeaseOutput", mock.Anything,
+				db.LeaseOutputParams{
+					WalletID: w.id,
+					ID:       db.LockID{1},
+					OutPoint: outPoint,
+					Duration: time.Hour,
+				},
+			).Return((*db.LeasedOutput)(nil), tc.storeErr).Once()
+
+			expiration, err := w.LeaseOutput(
+				t.Context(), wtxmgr.LockID{1}, outPoint,
+				time.Hour,
+			)
+			require.ErrorIs(t, err, tc.expectedErr)
+			require.True(t, expiration.IsZero())
+		})
+	}
+}
+
 // TestReleaseOutput tests the ReleaseOutput method.
 func TestReleaseOutput(t *testing.T) {
 	t.Parallel()
@@ -267,6 +317,52 @@ func TestReleaseOutput(t *testing.T) {
 	leaseID := wtxmgr.LockID{1}
 	err := w.ReleaseOutput(t.Context(), leaseID, utxo)
 	require.NoError(t, err)
+}
+
+// TestReleaseOutputErr tests that ReleaseOutput translates the store's
+// db-native sentinels into the public, wallet-owned errors.
+func TestReleaseOutputErr(t *testing.T) {
+	t.Parallel()
+
+	outPoint := wire.OutPoint{Hash: [32]byte{1}, Index: 0}
+	leaseID := wtxmgr.LockID{1}
+
+	tests := []struct {
+		name        string
+		storeErr    error
+		expectedErr error
+	}{
+		{
+			name:        "missing output",
+			storeErr:    db.ErrUtxoNotFound,
+			expectedErr: ErrUnknownOutput,
+		},
+		{
+			name:        "wrong lock id",
+			storeErr:    db.ErrOutputUnlockNotAllowed,
+			expectedErr: ErrOutputUnlockNotAllowed,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			w, mocks := createStartedWalletWithID(t, 7)
+
+			mocks.store.On(
+				"ReleaseOutput", mock.Anything,
+				db.ReleaseOutputParams{
+					WalletID: 7,
+					ID:       [32]byte{1},
+					OutPoint: outPoint,
+				},
+			).Return(tc.storeErr).Once()
+
+			err := w.ReleaseOutput(t.Context(), leaseID, outPoint)
+			require.ErrorIs(t, err, tc.expectedErr)
+		})
+	}
 }
 
 // TestListLeasedOutputs tests the ListLeasedOutputs method.

--- a/wallet/utxo_manager_test.go
+++ b/wallet/utxo_manager_test.go
@@ -286,14 +286,19 @@ func TestListLeasedOutputs(t *testing.T) {
 		Expiration: time.Now().Add(time.Hour),
 	}
 
-	// Mock the ListLockedOutputs method to return the leased output.
-	mocks.txStore.On("ListLockedOutputs", mock.Anything).Return(
-		[]*wtxmgr.LockedOutput{leasedOutput}, nil,
+	mocks.store.On("ListLeasedOutputs", mock.Anything, w.id).Return(
+		[]db.LeasedOutput{{
+			OutPoint:   wire.OutPoint{Hash: [32]byte{1}, Index: 0},
+			LockID:     db.LockID{1},
+			Expiration: leasedOutput.Expiration,
+		}}, nil,
 	)
 
-	// Now, try to list the leased outputs.
 	leasedOutputs, err := w.ListLeasedOutputs(t.Context())
 	require.NoError(t, err)
-	require.Len(t, leasedOutputs, 1)
-	require.Equal(t, leasedOutput, leasedOutputs[0])
+	require.Equal(t, []*LeasedOutput{{
+		OutPoint:   wire.OutPoint{Hash: [32]byte{1}, Index: 0},
+		LockID:     wtxmgr.LockID{1},
+		Expiration: leasedOutput.Expiration,
+	}}, leasedOutputs)
 }


### PR DESCRIPTION
## Summary

Complete UTXO-store migration through `db.Store`. Implements all four
`UtxoStore` methods on the kvdb backend and routes their wallet-side
consumers through the store — folded together so reviewers see the
kvdb impl and its wallet caller in the same chain.

- kvdb impls (with bundled tests): `GetUtxo`, `ListUTXOs`,
  `LeaseOutput`, `ListLeasedOutputs`
- wallet routes through the store: `GetUtxo`, `ListUnspent`,
  `LeaseOutput`, leased-outputs query
- shared test scaffolding: `kvdb/utils_test.go` matchers; wallet
  conversion helpers

## Why

- delivers the UTXO portion of the kvdb → db.Store migration in one
  reviewable chain instead of splitting it across multiple PRs
- mirrors the kvdb-impl + wallet-route interleave used on PR #1214
  (impl-address-manager-store) so each method's impl and its caller
  land together
- supersedes the previous split into PR #1203 (manager routing) and
  this PR (kvdb impls); #1203's content is now in this stack

## What Changed

- `wallet/internal/db/kvdb/utxostore.go`: implement `GetUtxo`,
  `ListUTXOs`, `LeaseOutput`, `ListLeasedOutputs` against the legacy
  `wtxmgr` / `waddrmgr` reads
- `wallet/internal/db/kvdb/utxostore_test.go`: unit coverage for each
- `wallet/utxo_manager.go`: wallet flows now consult `w.store` instead
  of touching `wtxmgr` directly
- `wallet/utxo_manager_test.go`: tests updated for store-backed mocks
- `wallet/internal/db/kvdb/utils_test.go`: shared test scaffolding
  (`testLegacyAddrStore`)

## Testing

- per-commit `GOWORK=off go build ./...` clean across all 10 commits
- `make lint`: 0 issues
- unit + itest CI: green