### PR TITLE
wallet: route account manager through Store + finish kvdb writes

### DIFF
--- a/waddrmgr/scoped_manager_accounts.go
+++ b/waddrmgr/scoped_manager_accounts.go
@@ -6,6 +6,7 @@ package waddrmgr
 
 import (
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
+	"github.com/btcsuite/btcwallet/internal/zero"
 	"github.com/btcsuite/btcwallet/walletdb"
 )
 
@@ -75,6 +76,81 @@ func (s *ScopedKeyManager) PutDerivedAccountWithKeys(
 	_, err = s.loadAccountInfo(ns, account)
 
 	return err
+}
+
+// DeriveAccountKeys derives the account-level extended public key and
+// encrypted private key for an already allocated derived account number.
+// It uses the scoped coin-type private key, so it continues to work after
+// Manager.NeuterRootKey has deleted the master HD private key.
+func (s *ScopedKeyManager) DeriveAccountKeys(ns walletdb.ReadBucket,
+	account uint32) ([]byte, []byte, error) {
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	if s.rootManager.WatchOnly() {
+		return nil, nil, managerError(ErrWatchingOnly, errWatchingOnly, nil)
+	}
+
+	if s.rootManager.IsLocked() {
+		return nil, nil, managerError(ErrLocked, errLocked, nil)
+	}
+
+	_, coinTypePrivEnc, err := fetchCoinTypeKeys(ns, &s.scope)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	serializedKeyPriv, err := s.rootManager.cryptoKeyPriv.Decrypt(
+		coinTypePrivEnc,
+	)
+	if err != nil {
+		str := "failed to decrypt cointype serialized private key"
+		return nil, nil, managerError(ErrLocked, str, err)
+	}
+
+	coinTypeKeyPriv, err := hdkeychain.NewKeyFromString(
+		string(serializedKeyPriv),
+	)
+	zero.Bytes(serializedKeyPriv)
+
+	if err != nil {
+		str := "failed to create cointype extended private key"
+		return nil, nil, managerError(ErrKeyChain, str, err)
+	}
+
+	defer coinTypeKeyPriv.Zero()
+
+	acctKeyPriv, err := deriveAccountKey(coinTypeKeyPriv, account)
+	if err != nil {
+		if IsError(err, ErrAccountNumTooHigh) {
+			return nil, nil, err
+		}
+
+		str := "failed to convert private key for account"
+
+		return nil, nil, managerError(ErrKeyChain, str, err)
+	}
+	defer acctKeyPriv.Zero()
+
+	acctKeyPub, err := acctKeyPriv.Neuter()
+	if err != nil {
+		str := "failed to convert public key for account"
+		return nil, nil, managerError(ErrKeyChain, str, err)
+	}
+
+	serializedPrivKey := []byte(acctKeyPriv.String())
+	defer zero.Bytes(serializedPrivKey)
+
+	acctPrivEnc, err := s.rootManager.cryptoKeyPriv.Encrypt(
+		serializedPrivKey,
+	)
+	if err != nil {
+		str := "failed to encrypt private key for account"
+		return nil, nil, managerError(ErrCrypto, str, err)
+	}
+
+	return []byte(acctKeyPub.String()), acctPrivEnc, nil
 }
 
 // AllocateImportedAccountNumber advances the per-scope lastAccount counter

--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -26,9 +26,11 @@ import (
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 )
 
