### PR TITLE
db+sql: enrich UtxoInfo + scoped AccountName filter on ListUtxosQuery

### DIFF
--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -1247,8 +1247,27 @@ type ListUtxosQuery struct {
 	// databases (signed 64-bit integers).
 	WalletID uint32
 
-	// Account is an optional BIP44 account-number filter.
+	// Scope optionally restricts the listing to a single key scope. When
+	// Account or AccountName is also set, Scope is required to
+	// disambiguate cross-scope account reuse: account numbers are
+	// allocated per scope and account names are unique only within a
+	// scope.
+	Scope *KeyScope
+
+	// Account optionally restricts the listing to one BIP44 account
+	// number. When Account is set, callers must also set Scope so the
+	// filter is uniquely scoped (see Scope above). Account is mutually
+	// exclusive with AccountName.
 	Account *uint32
+
+	// AccountName optionally restricts the listing to a single account
+	// by name. Account names are unique within a scope, so AccountName
+	// requires Scope. AccountName is mutually exclusive with Account:
+	// the caller picks one disambiguation handle, not both.
+	// AccountName is the public-facing handle for imported accounts
+	// whose AccountNumber collapses to 0 on read (NULL → zero for SQL
+	// backends).
+	AccountName *string
 
 	// MinConfs optionally requires each returned UTXO to have at least this
 	// many confirmations.
@@ -1257,6 +1276,55 @@ type ListUtxosQuery struct {
 	// MaxConfs optionally requires each returned UTXO to have at most this
 	// many confirmations.
 	MaxConfs *int32
+}
+
+// ErrListUtxosQueryAccountWithoutScope is returned by
+// ListUtxosQuery.Validate when Account is set but Scope is not.
+// Account numbers are allocated per-scope on legacy wallets, so a UTXO
+// listing filtered by account number alone would silently mix outputs
+// across scopes.
+var ErrListUtxosQueryAccountWithoutScope = errors.New(
+	"list utxos: Account requires Scope to disambiguate per-scope " +
+		"account-number reuse",
+)
+
+// ErrListUtxosQueryNameWithoutScope is returned by
+// ListUtxosQuery.Validate when AccountName is set but Scope is not.
+// Account names are unique only within a scope; a name-only UTXO
+// listing would return outputs across scopes (or depend on
+// backend-specific lookup behavior).
+var ErrListUtxosQueryNameWithoutScope = errors.New(
+	"list utxos: AccountName requires Scope (account names are " +
+		"scope-unique)",
+)
+
+// ErrListUtxosQueryAccountAndName is returned by
+// ListUtxosQuery.Validate when both Account and AccountName are set.
+// The two fields are mutually exclusive: picking one disambiguates
+// the account, picking both is contradictory.
+var ErrListUtxosQueryAccountAndName = errors.New(
+	"list utxos: Account and AccountName are mutually exclusive",
+)
+
+// Validate returns ErrListUtxosQueryAccountWithoutScope when Account
+// is set without Scope, ErrListUtxosQueryNameWithoutScope when
+// AccountName is set without Scope, or
+// ErrListUtxosQueryAccountAndName when both are set. All other
+// parameter combinations are accepted.
+func (q ListUtxosQuery) Validate() error {
+	if q.Account != nil && q.AccountName != nil {
+		return ErrListUtxosQueryAccountAndName
+	}
+
+	if q.Account != nil && q.Scope == nil {
+		return ErrListUtxosQueryAccountWithoutScope
+	}
+
+	if q.AccountName != nil && q.Scope == nil {
+		return ErrListUtxosQueryNameWithoutScope
+	}
+
+	return nil
 }
 
 // LeaseOutputParams contains the parameters for leasing a UTXO.

--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -1188,6 +1188,43 @@ type UtxoInfo struct {
 	//
 	// Unconfirmed UTXOs use the sentinel value UnminedHeight.
 	Height uint32
+
+	// AccountName is the name of the wallet account this UTXO belongs to.
+	// Populated by the SQL backends from accounts.account_name in the
+	// same query that returns the UTXO row; no follow-up store call is
+	// needed.
+	AccountName string
+
+	// Origin reports whether the UTXO belongs to a derived or imported
+	// account. The wallet's spendability rule combines this with the
+	// wallet-level Wallet.IsWatchOnly() to decide whether to surface
+	// imported-account outputs in coin selection (see Task 132).
+	Origin AccountOrigin
+
+	// AddrType is the address type of the UTXO's credited address (P2PKH,
+	// P2WKH, etc.). Sourced from addresses.type_id; lets coin selection
+	// reason about output type without a follow-up address read.
+	AddrType AddressType
+
+	// HasScript is true when the credited address has a persisted
+	// encrypted script (e.g. a P2WSH script-only import). Sourced from
+	// LEFT JOIN address_secrets so watch-only addresses without any
+	// secret row report false rather than dropping out of the result.
+	HasScript bool
+
+	// IsLocked is true when the UTXO has an active (non-expired) lease.
+	// Sourced from LEFT JOIN utxo_leases with the lease-expiration
+	// comparison done in SQL against a caller-supplied UTC timestamp; the
+	// API still models leases separately from UTXO existence, but the
+	// pre-computed flag lets the wallet skip a per-row lease lookup.
+	IsLocked bool
+
+	// KeyScope is the BIP-43 key scope (purpose + coin type) of the
+	// account that owns this UTXO, sourced from key_scopes. Callers use it
+	// instead of deriving a scope from AddrType, which is lossy (a P2WPKH
+	// change output under a BIP0049Plus account would misreport as
+	// BIP0084).
+	KeyScope KeyScope
 }
 
 // GetUtxoQuery contains the parameters for querying a UTXO.

--- a/wallet/internal/db/itest/tx_utxo_store_test.go
+++ b/wallet/internal/db/itest/tx_utxo_store_test.go
@@ -1893,15 +1893,156 @@ func TestListUTXOsFiltersByAccount(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	scope := db.KeyScopeBIP0084
 	account := uint32(1)
 	utxos, err := store.ListUTXOs(t.Context(), db.ListUtxosQuery{
 		WalletID: walletID,
+		Scope:    &scope,
 		Account:  &account,
 	})
 
 	require.NoError(t, err)
 	require.Len(t, utxos, 1)
 	require.Equal(t, txSavings.TxHash(), utxos[0].OutPoint.Hash)
+}
+
+// TestListUTXOsFiltersByAccountName verifies that ListUTXOs filters by the
+// paired (Scope, AccountName) combination. Account names are unique only
+// within a scope, so the Scope is required alongside AccountName.
+func TestListUTXOsFiltersByAccountName(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(
+		t, store, "wallet-list-utxos-account-name",
+	)
+	createDerivedAccount(
+		t, store, walletID, db.KeyScopeBIP0084, "default",
+	)
+	createDerivedAccount(
+		t, store, walletID, db.KeyScopeBIP0084, "savings",
+	)
+
+	defaultAddr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	savingsAddr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "savings", false,
+	)
+
+	txDefault := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{
+			{Value: 22000, PkScript: defaultAddr.ScriptPubKey},
+		},
+	)
+	txSavings := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{
+			{Value: 23000, PkScript: savingsAddr.ScriptPubKey},
+		},
+	)
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       txDefault,
+		Received: time.Unix(1710001700, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       txSavings,
+		Received: time.Unix(1710001710, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	scope := db.KeyScopeBIP0084
+	name := "savings"
+	utxos, err := store.ListUTXOs(t.Context(), db.ListUtxosQuery{
+		WalletID:    walletID,
+		Scope:       &scope,
+		AccountName: &name,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, utxos, 1)
+	require.Equal(t, txSavings.TxHash(), utxos[0].OutPoint.Hash)
+}
+
+// TestListUTXOsRejectsAccountWithoutScope verifies that the
+// ListUtxosQuery validator rejects a numeric account filter that arrives
+// without the matching key scope. Account numbers are allocated per scope,
+// so a number-only filter would silently mix outputs across scopes.
+func TestListUTXOsRejectsAccountWithoutScope(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(
+		t, store, "wallet-list-utxos-account-without-scope",
+	)
+
+	account := uint32(0)
+	_, err := store.ListUTXOs(t.Context(), db.ListUtxosQuery{
+		WalletID: walletID,
+		Account:  &account,
+	})
+
+	require.ErrorIs(
+		t, err, db.ErrListUtxosQueryAccountWithoutScope,
+	)
+}
+
+// TestListUTXOsRejectsNameWithoutScope verifies that AccountName-only
+// filters are rejected for the same scope-uniqueness reason that
+// BalanceParams enforces.
+func TestListUTXOsRejectsNameWithoutScope(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(
+		t, store, "wallet-list-utxos-name-without-scope",
+	)
+
+	name := "default"
+	_, err := store.ListUTXOs(t.Context(), db.ListUtxosQuery{
+		WalletID:    walletID,
+		AccountName: &name,
+	})
+
+	require.ErrorIs(
+		t, err, db.ErrListUtxosQueryNameWithoutScope,
+	)
+}
+
+// TestListUTXOsRejectsAccountAndName verifies that callers cannot pass
+// both Account and AccountName: those fields are mutually exclusive
+// disambiguation handles.
+func TestListUTXOsRejectsAccountAndName(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(
+		t, store, "wallet-list-utxos-account-and-name",
+	)
+
+	scope := db.KeyScopeBIP0084
+	account := uint32(0)
+	name := "default"
+	_, err := store.ListUTXOs(t.Context(), db.ListUtxosQuery{
+		WalletID:    walletID,
+		Scope:       &scope,
+		Account:     &account,
+		AccountName: &name,
+	})
+
+	require.ErrorIs(
+		t, err, db.ErrListUtxosQueryAccountAndName,
+	)
 }
 
 // TestLeaseOutputLocksCurrentUtxo verifies that LeaseOutput returns the active

--- a/wallet/internal/db/itest/tx_utxo_store_test.go
+++ b/wallet/internal/db/itest/tx_utxo_store_test.go
@@ -1749,9 +1749,8 @@ func TestUTXOEnrichmentFields(t *testing.T) {
 	scope := db.KeyScopeBIP0084
 
 	// Imported script address: the encrypted script secret drives HasScript,
-	// and its account drives Origin == ImportedAccount.
-	CreateImportedAccount(t, store, walletID, scope, importedName, true)
-
+	// and the import auto-creates the wallet-level imported bucket that drives
+	// Origin == ImportedAccount.
 	importedScript := RandomBytes(32)
 	_, err := store.NewImportedAddress(
 		t.Context(), db.NewImportedAddressParams{

--- a/wallet/internal/db/itest/tx_utxo_store_test.go
+++ b/wallet/internal/db/itest/tx_utxo_store_test.go
@@ -1726,6 +1726,129 @@ func TestListUTXOsReturnsCurrentWalletOutputs(t *testing.T) {
 	require.Equal(t, txOne.TxHash(), utxos[1].OutPoint.Hash)
 }
 
+// TestUTXOEnrichmentFields verifies that ListUTXOs and GetUtxo populate the
+// UtxoInfo enrichment fields (AccountName, Origin, AddrType, HasScript,
+// IsLocked, KeyScope) from the backing account/address/lease joins. It pairs a
+// positive case (an imported script address with an active lease) against a
+// negative case (a derived address with neither a script nor a lease) so a
+// regression in any join or row-to-UtxoInfo conversion fails the assertions.
+func TestUTXOEnrichmentFields(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+
+	// A watch-only wallet can host an imported script-only address: such an
+	// address carries a persisted encrypted script (so HasScript is true)
+	// but no private key, which the ADR 0012 invariant only permits on a
+	// watch-only wallet.
+	walletID := newWatchOnlyWallet(t, store, "wallet-utxo-enrichment")
+
+	const derivedName = "derived"
+
+	importedName := db.DefaultImportedAccountName
+	scope := db.KeyScopeBIP0084
+
+	// Imported script address: the encrypted script secret drives HasScript,
+	// and its account drives Origin == ImportedAccount.
+	CreateImportedAccount(t, store, walletID, scope, importedName, true)
+
+	importedScript := RandomBytes(32)
+	_, err := store.NewImportedAddress(
+		t.Context(), db.NewImportedAddressParams{
+			WalletID:        walletID,
+			Scope:           scope,
+			AddressType:     db.WitnessScript,
+			PubKey:          RandomBytes(33),
+			ScriptPubKey:    importedScript,
+			EncryptedScript: RandomBytes(48),
+		},
+	)
+	require.NoError(t, err)
+
+	// Derived address: no script secret, so HasScript stays false and
+	// Origin == DerivedAccount.
+	createDerivedAccount(t, store, walletID, scope, derivedName)
+	derivedAddr := newDerivedAddress(
+		t, store, walletID, scope, derivedName, false,
+	)
+
+	// Record one UTXO under each address.
+	importedTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 20000, PkScript: importedScript}},
+	)
+	derivedTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 30000, PkScript: derivedAddr.ScriptPubKey}},
+	)
+
+	for _, tx := range []*wire.MsgTx{importedTx, derivedTx} {
+		err = store.CreateTx(t.Context(), db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710002000, 0),
+			Status:   db.TxStatusPending,
+			Credits:  map[uint32]btcutil.Address{0: nil},
+		})
+		require.NoError(t, err)
+	}
+
+	importedOutPoint := wire.OutPoint{Hash: importedTx.TxHash(), Index: 0}
+	derivedOutPoint := wire.OutPoint{Hash: derivedTx.TxHash(), Index: 0}
+
+	// Lease only the imported UTXO so IsLocked distinguishes the two rows.
+	_, err = store.LeaseOutput(t.Context(), db.LeaseOutputParams{
+		WalletID: walletID,
+		OutPoint: importedOutPoint,
+		ID:       db.LockID{1},
+		Duration: 30 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	// Index ListUTXOs results by outpoint so assertions don't depend on the
+	// result ordering.
+	utxos, err := store.ListUTXOs(t.Context(), db.ListUtxosQuery{
+		WalletID: walletID,
+	})
+	require.NoError(t, err)
+	require.Len(t, utxos, 2)
+
+	byOutPoint := make(map[wire.OutPoint]db.UtxoInfo, len(utxos))
+	for _, u := range utxos {
+		byOutPoint[u.OutPoint] = u
+	}
+
+	imported, ok := byOutPoint[importedOutPoint]
+	require.True(t, ok, "imported UTXO missing from ListUTXOs")
+	require.Equal(t, importedName, imported.AccountName)
+	require.Equal(t, db.ImportedAccount, imported.Origin)
+	require.Equal(t, db.WitnessScript, imported.AddrType)
+	require.True(t, imported.HasScript)
+	require.True(t, imported.IsLocked)
+	require.Equal(t, scope, imported.KeyScope)
+
+	derived, ok := byOutPoint[derivedOutPoint]
+	require.True(t, ok, "derived UTXO missing from ListUTXOs")
+	require.Equal(t, derivedName, derived.AccountName)
+	require.Equal(t, db.DerivedAccount, derived.Origin)
+	require.Equal(t, db.WitnessPubKey, derived.AddrType)
+	require.False(t, derived.HasScript)
+	require.False(t, derived.IsLocked)
+	require.Equal(t, scope, derived.KeyScope)
+
+	// GetUtxo surfaces the same enriched view as ListUTXOs.
+	got, err := store.GetUtxo(t.Context(), db.GetUtxoQuery{
+		WalletID: walletID,
+		OutPoint: importedOutPoint,
+	})
+	require.NoError(t, err)
+	require.Equal(t, db.ImportedAccount, got.Origin)
+	require.Equal(t, db.WitnessScript, got.AddrType)
+	require.True(t, got.HasScript)
+	require.True(t, got.IsLocked)
+	require.Equal(t, scope, got.KeyScope)
+}
+
 // TestListUTXOsFiltersByAccount verifies that ListUTXOs applies the optional
 // account filter without affecting the underlying wallet ownership checks.
 func TestListUTXOsFiltersByAccount(t *testing.T) {

--- a/wallet/internal/db/pg/utxostore_getutxo.go
+++ b/wallet/internal/db/pg/utxostore_getutxo.go
@@ -28,6 +28,7 @@ func (s *Store) GetUtxo(ctx context.Context,
 	err = s.execRead(ctx, func(q *sqlc.Queries) error {
 		row, err := q.GetUtxoByOutpoint(
 			ctx, sqlc.GetUtxoByOutpointParams{
+				NowUtc:      time.Now().UTC(),
 				WalletID:    int64(query.WalletID),
 				TxHash:      query.OutPoint.Hash[:],
 				OutputIndex: outputIndex,
@@ -42,12 +43,37 @@ func (s *Store) GetUtxo(ctx context.Context,
 			return fmt.Errorf("get utxo: %w", err)
 		}
 
+		origin, err := db.IDToAccountOrigin[int16](row.OriginID)
+		if err != nil {
+			return fmt.Errorf("origin: %w", err)
+		}
+
+		addrType, err := db.IDToAddressType(row.TypeID)
+		if err != nil {
+			return fmt.Errorf("addr type: %w", err)
+		}
+
+		keyScope, err := db.KeyScopeFromIDs(row.Purpose, row.CoinType)
+		if err != nil {
+			return fmt.Errorf("key scope: %w", err)
+		}
+
 		utxo, err = utxoInfoFromRow(
 			row.TxHash, row.OutputIndex, row.Amount, row.ScriptPubKey,
 			row.ReceivedTime, row.IsCoinbase, row.BlockHeight,
 		)
+		if err != nil {
+			return err
+		}
 
-		return err
+		utxo.AccountName = row.AccountName
+		utxo.Origin = origin
+		utxo.AddrType = addrType
+		utxo.HasScript = row.HasScript
+		utxo.IsLocked = row.IsLocked
+		utxo.KeyScope = keyScope
+
+		return nil
 	})
 	if err != nil {
 		return nil, err

--- a/wallet/internal/db/pg/utxostore_listutxos.go
+++ b/wallet/internal/db/pg/utxostore_listutxos.go
@@ -18,9 +18,14 @@ import (
 func (s *Store) ListUTXOs(ctx context.Context,
 	query db.ListUtxosQuery) ([]db.UtxoInfo, error) {
 
+	err := query.Validate()
+	if err != nil {
+		return nil, err
+	}
+
 	var utxos []db.UtxoInfo
 
-	err := s.execRead(ctx, func(q *sqlc.Queries) error {
+	err = s.execRead(ctx, func(q *sqlc.Queries) error {
 		rows, err := q.ListUtxos(ctx, buildListUtxosParams(query))
 		if err != nil {
 			return fmt.Errorf("list utxos: %w", err)
@@ -59,10 +64,15 @@ func (s *Store) ListUTXOs(ctx context.Context,
 // check the query performs in SQL, in line with the existing Balance /
 // lease-query convention this repo follows.
 func buildListUtxosParams(query db.ListUtxosQuery) sqlc.ListUtxosParams {
+	purpose, coinType := db.ScopeFilter(query.Scope)
+
 	return sqlc.ListUtxosParams{
 		NowUtc:        time.Now().UTC(),
 		WalletID:      int64(query.WalletID),
+		Purpose:       purpose,
+		CoinType:      coinType,
 		AccountNumber: db.NullableUint32ToSQLInt64(query.Account),
+		AccountName:   db.NullableStringToSQLNullString(query.AccountName),
 		MinConfirms:   db.NullableInt32ToSQLInt32(query.MinConfs),
 		MaxConfirms:   db.NullableInt32ToSQLInt32(query.MaxConfs),
 	}

--- a/wallet/internal/db/pg/utxostore_listutxos.go
+++ b/wallet/internal/db/pg/utxostore_listutxos.go
@@ -3,6 +3,7 @@ package pg
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
@@ -11,7 +12,9 @@ import (
 // ListUTXOs lists all current wallet-owned UTXOs matching the caller filters.
 //
 // The result set is already constrained to outputs whose creating
-// transactions are still in `pending` or `published` status.
+// transactions are still in `pending` or `published` status. Enrichment
+// columns (account name + origin, address type, has-script bit, lease
+// status) are populated by the same query.
 func (s *Store) ListUTXOs(ctx context.Context,
 	query db.ListUtxosQuery) ([]db.UtxoInfo, error) {
 
@@ -26,9 +29,15 @@ func (s *Store) ListUTXOs(ctx context.Context,
 		utxos = make([]db.UtxoInfo, len(rows))
 		for i, row := range rows {
 			utxo, err := utxoInfoFromRow(
-				row.TxHash, row.OutputIndex, row.Amount, row.ScriptPubKey,
-				row.ReceivedTime, row.IsCoinbase, row.BlockHeight,
+				row.TxHash, row.OutputIndex, row.Amount,
+				row.ScriptPubKey, row.ReceivedTime, row.IsCoinbase,
+				row.BlockHeight,
 			)
+			if err != nil {
+				return err
+			}
+
+			err = applyListRowEnrichment(utxo, row)
 			if err != nil {
 				return err
 			}
@@ -46,12 +55,46 @@ func (s *Store) ListUTXOs(ctx context.Context,
 }
 
 // buildListUtxosParams prepares the typed nullable filters required by the
-// postgres ListUtxos query.
+// postgres ListUtxos query. The NowUtc argument feeds the lease-expiration
+// check the query performs in SQL, in line with the existing Balance /
+// lease-query convention this repo follows.
 func buildListUtxosParams(query db.ListUtxosQuery) sqlc.ListUtxosParams {
 	return sqlc.ListUtxosParams{
+		NowUtc:        time.Now().UTC(),
 		WalletID:      int64(query.WalletID),
 		AccountNumber: db.NullableUint32ToSQLInt64(query.Account),
 		MinConfirms:   db.NullableInt32ToSQLInt32(query.MinConfs),
 		MaxConfirms:   db.NullableInt32ToSQLInt32(query.MaxConfs),
 	}
+}
+
+// applyListRowEnrichment derives and sets the per-row UTXO enrichment
+// fields (account name + origin, address type, has-script bit, lease
+// status) on utxo from a ListUtxos result row.
+func applyListRowEnrichment(utxo *db.UtxoInfo,
+	row sqlc.ListUtxosRow) error {
+
+	origin, err := db.IDToAccountOrigin[int16](row.OriginID)
+	if err != nil {
+		return fmt.Errorf("origin: %w", err)
+	}
+
+	addrType, err := db.IDToAddressType(row.TypeID)
+	if err != nil {
+		return fmt.Errorf("addr type: %w", err)
+	}
+
+	keyScope, err := db.KeyScopeFromIDs(row.Purpose, row.CoinType)
+	if err != nil {
+		return fmt.Errorf("key scope: %w", err)
+	}
+
+	utxo.AccountName = row.AccountName
+	utxo.Origin = origin
+	utxo.AddrType = addrType
+	utxo.HasScript = row.HasScript
+	utxo.IsLocked = row.IsLocked
+	utxo.KeyScope = keyScope
+
+	return nil
 }

--- a/wallet/internal/db/sqlite/utxostore_getutxo.go
+++ b/wallet/internal/db/sqlite/utxostore_getutxo.go
@@ -23,6 +23,7 @@ func (s *Store) GetUtxo(ctx context.Context,
 	err := s.execRead(ctx, func(q *sqlc.Queries) error {
 		row, err := q.GetUtxoByOutpoint(
 			ctx, sqlc.GetUtxoByOutpointParams{
+				NowUtc:      time.Now().UTC(),
 				WalletID:    int64(query.WalletID),
 				TxHash:      query.OutPoint.Hash[:],
 				OutputIndex: int64(query.OutPoint.Index),
@@ -37,12 +38,37 @@ func (s *Store) GetUtxo(ctx context.Context,
 			return fmt.Errorf("get utxo: %w", err)
 		}
 
+		origin, err := db.IDToAccountOrigin[int64](row.OriginID)
+		if err != nil {
+			return fmt.Errorf("origin: %w", err)
+		}
+
+		addrType, err := db.IDToAddressType(row.TypeID)
+		if err != nil {
+			return fmt.Errorf("addr type: %w", err)
+		}
+
+		keyScope, err := db.KeyScopeFromIDs(row.Purpose, row.CoinType)
+		if err != nil {
+			return fmt.Errorf("key scope: %w", err)
+		}
+
 		utxo, err = utxoInfoFromRow(
 			row.TxHash, row.OutputIndex, row.Amount, row.ScriptPubKey,
 			row.ReceivedTime, row.IsCoinbase, row.BlockHeight,
 		)
+		if err != nil {
+			return err
+		}
 
-		return err
+		utxo.AccountName = row.AccountName
+		utxo.Origin = origin
+		utxo.AddrType = addrType
+		utxo.HasScript = row.HasScript
+		utxo.IsLocked = row.IsLocked != 0
+		utxo.KeyScope = keyScope
+
+		return nil
 	})
 	if err != nil {
 		return nil, err

--- a/wallet/internal/db/sqlite/utxostore_listutxos.go
+++ b/wallet/internal/db/sqlite/utxostore_listutxos.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
@@ -11,7 +12,9 @@ import (
 // ListUTXOs lists all current wallet-owned UTXOs matching the caller filters.
 //
 // The result set is already constrained to outputs whose creating
-// transactions are still in `pending` or `published` status.
+// transactions are still in `pending` or `published` status. Enrichment
+// columns (account name + origin, address type, has-script bit, lease
+// status) are populated by the same query.
 func (s *Store) ListUTXOs(ctx context.Context,
 	query db.ListUtxosQuery) ([]db.UtxoInfo, error) {
 
@@ -19,6 +22,7 @@ func (s *Store) ListUTXOs(ctx context.Context,
 
 	err := s.execRead(ctx, func(q *sqlc.Queries) error {
 		rows, err := q.ListUtxos(ctx, sqlc.ListUtxosParams{
+			NowUtc:        time.Now().UTC(),
 			WalletID:      int64(query.WalletID),
 			AccountNumber: db.NullableUint32ToSQLInt64(query.Account),
 			MinConfirms:   db.NullableInt32ToSQLInt64(query.MinConfs),
@@ -31,9 +35,15 @@ func (s *Store) ListUTXOs(ctx context.Context,
 		utxos = make([]db.UtxoInfo, len(rows))
 		for i, row := range rows {
 			utxo, err := utxoInfoFromRow(
-				row.TxHash, row.OutputIndex, row.Amount, row.ScriptPubKey,
-				row.ReceivedTime, row.IsCoinbase, row.BlockHeight,
+				row.TxHash, row.OutputIndex, row.Amount,
+				row.ScriptPubKey, row.ReceivedTime, row.IsCoinbase,
+				row.BlockHeight,
 			)
+			if err != nil {
+				return err
+			}
+
+			err = applyListRowEnrichment(utxo, row)
 			if err != nil {
 				return err
 			}
@@ -48,4 +58,35 @@ func (s *Store) ListUTXOs(ctx context.Context,
 	}
 
 	return utxos, nil
+}
+
+// applyListRowEnrichment derives and sets the per-row UTXO enrichment
+// fields (account name + origin, address type, has-script bit, lease
+// status) on utxo from a ListUtxos result row.
+func applyListRowEnrichment(utxo *db.UtxoInfo,
+	row sqlc.ListUtxosRow) error {
+
+	origin, err := db.IDToAccountOrigin[int64](row.OriginID)
+	if err != nil {
+		return fmt.Errorf("origin: %w", err)
+	}
+
+	addrType, err := db.IDToAddressType(row.TypeID)
+	if err != nil {
+		return fmt.Errorf("addr type: %w", err)
+	}
+
+	keyScope, err := db.KeyScopeFromIDs(row.Purpose, row.CoinType)
+	if err != nil {
+		return fmt.Errorf("key scope: %w", err)
+	}
+
+	utxo.AccountName = row.AccountName
+	utxo.Origin = origin
+	utxo.AddrType = addrType
+	utxo.HasScript = row.HasScript
+	utxo.IsLocked = row.IsLocked != 0
+	utxo.KeyScope = keyScope
+
+	return nil
 }

--- a/wallet/internal/db/sqlite/utxostore_listutxos.go
+++ b/wallet/internal/db/sqlite/utxostore_listutxos.go
@@ -18,13 +18,23 @@ import (
 func (s *Store) ListUTXOs(ctx context.Context,
 	query db.ListUtxosQuery) ([]db.UtxoInfo, error) {
 
+	err := query.Validate()
+	if err != nil {
+		return nil, err
+	}
+
 	var utxos []db.UtxoInfo
 
-	err := s.execRead(ctx, func(q *sqlc.Queries) error {
+	err = s.execRead(ctx, func(q *sqlc.Queries) error {
+		purpose, coinType := db.ScopeFilter(query.Scope)
+
 		rows, err := q.ListUtxos(ctx, sqlc.ListUtxosParams{
 			NowUtc:        time.Now().UTC(),
 			WalletID:      int64(query.WalletID),
+			Purpose:       purpose,
+			CoinType:      coinType,
 			AccountNumber: db.NullableUint32ToSQLInt64(query.Account),
+			AccountName:   db.NullableStringToSQLNullString(query.AccountName),
 			MinConfirms:   db.NullableInt32ToSQLInt64(query.MinConfs),
 			MaxConfirms:   db.NullableInt32ToSQLInt64(query.MaxConfs),
 		})

--- a/wallet/internal/db/utxo_store_common.go
+++ b/wallet/internal/db/utxo_store_common.go
@@ -54,8 +54,26 @@ func buildOutPoint(hash []byte, outputIndex uint32) (wire.OutPoint, error) {
 	return wire.OutPoint{Hash: *txHash, Index: outputIndex}, nil
 }
 
-// BuildUtxoInfo converts normalized SQL result fields into the public UtxoInfo
-// shape returned by the db interfaces.
+// KeyScopeFromIDs builds a KeyScope from the raw purpose / coin_type columns
+// selected from key_scopes, validating the int64 -> uint32 narrowing.
+func KeyScopeFromIDs(purpose, coinType int64) (KeyScope, error) {
+	p, err := Int64ToUint32(purpose)
+	if err != nil {
+		return KeyScope{}, fmt.Errorf("scope purpose: %w", err)
+	}
+
+	c, err := Int64ToUint32(coinType)
+	if err != nil {
+		return KeyScope{}, fmt.Errorf("scope coin type: %w", err)
+	}
+
+	return KeyScope{Purpose: p, Coin: c}, nil
+}
+
+// BuildUtxoInfo converts the normalized base SQL result fields into the public
+// UtxoInfo shape. Backends set the per-row enrichment fields (AccountName,
+// Origin, AddrType, HasScript, IsLocked, KeyScope) directly on the returned
+// value after this call.
 func BuildUtxoInfo(hash []byte, outputIndex uint32, amount int64,
 	pkScript []byte, received time.Time, isCoinbase bool,
 	blockHeight *uint32) (*UtxoInfo, error) {

--- a/wallet/internal/sql/pg/queries/utxos.sql
+++ b/wallet/internal/sql/pg/queries/utxos.sql
@@ -84,17 +84,37 @@ SELECT
     a.script_pub_key,
     t.received_time,
     t.is_coinbase,
-    t.block_height
+    t.block_height,
+    -- Enrichment columns derived from the ownership joins below.
+    acc.account_name, -- owning account
+    acc.origin_id, -- derived vs imported account
+    a.type_id, -- address type, used for coin selection
+    ks.purpose, -- BIP-43 key scope purpose
+    ks.coin_type, -- BIP-43 key scope coin type
+    -- has_script: the credited address has a persisted encrypted script (e.g. a
+    -- P2WSH script-only import). LEFT JOIN, so addresses with no secret report
+    -- FALSE instead of being dropped.
+    (asec.encrypted_script IS NOT NULL)::BOOLEAN AS has_script,
+    -- is_locked: TRUE when an active (non-expired) lease exists for this output.
+    -- now_utc is a caller-supplied current UTC timestamp used for the lease
+    -- expiry comparison; passed in rather than read from the DB clock so results
+    -- are deterministic/testable and consistent with the Balance/lease queries.
+    coalesce(
+        l.utxo_id IS NOT NULL
+        AND l.expires_at > sqlc.arg('now_utc')::TIMESTAMP, FALSE
+    )::BOOLEAN AS is_locked
 FROM transactions AS t
-INNER JOIN utxos AS u ON t.id = u.tx_id
+INNER JOIN utxos AS u ON t.id = u.tx_id -- INNER joins enforce wallet ownership
 INNER JOIN addresses AS a ON u.address_id = a.id
 INNER JOIN accounts AS acc ON a.account_id = acc.id
-INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
+INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id -- non-wallet rows are dropped
+LEFT JOIN utxo_leases AS l ON u.id = l.utxo_id -- LEFT joins: optional enrichment
+LEFT JOIN address_secrets AS asec ON a.id = asec.address_id
 WHERE
-    t.wallet_id = $1
-    AND ks.wallet_id = $1
-    AND t.tx_hash = $2
-    AND u.output_index = $3
+    t.wallet_id = sqlc.arg('wallet_id')
+    AND ks.wallet_id = sqlc.arg('wallet_id')
+    AND t.tx_hash = sqlc.arg('tx_hash')
+    AND u.output_index = sqlc.arg('output_index')
     AND u.spent_by_tx_id IS NULL
     AND t.tx_status IN (0, 1);
 
@@ -126,12 +146,32 @@ SELECT
     a.script_pub_key,
     t.received_time,
     t.is_coinbase,
-    t.block_height
+    t.block_height,
+    -- Enrichment columns derived from the ownership joins below.
+    acc.account_name, -- owning account
+    acc.origin_id, -- derived vs imported account
+    a.type_id, -- address type, used for coin selection
+    ks.purpose, -- BIP-43 key scope purpose
+    ks.coin_type, -- BIP-43 key scope coin type
+    -- has_script: the credited address has a persisted encrypted script (e.g. a
+    -- P2WSH script-only import). LEFT JOIN, so addresses with no secret report
+    -- FALSE instead of being dropped.
+    (asec.encrypted_script IS NOT NULL)::BOOLEAN AS has_script,
+    -- is_locked: TRUE when an active (non-expired) lease exists for this output.
+    -- now_utc is a caller-supplied current UTC timestamp used for the lease
+    -- expiry comparison; passed in rather than read from the DB clock so results
+    -- are deterministic/testable and consistent with the Balance/lease queries.
+    coalesce(
+        l.utxo_id IS NOT NULL
+        AND l.expires_at > sqlc.arg('now_utc')::TIMESTAMP, FALSE
+    )::BOOLEAN AS is_locked
 FROM transactions AS t
-INNER JOIN utxos AS u ON t.id = u.tx_id
+INNER JOIN utxos AS u ON t.id = u.tx_id -- INNER joins enforce wallet ownership
 INNER JOIN addresses AS a ON u.address_id = a.id
 INNER JOIN accounts AS acc ON a.account_id = acc.id
-INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
+INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id -- non-wallet rows are dropped
+LEFT JOIN utxo_leases AS l ON u.id = l.utxo_id -- LEFT joins: optional enrichment
+LEFT JOIN address_secrets AS asec ON a.id = asec.address_id
 LEFT JOIN wallet_sync_states AS s ON t.wallet_id = s.wallet_id
 WHERE
     t.wallet_id = sqlc.arg('wallet_id')

--- a/wallet/internal/sql/pg/queries/utxos.sql
+++ b/wallet/internal/sql/pg/queries/utxos.sql
@@ -191,6 +191,10 @@ WHERE
         OR acc.account_number = sqlc.narg('account_number')::BIGINT
     )
     AND (
+        sqlc.narg('account_name')::TEXT IS NULL
+        OR acc.account_name = sqlc.narg('account_name')::TEXT
+    )
+    AND (
         sqlc.narg('min_confirms')::INTEGER IS NULL
         OR sqlc.narg('min_confirms')::INTEGER = 0
         OR (

--- a/wallet/internal/sql/pg/sqlc/utxos.sql.go
+++ b/wallet/internal/sql/pg/sqlc/utxos.sql.go
@@ -607,19 +607,12 @@ WHERE
         OR acc.account_number = $5::BIGINT
     )
     AND (
-        $6::INTEGER IS NULL
-        OR $6::INTEGER = 0
-        OR (
-            CASE
-                WHEN t.block_height IS NULL THEN 0
-                WHEN s.synced_height IS NULL THEN NULL
-                WHEN t.block_height > s.synced_height THEN NULL
-                ELSE s.synced_height - t.block_height + 1
-            END
-        ) >= $6::INTEGER
+        $6::TEXT IS NULL
+        OR acc.account_name = $6::TEXT
     )
     AND (
         $7::INTEGER IS NULL
+        OR $7::INTEGER = 0
         OR (
             CASE
                 WHEN t.block_height IS NULL THEN 0
@@ -627,7 +620,18 @@ WHERE
                 WHEN t.block_height > s.synced_height THEN NULL
                 ELSE s.synced_height - t.block_height + 1
             END
-        ) <= $7::INTEGER
+        ) >= $7::INTEGER
+    )
+    AND (
+        $8::INTEGER IS NULL
+        OR (
+            CASE
+                WHEN t.block_height IS NULL THEN 0
+                WHEN s.synced_height IS NULL THEN NULL
+                WHEN t.block_height > s.synced_height THEN NULL
+                ELSE s.synced_height - t.block_height + 1
+            END
+        ) <= $8::INTEGER
     )
 ORDER BY u.amount, t.tx_hash, u.output_index
 `
@@ -638,6 +642,7 @@ type ListUtxosParams struct {
 	Purpose       sql.NullInt64
 	CoinType      sql.NullInt64
 	AccountNumber sql.NullInt64
+	AccountName   sql.NullString
 	MinConfirms   sql.NullInt32
 	MaxConfirms   sql.NullInt32
 }
@@ -687,6 +692,7 @@ func (q *Queries) ListUtxos(ctx context.Context, arg ListUtxosParams) ([]ListUtx
 		arg.Purpose,
 		arg.CoinType,
 		arg.AccountNumber,
+		arg.AccountName,
 		arg.MinConfirms,
 		arg.MaxConfirms,
 	)

--- a/wallet/internal/sql/pg/sqlc/utxos.sql.go
+++ b/wallet/internal/sql/pg/sqlc/utxos.sql.go
@@ -224,22 +224,43 @@ SELECT
     a.script_pub_key,
     t.received_time,
     t.is_coinbase,
-    t.block_height
+    t.block_height,
+    -- Enrichment columns derived from the ownership joins below.
+    acc.account_name, -- owning account
+    acc.origin_id, -- derived vs imported account
+    a.type_id, -- address type, used for coin selection
+    ks.purpose, -- BIP-43 key scope purpose
+    ks.coin_type, -- BIP-43 key scope coin type
+    -- has_script: the credited address has a persisted encrypted script (e.g. a
+    -- P2WSH script-only import). LEFT JOIN, so addresses with no secret report
+    -- FALSE instead of being dropped.
+    (asec.encrypted_script IS NOT NULL)::BOOLEAN AS has_script,
+    -- is_locked: TRUE when an active (non-expired) lease exists for this output.
+    -- now_utc is a caller-supplied current UTC timestamp used for the lease
+    -- expiry comparison; passed in rather than read from the DB clock so results
+    -- are deterministic/testable and consistent with the Balance/lease queries.
+    coalesce(
+        l.utxo_id IS NOT NULL
+        AND l.expires_at > $1::TIMESTAMP, FALSE
+    )::BOOLEAN AS is_locked
 FROM transactions AS t
-INNER JOIN utxos AS u ON t.id = u.tx_id
+INNER JOIN utxos AS u ON t.id = u.tx_id -- INNER joins enforce wallet ownership
 INNER JOIN addresses AS a ON u.address_id = a.id
 INNER JOIN accounts AS acc ON a.account_id = acc.id
-INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
+INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id -- non-wallet rows are dropped
+LEFT JOIN utxo_leases AS l ON u.id = l.utxo_id -- LEFT joins: optional enrichment
+LEFT JOIN address_secrets AS asec ON a.id = asec.address_id
 WHERE
-    t.wallet_id = $1
-    AND ks.wallet_id = $1
-    AND t.tx_hash = $2
-    AND u.output_index = $3
+    t.wallet_id = $2
+    AND ks.wallet_id = $2
+    AND t.tx_hash = $3
+    AND u.output_index = $4
     AND u.spent_by_tx_id IS NULL
     AND t.tx_status IN (0, 1)
 `
 
 type GetUtxoByOutpointParams struct {
+	NowUtc      time.Time
 	WalletID    int64
 	TxHash      []byte
 	OutputIndex int32
@@ -253,6 +274,13 @@ type GetUtxoByOutpointRow struct {
 	ReceivedTime time.Time
 	IsCoinbase   bool
 	BlockHeight  sql.NullInt32
+	AccountName  string
+	OriginID     int16
+	TypeID       int16
+	Purpose      int64
+	CoinType     int64
+	HasScript    bool
+	IsLocked     bool
 }
 
 // Retrieves a single unspent UTXO by its outpoint.
@@ -271,7 +299,12 @@ type GetUtxoByOutpointRow struct {
 //   - The wallet-scoped tx hash lookup and unique outpoint constraint keep the
 //     join fanout to at most one candidate output.
 func (q *Queries) GetUtxoByOutpoint(ctx context.Context, arg GetUtxoByOutpointParams) (GetUtxoByOutpointRow, error) {
-	row := q.queryRow(ctx, q.getUtxoByOutpointStmt, GetUtxoByOutpoint, arg.WalletID, arg.TxHash, arg.OutputIndex)
+	row := q.queryRow(ctx, q.getUtxoByOutpointStmt, GetUtxoByOutpoint,
+		arg.NowUtc,
+		arg.WalletID,
+		arg.TxHash,
+		arg.OutputIndex,
+	)
 	var i GetUtxoByOutpointRow
 	err := row.Scan(
 		&i.TxHash,
@@ -281,6 +314,13 @@ func (q *Queries) GetUtxoByOutpoint(ctx context.Context, arg GetUtxoByOutpointPa
 		&i.ReceivedTime,
 		&i.IsCoinbase,
 		&i.BlockHeight,
+		&i.AccountName,
+		&i.OriginID,
+		&i.TypeID,
+		&i.Purpose,
+		&i.CoinType,
+		&i.HasScript,
+		&i.IsLocked,
 	)
 	return i, err
 }
@@ -522,44 +562,53 @@ SELECT
     a.script_pub_key,
     t.received_time,
     t.is_coinbase,
-    t.block_height
+    t.block_height,
+    -- Enrichment columns derived from the ownership joins below.
+    acc.account_name, -- owning account
+    acc.origin_id, -- derived vs imported account
+    a.type_id, -- address type, used for coin selection
+    ks.purpose, -- BIP-43 key scope purpose
+    ks.coin_type, -- BIP-43 key scope coin type
+    -- has_script: the credited address has a persisted encrypted script (e.g. a
+    -- P2WSH script-only import). LEFT JOIN, so addresses with no secret report
+    -- FALSE instead of being dropped.
+    (asec.encrypted_script IS NOT NULL)::BOOLEAN AS has_script,
+    -- is_locked: TRUE when an active (non-expired) lease exists for this output.
+    -- now_utc is a caller-supplied current UTC timestamp used for the lease
+    -- expiry comparison; passed in rather than read from the DB clock so results
+    -- are deterministic/testable and consistent with the Balance/lease queries.
+    coalesce(
+        l.utxo_id IS NOT NULL
+        AND l.expires_at > $1::TIMESTAMP, FALSE
+    )::BOOLEAN AS is_locked
 FROM transactions AS t
-INNER JOIN utxos AS u ON t.id = u.tx_id
+INNER JOIN utxos AS u ON t.id = u.tx_id -- INNER joins enforce wallet ownership
 INNER JOIN addresses AS a ON u.address_id = a.id
 INNER JOIN accounts AS acc ON a.account_id = acc.id
-INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
+INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id -- non-wallet rows are dropped
+LEFT JOIN utxo_leases AS l ON u.id = l.utxo_id -- LEFT joins: optional enrichment
+LEFT JOIN address_secrets AS asec ON a.id = asec.address_id
 LEFT JOIN wallet_sync_states AS s ON t.wallet_id = s.wallet_id
 WHERE
-    t.wallet_id = $1
-    AND ks.wallet_id = $1
+    t.wallet_id = $2
+    AND ks.wallet_id = $2
     AND u.spent_by_tx_id IS NULL
     AND t.tx_status IN (0, 1)
     AND (
-        $2::BIGINT IS NULL
-        OR ks.purpose = $2::BIGINT
-    )
-    AND (
         $3::BIGINT IS NULL
-        OR ks.coin_type = $3::BIGINT
+        OR ks.purpose = $3::BIGINT
     )
     AND (
         $4::BIGINT IS NULL
-        OR acc.account_number = $4::BIGINT
+        OR ks.coin_type = $4::BIGINT
     )
     AND (
-        $5::INTEGER IS NULL
-        OR $5::INTEGER = 0
-        OR (
-            CASE
-                WHEN t.block_height IS NULL THEN 0
-                WHEN s.synced_height IS NULL THEN NULL
-                WHEN t.block_height > s.synced_height THEN NULL
-                ELSE s.synced_height - t.block_height + 1
-            END
-        ) >= $5::INTEGER
+        $5::BIGINT IS NULL
+        OR acc.account_number = $5::BIGINT
     )
     AND (
         $6::INTEGER IS NULL
+        OR $6::INTEGER = 0
         OR (
             CASE
                 WHEN t.block_height IS NULL THEN 0
@@ -567,12 +616,24 @@ WHERE
                 WHEN t.block_height > s.synced_height THEN NULL
                 ELSE s.synced_height - t.block_height + 1
             END
-        ) <= $6::INTEGER
+        ) >= $6::INTEGER
+    )
+    AND (
+        $7::INTEGER IS NULL
+        OR (
+            CASE
+                WHEN t.block_height IS NULL THEN 0
+                WHEN s.synced_height IS NULL THEN NULL
+                WHEN t.block_height > s.synced_height THEN NULL
+                ELSE s.synced_height - t.block_height + 1
+            END
+        ) <= $7::INTEGER
     )
 ORDER BY u.amount, t.tx_hash, u.output_index
 `
 
 type ListUtxosParams struct {
+	NowUtc        time.Time
 	WalletID      int64
 	Purpose       sql.NullInt64
 	CoinType      sql.NullInt64
@@ -589,6 +650,13 @@ type ListUtxosRow struct {
 	ReceivedTime time.Time
 	IsCoinbase   bool
 	BlockHeight  sql.NullInt32
+	AccountName  string
+	OriginID     int16
+	TypeID       int16
+	Purpose      int64
+	CoinType     int64
+	HasScript    bool
+	IsLocked     bool
 }
 
 // Lists unspent UTXOs that match the provided filters.
@@ -614,6 +682,7 @@ type ListUtxosRow struct {
 //     distinguish "not set" from an explicit zero-conf request.
 func (q *Queries) ListUtxos(ctx context.Context, arg ListUtxosParams) ([]ListUtxosRow, error) {
 	rows, err := q.query(ctx, q.listUtxosStmt, ListUtxos,
+		arg.NowUtc,
 		arg.WalletID,
 		arg.Purpose,
 		arg.CoinType,
@@ -636,6 +705,13 @@ func (q *Queries) ListUtxos(ctx context.Context, arg ListUtxosParams) ([]ListUtx
 			&i.ReceivedTime,
 			&i.IsCoinbase,
 			&i.BlockHeight,
+			&i.AccountName,
+			&i.OriginID,
+			&i.TypeID,
+			&i.Purpose,
+			&i.CoinType,
+			&i.HasScript,
+			&i.IsLocked,
 		); err != nil {
 			return nil, err
 		}

--- a/wallet/internal/sql/sqlite/queries/utxos.sql
+++ b/wallet/internal/sql/sqlite/queries/utxos.sql
@@ -195,6 +195,10 @@ WHERE
         OR acc.account_number = cast(sqlc.narg('account_number') AS INTEGER)
     )
     AND (
+        cast(sqlc.narg('account_name') AS TEXT) IS NULL
+        OR acc.account_name = cast(sqlc.narg('account_name') AS TEXT)
+    )
+    AND (
         cast(sqlc.narg('min_confirms') AS INTEGER) IS NULL
         OR cast(sqlc.narg('min_confirms') AS INTEGER) = 0
         OR (

--- a/wallet/internal/sql/sqlite/queries/utxos.sql
+++ b/wallet/internal/sql/sqlite/queries/utxos.sql
@@ -84,17 +84,39 @@ SELECT
     a.script_pub_key,
     t.received_time,
     t.is_coinbase,
-    t.block_height
+    t.block_height,
+    -- Enrichment columns derived from the ownership joins below.
+    acc.account_name, -- owning account
+    acc.origin_id, -- derived vs imported account
+    a.type_id, -- address type, used for coin selection
+    ks.purpose, -- BIP-43 key scope purpose
+    ks.coin_type, -- BIP-43 key scope coin type
+    -- has_script: the credited address has a persisted encrypted script (e.g. a
+    -- P2WSH script-only import). LEFT JOIN, so addresses with no secret report
+    -- FALSE instead of being dropped.
+    asec.encrypted_script IS NOT NULL AS has_script,
+    -- is_locked: TRUE when an active (non-expired) lease exists for this output.
+    -- now_utc is a caller-supplied current UTC timestamp used for the lease
+    -- expiry comparison; passed in rather than read from the DB clock so results
+    -- are deterministic/testable and consistent with the Balance/lease queries.
+    CASE
+        WHEN
+            l.utxo_id IS NOT NULL
+            AND l.expires_at > sqlc.arg('now_utc') THEN 1
+        ELSE 0
+    END AS is_locked
 FROM transactions AS t
-INNER JOIN utxos AS u ON t.id = u.tx_id
+INNER JOIN utxos AS u ON t.id = u.tx_id -- INNER joins enforce wallet ownership
 INNER JOIN addresses AS a ON u.address_id = a.id
 INNER JOIN accounts AS acc ON a.account_id = acc.id
-INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
+INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id -- non-wallet rows are dropped
+LEFT JOIN utxo_leases AS l ON u.id = l.utxo_id -- LEFT joins: optional enrichment
+LEFT JOIN address_secrets AS asec ON a.id = asec.address_id
 WHERE
-    t.wallet_id = ?1
-    AND ks.wallet_id = ?1
-    AND t.tx_hash = ?2
-    AND u.output_index = ?3
+    t.wallet_id = sqlc.arg('wallet_id')
+    AND ks.wallet_id = sqlc.arg('wallet_id')
+    AND t.tx_hash = sqlc.arg('tx_hash')
+    AND u.output_index = sqlc.arg('output_index')
     AND u.spent_by_tx_id IS NULL
     AND t.tx_status IN (0, 1);
 
@@ -126,12 +148,34 @@ SELECT
     a.script_pub_key,
     t.received_time,
     t.is_coinbase,
-    t.block_height
+    t.block_height,
+    -- Enrichment columns derived from the ownership joins below.
+    acc.account_name, -- owning account
+    acc.origin_id, -- derived vs imported account
+    a.type_id, -- address type, used for coin selection
+    ks.purpose, -- BIP-43 key scope purpose
+    ks.coin_type, -- BIP-43 key scope coin type
+    -- has_script: the credited address has a persisted encrypted script (e.g. a
+    -- P2WSH script-only import). LEFT JOIN, so addresses with no secret report
+    -- FALSE instead of being dropped.
+    asec.encrypted_script IS NOT NULL AS has_script,
+    -- is_locked: TRUE when an active (non-expired) lease exists for this output.
+    -- now_utc is a caller-supplied current UTC timestamp used for the lease
+    -- expiry comparison; passed in rather than read from the DB clock so results
+    -- are deterministic/testable and consistent with the Balance/lease queries.
+    CASE
+        WHEN
+            l.utxo_id IS NOT NULL
+            AND l.expires_at > sqlc.arg('now_utc') THEN 1
+        ELSE 0
+    END AS is_locked
 FROM transactions AS t
-INNER JOIN utxos AS u ON t.id = u.tx_id
+INNER JOIN utxos AS u ON t.id = u.tx_id -- INNER joins enforce wallet ownership
 INNER JOIN addresses AS a ON u.address_id = a.id
 INNER JOIN accounts AS acc ON a.account_id = acc.id
-INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
+INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id -- non-wallet rows are dropped
+LEFT JOIN utxo_leases AS l ON u.id = l.utxo_id -- LEFT joins: optional enrichment
+LEFT JOIN address_secrets AS asec ON a.id = asec.address_id
 LEFT JOIN wallet_sync_states AS s ON t.wallet_id = s.wallet_id
 WHERE
     t.wallet_id = sqlc.arg('wallet_id')

--- a/wallet/internal/sql/sqlite/sqlc/utxos.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/utxos.sql.go
@@ -229,22 +229,45 @@ SELECT
     a.script_pub_key,
     t.received_time,
     t.is_coinbase,
-    t.block_height
+    t.block_height,
+    -- Enrichment columns derived from the ownership joins below.
+    acc.account_name, -- owning account
+    acc.origin_id, -- derived vs imported account
+    a.type_id, -- address type, used for coin selection
+    ks.purpose, -- BIP-43 key scope purpose
+    ks.coin_type, -- BIP-43 key scope coin type
+    -- has_script: the credited address has a persisted encrypted script (e.g. a
+    -- P2WSH script-only import). LEFT JOIN, so addresses with no secret report
+    -- FALSE instead of being dropped.
+    asec.encrypted_script IS NOT NULL AS has_script,
+    -- is_locked: TRUE when an active (non-expired) lease exists for this output.
+    -- now_utc is a caller-supplied current UTC timestamp used for the lease
+    -- expiry comparison; passed in rather than read from the DB clock so results
+    -- are deterministic/testable and consistent with the Balance/lease queries.
+    CASE
+        WHEN
+            l.utxo_id IS NOT NULL
+            AND l.expires_at > ?1 THEN 1
+        ELSE 0
+    END AS is_locked
 FROM transactions AS t
-INNER JOIN utxos AS u ON t.id = u.tx_id
+INNER JOIN utxos AS u ON t.id = u.tx_id -- INNER joins enforce wallet ownership
 INNER JOIN addresses AS a ON u.address_id = a.id
 INNER JOIN accounts AS acc ON a.account_id = acc.id
-INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
+INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id -- non-wallet rows are dropped
+LEFT JOIN utxo_leases AS l ON u.id = l.utxo_id -- LEFT joins: optional enrichment
+LEFT JOIN address_secrets AS asec ON a.id = asec.address_id
 WHERE
-    t.wallet_id = ?1
-    AND ks.wallet_id = ?1
-    AND t.tx_hash = ?2
-    AND u.output_index = ?3
+    t.wallet_id = ?2
+    AND ks.wallet_id = ?2
+    AND t.tx_hash = ?3
+    AND u.output_index = ?4
     AND u.spent_by_tx_id IS NULL
     AND t.tx_status IN (0, 1)
 `
 
 type GetUtxoByOutpointParams struct {
+	NowUtc      time.Time
 	WalletID    int64
 	TxHash      []byte
 	OutputIndex int64
@@ -258,6 +281,13 @@ type GetUtxoByOutpointRow struct {
 	ReceivedTime time.Time
 	IsCoinbase   bool
 	BlockHeight  sql.NullInt64
+	AccountName  string
+	OriginID     int64
+	TypeID       int64
+	Purpose      int64
+	CoinType     int64
+	HasScript    bool
+	IsLocked     int64
 }
 
 // Retrieves a single unspent UTXO by its outpoint.
@@ -276,7 +306,12 @@ type GetUtxoByOutpointRow struct {
 //   - The wallet-scoped tx hash lookup and unique outpoint constraint keep the
 //     join fanout to at most one candidate output.
 func (q *Queries) GetUtxoByOutpoint(ctx context.Context, arg GetUtxoByOutpointParams) (GetUtxoByOutpointRow, error) {
-	row := q.queryRow(ctx, q.getUtxoByOutpointStmt, GetUtxoByOutpoint, arg.WalletID, arg.TxHash, arg.OutputIndex)
+	row := q.queryRow(ctx, q.getUtxoByOutpointStmt, GetUtxoByOutpoint,
+		arg.NowUtc,
+		arg.WalletID,
+		arg.TxHash,
+		arg.OutputIndex,
+	)
 	var i GetUtxoByOutpointRow
 	err := row.Scan(
 		&i.TxHash,
@@ -286,6 +321,13 @@ func (q *Queries) GetUtxoByOutpoint(ctx context.Context, arg GetUtxoByOutpointPa
 		&i.ReceivedTime,
 		&i.IsCoinbase,
 		&i.BlockHeight,
+		&i.AccountName,
+		&i.OriginID,
+		&i.TypeID,
+		&i.Purpose,
+		&i.CoinType,
+		&i.HasScript,
+		&i.IsLocked,
 	)
 	return i, err
 }
@@ -527,44 +569,55 @@ SELECT
     a.script_pub_key,
     t.received_time,
     t.is_coinbase,
-    t.block_height
+    t.block_height,
+    -- Enrichment columns derived from the ownership joins below.
+    acc.account_name, -- owning account
+    acc.origin_id, -- derived vs imported account
+    a.type_id, -- address type, used for coin selection
+    ks.purpose, -- BIP-43 key scope purpose
+    ks.coin_type, -- BIP-43 key scope coin type
+    -- has_script: the credited address has a persisted encrypted script (e.g. a
+    -- P2WSH script-only import). LEFT JOIN, so addresses with no secret report
+    -- FALSE instead of being dropped.
+    asec.encrypted_script IS NOT NULL AS has_script,
+    -- is_locked: TRUE when an active (non-expired) lease exists for this output.
+    -- now_utc is a caller-supplied current UTC timestamp used for the lease
+    -- expiry comparison; passed in rather than read from the DB clock so results
+    -- are deterministic/testable and consistent with the Balance/lease queries.
+    CASE
+        WHEN
+            l.utxo_id IS NOT NULL
+            AND l.expires_at > ?1 THEN 1
+        ELSE 0
+    END AS is_locked
 FROM transactions AS t
-INNER JOIN utxos AS u ON t.id = u.tx_id
+INNER JOIN utxos AS u ON t.id = u.tx_id -- INNER joins enforce wallet ownership
 INNER JOIN addresses AS a ON u.address_id = a.id
 INNER JOIN accounts AS acc ON a.account_id = acc.id
-INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
+INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id -- non-wallet rows are dropped
+LEFT JOIN utxo_leases AS l ON u.id = l.utxo_id -- LEFT joins: optional enrichment
+LEFT JOIN address_secrets AS asec ON a.id = asec.address_id
 LEFT JOIN wallet_sync_states AS s ON t.wallet_id = s.wallet_id
 WHERE
-    t.wallet_id = ?1
-    AND ks.wallet_id = ?1
+    t.wallet_id = ?2
+    AND ks.wallet_id = ?2
     AND u.spent_by_tx_id IS NULL
     AND t.tx_status IN (0, 1)
     AND (
-        cast(?2 AS INTEGER) IS NULL
-        OR ks.purpose = cast(?2 AS INTEGER)
-    )
-    AND (
         cast(?3 AS INTEGER) IS NULL
-        OR ks.coin_type = cast(?3 AS INTEGER)
+        OR ks.purpose = cast(?3 AS INTEGER)
     )
     AND (
         cast(?4 AS INTEGER) IS NULL
-        OR acc.account_number = cast(?4 AS INTEGER)
+        OR ks.coin_type = cast(?4 AS INTEGER)
     )
     AND (
         cast(?5 AS INTEGER) IS NULL
-        OR cast(?5 AS INTEGER) = 0
-        OR (
-            CASE
-                WHEN t.block_height IS NULL THEN 0
-                WHEN s.synced_height IS NULL THEN NULL
-                WHEN t.block_height > s.synced_height THEN NULL
-                ELSE s.synced_height - t.block_height + 1
-            END
-        ) >= cast(?5 AS INTEGER)
+        OR acc.account_number = cast(?5 AS INTEGER)
     )
     AND (
         cast(?6 AS INTEGER) IS NULL
+        OR cast(?6 AS INTEGER) = 0
         OR (
             CASE
                 WHEN t.block_height IS NULL THEN 0
@@ -572,12 +625,24 @@ WHERE
                 WHEN t.block_height > s.synced_height THEN NULL
                 ELSE s.synced_height - t.block_height + 1
             END
-        ) <= cast(?6 AS INTEGER)
+        ) >= cast(?6 AS INTEGER)
+    )
+    AND (
+        cast(?7 AS INTEGER) IS NULL
+        OR (
+            CASE
+                WHEN t.block_height IS NULL THEN 0
+                WHEN s.synced_height IS NULL THEN NULL
+                WHEN t.block_height > s.synced_height THEN NULL
+                ELSE s.synced_height - t.block_height + 1
+            END
+        ) <= cast(?7 AS INTEGER)
     )
 ORDER BY u.amount, t.tx_hash, u.output_index
 `
 
 type ListUtxosParams struct {
+	NowUtc        time.Time
 	WalletID      int64
 	Purpose       sql.NullInt64
 	CoinType      sql.NullInt64
@@ -594,6 +659,13 @@ type ListUtxosRow struct {
 	ReceivedTime time.Time
 	IsCoinbase   bool
 	BlockHeight  sql.NullInt64
+	AccountName  string
+	OriginID     int64
+	TypeID       int64
+	Purpose      int64
+	CoinType     int64
+	HasScript    bool
+	IsLocked     int64
 }
 
 // Lists unspent UTXOs that match the provided filters.
@@ -619,6 +691,7 @@ type ListUtxosRow struct {
 //     distinguish "not set" from an explicit zero-conf request.
 func (q *Queries) ListUtxos(ctx context.Context, arg ListUtxosParams) ([]ListUtxosRow, error) {
 	rows, err := q.query(ctx, q.listUtxosStmt, ListUtxos,
+		arg.NowUtc,
 		arg.WalletID,
 		arg.Purpose,
 		arg.CoinType,
@@ -641,6 +714,13 @@ func (q *Queries) ListUtxos(ctx context.Context, arg ListUtxosParams) ([]ListUtx
 			&i.ReceivedTime,
 			&i.IsCoinbase,
 			&i.BlockHeight,
+			&i.AccountName,
+			&i.OriginID,
+			&i.TypeID,
+			&i.Purpose,
+			&i.CoinType,
+			&i.HasScript,
+			&i.IsLocked,
 		); err != nil {
 			return nil, err
 		}

--- a/wallet/internal/sql/sqlite/sqlc/utxos.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/utxos.sql.go
@@ -616,19 +616,12 @@ WHERE
         OR acc.account_number = cast(?5 AS INTEGER)
     )
     AND (
-        cast(?6 AS INTEGER) IS NULL
-        OR cast(?6 AS INTEGER) = 0
-        OR (
-            CASE
-                WHEN t.block_height IS NULL THEN 0
-                WHEN s.synced_height IS NULL THEN NULL
-                WHEN t.block_height > s.synced_height THEN NULL
-                ELSE s.synced_height - t.block_height + 1
-            END
-        ) >= cast(?6 AS INTEGER)
+        cast(?6 AS TEXT) IS NULL
+        OR acc.account_name = cast(?6 AS TEXT)
     )
     AND (
         cast(?7 AS INTEGER) IS NULL
+        OR cast(?7 AS INTEGER) = 0
         OR (
             CASE
                 WHEN t.block_height IS NULL THEN 0
@@ -636,7 +629,18 @@ WHERE
                 WHEN t.block_height > s.synced_height THEN NULL
                 ELSE s.synced_height - t.block_height + 1
             END
-        ) <= cast(?7 AS INTEGER)
+        ) >= cast(?7 AS INTEGER)
+    )
+    AND (
+        cast(?8 AS INTEGER) IS NULL
+        OR (
+            CASE
+                WHEN t.block_height IS NULL THEN 0
+                WHEN s.synced_height IS NULL THEN NULL
+                WHEN t.block_height > s.synced_height THEN NULL
+                ELSE s.synced_height - t.block_height + 1
+            END
+        ) <= cast(?8 AS INTEGER)
     )
 ORDER BY u.amount, t.tx_hash, u.output_index
 `
@@ -647,6 +651,7 @@ type ListUtxosParams struct {
 	Purpose       sql.NullInt64
 	CoinType      sql.NullInt64
 	AccountNumber sql.NullInt64
+	AccountName   sql.NullString
 	MinConfirms   sql.NullInt64
 	MaxConfirms   sql.NullInt64
 }
@@ -696,6 +701,7 @@ func (q *Queries) ListUtxos(ctx context.Context, arg ListUtxosParams) ([]ListUtx
 		arg.Purpose,
 		arg.CoinType,
 		arg.AccountNumber,
+		arg.AccountName,
 		arg.MinConfirms,
 		arg.MaxConfirms,
 	)


### PR DESCRIPTION
## Summary

Prep PR for the kvdb UTXO migration. Extends `db.UtxoInfo` with
per-row enrichment fields (`AccountName`, `Origin`, `AddrType`,
`HasScript`, `IsLocked`) populated by joined SQL queries, and
adds a scoped `(Scope, AccountName)` filter to `ListUtxosQuery`
so callers can disambiguate imported accounts whose
`AccountNumber` collapses to 0 on SQL read (NULL → zero).

Stack position: **#3** of the kvdb-migration stack. Stacks on
top of #1246 (enforce-wallet-level-watch-only).

## Changes

- `db.UtxoInfo` gains `AccountName`, `Origin`, `AddrType`,
  `HasScript`, `IsLocked` populated from one joined query so
  wallet consumers no longer need follow-up `GetAddress` /
  `ListLeasedOutputs` calls per UTXO.
- pg/sqlite `ListUtxos` + `GetUtxoByOutpoint` queries gain the
  enrichment columns and LEFT JOIN `utxo_leases` +
  `address_secrets` for the `IsLocked` / `HasScript` derivation.
- `ListUtxosQuery` adds `Scope *KeyScope` + `AccountName *string`
  fields. Numeric `Account` now requires `Scope` (per-scope
  uniqueness); `AccountName` is mutually exclusive with
  `Account`. Validator returns the matching sentinels.
- Cross-backend itests verify the new filter contract under pg,
  sqlite, and kvdb.

## Test plan

- [ ] `GOWORK=off go test ./wallet/...`
- [ ] `make itest-db db=postgres`
- [ ] `make itest-db db=sqlite`
- [ ] CI green on Format / compilation / lint check