### PR TITLE
wallet: migrate address-store read path + signer derivation

### DIFF
--- a/wallet/address_manager.go
+++ b/wallet/address_manager.go
@@ -201,6 +201,8 @@ var _ AddressManager = (*Wallet)(nil)
 
 // addressInfoFromManagedAddress converts one legacy managed address into the
 // wallet-owned metadata shape used by the prep work.
+//
+//nolint:unparam // Preserve the legacy caller error shape during migration.
 func addressInfoFromManagedAddress(
 	managedAddr waddrmgr.ManagedAddress) (AddressInfo, error) {
 
@@ -523,30 +525,7 @@ func nextUnusedStoreAddress(storeAddr db.AddressInfo,
 }
 
 // GetAddressInfo returns detailed information regarding a wallet address.
-//
-// This method provides metadata about a managed address, such as its type,
-// derivation path, and whether it's internal or compressed.
-//
-// How it works:
-// The method performs a direct lookup in the address manager to find the
-// requested address.
-//
-// Logical Steps:
-//  1. Initiate a read-only database transaction.
-//  2. Call the underlying address manager's `Address` method to look up the
-//     address.
-//  3. Return the managed address information.
-//
-// Database Actions:
-//   - This method performs a single read-only database transaction
-//     (`walletdb.View`).
-//   - It reads from the `waddrmgr` namespace to find the address.
-//
-// Time Complexity:
-//   - The operation is a direct database lookup, making its complexity roughly
-//     O(1) or O(log N) depending on the database backend's indexing strategy
-//     for addresses. It is a very fast operation.
-func (w *Wallet) GetAddressInfo(_ context.Context, a btcutil.Address) (
+func (w *Wallet) GetAddressInfo(ctx context.Context, a btcutil.Address) (
 	AddressInfo, error) {
 
 	err := w.state.validateStarted()
@@ -554,20 +533,22 @@ func (w *Wallet) GetAddressInfo(_ context.Context, a btcutil.Address) (
 		return AddressInfo{}, err
 	}
 
-	var managedAddress waddrmgr.ManagedAddress
+	scriptPubKey, err := txscript.PayToAddrScript(a)
+	if err != nil {
+		return AddressInfo{}, fmt.Errorf("pay to addr script: %w", err)
+	}
 
-	err = walletdb.View(w.cfg.DB, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-
-		managedAddress, err = w.addrStore.Address(addrmgrNs, a)
-
-		return err
-	})
+	storeAddr, err := w.store.GetAddress(
+		ctx, db.GetAddressQuery{
+			WalletID:     w.id,
+			ScriptPubKey: scriptPubKey,
+		},
+	)
 	if err != nil {
 		return AddressInfo{}, err
 	}
 
-	return addressInfoFromManagedAddress(managedAddress)
+	return addressInfoFromStoreAddress(storeAddr, w.cfg.ChainParams)
 }
 
 // ListAddresses lists all addresses for a given account, including their
@@ -821,9 +802,10 @@ func encryptTaprootScript(vault keyvault.Vault,
 //     sign for (e.g., P2WKH, NP2WKH, P2TR).
 //  3. Based on the address type, construct the appropriate scripts:
 //     - For nested P2WKH (NP2WKH), it returns the inner witness program as the
-//     redeem script.
+//     redeem script and also builds the single-push sigScript wrapper used in
+//     the final input.
 //     - For native SegWit outputs (P2WKH, P2TR), the `witnessProgram` is the
-//     output's `pkScript`, while the redeem script is nil.
+//     output's `pkScript`, while the redeem script and sigScript are nil.
 //
 // Database Actions:
 //   - This method performs a read-only database access to fetch address
@@ -854,58 +836,71 @@ func (w *Wallet) ScriptForOutput(ctx context.Context, output wire.TxOut) (
 			"for %s: %w", addr.String(), err)
 	}
 
-	if addressInfo.PubKey == nil {
-		return OutputScriptInfo{}, fmt.Errorf("%w: addr %s",
-			ErrNotPubKeyAddress, addressInfo.Addr)
-	}
-
-	witnessProgram := output.PkScript
-
-	var redeemScript []byte
-	if addressInfo.AddrType == waddrmgr.NestedWitnessPubKey {
-		redeemScript, err = nestedWitnessProgramFromPubKey(
-			addressInfo.PubKey, w.cfg.ChainParams,
-		)
-		if err != nil {
-			return OutputScriptInfo{}, err
-		}
-
-		// For nested P2WPKH-in-P2SH, the redeem script committed by the outer
-		// P2SH output is the same inner witness program used for signing.
-		witnessProgram = redeemScript
-	} else if addressInfo.AddrType != waddrmgr.PubKeyHash &&
-		addressInfo.AddrType != waddrmgr.WitnessPubKey &&
-		addressInfo.AddrType != waddrmgr.TaprootPubKey {
-
-		return OutputScriptInfo{}, fmt.Errorf("%w: %v",
-			ErrUnsupportedAddressType, addressInfo.AddrType)
+	witnessProgram, redeemScript, sigScript, err := buildScriptsForAddressInfo(
+		addressInfo, output.PkScript, w.cfg.ChainParams,
+	)
+	if err != nil {
+		return OutputScriptInfo{}, err
 	}
 
 	return OutputScriptInfo{
 		AddressInfo:    addressInfo,
 		WitnessProgram: witnessProgram,
 		RedeemScript:   redeemScript,
+		SigScript:      sigScript,
 	}, nil
 }
 
-// nestedWitnessProgramFromPubKey builds the inner witness program used by a
-// nested P2WPKH-in-P2SH output from one compressed public key.
-func nestedWitnessProgramFromPubKey(pubKey *btcec.PublicKey,
-	chainParams *chaincfg.Params) ([]byte, error) {
+// buildScriptsForAddressInfo constructs the witness program, redeem script,
+// and final sigScript for a wallet-owned address metadata record.
+func buildScriptsForAddressInfo(addressInfo AddressInfo, pkScript []byte,
+	_ *chaincfg.Params) ([]byte, []byte, []byte, error) {
 
-	witnessAddr, err := btcutil.NewAddressWitnessPubKeyHash(
-		btcutil.Hash160(pubKey.SerializeCompressed()), chainParams,
+	if addressInfo.PubKey == nil {
+		return nil, nil, nil, fmt.Errorf("%w: addr %s", ErrNotPubKeyAddress,
+			addressInfo.Addr)
+	}
+
+	// For nested witness spends, the redeem script committed to by the outer
+	// P2SH output is the inner witness program, while the sigScript is a single
+	// push of that redeem script. For all other supported single-key families,
+	// the previous output pkScript remains the correct subscript for signing.
+	witnessProgram := pkScript
+
+	var (
+		redeemScript []byte
+		sigScript    []byte
+		err          error
 	)
-	if err != nil {
-		return nil, fmt.Errorf("new witness pubkey hash: %w", err)
+
+	spendType := addressInfo.AddrType.SpendType()
+	if spendType == waddrmgr.SpendTypeNestedWitnessKey {
+		redeemScript, err = txscript.NewScriptBuilder().
+			AddOp(txscript.OP_0).
+			AddData(btcutil.Hash160(addressInfo.PubKey.SerializeCompressed())).
+			Script()
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("build nested witness "+
+				"program: %w", err)
+		}
+
+		sigScript, err = txscript.NewScriptBuilder().
+			AddData(redeemScript).
+			Script()
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("encode redeem script: %w", err)
+		}
+
+		witnessProgram = redeemScript
+	} else if spendType != waddrmgr.SpendTypeLegacyKey &&
+		spendType != waddrmgr.SpendTypeWitnessKey &&
+		spendType != waddrmgr.SpendTypeTaprootKeyPath {
+
+		return nil, nil, nil, fmt.Errorf("%w: %v", ErrUnsupportedAddressType,
+			addressInfo.AddrType)
 	}
 
-	witnessProgram, err := txscript.PayToAddrScript(witnessAddr)
-	if err != nil {
-		return nil, fmt.Errorf("pay to witness address: %w", err)
-	}
-
-	return witnessProgram, nil
+	return witnessProgram, redeemScript, sigScript, nil
 }
 
 // GetDerivationInfo returns the BIP-32 derivation path for a given address.

--- a/wallet/address_manager.go
+++ b/wallet/address_manager.go
@@ -618,42 +618,46 @@ func (w *Wallet) GetAddressInfo(ctx context.Context, a btcutil.Address) (
 	return addressInfoFromStoreAddress(storeAddr, w.cfg.ChainParams)
 }
 
+// legacyAddressBalances returns wallet address balances from the legacy
+// transaction store.
+//
+// TODO(yy): remove this helper once the UTXO store implementation is
+// finished — Wallet.ListAddresses will source balances via
+// Store.ListUTXOs instead.
+func (w *Wallet) legacyAddressBalances() (map[string]btcutil.Amount, error) {
+	balances := make(map[string]btcutil.Amount)
+
+	err := walletdb.View(w.cfg.DB, func(tx walletdb.ReadTx) error {
+		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
+
+		utxos, err := w.txStore.UnspentOutputs(txmgrNs)
+		if err != nil {
+			return err
+		}
+
+		for i := range utxos {
+			addr := extractAddrFromPKScript(
+				utxos[i].PkScript, w.cfg.ChainParams,
+			)
+			if addr == nil {
+				continue
+			}
+
+			balances[addr.String()] += utxos[i].Amount
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return balances, nil
+}
+
 // ListAddresses lists all addresses for a given account, including their
 // balances.
-//
-// This method provides a comprehensive view of all addresses within a
-// specific account, along with their current confirmed balances.
-//
-// How it works:
-// The method first calculates the balances of all UTXOs in the wallet and
-// stores them in a map. It then iterates through all addresses of the
-// specified account and looks up their balance in the map.
-//
-// Logical Steps:
-//  1. Initiate a read-only database transaction.
-//  2. Create a map to store address balances.
-//  3. Iterate through all unspent transaction outputs (UTXOs) in the
-//     wallet's `wtxmgr` namespace.
-//  4. For each UTXO, extract the address and add the output's value to the
-//     address's balance in the map.
-//  5. Fetch the scoped key manager for the given address type.
-//  6. Look up the account number for the given account name.
-//  7. Iterate through all addresses in that account.
-//  8. For each address, create an `AddressProperty` with the address and its
-//     balance from the map.
-//  9. Return the list of `AddressProperty` objects.
-//
-// Database Actions:
-//   - This method performs a single read-only database transaction
-//     (`walletdb.View`).
-//   - It reads from both the `wtxmgr` and `waddrmgr` namespaces.
-//
-// Time Complexity:
-//   - The complexity is O(U + A), where U is the number of unspent
-//     transaction outputs in the wallet and A is the number of addresses in
-//     the specified account. This is because it iterates through all UTXOs to
-//     build the balance map and then iterates through all account addresses.
-func (w *Wallet) ListAddresses(_ context.Context, accountName string,
+func (w *Wallet) ListAddresses(ctx context.Context, accountName string,
 	addrType waddrmgr.AddressType) ([]AddressProperty, error) {
 
 	err := w.state.validateStarted()
@@ -661,60 +665,49 @@ func (w *Wallet) ListAddresses(_ context.Context, accountName string,
 		return nil, err
 	}
 
-	var properties []AddressProperty
+	keyScope, err := addrType.KeyScope()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrUnknownAddrType, addrType)
+	}
 
-	err = walletdb.View(w.cfg.DB, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
-
-		// First, we'll create a map of address to balance by iterating
-		// through all the unspent outputs.
-		addrToBalance := make(map[string]btcutil.Amount)
-
-		utxos, err := w.txStore.UnspentOutputs(txmgrNs)
-		if err != nil {
-			return err
-		}
-
-		for _, utxo := range utxos {
-			addr := extractAddrFromPKScript(
-				utxo.PkScript, w.cfg.ChainParams,
-			)
-			if addr == nil {
-				continue
-			}
-
-			addrToBalance[addr.String()] += utxo.Amount
-		}
-
-		keyScope, err := addrType.KeyScope()
-		if err != nil {
-			return fmt.Errorf("%w: %v", ErrUnknownAddrType, addrType)
-		}
-
-		manager, err := w.addrStore.FetchScopedKeyManager(keyScope)
-		if err != nil {
-			return err
-		}
-
-		acctNum, err := manager.LookupAccount(addrmgrNs, accountName)
-		if err != nil {
-			return err
-		}
-
-		return manager.ForEachAccountAddress(addrmgrNs, acctNum,
-			func(maddr waddrmgr.ManagedAddress) error {
-				addr := maddr.Address()
-				properties = append(properties, AddressProperty{
-					Address: addr,
-					Balance: addrToBalance[addr.String()],
-				})
-
-				return nil
-			})
-	})
+	req, err := addressPageRequest()
 	if err != nil {
 		return nil, err
+	}
+
+	// TODO(yy): switch to Store.ListUTXOs once it is implemented for
+	// kvdb (PR #1238).
+	balances, err := w.legacyAddressBalances()
+	if err != nil {
+		return nil, err
+	}
+
+	properties := make([]AddressProperty, 0)
+
+	addresses := w.store.IterAddresses(
+		ctx, db.ListAddressesQuery{
+			WalletID:    w.id,
+			AccountName: accountName,
+			Scope:       db.KeyScope(keyScope),
+			Page:        req,
+		},
+	)
+	for storeAddr, err := range addresses {
+		if err != nil {
+			return nil, err
+		}
+
+		addr := extractAddrFromPKScript(
+			storeAddr.ScriptPubKey, w.cfg.ChainParams,
+		)
+		if addr == nil {
+			continue
+		}
+
+		properties = append(properties, AddressProperty{
+			Address: addr,
+			Balance: balances[addr.String()],
+		})
 	}
 
 	return properties, nil

--- a/wallet/address_manager.go
+++ b/wallet/address_manager.go
@@ -30,6 +30,15 @@ import (
 )
 
 var (
+	// errMissingAccountPubKey is returned by deriveAddressData when the
+	// AddressDerivationParams arrive without the account-level extended public
+	// key required to derive an address. The wallet's account loader is
+	// expected to fill this in for every SQL-store account before address
+	// derivation.
+	errMissingAccountPubKey = errors.New(
+		"missing account public key for derivation",
+	)
+
 	// ErrDerivationPathNotFound is returned when the derivation path for a
 	// given script cannot be found. This may be because the script does
 	// not belong to the wallet, is imported, or is not a pubkey-based
@@ -300,6 +309,64 @@ func addressInfoFromStoreAddress(storeAddr *db.AddressInfo,
 	}
 
 	return info, nil
+}
+
+// deriveAddressData derives one SQL-store address from account public material.
+func (w *Wallet) deriveAddressData(_ context.Context,
+	params db.AddressDerivationParams) (*db.DerivedAddressData, error) {
+
+	if len(params.AccountPubKey) == 0 {
+		return nil, fmt.Errorf("%w: scope=%v account=%d",
+			errMissingAccountPubKey, params.Scope, params.AccountNumber)
+	}
+
+	accountPubKey, err := hdkeychain.NewKeyFromString(
+		string(params.AccountPubKey),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("parse account pubkey: %w", err)
+	}
+
+	branchKey, err := deriveChildKey(accountPubKey, params.Branch)
+	if err != nil {
+		return nil, fmt.Errorf("derive branch: %w", err)
+	}
+	defer branchKey.Zero()
+
+	addrKey, err := deriveChildKey(branchKey, params.Index)
+	if err != nil {
+		return nil, fmt.Errorf("derive address index: %w", err)
+	}
+	defer addrKey.Zero()
+
+	pubKey, err := addrKey.ECPubKey()
+	if err != nil {
+		return nil, fmt.Errorf("derive address pubkey: %w", err)
+	}
+
+	pubKeyBytes := pubKey.SerializeCompressed()
+
+	walletAddrType, err := addresstype.ToWallet(params.AddrType, false)
+	if err != nil {
+		return nil, fmt.Errorf("address type: %w", err)
+	}
+
+	addr, err := walletAddrType.AddrFromPubKeyBytes(
+		pubKeyBytes, w.cfg.ChainParams,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("derive address: %w", err)
+	}
+
+	scriptPubKey, err := txscript.PayToAddrScript(addr)
+	if err != nil {
+		return nil, fmt.Errorf("pay to addr: %w", err)
+	}
+
+	return &db.DerivedAddressData{
+		ScriptPubKey: scriptPubKey,
+		PubKey:       pubKeyBytes,
+	}, nil
 }
 
 // storeAddressPubKeyCompressed reports whether store pubkey bytes use the

--- a/wallet/address_manager.go
+++ b/wallet/address_manager.go
@@ -675,8 +675,8 @@ func (w *Wallet) ListAddresses(ctx context.Context, accountName string,
 		return nil, err
 	}
 
-	// TODO(yy): switch to Store.ListUTXOs once it is implemented for
-	// kvdb (PR #1238).
+	// TODO(yy): switch to Store.ListUTXOs once the kvdb backend
+	// implements it.
 	balances, err := w.legacyAddressBalances()
 	if err != nil {
 		return nil, err
@@ -1005,6 +1005,10 @@ func derivationForAddressInfo(addressInfo AddressInfo) (
 	}
 
 	keyScope := addressInfo.Derivation.KeyScope
+	if keyScope == (waddrmgr.KeyScope{}) {
+		return nil, fmt.Errorf("%w: derivation scope not found for %v",
+			ErrDerivationPathNotFound, addressInfo.Addr)
+	}
 
 	derivationInfo := &psbt.Bip32Derivation{
 		PubKey:               addressInfo.PubKey.SerializeCompressed(),

--- a/wallet/address_manager_test.go
+++ b/wallet/address_manager_test.go
@@ -7,7 +7,6 @@ package wallet
 import (
 	"iter"
 	"testing"
-	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
@@ -18,7 +17,6 @@ import (
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/addresstype"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
-	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -596,10 +594,8 @@ func TestGetDerivationInfoNoDerivationInfo(t *testing.T) {
 func TestListAddresses(t *testing.T) {
 	t.Parallel()
 
-	// Create a new test wallet.
 	w, deps := createStartedWalletWithMocks(t)
 
-	// Get a new address and give it a balance.
 	mockAddr, _ := btcutil.NewAddressWitnessPubKeyHash(
 		make([]byte, 20), w.cfg.ChainParams,
 	)
@@ -615,68 +611,21 @@ func TestListAddresses(t *testing.T) {
 
 	pkScript, err := txscript.PayToAddrScript(addr)
 	require.NoError(t, err)
-
-	// We need to create a realistic transaction that has at least one
-	// input.
-	deps.txStore.On("InsertTx", mock.Anything, mock.Anything,
-		mock.Anything).Return(nil).Once()
-	deps.txStore.On("AddCredit", mock.Anything, mock.Anything,
-		mock.Anything, uint32(0), false).Return(nil).Once()
-	deps.addrStore.On("MarkUsed", mock.Anything, addr).Return(nil).Once()
-
-	err = walletdb.Update(w.cfg.DB, func(tx walletdb.ReadWriteTx) error {
-		txmgrNs := tx.ReadWriteBucket(wtxmgrNamespaceKey)
-
-		// Create a new transaction and set the output to the address
-		// we want to mark as used.
-		msgTx := TstTx.MsgTx()
-		msgTx.TxOut = []*wire.TxOut{{
-			PkScript: pkScript,
-			Value:    1000,
-		}}
-
-		rec, err := wtxmgr.NewTxRecordFromMsgTx(msgTx, time.Now())
-		if err != nil {
-			return err
-		}
-
-		err = w.txStore.InsertTx(txmgrNs, rec, nil)
-		if err != nil {
-			return err
-		}
-
-		err = w.txStore.AddCredit(txmgrNs, rec, nil, 0, false)
-		if err != nil {
-			return err
-		}
-
-		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-
-		return w.addrStore.MarkUsed(addrmgrNs, addr)
-	})
+	req, err := addressPageRequest()
 	require.NoError(t, err)
 
-	// List the addresses for the default account.
-	deps.txStore.On("UnspentOutputs", mock.Anything).Return([]wtxmgr.Credit{
-		{
-			Amount:   1000,
-			PkScript: pkScript,
+	deps.store.On(
+		"IterAddresses", mock.Anything,
+		db.ListAddressesQuery{
+			WalletID:    w.id,
+			AccountName: "default",
+			Scope:       db.KeyScope(waddrmgr.KeyScopeBIP0084),
+			Page:        req,
 		},
-	}, nil).Once()
-
-	deps.addrStore.On("FetchScopedKeyManager", mock.Anything).
-		Return(deps.accountManager, nil).Once()
-
-	deps.accountManager.On("LookupAccount", mock.Anything, "default").
-		Return(uint32(0), nil).Once()
-
-	deps.accountManager.On("ForEachAccountAddress", mock.Anything, uint32(0),
-		mock.Anything).Run(func(args mock.Arguments) {
-		f, ok := args.Get(2).(func(waddrmgr.ManagedAddress) error)
-		require.True(t, ok)
-		deps.addr.On("Address").Return(addr).Once()
-		_ = f(deps.addr)
-	}).Return(nil).Once()
+	).Return(addressIter(db.AddressInfo{ScriptPubKey: pkScript})).Once()
+	deps.txStore.On(
+		"UnspentOutputs", mock.Anything,
+	).Return([]wtxmgr.Credit{{Amount: 1000, PkScript: pkScript}}, nil).Once()
 
 	addrs, err := w.ListAddresses(
 		t.Context(), "default", waddrmgr.WitnessPubKey,

--- a/wallet/address_manager_test.go
+++ b/wallet/address_manager_test.go
@@ -111,6 +111,41 @@ func expectSignerAddressInfo(t *testing.T, w *Wallet, deps *mockWalletDeps,
 	internal, imported bool, pubKey *btcec.PublicKey) {
 
 	t.Helper()
+	expectSignerAddressInfoWithKeyScope(
+		t, w, deps, addr, addrType, internal, imported, pubKey,
+		waddrmgr.KeyScope{},
+	)
+}
+
+// expectSignerDerivedAddressInfo mocks Store.GetAddress to return address
+// metadata with a usable derivation scope for PSBT derivation tests. The
+// helper hard-codes internal=false because every PSBT derivation test
+// asserts against an external-branch address.
+func expectSignerDerivedAddressInfo(t *testing.T, w *Wallet,
+	deps *mockWalletDeps, addr btcutil.Address, addrType db.AddressType,
+	pubKey *btcec.PublicKey) {
+
+	t.Helper()
+
+	walletAddrType, err := addresstype.ToWallet(addrType, false)
+	require.NoError(t, err)
+
+	keyScope, err := walletAddrType.KeyScope()
+	require.NoError(t, err)
+
+	expectSignerAddressInfoWithKeyScope(
+		t, w, deps, addr, addrType, false, false, pubKey, keyScope,
+	)
+}
+
+// expectSignerAddressInfoWithKeyScope mocks Store.GetAddress with the provided
+// derivation scope. A zero key scope represents missing derivation metadata.
+func expectSignerAddressInfoWithKeyScope(t *testing.T, w *Wallet,
+	deps *mockWalletDeps, addr btcutil.Address, addrType db.AddressType,
+	internal, imported bool, pubKey *btcec.PublicKey,
+	keyScope waddrmgr.KeyScope) {
+
+	t.Helper()
 
 	pkScript, err := txscript.PayToAddrScript(addr)
 	require.NoError(t, err)
@@ -130,19 +165,25 @@ func expectSignerAddressInfo(t *testing.T, w *Wallet, deps *mockWalletDeps,
 		pubKeyBytes = pubKey.SerializeCompressed()
 	}
 
+	storeInfo := &db.AddressInfo{
+		ScriptPubKey: pkScript,
+		AddrType:     addrType,
+		Origin:       origin,
+		Branch:       branch,
+		PubKey:       pubKeyBytes,
+	}
+	if keyScope != (waddrmgr.KeyScope{}) {
+		storeInfo.KeyScope = db.KeyScope(keyScope)
+		storeInfo.MasterKeyFingerprint = 1
+	}
+
 	deps.store.On(
 		"GetAddress", mock.Anything,
 		db.GetAddressQuery{
 			WalletID:     w.id,
 			ScriptPubKey: pkScript,
 		},
-	).Return(&db.AddressInfo{
-		ScriptPubKey: pkScript,
-		AddrType:     addrType,
-		Origin:       origin,
-		Branch:       branch,
-		PubKey:       pubKeyBytes,
-	}, nil)
+	).Return(storeInfo, nil)
 }
 
 // addressIter returns an address iterator over static test records.

--- a/wallet/address_manager_test.go
+++ b/wallet/address_manager_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/addresstype"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
@@ -101,6 +102,51 @@ func expectStoreNewAddress(t *testing.T, w *Wallet, deps *mockWalletDeps,
 	deps.chain.On("NotifyReceived", []btcutil.Address{addr}).Return(nil).Once()
 }
 
+// expectSignerAddressInfo mocks Store.GetAddress to return a minimal
+// AddressInfo for tests that exercise the wallet's address-info read
+// path. No call-count constraint — the same address may be looked up
+// multiple times (input decoration + change output info).
+//
+//nolint:unparam // Keep branch metadata in the helper signature.
+func expectSignerAddressInfo(t *testing.T, w *Wallet, deps *mockWalletDeps,
+	addr btcutil.Address, addrType db.AddressType,
+	internal, imported bool, pubKey *btcec.PublicKey) {
+
+	t.Helper()
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	origin := db.DerivedAccount
+	if imported {
+		origin = db.ImportedAccount
+	}
+
+	var branch uint32
+	if internal {
+		branch = 1
+	}
+
+	var pubKeyBytes []byte
+	if pubKey != nil {
+		pubKeyBytes = pubKey.SerializeCompressed()
+	}
+
+	deps.store.On(
+		"GetAddress", mock.Anything,
+		db.GetAddressQuery{
+			WalletID:     w.id,
+			ScriptPubKey: pkScript,
+		},
+	).Return(&db.AddressInfo{
+		ScriptPubKey: pkScript,
+		AddrType:     addrType,
+		Origin:       origin,
+		Branch:       branch,
+		PubKey:       pubKeyBytes,
+	}, nil)
+}
+
 // addressIter returns an address iterator over static test records.
 func addressIter(items ...db.AddressInfo) iter.Seq2[db.AddressInfo, error] {
 	return func(yield func(db.AddressInfo, error) bool) {
@@ -115,6 +161,24 @@ func addressIter(items ...db.AddressInfo) iter.Seq2[db.AddressInfo, error] {
 // TestNewAddress tests the NewAddress method, ensuring it can generate
 // various address types for different accounts and correctly handles both
 // internal and external address generation.
+// expectStoreAddressInfo configures mock expectations for address lookup.
+func expectStoreAddressInfo(t *testing.T, w *Wallet, deps *mockWalletDeps,
+	addr btcutil.Address, info *db.AddressInfo) {
+
+	t.Helper()
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	deps.store.On(
+		"GetAddress", mock.Anything,
+		db.GetAddressQuery{
+			WalletID:     w.id,
+			ScriptPubKey: pkScript,
+		},
+	).Return(info, nil).Once()
+}
+
 func TestNewAddress(t *testing.T) {
 	t.Parallel()
 
@@ -213,8 +277,17 @@ func TestNewAddress(t *testing.T) {
 			scope, err := tc.addrType.KeyScope()
 			require.NoError(t, err)
 
+			storeAddrType, err := addresstype.FromWallet(tc.addrType)
+			require.NoError(t, err)
+
 			expectStoreNewAddress(
 				t, w, deps, tc.accountName, scope, tc.change, addr,
+			)
+			expectStoreAddressInfo(t, w, deps, addr,
+				derivedAddressInfoFromAddr(
+					t, addr, storeAddrType.Type, tc.accountName, scope,
+					tc.change, 0, 0, nil,
+				),
 			)
 
 			addr, err = w.NewAddress(
@@ -225,6 +298,10 @@ func TestNewAddress(t *testing.T) {
 			require.NotNil(t, addr)
 
 			require.IsType(t, tc.expectedAddrType, addr)
+
+			addrInfo, err := w.GetAddressInfo(t.Context(), addr)
+			require.NoError(t, err)
+			require.Equal(t, tc.change, addrInfo.Internal)
 		})
 	}
 }
@@ -324,71 +401,40 @@ func TestGetUnusedAddress(t *testing.T) {
 func TestGetAddressInfo(t *testing.T) {
 	t.Parallel()
 
-	// Create a new test wallet.
 	w, deps := createStartedWalletWithMocks(t)
-
-	// Get a new external address to test with.
-	var addr btcutil.Address
-
-	addr, _ = btcutil.NewAddressWitnessPubKeyHash(
-		make([]byte, 20), w.cfg.ChainParams,
-	)
-
-	expectStoreNewAddress(
-		t, w, deps, "default", waddrmgr.KeyScopeBIP0084, false, addr,
-	)
-
-	extAddr, err := w.NewAddress(
-		t.Context(), "default", waddrmgr.WitnessPubKey, false,
-	)
+	privKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 
-	// Get the address info for the external address.
-	deps.addrStore.On("Address", mock.Anything, extAddr).
-		Return(deps.addr, nil).Once()
-	deps.addr.On("Address").Return(extAddr).Once()
-	deps.addr.On("Internal").Return(false).Once()
-	deps.addr.On("Compressed").Return(true).Once()
-	deps.addr.On("Imported").Return(false).Once()
-	deps.addr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
+	pubKey := privKey.PubKey()
+
+	extAddr, _ := btcutil.NewAddressWitnessPubKeyHash(
+		make([]byte, 20), w.cfg.ChainParams,
+	)
+	expectStoreAddressInfo(t, w, deps, extAddr, derivedAddressInfoFromAddr(
+		t, extAddr, db.WitnessPubKey, "default", waddrmgr.KeyScopeBIP0084,
+		false, 0, 0, pubKey,
+	))
 
 	extInfo, err := w.GetAddressInfo(t.Context(), extAddr)
 	require.NoError(t, err)
 
-	// Check the external address info.
 	require.Equal(t, extAddr.String(), extInfo.Addr.String())
 	require.False(t, extInfo.Internal)
 	require.True(t, extInfo.Compressed)
 	require.False(t, extInfo.Imported)
 	require.Equal(t, waddrmgr.WitnessPubKey, extInfo.AddrType)
 
-	// Get a new internal address to test with.
-	addr, _ = btcutil.NewAddressWitnessPubKeyHash(
+	intAddr, _ := btcutil.NewAddressWitnessPubKeyHash(
 		make([]byte, 20), w.cfg.ChainParams,
 	)
-
-	expectStoreNewAddress(
-		t, w, deps, "default", waddrmgr.KeyScopeBIP0084, true, addr,
-	)
-
-	intAddr, err := w.NewAddress(
-		t.Context(), "default", waddrmgr.WitnessPubKey, true,
-	)
-	require.NoError(t, err)
-
-	// Get the address info for the internal address.
-	deps.addrStore.On("Address", mock.Anything, intAddr).
-		Return(deps.addr, nil).Once()
-	deps.addr.On("Address").Return(intAddr).Once()
-	deps.addr.On("Internal").Return(true).Once()
-	deps.addr.On("Compressed").Return(true).Once()
-	deps.addr.On("Imported").Return(false).Once()
-	deps.addr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
+	expectStoreAddressInfo(t, w, deps, intAddr, derivedAddressInfoFromAddr(
+		t, intAddr, db.WitnessPubKey, "default", waddrmgr.KeyScopeBIP0084,
+		true, 0, 0, pubKey,
+	))
 
 	intInfo, err := w.GetAddressInfo(t.Context(), intAddr)
 	require.NoError(t, err)
 
-	// Check the internal address info.
 	require.Equal(t, intAddr.String(), intInfo.Addr.String())
 	require.True(t, intInfo.Internal)
 	require.True(t, intInfo.Compressed)
@@ -401,34 +447,13 @@ func TestGetAddressInfo(t *testing.T) {
 func TestGetDerivationInfoExternalAddressSuccess(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Create a new test wallet and a new p2wkh address to test
-	// with.
 	w, deps := createStartedWalletWithMocks(t)
-	mockAddr, _ := btcutil.NewAddressWitnessPubKeyHash(
+	addr, _ := btcutil.NewAddressWitnessPubKeyHash(
 		make([]byte, 20), w.cfg.ChainParams,
 	)
 
-	expectStoreNewAddress(
-		t, w, deps, "default", waddrmgr.KeyScopeBIP0084, false, mockAddr,
-	)
-
-	addr, err := w.NewAddress(
-		t.Context(), "default", waddrmgr.WitnessPubKey, false,
-	)
-	require.NoError(t, err)
-
-	// Act: Get the derivation info for the address.
-	deps.addrStore.On("Address", mock.Anything, addr).
-		Return(deps.pubKeyAddr, nil).Once()
-	deps.pubKeyAddr.On("Address").Return(addr).Once()
-	deps.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
-	deps.pubKeyAddr.On("Imported").Return(false).Once()
-	deps.pubKeyAddr.On("Internal").Return(false).Once()
-	deps.pubKeyAddr.On("Compressed").Return(true).Once()
-
 	privKey, _ := btcec.NewPrivateKey()
 	pubKey := privKey.PubKey()
-	deps.pubKeyAddr.On("PubKey").Return(pubKey).Once()
 
 	scope := waddrmgr.KeyScopeBIP0084
 	path := waddrmgr.DerivationPath{
@@ -437,11 +462,13 @@ func TestGetDerivationInfoExternalAddressSuccess(t *testing.T) {
 		Index:                0,
 		MasterKeyFingerprint: 123,
 	}
-	deps.pubKeyAddr.On("DerivationInfo").Return(scope, path, true).Once()
+	expectStoreAddressInfo(t, w, deps, addr, derivedAddressInfoFromAddr(
+		t, addr, db.WitnessPubKey, "default", scope, false, path.Index,
+		path.MasterKeyFingerprint, pubKey,
+	))
 
 	derivationInfo, err := w.GetDerivationInfo(t.Context(), addr)
 
-	// Assert: Check that the correct derivation info is returned.
 	require.NoError(t, err)
 	require.NotNil(t, derivationInfo)
 
@@ -464,34 +491,13 @@ func TestGetDerivationInfoExternalAddressSuccess(t *testing.T) {
 func TestGetDerivationInfoInternalAddressSuccess(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Create a new test wallet and a new p2wkh change address to
-	// test with.
 	w, deps := createStartedWalletWithMocks(t)
-	mockAddr, _ := btcutil.NewAddressWitnessPubKeyHash(
+	addr, _ := btcutil.NewAddressWitnessPubKeyHash(
 		make([]byte, 20), w.cfg.ChainParams,
 	)
 
-	expectStoreNewAddress(
-		t, w, deps, "default", waddrmgr.KeyScopeBIP0084, true, mockAddr,
-	)
-
-	addr, err := w.NewAddress(
-		t.Context(), "default", waddrmgr.WitnessPubKey, true,
-	)
-	require.NoError(t, err)
-
-	// Act: Get the derivation info for the address.
-	deps.addrStore.On("Address", mock.Anything, addr).
-		Return(deps.pubKeyAddr, nil).Once()
-	deps.pubKeyAddr.On("Address").Return(addr).Once()
-	deps.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
-	deps.pubKeyAddr.On("Imported").Return(false).Once()
-	deps.pubKeyAddr.On("Internal").Return(true).Once()
-	deps.pubKeyAddr.On("Compressed").Return(true).Once()
-
 	privKey, _ := btcec.NewPrivateKey()
 	pubKey := privKey.PubKey()
-	deps.pubKeyAddr.On("PubKey").Return(pubKey).Once()
 
 	scope := waddrmgr.KeyScopeBIP0084
 	path := waddrmgr.DerivationPath{
@@ -500,11 +506,13 @@ func TestGetDerivationInfoInternalAddressSuccess(t *testing.T) {
 		Index:                0,
 		MasterKeyFingerprint: 123,
 	}
-	deps.pubKeyAddr.On("DerivationInfo").Return(scope, path, true).Once()
+	expectStoreAddressInfo(t, w, deps, addr, derivedAddressInfoFromAddr(
+		t, addr, db.WitnessPubKey, "default", scope, true, path.Index,
+		path.MasterKeyFingerprint, pubKey,
+	))
 
 	derivationInfo, err := w.GetDerivationInfo(t.Context(), addr)
 
-	// Assert: Check that the correct derivation info is returned.
 	require.NoError(t, err)
 	require.NotNil(t, derivationInfo)
 
@@ -540,16 +548,21 @@ func TestGetDerivationInfoNoDerivationInfo(t *testing.T) {
 
 	// Act & Assert: Check that we get an error for an address not in the
 	// wallet.
-	deps.addrStore.On("Address", mock.Anything, addr).Return(
-		nil, errDBMock).Once()
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	deps.store.On(
+		"GetAddress", mock.Anything,
+		db.GetAddressQuery{
+			WalletID:     w.id,
+			ScriptPubKey: pkScript,
+		},
+	).Return(nil, errDBMock).Once()
 
 	_, err = w.GetDerivationInfo(t.Context(), addr)
 	require.Error(t, err)
 
 	// Arrange: Import the key as a watch-only address.
-	pkScript, err := txscript.PayToAddrScript(addr)
-	require.NoError(t, err)
-
 	deps.store.On(
 		"NewImportedAddress", mock.Anything,
 		db.NewImportedAddressParams{
@@ -570,17 +583,9 @@ func TestGetDerivationInfoNoDerivationInfo(t *testing.T) {
 
 	// Act & Assert: Check that we still get an error because it's an
 	// imported key.
-	deps.addrStore.On("Address", mock.Anything, addr).
-		Return(deps.pubKeyAddr, nil).Once()
-	deps.pubKeyAddr.On("Address").Return(addr).Once()
-	deps.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
-	deps.pubKeyAddr.On("Imported").Return(true).Once()
-	deps.pubKeyAddr.On("Internal").Return(false).Once()
-	deps.pubKeyAddr.On("Compressed").Return(true).Once()
-	deps.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-	deps.pubKeyAddr.On("DerivationInfo").Return(
-		waddrmgr.KeyScope{}, waddrmgr.DerivationPath{}, false,
-	).Once()
+	expectStoreAddressInfo(t, w, deps, addr, importedPubKeyAddressInfoFromAddr(
+		t, addr, waddrmgr.KeyScopeBIP0084, pubKey,
+	))
 
 	_, err = w.GetDerivationInfo(t.Context(), addr)
 	require.ErrorIs(t, err, ErrDerivationPathNotFound)
@@ -720,6 +725,14 @@ func TestImportPublicKey(t *testing.T) {
 
 	err = w.ImportPublicKey(t.Context(), pubKey, waddrmgr.WitnessPubKey)
 	require.NoError(t, err)
+
+	expectStoreAddressInfo(t, w, deps, addr, importedPubKeyAddressInfoFromAddr(
+		t, addr, waddrmgr.KeyScopeBIP0084, pubKey,
+	))
+
+	info, err := w.GetAddressInfo(t.Context(), addr)
+	require.NoError(t, err)
+	require.NotNil(t, info)
 }
 
 // TestImportTaprootScript tests the ImportTaprootScript method to ensure it can
@@ -797,23 +810,12 @@ func TestImportTaprootScript(t *testing.T) {
 func TestScriptForOutput(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Create a started wallet, one witness output, and matching
-	// managed address metadata.
 	w, deps := createStartedWalletWithMocks(t)
 
-	// Create a new p2wkh address and output.
-	mockAddr, _ := btcutil.NewAddressWitnessPubKeyHash(
+	addr, _ := btcutil.NewAddressWitnessPubKeyHash(
 		make([]byte, 20), w.cfg.ChainParams,
 	)
 
-	expectStoreNewAddress(
-		t, w, deps, "default", waddrmgr.KeyScopeBIP0084, false, mockAddr,
-	)
-
-	addr, err := w.NewAddress(
-		t.Context(), "default", waddrmgr.WitnessPubKey, false,
-	)
-	require.NoError(t, err)
 	pkScript, err := txscript.PayToAddrScript(addr)
 	require.NoError(t, err)
 
@@ -823,24 +825,15 @@ func TestScriptForOutput(t *testing.T) {
 	}
 
 	_, pubKey := deterministicPrivKey(t)
+	expectStoreAddressInfo(t, w, deps, addr, derivedAddressInfoFromAddr(
+		t, addr, db.WitnessPubKey, "default", waddrmgr.KeyScopeBIP0084,
+		false, 0, 0, pubKey,
+	))
 
-	deps.addrStore.On("Address", mock.Anything, addr).
-		Return(deps.pubKeyAddr, nil).Once()
-	deps.pubKeyAddr.On("Address").Return(addr).Once()
-	deps.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
-	deps.pubKeyAddr.On("Imported").Return(false).Once()
-	deps.pubKeyAddr.On("Internal").Return(false).Once()
-	deps.pubKeyAddr.On("Compressed").Return(true).Once()
-	deps.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-	deps.pubKeyAddr.On("DerivationInfo").Return(
-		waddrmgr.KeyScopeBIP0084, waddrmgr.DerivationPath{}, false,
-	).Once()
-
-	// Act: Build the spending metadata for the witness output.
 	script, err := w.ScriptForOutput(t.Context(), output)
 	require.NoError(t, err)
 
-	// Assert: The output metadata matches the native witness spend shape.
+	// Check that the script is correct.
 	require.Equal(t, addr, script.Addr)
 	require.Equal(t, waddrmgr.WitnessPubKey, script.AddrType)
 	require.Equal(t, pkScript, script.WitnessProgram)
@@ -852,8 +845,6 @@ func TestScriptForOutput(t *testing.T) {
 func TestScriptForOutputNestedWitness(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Create a started wallet, a nested witness output, and matching
-	// managed address metadata.
 	w, deps := createStartedWalletWithMocks(t)
 	_, pubKey := deterministicPrivKey(t)
 	witnessProgram, err := txscript.NewScriptBuilder().
@@ -866,31 +857,25 @@ func TestScriptForOutputNestedWitness(t *testing.T) {
 	require.NoError(t, err)
 	pkScript, err := txscript.PayToAddrScript(addr)
 	require.NoError(t, err)
+	expectedSigScript, err := txscript.NewScriptBuilder().
+		AddData(witnessProgram).
+		Script()
+	require.NoError(t, err)
 
-	deps.addrStore.On("Address", mock.Anything, addr).
-		Return(deps.pubKeyAddr, nil).Once()
-	deps.pubKeyAddr.On("Address").Return(addr).Once()
-	deps.pubKeyAddr.On("AddrType").Return(waddrmgr.NestedWitnessPubKey).Once()
-	deps.pubKeyAddr.On("Imported").Return(false).Once()
-	deps.pubKeyAddr.On("Internal").Return(false).Once()
-	deps.pubKeyAddr.On("Compressed").Return(true).Once()
-	deps.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-	deps.pubKeyAddr.On("DerivationInfo").Return(
-		waddrmgr.KeyScopeBIP0049Plus, waddrmgr.DerivationPath{}, false,
-	).Once()
+	expectStoreAddressInfo(t, w, deps, addr, derivedAddressInfoFromAddr(
+		t, addr, db.NestedWitnessPubKey, "default",
+		waddrmgr.KeyScopeBIP0049Plus, false, 0, 0, pubKey,
+	))
 
-	// Act: Build the spending metadata for the nested witness output.
 	scriptInfo, err := w.ScriptForOutput(t.Context(), wire.TxOut{
 		Value:    1000,
 		PkScript: pkScript,
 	})
 	require.NoError(t, err)
-
-	// Assert: The output metadata carries the inner witness program and redeem
-	// script required for nested witness spends.
 	require.Equal(t, addr, scriptInfo.Addr)
 	require.Equal(t, waddrmgr.NestedWitnessPubKey,
 		scriptInfo.AddrType)
 	require.Equal(t, witnessProgram, scriptInfo.WitnessProgram)
 	require.Equal(t, witnessProgram, scriptInfo.RedeemScript)
+	require.Equal(t, expectedSigScript, scriptInfo.SigScript)
 }

--- a/wallet/internal/db/kvdb/addressstore.go
+++ b/wallet/internal/db/kvdb/addressstore.go
@@ -19,6 +19,9 @@ import (
 	"github.com/btcsuite/btcwallet/walletdb"
 )
 
+// A compile-time assertion to ensure Store implements the address store.
+var _ db.AddressStore = (*Store)(nil)
+
 var (
 	// errUnexpectedAddressCount is returned when legacy address derivation
 	// returns a number of addresses different from the requested count.
@@ -269,9 +272,7 @@ func resolvedAddressInfo(ns walletdb.ReadBucket,
 		return nil, err
 	}
 
-	err = setAddressID(
-		ns, manager, account, resolver.WatchOnly(), info,
-	)
+	err = setAddressID(ns, manager, account, resolver.WatchOnly(), info)
 	if err != nil {
 		return nil, err
 	}
@@ -279,13 +280,46 @@ func resolvedAddressInfo(ns walletdb.ReadBucket,
 	return info, nil
 }
 
-// ListAddresses is not yet implemented for kvdb.
+// ListAddresses returns one page of addresses from the legacy address-manager
+// path.
 func (s *Store) ListAddresses(ctx context.Context,
-	_ db.ListAddressesQuery) (page.Result[db.AddressInfo, uint32], error) {
+	query db.ListAddressesQuery) (page.Result[db.AddressInfo, uint32], error) {
 
-	return page.Result[db.AddressInfo, uint32]{}, notImplemented(
-		ctx, "ListAddresses",
+	err := ctx.Err()
+	if err != nil {
+		return page.Result[db.AddressInfo, uint32]{}, err
+	}
+
+	if query.Page.Limit() == 0 {
+		return page.Result[db.AddressInfo, uint32]{}, db.ErrInvalidPageLimit
+	}
+
+	addrMgr := s.addrStore
+
+	manager, err := addrMgr.FetchScopedKeyManager(
+		waddrmgr.KeyScope(query.Scope),
 	)
+	if err != nil {
+		return page.Result[db.AddressInfo, uint32]{},
+			fmt.Errorf("ListAddresses: fetch scoped manager: %w", err)
+	}
+
+	items, err := listAddressItems(
+		s.db, manager, addrMgr.WatchOnly(), query,
+	)
+	if err != nil {
+		return page.Result[db.AddressInfo, uint32]{},
+			fmt.Errorf("ListAddresses: %w", err)
+	}
+
+	result := page.BuildResult(
+		query.Page, items,
+		func(item db.AddressInfo) uint32 {
+			return item.ID
+		},
+	)
+
+	return result, nil
 }
 
 // IterAddresses returns an iterator over paginated legacy address-manager
@@ -545,6 +579,42 @@ func importTaprootScriptAddress(ns walletdb.ReadWriteBucket,
 	return managedAddr, nil
 }
 
+// listAddressItems loads, filters, and paginates account addresses from one
+// legacy scoped manager.
+func listAddressItems(dbConn walletdb.DB,
+	manager waddrmgr.AccountStore, walletIsWatchOnly bool,
+	query db.ListAddressesQuery) ([]db.AddressInfo, error) {
+
+	var items []db.AddressInfo
+
+	err := walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgr.NamespaceKey)
+		if ns == nil {
+			return errMissingAddrmgrNamespace
+		}
+
+		account, err := manager.LookupAccount(ns, query.AccountName)
+		if err != nil {
+			if waddrmgr.IsError(err, waddrmgr.ErrAccountNotFound) {
+				return db.ErrAccountNotFound
+			}
+
+			return fmt.Errorf("lookup account: %w", err)
+		}
+
+		items, err = accountAddressInfos(
+			ns, manager, account, walletIsWatchOnly,
+		)
+
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list address items: %w", err)
+	}
+
+	return addressPageItems(items, query), nil
+}
+
 // setAddressID assigns target's synthetic ID from the current legacy
 // account view.
 func setAddressID(ns walletdb.ReadBucket, manager waddrmgr.AccountStore,
@@ -638,6 +708,25 @@ func addressLess(a, b db.AddressInfo) bool {
 	}
 
 	return bytes.Compare(a.ScriptPubKey, b.ScriptPubKey) < 0
+}
+
+// addressPageItems applies cursor pagination to already sorted address items.
+func addressPageItems(items []db.AddressInfo,
+	query db.ListAddressesQuery) []db.AddressInfo {
+
+	start := 0
+	if query.Page.After != nil {
+		for start < len(items) && items[start].ID <= *query.Page.After {
+			start++
+		}
+	}
+
+	limit := start + int(query.Page.Limit()) + 1
+	if limit > len(items) {
+		limit = len(items)
+	}
+
+	return items[start:limit]
 }
 
 // managedAddressInfo adapts one legacy managed address into the db address view

--- a/wallet/internal/db/kvdb/addressstore.go
+++ b/wallet/internal/db/kvdb/addressstore.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcwallet/waddrmgr"
@@ -200,11 +201,82 @@ func validateImportedAddress(params db.NewImportedAddressParams,
 	return nil
 }
 
-// GetAddress is not yet implemented for kvdb.
+// GetAddress retrieves one address through the legacy address-manager path.
 func (s *Store) GetAddress(ctx context.Context,
-	_ db.GetAddressQuery) (*db.AddressInfo, error) {
+	query db.GetAddressQuery) (*db.AddressInfo, error) {
 
-	return nil, notImplemented(ctx, "GetAddress")
+	err := ctx.Err()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(query.ScriptPubKey) == 0 {
+		return nil, db.ErrInvalidAddressQuery
+	}
+
+	addrMgr := s.addrStore
+
+	addr := addressFromScript(
+		query.ScriptPubKey, addrMgr.ChainParams(),
+	)
+	if addr == nil {
+		return nil, db.ErrAddressNotFound
+	}
+
+	var info *db.AddressInfo
+
+	err = walletdb.View(s.db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgr.NamespaceKey)
+		if ns == nil {
+			return errMissingAddrmgrNamespace
+		}
+
+		info, err = resolvedAddressInfo(ns, addrMgr, addr)
+
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("GetAddress: %w", err)
+	}
+
+	return info, nil
+}
+
+// resolvedAddressInfo resolves one legacy managed address and assigns its
+// synthetic address ID.
+func resolvedAddressInfo(ns walletdb.ReadBucket,
+	resolver waddrmgr.AddrStore,
+	addr btcutil.Address) (*db.AddressInfo, error) {
+
+	managedAddr, err := resolver.Address(ns, addr)
+	if err != nil {
+		if waddrmgr.IsError(err, waddrmgr.ErrAddressNotFound) {
+			return nil, db.ErrAddressNotFound
+		}
+
+		return nil, fmt.Errorf("lookup address: %w", err)
+	}
+
+	manager, account, err := resolver.AddrAccount(ns, addr)
+	if err != nil {
+		return nil, fmt.Errorf("lookup address account: %w", err)
+	}
+
+	info, err := managedAddressInfo(
+		ns, manager, resolver.WatchOnly(), managedAddr,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	err = setAddressID(
+		ns, manager, account, resolver.WatchOnly(), info,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return info, nil
 }
 
 // ListAddresses is not yet implemented for kvdb.
@@ -683,4 +755,23 @@ func managedAddressIsWatchOnly(walletIsWatchOnly bool,
 	}
 
 	return !hasPrivateKey, nil
+}
+
+// addressFromScript extracts the unique standard address for a script.
+func addressFromScript(pkScript []byte,
+	chainParams *chaincfg.Params) btcutil.Address {
+
+	_, addrs, _, err := txscript.ExtractPkScriptAddrs(
+		pkScript, chainParams,
+	)
+	if err != nil || len(addrs) == 0 {
+		return nil
+	}
+
+	encoded, err := txscript.PayToAddrScript(addrs[0])
+	if err != nil || !bytes.Equal(encoded, pkScript) {
+		return nil
+	}
+
+	return addrs[0]
 }

--- a/wallet/internal/db/kvdb/addressstore_test.go
+++ b/wallet/internal/db/kvdb/addressstore_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -46,6 +47,15 @@ func TestAddressStoreNewDerivedAddress(t *testing.T) {
 	require.Equal(t, props.AccountNumber, info.AccountID)
 	require.NotEmpty(t, info.ScriptPubKey)
 	require.NotEmpty(t, info.PubKey)
+
+	got, err := store.GetAddress(
+		t.Context(), db.GetAddressQuery{
+			WalletID:     0,
+			ScriptPubKey: info.ScriptPubKey,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, info, got)
 }
 
 // TestAddressStoreImportedPublicKeyIsWatchOnly verifies that imported public
@@ -87,6 +97,122 @@ func TestAddressStoreImportedPublicKeyIsWatchOnly(t *testing.T) {
 	require.Equal(t, pkScript, info.ScriptPubKey)
 	require.Equal(t, pubKeyBytes, info.PubKey)
 	require.True(t, info.IsWatchOnly)
+
+	got, err := store.GetAddress(
+		t.Context(), db.GetAddressQuery{
+			WalletID:     0,
+			ScriptPubKey: pkScript,
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, got.IsWatchOnly)
+}
+
+// TestGetAddressBareMultisigReturnsNotFound verifies that GetAddress rejects
+// scripts that cannot be uniquely identified by their extracted address.
+func TestGetAddressBareMultisigReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	addrStore := newSpendableAddrMgr(t, dbConn)
+	store := NewStore(dbConn, nil, addrStore)
+
+	privKey1, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	privKey2, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	pubKeyBytes := privKey1.PubKey().SerializeCompressed()
+	addr, err := btcutil.NewAddressPubKeyHash(
+		btcutil.Hash160(pubKeyBytes), addrStore.ChainParams(),
+	)
+	require.NoError(t, err)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	pubKeyAddr, err := btcutil.NewAddressPubKey(
+		pubKeyBytes, addrStore.ChainParams(),
+	)
+	require.NoError(t, err)
+
+	_, err = store.NewImportedAddress(
+		t.Context(), db.NewImportedAddressParams{
+			WalletID:     0,
+			Scope:        db.KeyScope(waddrmgr.KeyScopeBIP0044),
+			AddressType:  db.PubKeyHash,
+			ScriptPubKey: pkScript,
+			PubKey:       pubKeyBytes,
+		},
+	)
+	require.NoError(t, err)
+
+	otherPubKeyAddr, err := btcutil.NewAddressPubKey(
+		privKey2.PubKey().SerializeCompressed(), addrStore.ChainParams(),
+	)
+	require.NoError(t, err)
+
+	multisigScript, err := txscript.MultiSigScript(
+		[]*btcutil.AddressPubKey{pubKeyAddr, otherPubKeyAddr}, 1,
+	)
+	require.NoError(t, err)
+
+	_, err = store.GetAddress(t.Context(), db.GetAddressQuery{
+		WalletID:     0,
+		ScriptPubKey: multisigScript,
+	})
+	require.ErrorIs(t, err, db.ErrAddressNotFound)
+}
+
+// TestAddressStoreImportedPrivateKeyIsSpendable verifies that legacy imported
+// private keys are not marked watch-only.
+func TestAddressStoreImportedPrivateKeyIsSpendable(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	addrStore := newSpendableAddrMgr(t, dbConn)
+	store := NewStore(dbConn, nil, addrStore)
+
+	unlockAddrStore(t, dbConn, addrStore)
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	wif, err := btcutil.NewWIF(privKey, addrStore.ChainParams(), false)
+	require.NoError(t, err)
+
+	manager, err := addrStore.FetchScopedKeyManager(waddrmgr.KeyScopeBIP0084)
+	require.NoError(t, err)
+
+	var pkScript []byte
+
+	err = walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+
+		managedAddr, err := manager.ImportPrivateKey(ns, wif, nil)
+		if err != nil {
+			return err
+		}
+
+		pkScript, err = txscript.PayToAddrScript(managedAddr.Address())
+
+		return err
+	})
+	require.NoError(t, err)
+
+	got, err := store.GetAddress(
+		t.Context(), db.GetAddressQuery{
+			WalletID:     0,
+			ScriptPubKey: pkScript,
+		},
+	)
+	require.NoError(t, err)
+	require.False(t, got.IsWatchOnly)
+	require.Len(t, got.PubKey, len(privKey.PubKey().SerializeUncompressed()))
 }
 
 // TestAddressStoreImportedPublicKeyRejectsMismatch verifies that kvdb rejects
@@ -213,6 +339,16 @@ func TestAddressStoreImportTaprootScript(t *testing.T) {
 	require.Equal(t, db.TaprootPubKey, info.AddrType)
 	require.True(t, info.HasScript)
 	require.Equal(t, pkScript, info.ScriptPubKey)
+
+	got, err := store.GetAddress(
+		t.Context(), db.GetAddressQuery{
+			WalletID:     0,
+			ScriptPubKey: pkScript,
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, got.HasScript)
+	require.Equal(t, db.TaprootPubKey, got.AddrType)
 }
 
 // TestManagedAddressIsWatchOnlyUnsupportedPubKey verifies that unsupported
@@ -293,6 +429,20 @@ func (m *unsupportedManagedPubKeyAddress) DerivationInfo() (waddrmgr.KeyScope,
 	path, _ := args.Get(1).(waddrmgr.DerivationPath)
 
 	return scope, path, args.Bool(2)
+}
+
+// unlockAddrStore unlocks the legacy address manager for private-key imports.
+func unlockAddrStore(t *testing.T, dbConn walletdb.DB,
+	addrStore *waddrmgr.Manager) {
+
+	t.Helper()
+
+	err := walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgr.NamespaceKey)
+
+		return addrStore.Unlock(ns, testPrivPass)
+	})
+	require.NoError(t, err)
 }
 
 // testTaprootScript returns a tapscript and its P2TR output script.

--- a/wallet/internal/db/kvdb/addressstore_test.go
+++ b/wallet/internal/db/kvdb/addressstore_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/db/page"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -56,6 +57,124 @@ func TestAddressStoreNewDerivedAddress(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, info, got)
+
+	pageReq, err := page.NewRequest[uint32](10)
+	require.NoError(t, err)
+	result, err := store.ListAddresses(
+		t.Context(), db.ListAddressesQuery{
+			WalletID:    0,
+			AccountName: "addr",
+			Scope:       db.KeyScope(waddrmgr.KeyScopeBIP0084),
+			Page:        pageReq,
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, result.Items, 1)
+	require.Equal(t, *info, result.Items[0])
+}
+
+// TestAddressStoreNewDerivedAddressWatchOnlyWallet verifies that derived
+// address metadata inherits wallet-level watch-only mode.
+func TestAddressStoreNewDerivedAddressWatchOnlyWallet(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	addrStore := newSpendableAddrMgr(t, dbConn)
+	store := NewStore(dbConn, nil, addrStore)
+	createLegacyAccount(
+		t, dbConn, addrStore, waddrmgr.KeyScopeBIP0084, "watch",
+	)
+	convertAddrStoreToWatchOnly(t, dbConn, addrStore)
+
+	info, err := store.NewDerivedAddress(
+		t.Context(), db.NewDerivedAddressParams{
+			WalletID:    0,
+			AccountName: "watch",
+			Scope:       db.KeyScope(waddrmgr.KeyScopeBIP0084),
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, info.IsWatchOnly)
+
+	got, err := store.GetAddress(
+		t.Context(), db.GetAddressQuery{
+			WalletID:     0,
+			ScriptPubKey: info.ScriptPubKey,
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, got.IsWatchOnly)
+
+	pageReq, err := page.NewRequest[uint32](10)
+	require.NoError(t, err)
+	result, err := store.ListAddresses(
+		t.Context(), db.ListAddressesQuery{
+			WalletID:    0,
+			AccountName: "watch",
+			Scope:       db.KeyScope(waddrmgr.KeyScopeBIP0084),
+			Page:        pageReq,
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, result.Items, 1)
+	require.True(t, result.Items[0].IsWatchOnly)
+}
+
+// TestAddressStoreListAddressesPagination verifies that kvdb pagination uses
+// collision-free synthetic IDs and does not skip or repeat addresses.
+func TestAddressStoreListAddressesPagination(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	addrStore := newSpendableAddrMgr(t, dbConn)
+	store := NewStore(dbConn, nil, addrStore)
+	createLegacyAccount(
+		t, dbConn, addrStore, waddrmgr.KeyScopeBIP0084, "page",
+	)
+
+	for range 5 {
+		_, err := store.NewDerivedAddress(
+			t.Context(), db.NewDerivedAddressParams{
+				WalletID:    0,
+				AccountName: "page",
+				Scope:       db.KeyScope(waddrmgr.KeyScopeBIP0084),
+			},
+		)
+		require.NoError(t, err)
+	}
+
+	pageReq, err := page.NewRequest[uint32](2)
+	require.NoError(t, err)
+
+	query := db.ListAddressesQuery{
+		WalletID:    0,
+		AccountName: "page",
+		Scope:       db.KeyScope(waddrmgr.KeyScopeBIP0084),
+		Page:        pageReq,
+	}
+
+	var addresses []db.AddressInfo
+	for {
+		result, err := store.ListAddresses(t.Context(), query)
+		require.NoError(t, err)
+
+		addresses = append(addresses, result.Items...)
+		if result.Next == nil {
+			break
+		}
+
+		query.Page.After = result.Next
+	}
+
+	require.Len(t, addresses, 5)
+
+	for i := range addresses {
+		require.Equal(t, uint32(i+1), addresses[i].ID)
+	}
 }
 
 // TestAddressStoreImportedPublicKeyIsWatchOnly verifies that imported public
@@ -441,6 +560,21 @@ func unlockAddrStore(t *testing.T, dbConn walletdb.DB,
 		ns := tx.ReadBucket(waddrmgr.NamespaceKey)
 
 		return addrStore.Unlock(ns, testPrivPass)
+	})
+	require.NoError(t, err)
+}
+
+// convertAddrStoreToWatchOnly converts the legacy address manager to
+// wallet-level watch-only mode for metadata adapter tests.
+func convertAddrStoreToWatchOnly(t *testing.T, dbConn walletdb.DB,
+	addrStore *waddrmgr.Manager) {
+
+	t.Helper()
+
+	err := walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+
+		return addrStore.ConvertToWatchingOnly(ns)
 	})
 	require.NoError(t, err)
 }

--- a/wallet/psbt_manager_test.go
+++ b/wallet/psbt_manager_test.go
@@ -283,8 +283,8 @@ func TestDecorateInputSegWitV0(t *testing.T) {
 	// Arrange: Mock the address manager to return our P2WKH address as a
 	// ManagedPubKeyAddress when `Address` is called with the P2WKH
 	// address.
-	expectSignerAddressInfo(
-		t, w, mocks, p2wkhAddr, db.WitnessPubKey, false, false, pubKey,
+	expectSignerDerivedAddressInfo(
+		t, w, mocks, p2wkhAddr, db.WitnessPubKey, pubKey,
 	)
 
 	// Arrange: Mock the ManagedPubKeyAddress methods to return relevant
@@ -340,8 +340,8 @@ func TestDecorateInputTaproot(t *testing.T) {
 	// Arrange: Mock the address manager to return our Taproot address as a
 	// ManagedPubKeyAddress when `Address` is called with the Taproot
 	// address.
-	expectSignerAddressInfo(
-		t, w, mocks, taprootAddr, db.TaprootPubKey, false, false, pubKey,
+	expectSignerDerivedAddressInfo(
+		t, w, mocks, taprootAddr, db.TaprootPubKey, pubKey,
 	)
 
 	// Arrange: Mock the ManagedPubKeyAddress methods to return relevant
@@ -543,10 +543,10 @@ func TestDecorateInputErrDerivationMissing(t *testing.T) {
 
 	w, mocks := createStartedWalletWithMocks(t)
 
-	// Arrange: Mock AddressInfo to return a ManagedPubKeyAddress that has
-	// no derivation info.
+	// Arrange: Mock AddressInfo to return a non-imported pubkey address
+	// whose store record has no usable derivation scope.
 	expectSignerAddressInfo(
-		t, w, mocks, p2wkhAddr, db.WitnessPubKey, false, true, pubKey,
+		t, w, mocks, p2wkhAddr, db.WitnessPubKey, false, false, pubKey,
 	)
 
 	utxo := &wire.TxOut{
@@ -590,8 +590,8 @@ func TestDecorateInputNestedWitnessUsesRedeemScript(t *testing.T) {
 	require.NoError(t, err)
 
 	w, mocks := createStartedWalletWithMocks(t)
-	expectSignerAddressInfo(
-		t, w, mocks, nestedAddr, db.NestedWitnessPubKey, false, false, pubKey,
+	expectSignerDerivedAddressInfo(
+		t, w, mocks, nestedAddr, db.NestedWitnessPubKey, pubKey,
 	)
 
 	pInput := &psbt.PInput{}
@@ -698,8 +698,8 @@ func TestDecorateInputsSuccess(t *testing.T) {
 	).Return(txDetails2, nil)
 
 	// Arrange: Mock Address lookup (common for both known inputs).
-	expectSignerAddressInfo(
-		t, w, mocks, p2wkhAddr, db.WitnessPubKey, false, false, pubKey,
+	expectSignerDerivedAddressInfo(
+		t, w, mocks, p2wkhAddr, db.WitnessPubKey, pubKey,
 	)
 
 	// Arrange: Mock ManagedPubKeyAddress methods.
@@ -1147,8 +1147,8 @@ func TestAddChangeOutputInfoSuccess(t *testing.T) {
 	w, mocks := createStartedWalletWithMocks(t)
 
 	// Arrange: Mock Store.GetAddress for the change address.
-	expectSignerAddressInfo(
-		t, w, mocks, p2wkhAddr, db.WitnessPubKey, false, false, pubKey,
+	expectSignerDerivedAddressInfo(
+		t, w, mocks, p2wkhAddr, db.WitnessPubKey, pubKey,
 	)
 
 	// Act: Call addChangeOutputInfo.
@@ -1379,8 +1379,8 @@ func TestPopulatePsbtPacketErrors(t *testing.T) {
 			Return(txDetails, nil)
 
 		// Mock Address lookup for Input.
-		expectSignerAddressInfo(
-			t, w, mocks, addrIn, db.WitnessPubKey, false, false, pubKey,
+		expectSignerDerivedAddressInfo(
+			t, w, mocks, addrIn, db.WitnessPubKey, pubKey,
 		)
 
 		// Mock Store.GetAddress for Output (Fail)
@@ -1465,10 +1465,12 @@ func TestPopulatePsbtPacketSuccess(t *testing.T) {
 	// change output info).
 	mocks.store.On("GetAddress", mock.Anything, mock.Anything).
 		Return(&db.AddressInfo{
-			ScriptPubKey: p2wkhScript,
-			AddrType:     db.WitnessPubKey,
-			Origin:       db.DerivedAccount,
-			PubKey:       pubKey.SerializeCompressed(),
+			ScriptPubKey:         p2wkhScript,
+			AddrType:             db.WitnessPubKey,
+			Origin:               db.DerivedAccount,
+			KeyScope:             db.KeyScope(waddrmgr.KeyScopeBIP0084),
+			MasterKeyFingerprint: 1,
+			PubKey:               pubKey.SerializeCompressed(),
 		}, nil)
 
 	// Act: Call populatePsbtPacket.
@@ -1603,8 +1605,8 @@ func TestFundPsbtWorkflow(t *testing.T) {
 		Return(mocks.accountManager, nil).Times(3)
 
 	// 8. Mock Store.GetAddress for decorateInput during DecorateInputs:
-	expectSignerAddressInfo(
-		t, w, mocks, p2wkhAddr, db.WitnessPubKey, false, false, pubKey,
+	expectSignerDerivedAddressInfo(
+		t, w, mocks, p2wkhAddr, db.WitnessPubKey, pubKey,
 	)
 
 	// --- Mock accountManager ---

--- a/wallet/psbt_manager_test.go
+++ b/wallet/psbt_manager_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/pkg/btcunit"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wallet/txauthor"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/stretchr/testify/mock"
@@ -277,38 +278,17 @@ func TestDecorateInputSegWitV0(t *testing.T) {
 	p2wkhScript, err := txscript.PayToAddrScript(p2wkhAddr)
 	require.NoError(t, err)
 
-	// Arrange: Define key scope and derivation path for address manager
-	// mocks.
-	keyScope := waddrmgr.KeyScopeBIP0084
-	derivationPath := waddrmgr.DerivationPath{
-		Account: 0,
-		Branch:  0,
-		Index:   0,
-	}
-
 	w, mocks := createStartedWalletWithMocks(t)
 
 	// Arrange: Mock the address manager to return our P2WKH address as a
 	// ManagedPubKeyAddress when `Address` is called with the P2WKH
 	// address.
-	mocks.addrStore.On(
-		"Address", mock.Anything,
-		mock.MatchedBy(func(addr btcutil.Address) bool {
-			return addr.String() == p2wkhAddr.String()
-		}),
-	).Return(mocks.pubKeyAddr, nil)
+	expectSignerAddressInfo(
+		t, w, mocks, p2wkhAddr, db.WitnessPubKey, false, false, pubKey,
+	)
 
 	// Arrange: Mock the ManagedPubKeyAddress methods to return relevant
 	// derivation and public key information.
-	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Once()
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
-	mocks.pubKeyAddr.On("Imported").Return(false).Once()
-	mocks.pubKeyAddr.On("Internal").Return(false).Once()
-	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-	mocks.pubKeyAddr.On("DerivationInfo").Return(
-		keyScope, derivationPath, true,
-	).Once()
 
 	// Arrange: Create a UTXO with the P2WKH script and an empty PSBT input.
 	utxo := &wire.TxOut{
@@ -355,40 +335,19 @@ func TestDecorateInputTaproot(t *testing.T) {
 	taprootScript, err := txscript.PayToAddrScript(taprootAddr)
 	require.NoError(t, err)
 
-	// Arrange: Define key scope and derivation path for address manager
-	// mocks.
-	keyScope := waddrmgr.KeyScopeBIP0084
-	derivationPath := waddrmgr.DerivationPath{
-		Account: 0,
-		Branch:  0,
-		Index:   0,
-	}
-
 	w, mocks := createStartedWalletWithMocks(t)
 
 	// Arrange: Mock the address manager to return our Taproot address as a
 	// ManagedPubKeyAddress when `Address` is called with the Taproot
 	// address.
-	mocks.addrStore.On(
-		"Address", mock.Anything,
-		mock.MatchedBy(func(addr btcutil.Address) bool {
-			return addr.String() == taprootAddr.String()
-		}),
-	).Return(mocks.pubKeyAddr, nil)
+	expectSignerAddressInfo(
+		t, w, mocks, taprootAddr, db.TaprootPubKey, false, false, pubKey,
+	)
 
 	// Arrange: Mock the ManagedPubKeyAddress methods to return relevant
 	// derivation and public key information. AddrType is not strictly
 	// checked for Taproot inputs in decorateInput, so no mock is needed
 	// for it.
-	mocks.pubKeyAddr.On("Address").Return(taprootAddr).Once()
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.TaprootPubKey).Once()
-	mocks.pubKeyAddr.On("Imported").Return(false).Once()
-	mocks.pubKeyAddr.On("Internal").Return(false).Once()
-	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-	mocks.pubKeyAddr.On("DerivationInfo").Return(
-		keyScope, derivationPath, true,
-	).Once()
 
 	// Arrange: Create a UTXO with the Taproot script and an empty PSBT
 	// input.
@@ -460,10 +419,9 @@ func TestDecorateInputErrAddrInfo(t *testing.T) {
 
 	w, mocks := createStartedWalletWithMocks(t)
 
-	// Arrange: Mock AddressInfo to return an error.
-	mocks.addrStore.On(
-		"Address", mock.Anything, mock.Anything,
-	).Return(nil, errDb)
+	// Arrange: Mock Store.GetAddress to return an error.
+	mocks.store.On("GetAddress", mock.Anything, mock.Anything).
+		Return((*db.AddressInfo)(nil), errDb)
 
 	utxo := &wire.TxOut{
 		Value:    1000,
@@ -500,17 +458,14 @@ func TestDecorateInputErrNotPubKey(t *testing.T) {
 
 	w, mocks := createStartedWalletWithMocks(t)
 
-	// Arrange: Mock AddressInfo to return a generic ManagedAddress
-	// (mocks.addr) instead of a ManagedPubKeyAddress (mocks.pubKeyAddr).
-	mocks.addrStore.On(
-		"Address", mock.Anything, mock.Anything,
-	).Return(mocks.addr, nil)
-
-	mocks.addr.On("Address").Return(p2wkhAddr)
-	mocks.addr.On("AddrType").Return(waddrmgr.Script)
-	mocks.addr.On("Imported").Return(false)
-	mocks.addr.On("Internal").Return(false)
-	mocks.addr.On("Compressed").Return(false)
+	// Arrange: Mock Store.GetAddress to return an AddressInfo without
+	// a PubKey so buildScriptsForAddressInfo errors with ErrNotPubKeyAddress.
+	mocks.store.On("GetAddress", mock.Anything, mock.Anything).
+		Return(&db.AddressInfo{
+			ScriptPubKey: p2wkhScript,
+			AddrType:     db.WitnessPubKey,
+			Origin:       db.DerivedAccount,
+		}, nil)
 
 	utxo := &wire.TxOut{
 		Value:    1000,
@@ -549,19 +504,9 @@ func TestDecorateInputErrImported(t *testing.T) {
 
 	// Arrange: Mock AddressInfo to return a ManagedPubKeyAddress that is
 	// marked as imported.
-	mocks.addrStore.On(
-		"Address", mock.Anything, mock.Anything,
-	).Return(mocks.pubKeyAddr, nil)
-
-	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Once()
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
-	mocks.pubKeyAddr.On("Imported").Return(true).Once()
-	mocks.pubKeyAddr.On("Internal").Return(false).Once()
-	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-	mocks.pubKeyAddr.On("DerivationInfo").Return(
-		waddrmgr.KeyScope{}, waddrmgr.DerivationPath{}, false,
-	).Once()
+	expectSignerAddressInfo(
+		t, w, mocks, p2wkhAddr, db.WitnessPubKey, false, true, pubKey,
+	)
 
 	utxo := &wire.TxOut{
 		Value:    1000,
@@ -600,19 +545,9 @@ func TestDecorateInputErrDerivationMissing(t *testing.T) {
 
 	// Arrange: Mock AddressInfo to return a ManagedPubKeyAddress that has
 	// no derivation info.
-	mocks.addrStore.On(
-		"Address", mock.Anything, mock.Anything,
-	).Return(mocks.pubKeyAddr, nil)
-
-	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Once()
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
-	mocks.pubKeyAddr.On("Imported").Return(false).Once()
-	mocks.pubKeyAddr.On("Internal").Return(false).Once()
-	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-	mocks.pubKeyAddr.On("DerivationInfo").Return(
-		waddrmgr.KeyScope{}, waddrmgr.DerivationPath{}, false,
-	).Once()
+	expectSignerAddressInfo(
+		t, w, mocks, p2wkhAddr, db.WitnessPubKey, false, true, pubKey,
+	)
 
 	utxo := &wire.TxOut{
 		Value:    1000,
@@ -655,21 +590,9 @@ func TestDecorateInputNestedWitnessUsesRedeemScript(t *testing.T) {
 	require.NoError(t, err)
 
 	w, mocks := createStartedWalletWithMocks(t)
-	mocks.addrStore.On(
-		"Address", mock.Anything, mock.Anything,
-	).Return(mocks.pubKeyAddr, nil)
-
-	mocks.pubKeyAddr.On("Address").Return(nestedAddr).Once()
-	mocks.pubKeyAddr.On("AddrType").Return(
-		waddrmgr.NestedWitnessPubKey,
-	).Once()
-	mocks.pubKeyAddr.On("Imported").Return(false).Once()
-	mocks.pubKeyAddr.On("Internal").Return(false).Once()
-	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-	mocks.pubKeyAddr.On("DerivationInfo").Return(
-		waddrmgr.KeyScopeBIP0049Plus, waddrmgr.DerivationPath{}, true,
-	).Once()
+	expectSignerAddressInfo(
+		t, w, mocks, nestedAddr, db.NestedWitnessPubKey, false, false, pubKey,
+	)
 
 	pInput := &psbt.PInput{}
 	utxo := &wire.TxOut{Value: 1000, PkScript: pkScript}
@@ -775,32 +698,11 @@ func TestDecorateInputsSuccess(t *testing.T) {
 	).Return(txDetails2, nil)
 
 	// Arrange: Mock Address lookup (common for both known inputs).
-	mocks.addrStore.On(
-		"Address", mock.Anything,
-		mock.MatchedBy(func(addr btcutil.Address) bool {
-			return addr.String() == p2wkhAddr.String()
-		}),
-	).Return(mocks.pubKeyAddr, nil)
+	expectSignerAddressInfo(
+		t, w, mocks, p2wkhAddr, db.WitnessPubKey, false, false, pubKey,
+	)
 
 	// Arrange: Mock ManagedPubKeyAddress methods.
-	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Once()
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
-	mocks.pubKeyAddr.On("Imported").Return(false).Once()
-	mocks.pubKeyAddr.On("Internal").Return(false).Once()
-	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-	mocks.pubKeyAddr.On("DerivationInfo").Return(
-		waddrmgr.KeyScopeBIP0084, waddrmgr.DerivationPath{}, true,
-	).Once()
-	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Once()
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
-	mocks.pubKeyAddr.On("Imported").Return(false).Once()
-	mocks.pubKeyAddr.On("Internal").Return(false).Once()
-	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-	mocks.pubKeyAddr.On("DerivationInfo").Return(
-		waddrmgr.KeyScopeBIP0084, waddrmgr.DerivationPath{}, true,
-	).Once()
 
 	// Act: Call DecorateInputs with skipUnknown=true.
 	_, err = w.DecorateInputs(t.Context(), packet, true)
@@ -932,10 +834,9 @@ func TestDecorateInputsErrDecorationFailed(t *testing.T) {
 		"TxDetails", mock.Anything, mock.Anything,
 	).Return(txDetails, nil)
 
-	// Arrange: Mock AddressInfo to fail (causing decorateInput to fail).
-	mocks.addrStore.On(
-		"Address", mock.Anything, mock.Anything,
-	).Return(nil, errDb)
+	// Arrange: Mock Store.GetAddress to fail (causing decorateInput to fail).
+	mocks.store.On("GetAddress", mock.Anything, mock.Anything).
+		Return((*db.AddressInfo)(nil), errDb)
 
 	// Act: Call DecorateInputs.
 	_, err = w.DecorateInputs(t.Context(), packet, true)
@@ -1245,23 +1146,10 @@ func TestAddChangeOutputInfoSuccess(t *testing.T) {
 
 	w, mocks := createStartedWalletWithMocks(t)
 
-	// Arrange: Mock Address lookup.
-	mocks.addrStore.On(
-		"Address", mock.Anything,
-		mock.MatchedBy(func(addr btcutil.Address) bool {
-			return addr.String() == p2wkhAddr.String()
-		}),
-	).Return(mocks.pubKeyAddr, nil)
-
-	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Once()
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
-	mocks.pubKeyAddr.On("Imported").Return(false).Once()
-	mocks.pubKeyAddr.On("Internal").Return(false).Once()
-	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-	mocks.pubKeyAddr.On("DerivationInfo").Return(
-		waddrmgr.KeyScopeBIP0084, waddrmgr.DerivationPath{}, true,
-	).Once()
+	// Arrange: Mock Store.GetAddress for the change address.
+	expectSignerAddressInfo(
+		t, w, mocks, p2wkhAddr, db.WitnessPubKey, false, false, pubKey,
+	)
 
 	// Act: Call addChangeOutputInfo.
 	err = w.addChangeOutputInfo(t.Context(), packet, authoredTx)
@@ -1306,10 +1194,9 @@ func TestAddChangeOutputInfoErrScriptFail(t *testing.T) {
 
 	w, mocks := createStartedWalletWithMocks(t)
 
-	// Arrange: Mock Address lookup to fail.
-	mocks.addrStore.On(
-		"Address", mock.Anything, mock.Anything,
-	).Return(nil, errDb)
+	// Arrange: Mock Store.GetAddress to fail.
+	mocks.store.On("GetAddress", mock.Anything, mock.Anything).
+		Return((*db.AddressInfo)(nil), errDb)
 
 	// Act: Call addChangeOutputInfo.
 	err = w.addChangeOutputInfo(t.Context(), packet, authoredTx)
@@ -1348,15 +1235,14 @@ func TestAddChangeOutputInfoErrNotPubKey(t *testing.T) {
 
 	w, mocks := createStartedWalletWithMocks(t)
 
-	// Arrange: Mock Address lookup to return a generic address.
-	mocks.addrStore.On(
-		"Address", mock.Anything, mock.Anything,
-	).Return(mocks.addr, nil)
-	mocks.addr.On("Address").Return(p2wkhAddr)
-	mocks.addr.On("AddrType").Return(waddrmgr.WitnessPubKey)
-	mocks.addr.On("Imported").Return(false)
-	mocks.addr.On("Internal").Return(false)
-	mocks.addr.On("Compressed").Return(true)
+	// Arrange: Mock Store.GetAddress to return an AddressInfo with no
+	// PubKey so buildScriptsForAddressInfo returns ErrNotPubKeyAddress.
+	mocks.store.On("GetAddress", mock.Anything, mock.Anything).
+		Return(&db.AddressInfo{
+			ScriptPubKey: p2wkhScript,
+			AddrType:     db.WitnessPubKey,
+			Origin:       db.DerivedAccount,
+		}, nil)
 
 	// Act: Call addChangeOutputInfo.
 	err = w.addChangeOutputInfo(t.Context(), packet, authoredTx)
@@ -1396,20 +1282,15 @@ func TestAddChangeOutputInfoErrDerivationUnknown(t *testing.T) {
 
 	w, mocks := createStartedWalletWithMocks(t)
 
-	// Arrange: Mock Address lookup.
-	mocks.addrStore.On(
-		"Address", mock.Anything, mock.Anything,
-	).Return(mocks.pubKeyAddr, nil)
-
-	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Once()
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
-	mocks.pubKeyAddr.On("Imported").Return(false).Once()
-	mocks.pubKeyAddr.On("Internal").Return(false).Once()
-	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-	mocks.pubKeyAddr.On("DerivationInfo").Return(
-		waddrmgr.KeyScope{}, waddrmgr.DerivationPath{}, false,
-	).Once()
+	// Arrange: Mock Store.GetAddress to return an imported AddressInfo
+	// so addChangeOutputInfo fails (change addr cannot be imported).
+	mocks.store.On("GetAddress", mock.Anything, mock.Anything).
+		Return(&db.AddressInfo{
+			ScriptPubKey: p2wkhScript,
+			AddrType:     db.WitnessPubKey,
+			Origin:       db.ImportedAccount,
+			PubKey:       pubKey.SerializeCompressed(),
+		}, nil)
 
 	// Act: Call addChangeOutputInfo.
 	err = w.addChangeOutputInfo(t.Context(), packet, authoredTx)
@@ -1497,33 +1378,20 @@ func TestPopulatePsbtPacketErrors(t *testing.T) {
 		mocks.txStore.On("TxDetails", mock.Anything, mock.Anything).
 			Return(txDetails, nil)
 
-		// Mock Address lookup for Input (Success)
-		mocks.addrStore.On(
-			"Address", mock.Anything,
-			mock.MatchedBy(func(a btcutil.Address) bool {
-				return a.String() == addrIn.String()
-			}),
-		).Return(mocks.pubKeyAddr, nil)
+		// Mock Address lookup for Input.
+		expectSignerAddressInfo(
+			t, w, mocks, addrIn, db.WitnessPubKey, false, false, pubKey,
+		)
 
-		mocks.pubKeyAddr.On("Address").Return(addrIn).Once()
-		mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
-		mocks.pubKeyAddr.On("Imported").Return(false).Once()
-		mocks.pubKeyAddr.On("Internal").Return(false).Once()
-		mocks.pubKeyAddr.On("Compressed").Return(true).Once()
-		mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-		mocks.pubKeyAddr.On("DerivationInfo").Return(
-			waddrmgr.KeyScopeBIP0084, waddrmgr.DerivationPath{}, true,
-		).Once()
+		// Mock Store.GetAddress for Output (Fail)
+		scriptOut2, err := txscript.PayToAddrScript(addrOut)
+		require.NoError(t, err)
+		mocks.store.On("GetAddress", mock.Anything, db.GetAddressQuery{
+			WalletID:     w.id,
+			ScriptPubKey: scriptOut2,
+		}).Return((*db.AddressInfo)(nil), errDb)
 
-		// Mock Address lookup for Output (Fail)
-		mocks.addrStore.On(
-			"Address", mock.Anything,
-			mock.MatchedBy(func(a btcutil.Address) bool {
-				return a.String() == addrOut.String()
-			}),
-		).Return(nil, errDb)
-
-		_, _, err := w.populatePsbtPacket(
+		_, _, err = w.populatePsbtPacket(
 			t.Context(), packet, authoredTx,
 		)
 		require.ErrorIs(t, err, errDb)
@@ -1595,29 +1463,13 @@ func TestPopulatePsbtPacketSuccess(t *testing.T) {
 
 	// Arrange: Mock Address lookup (used for both input decoration and
 	// change output info).
-	mocks.addrStore.On("Address", mock.Anything, mock.Anything).
-		Return(mocks.pubKeyAddr, nil)
-
-	// Arrange: Mock ManagedPubKeyAddress methods for both input decoration and
-	// change output info.
-	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Once()
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
-	mocks.pubKeyAddr.On("Imported").Return(false).Once()
-	mocks.pubKeyAddr.On("Internal").Return(false).Once()
-	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-	mocks.pubKeyAddr.On("DerivationInfo").Return(
-		waddrmgr.KeyScopeBIP0084, waddrmgr.DerivationPath{}, true,
-	).Once()
-	mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Once()
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
-	mocks.pubKeyAddr.On("Imported").Return(false).Once()
-	mocks.pubKeyAddr.On("Internal").Return(false).Once()
-	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-	mocks.pubKeyAddr.On("DerivationInfo").Return(
-		waddrmgr.KeyScopeBIP0084, waddrmgr.DerivationPath{}, true,
-	).Once()
+	mocks.store.On("GetAddress", mock.Anything, mock.Anything).
+		Return(&db.AddressInfo{
+			ScriptPubKey: p2wkhScript,
+			AddrType:     db.WitnessPubKey,
+			Origin:       db.DerivedAccount,
+			PubKey:       pubKey.SerializeCompressed(),
+		}, nil)
 
 	// Act: Call populatePsbtPacket.
 	updatedPacket, changeIdx, err := w.populatePsbtPacket(
@@ -1750,13 +1602,10 @@ func TestFundPsbtWorkflow(t *testing.T) {
 	mocks.addrStore.On("FetchScopedKeyManager", waddrmgr.KeyScopeBIP0084).
 		Return(mocks.accountManager, nil).Times(3)
 
-	// 8. Mock `addrStore.Address` for `decorateInput` during
-	//    `DecorateInputs`:
-	mocks.addrStore.On("Address", mock.Anything,
-		mock.MatchedBy(func(addr btcutil.Address) bool {
-			return addr.String() == p2wkhAddr.String()
-		}),
-	).Return(mocks.pubKeyAddr, nil).Times(2)
+	// 8. Mock Store.GetAddress for decorateInput during DecorateInputs:
+	expectSignerAddressInfo(
+		t, w, mocks, p2wkhAddr, db.WitnessPubKey, false, false, pubKey,
+	)
 
 	// --- Mock accountManager ---
 	// 3. Mock `accountManager.LookupAccount` for the default account:
@@ -1785,27 +1634,6 @@ func TestFundPsbtWorkflow(t *testing.T) {
 	// 6. The generated change address is read directly while assembling the
 	// transaction.
 	mockManagedAddr.On("Address").Return(changeAddr).Once()
-
-	// 9. Mock the metadata reads needed by both input decoration and change
-	// output info.
-	mocks.pubKeyAddr.On("Address").Return(changeAddr).Once()
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
-	mocks.pubKeyAddr.On("Imported").Return(false).Once()
-	mocks.pubKeyAddr.On("Internal").Return(false).Once()
-	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-	mocks.pubKeyAddr.On("DerivationInfo").Return(
-		waddrmgr.KeyScopeBIP0084, waddrmgr.DerivationPath{}, true,
-	).Once()
-	mocks.pubKeyAddr.On("Address").Return(changeAddr).Once()
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
-	mocks.pubKeyAddr.On("Imported").Return(false).Once()
-	mocks.pubKeyAddr.On("Internal").Return(false).Once()
-	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-	mocks.pubKeyAddr.On("DerivationInfo").Return(
-		waddrmgr.KeyScopeBIP0084, waddrmgr.DerivationPath{}, true,
-	).Once()
 
 	// Act: Execute the FundPsbt workflow with the configured intent.
 	fundedPacket, changeIndex, err := w.FundPsbt(t.Context(), intent)
@@ -3523,18 +3351,11 @@ func TestFinalizeInput(t *testing.T) {
 		w, mocks := createUnlockedWalletWithMocks(t)
 
 		// Arrange: Mock dependencies.
-		mocks.addrStore.On(
-			"Address", mock.Anything, mock.Anything,
-		).Return(mocks.pubKeyAddr, nil).Twice()
-		mocks.pubKeyAddr.On("Address").Return(p2wkhAddr).Once()
-		mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
-		mocks.pubKeyAddr.On("Imported").Return(false).Once()
-		mocks.pubKeyAddr.On("Internal").Return(false).Once()
-		mocks.pubKeyAddr.On("Compressed").Return(true).Once()
-		mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-		mocks.pubKeyAddr.On("DerivationInfo").Return(
-			waddrmgr.KeyScopeBIP0084, waddrmgr.DerivationPath{}, true,
-		).Once()
+		expectSignerAddressInfo(
+			t, w, mocks, p2wkhAddr, db.WitnessPubKey, false, false, pubKey,
+		)
+		mocks.addrStore.On("Address", mock.Anything, mock.Anything).
+			Return(mocks.pubKeyAddr, nil).Once()
 		expectDerivedSignerPrivKey(
 			t, mocks, waddrmgr.KeyScopeBIP0084,
 			waddrmgr.DerivationPath{}, privKey,
@@ -3685,23 +3506,20 @@ func TestFinalizePsbtSuccess(t *testing.T) {
 
 			w, mocks := createUnlockedWalletWithMocks(t)
 
-			// Arrange: Mock address lookup.
-			mocks.addrStore.On(
-				"Address", mock.Anything,
+			// Arrange: Mock Store.GetAddress for ScriptForOutput.
+			dbAddrType := db.WitnessPubKey
+			if tc.addrType == waddrmgr.TaprootPubKey {
+				dbAddrType = db.TaprootPubKey
+			}
+
+			expectSignerAddressInfo(
+				t, w, mocks, tc.addr, dbAddrType, false, false, pubKey,
+			)
+			mocks.addrStore.On("Address", mock.Anything,
 				mock.MatchedBy(func(a btcutil.Address) bool {
 					return a.String() == tc.addr.String()
 				}),
-			).Return(mocks.pubKeyAddr, nil).Twice()
-			mocks.pubKeyAddr.On("Address").Return(tc.addr).Once()
-			mocks.pubKeyAddr.On("AddrType").Return(tc.addrType).Once()
-			mocks.pubKeyAddr.On("Imported").Return(false).Once()
-			mocks.pubKeyAddr.On("Internal").Return(false).Once()
-			mocks.pubKeyAddr.On("Compressed").Return(true).Once()
-			mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-			mocks.pubKeyAddr.On("DerivationInfo").Return(
-				keyScope, waddrmgr.DerivationPath{}, true,
-			).Once()
-
+			).Return(mocks.pubKeyAddr, nil).Once()
 			// Create a copy of the private key to avoid data races
 			// when parallel tests call Zero() on it.
 			privKeyCopy := *privKey
@@ -3769,12 +3587,11 @@ func TestFinalizePsbtErrors(t *testing.T) {
 
 		w, mocks := createUnlockedWalletWithMocks(t)
 
-		// Arrange: Mock Address lookup to return error (or watch only).
-		// Simulating "Address not found" or "Key not found".
+		// Arrange: Mock Store.GetAddress to return an error.
 		// ComputeUnlockingScript will fail, log, and continue.
 		// Then MaybeFinalizeAll will fail because no witness.
-		mocks.addrStore.On("Address", mock.Anything, mock.Anything).
-			Return(nil, errAddrNotFound)
+		mocks.store.On("GetAddress", mock.Anything, mock.Anything).
+			Return((*db.AddressInfo)(nil), errAddrNotFound)
 
 		// Act.
 		err = w.FinalizePsbt(t.Context(), packet)

--- a/wallet/signer.go
+++ b/wallet/signer.go
@@ -829,6 +829,15 @@ func (w *Wallet) resolvePrivKey(pubKeyAddr waddrmgr.ManagedPubKeyAddress) (
 func (w *Wallet) resolveDerivedPathPrivKey(keyScope waddrmgr.KeyScope,
 	derivationPath waddrmgr.DerivationPath) (*btcec.PrivateKey, error) {
 
+	// TODO(yy): SQL-only accounts (created via Store.CreateDerivedAccount
+	// without a mirrored legacy waddrmgr account) miss both
+	// DeriveFromKeyPathCache and the DB-backed DeriveFromKeyPath fallback
+	// below because the legacy waddrmgr has no row for them. The
+	// signer-store PR (impl-tx-creator-store) will replace this path for
+	// SQL-only accounts with a keyVault-backed derivation: fetch
+	// account_secrets.encrypted_priv_key, decrypt via w.keyVault, and
+	// derive at branch/index locally — symmetric to deriveAddressData's
+	// AccountPubKey plumbing on the public-key side.
 	accountManager, err := w.addrStore.FetchScopedKeyManager(keyScope)
 	if err != nil {
 		return nil, fmt.Errorf("fetch scoped key manager: %w", err)

--- a/wallet/signer.go
+++ b/wallet/signer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 )
 
@@ -1037,7 +1038,7 @@ func (w *Wallet) DerivePrivKey(_ context.Context, path BIP32Path) (
 // GetPrivKeyForAddress returns the private key for a given address.
 //
 // DANGER: This method exports sensitive key material.
-func (w *Wallet) GetPrivKeyForAddress(_ context.Context, a btcutil.Address) (
+func (w *Wallet) GetPrivKeyForAddress(ctx context.Context, a btcutil.Address) (
 	*btcec.PrivateKey, error) {
 
 	err := w.state.canSign()
@@ -1045,7 +1046,31 @@ func (w *Wallet) GetPrivKeyForAddress(_ context.Context, a btcutil.Address) (
 		return nil, err
 	}
 
-	return w.PrivKeyForAddress(a)
+	// Try the store-routed lookup so SQL-derived addresses (persisted
+	// only in the store) can be signed for. Fall back to the legacy
+	// waddrmgr lookup ONLY when the address is genuinely not in the
+	// store, or when the store record lacks usable derivation metadata
+	// (imported / kvdb cases). Unexpected store errors must surface — do
+	// not mask them.
+	info, err := w.GetAddressInfo(ctx, a)
+	switch {
+	case err == nil && canUseAddressInfoDerivation(info):
+		return w.privKeyForAddressInfo(info)
+
+	case err == nil:
+		// Store record exists but no usable derivation info
+		// (imported case).
+		return w.PrivKeyForAddress(a)
+
+	case errors.Is(err, db.ErrAddressNotFound):
+		// Address not in the store — fall through to the legacy
+		// lookup (kvdb path or pre-store legacy address).
+		return w.PrivKeyForAddress(a)
+
+	default:
+		// Unexpected store error: surface, don't mask.
+		return nil, fmt.Errorf("GetPrivKeyForAddress: %w", err)
+	}
 }
 
 // PrivKeyForAddress looks up the associated private key for a P2PKH or P2PK

--- a/wallet/signer.go
+++ b/wallet/signer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
@@ -696,7 +697,7 @@ func (w *Wallet) ComputeUnlockingScript(ctx context.Context,
 		return nil, err
 	}
 
-	privKey, err := w.privKeyForOutput(scriptInfo.Addr)
+	privKey, err := w.privKeyForOutput(scriptInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -717,16 +718,52 @@ func (w *Wallet) ComputeUnlockingScript(ctx context.Context,
 }
 
 // privKeyForOutput returns the private key needed to sign for the given
-// wallet-controlled address.
-func (w *Wallet) privKeyForOutput(addr btcutil.Address) (
+// wallet-controlled output.
+func (w *Wallet) privKeyForOutput(scriptInfo OutputScriptInfo) (
 	*btcec.PrivateKey, error) {
 
-	pubKeyAddr, err := w.loadManagedPubKeyAddr(addr)
+	if canUseAddressInfoDerivation(scriptInfo.AddressInfo) {
+		return w.privKeyForAddressInfo(scriptInfo.AddressInfo)
+	}
+
+	pubKeyAddr, err := w.loadManagedPubKeyAddr(scriptInfo.Addr)
 	if err != nil {
 		return nil, err
 	}
 
 	return w.resolvePrivKey(pubKeyAddr)
+}
+
+// canUseAddressInfoDerivation reports whether address metadata contains enough
+// derivation information to derive a private key without a legacy address row.
+func canUseAddressInfoDerivation(addressInfo AddressInfo) bool {
+	if addressInfo.Imported || addressInfo.Derivation == nil {
+		return false
+	}
+
+	return addressInfo.Derivation.KeyScope != (waddrmgr.KeyScope{})
+}
+
+// privKeyForAddressInfo derives the private key described by store-backed
+// address metadata.
+func (w *Wallet) privKeyForAddressInfo(addressInfo AddressInfo) (
+	*btcec.PrivateKey, error) {
+
+	derivation := addressInfo.Derivation
+	if derivation == nil {
+		return nil, fmt.Errorf("%w: derivation info not found for %v",
+			ErrDerivationPathNotFound, addressInfo.Addr)
+	}
+
+	derivationPath := waddrmgr.DerivationPath{
+		InternalAccount:      derivation.Account,
+		Account:              derivation.Account + hdkeychain.HardenedKeyStart,
+		Branch:               derivation.Branch,
+		Index:                derivation.Index,
+		MasterKeyFingerprint: derivation.MasterKeyFingerprint,
+	}
+
+	return w.resolveDerivedPathPrivKey(derivation.KeyScope, derivationPath)
 }
 
 // loadManagedPubKeyAddr loads a managed pubkey address for signer-private key
@@ -782,6 +819,14 @@ func (w *Wallet) resolvePrivKey(pubKeyAddr waddrmgr.ManagedPubKeyAddress) (
 		return nil, fmt.Errorf("%w: addr=%v", ErrDerivationPathNotFound,
 			pubKeyAddr.Address())
 	}
+
+	return w.resolveDerivedPathPrivKey(keyScope, derivationPath)
+}
+
+// resolveDerivedPathPrivKey resolves one derived private key through the scoped
+// manager cache or the database-backed fallback.
+func (w *Wallet) resolveDerivedPathPrivKey(keyScope waddrmgr.KeyScope,
+	derivationPath waddrmgr.DerivationPath) (*btcec.PrivateKey, error) {
 
 	accountManager, err := w.addrStore.FetchScopedKeyManager(keyScope)
 	if err != nil {

--- a/wallet/signer_test.go
+++ b/wallet/signer_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -945,8 +946,7 @@ func TestComputeUnlockingScriptSQLDerivedAddress(t *testing.T) {
 
 // TestGetPrivKeyForAddressSQLDerivedAddress verifies that GetPrivKeyForAddress
 // recovers the private key for an address whose only persistent record lives
-// in the SQL store. Regression coverage for the GetPrivKeyForAddress path
-// raised in PR #1214 review comment r3287556227.
+// in the SQL store.
 func TestGetPrivKeyForAddressSQLDerivedAddress(t *testing.T) {
 	t.Parallel()
 
@@ -971,9 +971,45 @@ func TestGetPrivKeyForAddressSQLDerivedAddress(t *testing.T) {
 
 	priv, err := w.GetPrivKeyForAddress(t.Context(), addr)
 	require.NoError(t, err, "GetPrivKeyForAddress must succeed for "+
-		"SQL-derived addresses (regression r3287556227)")
+		"SQL-derived addresses")
 	require.NotNil(t, priv)
 	priv.Zero()
+}
+
+// TestNewAddressOnSQLOnlyAccount verifies that SQL-owned accounts can derive
+// receive addresses without a mirrored legacy waddrmgr account.
+//
+// The test exercises the public-key path only. Signing with addresses owned
+// by a SQL-only account currently routes through the legacy waddrmgr
+// derivation cache, which does not see SQL-only accounts; that gap is
+// tracked separately and will be closed by the signer-store work on
+// impl-tx-creator-store using keyVault-backed account-secret derivation.
+func TestNewAddressOnSQLOnlyAccount(t *testing.T) {
+	t.Parallel()
+
+	w, chain := newSQLAddressSigningWallet(t)
+
+	_, err := w.store.CreateDerivedAccount(
+		t.Context(), db.CreateDerivedAccountParams{
+			WalletID: w.id,
+			Scope:    db.KeyScope(waddrmgr.KeyScopeBIP0084),
+			Name:     "secondary",
+		}, testAccountDerivationFunc(),
+	)
+	require.NoError(t, err)
+
+	chain.On(
+		"NotifyReceived",
+		mock.MatchedBy(func(addrs []btcutil.Address) bool {
+			return len(addrs) == 1
+		}),
+	).Return(nil).Once()
+
+	addr, err := w.NewAddress(
+		t.Context(), "secondary", waddrmgr.WitnessPubKey, false,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, addr)
 }
 
 // TestComputeUnlockingScriptFail_ScriptForOutput tests failure when
@@ -1421,11 +1457,31 @@ func newSpendableAddressManager(t *testing.T,
 // testAccountDerivationFunc returns minimal spendable account material for SQL
 // account creation in signer tests.
 func testAccountDerivationFunc() db.AccountDerivationFunc {
-	return func(_ context.Context, _ db.KeyScope, _ uint32,
+	return func(_ context.Context, scope db.KeyScope, accountNumber uint32,
 		walletIsWatchOnly bool) (*db.DerivedAccountData, error) {
 
+		seed := bytes.Repeat([]byte{0x5A}, hdkeychain.RecommendedSeedLen)
+
+		masterKey, err := hdkeychain.NewMaster(seed, &chainParams)
+		if err != nil {
+			return nil, fmt.Errorf("new master key: %w", err)
+		}
+
+		accountKey, err := deriveBIP44AccountKey(
+			masterKey, scope, accountNumber,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("derive account key: %w", err)
+		}
+		defer accountKey.Zero()
+
+		accountPubKey, err := accountKey.Neuter()
+		if err != nil {
+			return nil, fmt.Errorf("neuter account key: %w", err)
+		}
+
 		data := &db.DerivedAccountData{
-			PublicKey:            []byte{2},
+			PublicKey:            []byte(accountPubKey.String()),
 			MasterKeyFingerprint: 1,
 		}
 		if !walletIsWatchOnly {

--- a/wallet/signer_test.go
+++ b/wallet/signer_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -578,23 +579,12 @@ func TestComputeUnlockingScriptP2PKH(t *testing.T) {
 	// when queried, will provide the private key for signing. This
 	// simulates a real scenario where the wallet's address manager would
 	// fetch the key from the database.
+	expectSignerAddressInfo(
+		t, w, mocks, addr, db.PubKeyHash, false, false, pubKey,
+	)
 	mocks.addrStore.On("Address",
 		mock.Anything, addr,
-	).Return(mocks.pubKeyAddr, nil).Twice()
-	mocks.pubKeyAddr.On("Address").Return(addr).Once()
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.PubKeyHash).Once()
-	mocks.pubKeyAddr.On("Imported").Return(false).Once()
-	mocks.pubKeyAddr.On("Internal").Return(false).Once()
-	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-	mocks.pubKeyAddr.On("DerivationInfo").Return(
-		waddrmgr.KeyScopeBIP0044, waddrmgr.DerivationPath{
-			InternalAccount: 0,
-			Account:         0,
-			Branch:          0,
-			Index:           0,
-		}, true,
-	).Once()
+	).Return(mocks.pubKeyAddr, nil).Once()
 
 	// Configure the full mock chain to return the test private key.
 	//
@@ -669,23 +659,12 @@ func TestComputeUnlockingScriptP2WKH(t *testing.T) {
 	// The wallet needs to be able to find the private key for the given
 	// address. We mock the address store to return a mock address that,
 	// when queried, will provide the private key for signing.
+	expectSignerAddressInfo(
+		t, w, mocks, addr, db.WitnessPubKey, false, false, pubKey,
+	)
 	mocks.addrStore.On("Address",
 		mock.Anything, addr,
-	).Return(mocks.pubKeyAddr, nil).Twice()
-	mocks.pubKeyAddr.On("Address").Return(addr).Once()
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Once()
-	mocks.pubKeyAddr.On("Imported").Return(false).Once()
-	mocks.pubKeyAddr.On("Internal").Return(false).Once()
-	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-	mocks.pubKeyAddr.On("DerivationInfo").Return(
-		waddrmgr.KeyScopeBIP0084, waddrmgr.DerivationPath{
-			InternalAccount: 0,
-			Account:         0,
-			Branch:          0,
-			Index:           0,
-		}, true,
-	).Once()
+	).Return(mocks.pubKeyAddr, nil).Once()
 
 	// Configure the full mock chain to return the test private key.
 	//
@@ -764,23 +743,12 @@ func TestComputeUnlockingScriptNP2WKH(t *testing.T) {
 	// when queried, will provide the private key for signing. For NP2WKH,
 	// the wallet also needs the public key to reconstruct the witness
 	// program, so we mock that as well.
+	expectSignerAddressInfo(
+		t, w, mocks, addr, db.NestedWitnessPubKey, false, false, pubKey,
+	)
 	mocks.addrStore.On("Address",
 		mock.Anything, addr,
-	).Return(mocks.pubKeyAddr, nil).Twice()
-	mocks.pubKeyAddr.On("Address").Return(addr).Once()
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.NestedWitnessPubKey).Once()
-	mocks.pubKeyAddr.On("Imported").Return(false).Once()
-	mocks.pubKeyAddr.On("Internal").Return(false).Once()
-	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-	mocks.pubKeyAddr.On("DerivationInfo").Return(
-		waddrmgr.KeyScopeBIP0049Plus, waddrmgr.DerivationPath{
-			InternalAccount: 0,
-			Account:         0,
-			Branch:          0,
-			Index:           0,
-		}, true,
-	).Once()
+	).Return(mocks.pubKeyAddr, nil).Once()
 
 	// Configure the full mock chain to return the test private key.
 	//
@@ -857,23 +825,12 @@ func TestComputeUnlockingScriptP2TR(t *testing.T) {
 	// The wallet needs to be able to find the private key for the given
 	// address. We mock the address store to return a mock address that,
 	// when queried, will provide the private key for signing.
+	expectSignerAddressInfo(
+		t, w, mocks, addr, db.TaprootPubKey, false, false, pubKey,
+	)
 	mocks.addrStore.On("Address",
 		mock.Anything, addr,
-	).Return(mocks.pubKeyAddr, nil).Twice()
-	mocks.pubKeyAddr.On("Address").Return(addr).Once()
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.TaprootPubKey).Once()
-	mocks.pubKeyAddr.On("Imported").Return(false).Once()
-	mocks.pubKeyAddr.On("Internal").Return(false).Once()
-	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-	mocks.pubKeyAddr.On("DerivationInfo").Return(
-		waddrmgr.KeyScopeBIP0086, waddrmgr.DerivationPath{
-			InternalAccount: 0,
-			Account:         0,
-			Branch:          0,
-			Index:           0,
-		}, true,
-	).Once()
+	).Return(mocks.pubKeyAddr, nil).Once()
 
 	// Configure the full mock chain to return the test private key.
 	//
@@ -951,9 +908,13 @@ func TestComputeUnlockingScriptFail_ScriptForOutput(t *testing.T) {
 	// Arrange: Set up the wallet and mocks.
 	w, mocks := createUnlockedWalletWithMocks(t)
 
-	// Mock the address store to return an error.
-	mocks.addrStore.On("Address", mock.Anything, addr).
-		Return((*mockManagedAddress)(nil), errManagerNotFound).Once()
+	// Mock the store to return an error.
+	pkScript_, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+	mocks.store.On("GetAddress", mock.Anything, db.GetAddressQuery{
+		WalletID:     w.id,
+		ScriptPubKey: pkScript_,
+	}).Return((*db.AddressInfo)(nil), errManagerNotFound).Once()
 
 	params := &UnlockingScriptParams{
 		Tx:        tx,
@@ -994,22 +955,11 @@ func TestComputeUnlockingScriptFail_PrivKey(t *testing.T) {
 	w, mocks := createUnlockedWalletWithMocks(t)
 
 	// Mock address store and managed address.
+	expectSignerAddressInfo(
+		t, w, mocks, addr, db.PubKeyHash, false, false, pubKey,
+	)
 	mocks.addrStore.On("Address", mock.Anything, addr).
-		Return(mocks.pubKeyAddr, nil).Twice()
-	mocks.pubKeyAddr.On("Address").Return(addr).Once()
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.PubKeyHash).Once()
-	mocks.pubKeyAddr.On("Imported").Return(false).Once()
-	mocks.pubKeyAddr.On("Internal").Return(false).Once()
-	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-	mocks.pubKeyAddr.On("DerivationInfo").Return(
-		waddrmgr.KeyScopeBIP0044, waddrmgr.DerivationPath{
-			InternalAccount: 0,
-			Account:         0,
-			Branch:          0,
-			Index:           0,
-		}, true,
-	).Once()
+		Return(mocks.pubKeyAddr, nil).Once()
 	mocks.pubKeyAddr.On("Imported").Return(false).Once()
 	mocks.pubKeyAddr.On("DerivationInfo").Return(
 		waddrmgr.KeyScopeBIP0044,
@@ -1112,22 +1062,11 @@ func TestComputeUnlockingScriptFail_Tweak(t *testing.T) {
 	w, mocks := createUnlockedWalletWithMocks(t)
 
 	// Mock address store and managed address.
+	expectSignerAddressInfo(
+		t, w, mocks, addr, db.PubKeyHash, false, false, pubKey,
+	)
 	mocks.addrStore.On("Address", mock.Anything, addr).
-		Return(mocks.pubKeyAddr, nil).Twice()
-	mocks.pubKeyAddr.On("Address").Return(addr).Once()
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.PubKeyHash).Once()
-	mocks.pubKeyAddr.On("Imported").Return(false).Once()
-	mocks.pubKeyAddr.On("Internal").Return(false).Once()
-	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-	mocks.pubKeyAddr.On("DerivationInfo").Return(
-		waddrmgr.KeyScopeBIP0044, waddrmgr.DerivationPath{
-			InternalAccount: 0,
-			Account:         0,
-			Branch:          0,
-			Index:           0,
-		}, true,
-	).Once()
+		Return(mocks.pubKeyAddr, nil).Once()
 
 	privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
 	expectDerivedSignerPrivKey(
@@ -1182,17 +1121,9 @@ func TestComputeUnlockingScriptFail_UnsupportedAddr(t *testing.T) {
 	w, mocks := createUnlockedWalletWithMocks(t)
 
 	// Mock address store and managed address.
-	mocks.addrStore.On("Address", mock.Anything, addr).
-		Return(mocks.pubKeyAddr, nil).Once()
-	mocks.pubKeyAddr.On("Address").Return(addr).Once()
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.RawPubKey).Once()
-	mocks.pubKeyAddr.On("Imported").Return(false).Once()
-	mocks.pubKeyAddr.On("Internal").Return(false).Once()
-	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-	mocks.pubKeyAddr.On("DerivationInfo").Return(
-		waddrmgr.KeyScopeBIP0044, waddrmgr.DerivationPath{}, false,
-	).Once()
+	expectSignerAddressInfo(
+		t, w, mocks, addr, db.RawPubKey, false, false, pubKey,
+	)
 
 	params := &UnlockingScriptParams{
 		Tx:        tx,
@@ -1228,21 +1159,18 @@ func TestComputeUnlockingScriptUnknownAddrType(t *testing.T) {
 
 	prevOut, tx := createDummyTestTx(pkScript)
 
-	// Mock address lookup to return a valid managed address.
-	mocks.addrStore.On("Address", mock.Anything, addr).
-		Return(mocks.pubKeyAddr, nil).Once()
-	mocks.pubKeyAddr.On("Address").Return(addr).Once()
-	mocks.pubKeyAddr.On("Imported").Return(false).Once()
-	mocks.pubKeyAddr.On("Internal").Return(false).Once()
-	mocks.pubKeyAddr.On("Compressed").Return(true).Once()
-	mocks.pubKeyAddr.On("PubKey").Return(pubKey).Once()
-	mocks.pubKeyAddr.On("DerivationInfo").Return(
-		waddrmgr.KeyScope{}, waddrmgr.DerivationPath{}, false,
-	).Once()
-
-	// Mock the address type to return an unknown type (e.g. 99) so the address
-	// descriptor lookup fails before signing begins.
-	mocks.pubKeyAddr.On("AddrType").Return(waddrmgr.AddressType(99))
+	pkScript99, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+	// Mock Store.GetAddress to return an unknown addr type so the
+	// addressInfoFromStoreAddress conversion rejects it.
+	mocks.store.On("GetAddress", mock.Anything, db.GetAddressQuery{
+		WalletID:     w.id,
+		ScriptPubKey: pkScript99,
+	}).Return(&db.AddressInfo{
+		ScriptPubKey: pkScript99,
+		AddrType:     db.AddressType(99),
+		Origin:       db.DerivedAccount,
+	}, nil).Once()
 
 	fetcher := txscript.NewCannedPrevOutputFetcher(pkScript, 10000)
 
@@ -1258,7 +1186,7 @@ func TestComputeUnlockingScriptUnknownAddrType(t *testing.T) {
 
 	// Assert: Verify that the unknown address type is rejected while building
 	// output metadata.
-	require.ErrorIs(t, err, ErrUnsupportedAddressType)
+	require.ErrorIs(t, err, ErrUnknownAddrType)
 }
 
 // createDummyTestTx creates a dummy transaction for testing purposes.

--- a/wallet/signer_test.go
+++ b/wallet/signer_test.go
@@ -5,19 +5,26 @@
 package wallet
 
 import (
+	"bytes"
+	"context"
 	"encoding/hex"
 	"errors"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	sqlitedb "github.com/btcsuite/btcwallet/wallet/internal/db/sqlite"
+	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -884,6 +891,58 @@ func TestComputeUnlockingScriptP2TR(t *testing.T) {
 	require.Equal(t, byte(0), privKeyCopy.Serialize()[0])
 }
 
+// TestComputeUnlockingScriptSQLDerivedAddress verifies that an address created
+// only in the SQL address store can still be signed for using its derivation
+// metadata.
+func TestComputeUnlockingScriptSQLDerivedAddress(t *testing.T) {
+	t.Parallel()
+
+	w, chain := newSQLAddressSigningWallet(t)
+	chain.On(
+		"NotifyReceived",
+		mock.MatchedBy(func(addrs []btcutil.Address) bool {
+			return len(addrs) == 1
+		}),
+	).Return(nil).Once()
+
+	addr, err := w.NewAddress(
+		t.Context(), "default", waddrmgr.WitnessPubKey, false,
+	)
+	require.NoError(t, err)
+
+	_, err = w.loadManagedPubKeyAddr(addr)
+	require.Error(t, err)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	prevOut, tx := createDummyTestTx(pkScript)
+	fetcher := txscript.NewCannedPrevOutputFetcher(
+		prevOut.PkScript, prevOut.Value,
+	)
+	sigHashes := txscript.NewTxSigHashes(tx, fetcher)
+	params := &UnlockingScriptParams{
+		Tx:         tx,
+		InputIndex: 0,
+		Output:     prevOut,
+		SigHashes:  sigHashes,
+		HashType:   txscript.SigHashAll,
+	}
+
+	script, err := w.ComputeUnlockingScript(t.Context(), params)
+	require.NoError(t, err)
+	require.Nil(t, script.SigScript)
+	require.NotNil(t, script.Witness)
+
+	tx.TxIn[0].Witness = script.Witness
+	vm, err := txscript.NewEngine(
+		prevOut.PkScript, tx, 0, txscript.StandardVerifyFlags, nil,
+		sigHashes, prevOut.Value, fetcher,
+	)
+	require.NoError(t, err)
+	require.NoError(t, vm.Execute(), "script execution failed")
+}
+
 // TestComputeUnlockingScriptFail_ScriptForOutput tests failure when
 // ScriptForOutput returns an error.
 func TestComputeUnlockingScriptFail_ScriptForOutput(t *testing.T) {
@@ -962,8 +1021,7 @@ func TestComputeUnlockingScriptFail_PrivKey(t *testing.T) {
 		Return(mocks.pubKeyAddr, nil).Once()
 	mocks.pubKeyAddr.On("Imported").Return(false).Once()
 	mocks.pubKeyAddr.On("DerivationInfo").Return(
-		waddrmgr.KeyScopeBIP0044,
-		waddrmgr.DerivationPath{
+		waddrmgr.KeyScopeBIP0044, waddrmgr.DerivationPath{
 			InternalAccount: 0,
 			Account:         0,
 			Branch:          0,
@@ -1197,6 +1255,152 @@ func createDummyTestTx(pkScript []byte) (*wire.TxOut, *wire.MsgTx) {
 	tx.AddTxOut(wire.NewTxOut(90000, nil))
 
 	return prevOut, tx
+}
+
+// newSQLAddressSigningWallet returns a started, unlocked wallet whose address
+// records are stored in SQLite while signing keys come from legacy waddrmgr.
+func newSQLAddressSigningWallet(t *testing.T) (*Wallet, *mockChain) {
+	t.Helper()
+
+	legacyDB, cleanup := setupTestDB(t)
+	t.Cleanup(cleanup)
+
+	addrStore := newSpendableAddressManager(t, legacyDB)
+	t.Cleanup(func() {
+		addrStore.Close()
+	})
+
+	var w *Wallet
+
+	deriveAddress := func(ctx context.Context,
+		params db.AddressDerivationParams) (*db.DerivedAddressData, error) {
+
+		return w.deriveAddressData(ctx, params)
+	}
+
+	store, err := sqlitedb.NewStore(t.Context(), sqlitedb.Config{
+		DBPath:        filepath.Join(t.TempDir(), "wallet.sqlite"),
+		DeriveAddress: deriveAddress,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+
+	walletInfo, err := store.CreateWallet(
+		t.Context(), db.CreateWalletParams{
+			Name:                     "sql-signing",
+			ManagerVersion:           1,
+			EncryptedMasterPrivKey:   []byte{1},
+			MasterPubKey:             []byte{2},
+			MasterKeyPrivParams:      []byte{3},
+			EncryptedCryptoPrivKey:   []byte{4},
+			EncryptedCryptoScriptKey: []byte{5},
+		},
+	)
+	require.NoError(t, err)
+
+	_, err = store.CreateDerivedAccount(
+		t.Context(), db.CreateDerivedAccountParams{
+			WalletID: walletInfo.ID,
+			Scope:    db.KeyScope(waddrmgr.KeyScopeBIP0084),
+			Name:     "default",
+		}, testAccountDerivationFunc(),
+	)
+	require.NoError(t, err)
+
+	chain := &mockChain{}
+	w = &Wallet{
+		addrStore: addrStore,
+		store:     store,
+		keyVault:  addrStore,
+		state:     newWalletState(nil),
+		cfg: Config{
+			DB:          legacyDB,
+			Chain:       chain,
+			ChainParams: &chainParams,
+		},
+		id: walletInfo.ID,
+	}
+
+	require.NoError(t, w.state.toStarting())
+	require.NoError(t, w.state.toStarted())
+	w.state.toUnlocked()
+
+	t.Cleanup(func() {
+		chain.AssertExpectations(t)
+	})
+
+	return w, chain
+}
+
+// newSpendableAddressManager creates and unlocks a deterministic legacy
+// waddrmgr manager for signer integration tests.
+func newSpendableAddressManager(t *testing.T,
+	dbConn walletdb.DB) *waddrmgr.Manager {
+
+	t.Helper()
+
+	const (
+		pubPass  = "pub"
+		privPass = "priv"
+	)
+
+	seed := bytes.Repeat([]byte{0x5A}, hdkeychain.RecommendedSeedLen)
+	rootKey, err := hdkeychain.NewMaster(seed, &chainParams)
+	require.NoError(t, err)
+
+	var mgr *waddrmgr.Manager
+
+	err = walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+		err := waddrmgr.Create(
+			ns, rootKey, []byte(pubPass), []byte(privPass),
+			&chainParams, &waddrmgr.FastScryptOptions, time.Time{},
+		)
+		if err != nil {
+			return err
+		}
+
+		mgr, err = waddrmgr.Open(ns, []byte(pubPass), &chainParams)
+		if err != nil {
+			return err
+		}
+
+		return mgr.Unlock(ns, []byte(privPass))
+	})
+	require.NoError(t, err)
+
+	manager, err := mgr.FetchScopedKeyManager(waddrmgr.KeyScopeBIP0084)
+	require.NoError(t, err)
+	err = walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+		_, err := manager.LookupAccount(ns, "default")
+
+		return err
+	})
+	require.NoError(t, err)
+
+	return mgr
+}
+
+// testAccountDerivationFunc returns minimal spendable account material for SQL
+// account creation in signer tests.
+func testAccountDerivationFunc() db.AccountDerivationFunc {
+	return func(_ context.Context, _ db.KeyScope, _ uint32,
+		walletIsWatchOnly bool) (*db.DerivedAccountData, error) {
+
+		data := &db.DerivedAccountData{
+			PublicKey:            []byte{2},
+			MasterKeyFingerprint: 1,
+		}
+		if !walletIsWatchOnly {
+			data.EncryptedPrivateKey = []byte{3}
+		}
+
+		return data, nil
+	}
 }
 
 // TestComputeRawSigLegacyP2PKH tests the successful signing of a legacy P2PKH

--- a/wallet/signer_test.go
+++ b/wallet/signer_test.go
@@ -943,6 +943,39 @@ func TestComputeUnlockingScriptSQLDerivedAddress(t *testing.T) {
 	require.NoError(t, vm.Execute(), "script execution failed")
 }
 
+// TestGetPrivKeyForAddressSQLDerivedAddress verifies that GetPrivKeyForAddress
+// recovers the private key for an address whose only persistent record lives
+// in the SQL store. Regression coverage for the GetPrivKeyForAddress path
+// raised in PR #1214 review comment r3287556227.
+func TestGetPrivKeyForAddressSQLDerivedAddress(t *testing.T) {
+	t.Parallel()
+
+	w, chain := newSQLAddressSigningWallet(t)
+	chain.On(
+		"NotifyReceived",
+		mock.MatchedBy(func(addrs []btcutil.Address) bool {
+			return len(addrs) == 1
+		}),
+	).Return(nil).Once()
+
+	addr, err := w.NewAddress(
+		t.Context(), "default", waddrmgr.WitnessPubKey, false,
+	)
+	require.NoError(t, err)
+
+	// The legacy managed-address lookup should fail for a SQL-only
+	// derived address — this confirms the test exercises the derivation
+	// path rather than the kvdb fallback.
+	_, err = w.loadManagedPubKeyAddr(addr)
+	require.Error(t, err)
+
+	priv, err := w.GetPrivKeyForAddress(t.Context(), addr)
+	require.NoError(t, err, "GetPrivKeyForAddress must succeed for "+
+		"SQL-derived addresses (regression r3287556227)")
+	require.NotNil(t, priv)
+	priv.Zero()
+}
+
 // TestComputeUnlockingScriptFail_ScriptForOutput tests failure when
 // ScriptForOutput returns an error.
 func TestComputeUnlockingScriptFail_ScriptForOutput(t *testing.T) {
@@ -2111,7 +2144,8 @@ func TestDerivePrivKeyFails(t *testing.T) {
 }
 
 // TestGetPrivKeyForAddressSuccess tests the successful retrieval of a private
-// key by address.
+// key by address via the legacy fallback when the address is not in the
+// store (kvdb-backed wallet path).
 func TestGetPrivKeyForAddressSuccess(t *testing.T) {
 	t.Parallel()
 
@@ -2125,6 +2159,17 @@ func TestGetPrivKeyForAddressSuccess(t *testing.T) {
 		pubKeyHash, w.cfg.ChainParams,
 	)
 	require.NoError(t, err)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	// The store returns ErrAddressNotFound so GetPrivKeyForAddress falls
+	// through to the legacy PrivKeyForAddress path. This matches the
+	// kvdb-backed wallet shape.
+	mocks.store.On("GetAddress", mock.Anything, db.GetAddressQuery{
+		WalletID:     w.id,
+		ScriptPubKey: pkScript,
+	}).Return((*db.AddressInfo)(nil), db.ErrAddressNotFound).Once()
 
 	// Configure the mock chain to return the test private key.
 	//
@@ -2144,7 +2189,8 @@ func TestGetPrivKeyForAddressSuccess(t *testing.T) {
 }
 
 // TestGetPrivKeyForAddressFail tests the failure cases for retrieval of a
-// private key by address.
+// private key by address. Each case exercises the legacy fallback after the
+// store reports ErrAddressNotFound.
 func TestGetPrivKeyForAddressFail(t *testing.T) {
 	t.Parallel()
 
@@ -2154,6 +2200,16 @@ func TestGetPrivKeyForAddressFail(t *testing.T) {
 		make([]byte, 20), w.cfg.ChainParams,
 	)
 	require.NoError(t, err)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	// The store does not know the address in either case, so
+	// GetPrivKeyForAddress falls through to PrivKeyForAddress.
+	mocks.store.On("GetAddress", mock.Anything, db.GetAddressQuery{
+		WalletID:     w.id,
+		ScriptPubKey: pkScript,
+	}).Return((*db.AddressInfo)(nil), db.ErrAddressNotFound).Twice()
 
 	// Case 1: Address lookup fails.
 	mocks.addrStore.On("Address", mock.Anything, addr).


### PR DESCRIPTION
## Summary

Split out from PR #1214 to keep both PRs under the ~10-commit cap matching the rest of this stack.

This PR carries the READ-side address routing on top of PR #1214 (which lands the WRITE-side):

- `kvdb: implement address lookup`
- `wallet: route GetAddressInfo and ScriptForOutput through store`
- `wallet: add derivation-based privKey path for store addresses`
- `kvdb: implement address listing`
- `wallet: route ListAddresses through store`
- `wallet: route GetPrivKeyForAddress through store-derived path`

The derivation-based privKey path is what lets SQL-derived addresses be spent — without it, `GetPrivKeyForAddress` and `ComputeUnlockingScript` would fail on SQL-backed wallets (the legacy `PrivKeyForAddress` lookup can't find SQL-only addresses; the new path consumes `AddressInfo.Derivation` from the store).

## Test plan

- [x] `GOWORK=off go build ./...` clean across each commit
- [x] `GOWORK=off go test ./wallet/...` passes
- [x] `make lint`: 0 issues
- [x] `TestGetPrivKeyForAddressSQLDerivedAddress` regression test added for the SQL-derived-address sign path
- [ ] CI: 13 checks pass

## Depends on

- #1214 (WRITE-side address routing + setup)