-// buildAccountDeriveFn pre-loads the wallet's master HD private key and
-// returns an AccountDerivationFunc closure. Watch-only wallets get a closure
-// that rejects derivation.
+// buildAccountDeriveFn returns an AccountDerivationFunc closure. Spendable
+// wallets normally preload the master HD private key before the store opens
+// its write transaction. Neutered-root kvdb wallets are the exception: they
+// need to defer a missing-root-key error to the store callback so kvdb can
+// derive from the scoped coin-type key inside its walletdb transaction.
 func (w *Wallet) buildAccountDeriveFn(
 	ctx context.Context) (db.AccountDerivationFunc, error) {
 
@@ -41,9 +43,19 @@ func (w *Wallet) buildAccountDeriveFn(
 	}
 
 	encrypted, err := w.store.GetEncryptedHDSeed(ctx, w.id)
-	if err != nil {
-		return nil, fmt.Errorf("load encrypted master HD priv: %w",
-			err)
+	switch {
+	case err == nil:
+
+	case errors.Is(err, db.ErrSecretNotFound):
+		return func(_ context.Context, _ db.KeyScope, _ uint32,
+			_ bool) (*db.DerivedAccountData, error) {
+
+			return nil, fmt.Errorf("load encrypted master HD priv: %w",
+				err)
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("load encrypted master HD priv: %w", err)
 	}
 
 	plaintext, err := w.keyVault.Decrypt(waddrmgr.CKTPrivate, encrypted)
@@ -179,6 +191,10 @@ func (w *Wallet) NewAccount(ctx context.Context, scope waddrmgr.KeyScope,
 		}
 
 		return nil, err
+	}
+
+	if info.Origin == db.DerivedAccount {
+		info.MasterKeyFingerprint = w.masterFingerprint
 	}
 
 	return info, nil

--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -308,42 +308,38 @@ func (w *Wallet) GetAccount(ctx context.Context, scope waddrmgr.KeyScope,
 
 // RenameAccount renames an existing account. The new name must be unique within
 // the same key scope. The reserved "imported" account cannot be renamed.
-//
-// The time complexity of this method is dominated by the database lookup for
-// the old account name.
-func (w *Wallet) RenameAccount(_ context.Context, scope waddrmgr.KeyScope,
-	oldName, newName string) error {
+func (w *Wallet) RenameAccount(ctx context.Context,
+	scope waddrmgr.KeyScope, oldName, newName string) error {
 
 	err := w.state.validateStarted()
 	if err != nil {
 		return err
 	}
 
-	manager, err := w.addrStore.FetchScopedKeyManager(scope)
-	if err != nil {
-		return err
-	}
-
-	// Validate the new account name to ensure it meets the required
-	// criteria.
 	err = waddrmgr.ValidateAccountName(newName)
 	if err != nil {
 		return err
 	}
 
-	return walletdb.Update(w.cfg.DB, func(tx walletdb.ReadWriteTx) error {
-		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-
-		// Look up the account number for the given name. This is
-		// required to perform the rename operation.
-		accNum, err := manager.LookupAccount(addrmgrNs, oldName)
-		if err != nil {
-			return err
+	err = w.store.RenameAccount(ctx, db.RenameAccountParams{
+		WalletID: w.id,
+		Scope:    db.KeyScope(scope),
+		OldName:  oldName,
+		NewName:  newName,
+	})
+	if err != nil {
+		// Preserve waddrmgr.ManagerError semantics so callers using
+		// waddrmgr.IsError(err, ...) keep working when kvdb wraps the
+		// underlying manager error via fmt.Errorf.
+		var mErr waddrmgr.ManagerError
+		if errors.As(err, &mErr) {
+			return mErr
 		}
 
-		// Perform the rename operation in the address manager.
-		return manager.RenameAccount(addrmgrNs, accNum, newName)
-	})
+		return err
+	}
+
+	return nil
 }
 
 // ImportAccount imports an account from an extended public or private key. The

--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -24,7 +24,6 @@ import (
 	"github.com/btcsuite/btcwallet/netparams"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
-	"github.com/btcsuite/btcwallet/walletdb"
 )
 
 // buildAccountDeriveFn pre-loads the wallet's master HD private key and
@@ -131,14 +130,15 @@ type AccountManager interface {
 	RenameAccount(ctx context.Context, scope waddrmgr.KeyScope,
 		oldName string, newName string) error
 
-	// ImportAccount imports an account from an extended public or private
-	// key. The key scope is derived from the version bytes of the
-	// extended key. The account name must be unique within the derived
-	// scope. If dryRun is true, the import is validated but not persisted.
+	// ImportAccount imports an account from an extended public key.
+	// Private extended keys are rejected. The key scope is derived from
+	// the version bytes of the extended key. The account name must be
+	// unique within the derived scope. If dryRun is true, the import is
+	// validated but not persisted.
 	ImportAccount(ctx context.Context, name string,
 		accountKey *hdkeychain.ExtendedKey,
 		masterKeyFingerprint uint32, addrType waddrmgr.AddressType,
-		dryRun bool) (*waddrmgr.AccountProperties, error)
+		dryRun bool) (*db.AccountInfo, error)
 }
 
 // A compile time check to ensure that Wallet implements the interface.
@@ -385,17 +385,20 @@ func (w *Wallet) RenameAccount(ctx context.Context,
 	return nil
 }
 
-// ImportAccount imports an account from an extended public or private key. The
-// key scope is derived from the version bytes of the extended key. The account
-// name must be unique within the derived scope. If dryRun is true, the import
-// is validated but not persisted.
+// ImportAccount imports an account from an extended public key. Private
+// extended keys are rejected. The key scope is derived from the version
+// bytes of the extended key. The account name must be unique within the
+// derived scope.
 //
-// The time complexity of this method is dominated by the database lookup to
-// ensure the account name is unique within the scope.
+// dryRun=true validates the import through the store and rolls the transaction
+// back; no account row is persisted.
+//
+// The time complexity of this method is dominated by the database lookup
+// to ensure the account name is unique within the scope.
 func (w *Wallet) ImportAccount(ctx context.Context,
 	name string, accountKey *hdkeychain.ExtendedKey,
 	masterKeyFingerprint uint32, addrType waddrmgr.AddressType,
-	dryRun bool) (*waddrmgr.AccountProperties, error) {
+	dryRun bool) (*db.AccountInfo, error) {
 
 	err := w.state.validateStarted()
 	if err != nil {
@@ -408,118 +411,65 @@ func (w *Wallet) ImportAccount(ctx context.Context,
 }
 
 // importAccountInternal is the internal implementation of ImportAccount,
-// allowing callers (like Manager.Create) to bypass the started check.
-//
-// TODO(yy): we will move the db operation to a dedicated method, so we can
-// ignore cyclop for now.
-//
-//nolint:cyclop
-func (w *Wallet) importAccountInternal(_ context.Context,
+// allowing Manager.Create to bypass the started check.
+func (w *Wallet) importAccountInternal(ctx context.Context,
 	name string, accountKey *hdkeychain.ExtendedKey,
 	masterKeyFingerprint uint32, addrType waddrmgr.AddressType,
-	dryRun bool) (*waddrmgr.AccountProperties, error) {
+	dryRun bool) (*db.AccountInfo, error) {
 
-	// Ensure we have a valid account public key. We require an account-level
-	// key (depth 3) to properly manage the derivation path.
-	err := validateExtendedPubKey(accountKey, true, w.cfg.ChainParams)
+	err := validateExtendedPubKey(
+		accountKey, true, w.cfg.ChainParams,
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	// Determine what key scope the account public key should belong to and
-	// whether it should use a custom address schema. This is inferred from
-	// the key's HD version bytes.
-	keyScope, addrSchema, err := keyScopeFromPubKey(accountKey, &addrType)
+	keyScope, addrSchema, err := keyScopeFromPubKey(
+		accountKey, &addrType,
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	var props *waddrmgr.AccountProperties
-
-	// We'll perform the import within a database update transaction to ensure
-	// atomicity. If dryRun is enabled, we'll return a special error at the end
-	// to trigger a rollback.
-	err = walletdb.Update(w.cfg.DB, func(tx walletdb.ReadWriteTx) error {
-		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-
-		// Check if a manager for this key scope already exists. If not, we'll
-		// create a new one using the inferred schema.
-		scopedMgr, err := w.addrStore.FetchScopedKeyManager(keyScope)
-		if err != nil {
-			scopedMgr, err = w.addrStore.NewScopedKeyManager(
-				ns, keyScope, *addrSchema,
-			)
-			if err != nil {
-				return err
-			}
+	info, err := w.store.CreateImportedAccount(ctx,
+		db.CreateImportedAccountParams{
+			WalletID:          w.id,
+			Name:              name,
+			Scope:             db.KeyScope(keyScope),
+			MasterFingerprint: masterKeyFingerprint,
+			PublicKey:         []byte(accountKey.String()),
+			DryRun:            dryRun,
+			AddrSchema:        dbScopeAddrSchema(addrSchema),
+		},
+	)
+	if err != nil {
+		// Preserve waddrmgr.ManagerError semantics so callers using
+		// waddrmgr.IsError(err, ...) keep working when kvdb wraps the
+		// underlying manager error via fmt.Errorf.
+		var mErr waddrmgr.ManagerError
+		if errors.As(err, &mErr) {
+			return nil, mErr
 		}
 
-		// Create the new watching-only account using the provided key. Since we
-		// only have the public key, the wallet won't be able to sign for this
-		// account unless the private key is also provided later.
-		account, err := scopedMgr.NewAccountWatchingOnly(
-			ns, name, accountKey, masterKeyFingerprint, addrSchema,
-		)
-		if err != nil {
-			return err
-		}
-
-		// Retrieve the properties for the newly created account.
-		props, err = scopedMgr.AccountProperties(ns, account)
-		if !dryRun {
-			return err
-		}
-
-		// If this is a dry-run, we'll generate a few addresses to simulate the
-		// import process and then roll back.
-		props, err = importAccountDryRun(ns, props, scopedMgr)
-		if err != nil {
-			return err
-		}
-
-		// Make sure we always roll back the dry-run transaction by returning an
-		// error here.
-		return walletdb.ErrDryRunRollBack
-	})
-
-	// If this was a dry-run, we ignore the rollback error.
-	if err != nil && !dryRun && !errors.Is(err, walletdb.ErrDryRunRollBack) {
 		return nil, err
 	}
 
-	return props, nil
+	return info, nil
 }
 
-// importAccountDryRun simulates an account import by generating a single
-// address for both the internal and external derivation branches. This ensures
-// that the provided account key is valid and can be used to derive addresses.
-// The changes made during this simulation are rolled back by the caller.
-func importAccountDryRun(ns walletdb.ReadWriteBucket,
-	props *waddrmgr.AccountProperties, scopedMgr waddrmgr.AccountStore) (
-	*waddrmgr.AccountProperties, error) {
+// dbScopeAddrSchema converts a waddrmgr per-account address schema override
+// into the account-store contract type.
+func dbScopeAddrSchema(
+	schema *waddrmgr.ScopeAddrSchema) *db.ScopeAddrSchema {
 
-	// The importAccount method above will cache the imported account within the
-	// scoped manager. Since this is a dry-run attempt, we'll want to invalidate
-	// the cache for it.
-	defer scopedMgr.InvalidateAccountCache(props.AccountNumber)
-
-	_, err := scopedMgr.NextExternalAddresses(ns, props.AccountNumber, 1)
-	if err != nil {
-		return nil, err
+	if schema == nil {
+		return nil
 	}
 
-	_, err = scopedMgr.NextInternalAddresses(ns, props.AccountNumber, 1)
-	if err != nil {
-		return nil, err
+	return &db.ScopeAddrSchema{
+		ExternalAddrType: db.AddressType(schema.ExternalAddrType),
+		InternalAddrType: db.AddressType(schema.InternalAddrType),
 	}
-
-	// Refresh the account's properties after generating the addresses.
-	props, err = scopedMgr.AccountProperties(ns, props.AccountNumber)
-	if err != nil {
-		return nil, err
-	}
-
-	return props, nil
 }
 
 // validateExtendedPubKey ensures a sane derived public key is provided.

--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -20,11 +20,52 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/internal/zero"
 	"github.com/btcsuite/btcwallet/netparams"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 )
+
+// buildAccountDeriveFn pre-loads the wallet's master HD private key and
+// returns an AccountDerivationFunc closure. Watch-only wallets get a closure
+// that rejects derivation.
+func (w *Wallet) buildAccountDeriveFn(
+	ctx context.Context) (db.AccountDerivationFunc, error) {
+
+	if w.addrStore.WatchOnly() {
+		return func(_ context.Context, _ db.KeyScope, _ uint32,
+			_ bool) (*db.DerivedAccountData, error) {
+
+			return nil, errWatchOnlyAccountDerivation
+		}, nil
+	}
+
+	encrypted, err := w.store.GetEncryptedHDSeed(ctx, w.id)
+	if err != nil {
+		return nil, fmt.Errorf("load encrypted master HD priv: %w",
+			err)
+	}
+
+	plaintext, err := w.keyVault.Decrypt(waddrmgr.CKTPrivate, encrypted)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt master HD priv: %w", err)
+	}
+
+	masterKey, err := hdkeychain.NewKeyFromString(string(plaintext))
+	zero.Bytes(plaintext)
+
+	if err != nil {
+		return nil, fmt.Errorf("parse master HD priv: %w", err)
+	}
+
+	fingerprint, err := masterKeyFingerprint(masterKey)
+	if err != nil {
+		return nil, fmt.Errorf("master key fingerprint: %w", err)
+	}
+
+	return newAccountDeriveFn(masterKey, w.keyVault, fingerprint), nil
+}
 
 // AccountManager provides a high-level interface for managing wallet
 // accounts.
@@ -62,7 +103,7 @@ type AccountManager interface {
 	// NewAccount creates a new account for a given key scope and name. The
 	// provided name must be unique within that key scope.
 	NewAccount(ctx context.Context, scope waddrmgr.KeyScope, name string) (
-		*waddrmgr.AccountProperties, error)
+		*db.AccountInfo, error)
 
 	// ListAccounts returns a list of all accounts managed by the wallet.
 	ListAccounts(ctx context.Context) ([]db.AccountInfo, error)
@@ -103,42 +144,44 @@ type AccountManager interface {
 // A compile time check to ensure that Wallet implements the interface.
 var _ AccountManager = (*Wallet)(nil)
 
-// NewAccount creates the next account and returns its account number. The name
-// must be unique under the kep scope. In order to support automatic seed
+// NewAccount creates the next account and returns its account info. The name
+// must be unique under the key scope. In order to support automatic seed
 // restoring, new accounts may not be created when all of the previous 100
 // accounts have no transaction history (this is a deviation from the BIP0044
 // spec, which allows no unused account gaps).
-func (w *Wallet) NewAccount(_ context.Context, scope waddrmgr.KeyScope,
-	name string) (*waddrmgr.AccountProperties, error) {
+func (w *Wallet) NewAccount(ctx context.Context, scope waddrmgr.KeyScope,
+	name string) (*db.AccountInfo, error) {
 
 	err := w.state.validateStarted()
 	if err != nil {
 		return nil, err
 	}
 
-	manager, err := w.addrStore.FetchScopedKeyManager(scope)
+	deriveFn, err := w.buildAccountDeriveFn(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	var props *waddrmgr.AccountProperties
-
-	err = walletdb.Update(w.cfg.DB, func(tx walletdb.ReadWriteTx) error {
-		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-
-		// Create a new account under the current key scope.
-		accNum, err := manager.NewAccount(addrmgrNs, name)
-		if err != nil {
-			return err
+	info, err := w.store.CreateDerivedAccount(ctx,
+		db.CreateDerivedAccountParams{
+			WalletID: w.id,
+			Scope:    db.KeyScope(scope),
+			Name:     name,
+		}, deriveFn,
+	)
+	if err != nil {
+		// Preserve the legacy waddrmgr.ManagerError contract so that
+		// callers using waddrmgr.IsError(err, ...) keep working after
+		// kvdb wraps the underlying manager error via fmt.Errorf.
+		var mErr waddrmgr.ManagerError
+		if errors.As(err, &mErr) {
+			return nil, mErr
 		}
 
-		// Get the account's properties.
-		props, err = manager.AccountProperties(addrmgrNs, accNum)
+		return nil, err
+	}
 
-		return err
-	})
-
-	return props, err
+	return info, nil
 }
 
 // propertiesToAccountInfo wraps a waddrmgr.AccountProperties + total

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -72,13 +72,15 @@ func expectAccountDeriveSetup(t *testing.T, deps *mockWalletDeps,
 	).Once()
 }
 
-// hardenedKey returns the hardened child index for the given key index.
+// hardenedKey converts a plain BIP32 child index to its hardened
+// counterpart by adding hdkeychain.HardenedKeyStart.
 func hardenedKey(key uint32) uint32 {
 	return key + hdkeychain.HardenedKeyStart
 }
 
-// deriveAcctPubKey derives the account extended public key for the scope and
-// path from the test root key.
+// deriveAcctPubKey walks the supplied hardened BIP32 path under root
+// using the scope's Purpose+Coin prefix, then returns the public
+// (Neuter'd) extended key of the resulting account.
 func deriveAcctPubKey(t *testing.T, root *hdkeychain.ExtendedKey,
 	scope waddrmgr.KeyScope, paths ...uint32) *hdkeychain.ExtendedKey {
 
@@ -170,8 +172,8 @@ func TestPropertiesToAccountInfoImportedClassifiedAndMasked(t *testing.T) {
 	require.Equal(t, importedFingerprint, info.MasterKeyFingerprint)
 }
 
-// TestListAccounts tests that ListAccounts returns the cache-backed
-// snapshot of all accounts for the wallet.
+// TestListAccounts verifies ListAccounts pairs cache.ListAccounts with
+// cache.AccountBalances.
 func TestListAccounts(t *testing.T) {
 	t.Parallel()
 
@@ -385,11 +387,8 @@ func TestGetAccount(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint32(1), info.AccountNumber)
 	require.Equal(t, name, info.AccountName)
-	require.Equal(
-		t,
-		btcutil.Amount(123),
-		info.ConfirmedBalance+info.UnconfirmedBalance,
-	)
+	require.Equal(t, btcutil.Amount(100), info.ConfirmedBalance)
+	require.Equal(t, btcutil.Amount(23), info.UnconfirmedBalance)
 	require.Equal(t, masterFP, info.MasterKeyFingerprint)
 }
 
@@ -429,8 +428,8 @@ func TestGetAccountIncludesImportedPseudoAccount(t *testing.T) {
 	require.Equal(t, uint32(3), account.ImportedKeyCount)
 }
 
-// TestNewAccount verifies NewAccount routes through w.store.CreateDerivedAccount
-// after the buildAccountDeriveFn closure resolves the encrypted master key.
+// TestNewAccount verifies NewAccount routes through
+// w.store.CreateDerivedAccount.
 func TestNewAccount(t *testing.T) {
 	t.Parallel()
 
@@ -515,127 +514,163 @@ func TestRenameAccount(t *testing.T) {
 	require.ErrorIs(t, err, db.ErrAccountNotFound)
 }
 
-// TestImportAccount tests that the ImportAccount works as expected.
+// TestImportAccount verifies the normal import path routes through
+// Store.CreateImportedAccount.
 func TestImportAccount(t *testing.T) {
 	t.Parallel()
 
-	// Create a new test wallet.
 	w, deps := createStartedWalletWithMocks(t)
 
-	// We'll start by creating a new account under the BIP0084 scope.
-	scope := waddrmgr.KeyScopeBIP0084
+	acctPubKey, masterFP := importAccountTestKey(t, 84)
+
 	addrType := waddrmgr.WitnessPubKey
-	masterPriv := "tprv8ZgxMBicQKsPeWwrFuNjEGTTDSY4mRLwd2KDJAPGa1AY" +
-		"quw38bZqNMSuB3V1Va3hqJBo9Pt8Sx7kBQer5cNMrb8SYquoWPt9" +
-		"Y3BZdhdtUcw"
-	root, err := hdkeychain.NewKeyFromString(masterPriv)
-	require.NoError(t, err)
-	acctPubKey := deriveAcctPubKey(t, root, scope, hardenedKey(0))
-
-	// Mock expectations for ImportAccount.
-	deps.addrStore.On("FetchScopedKeyManager", scope).
-		Return(deps.accountManager, nil).Once()
-
-	deps.accountManager.On("NewAccountWatchingOnly", mock.Anything,
-		testAccountName, acctPubKey, root.ParentFingerprint(),
-		mock.Anything).Return(uint32(1), nil).Once()
-	deps.accountManager.On("AccountProperties", mock.Anything, uint32(1)).
-		Return(&waddrmgr.AccountProperties{
-			AccountNumber: 1,
-			AccountName:   testAccountName,
-		}, nil).Once()
-
-	// We should be able to import the account.
-	props, err := w.ImportAccount(
-		t.Context(), testAccountName, acctPubKey,
-		root.ParentFingerprint(), addrType, false,
-	)
-	require.NoError(t, err)
-	require.Equal(t, testAccountName, props.AccountName)
-
+	scope := waddrmgr.KeyScopeBIP0084
 	dbScope := db.KeyScope{
 		Purpose: scope.Purpose,
 		Coin:    scope.Coin,
 	}
-	name := testAccountName
-	deps.store.On("GetAccount", mock.Anything, db.GetAccountQuery{
-		WalletID: 0,
-		Scope:    dbScope,
-		Name:     &name,
-	}).Return(&db.AccountInfo{
+
+	deps.store.On("CreateImportedAccount", mock.Anything,
+		db.CreateImportedAccountParams{
+			WalletID:          0,
+			Name:              testAccountName,
+			Scope:             dbScope,
+			MasterFingerprint: masterFP,
+			PublicKey:         []byte(acctPubKey.String()),
+		}).Return(&db.AccountInfo{
 		AccountNumber: 1,
 		AccountName:   testAccountName,
 		Origin:        db.ImportedAccount,
 		IsWatchOnly:   true,
 		KeyScope:      dbScope,
+		PublicKey:     []byte(acctPubKey.String()),
 	}, nil).Once()
 
-	// We should be able to get the account by its name.
-	_, err = w.GetAccount(t.Context(), scope, testAccountName)
-	require.NoError(t, err)
-
-	// Mock expectations for duplicate ImportAccount.
-	deps.addrStore.On("FetchScopedKeyManager", scope).
-		Return(deps.accountManager, nil).Once()
-	deps.accountManager.On("NewAccountWatchingOnly", mock.Anything,
-		testAccountName, acctPubKey, root.ParentFingerprint(),
-		mock.Anything).Return(uint32(0), waddrmgr.ManagerError{
-		ErrorCode: waddrmgr.ErrDuplicateAccount,
-	}).Once()
-
-	// We should not be able to import an account with the same name.
-	_, err = w.ImportAccount(
+	props, err := w.ImportAccount(
 		t.Context(), testAccountName, acctPubKey,
-		root.ParentFingerprint(), addrType, false,
+		masterFP, addrType, false,
 	)
-	require.Error(t, err)
-	require.True(
-		t, waddrmgr.IsError(err, waddrmgr.ErrDuplicateAccount),
-		"expected ErrDuplicateAccount",
+	require.NoError(t, err)
+	require.Equal(t, testAccountName, props.AccountName)
+}
+
+// TestImportAccountDryRun verifies that dry-run imports still route through
+// Store.CreateImportedAccount with the DryRun contract flag set.
+func TestImportAccountDryRun(t *testing.T) {
+	t.Parallel()
+
+	w, deps := createStartedWalletWithMocks(t)
+
+	acctPubKey, masterFP := importAccountTestKey(t, 84)
+
+	addrType := waddrmgr.WitnessPubKey
+	scope := waddrmgr.KeyScopeBIP0084
+	dbScope := db.KeyScope{
+		Purpose: scope.Purpose,
+		Coin:    scope.Coin,
+	}
+
+	deps.store.On("CreateImportedAccount", mock.Anything,
+		db.CreateImportedAccountParams{
+			WalletID:          0,
+			Name:              testAccountName,
+			Scope:             dbScope,
+			MasterFingerprint: masterFP,
+			PublicKey:         []byte(acctPubKey.String()),
+			DryRun:            true,
+		}).Return(&db.AccountInfo{
+		AccountName: testAccountName,
+		Origin:      db.ImportedAccount,
+		IsWatchOnly: true,
+		KeyScope:    dbScope,
+		PublicKey:   []byte(acctPubKey.String()),
+	}, nil).Once()
+
+	props, err := w.ImportAccount(
+		t.Context(), testAccountName, acctPubKey,
+		masterFP, addrType, true,
 	)
+	require.NoError(t, err)
+	require.Equal(t, testAccountName, props.AccountName)
+}
 
-	// Mock expectations for dry-run.
-	dryRunName := "dry run"
+// TestImportAccountAddrSchema verifies that strict BIP-49 imports pass their
+// per-account address-schema override through to the store.
+func TestImportAccountAddrSchema(t *testing.T) {
+	t.Parallel()
 
-	deps.addrStore.On("FetchScopedKeyManager", scope).
-		Return(deps.accountManager, nil).Once()
+	w, deps := createStartedWalletWithMocks(t)
 
-	deps.accountManager.On("NewAccountWatchingOnly", mock.Anything,
-		dryRunName, acctPubKey, root.ParentFingerprint(),
-		mock.Anything).Return(uint32(2), nil).Once()
-	deps.accountManager.On("AccountProperties", mock.Anything, uint32(2)).
-		Return(&waddrmgr.AccountProperties{
-			AccountNumber: 2,
-			AccountName:   dryRunName,
-		}, nil).Twice()
-	deps.accountManager.On("InvalidateAccountCache", uint32(2)).Return().Once()
-	deps.accountManager.On("NextExternalAddresses", mock.Anything, uint32(2),
-		uint32(1)).Return([]waddrmgr.ManagedAddress(nil), nil).Once()
-	deps.accountManager.On("NextInternalAddresses", mock.Anything, uint32(2),
-		uint32(1)).Return([]waddrmgr.ManagedAddress(nil), nil).Once()
+	acctPubKey, masterFP := importAccountTestKey(t, 49)
 
-	// We should be able to do a dry run of the import.
-	_, err = w.ImportAccount(
-		t.Context(), dryRunName, acctPubKey,
-		root.ParentFingerprint(), addrType, true,
+	addrType := waddrmgr.NestedWitnessPubKey
+	scope := waddrmgr.KeyScopeBIP0049Plus
+	dbScope := db.KeyScope{
+		Purpose: scope.Purpose,
+		Coin:    scope.Coin,
+	}
+	addrSchema := db.ScopeAddrSchema{
+		ExternalAddrType: db.NestedWitnessPubKey,
+		InternalAddrType: db.NestedWitnessPubKey,
+	}
+
+	deps.store.On("CreateImportedAccount", mock.Anything,
+		db.CreateImportedAccountParams{
+			WalletID:          0,
+			Name:              testAccountName,
+			Scope:             dbScope,
+			MasterFingerprint: masterFP,
+			PublicKey:         []byte(acctPubKey.String()),
+			AddrSchema:        &addrSchema,
+		}).Return(&db.AccountInfo{
+		AccountName: testAccountName,
+		Origin:      db.ImportedAccount,
+		IsWatchOnly: true,
+		KeyScope:    dbScope,
+		PublicKey:   []byte(acctPubKey.String()),
+	}, nil).Once()
+
+	props, err := w.ImportAccount(
+		t.Context(), testAccountName, acctPubKey,
+		masterFP, addrType, false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, testAccountName, props.AccountName)
+}
+
+// importAccountTestKey derives an account-level public key for import routing
+// tests using the requested BIP purpose.
+func importAccountTestKey(t *testing.T,
+	purposeNum uint32) (*hdkeychain.ExtendedKey, uint32) {
+
+	t.Helper()
+
+	root, err := hdkeychain.NewMaster(
+		[]byte{
+			0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+			0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+		},
+		&chainParams,
 	)
 	require.NoError(t, err)
 
-	deps.store.On("GetAccount", mock.Anything, db.GetAccountQuery{
-		WalletID: 0,
-		Scope:    dbScope,
-		Name:     &dryRunName,
-	}).Return((*db.AccountInfo)(nil), waddrmgr.ManagerError{
-		ErrorCode: waddrmgr.ErrAccountNotFound,
-	}).Once()
-
-	// The account should not have been imported.
-	_, err = w.GetAccount(t.Context(), scope, dryRunName)
-	require.Error(t, err)
-	require.True(
-		t, waddrmgr.IsError(err, waddrmgr.ErrAccountNotFound),
-		"expected ErrAccountNotFound",
+	purpose, err := root.DeriveNonStandard( //nolint:staticcheck
+		hardenedKey(purposeNum),
 	)
+	require.NoError(t, err)
+	cointype, err := purpose.DeriveNonStandard( //nolint:staticcheck
+		hardenedKey(1),
+	)
+	require.NoError(t, err)
+	acct, err := cointype.DeriveNonStandard( //nolint:staticcheck
+		hardenedKey(0),
+	)
+	require.NoError(t, err)
+
+	acctPubKey, err := acct.Neuter()
+	require.NoError(t, err)
+
+	return acctPubKey, root.ParentFingerprint()
 }
 
 // TestExtractAddrFromPKScript tests that the extractAddrFromPKScript

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -19,6 +19,59 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// stubAccountDeriveFn holds the master-key material the test wallet's
+// buildAccountDeriveFn path consumes.
+type stubAccountDeriveFn struct {
+	encryptedSeed        []byte
+	plaintextMasterKey   []byte
+	masterKey            *hdkeychain.ExtendedKey
+	masterKeyFingerprint uint32
+}
+
+// newStubAccountDeriveFn builds a deterministic master key + the byte
+// strings the GetEncryptedHDSeed/Decrypt mocks return.
+func newStubAccountDeriveFn(t *testing.T) stubAccountDeriveFn {
+	t.Helper()
+
+	seed := make([]byte, hdkeychain.RecommendedSeedLen)
+	for i := range seed {
+		seed[i] = byte(i + 1)
+	}
+
+	masterKey, err := hdkeychain.NewMaster(seed, &chainParams)
+	require.NoError(t, err)
+
+	fingerprint, err := masterKeyFingerprint(masterKey)
+	require.NoError(t, err)
+
+	plaintext := []byte(masterKey.String())
+	encrypted := append([]byte("enc:"), plaintext...)
+
+	return stubAccountDeriveFn{
+		encryptedSeed:        encrypted,
+		plaintextMasterKey:   plaintext,
+		masterKey:            masterKey,
+		masterKeyFingerprint: fingerprint,
+	}
+}
+
+// expectAccountDeriveSetup wires the mock expectations the new wallet
+// NewAccount path performs before invoking w.store.CreateDerivedAccount.
+// Decrypt returns a fresh copy so the wallet's post-parse zero.Bytes call
+// does not corrupt the shared stub across multiple invocations.
+func expectAccountDeriveSetup(t *testing.T, deps *mockWalletDeps,
+	stub stubAccountDeriveFn) {
+
+	t.Helper()
+
+	deps.store.On("GetEncryptedHDSeed", mock.Anything, uint32(0)).
+		Return(append([]byte(nil), stub.encryptedSeed...), nil).Once()
+	deps.addrStore.On("Decrypt", waddrmgr.CKTPrivate,
+		mock.Anything).Return(
+		append([]byte(nil), stub.plaintextMasterKey...), nil,
+	).Once()
+}
+
 // hardenedKey returns the hardened child index for the given key index.
 func hardenedKey(key uint32) uint32 {
 	return key + hdkeychain.HardenedKeyStart
@@ -374,6 +427,55 @@ func TestGetAccountIncludesImportedPseudoAccount(t *testing.T) {
 	require.Equal(t, db.ImportedAccount, account.Origin)
 	require.Equal(t, uint32(0), account.AccountNumber)
 	require.Equal(t, uint32(3), account.ImportedKeyCount)
+}
+
+// TestNewAccount verifies NewAccount routes through w.store.CreateDerivedAccount
+// after the buildAccountDeriveFn closure resolves the encrypted master key.
+func TestNewAccount(t *testing.T) {
+	t.Parallel()
+
+	w, deps := createStartedWalletWithMocks(t)
+	stub := newStubAccountDeriveFn(t)
+
+	scope := waddrmgr.KeyScopeBIP0084
+	dbScope := db.KeyScope{
+		Purpose: scope.Purpose,
+		Coin:    scope.Coin,
+	}
+
+	// Success path.
+	expectAccountDeriveSetup(t, deps, stub)
+	deps.store.On("CreateDerivedAccount", mock.Anything,
+		db.CreateDerivedAccountParams{
+			WalletID: 0,
+			Scope:    dbScope,
+			Name:     testAccountName,
+		}, mock.Anything).Return(
+		&db.AccountInfo{
+			AccountNumber: 1,
+			AccountName:   testAccountName,
+			Origin:        db.DerivedAccount,
+			KeyScope:      dbScope,
+		}, nil,
+	).Once()
+
+	account, err := w.NewAccount(t.Context(), scope, testAccountName)
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), account.AccountNumber)
+
+	// Duplicate-name path.
+	expectAccountDeriveSetup(t, deps, stub)
+	deps.store.On("CreateDerivedAccount", mock.Anything, mock.Anything,
+		mock.Anything).Return((*db.AccountInfo)(nil),
+		waddrmgr.ManagerError{
+			ErrorCode: waddrmgr.ErrDuplicateAccount,
+		}).Once()
+
+	_, err = w.NewAccount(t.Context(), scope, testAccountName)
+	require.Error(t, err)
+	require.True(t,
+		waddrmgr.IsError(err, waddrmgr.ErrDuplicateAccount),
+	)
 }
 
 // TestRenameAccount verifies RenameAccount routes through

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -6,6 +6,7 @@ package wallet
 
 import (
 	"encoding/binary"
+	"errors"
 	"strings"
 	"testing"
 
@@ -172,8 +173,8 @@ func TestPropertiesToAccountInfoImportedClassifiedAndMasked(t *testing.T) {
 	require.Equal(t, importedFingerprint, info.MasterKeyFingerprint)
 }
 
-// TestListAccounts verifies ListAccounts pairs cache.ListAccounts with
-// cache.AccountBalances.
+// TestListAccounts verifies ListAccounts returns account snapshots with the
+// wallet-level derived-account master fingerprint applied.
 func TestListAccounts(t *testing.T) {
 	t.Parallel()
 
@@ -435,6 +436,7 @@ func TestNewAccount(t *testing.T) {
 
 	w, deps := createStartedWalletWithMocks(t)
 	stub := newStubAccountDeriveFn(t)
+	w.masterFingerprint = stub.masterKeyFingerprint
 
 	scope := waddrmgr.KeyScopeBIP0084
 	dbScope := db.KeyScope{
@@ -461,6 +463,7 @@ func TestNewAccount(t *testing.T) {
 	account, err := w.NewAccount(t.Context(), scope, testAccountName)
 	require.NoError(t, err)
 	require.Equal(t, uint32(1), account.AccountNumber)
+	require.Equal(t, stub.masterKeyFingerprint, account.MasterKeyFingerprint)
 
 	// Duplicate-name path.
 	expectAccountDeriveSetup(t, deps, stub)
@@ -475,6 +478,46 @@ func TestNewAccount(t *testing.T) {
 	require.True(t,
 		waddrmgr.IsError(err, waddrmgr.ErrDuplicateAccount),
 	)
+}
+
+// TestNewAccountMissingHDSeedDefersToStore verifies that neutered-root kvdb
+// wallets can let the store fall back to scoped coin-type key derivation.
+func TestNewAccountMissingHDSeedDefersToStore(t *testing.T) {
+	t.Parallel()
+
+	w, deps := createStartedWalletWithMocks(t)
+
+	scope := waddrmgr.KeyScopeBIP0084
+	dbScope := db.KeyScope{
+		Purpose: scope.Purpose,
+		Coin:    scope.Coin,
+	}
+
+	deps.store.On("GetEncryptedHDSeed", mock.Anything, uint32(0)).
+		Return(nil, db.ErrSecretNotFound).Once()
+	deps.store.On("CreateDerivedAccount", mock.Anything,
+		db.CreateDerivedAccountParams{
+			WalletID: 0,
+			Scope:    dbScope,
+			Name:     testAccountName,
+		}, mock.MatchedBy(func(deriveFn db.AccountDerivationFunc) bool {
+			if deriveFn == nil {
+				return false
+			}
+
+			derived, err := deriveFn(t.Context(), dbScope, 1, false)
+
+			return derived == nil && errors.Is(err, db.ErrSecretNotFound)
+		})).Return(&db.AccountInfo{
+		AccountNumber: 1,
+		AccountName:   testAccountName,
+		Origin:        db.DerivedAccount,
+		KeyScope:      dbScope,
+	}, nil).Once()
+
+	account, err := w.NewAccount(t.Context(), scope, testAccountName)
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), account.AccountNumber)
 }
 
 // TestRenameAccount verifies RenameAccount routes through

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -376,114 +376,41 @@ func TestGetAccountIncludesImportedPseudoAccount(t *testing.T) {
 	require.Equal(t, uint32(3), account.ImportedKeyCount)
 }
 
-// TestRenameAccount tests that the RenameAccount method works as expected.
+// TestRenameAccount verifies RenameAccount routes through
+// w.store.RenameAccount with the correct params and preserves
+// db.ErrAccountNotFound passthrough.
 func TestRenameAccount(t *testing.T) {
 	t.Parallel()
 
-	// Create a new test wallet.
 	w, deps := createStartedWalletWithMocks(t)
 
-	// We'll create a new account under the BIP0084 scope.
 	scope := waddrmgr.KeyScopeBIP0084
 	dbScope := db.KeyScope{
 		Purpose: scope.Purpose,
 		Coin:    scope.Coin,
 	}
-	oldName := "old name"
-	newName := "new name"
 
-	deps.addrStore.On("FetchScopedKeyManager", scope).
-		Return(deps.accountManager, nil).Once()
-	deps.accountManager.On("NewAccount", mock.Anything, oldName).
-		Return(uint32(1), nil).Once()
-	deps.accountManager.On("AccountProperties", mock.Anything, uint32(1)).
-		Return(&waddrmgr.AccountProperties{
-			AccountNumber: 1,
-			AccountName:   oldName,
-		}, nil).Once()
-
-	_, err := w.NewAccount(t.Context(), scope, oldName)
-	require.NoError(t, err)
-
-	// Mock expectations for RenameAccount.
-	deps.addrStore.On("FetchScopedKeyManager", scope).
-		Return(deps.accountManager, nil).Once()
-	deps.accountManager.On("LookupAccount", mock.Anything, oldName).
-		Return(uint32(1), nil).Once()
-	deps.accountManager.On("RenameAccount", mock.Anything, uint32(1), newName).
-		Return(nil).Once()
-
-	// We should be able to rename the account.
-	err = w.RenameAccount(t.Context(), scope, oldName, newName)
-	require.NoError(t, err)
-
-	deps.store.On("GetAccount", mock.Anything, db.GetAccountQuery{
+	deps.store.On("RenameAccount", mock.Anything, db.RenameAccountParams{
 		WalletID: 0,
 		Scope:    dbScope,
-		Name:     &newName,
-	}).Return(&db.AccountInfo{
-		AccountNumber: 1,
-		AccountName:   newName,
-		Origin:        db.DerivedAccount,
-		KeyScope:      dbScope,
-	}, nil).Once()
+		OldName:  testAccountName,
+		NewName:  "renamed",
+	}).Return(nil).Once()
 
-	// We should be able to get the account by its new name.
-	account, err := w.GetAccount(t.Context(), scope, newName)
+	err := w.RenameAccount(t.Context(), scope, testAccountName, "renamed")
 	require.NoError(t, err)
-	require.Equal(t, newName, account.AccountName)
 
-	deps.store.On("GetAccount", mock.Anything, db.GetAccountQuery{
-		WalletID: 0,
-		Scope:    dbScope,
-		Name:     &oldName,
-	}).Return((*db.AccountInfo)(nil), waddrmgr.ManagerError{
-		ErrorCode: waddrmgr.ErrAccountNotFound,
-	}).Once()
-
-	// We should not be able to get the account by its old name.
-	_, err = w.GetAccount(t.Context(), scope, oldName)
+	// Invalid new name path (validated locally before the store call).
+	err = w.RenameAccount(t.Context(), scope, testAccountName, "")
 	require.Error(t, err)
-	require.True(
-		t, waddrmgr.IsError(err, waddrmgr.ErrAccountNotFound),
-		"expected ErrAccountNotFound",
-	)
 
-	// Mock expectations for RenameAccount (duplicate name).
-	deps.addrStore.On("FetchScopedKeyManager", scope).
-		Return(deps.accountManager, nil).Once()
+	// Not-found path.
+	deps.store.On("RenameAccount", mock.Anything, mock.Anything).Return(
+		db.ErrAccountNotFound,
+	).Once()
 
-	deps.accountManager.On("LookupAccount", mock.Anything, newName).
-		Return(uint32(1), nil).Once()
-	deps.accountManager.On(
-		"RenameAccount", mock.Anything, uint32(1), "default",
-	).Return(waddrmgr.ManagerError{
-		ErrorCode: waddrmgr.ErrDuplicateAccount,
-	}).Once()
-
-	// We should not be able to rename an account to an existing name.
-	err = w.RenameAccount(t.Context(), scope, newName, "default")
-	require.Error(t, err)
-	require.True(
-		t, waddrmgr.IsError(err, waddrmgr.ErrDuplicateAccount),
-		"expected ErrDuplicateAccount",
-	)
-
-	// Mock expectations for RenameAccount (non-existent account).
-	deps.addrStore.On("FetchScopedKeyManager", scope).
-		Return(deps.accountManager, nil).Once()
-	deps.accountManager.On("LookupAccount", mock.Anything, "non-existent").
-		Return(uint32(0), waddrmgr.ManagerError{
-			ErrorCode: waddrmgr.ErrAccountNotFound,
-		}).Once()
-
-	// We should not be able to rename a non-existent account.
-	err = w.RenameAccount(t.Context(), scope, "non-existent", "new name 2")
-	require.Error(t, err)
-	require.True(
-		t, waddrmgr.IsError(err, waddrmgr.ErrAccountNotFound),
-		"expected ErrAccountNotFound",
-	)
+	err = w.RenameAccount(t.Context(), scope, "missing", "x")
+	require.ErrorIs(t, err, db.ErrAccountNotFound)
 }
 
 // TestImportAccount tests that the ImportAccount works as expected.

--- a/wallet/internal/db/accounts_common.go
+++ b/wallet/internal/db/accounts_common.go
@@ -596,7 +596,7 @@ func EnsureKeyScope[Row any, GetArgs any, CreateArgs any](
 	ctx context.Context, getter func(context.Context, GetArgs) (Row, error),
 	getArgs GetArgs, creator func(context.Context, CreateArgs) (int64, error),
 	createArgs func(ScopeAddrSchema) CreateArgs, rowToID func(Row) int64,
-	scope KeyScope) (int64, error) {
+	scope KeyScope, schemaOverride *ScopeAddrSchema) (int64, error) {
 
 	scopeInfo, err := getter(ctx, getArgs)
 	if err == nil {
@@ -608,9 +608,16 @@ func EnsureKeyScope[Row any, GetArgs any, CreateArgs any](
 		return 0, fmt.Errorf("check key scope: %w", err)
 	}
 
-	defaultAddrSchema, err := getAddrSchemaForScope(scope)
-	if err != nil {
-		return 0, err
+	var addrSchema ScopeAddrSchema
+	if schemaOverride != nil {
+		addrSchema = *schemaOverride
+	} else {
+		defaultAddrSchema, err := getAddrSchemaForScope(scope)
+		if err != nil {
+			return 0, err
+		}
+
+		addrSchema = defaultAddrSchema
 	}
 
 	// Slow path: needs to create the scope. The SQL uses
@@ -618,7 +625,7 @@ func EnsureKeyScope[Row any, GetArgs any, CreateArgs any](
 	// - If INSERT succeeds (no conflict): returns the new row's id.
 	// - If INSERT conflicts (scope exists): returns NO rows, causing sqlc to
 	// return sql.ErrNoRows.
-	id, err := creator(ctx, createArgs(defaultAddrSchema))
+	id, err := creator(ctx, createArgs(addrSchema))
 	if err == nil {
 		return id, nil
 	}

--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -480,7 +480,7 @@ type CreateImportedAccountParams struct {
 	Name string
 
 	// Scope is the key scope for the account. The address schema for the
-	// scope will be determined by the default mapping for this scope.
+	// scope is determined by the default mapping unless AddrSchema is set.
 	Scope KeyScope
 
 	// MasterFingerprint is the fingerprint of the master key.
@@ -494,6 +494,13 @@ type CreateImportedAccountParams struct {
 	// to the database layer. A nil or empty slice means no account private
 	// key material is stored; the imported account will be watch-only.
 	EncryptedPrivateKey []byte
+
+	// DryRun simulates the import without committing any database writes.
+	DryRun bool
+
+	// AddrSchema optionally overrides the scope's default address schema for
+	// this imported account.
+	AddrSchema *ScopeAddrSchema
 }
 
 // GetAccountQuery contains the parameters for querying a single account. The

--- a/wallet/internal/db/itest/account_store_test.go
+++ b/wallet/internal/db/itest/account_store_test.go
@@ -1676,6 +1676,40 @@ func TestRenameAccount(t *testing.T) {
 	})
 }
 
+// TestRenameAccountRejectsImported verifies that imported accounts cannot be
+// renamed through the account store.
+func TestRenameAccountRejectsImported(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-rename-imported")
+	scope := db.KeyScopeBIP0084
+	name := "imported-rename"
+
+	CreateImportedAccount(t, store, walletID, scope, name)
+
+	err := store.RenameAccount(t.Context(), db.RenameAccountParams{
+		WalletID: walletID,
+		Scope:    scope,
+		OldName:  name,
+		NewName:  "renamed-imported",
+	})
+	require.ErrorIs(t, err, db.ErrAccountNotFound)
+
+	info, err := store.GetAccount(
+		t.Context(), getAccountQueryByName(walletID, scope, name),
+	)
+	require.NoError(t, err)
+	require.Equal(t, name, info.AccountName)
+
+	_, err = store.GetAccount(
+		t.Context(), getAccountQueryByName(
+			walletID, scope, "renamed-imported",
+		),
+	)
+	require.ErrorIs(t, err, db.ErrAccountNotFound)
+}
+
 // TestRenameAccountErrors verifies that RenameAccount returns appropriate
 // errors for invalid inputs and missing accounts.
 func TestRenameAccountErrors(t *testing.T) {

--- a/wallet/internal/db/kvdb/accountstore.go
+++ b/wallet/internal/db/kvdb/accountstore.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
@@ -21,6 +22,20 @@ var (
 	// not yet cached the scoped manager.
 	errScopedMgrUninitialized = errors.New(
 		"kvdb: scoped manager not initialized",
+	)
+
+	// errImportedAccountWithPriv is returned by CreateImportedAccount
+	// when a spendable wallet tries to import an account with private
+	// key material; waddrmgr's accountWatchOnly row has no priv-key
+	// column.
+	errImportedAccountWithPriv = errors.New(
+		"kvdb: imported accounts with private key material are not " +
+			"supported on waddrmgr-backed wallets",
+	)
+	// errNoDefaultSchema is returned when a scope import targets a
+	// KeyScope without a registered default address schema.
+	errNoDefaultSchema = errors.New(
+		"kvdb: no default schema for scope",
 	)
 )
 
@@ -182,11 +197,213 @@ func (o *createDerivedAccountOps) CreateDerivedAccount(_ context.Context,
 	}, nil
 }
 
-// CreateImportedAccount is not yet implemented for kvdb.
-func (s *Store) CreateImportedAccount(ctx context.Context,
-	_ db.CreateImportedAccountParams) (*db.AccountInfo, error) {
+// CreateImportedAccount persists an imported account into waddrmgr as a
+// watch-only row. kvdb does not persist an encrypted account private key
+// for imported accounts; spendable wallets that supply one get an error.
+func (s *Store) CreateImportedAccount(_ context.Context,
+	params db.CreateImportedAccountParams) (*db.AccountInfo, error) {
 
-	return nil, notImplemented(ctx, "CreateImportedAccount")
+	mgr := s.addrStore
+	walletIsWatchOnly := mgr.WatchOnly()
+
+	pubKey, err := validateImportedAccountParams(
+		params, walletIsWatchOnly,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	scope := waddrmgr.KeyScope{
+		Purpose: params.Scope.Purpose,
+		Coin:    params.Scope.Coin,
+	}
+
+	var info *db.AccountInfo
+
+	err = walletdb.Update(s.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+		if ns == nil {
+			return db.ErrAccountNotFound
+		}
+
+		built, err := s.putImportedAccount(
+			ns, scope, params, pubKey, walletIsWatchOnly,
+		)
+		if err != nil {
+			return err
+		}
+
+		info = built
+
+		if params.DryRun {
+			return walletdb.ErrDryRunRollBack
+		}
+
+		return nil
+	})
+	if err != nil {
+		if params.DryRun && errors.Is(err, walletdb.ErrDryRunRollBack) {
+			return info, nil
+		}
+
+		return nil, err
+	}
+
+	return info, nil
+}
+
+// validateImportedAccountParams performs kvdb-specific import validation and
+// returns the parsed account public key.
+func validateImportedAccountParams(params db.CreateImportedAccountParams,
+	walletIsWatchOnly bool) (*hdkeychain.ExtendedKey, error) {
+
+	err := params.ValidateBasic()
+	if err != nil {
+		return nil, err
+	}
+
+	err = params.ValidateWatchOnly(walletIsWatchOnly)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(params.EncryptedPrivateKey) > 0 && !walletIsWatchOnly {
+		return nil, errImportedAccountWithPriv
+	}
+
+	pubKey, err := hdkeychain.NewKeyFromString(string(params.PublicKey))
+	if err != nil {
+		return nil, fmt.Errorf("parse account public key: %w", err)
+	}
+
+	if pubKey.IsPrivate() {
+		return nil, errImportedAccountWithPriv
+	}
+
+	return pubKey, nil
+}
+
+// putImportedAccount writes a validated imported account using waddrmgr's
+// legacy watch-only account creation path.
+func (s *Store) putImportedAccount(ns walletdb.ReadWriteBucket,
+	scope waddrmgr.KeyScope, params db.CreateImportedAccountParams,
+	pubKey *hdkeychain.ExtendedKey,
+	walletIsWatchOnly bool) (*db.AccountInfo, error) {
+
+	addrSchema := waddrmgrScopeAddrSchema(params.AddrSchema)
+
+	scopedMgr, err := s.scopedManagerOrCreate(
+		ns, scope, addrSchema, params.DryRun,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	accountNumber, err := scopedMgr.NewAccountWatchingOnly(
+		ns, params.Name, pubKey, params.MasterFingerprint, addrSchema,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if params.DryRun {
+		return dryRunImportedAccount(
+			ns, scopedMgr, accountNumber, walletIsWatchOnly,
+		)
+	}
+
+	// Persist the creation timestamp into the kvdb-owned side
+	// bucket. The subsequent loadAccountInfo call reads it back.
+	err = putAccountCreatedAt(
+		ns, scope, accountNumber, time.Now().UTC(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("persist created-at: %w", err)
+	}
+
+	return loadAccountInfo(
+		ns, scopedMgr, accountNumber, walletIsWatchOnly,
+	)
+}
+
+// scopedManagerOrCreate returns the scoped key manager for the given scope.
+// It falls back to creating the scope on persisted imports, but not on dry
+// runs because NewScopedKeyManager mutates the in-memory manager before the
+// surrounding walletdb transaction can roll back.
+func (s *Store) scopedManagerOrCreate(ns walletdb.ReadWriteBucket,
+	scope waddrmgr.KeyScope,
+	addrSchema *waddrmgr.ScopeAddrSchema,
+	dryRun bool) (waddrmgr.AccountStore, error) {
+
+	scopedMgr, err := s.addrStore.FetchScopedKeyManager(scope)
+	if err == nil {
+		return scopedMgr, nil
+	}
+
+	if !waddrmgr.IsError(err, waddrmgr.ErrScopeNotFound) {
+		return nil, translateAccountErr(err, db.ErrAccountNotFound)
+	}
+
+	if dryRun {
+		return nil, translateAccountErr(err, db.ErrKeyScopeNotFound)
+	}
+
+	if addrSchema == nil {
+		defaultSchema, ok := waddrmgr.ScopeAddrMap[scope]
+		if !ok {
+			return nil, fmt.Errorf("%w %s", errNoDefaultSchema, scope)
+		}
+
+		addrSchema = &defaultSchema
+	}
+
+	scopedMgr, err = s.addrStore.NewScopedKeyManager(
+		ns, scope, *addrSchema,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("new scoped key manager: %w", err)
+	}
+
+	return scopedMgr, nil
+}
+
+// dryRunImportedAccount validates an imported account by deriving one external
+// and one internal address, then returns the refreshed account snapshot. The
+// caller rolls back the surrounding transaction.
+func dryRunImportedAccount(ns walletdb.ReadWriteBucket,
+	scopedMgr waddrmgr.AccountStore, accountNumber uint32,
+	walletIsWatchOnly bool) (*db.AccountInfo, error) {
+
+	defer scopedMgr.InvalidateAccountCache(accountNumber)
+
+	_, err := scopedMgr.NextExternalAddresses(ns, accountNumber, 1)
+	if err != nil {
+		return nil, fmt.Errorf("derive external address: %w", err)
+	}
+
+	_, err = scopedMgr.NextInternalAddresses(ns, accountNumber, 1)
+	if err != nil {
+		return nil, fmt.Errorf("derive internal address: %w", err)
+	}
+
+	return loadAccountInfo(
+		ns, scopedMgr, accountNumber, walletIsWatchOnly,
+	)
+}
+
+// waddrmgrScopeAddrSchema converts the account-store schema type into the
+// waddrmgr per-account address schema type.
+func waddrmgrScopeAddrSchema(
+	schema *db.ScopeAddrSchema) *waddrmgr.ScopeAddrSchema {
+
+	if schema == nil {
+		return nil
+	}
+
+	return &waddrmgr.ScopeAddrSchema{
+		ExternalAddrType: waddrmgr.AddressType(schema.ExternalAddrType),
+		InternalAddrType: waddrmgr.AddressType(schema.InternalAddrType),
+	}
 }
 
 // GetAccount returns the account identified by the given query within the
@@ -361,11 +578,15 @@ func loadAccountInfo(ns walletdb.ReadBucket,
 	// wallet-layer override fills in the cached value at the public
 	// boundary for the legacy case.
 	fingerprint := props.MasterKeyFingerprint
-	if persisted, ok, fpErr := getAccountMasterFingerprint(
+
+	persisted, ok, fpErr := getAccountMasterFingerprint(
 		ns, scope, props.AccountNumber,
-	); fpErr != nil {
+	)
+	if fpErr != nil {
 		return nil, fmt.Errorf("read master fingerprint: %w", fpErr)
-	} else if ok {
+	}
+
+	if ok {
 		fingerprint = persisted
 	}
 
@@ -644,6 +865,11 @@ func (s *Store) RenameAccount(_ context.Context,
 			return err
 		}
 
+		err = assertRenameableAccount(ns, scopedMgr, acctNum)
+		if err != nil {
+			return err
+		}
+
 		err = scopedMgr.RenameAccount(ns, acctNum, params.NewName)
 		if err != nil {
 			return translateAccountErr(err, db.ErrAccountNotFound)
@@ -669,6 +895,28 @@ func resolveRenameAccountNumber(ns walletdb.ReadBucket,
 	}
 
 	return acctNum, nil
+}
+
+// assertRenameableAccount rejects imported accounts before calling
+// waddrmgr.RenameAccount, which only knows about the legacy imported-address
+// pseudo-account slot.
+func assertRenameableAccount(ns walletdb.ReadBucket,
+	scopedMgr waddrmgr.AccountStore, acctNum uint32) error {
+
+	if acctNum == waddrmgr.ImportedAddrAccount {
+		return db.ErrAccountNotFound
+	}
+
+	isImported, err := scopedMgr.IsImportedAccount(ns, acctNum)
+	if err != nil {
+		return translateAccountErr(err, db.ErrAccountNotFound)
+	}
+
+	if isImported {
+		return db.ErrAccountNotFound
+	}
+
+	return nil
 }
 
 // accountBalanceKey identifies one (scope, account) bucket within the

--- a/wallet/internal/db/kvdb/accountstore.go
+++ b/wallet/internal/db/kvdb/accountstore.go
@@ -2,8 +2,11 @@ package kvdb
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/txscript"
@@ -12,12 +15,171 @@ import (
 	"github.com/btcsuite/btcwallet/walletdb"
 )
 
-// CreateDerivedAccount is not yet implemented for kvdb.
-func (s *Store) CreateDerivedAccount(ctx context.Context,
-	_ db.CreateDerivedAccountParams,
-	_ db.AccountDerivationFunc) (*db.AccountInfo, error) {
+var (
+	// errScopedMgrUninitialized is returned by the
+	// CreateDerivedAccount ops adapter when an EnsureScope step has
+	// not yet cached the scoped manager.
+	errScopedMgrUninitialized = errors.New(
+		"kvdb: scoped manager not initialized",
+	)
+)
 
-	return nil, notImplemented(ctx, "CreateDerivedAccount")
+// CreateDerivedAccount runs the shared CreateDerivedAccountWithOps workflow
+// on top of waddrmgr's bucket layout via the createDerivedAccountOps
+// adapter.
+func (s *Store) CreateDerivedAccount(ctx context.Context,
+	params db.CreateDerivedAccountParams,
+	deriveFn db.AccountDerivationFunc) (*db.AccountInfo, error) {
+
+	mgr := s.addrStore
+
+	var info *db.AccountInfo
+
+	err := walletdb.Update(s.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+		if ns == nil {
+			return db.ErrAccountNotFound
+		}
+
+		ops := &createDerivedAccountOps{mgr: mgr, ns: ns}
+
+		built, err := db.CreateDerivedAccountWithOps(
+			ctx, params, ops, deriveFn,
+		)
+		if err != nil {
+			return err
+		}
+
+		info = built
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return info, nil
+}
+
+// createDerivedAccountOps adapts the shared workflow to waddrmgr. The
+// same walletdb tx (via ns) covers every step so allocation and
+// persistence roll back together on failure.
+type createDerivedAccountOps struct {
+	mgr       waddrmgr.AddrStore
+	ns        walletdb.ReadWriteBucket
+	scope     waddrmgr.KeyScope
+	scopedMgr waddrmgr.AccountStore
+}
+
+// WalletWatchOnly implements db.CreateDerivedAccountOps.
+func (o *createDerivedAccountOps) WalletWatchOnly(
+	_ context.Context, _ uint32) (bool, error) {
+
+	return o.mgr.WatchOnly(), nil
+}
+
+// EnsureScope implements db.CreateDerivedAccountOps. waddrmgr scopes are
+// pre-registered; the call only fetches and caches the scoped manager.
+func (o *createDerivedAccountOps) EnsureScope(_ context.Context,
+	_ uint32, scope db.KeyScope) (int64, error) {
+
+	waddrScope := waddrmgr.KeyScope{
+		Purpose: scope.Purpose,
+		Coin:    scope.Coin,
+	}
+
+	scopedMgr, err := o.mgr.FetchScopedKeyManager(waddrScope)
+	if err != nil {
+		return 0, translateAccountErr(err, db.ErrAccountNotFound)
+	}
+
+	o.scope = waddrScope
+	o.scopedMgr = scopedMgr
+
+	return 0, nil
+}
+
+// AllocateAccountNumber implements db.CreateDerivedAccountOps.
+func (o *createDerivedAccountOps) AllocateAccountNumber(_ context.Context,
+	_ int64) (int64, error) {
+
+	if o.scopedMgr == nil {
+		return 0, errScopedMgrUninitialized
+	}
+
+	account, err := o.scopedMgr.AllocateDerivedAccountNumber(o.ns)
+	if err != nil {
+		return 0, fmt.Errorf("allocate account number: %w", err)
+	}
+
+	return int64(account), nil
+}
+
+// CreateDerivedAccount implements db.CreateDerivedAccountOps. The plaintext
+// public key is encrypted via waddrmgr cryptoKeyPub inside
+// PutDerivedAccountWithKeys.
+func (o *createDerivedAccountOps) CreateDerivedAccount(_ context.Context,
+	_ int64, accountNumber int64, name string,
+	derived *db.DerivedAccountData) (db.CreateDerivedAccountRow, error) {
+
+	if o.scopedMgr == nil {
+		return db.CreateDerivedAccountRow{}, errScopedMgrUninitialized
+	}
+
+	//nolint:gosec // accountNumber is bounded by MaxAccountNumber.
+	err := o.scopedMgr.PutDerivedAccountWithKeys(
+		o.ns, uint32(accountNumber), name,
+		derived.PublicKey, derived.EncryptedPrivateKey,
+	)
+	if err != nil {
+		return db.CreateDerivedAccountRow{}, fmt.Errorf(
+			"put derived account: %w", err,
+		)
+	}
+
+	// Persist the creation timestamp into the kvdb-owned side
+	// bucket. Returning the same value to the caller keeps the
+	// create return and the next read in sync.
+	now := time.Now().UTC()
+	scope := o.scopedMgr.Scope()
+
+	//nolint:gosec // accountNumber is bounded by MaxAccountNumber.
+	err = putAccountCreatedAt(
+		o.ns, scope, uint32(accountNumber), now,
+	)
+	if err != nil {
+		return db.CreateDerivedAccountRow{}, fmt.Errorf(
+			"persist created-at: %w", err,
+		)
+	}
+
+	// Persist the master fingerprint into a parallel kvdb-owned
+	// side bucket. waddrmgr's default-account row has no
+	// fingerprint column, so without this the derived round-trip
+	// would read back 0 from props on every subsequent
+	// GetAccount/ListAccount; the wallet layer would then have to
+	// fill it in via the legacy override. New rows written through
+	// this path round-trip the value natively; legacy rows
+	// (created before this side bucket existed) still rely on the
+	// wallet-layer override as the canonical compatibility fallback.
+	//nolint:gosec // accountNumber is bounded by MaxAccountNumber.
+	err = putAccountMasterFingerprint(
+		o.ns, scope, uint32(accountNumber),
+		derived.MasterKeyFingerprint,
+	)
+	if err != nil {
+		return db.CreateDerivedAccountRow{}, fmt.Errorf(
+			"persist master fingerprint: %w", err,
+		)
+	}
+
+	return db.CreateDerivedAccountRow{
+		AccountNumber: sql.NullInt64{
+			Int64: accountNumber,
+			Valid: true,
+		},
+		CreatedAt: now,
+	}, nil
 }
 
 // CreateImportedAccount is not yet implemented for kvdb.
@@ -191,10 +353,21 @@ func loadAccountInfo(ns walletdb.ReadBucket,
 
 	// For imported accounts the per-row master_fingerprint is the
 	// parent xpub fingerprint persisted on the watch-only row. For
-	// derived accounts waddrmgr's default-account row stores 0;
-	// Wallet.GetAccount and Wallet.listAccountInfos fill in the
-	// cached master fingerprint after the read.
+	// derived accounts waddrmgr's default-account row has no
+	// fingerprint column; the kvdb side bucket
+	// (accountMasterFingerprintBucketKey) holds it for new rows
+	// written through this adapter. Legacy derived rows have no
+	// side-bucket entry and props.MasterKeyFingerprint is 0; the
+	// wallet-layer override fills in the cached value at the public
+	// boundary for the legacy case.
 	fingerprint := props.MasterKeyFingerprint
+	if persisted, ok, fpErr := getAccountMasterFingerprint(
+		ns, scope, props.AccountNumber,
+	); fpErr != nil {
+		return nil, fmt.Errorf("read master fingerprint: %w", fpErr)
+	} else if ok {
+		fingerprint = persisted
+	}
 
 	// Imported accounts in kvdb share waddrmgr's per-scope counter
 	// internally, but the AccountInfo contract masks their

--- a/wallet/internal/db/kvdb/accountstore.go
+++ b/wallet/internal/db/kvdb/accountstore.go
@@ -437,11 +437,65 @@ func selectScopedManagers(mgr waddrmgr.AddrStore, filter *db.KeyScope) (
 	return []waddrmgr.AccountStore{scopedMgr}, nil
 }
 
-// RenameAccount is not yet implemented for kvdb.
-func (s *Store) RenameAccount(ctx context.Context,
-	_ db.RenameAccountParams) error {
+// RenameAccount renames an existing account within a scope.
+func (s *Store) RenameAccount(_ context.Context,
+	params db.RenameAccountParams) error {
 
-	return notImplemented(ctx, "RenameAccount")
+	err := params.Validate()
+	if err != nil {
+		return err
+	}
+
+	mgr := s.addrStore
+
+	scope := waddrmgr.KeyScope{
+		Purpose: params.Scope.Purpose,
+		Coin:    params.Scope.Coin,
+	}
+
+	return walletdb.Update(s.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+		if ns == nil {
+			return db.ErrAccountNotFound
+		}
+
+		scopedMgr, err := mgr.FetchScopedKeyManager(scope)
+		if err != nil {
+			return translateAccountErr(err, db.ErrAccountNotFound)
+		}
+
+		acctNum, err := resolveRenameAccountNumber(
+			ns, scopedMgr, params,
+		)
+		if err != nil {
+			return err
+		}
+
+		err = scopedMgr.RenameAccount(ns, acctNum, params.NewName)
+		if err != nil {
+			return translateAccountErr(err, db.ErrAccountNotFound)
+		}
+
+		return nil
+	})
+}
+
+// resolveRenameAccountNumber turns a RenameAccountParams into the legacy
+// account number, looking up by OldName when AccountNumber is nil.
+func resolveRenameAccountNumber(ns walletdb.ReadBucket,
+	scopedMgr waddrmgr.AccountStore,
+	params db.RenameAccountParams) (uint32, error) {
+
+	if params.AccountNumber != nil {
+		return *params.AccountNumber, nil
+	}
+
+	acctNum, err := scopedMgr.LookupAccount(ns, params.OldName)
+	if err != nil {
+		return 0, translateAccountErr(err, db.ErrAccountNotFound)
+	}
+
+	return acctNum, nil
 }
 
 // accountBalanceKey identifies one (scope, account) bucket within the

--- a/wallet/internal/db/kvdb/accountstore.go
+++ b/wallet/internal/db/kvdb/accountstore.go
@@ -37,6 +37,13 @@ var (
 	errNoDefaultSchema = errors.New(
 		"kvdb: no default schema for scope",
 	)
+
+	// errScopedAccountDeriverUnsupported is returned when a mocked or
+	// alternate scoped manager does not provide kvdb's native derivation
+	// fallback.
+	errScopedAccountDeriverUnsupported = errors.New(
+		"kvdb: scoped account derivation unsupported",
+	)
 )
 
 // CreateDerivedAccount runs the shared CreateDerivedAccountWithOps workflow
@@ -57,6 +64,7 @@ func (s *Store) CreateDerivedAccount(ctx context.Context,
 		}
 
 		ops := &createDerivedAccountOps{mgr: mgr, ns: ns}
+		deriveFn = ops.deriveWithScopedFallback(deriveFn)
 
 		built, err := db.CreateDerivedAccountWithOps(
 			ctx, params, ops, deriveFn,
@@ -84,6 +92,11 @@ type createDerivedAccountOps struct {
 	ns        walletdb.ReadWriteBucket
 	scope     waddrmgr.KeyScope
 	scopedMgr waddrmgr.AccountStore
+}
+
+type derivedAccountKeyDeriver interface {
+	DeriveAccountKeys(ns walletdb.ReadBucket,
+		account uint32) ([]byte, []byte, error)
 }
 
 // WalletWatchOnly implements db.CreateDerivedAccountOps.
@@ -194,6 +207,57 @@ func (o *createDerivedAccountOps) CreateDerivedAccount(_ context.Context,
 			Valid: true,
 		},
 		CreatedAt: now,
+	}, nil
+}
+
+// deriveWithScopedFallback wraps the wallet-supplied derivation callback with
+// the legacy kvdb fallback. Neutered-root wallets no longer have the master HD
+// private key, but their scoped coin-type private keys remain and are the
+// legacy source for deriving additional accounts within an existing scope.
+func (o *createDerivedAccountOps) deriveWithScopedFallback(
+	deriveFn db.AccountDerivationFunc) db.AccountDerivationFunc {
+
+	if deriveFn == nil {
+		return nil
+	}
+
+	return func(ctx context.Context, scope db.KeyScope, account uint32,
+		walletIsWatchOnly bool) (*db.DerivedAccountData, error) {
+
+		derived, err := deriveFn(
+			ctx, scope, account, walletIsWatchOnly,
+		)
+		if err == nil || !errors.Is(err, db.ErrSecretNotFound) {
+			return derived, err
+		}
+
+		return o.deriveAccountFromScopedKey(account)
+	}
+}
+
+// deriveAccountFromScopedKey derives account material from waddrmgr's scoped
+// coin-type private key after the shared workflow has allocated the next
+// account number.
+func (o *createDerivedAccountOps) deriveAccountFromScopedKey(
+	account uint32) (*db.DerivedAccountData, error) {
+
+	if o.scopedMgr == nil {
+		return nil, errScopedMgrUninitialized
+	}
+
+	deriver, ok := o.scopedMgr.(derivedAccountKeyDeriver)
+	if !ok {
+		return nil, errScopedAccountDeriverUnsupported
+	}
+
+	pubKey, encPrivKey, err := deriver.DeriveAccountKeys(o.ns, account)
+	if err != nil {
+		return nil, fmt.Errorf("derive scoped account: %w", err)
+	}
+
+	return &db.DerivedAccountData{
+		PublicKey:           pubKey,
+		EncryptedPrivateKey: encPrivKey,
 	}, nil
 }
 

--- a/wallet/internal/db/kvdb/accountstore_fingerprints.go
+++ b/wallet/internal/db/kvdb/accountstore_fingerprints.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package kvdb
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/walletdb"
+)
+
+// accountMasterFingerprintBucketKey is the sub-bucket under the
+// waddrmgr namespace that holds the per-account BIP32 master-key
+// fingerprint for derived accounts. waddrmgr's default-account row
+// has no fingerprint column at all; the kvdb adapter stores the value
+// here so the db.AccountInfo.MasterKeyFingerprint contract is
+// satisfied without changing waddrmgr's bucket layout.
+//
+// Imported (watch-only) accounts persist the fingerprint in waddrmgr's
+// accountWatchOnly row; this side bucket is derived-only.
+var accountMasterFingerprintBucketKey = []byte("account-master-fingerprint")
+
+// masterFingerprintValueLen is the on-disk byte width of a master-
+// fingerprint entry encoded as a big-endian uint32.
+const masterFingerprintValueLen = 4
+
+// errMasterFingerprintUnexpectedSize is returned when the side
+// bucket's value for an existing (scope, account) key has an
+// unexpected byte width. The kvdb adapter rejects rather than
+// silently truncating because a short value would decode as an
+// arbitrary uint32.
+var errMasterFingerprintUnexpectedSize = errors.New(
+	"master-fingerprint bucket value has unexpected byte width",
+)
+
+// putAccountMasterFingerprint writes the master fingerprint for an
+// account to the side bucket. The caller must hold a
+// walletdb.ReadWriteTx and pass the waddrmgr namespace bucket; the
+// helper creates the sub-bucket on first use.
+func putAccountMasterFingerprint(ns walletdb.ReadWriteBucket,
+	scope waddrmgr.KeyScope, account uint32, fingerprint uint32) error {
+
+	bucket, err := ns.CreateBucketIfNotExists(
+		accountMasterFingerprintBucketKey,
+	)
+	if err != nil {
+		return fmt.Errorf("create fingerprint bucket: %w", err)
+	}
+
+	// Reuse the timestamp key shape: (scope.Purpose, scope.Coin,
+	// account) packed big-endian — same per-(scope, account) layout.
+	key := newAccountCreatedAtKey(scope, account)
+
+	var value [masterFingerprintValueLen]byte
+	binary.BigEndian.PutUint32(value[:], fingerprint)
+
+	err = bucket.Put(key[:], value[:])
+	if err != nil {
+		return fmt.Errorf("put fingerprint: %w", err)
+	}
+
+	return nil
+}
+
+// getAccountMasterFingerprint returns the master fingerprint for an
+// account. If no entry exists for (scope, account) the helper returns
+// (0, false, nil) meaning "no side-bucket entry". Callers MUST treat
+// a false ok as "fall back to whatever waddrmgr has" — for legacy
+// derived rows that value is 0 (waddrmgr's default-account row has no
+// fingerprint column), so the wallet-layer override remains the
+// compatibility path for legacy data.
+func getAccountMasterFingerprint(ns walletdb.ReadBucket,
+	scope waddrmgr.KeyScope,
+	account uint32) (uint32, bool, error) {
+
+	bucket := ns.NestedReadBucket(accountMasterFingerprintBucketKey)
+	if bucket == nil {
+		return 0, false, nil
+	}
+
+	key := newAccountCreatedAtKey(scope, account)
+	raw := bucket.Get(key[:])
+
+	if raw == nil {
+		return 0, false, nil
+	}
+
+	if len(raw) != masterFingerprintValueLen {
+		return 0, false, fmt.Errorf(
+			"%w: scope=%v account=%d: expected %d bytes, got %d",
+			errMasterFingerprintUnexpectedSize, scope, account,
+			masterFingerprintValueLen, len(raw),
+		)
+	}
+
+	return binary.BigEndian.Uint32(raw), true, nil
+}

--- a/wallet/internal/db/kvdb/accountstore_fingerprints_test.go
+++ b/wallet/internal/db/kvdb/accountstore_fingerprints_test.go
@@ -1,0 +1,180 @@
+package kvdb
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil/hdkeychain"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/stretchr/testify/require"
+)
+
+// fingerprintDeriveFnFixture returns an AccountDerivationFunc local to the
+// fingerprint-test file. It derives a real account-level extended key
+// from a deterministic seed so PutDerivedAccountWithKeys' public-key
+// decryption succeeds, and stamps a fixed MasterKeyFingerprint so the
+// round-trip assertions are observable.
+//
+// This file keeps its derivation fixture local so these fingerprint tests
+// do not depend on broader account-store test helpers.
+func fingerprintDeriveFnFixture(t *testing.T,
+	mgr *waddrmgr.Manager) db.AccountDerivationFunc {
+
+	t.Helper()
+
+	seed := bytes.Repeat([]byte{0xFA}, hdkeychain.RecommendedSeedLen)
+	masterKey, err := hdkeychain.NewMaster(seed, &chaincfg.SimNetParams)
+	require.NoError(t, err)
+
+	return func(_ context.Context, scope db.KeyScope, accountNumber uint32,
+		_ bool) (*db.DerivedAccountData, error) {
+
+		purposeKey, err := masterKey.DeriveNonStandard(
+			scope.Purpose + hdkeychain.HardenedKeyStart,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		coinKey, err := purposeKey.DeriveNonStandard(
+			scope.Coin + hdkeychain.HardenedKeyStart,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		acctPriv, err := coinKey.DeriveNonStandard(
+			accountNumber + hdkeychain.HardenedKeyStart,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		acctPub, err := acctPriv.Neuter()
+		if err != nil {
+			return nil, err
+		}
+
+		encPriv, err := mgr.Encrypt(
+			waddrmgr.CKTPrivate, []byte(acctPriv.String()),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		return &db.DerivedAccountData{
+			PublicKey:            []byte(acctPub.String()),
+			EncryptedPrivateKey:  encPriv,
+			MasterKeyFingerprint: testFingerprintValue,
+		}, nil
+	}
+}
+
+// testFingerprintValue is the deterministic MasterKeyFingerprint that
+// fingerprintDeriveFnFixture stamps on every derived account.
+const testFingerprintValue uint32 = 0xC0DEC0DE
+
+// TestCreateDerivedAccountPersistsMasterKeyFingerprint verifies a
+// derived account's master fingerprint round-trips through the
+// kvdb side bucket independently of waddrmgr's default-account row
+// (which has no fingerprint column).
+func TestCreateDerivedAccountPersistsMasterKeyFingerprint(t *testing.T) {
+	t.Parallel()
+
+	store, mgr, cleanup := newAccountStoreFixture(t)
+	t.Cleanup(cleanup)
+
+	scope := db.KeyScope{
+		Purpose: waddrmgr.KeyScopeBIP0084.Purpose,
+		Coin:    waddrmgr.KeyScopeBIP0084.Coin,
+	}
+
+	deriveFn := fingerprintDeriveFnFixture(t, mgr)
+	info, err := store.CreateDerivedAccount(t.Context(),
+		db.CreateDerivedAccountParams{
+			Scope: scope,
+			Name:  "fp-derived",
+		},
+		deriveFn,
+	)
+	require.NoError(t, err)
+	require.Equal(t, testFingerprintValue, info.MasterKeyFingerprint)
+
+	// Round-trip via Store.GetAccount — the value must come back
+	// from the side bucket, not from waddrmgr's row.
+	name := "fp-derived"
+	got, err := store.GetAccount(t.Context(), db.GetAccountQuery{
+		Scope: scope,
+		Name:  &name,
+	})
+	require.NoError(t, err)
+	require.Equal(t, testFingerprintValue, got.MasterKeyFingerprint)
+}
+
+// TestLoadAccountInfoFallsBackOnMissingFingerprintRow verifies the
+// legacy-compatibility path: a derived account whose side-bucket entry
+// is missing reads back props.MasterKeyFingerprint (which is 0 for
+// waddrmgr default-account rows). The wallet-layer override is the
+// canonical compatibility fallback at the public boundary; this test
+// pins the store-layer behavior (returns 0 honestly).
+func TestLoadAccountInfoFallsBackOnMissingFingerprintRow(t *testing.T) {
+	t.Parallel()
+
+	store, mgr, cleanup := newAccountStoreFixture(t)
+	t.Cleanup(cleanup)
+
+	scope := db.KeyScope{
+		Purpose: waddrmgr.KeyScopeBIP0084.Purpose,
+		Coin:    waddrmgr.KeyScopeBIP0084.Coin,
+	}
+	mgrScope := waddrmgr.KeyScope{
+		Purpose: scope.Purpose, Coin: scope.Coin,
+	}
+
+	deriveFn := fingerprintDeriveFnFixture(t, mgr)
+	info, err := store.CreateDerivedAccount(
+		t.Context(),
+		db.CreateDerivedAccountParams{
+			Scope: scope,
+			Name:  "fp-derived-fallback",
+		},
+		deriveFn,
+	)
+	require.NoError(t, err)
+	require.Equal(t, testFingerprintValue, info.MasterKeyFingerprint)
+
+	// Manually delete the side-bucket entry to simulate a legacy
+	// derived account that pre-dates the side bucket.
+	err = walletdb.Update(store.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+		bucket := ns.NestedReadWriteBucket(
+			accountMasterFingerprintBucketKey,
+		)
+		require.NotNil(t, bucket)
+
+		key := newAccountCreatedAtKey(
+			mgrScope, info.AccountNumber,
+		)
+
+		return bucket.Delete(key[:])
+	})
+	require.NoError(t, err)
+
+	// Read back — store now returns 0 (waddrmgr's default-account
+	// row has no fingerprint). The wallet-layer override outside
+	// of kvdb backfills the cached master fingerprint at the
+	// public boundary.
+	name := "fp-derived-fallback"
+	got, err := store.GetAccount(t.Context(), db.GetAccountQuery{
+		Scope: scope,
+		Name:  &name,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint32(0), got.MasterKeyFingerprint,
+		"missing side-bucket entry must fall back to waddrmgr's 0",
+	)
+}

--- a/wallet/internal/db/kvdb/accountstore_test.go
+++ b/wallet/internal/db/kvdb/accountstore_test.go
@@ -189,6 +189,80 @@ func TestListAccountsByNameIncludesImportedPseudoAccount(t *testing.T) {
 	require.Equal(t, uint32(0), infos[0].AccountNumber)
 }
 
+// TestRenameAccountByName verifies that RenameAccount renames by old
+// name and that GetAccount with the new name returns the same row.
+func TestRenameAccountByName(t *testing.T) {
+	t.Parallel()
+
+	store, mgr, cleanup := newAccountStoreFixture(t)
+	t.Cleanup(cleanup)
+
+	accountNumber := createDerivedAccount(
+		t, store.db, mgr, waddrmgr.KeyScopeBIP0084, savingsAccountName,
+	)
+
+	err := store.RenameAccount(t.Context(), db.RenameAccountParams{
+		Scope: db.KeyScope{
+			Purpose: waddrmgr.KeyScopeBIP0084.Purpose,
+			Coin:    waddrmgr.KeyScopeBIP0084.Coin,
+		},
+		OldName: savingsAccountName,
+		NewName: "renamed",
+	})
+	require.NoError(t, err)
+
+	newName := "renamed"
+	info, err := store.GetAccount(t.Context(), db.GetAccountQuery{
+		Scope: db.KeyScope{
+			Purpose: waddrmgr.KeyScopeBIP0084.Purpose,
+			Coin:    waddrmgr.KeyScopeBIP0084.Coin,
+		},
+		Name: &newName,
+	})
+	require.NoError(t, err)
+	require.Equal(t, accountNumber, info.AccountNumber)
+}
+
+// TestRenameAccountByNumber verifies the AccountNumber-keyed rename branch.
+func TestRenameAccountByNumber(t *testing.T) {
+	t.Parallel()
+
+	store, mgr, cleanup := newAccountStoreFixture(t)
+	t.Cleanup(cleanup)
+
+	accountNumber := createDerivedAccount(
+		t, store.db, mgr, waddrmgr.KeyScopeBIP0084, savingsAccountName,
+	)
+
+	err := store.RenameAccount(t.Context(), db.RenameAccountParams{
+		Scope: db.KeyScope{
+			Purpose: waddrmgr.KeyScopeBIP0084.Purpose,
+			Coin:    waddrmgr.KeyScopeBIP0084.Coin,
+		},
+		AccountNumber: &accountNumber,
+		NewName:       "renamed-by-number",
+	})
+	require.NoError(t, err)
+}
+
+// TestRenameAccountNotFound verifies the not-found translation.
+func TestRenameAccountNotFound(t *testing.T) {
+	t.Parallel()
+
+	store, _, cleanup := newAccountStoreFixture(t)
+	t.Cleanup(cleanup)
+
+	err := store.RenameAccount(t.Context(), db.RenameAccountParams{
+		Scope: db.KeyScope{
+			Purpose: waddrmgr.KeyScopeBIP0084.Purpose,
+			Coin:    waddrmgr.KeyScopeBIP0084.Coin,
+		},
+		OldName: "nonexistent",
+		NewName: "anything",
+	})
+	require.ErrorIs(t, err, db.ErrAccountNotFound)
+}
+
 // newCreditedFixture builds an account store backed by a spendable wallet
 // with a wired-up wtxmgr txStore and returns a helper that credits a
 // confirmed UTXO at the next external address of a derived account.

--- a/wallet/internal/db/kvdb/accountstore_test.go
+++ b/wallet/internal/db/kvdb/accountstore_test.go
@@ -494,6 +494,59 @@ func TestCreateDerivedAccountRollsBackOnDeriveError(t *testing.T) {
 		"account numbers should be contiguous after rollback")
 }
 
+// TestCreateDerivedAccountFallsBackToScopedKey verifies that kvdb can create
+// derived accounts after the master root private key has been neutered.
+func TestCreateDerivedAccountFallsBackToScopedKey(t *testing.T) {
+	t.Parallel()
+
+	store, mgr, cleanup := newAccountStoreFixture(t)
+	t.Cleanup(cleanup)
+
+	err := walletdb.Update(store.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+		return mgr.NeuterRootKey(ns)
+	})
+	require.NoError(t, err)
+
+	_, err = store.GetEncryptedHDSeed(t.Context(), 0)
+	require.ErrorIs(t, err, db.ErrSecretNotFound)
+
+	missingRootDerive := func(_ context.Context, _ db.KeyScope, _ uint32,
+		_ bool) (*db.DerivedAccountData, error) {
+
+		return nil, db.ErrSecretNotFound
+	}
+
+	info, err := store.CreateDerivedAccount(t.Context(),
+		db.CreateDerivedAccountParams{
+			Scope: db.KeyScope{
+				Purpose: waddrmgr.KeyScopeBIP0084.Purpose,
+				Coin:    waddrmgr.KeyScopeBIP0084.Coin,
+			},
+			Name: savingsAccountName,
+		}, missingRootDerive,
+	)
+	require.NoError(t, err)
+	require.Equal(t, savingsAccountName, info.AccountName)
+	require.Equal(t, db.DerivedAccount, info.Origin)
+	require.NotEmpty(t, info.PublicKey)
+
+	parsed, err := hdkeychain.NewKeyFromString(string(info.PublicKey))
+	require.NoError(t, err)
+	require.False(t, parsed.IsPrivate())
+
+	name := savingsAccountName
+	read, err := store.GetAccount(t.Context(), db.GetAccountQuery{
+		Scope: db.KeyScope{
+			Purpose: waddrmgr.KeyScopeBIP0084.Purpose,
+			Coin:    waddrmgr.KeyScopeBIP0084.Coin,
+		},
+		Name: &name,
+	})
+	require.NoError(t, err)
+	require.Equal(t, info.AccountNumber, read.AccountNumber)
+}
+
 var errTestBoom = errors.New("kvdb test boom")
 
 // TestCreateImportedAccount verifies the watch-only-imported account

--- a/wallet/internal/db/kvdb/accountstore_test.go
+++ b/wallet/internal/db/kvdb/accountstore_test.go
@@ -1,12 +1,16 @@
 package kvdb
 
 import (
+	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
@@ -262,6 +266,166 @@ func TestRenameAccountNotFound(t *testing.T) {
 	})
 	require.ErrorIs(t, err, db.ErrAccountNotFound)
 }
+
+// kvdbDeriveFnFixture returns an AccountDerivationFunc that derives an
+// account-level extended key from the test wallet's known seed. The
+// resulting DerivedAccountData mirrors the production wallet's deriveFn:
+// plaintext PublicKey + encrypted private key (encrypted with the test
+// manager's cryptoKeyPriv) + fixed MasterKeyFingerprint.
+func kvdbDeriveFnFixture(t *testing.T,
+	mgr *waddrmgr.Manager) db.AccountDerivationFunc {
+
+	t.Helper()
+
+	seed := bytes.Repeat([]byte{0x5A}, hdkeychain.RecommendedSeedLen)
+	masterKey, err := hdkeychain.NewMaster(seed, &chaincfg.SimNetParams)
+	require.NoError(t, err)
+
+	return func(_ context.Context, scope db.KeyScope, accountNumber uint32,
+		_ bool) (*db.DerivedAccountData, error) {
+
+		purposeKey, err := masterKey.DeriveNonStandard(
+			scope.Purpose + hdkeychain.HardenedKeyStart,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		coinKey, err := purposeKey.DeriveNonStandard(
+			scope.Coin + hdkeychain.HardenedKeyStart,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		acctPriv, err := coinKey.DeriveNonStandard(
+			accountNumber + hdkeychain.HardenedKeyStart,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		acctPub, err := acctPriv.Neuter()
+		if err != nil {
+			return nil, err
+		}
+
+		encPriv, err := mgr.Encrypt(
+			waddrmgr.CKTPrivate, []byte(acctPriv.String()),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		return &db.DerivedAccountData{
+			PublicKey:            []byte(acctPub.String()),
+			EncryptedPrivateKey:  encPriv,
+			MasterKeyFingerprint: 0xC0DEC0DE,
+		}, nil
+	}
+}
+
+// TestCreateDerivedAccount verifies that CreateDerivedAccount persists
+// the wallet-derived account material and that a subsequent GetAccount
+// returns the same row.
+func TestCreateDerivedAccount(t *testing.T) {
+	t.Parallel()
+
+	store, mgr, cleanup := newAccountStoreFixture(t)
+	t.Cleanup(cleanup)
+
+	deriveFn := kvdbDeriveFnFixture(t, mgr)
+
+	info, err := store.CreateDerivedAccount(t.Context(),
+		db.CreateDerivedAccountParams{
+			Scope: db.KeyScope{
+				Purpose: waddrmgr.KeyScopeBIP0084.Purpose,
+				Coin:    waddrmgr.KeyScopeBIP0084.Coin,
+			},
+			Name: savingsAccountName,
+		}, deriveFn,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	require.Equal(t, savingsAccountName, info.AccountName)
+	require.Equal(t, db.DerivedAccount, info.Origin)
+	require.NotEmpty(t, info.PublicKey)
+	require.Equal(t, uint32(0xC0DEC0DE), info.MasterKeyFingerprint)
+
+	// A subsequent GetAccount must observe the new row.
+	name := savingsAccountName
+	read, err := store.GetAccount(t.Context(), db.GetAccountQuery{
+		Scope: db.KeyScope{
+			Purpose: waddrmgr.KeyScopeBIP0084.Purpose,
+			Coin:    waddrmgr.KeyScopeBIP0084.Coin,
+		},
+		Name: &name,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, read)
+	require.Equal(t, info.AccountNumber, read.AccountNumber)
+	require.Equal(t, savingsAccountName, read.AccountName)
+}
+
+// TestCreateDerivedAccountRollsBackOnDeriveError verifies that when the
+// derivation callback fails after the account number has been allocated,
+// the underlying walletdb transaction rolls back so the lastAccount counter
+// is restored.
+func TestCreateDerivedAccountRollsBackOnDeriveError(t *testing.T) {
+	t.Parallel()
+
+	store, mgr, cleanup := newAccountStoreFixture(t)
+	t.Cleanup(cleanup)
+
+	failDerive := func(_ context.Context, _ db.KeyScope, _ uint32,
+		_ bool) (*db.DerivedAccountData, error) {
+
+		return nil, errTestBoom
+	}
+
+	_, err := store.CreateDerivedAccount(t.Context(),
+		db.CreateDerivedAccountParams{
+			Scope: db.KeyScope{
+				Purpose: waddrmgr.KeyScopeBIP0084.Purpose,
+				Coin:    waddrmgr.KeyScopeBIP0084.Coin,
+			},
+			Name: "doomed",
+		}, failDerive,
+	)
+	require.ErrorIs(t, err, errTestBoom)
+
+	// Now a successful CreateDerivedAccount must reuse the rolled-back
+	// account number rather than skipping it; we verify by creating two
+	// accounts and observing contiguous account numbers.
+	deriveFn := kvdbDeriveFnFixture(t, mgr)
+
+	info1, err := store.CreateDerivedAccount(t.Context(),
+		db.CreateDerivedAccountParams{
+			Scope: db.KeyScope{
+				Purpose: waddrmgr.KeyScopeBIP0084.Purpose,
+				Coin:    waddrmgr.KeyScopeBIP0084.Coin,
+			},
+			Name: "first",
+		}, deriveFn,
+	)
+	require.NoError(t, err)
+
+	info2, err := store.CreateDerivedAccount(t.Context(),
+		db.CreateDerivedAccountParams{
+			Scope: db.KeyScope{
+				Purpose: waddrmgr.KeyScopeBIP0084.Purpose,
+				Coin:    waddrmgr.KeyScopeBIP0084.Coin,
+			},
+			Name: "second",
+		}, deriveFn,
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, info1.AccountNumber+1, info2.AccountNumber,
+		"account numbers should be contiguous after rollback")
+}
+
+var errTestBoom = errors.New("kvdb test boom")
 
 // newCreditedFixture builds an account store backed by a spendable wallet
 // with a wired-up wtxmgr txStore and returns a helper that credits a

--- a/wallet/internal/db/kvdb/accountstore_test.go
+++ b/wallet/internal/db/kvdb/accountstore_test.go
@@ -267,6 +267,75 @@ func TestRenameAccountNotFound(t *testing.T) {
 	require.ErrorIs(t, err, db.ErrAccountNotFound)
 }
 
+// TestRenameAccountRejectsImported verifies that kvdb rejects imported account
+// renames both by name and by waddrmgr's internal account number.
+func TestRenameAccountRejectsImported(t *testing.T) {
+	t.Parallel()
+
+	store, _, cleanup := newAccountStoreFixture(t)
+	t.Cleanup(cleanup)
+
+	seed := bytes.Repeat([]byte{0xC1}, hdkeychain.RecommendedSeedLen)
+	master, err := hdkeychain.NewMaster(seed, &chaincfg.SimNetParams)
+	require.NoError(t, err)
+	masterPub, err := master.Neuter()
+	require.NoError(t, err)
+
+	scope := db.KeyScope{
+		Purpose: waddrmgr.KeyScopeBIP0084.Purpose,
+		Coin:    waddrmgr.KeyScopeBIP0084.Coin,
+	}
+	name := "imported-rename"
+
+	_, err = store.CreateImportedAccount(t.Context(),
+		db.CreateImportedAccountParams{
+			Scope:             scope,
+			Name:              name,
+			MasterFingerprint: 0xDEADBEEF,
+			PublicKey:         []byte(masterPub.String()),
+		},
+	)
+	require.NoError(t, err)
+
+	err = store.RenameAccount(t.Context(), db.RenameAccountParams{
+		Scope:   scope,
+		OldName: name,
+		NewName: "renamed-imported",
+	})
+	require.ErrorIs(t, err, db.ErrAccountNotFound)
+
+	mgrScope := waddrmgr.KeyScope(scope)
+	scopedMgr, err := store.addrStore.FetchScopedKeyManager(mgrScope)
+	require.NoError(t, err)
+
+	var internalNumber uint32
+
+	err = walletdb.View(store.db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgr.NamespaceKey)
+
+		var err error
+
+		internalNumber, err = scopedMgr.LookupAccount(ns, name)
+
+		return err
+	})
+	require.NoError(t, err)
+
+	err = store.RenameAccount(t.Context(), db.RenameAccountParams{
+		Scope:         scope,
+		AccountNumber: &internalNumber,
+		NewName:       "renamed-imported",
+	})
+	require.ErrorIs(t, err, db.ErrAccountNotFound)
+
+	info, err := store.GetAccount(t.Context(), db.GetAccountQuery{
+		Scope: scope,
+		Name:  &name,
+	})
+	require.NoError(t, err)
+	require.Equal(t, name, info.AccountName)
+}
+
 // kvdbDeriveFnFixture returns an AccountDerivationFunc that derives an
 // account-level extended key from the test wallet's known seed. The
 // resulting DerivedAccountData mirrors the production wallet's deriveFn:
@@ -426,6 +495,219 @@ func TestCreateDerivedAccountRollsBackOnDeriveError(t *testing.T) {
 }
 
 var errTestBoom = errors.New("kvdb test boom")
+
+// TestCreateImportedAccount verifies the watch-only-imported account
+// path: kvdb persists the row, GetAccount returns Origin=ImportedAccount,
+// and the AccountInfo.MasterKeyFingerprint round-trips.
+func TestCreateImportedAccount(t *testing.T) {
+	t.Parallel()
+
+	store, _, cleanup := newAccountStoreFixture(t)
+	t.Cleanup(cleanup)
+
+	// Build a deterministic account-level pub key for the import.
+	seed := bytes.Repeat([]byte{0xBB}, hdkeychain.RecommendedSeedLen)
+	master, err := hdkeychain.NewMaster(seed, &chaincfg.SimNetParams)
+	require.NoError(t, err)
+	masterPub, err := master.Neuter()
+	require.NoError(t, err)
+
+	info, err := store.CreateImportedAccount(t.Context(),
+		db.CreateImportedAccountParams{
+			Scope: db.KeyScope{
+				Purpose: waddrmgr.KeyScopeBIP0084.Purpose,
+				Coin:    waddrmgr.KeyScopeBIP0084.Coin,
+			},
+			Name:              "imported-xpub",
+			MasterFingerprint: 0xDEADBEEF,
+			PublicKey:         []byte(masterPub.String()),
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	require.Equal(t, "imported-xpub", info.AccountName)
+	require.Equal(t, db.ImportedAccount, info.Origin)
+	require.True(t, info.IsWatchOnly)
+	require.Equal(t, uint32(0xDEADBEEF), info.MasterKeyFingerprint)
+}
+
+// TestCreateImportedAccountRejectsPrivateKey verifies that the kvdb
+// adapter refuses imported accounts with private key material on
+// spendable wallets, since waddrmgr's accountWatchOnly row has no
+// private-key column.
+func TestCreateImportedAccountRejectsPrivateKey(t *testing.T) {
+	t.Parallel()
+
+	store, _, cleanup := newAccountStoreFixture(t)
+	t.Cleanup(cleanup)
+
+	seed := bytes.Repeat([]byte{0xBB}, hdkeychain.RecommendedSeedLen)
+	master, err := hdkeychain.NewMaster(seed, &chaincfg.SimNetParams)
+	require.NoError(t, err)
+	masterPub, err := master.Neuter()
+	require.NoError(t, err)
+
+	_, err = store.CreateImportedAccount(t.Context(),
+		db.CreateImportedAccountParams{
+			Scope: db.KeyScope{
+				Purpose: waddrmgr.KeyScopeBIP0084.Purpose,
+				Coin:    waddrmgr.KeyScopeBIP0084.Coin,
+			},
+			Name:                "imported-spendable",
+			MasterFingerprint:   0xDEADBEEF,
+			PublicKey:           []byte(masterPub.String()),
+			EncryptedPrivateKey: []byte{0xAA, 0xBB},
+		},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not supported")
+}
+
+// TestCreateImportedAccountDryRunRollsBack verifies that DryRun validates the
+// import and derives sample addresses without persisting the imported row.
+func TestCreateImportedAccountDryRunRollsBack(t *testing.T) {
+	t.Parallel()
+
+	store, _, cleanup := newAccountStoreFixture(t)
+	t.Cleanup(cleanup)
+
+	seed := bytes.Repeat([]byte{0xBC}, hdkeychain.RecommendedSeedLen)
+	master, err := hdkeychain.NewMaster(seed, &chaincfg.SimNetParams)
+	require.NoError(t, err)
+	masterPub, err := master.Neuter()
+	require.NoError(t, err)
+
+	scope := db.KeyScope{
+		Purpose: waddrmgr.KeyScopeBIP0084.Purpose,
+		Coin:    waddrmgr.KeyScopeBIP0084.Coin,
+	}
+	name := "imported-dry-run"
+
+	info, err := store.CreateImportedAccount(t.Context(),
+		db.CreateImportedAccountParams{
+			Scope:             scope,
+			Name:              name,
+			MasterFingerprint: 0xDEADBEEF,
+			PublicKey:         []byte(masterPub.String()),
+			DryRun:            true,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, name, info.AccountName)
+
+	_, err = store.GetAccount(t.Context(), db.GetAccountQuery{
+		Scope: scope,
+		Name:  &name,
+	})
+	require.ErrorIs(t, err, db.ErrAccountNotFound)
+}
+
+// TestCreateImportedAccountDryRunMissingScopeDoesNotRegisterScope verifies a
+// dry run does not leave a missing scope registered in memory after the
+// database transaction rolls back.
+func TestCreateImportedAccountDryRunMissingScopeDoesNotRegisterScope(
+	t *testing.T) {
+
+	t.Parallel()
+
+	store, _, cleanup := newAccountStoreFixture(t)
+	t.Cleanup(cleanup)
+
+	seed := bytes.Repeat([]byte{0xC2}, hdkeychain.RecommendedSeedLen)
+	master, err := hdkeychain.NewMaster(seed, &chaincfg.SimNetParams)
+	require.NoError(t, err)
+	masterPub, err := master.Neuter()
+	require.NoError(t, err)
+
+	scope := db.KeyScope{Purpose: 1234, Coin: 0}
+	mgrScope := waddrmgr.KeyScope(scope)
+	addrSchema := db.ScopeAddrSchema{
+		ExternalAddrType: db.WitnessPubKey,
+		InternalAddrType: db.WitnessPubKey,
+	}
+
+	_, err = store.addrStore.FetchScopedKeyManager(mgrScope)
+	require.True(t, waddrmgr.IsError(err, waddrmgr.ErrScopeNotFound))
+
+	_, err = store.CreateImportedAccount(t.Context(),
+		db.CreateImportedAccountParams{
+			Scope:             scope,
+			Name:              "dry-run-missing-scope",
+			MasterFingerprint: 0xDEADBEEF,
+			PublicKey:         []byte(masterPub.String()),
+			AddrSchema:        &addrSchema,
+			DryRun:            true,
+		},
+	)
+	require.ErrorIs(t, err, db.ErrKeyScopeNotFound)
+
+	_, err = store.addrStore.FetchScopedKeyManager(mgrScope)
+	require.True(t, waddrmgr.IsError(err, waddrmgr.ErrScopeNotFound))
+}
+
+// TestCreateImportedAccountUsesAddrSchema verifies that kvdb forwards the
+// per-account address schema override to waddrmgr.
+func TestCreateImportedAccountUsesAddrSchema(t *testing.T) {
+	t.Parallel()
+
+	store, _, cleanup := newAccountStoreFixture(t)
+	t.Cleanup(cleanup)
+
+	seed := bytes.Repeat([]byte{0xBD}, hdkeychain.RecommendedSeedLen)
+	master, err := hdkeychain.NewMaster(seed, &chaincfg.SimNetParams)
+	require.NoError(t, err)
+	masterPub, err := master.Neuter()
+	require.NoError(t, err)
+
+	scope := db.KeyScope{
+		Purpose: waddrmgr.KeyScopeBIP0049Plus.Purpose,
+		Coin:    waddrmgr.KeyScopeBIP0049Plus.Coin,
+	}
+	addrSchema := db.ScopeAddrSchema{
+		ExternalAddrType: db.NestedWitnessPubKey,
+		InternalAddrType: db.NestedWitnessPubKey,
+	}
+
+	name := "imported-schema"
+	_, err = store.CreateImportedAccount(t.Context(),
+		db.CreateImportedAccountParams{
+			Scope:             scope,
+			Name:              name,
+			MasterFingerprint: 0xDEADBEEF,
+			PublicKey:         []byte(masterPub.String()),
+			AddrSchema:        &addrSchema,
+		},
+	)
+	require.NoError(t, err)
+
+	scopedMgr, err := store.addrStore.FetchScopedKeyManager(
+		waddrmgr.KeyScope(scope),
+	)
+	require.NoError(t, err)
+
+	err = walletdb.View(store.db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgr.NamespaceKey)
+
+		accountNumber, err := scopedMgr.LookupAccount(ns, name)
+		if err != nil {
+			return err
+		}
+
+		props, err := scopedMgr.AccountProperties(
+			ns, accountNumber,
+		)
+		if err != nil {
+			return err
+		}
+
+		require.NotNil(t, props.AddrSchema)
+		require.Equal(t, waddrmgr.KeyScopeBIP0049AddrSchema,
+			*props.AddrSchema)
+
+		return nil
+	})
+	require.NoError(t, err)
+}
 
 // newCreditedFixture builds an account store backed by a spendable wallet
 // with a wired-up wtxmgr txStore and returns a helper that credits a
@@ -769,4 +1051,88 @@ func TestListAccountsSkipBalanceZeros(t *testing.T) {
 			a.AccountName,
 		)
 	}
+}
+
+// TestCreateImportedAccountAllowsMultipleInScope verifies kvdb retains the
+// legacy watch-only account behavior: imported accounts share the normal
+// per-scope account counter, so multiple imported accounts can exist in the
+// same scope under different names.
+func TestCreateImportedAccountAllowsMultipleInScope(t *testing.T) {
+	t.Parallel()
+
+	store, _, cleanup := newAccountStoreFixture(t)
+	t.Cleanup(cleanup)
+
+	seed := bytes.Repeat([]byte{0xCC}, hdkeychain.RecommendedSeedLen)
+	master, err := hdkeychain.NewMaster(seed, &chaincfg.SimNetParams)
+	require.NoError(t, err)
+	masterPub, err := master.Neuter()
+	require.NoError(t, err)
+
+	scope := db.KeyScope{
+		Purpose: waddrmgr.KeyScopeBIP0084.Purpose,
+		Coin:    waddrmgr.KeyScopeBIP0084.Coin,
+	}
+
+	first, err := store.CreateImportedAccount(t.Context(),
+		db.CreateImportedAccountParams{
+			Scope:             scope,
+			Name:              "alice-import",
+			MasterFingerprint: 0xDEADBEEF,
+			PublicKey:         []byte(masterPub.String()),
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	require.Equal(t, "alice-import", first.AccountName)
+
+	second, err := store.CreateImportedAccount(t.Context(),
+		db.CreateImportedAccountParams{
+			Scope:             scope,
+			Name:              "bob-import",
+			MasterFingerprint: 0xFEEDFACE,
+			PublicKey:         []byte(masterPub.String()),
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	require.Equal(t, "bob-import", second.AccountName)
+
+	mgrScope := waddrmgr.KeyScope(scope)
+	scopedMgr, err := store.addrStore.FetchScopedKeyManager(mgrScope)
+	require.NoError(t, err)
+
+	var firstNumber, secondNumber uint32
+
+	err = walletdb.View(store.db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgr.NamespaceKey)
+
+		var err error
+
+		firstNumber, err = scopedMgr.LookupAccount(
+			ns, first.AccountName,
+		)
+		if err != nil {
+			return err
+		}
+
+		secondNumber, err = scopedMgr.LookupAccount(
+			ns, second.AccountName,
+		)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, firstNumber+1, secondNumber)
+
+	got, err := store.GetAccount(t.Context(), db.GetAccountQuery{
+		Scope: scope,
+		Name:  &second.AccountName,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "bob-import", got.AccountName)
+	require.Equal(t, uint32(0xFEEDFACE), got.MasterKeyFingerprint)
 }

--- a/wallet/internal/db/kvdb/accountstore_timestamps.go
+++ b/wallet/internal/db/kvdb/accountstore_timestamps.go
@@ -52,6 +52,32 @@ func newAccountCreatedAtKey(scope waddrmgr.KeyScope,
 	return k
 }
 
+// putAccountCreatedAt writes the creation timestamp for an account to
+// the side bucket. The caller must hold a walletdb.ReadWriteTx and
+// pass the waddrmgr namespace bucket; the helper creates the
+// sub-bucket on first use.
+func putAccountCreatedAt(ns walletdb.ReadWriteBucket,
+	scope waddrmgr.KeyScope, account uint32, t time.Time) error {
+
+	bucket, err := ns.CreateBucketIfNotExists(accountCreatedAtBucketKey)
+	if err != nil {
+		return fmt.Errorf("create created-at bucket: %w", err)
+	}
+
+	key := newAccountCreatedAtKey(scope, account)
+
+	var value [createdAtValueLen]byte
+	//nolint:gosec // UnixNano() always fits in uint64 for times after 1970.
+	binary.BigEndian.PutUint64(value[:], uint64(t.UTC().UnixNano()))
+
+	err = bucket.Put(key[:], value[:])
+	if err != nil {
+		return fmt.Errorf("put created-at: %w", err)
+	}
+
+	return nil
+}
+
 // readAccountCreatedAt returns the creation timestamp for an account.
 // If no entry exists for (scope, account) the helper returns
 // time.Time{} (Go's zero value) and a nil error, meaning "unknown".

--- a/wallet/internal/db/kvdb/utxostore.go
+++ b/wallet/internal/db/kvdb/utxostore.go
@@ -7,6 +7,10 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
@@ -95,9 +99,234 @@ func (s *Store) ListLeasedOutputs(ctx context.Context,
 	return nil, notImplemented(ctx, "ListLeasedOutputs")
 }
 
-// Balance is not yet implemented for kvdb.
-func (s *Store) Balance(ctx context.Context,
-	_ db.BalanceParams) (db.BalanceResult, error) {
+// Balance sums the wallet's unspent outputs that satisfy the supplied
+// filters. The walk iterates every UTXO owned by the address manager
+// and applies Scope, Account, MinConfs, MaxConfs, and CoinbaseMaturity
+// in turn. Outputs whose script does not extract to a recognized
+// address, or that waddrmgr cannot map to an account, are skipped.
+func (s *Store) Balance(_ context.Context,
+	params db.BalanceParams) (db.BalanceResult, error) {
 
-	return db.BalanceResult{}, notImplemented(ctx, "Balance")
+	err := params.Validate()
+	if err != nil {
+		return db.BalanceResult{}, err
+	}
+
+	var scopeFilter *waddrmgr.KeyScope
+	if params.Scope != nil {
+		scopeFilter = &waddrmgr.KeyScope{
+			Purpose: params.Scope.Purpose,
+			Coin:    params.Scope.Coin,
+		}
+	}
+
+	var result db.BalanceResult
+
+	err = walletdb.View(s.db, func(tx walletdb.ReadTx) error {
+		addrmgrNs := tx.ReadBucket(waddrmgr.NamespaceKey)
+		if addrmgrNs == nil {
+			return nil
+		}
+
+		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
+
+		total, locked, err := s.walkBalanceUTXOs(
+			addrmgrNs, txmgrNs, params, scopeFilter,
+		)
+		if err != nil {
+			return err
+		}
+
+		result.Total = total
+		result.Locked = locked
+
+		return nil
+	})
+	if err != nil {
+		return db.BalanceResult{}, fmt.Errorf("balance: %w", err)
+	}
+
+	return result, nil
+}
+
+// walkBalanceUTXOs iterates the wallet's unspent outputs and sums total and
+// locked amounts for those that satisfy the BalanceParams filters. The caller
+// holds the wallet db read transaction.
+func (s *Store) walkBalanceUTXOs(addrmgrNs, txmgrNs walletdb.ReadBucket,
+	params db.BalanceParams,
+	scopeFilter *waddrmgr.KeyScope) (btcutil.Amount, btcutil.Amount, error) {
+
+	if s.txStore == nil || txmgrNs == nil {
+		return 0, 0, nil
+	}
+
+	nameFound, err := s.resolveBalanceNameFilter(
+		addrmgrNs, &params, scopeFilter,
+	)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	if !nameFound {
+		return 0, 0, nil
+	}
+
+	syncBlock := s.addrStore.SyncedTo()
+	chainParams := s.addrStore.ChainParams()
+
+	unspent, err := s.txStore.UnspentOutputsIncludingLocked(txmgrNs)
+	if err != nil {
+		return 0, 0, fmt.Errorf("unspent outputs: %w", err)
+	}
+
+	var total, locked btcutil.Amount
+	for i := range unspent {
+		output := &unspent[i]
+
+		owner, account, ok := s.classifyBalanceUTXO(
+			addrmgrNs, output, chainParams,
+		)
+		if !ok {
+			continue
+		}
+
+		if !balanceFilterAllows(
+			scopeFilter, owner, params, account,
+		) {
+
+			continue
+		}
+
+		if !confsAllowed(
+			output, syncBlock.Height, params,
+		) {
+
+			continue
+		}
+
+		total, locked = addBalanceOutput(total, locked, output)
+	}
+
+	return total, locked, nil
+}
+
+// addBalanceOutput adds an accepted output to the total balance and, when the
+// output is locked, the locked subset.
+func addBalanceOutput(total, locked btcutil.Amount,
+	output *wtxmgr.Credit) (btcutil.Amount, btcutil.Amount) {
+
+	total += output.Amount
+	if output.Locked {
+		locked += output.Amount
+	}
+
+	return total, locked
+}
+
+// resolveBalanceNameFilter resolves BalanceParams.Name into the real waddrmgr
+// account number before the UTXO walk. A missing name means no UTXOs match,
+// so the caller should return a zero balance without an error.
+func (s *Store) resolveBalanceNameFilter(addrmgrNs walletdb.ReadBucket,
+	params *db.BalanceParams, scopeFilter *waddrmgr.KeyScope) (bool, error) {
+
+	if params.Name == nil {
+		return true, nil
+	}
+
+	scopedMgr, err := s.addrStore.FetchScopedKeyManager(*scopeFilter)
+	if err != nil {
+		return false, fmt.Errorf("fetch scoped manager: %w", err)
+	}
+
+	acctNum, err := scopedMgr.LookupAccount(addrmgrNs, *params.Name)
+	if err != nil {
+		if waddrmgr.IsError(err, waddrmgr.ErrAccountNotFound) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("lookup account: %w", err)
+	}
+
+	// Internal filtering stays on the real account number; the public
+	// AccountInfo.AccountNumber masking only applies at the read API boundary.
+	params.Account = &acctNum
+
+	return true, nil
+}
+
+// classifyBalanceUTXO maps an unspent output to its owning address and
+// wallet account. It returns ok=false when the script does not extract
+// to a recognized address or waddrmgr cannot map it to an account; the
+// caller should skip such outputs.
+func (s *Store) classifyBalanceUTXO(addrmgrNs walletdb.ReadBucket,
+	output *wtxmgr.Credit,
+	chainParams *chaincfg.Params) (waddrmgr.AccountStore, uint32, bool) {
+
+	_, addrs, _, err := txscript.ExtractPkScriptAddrs(
+		output.PkScript, chainParams,
+	)
+	if err != nil || len(addrs) == 0 {
+		return nil, 0, false
+	}
+
+	owner, account, err := s.addrStore.AddrAccount(addrmgrNs, addrs[0])
+	if err != nil {
+		return nil, 0, false
+	}
+
+	return owner, account, true
+}
+
+// balanceFilterAllows reports whether an output's owning address and
+// account survive the Scope and Account filters from BalanceParams.
+func balanceFilterAllows(scopeFilter *waddrmgr.KeyScope,
+	owner waddrmgr.AccountStore, params db.BalanceParams,
+	account uint32) bool {
+
+	if scopeFilter != nil && *scopeFilter != owner.Scope() {
+		return false
+	}
+
+	if params.Account != nil && *params.Account != account {
+		return false
+	}
+
+	return true
+}
+
+// confsAllowed reports whether an unspent output's confirmation depth
+// passes the BalanceParams filters (MinConfs, MaxConfs, and the
+// CoinbaseMaturity gate that applies to coinbase outputs).
+func confsAllowed(output *wtxmgr.Credit, syncHeight int32,
+	params db.BalanceParams) bool {
+
+	confs := calcConfs(output.Height, syncHeight)
+
+	if params.MinConfs != nil && confs < *params.MinConfs {
+		return false
+	}
+
+	if params.MaxConfs != nil && confs > *params.MaxConfs {
+		return false
+	}
+
+	if output.FromCoinBase && params.CoinbaseMaturity != nil &&
+		confs < *params.CoinbaseMaturity {
+
+		return false
+	}
+
+	return true
+}
+
+// calcConfs returns the number of confirmations for an output at
+// outputHeight given a chain tip of curHeight. Unconfirmed outputs
+// (height == -1) return 0; future-dated outputs (height > tip) clamp
+// to 0.
+func calcConfs(outputHeight, curHeight int32) int32 {
+	if outputHeight <= 0 || outputHeight > curHeight {
+		return 0
+	}
+
+	return curHeight - outputHeight + 1
 }

--- a/wallet/internal/db/kvdb/utxostore_balance_test.go
+++ b/wallet/internal/db/kvdb/utxostore_balance_test.go
@@ -286,12 +286,28 @@ func TestBalanceNameFilter(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	scopedMgr, err := store.addrStore.FetchScopedKeyManager(scope)
+	require.NoError(t, err)
+
+	var importedAccount uint32
+
+	err = walletdb.View(store.db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgr.NamespaceKey)
+
+		var err error
+
+		importedAccount, err = scopedMgr.LookupAccount(ns, importedName)
+
+		return err
+	})
+	require.NoError(t, err)
+
 	creditAccountAddressAtHeight(
 		t, store.db, mgr, txStore, scope, 0, btcutil.Amount(100),
 		balanceTestTipHeight, false,
 	)
 	creditAccountAddressAtHeight(
-		t, store.db, mgr, txStore, scope, waddrmgr.MaxAccountNum,
+		t, store.db, mgr, txStore, scope, importedAccount,
 		btcutil.Amount(300), balanceTestTipHeight, false,
 	)
 

--- a/wallet/internal/db/kvdb/utxostore_balance_test.go
+++ b/wallet/internal/db/kvdb/utxostore_balance_test.go
@@ -1,0 +1,461 @@
+package kvdb
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/hdkeychain"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+	"github.com/stretchr/testify/require"
+)
+
+const balanceTestTipHeight int32 = 100
+
+// TestBalanceScopeFilter verifies the Scope filter narrows the sum to
+// UTXOs belonging to that scope's accounts. Wallets with accounts under
+// two scopes get a per-scope balance via BalanceParams.Scope.
+func TestBalanceScopeFilter(t *testing.T) {
+	t.Parallel()
+
+	store, mgr, txStore, cleanup := newCreditedFixture(t)
+	t.Cleanup(cleanup)
+
+	creditNextAccountAddress(
+		t, store.db, mgr, txStore,
+		waddrmgr.KeyScopeBIP0084, 0, btcutil.Amount(100),
+	)
+	creditNextAccountAddress(
+		t, store.db, mgr, txStore,
+		waddrmgr.KeyScopeBIP0049Plus, 0, btcutil.Amount(200),
+	)
+
+	bip84 := db.KeyScope{
+		Purpose: waddrmgr.KeyScopeBIP0084.Purpose,
+		Coin:    waddrmgr.KeyScopeBIP0084.Coin,
+	}
+	bip49 := db.KeyScope{
+		Purpose: waddrmgr.KeyScopeBIP0049Plus.Purpose,
+		Coin:    waddrmgr.KeyScopeBIP0049Plus.Coin,
+	}
+
+	res, err := store.Balance(t.Context(), db.BalanceParams{
+		Scope: &bip84,
+	})
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(100), res.Total)
+
+	res, err = store.Balance(t.Context(), db.BalanceParams{
+		Scope: &bip49,
+	})
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(200), res.Total)
+
+	res, err = store.Balance(t.Context(), db.BalanceParams{})
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(300), res.Total)
+}
+
+// TestBalanceAccountFilter verifies the Account filter narrows the sum
+// to UTXOs whose owning account number matches the supplied filter.
+func TestBalanceAccountFilter(t *testing.T) {
+	t.Parallel()
+
+	store, mgr, txStore, cleanup := newCreditedFixture(t)
+	t.Cleanup(cleanup)
+
+	scope := waddrmgr.KeyScopeBIP0084
+	bip84 := db.KeyScope{
+		Purpose: scope.Purpose, Coin: scope.Coin,
+	}
+
+	scopedMgr, err := mgr.FetchScopedKeyManager(scope)
+	require.NoError(t, err)
+
+	// Create a second derived account in the same scope.
+	var acct1 uint32
+
+	err = walletdb.Update(store.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+
+		var inner error
+
+		acct1, inner = scopedMgr.NewAccount(ns, "account-1")
+
+		return inner
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, uint32(0), acct1)
+
+	creditNextAccountAddress(
+		t, store.db, mgr, txStore, scope, 0, btcutil.Amount(100),
+	)
+	creditNextAccountAddress(
+		t, store.db, mgr, txStore, scope, acct1, btcutil.Amount(200),
+	)
+
+	acct0 := uint32(0)
+	res, err := store.Balance(t.Context(), db.BalanceParams{
+		Scope:   &bip84,
+		Account: &acct0,
+	})
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(100), res.Total)
+
+	res, err = store.Balance(t.Context(), db.BalanceParams{
+		Scope:   &bip84,
+		Account: &acct1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(200), res.Total)
+}
+
+// TestBalanceReturnsLockedSubset verifies locked credits contribute to Total
+// and are also reported through the Locked subset.
+func TestBalanceReturnsLockedSubset(t *testing.T) {
+	t.Parallel()
+
+	store, mgr, txStore, cleanup := newCreditedFixture(t)
+	t.Cleanup(cleanup)
+
+	scope := waddrmgr.KeyScopeBIP0084
+	creditAccountAddressAtHeight(
+		t, store.db, mgr, txStore, scope, 0, btcutil.Amount(100),
+		balanceTestTipHeight, false,
+	)
+	lockedOutPoint := creditAccountAddressAtHeight(
+		t, store.db, mgr, txStore, scope, 0, btcutil.Amount(200),
+		balanceTestTipHeight, false,
+	)
+
+	lockID := wtxmgr.LockID{1}
+	err := walletdb.Update(store.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+
+		_, err := txStore.LockOutput(ns, lockID, lockedOutPoint, time.Hour)
+
+		return err
+	})
+	require.NoError(t, err)
+
+	res, err := store.Balance(t.Context(), db.BalanceParams{})
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(300), res.Total)
+	require.Equal(t, btcutil.Amount(200), res.Locked)
+}
+
+// TestBalanceMinConfs verifies that Balance skips outputs below MinConfs.
+func TestBalanceMinConfs(t *testing.T) {
+	t.Parallel()
+
+	store, mgr, txStore, cleanup := newCreditedFixture(t)
+	t.Cleanup(cleanup)
+
+	scope := waddrmgr.KeyScopeBIP0084
+	creditAccountAddressAtHeight(
+		t, store.db, mgr, txStore, scope, 0, btcutil.Amount(100),
+		balanceTestTipHeight, false,
+	)
+	creditAccountAddressAtHeight(
+		t, store.db, mgr, txStore, scope, 0, btcutil.Amount(200),
+		balanceTestTipHeight-4, false,
+	)
+
+	minConfs := int32(2)
+	res, err := store.Balance(t.Context(), db.BalanceParams{
+		MinConfs: &minConfs,
+	})
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(200), res.Total)
+}
+
+// TestBalanceMaxConfs verifies that Balance skips outputs above MaxConfs.
+func TestBalanceMaxConfs(t *testing.T) {
+	t.Parallel()
+
+	store, mgr, txStore, cleanup := newCreditedFixture(t)
+	t.Cleanup(cleanup)
+
+	scope := waddrmgr.KeyScopeBIP0084
+	creditAccountAddressAtHeight(
+		t, store.db, mgr, txStore, scope, 0, btcutil.Amount(100),
+		balanceTestTipHeight, false,
+	)
+	creditAccountAddressAtHeight(
+		t, store.db, mgr, txStore, scope, 0, btcutil.Amount(200),
+		balanceTestTipHeight-4, false,
+	)
+
+	maxConfs := int32(2)
+	res, err := store.Balance(t.Context(), db.BalanceParams{
+		MaxConfs: &maxConfs,
+	})
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(100), res.Total)
+}
+
+// TestBalanceCoinbaseMaturity verifies that CoinbaseMaturity only gates
+// coinbase outputs and leaves non-coinbase outputs unaffected.
+func TestBalanceCoinbaseMaturity(t *testing.T) {
+	t.Parallel()
+
+	store, mgr, txStore, cleanup := newCreditedFixture(t)
+	t.Cleanup(cleanup)
+
+	scope := waddrmgr.KeyScopeBIP0084
+	creditAccountAddressAtHeight(
+		t, store.db, mgr, txStore, scope, 0, btcutil.Amount(100),
+		balanceTestTipHeight, true,
+	)
+	creditAccountAddressAtHeight(
+		t, store.db, mgr, txStore, scope, 0, btcutil.Amount(200),
+		balanceTestTipHeight-9, true,
+	)
+	creditAccountAddressAtHeight(
+		t, store.db, mgr, txStore, scope, 0, btcutil.Amount(300),
+		balanceTestTipHeight, false,
+	)
+
+	maturity := int32(2)
+	res, err := store.Balance(t.Context(), db.BalanceParams{
+		CoinbaseMaturity: &maturity,
+	})
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(500), res.Total)
+}
+
+// TestBalanceSkipsUnownedAddress verifies that Balance ignores txstore credits
+// whose script does not map back to a wallet-managed address.
+func TestBalanceSkipsUnownedAddress(t *testing.T) {
+	t.Parallel()
+
+	store, mgr, txStore, cleanup := newCreditedFixture(t)
+	t.Cleanup(cleanup)
+
+	scope := waddrmgr.KeyScopeBIP0084
+	creditAccountAddressAtHeight(
+		t, store.db, mgr, txStore, scope, 0, btcutil.Amount(100),
+		balanceTestTipHeight, false,
+	)
+	creditUnownedOutputAtHeight(
+		t, store.db, mgr, txStore, btcutil.Amount(900),
+		balanceTestTipHeight,
+	)
+
+	res, err := store.Balance(t.Context(), db.BalanceParams{})
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(100), res.Total)
+}
+
+// TestBalanceNameFilter verifies that Balance can resolve a public account
+// name to the backend's internal account number, including imported accounts.
+func TestBalanceNameFilter(t *testing.T) {
+	t.Parallel()
+
+	store, mgr, txStore, cleanup := newCreditedFixture(t)
+	t.Cleanup(cleanup)
+
+	scope := waddrmgr.KeyScopeBIP0084
+	dbScope := db.KeyScope{
+		Purpose: scope.Purpose,
+		Coin:    scope.Coin,
+	}
+
+	seed := bytes.Repeat([]byte{0xBE}, hdkeychain.RecommendedSeedLen)
+	master, err := hdkeychain.NewMaster(seed, &chaincfg.SimNetParams)
+	require.NoError(t, err)
+	masterPub, err := master.Neuter()
+	require.NoError(t, err)
+
+	importedName := "imported-balance"
+	_, err = store.CreateImportedAccount(t.Context(),
+		db.CreateImportedAccountParams{
+			Scope:             dbScope,
+			Name:              importedName,
+			MasterFingerprint: 0xDEADBEEF,
+			PublicKey:         []byte(masterPub.String()),
+		},
+	)
+	require.NoError(t, err)
+
+	creditAccountAddressAtHeight(
+		t, store.db, mgr, txStore, scope, 0, btcutil.Amount(100),
+		balanceTestTipHeight, false,
+	)
+	creditAccountAddressAtHeight(
+		t, store.db, mgr, txStore, scope, waddrmgr.MaxAccountNum,
+		btcutil.Amount(300), balanceTestTipHeight, false,
+	)
+
+	res, err := store.Balance(t.Context(), db.BalanceParams{
+		Scope: &dbScope,
+		Name:  &importedName,
+	})
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(300), res.Total)
+
+	missing := "missing"
+	res, err = store.Balance(t.Context(), db.BalanceParams{
+		Scope: &dbScope,
+		Name:  &missing,
+	})
+	require.NoError(t, err)
+	require.Zero(t, res.Total)
+}
+
+// TestCalcConfs is a table-driven test of the calcConfs helper. Covers
+// the documented edges: unconfirmed (height<=0), future-dated
+// (height>tip), and the normal (tip - height + 1) calculation.
+func TestCalcConfs(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		outputHeight int32
+		curHeight    int32
+		want         int32
+	}{
+		{"unconfirmed-zero-height", 0, 100, 0},
+		{"unconfirmed-negative-one", -1, 100, 0},
+		{"future-dated", 110, 100, 0},
+		{"single-confirmation", 10, 10, 1},
+		{"normal-six-confirmations", 10, 15, 6},
+		{"early-block-deep-chain", 1, 1000, 1000},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := calcConfs(tc.outputHeight, tc.curHeight)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// creditAccountAddressAtHeight derives the next external address for account,
+// inserts a credit paying to it at height, and returns the credited outpoint.
+func creditAccountAddressAtHeight(t *testing.T, dbConn walletdb.DB,
+	mgr *waddrmgr.Manager, txStore *wtxmgr.Store,
+	scope waddrmgr.KeyScope, account uint32, amount btcutil.Amount,
+	height int32, coinbase bool) wire.OutPoint {
+
+	t.Helper()
+
+	scopedMgr, err := mgr.FetchScopedKeyManager(scope)
+	require.NoError(t, err)
+
+	var pkScript []byte
+
+	err = walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+
+		addrs, err := scopedMgr.NextExternalAddresses(ns, account, 1)
+		if err != nil {
+			return err
+		}
+
+		pkScript, err = txscript.PayToAddrScript(addrs[0].Address())
+
+		return err
+	})
+	require.NoError(t, err)
+
+	return insertBalanceCredit(
+		t, dbConn, mgr, txStore, pkScript, amount, height, coinbase,
+	)
+}
+
+// creditUnownedOutputAtHeight inserts a txstore credit whose script belongs to
+// an address that is not managed by the wallet.
+func creditUnownedOutputAtHeight(t *testing.T, dbConn walletdb.DB,
+	mgr *waddrmgr.Manager, txStore *wtxmgr.Store, amount btcutil.Amount,
+	height int32) {
+
+	t.Helper()
+
+	addr, err := btcutil.NewAddressPubKeyHash(
+		bytes.Repeat([]byte{0x01}, 20), &chaincfg.SimNetParams,
+	)
+	require.NoError(t, err)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	_ = insertBalanceCredit(
+		t, dbConn, mgr, txStore, pkScript, amount, height, false,
+	)
+}
+
+// insertBalanceCredit records a txstore credit and advances the wallet sync
+// height to the balance-test tip. It returns the credited outpoint.
+func insertBalanceCredit(t *testing.T, dbConn walletdb.DB,
+	mgr *waddrmgr.Manager, txStore *wtxmgr.Store, pkScript []byte,
+	amount btcutil.Amount, height int32, coinbase bool) wire.OutPoint {
+
+	t.Helper()
+
+	txHash := chainhash.Hash{
+		byte(height), byte(amount), byte(amount >> 8), byte(len(pkScript)),
+	}
+	if coinbase {
+		txHash[31] = 1
+	}
+
+	txMsg := &wire.MsgTx{Version: 1}
+	if coinbase {
+		txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+			Index: ^uint32(0),
+		}})
+	} else {
+		txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+			Hash: txHash,
+		}})
+	}
+
+	txMsg.AddTxOut(&wire.TxOut{
+		Value:    int64(amount),
+		PkScript: pkScript,
+	})
+
+	rec, err := wtxmgr.NewTxRecordFromMsgTx(txMsg, time.Now())
+	require.NoError(t, err)
+
+	blockHash := chainhash.Hash{byte(height), byte(amount >> 16)}
+	block := &wtxmgr.BlockMeta{
+		Block: wtxmgr.Block{Hash: blockHash, Height: height},
+		Time:  time.Now(),
+	}
+
+	err = walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+
+		err := txStore.InsertTx(ns, rec, block)
+		if err != nil {
+			return err
+		}
+
+		return txStore.AddCredit(ns, rec, block, 0, coinbase)
+	})
+	require.NoError(t, err)
+
+	err = walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+
+		return mgr.SetSyncedTo(ns, &waddrmgr.BlockStamp{
+			Hash:   blockHash,
+			Height: balanceTestTipHeight,
+		})
+	})
+	require.NoError(t, err)
+
+	return wire.OutPoint{Hash: rec.Hash, Index: 0}
+}

--- a/wallet/internal/db/kvdb/utxostore_test.go
+++ b/wallet/internal/db/kvdb/utxostore_test.go
@@ -112,3 +112,36 @@ func TestReleaseOutputMissingNamespace(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, walletdb.ErrBucketNotFound)
 }
+
+// TestBalanceRejectsAccountWithoutScope verifies that Balance enforces
+// the BalanceParams contract: an Account filter requires a Scope filter to
+// avoid cross-scope account-number collisions.
+func TestBalanceRejectsAccountWithoutScope(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	store := NewStore(dbConn, nil, nil)
+
+	acct := uint32(0)
+	_, err := store.Balance(t.Context(), db.BalanceParams{
+		Account: &acct,
+	})
+	require.ErrorIs(t, err, db.ErrBalanceParamsAccountWithoutScope)
+}
+
+// TestBalanceEmptyWallet verifies that Balance returns zero on a wallet
+// with no UTXOs and a nil tx store.
+func TestBalanceEmptyWallet(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	store := NewStore(dbConn, nil, nil)
+
+	result, err := store.Balance(t.Context(), db.BalanceParams{})
+	require.NoError(t, err)
+	require.Zero(t, result.Total)
+}

--- a/wallet/internal/db/pg/accounts.go
+++ b/wallet/internal/db/pg/accounts.go
@@ -14,6 +14,8 @@ import (
 // Ensure Store satisfies the AccountStore interface.
 var _ db.AccountStore = (*Store)(nil)
 
+var errDryRunRollback = errors.New("postgres imported account dry run rollback")
+
 // GetAccount retrieves information about a specific account, identified by its
 // name or account number within a given key scope.
 func (s *Store) GetAccount(ctx context.Context,
@@ -125,7 +127,7 @@ func (o createDerivedAccountOps) WalletWatchOnly(ctx context.Context,
 func (o createDerivedAccountOps) EnsureScope(ctx context.Context,
 	walletID uint32, scope db.KeyScope) (int64, error) {
 
-	return ensureKeyScope(ctx, o.q, walletID, scope)
+	return ensureKeyScope(ctx, o.q, walletID, scope, nil)
 }
 
 // AllocateAccountNumber implements db.CreateDerivedAccountOps.
@@ -201,7 +203,10 @@ func (s *Store) CreateImportedAccount(ctx context.Context,
 
 		props, err = db.CreateImportedAccount(
 			ctx, params, func() (int64, error) {
-				return ensureKeyScope(ctx, qtx, params.WalletID, params.Scope)
+				return ensureKeyScope(
+					ctx, qtx, params.WalletID, params.Scope,
+					params.AddrSchema,
+				)
 			}, func() (bool, error) {
 				return getWalletWatchOnly(ctx, qtx, params.WalletID)
 			}, qtx.CreateImportedAccount,
@@ -212,10 +217,26 @@ func (s *Store) CreateImportedAccount(ctx context.Context,
 				return getAccountProps(ctx, qtx, accountID)
 			},
 		)
+		if err != nil {
+			return err
+		}
 
-		return err
+		if params.DryRun {
+			// TODO: Reuse the SQL address-derivation helpers to match
+			// kvdb/legacy dry-run by deriving sample external and
+			// internal addresses before rolling this tx back. Account
+			// import needs a derivation callback before it can call
+			// those helpers.
+			return errDryRunRollback
+		}
+
+		return nil
 	})
 	if err != nil {
+		if params.DryRun && errors.Is(err, errDryRunRollback) {
+			return props, nil
+		}
+
 		return nil, err
 	}
 
@@ -307,7 +328,7 @@ func getAccountProps(ctx context.Context, qtx *sqlc.Queries,
 // ensureKeyScope retrieves an existing key scope or creates it if missing for
 // PostgreSQL. It returns the scope ID once available.
 func ensureKeyScope(ctx context.Context, qtx *sqlc.Queries, walletID uint32,
-	scope db.KeyScope) (int64, error) {
+	scope db.KeyScope, addrSchema *db.ScopeAddrSchema) (int64, error) {
 
 	return db.EnsureKeyScope(
 		ctx, qtx.GetKeyScopeByWalletAndScope,
@@ -332,7 +353,7 @@ func ensureKeyScope(ctx context.Context, qtx *sqlc.Queries, walletID uint32,
 		},
 		func(row sqlc.GetKeyScopeByWalletAndScopeRow) int64 {
 			return row.ID
-		}, scope,
+		}, scope, addrSchema,
 	)
 }
 

--- a/wallet/internal/db/sqlite/accounts.go
+++ b/wallet/internal/db/sqlite/accounts.go
@@ -14,6 +14,8 @@ import (
 // Ensure Store satisfies the AccountStore interface.
 var _ db.AccountStore = (*Store)(nil)
 
+var errDryRunRollback = errors.New("sqlite imported account dry run rollback")
+
 // GetAccount retrieves information about a specific account, identified by its
 // name or account number within a given key scope.
 func (s *Store) GetAccount(ctx context.Context,
@@ -125,7 +127,7 @@ func (o createDerivedAccountOps) WalletWatchOnly(ctx context.Context,
 func (o createDerivedAccountOps) EnsureScope(ctx context.Context,
 	walletID uint32, scope db.KeyScope) (int64, error) {
 
-	return ensureKeyScope(ctx, o.q, walletID, scope)
+	return ensureKeyScope(ctx, o.q, walletID, scope, nil)
 }
 
 // AllocateAccountNumber implements db.CreateDerivedAccountOps.
@@ -190,7 +192,8 @@ func (o createDerivedAccountOps) CreateDerivedAccount(ctx context.Context,
 // ensureKeyScope retrieves an existing key scope or creates it if missing
 // for SQLite. It returns the scope ID once available.
 func ensureKeyScope(ctx context.Context, qtx *sqlc.Queries,
-	walletID uint32, scope db.KeyScope) (int64, error) {
+	walletID uint32, scope db.KeyScope,
+	addrSchema *db.ScopeAddrSchema) (int64, error) {
 
 	return db.EnsureKeyScope(
 		ctx, qtx.GetKeyScopeByWalletAndScope,
@@ -215,7 +218,7 @@ func ensureKeyScope(ctx context.Context, qtx *sqlc.Queries,
 		},
 		func(row sqlc.GetKeyScopeByWalletAndScopeRow) int64 {
 			return row.ID
-		}, scope,
+		}, scope, addrSchema,
 	)
 }
 
@@ -237,6 +240,7 @@ func (s *Store) CreateImportedAccount(ctx context.Context,
 			func() (int64, error) {
 				return ensureKeyScope(
 					ctx, qtx, params.WalletID, params.Scope,
+					params.AddrSchema,
 				)
 			},
 			func() (bool, error) {
@@ -252,10 +256,26 @@ func (s *Store) CreateImportedAccount(ctx context.Context,
 				return getAccountProps(ctx, qtx, accountID)
 			},
 		)
+		if err != nil {
+			return err
+		}
 
-		return err
+		if params.DryRun {
+			// TODO: Reuse the SQL address-derivation helpers to match
+			// kvdb/legacy dry-run by deriving sample external and
+			// internal addresses before rolling this tx back. Account
+			// import needs a derivation callback before it can call
+			// those helpers.
+			return errDryRunRollback
+		}
+
+		return nil
 	})
 	if err != nil {
+		if params.DryRun && errors.Is(err, errDryRunRollback) {
+			return props, nil
+		}
+
 		return nil, err
 	}
 

--- a/wallet/internal/sql/pg/queries/accounts.sql
+++ b/wallet/internal/sql/pg/queries/accounts.sql
@@ -344,7 +344,8 @@ WHERE
             AND key_scopes.purpose = sqlc.arg('purpose')
             AND key_scopes.coin_type = sqlc.arg('coin_type')
     )
-    AND account_name = sqlc.arg(old_name);
+    AND account_name = sqlc.arg(old_name)
+    AND account_number IS NOT NULL;
 
 -- name: CreateDerivedAccountWithNumber :one
 -- Test-only: Creates a derived account with a specific account number.

--- a/wallet/internal/sql/pg/sqlc/accounts.sql.go
+++ b/wallet/internal/sql/pg/sqlc/accounts.sql.go
@@ -1084,6 +1084,7 @@ WHERE
             AND key_scopes.coin_type = $4
     )
     AND account_name = $5
+    AND account_number IS NOT NULL
 `
 
 type UpdateAccountNameByWalletScopeAndNameParams struct {

--- a/wallet/internal/sql/sqlite/queries/accounts.sql
+++ b/wallet/internal/sql/sqlite/queries/accounts.sql
@@ -344,7 +344,8 @@ WHERE
             AND key_scopes.purpose = sqlc.arg('purpose')
             AND key_scopes.coin_type = sqlc.arg('coin_type')
     )
-    AND account_name = sqlc.arg(old_name);
+    AND account_name = sqlc.arg(old_name)
+    AND account_number IS NOT NULL;
 
 -- name: CreateDerivedAccountWithNumber :one
 -- Test-only: Creates a derived account with a specific account number.

--- a/wallet/internal/sql/sqlite/sqlc/accounts.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/accounts.sql.go
@@ -1094,6 +1094,7 @@ WHERE
             AND key_scopes.coin_type = ?4
     )
     AND account_name = ?5
+    AND account_number IS NOT NULL
 `
 
 type UpdateAccountNameByWalletScopeAndNameParams struct {


### PR DESCRIPTION
## Summary

Write-side half of the account-store migration, stacked on top of
PR #1236 (read-side). Each kvdb writer ships in the same PR as its
wallet-side routing — the manager no longer holds a raw waddrmgr
path for any account-store entrypoint after this PR lands.

(PR #1215, the previous attempt for this slice, is permanently
stuck in a merged-but-not-merged state, so this PR replaces it.)

## Commits

1. `kvdb: implement RenameAccount` — kvdb writer for the rename
   path. Looks up the account number, calls
   `waddrmgr.AccountStore.RenameAccount`, translates the
   not-found error to `db.ErrAccountNotFound`.
2. `wallet: route RenameAccount through Store` —
   `Wallet.RenameAccount` validates locally and dispatches to
   `w.store.RenameAccount`.
3. `wallet: route Balance through Store` — `Wallet.Balance` pulls
   the account snapshot via `w.cache.GetAccount` and the balance
   via `w.store.Balance`. No more `walletdb.View` inside the
   wallet manager for balances.
4. `kvdb: implement CreateDerivedAccount via ops adapter` — kvdb
   writer for the derived-key creation path. Honors the
   `db.AccountDerivationFunc` callback contract. Re-introduces
   `putAccountCreatedAt` for the kvdb-owned created-at side
   bucket.
5. `wallet: route NewAccount through Store` — `Wallet.NewAccount`
   builds an `AccountDerivationFunc` via `w.buildAccountDeriveFn`
   (re-introduced here) and dispatches to
   `w.store.CreateDerivedAccount`. `(w *Wallet).accountInfoToProperties`
   is now used on the return path.
6. `kvdb: implement CreateImportedAccount` — kvdb writer for the
   watch-only-import path. Adds matching kvdb-side unit coverage
   in `accountstore_test.go`.
7. `wallet: route ImportAccount through Store; drop dry-run` —
   `Wallet.ImportAccount` dispatches to
   `w.store.CreateImportedAccount`. Dry-run is no longer
   supported on the new entrypoint (callers needing the
   simulate-and-rollback flow continue to use the deprecated
   `Wallet.ImportAccountDryRun`); the new sentinel
   `errDryRunImportNotSupported` surfaces the explicit rejection.

## Stacking

- base: `impl-account-kvdb` (PR #1236)
- head: `impl-account-manager-store`

Land #1236 first; this PR is meant to follow.

## Testing

- `GOWORK=off go test ./wallet/... ./wallet/internal/db/...`
- per-commit build verification with `GOWORK=off go build ./...`
- CI: unit (cover + race), itest (bitcoind v28/v30, btcd,
  neutrino), postgres + sqlite itest (cover + race), lint