### PR TITLE
wallet: route tx publisher + tx-store writes through Store

### DIFF
--- a/wallet/internal/bwtest/mock/store.go
+++ b/wallet/internal/bwtest/mock/store.go
@@ -223,6 +223,18 @@ func (m *Store) GetAddress(ctx context.Context,
 	return args.Get(0).(*db.AddressInfo), args.Error(1)
 }
 
+// ResolveOwnedAddresses implements the db.AddressStore interface.
+func (m *Store) ResolveOwnedAddresses(ctx context.Context,
+	query db.ResolveOwnedAddressesQuery) (map[string]*db.AddressInfo, error) {
+
+	args := m.Called(ctx, query)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(map[string]*db.AddressInfo), args.Error(1)
+}
+
 // ListAddresses implements the db.AddressStore interface.
 func (m *Store) ListAddresses(ctx context.Context,
 	query db.ListAddressesQuery) (page.Result[db.AddressInfo, uint32], error) {

--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -1019,15 +1019,33 @@ type CreateTxParams struct {
 	// Label is an optional label for the transaction.
 	Label string
 
-	// Credits maps wallet-owned output indexes to their display addresses.
+	// Credits maps wallet-owned output indexes to the resolved address that
+	// makes the output ours.
 	//
 	// The output index is the map key, so duplicate credited outputs are
 	// impossible by construction.
 	//
-	// NOTE: The address value is for display only. The database layer still
-	// matches ownership by the output's script_pub_key
-	// (`params.Tx.TxOut[index].PkScript`), which is the canonical key
-	// used by the address schema.
+	// A non-nil address is authoritative for ownership: the store resolves the
+	// owning address row by that address's own script (PayToAddrScript),
+	// not by the full output script. This lets a bare-multisig output the
+	// wallet partly owns resolve to the wallet-owned member, whose script the
+	// multisig output script itself would never match. For a single-address
+	// output the member script equals the output script, so the lookup is
+	// unchanged.
+	//
+	// Because that address is trusted as the owner, the store first validates
+	// that the credited output actually pays it. Membership (not strict script
+	// equality) is required so bare-multisig members pass, while an address the
+	// output does not pay is rejected with ErrInvalidParam rather than
+	// recording a UTXO owned by an unrelated address.
+	//
+	// A nil address means the caller has no resolved owner; the store then
+	// keys ownership on the output's own script_pub_key
+	// (`params.Tx.TxOut[index].PkScript`).
+	//
+	// NOTE: This only selects the address-ownership lookup key. The stored
+	// UTXO always records the on-chain output script, never the member
+	// script.
 	Credits map[uint32]btcutil.Address
 }
 

--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -791,6 +791,22 @@ type GetAddressQuery struct {
 	ScriptPubKey []byte
 }
 
+// ResolveOwnedAddressesQuery contains the parameters for a batched,
+// wallet-scoped address ownership lookup. It resolves which of the supplied
+// script pubkeys belong to the wallet in a single store operation.
+type ResolveOwnedAddressesQuery struct {
+	// WalletID is the ID of the wallet to query.
+	//
+	// NOTE: uint32 is used to ensure compatibility with standard SQL
+	// databases (signed 64-bit integers).
+	WalletID uint32
+
+	// ScriptPubKeys is the set of script pubkeys to resolve. Order is not
+	// significant and duplicates are tolerated. An empty or nil slice
+	// yields an empty result without touching the backend.
+	ScriptPubKeys [][]byte
+}
+
 // GetAddressSecretQuery contains the parameters for querying an address
 // secret. The query is wallet-scoped: it retrieves the encrypted secret
 // material for a specific address within a wallet.

--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -327,6 +327,23 @@ type AddressStore interface {
 	// an error if the address is not found.
 	GetAddress(ctx context.Context, query GetAddressQuery) (*AddressInfo, error)
 
+	// ResolveOwnedAddresses resolves a batch of script pubkeys to the subset
+	// that is owned by the wallet in a single store operation. It is intended
+	// to replace a per-script GetAddress loop on hot paths such as transaction-
+	// output ownership filtering.
+	//
+	// The result is keyed by string(ScriptPubKey). Only wallet-owned scripts
+	// appear in the map: a script absent from the result is simply not owned
+	// by the wallet (the batched equivalent of GetAddress returning
+	// ErrAddressNotFound), which is not an error. Both the wallet ID and the
+	// supplied script set constrain the lookup.
+	//
+	// An empty or nil ScriptPubKeys slice returns an empty, non-nil map
+	// without issuing a backend query or returning an error.
+	ResolveOwnedAddresses(ctx context.Context,
+		query ResolveOwnedAddressesQuery) (
+		map[string]*AddressInfo, error)
+
 	// ListAddresses returns one page of addresses for the given query,
 	// including a next-cursor for the following page.
 	ListAddresses(ctx context.Context, query ListAddressesQuery) (

--- a/wallet/internal/db/itest/address_store_test.go
+++ b/wallet/internal/db/itest/address_store_test.go
@@ -1574,6 +1574,111 @@ func TestGetAddress(t *testing.T) {
 	}
 }
 
+// TestResolveOwnedAddresses verifies the batched address resolver: it returns
+// only the wallet-owned subset of a mixed script set, omits scripts that do not
+// belong to the wallet, and treats an empty input as an empty result without
+// error.
+func TestResolveOwnedAddresses(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+
+	walletID := newWatchOnlyWallet(t, store, "resolve-addresses-wallet")
+
+	// Import three addresses with known scripts; these are the wallet-owned
+	// scripts the batch lookup must resolve.
+	ownedScripts := make([][]byte, 0, 3)
+	for range 3 {
+		script := RandomBytes(32)
+		_, err := store.NewImportedAddress(
+			t.Context(), db.NewImportedAddressParams{
+				WalletID:     walletID,
+				Scope:        db.KeyScopeBIP0084,
+				AddressType:  db.WitnessPubKey,
+				PubKey:       RandomBytes(33),
+				ScriptPubKey: script,
+			},
+		)
+		require.NoError(t, err)
+
+		ownedScripts = append(ownedScripts, script)
+	}
+
+	// Two scripts the wallet does not own. They must be omitted from the
+	// result rather than surfaced as an error.
+	foreignScripts := [][]byte{RandomBytes(32), RandomBytes(32)}
+
+	t.Run("mixed owned and foreign", func(t *testing.T) {
+		t.Parallel()
+
+		query := db.ResolveOwnedAddressesQuery{WalletID: walletID}
+		query.ScriptPubKeys = append(query.ScriptPubKeys, ownedScripts...)
+		query.ScriptPubKeys = append(
+			query.ScriptPubKeys, foreignScripts...,
+		)
+
+		owned, err := store.ResolveOwnedAddresses(t.Context(), query)
+		require.NoError(t, err)
+
+		// Only the owned scripts come back, keyed by string(script).
+		require.Len(t, owned, len(ownedScripts))
+
+		for _, script := range ownedScripts {
+			info, ok := owned[string(script)]
+			require.True(t, ok)
+			require.Equal(t, script, info.ScriptPubKey)
+		}
+
+		for _, script := range foreignScripts {
+			_, ok := owned[string(script)]
+			require.False(t, ok)
+		}
+	})
+
+	t.Run("only foreign scripts", func(t *testing.T) {
+		t.Parallel()
+
+		owned, err := store.ResolveOwnedAddresses(
+			t.Context(), db.ResolveOwnedAddressesQuery{
+				WalletID:      walletID,
+				ScriptPubKeys: foreignScripts,
+			},
+		)
+		require.NoError(t, err)
+		require.Empty(t, owned)
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		t.Parallel()
+
+		owned, err := store.ResolveOwnedAddresses(
+			t.Context(), db.ResolveOwnedAddressesQuery{WalletID: walletID},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, owned)
+		require.Empty(t, owned)
+	})
+
+	t.Run("wallet scoping", func(t *testing.T) {
+		t.Parallel()
+
+		// A different wallet must not see the first wallet's owned
+		// scripts even when asked for them by script.
+		otherWalletID := newWatchOnlyWallet(
+			t, store, "resolve-addresses-other-wallet",
+		)
+
+		owned, err := store.ResolveOwnedAddresses(
+			t.Context(), db.ResolveOwnedAddressesQuery{
+				WalletID:      otherWalletID,
+				ScriptPubKeys: ownedScripts,
+			},
+		)
+		require.NoError(t, err)
+		require.Empty(t, owned)
+	})
+}
+
 // TestListAddresses verifies that ListAddresses correctly returns addresses
 // with page-contract behavior, filters by scope appropriately, and handles
 // empty results without error.

--- a/wallet/internal/db/itest/tx_utxo_store_test.go
+++ b/wallet/internal/db/itest/tx_utxo_store_test.go
@@ -104,7 +104,6 @@ func TestCreateTxCreditBareMultisigMember(t *testing.T) {
 
 	scope := db.KeyScopeBIP0084
 	importedName := db.DefaultImportedAccountName
-	CreateImportedAccount(t, store, walletID, scope, importedName, true)
 
 	// Build a 1-of-2 bare-multisig script. memberScript is the member's own
 	// P2PK script (what PayToAddrScript(memberAddr) yields), which the wallet

--- a/wallet/internal/db/itest/tx_utxo_store_test.go
+++ b/wallet/internal/db/itest/tx_utxo_store_test.go
@@ -6,8 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/stretchr/testify/require"
@@ -58,6 +61,161 @@ func TestCreateTxStoresWalletCredit(t *testing.T) {
 	_, ok := txIDByHash(t, store, walletID, tx.TxHash())
 	require.True(t, ok)
 	require.True(t, walletUtxoExists(t, store, walletID, wire.OutPoint{
+		Hash: tx.TxHash(), Index: 0,
+	}))
+}
+
+// TestCreateTxCreditBareMultisigMember verifies that CreateTx records a
+// bare-multisig output that the wallet partly owns: the wallet holds one
+// member pubkey address, but not the full multisig output script.
+//
+// This is the SQL counterpart to the kvdb TestCreateTxCreditBareMultisigMember
+// and locks in parity between the two backends. The publisher's ownership
+// filter resolves such an output to the wallet-owned member address and passes
+// it as the credit address; the store must therefore key ownership on the
+// member's own script, not on the full multisig output script that no address
+// row would ever match.
+//
+// Scenario:
+//   - The wallet imports one P2PK member address (script-only on a watch-only
+//     wallet, which the ADR 0012 invariant allows).
+//   - A transaction pays a 1-of-2 bare-multisig output built from that member
+//     plus a foreign key. The full multisig script is NOT a wallet address.
+//
+// Action:
+//   - Insert the transaction through CreateTx with Credits[0] set to the
+//     member address.
+//
+// Assertions:
+//   - CreateTx succeeds (no ErrAddressNotFound) and the credited output exists.
+//   - GetUtxo resolves the UTXO to the imported member address (imported
+//     origin, raw-pubkey type) rather than the multisig output script.
+//
+// Without the fix, the store looks the credit up by the full multisig output
+// script, finds no address row, and CreateTx fails with ErrAddressNotFound.
+func TestCreateTxCreditBareMultisigMember(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+
+	// A script-only import (no private key) requires a watch-only wallet per
+	// the ADR 0012 spendable-wallet invariant.
+	walletID := newWatchOnlyWallet(t, store, "wallet-bare-multisig-credit")
+
+	scope := db.KeyScopeBIP0084
+	importedName := db.DefaultImportedAccountName
+	CreateImportedAccount(t, store, walletID, scope, importedName, true)
+
+	// Build a 1-of-2 bare-multisig script. memberScript is the member's own
+	// P2PK script (what PayToAddrScript(memberAddr) yields), which the wallet
+	// imports as an address. multiSigScript is the full on-chain output script,
+	// which is deliberately never registered as a wallet address.
+	memberAddr, memberScript, multiSigScript := newMultisigScript(t)
+	require.NotEqual(t, memberScript, multiSigScript)
+
+	_, err := store.NewImportedAddress(
+		t.Context(), db.NewImportedAddressParams{
+			WalletID:        walletID,
+			Scope:           scope,
+			AddressType:     db.RawPubKey,
+			PubKey:          memberAddr.ScriptAddress(),
+			ScriptPubKey:    memberScript,
+			EncryptedScript: RandomBytes(48),
+		},
+	)
+	require.NoError(t, err)
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 7000, PkScript: multiSigScript}},
+	)
+
+	// Credits[0] carries the resolved member address, exactly as the publisher
+	// supplies it after filtering ownership by the member script.
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       tx,
+		Received: time.Unix(1710004000, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: memberAddr},
+	})
+	require.NoError(t, err)
+
+	outPoint := wire.OutPoint{Hash: tx.TxHash(), Index: 0}
+	require.True(t, walletUtxoExists(t, store, walletID, outPoint))
+
+	// The credit must resolve to the imported member address, not the multisig
+	// output script. Origin and address type prove the resolved address row is
+	// the member import.
+	utxo, err := store.GetUtxo(t.Context(), db.GetUtxoQuery{
+		WalletID: walletID,
+		OutPoint: outPoint,
+	})
+	require.NoError(t, err)
+	require.Equal(t, importedName, utxo.AccountName)
+	require.Equal(t, db.ImportedAccount, utxo.Origin)
+	require.Equal(t, db.RawPubKey, utxo.AddrType)
+}
+
+// TestCreateTxCreditAddrMismatch verifies that CreateTx rejects a non-nil
+// credit address that the credited output does not pay to, instead of
+// recording a UTXO owned by an unrelated address.
+//
+// A non-nil Credits[index] is authoritative for ownership, so the store must
+// confirm the output actually pays that address before trusting it. This is
+// the SQL counterpart to the kvdb TestCreateTxCreditAddrMismatch and keeps the
+// two backends consistent: kvdb validates membership via its own
+// validateCreditAddr, and the SQL backends validate it through the shared
+// ValidateCreditAddrMembership before the credit lookup.
+//
+// Scenario:
+//   - The output pays a wallet-owned derived address.
+//   - Credits[0] instead names an unrelated address the output never pays.
+//
+// Assertions:
+//   - CreateTx fails with ErrInvalidParam and records nothing.
+func TestCreateTxCreditAddrMismatch(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-credit-addr-mismatch")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	// The output pays this wallet-owned address.
+	paidAddr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+
+	// The credit names a different address that the output script does not
+	// pay to, simulating a caller mislabeling the credited output.
+	wrongKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	wrongAddr, err := btcutil.NewAddressPubKey(
+		wrongKey.PubKey().SerializeCompressed(),
+		&chaincfg.RegressionNetParams,
+	)
+	require.NoError(t, err)
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 6000, PkScript: paidAddr.ScriptPubKey}},
+	)
+
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       tx,
+		Received: time.Unix(1710004200, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]btcutil.Address{0: wrongAddr},
+	})
+	require.ErrorIs(t, err, db.ErrInvalidParam)
+
+	// The rejected insert must not have created the transaction row or a
+	// UTXO.
+	_, ok := txIDByHash(t, store, walletID, tx.TxHash())
+	require.False(t, ok)
+	require.False(t, walletUtxoExists(t, store, walletID, wire.OutPoint{
 		Hash: tx.TxHash(), Index: 0,
 	}))
 }
@@ -2510,6 +2668,42 @@ func newRegularTx(inputs []wire.OutPoint, outputs []*wire.TxOut) *wire.MsgTx {
 // randomOutPoint returns one fixture outpoint backed by a random hash.
 func randomOutPoint() wire.OutPoint {
 	return wire.OutPoint{Hash: RandomHash(), Index: 0}
+}
+
+// newMultisigScript builds a 1-of-2 bare-multisig output script and returns the
+// first member's pubkey address, that member's own P2PK script, and the full
+// multisig output script. The member script is what PayToAddrScript(memberAddr)
+// yields and is what a wallet would register as an address; the multisig script
+// is the on-chain output script, which is never a wallet address by itself.
+func newMultisigScript(t *testing.T) (*btcutil.AddressPubKey, []byte, []byte) {
+	t.Helper()
+
+	firstKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	secondKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	memberAddr, err := btcutil.NewAddressPubKey(
+		firstKey.PubKey().SerializeCompressed(),
+		&chaincfg.RegressionNetParams,
+	)
+	require.NoError(t, err)
+
+	memberScript, err := txscript.PayToAddrScript(memberAddr)
+	require.NoError(t, err)
+
+	builder := txscript.NewScriptBuilder()
+	builder.AddInt64(1)
+	builder.AddData(firstKey.PubKey().SerializeCompressed())
+	builder.AddData(secondKey.PubKey().SerializeCompressed())
+	builder.AddInt64(2)
+	builder.AddOp(txscript.OP_CHECKMULTISIG)
+
+	multiSigScript, err := builder.Script()
+	require.NoError(t, err)
+
+	return memberAddr, memberScript, multiSigScript
 }
 
 // txHashes returns transaction hashes in result order.

--- a/wallet/internal/db/kvdb/addressstore.go
+++ b/wallet/internal/db/kvdb/addressstore.go
@@ -249,6 +249,92 @@ func (s *Store) GetAddress(ctx context.Context,
 	return info, nil
 }
 
+// ResolveOwnedAddresses resolves a batch of script pubkeys to the subset owned
+// by the wallet using a single read-only walletdb transaction. It restores the
+// single-transaction pattern for output ownership filtering, replacing a
+// per-script GetAddress loop.
+func (s *Store) ResolveOwnedAddresses(ctx context.Context,
+	query db.ResolveOwnedAddressesQuery) (map[string]*db.AddressInfo, error) {
+
+	err := ctx.Err()
+	if err != nil {
+		return nil, err
+	}
+
+	owned := make(map[string]*db.AddressInfo)
+
+	// An empty request resolves to an empty result without opening a
+	// transaction, matching the SQL backends.
+	if len(query.ScriptPubKeys) == 0 {
+		return owned, nil
+	}
+
+	addrMgr := s.addrStore
+
+	err = walletdb.View(s.db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgr.NamespaceKey)
+		if ns == nil {
+			return errMissingAddrmgrNamespace
+		}
+
+		return resolveOwnedScripts(
+			ns, addrMgr, query.ScriptPubKeys, owned,
+		)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ResolveOwnedAddresses: %w", err)
+	}
+
+	return owned, nil
+}
+
+// resolveOwnedScripts resolves each script pubkey to its wallet-owned address
+// inside an open read transaction, recording hits in owned keyed by
+// string(script). Scripts that resolve to no standard address or to no wallet
+// row are simply skipped, since a miss means the script is not owned.
+func resolveOwnedScripts(ns walletdb.ReadBucket, addrMgr waddrmgr.AddrStore,
+	scripts [][]byte, owned map[string]*db.AddressInfo) error {
+
+	chainParams := addrMgr.ChainParams()
+
+	for _, script := range scripts {
+		if len(script) == 0 {
+			continue
+		}
+
+		// Skip scripts that already resolved on a prior iteration so
+		// duplicate inputs cost a single lookup.
+		key := string(script)
+		if _, ok := owned[key]; ok {
+			continue
+		}
+
+		// A script with no standard address can never match a wallet
+		// row, so it is simply not owned.
+		addr := addressFromScript(script, chainParams)
+		if addr == nil {
+			continue
+		}
+
+		info, err := resolvedAddressInfo(ns, addrMgr, addr)
+
+		// A missing address means the script is not owned by the
+		// wallet, which is the common case, so we keep resolving the
+		// remaining scripts.
+		switch {
+		case errors.Is(err, db.ErrAddressNotFound):
+			continue
+
+		case err != nil:
+			return err
+		}
+
+		owned[key] = info
+	}
+
+	return nil
+}
+
 // resolvedAddressInfo resolves one legacy managed address and assigns its
 // synthetic address ID.
 func resolvedAddressInfo(ns walletdb.ReadBucket,

--- a/wallet/internal/db/kvdb/addressstore_test.go
+++ b/wallet/internal/db/kvdb/addressstore_test.go
@@ -285,6 +285,109 @@ func TestGetAddressBareMultisigReturnsNotFound(t *testing.T) {
 	require.ErrorIs(t, err, db.ErrAddressNotFound)
 }
 
+// TestAddressStoreResolveOwnedAddresses verifies that the batched resolver
+// returns only the wallet-owned subset of a mixed script set in a single
+// transaction, omits scripts that are not owned, and treats an empty input as
+// an empty result without error.
+func TestAddressStoreResolveOwnedAddresses(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	addrStore := newSpendableAddrMgr(t, dbConn)
+	store := NewStore(dbConn, nil, addrStore)
+
+	// importP2WKH imports a fresh P2WKH address and returns its script.
+	importP2WKH := func(t *testing.T) []byte {
+		t.Helper()
+
+		privKey, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+
+		addr, err := btcutil.NewAddressWitnessPubKeyHash(
+			btcutil.Hash160(privKey.PubKey().SerializeCompressed()),
+			addrStore.ChainParams(),
+		)
+		require.NoError(t, err)
+
+		script, err := txscript.PayToAddrScript(addr)
+		require.NoError(t, err)
+
+		_, err = store.NewImportedAddress(
+			t.Context(), db.NewImportedAddressParams{
+				WalletID:     0,
+				Scope:        db.KeyScope(waddrmgr.KeyScopeBIP0084),
+				AddressType:  db.WitnessPubKey,
+				ScriptPubKey: script,
+				PubKey: privKey.PubKey().
+					SerializeCompressed(),
+			},
+		)
+		require.NoError(t, err)
+
+		return script
+	}
+
+	owned1 := importP2WKH(t)
+	owned2 := importP2WKH(t)
+
+	// A valid P2WKH script for a key the wallet never imported.
+	foreignKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	foreignAddr, err := btcutil.NewAddressWitnessPubKeyHash(
+		btcutil.Hash160(foreignKey.PubKey().SerializeCompressed()),
+		addrStore.ChainParams(),
+	)
+	require.NoError(t, err)
+	foreignScript, err := txscript.PayToAddrScript(foreignAddr)
+	require.NoError(t, err)
+
+	t.Run("mixed owned and foreign", func(t *testing.T) {
+		t.Parallel()
+
+		owned, err := store.ResolveOwnedAddresses(
+			t.Context(), db.ResolveOwnedAddressesQuery{
+				WalletID: 0,
+				ScriptPubKeys: [][]byte{
+					owned1, foreignScript, owned2,
+				},
+			},
+		)
+		require.NoError(t, err)
+
+		require.Len(t, owned, 2)
+		require.Contains(t, owned, string(owned1))
+		require.Contains(t, owned, string(owned2))
+		require.NotContains(t, owned, string(foreignScript))
+	})
+
+	t.Run("duplicate scripts resolve once", func(t *testing.T) {
+		t.Parallel()
+
+		owned, err := store.ResolveOwnedAddresses(
+			t.Context(), db.ResolveOwnedAddressesQuery{
+				WalletID:      0,
+				ScriptPubKeys: [][]byte{owned1, owned1},
+			},
+		)
+		require.NoError(t, err)
+		require.Len(t, owned, 1)
+		require.Contains(t, owned, string(owned1))
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		t.Parallel()
+
+		owned, err := store.ResolveOwnedAddresses(
+			t.Context(), db.ResolveOwnedAddressesQuery{WalletID: 0},
+		)
+		require.NoError(t, err)
+		require.NotNil(t, owned)
+		require.Empty(t, owned)
+	})
+}
+
 // TestAddressStoreImportedPrivateKeyIsSpendable verifies that legacy imported
 // private keys are not marked watch-only.
 func TestAddressStoreImportedPrivateKeyIsSpendable(t *testing.T) {

--- a/wallet/internal/db/kvdb/txstore.go
+++ b/wallet/internal/db/kvdb/txstore.go
@@ -6,10 +6,18 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 )
+
+// A compile-time assertion to ensure Store implements the transaction store.
+var _ db.TxStore = (*Store)(nil)
 
 // errLegacyHeightOverflow reports that one db height cannot fit into the
 // signed legacy wtxmgr height domain.
@@ -18,6 +26,131 @@ var errLegacyHeightOverflow = errors.New("legacy height overflows int32")
 // CreateTx is not yet implemented for kvdb.
 func (s *Store) CreateTx(ctx context.Context, _ db.CreateTxParams) error {
 	return notImplemented(ctx, "CreateTx")
+}
+
+// addCreateTxCredits records wallet-owned outputs for a legacy transaction.
+func (s *Store) addCreateTxCredits(addrmgrNs,
+	txmgrNs walletdb.ReadWriteBucket, txRec *wtxmgr.TxRecord,
+	credits map[uint32]btcutil.Address) error {
+
+	if len(credits) == 0 {
+		return nil
+	}
+
+	// CreateTx guarantees a non-nil addrStore whenever there are credits,
+	// so it is safe to read chain params here.
+	chainParams := s.addrStore.ChainParams()
+
+	// Record each credit individually. The per-credit body lives in
+	// addCreateTxCredit so this loop stays a thin driver and neither
+	// function exceeds the cyclomatic-complexity budget.
+	for index, addr := range credits {
+		err := s.addCreateTxCredit(
+			addrmgrNs, txmgrNs, txRec, index, addr, chainParams,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// addCreateTxCredit records a single wallet-owned output for a legacy
+// transaction, resolving ownership either from the caller-supplied address or,
+// when none is given, from the output's own script.
+func (s *Store) addCreateTxCredit(addrmgrNs,
+	txmgrNs walletdb.ReadWriteBucket, txRec *wtxmgr.TxRecord, index uint32,
+	addr btcutil.Address, chainParams *chaincfg.Params) error {
+
+	// A nil credit address means the caller has no resolved owner for this
+	// output, so the Store contract (CreateTxParams.Credits) keys ownership
+	// on the output's own script. SQL implements this fallback, so kvdb
+	// must match it rather than panic: record the credit straight from the
+	// output index without an address-manager lookup or used-marking, and
+	// skip membership validation, which has no caller address to check.
+	// Reaching validateCreditAddr with a nil addr would otherwise panic on
+	// addr.EncodeAddress().
+	if addr == nil {
+		if int(index) >= len(txRec.MsgTx.TxOut) {
+			return fmt.Errorf("credit output %d: %w: index out of "+
+				"range", index, db.ErrInvalidParam)
+		}
+
+		// change is false: with no resolved internal/external address
+		// there is no derivation branch to consult, and the legacy
+		// wtxmgr credit only needs the output index.
+		err := s.txStore.AddCredit(txmgrNs, txRec, nil, index, false)
+		if err != nil {
+			return fmt.Errorf("add credit output %d: %w", index, err)
+		}
+
+		return nil
+	}
+
+	// Validate the caller-supplied credit against the actual output script
+	// before trusting it. Otherwise a caller could credit output N with any
+	// wallet address even when TxOut[N] pays elsewhere, corrupting UTXO
+	// ownership.
+	err := validateCreditAddr(txRec.MsgTx, index, addr, chainParams)
+	if err != nil {
+		return err
+	}
+
+	managedAddr, err := s.addrStore.Address(addrmgrNs, addr)
+	if waddrmgr.IsError(err, waddrmgr.ErrAddressNotFound) {
+		return fmt.Errorf("credit output %d: %w", index,
+			db.ErrAddressNotFound)
+	}
+
+	if err != nil {
+		return fmt.Errorf("lookup credit address %d: %w", index, err)
+	}
+
+	err = s.txStore.AddCredit(
+		txmgrNs, txRec, nil, index, managedAddr.Internal(),
+	)
+	if err != nil {
+		return fmt.Errorf("add credit output %d: %w", index, err)
+	}
+
+	err = s.addrStore.MarkUsed(addrmgrNs, addr)
+	if err != nil {
+		return fmt.Errorf("mark credit address used %d: %w", index, err)
+	}
+
+	return nil
+}
+
+// validateCreditAddr verifies that the caller-supplied credit address is one of
+// the addresses encoded in the output script it claims to credit. Membership
+// (not equality) is required so bare-multisig scripts, where the wallet owns
+// one of several pubkeys, still validate.
+func validateCreditAddr(msgTx wire.MsgTx, index uint32, addr btcutil.Address,
+	chainParams *chaincfg.Params) error {
+
+	if int(index) >= len(msgTx.TxOut) {
+		return fmt.Errorf("credit output %d: %w: index out of range",
+			index, db.ErrInvalidParam)
+	}
+
+	_, addrs, _, err := txscript.ExtractPkScriptAddrs(
+		msgTx.TxOut[index].PkScript, chainParams,
+	)
+	if err != nil {
+		return fmt.Errorf("credit output %d: extract script addrs: %w",
+			index, err)
+	}
+
+	want := addr.EncodeAddress()
+	for _, scriptAddr := range addrs {
+		if scriptAddr.EncodeAddress() == want {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("credit output %d: %w: address %s not paid by "+
+		"output script", index, db.ErrInvalidParam, want)
 }
 
 // UpdateTx re-implements the legacy kvdb label update path through the

--- a/wallet/internal/db/kvdb/txstore.go
+++ b/wallet/internal/db/kvdb/txstore.go
@@ -23,9 +23,94 @@ var _ db.TxStore = (*Store)(nil)
 // signed legacy wtxmgr height domain.
 var errLegacyHeightOverflow = errors.New("legacy height overflows int32")
 
-// CreateTx is not yet implemented for kvdb.
-func (s *Store) CreateTx(ctx context.Context, _ db.CreateTxParams) error {
-	return notImplemented(ctx, "CreateTx")
+// CreateTx records an unmined transaction through the legacy wtxmgr path.
+//
+// Unlike the SQL backends, kvdb does NOT route through the shared
+// db.CreateTxWithOps orchestration, and this divergence is deliberate. That
+// shared flow owns the full CreateTx contract: confirmed-transaction inserts,
+// input-conflict discovery, invalidation/replacement of the displaced unmined
+// branch, and wallet-owned spent-input marking. The legacy wtxmgr data model
+// underneath kvdb is unmined-only and has no representation for that
+// confirmed-history, replacement, or spend-edge bookkeeping, so an adapter for
+// the shared ops would collapse most stages to notImplemented and add
+// boilerplate without sharing meaningful logic.
+//
+// kvdb therefore implements only the unmined-insertion path directly and
+// returns an explicit unsupported error for confirmed inserts (Block != nil)
+// below. It still reuses the shared, backend-independent request preparation
+// (db.NewCreateTxRequest) so parameter validation stays uniform across
+// backends; only the post-validation write sequencing is bespoke.
+func (s *Store) CreateTx(ctx context.Context,
+	params db.CreateTxParams) error {
+
+	req, err := db.NewCreateTxRequest(params)
+	if err != nil {
+		return fmt.Errorf("create tx request: %w", err)
+	}
+
+	if req.Params.Block != nil {
+		return notImplemented(ctx, "CreateTx confirmed")
+	}
+
+	txRec, err := wtxmgr.NewTxRecordFromMsgTx(req.Params.Tx, req.Received)
+	if err != nil {
+		return fmt.Errorf("build tx record: %w", err)
+	}
+
+	err = walletdb.Update(s.db, func(tx walletdb.ReadWriteTx) error {
+		return s.createTxWithTx(tx, txRec, req.Params)
+	})
+	if err != nil {
+		return fmt.Errorf("kvdb.Store.CreateTx: %w", err)
+	}
+
+	return nil
+}
+
+// createTxWithTx records a transaction within one legacy walletdb update.
+func (s *Store) createTxWithTx(tx walletdb.ReadWriteTx,
+	txRec *wtxmgr.TxRecord, params db.CreateTxParams) error {
+
+	// The waddrmgr namespace is only consulted when recording credits, so
+	// only require it then. This mirrors the credit-gated addrStore guard
+	// in CreateTx and lets a credit-less (sweep) tx be recorded without the
+	// address-manager bucket.
+	var addrmgrNs walletdb.ReadWriteBucket
+	if len(params.Credits) > 0 {
+		addrmgrNs = tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+		if addrmgrNs == nil {
+			return errMissingAddrmgrNamespace
+		}
+	}
+
+	txmgrNs := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+	if txmgrNs == nil {
+		return errMissingTxmgrNamespace
+	}
+
+	exists, err := s.txStore.InsertTxCheckIfExists(
+		txmgrNs, txRec, nil,
+	)
+	if err != nil {
+		return fmt.Errorf("insert transaction: %w", err)
+	}
+
+	if exists {
+		return db.ErrTxAlreadyExists
+	}
+
+	if len(params.Label) != 0 {
+		err := s.txStore.PutTxLabel(
+			txmgrNs, txRec.Hash, params.Label,
+		)
+		if err != nil {
+			return fmt.Errorf("put transaction label: %w", err)
+		}
+	}
+
+	return s.addCreateTxCredits(
+		addrmgrNs, txmgrNs, txRec, params.Credits,
+	)
 }
 
 // addCreateTxCredits records wallet-owned outputs for a legacy transaction.

--- a/wallet/internal/db/kvdb/txstore.go
+++ b/wallet/internal/db/kvdb/txstore.go
@@ -461,11 +461,37 @@ func (s *Store) DeleteTx(ctx context.Context, _ db.DeleteTxParams) error {
 	return notImplemented(ctx, "DeleteTx")
 }
 
-// InvalidateUnminedTx is not yet implemented for kvdb.
-func (s *Store) InvalidateUnminedTx(ctx context.Context,
-	_ db.InvalidateUnminedTxParams) error {
+// InvalidateUnminedTx invalidates an unmined tx through the legacy wtxmgr path.
+func (s *Store) InvalidateUnminedTx(_ context.Context,
+	params db.InvalidateUnminedTxParams) error {
 
-	return notImplemented(ctx, "InvalidateUnminedTx")
+	err := walletdb.Update(s.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+		if ns == nil {
+			return errMissingTxmgrNamespace
+		}
+
+		details, err := s.txStore.TxDetails(ns, &params.Txid)
+		if err != nil {
+			return fmt.Errorf("lookup transaction details: %w", err)
+		}
+
+		if details == nil {
+			return db.ErrTxNotFound
+		}
+
+		if details.Block.Height >= 0 {
+			return fmt.Errorf("tx %s is confirmed: %w", params.Txid,
+				db.ErrInvalidateTx)
+		}
+
+		return s.txStore.RemoveUnminedTx(ns, &details.TxRecord)
+	})
+	if err != nil {
+		return fmt.Errorf("kvdb.Store.InvalidateUnminedTx: %w", err)
+	}
+
+	return nil
 }
 
 // RollbackToBlock is not yet implemented for kvdb.

--- a/wallet/internal/db/kvdb/txstore_test.go
+++ b/wallet/internal/db/kvdb/txstore_test.go
@@ -4,9 +4,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	bwmock "github.com/btcsuite/btcwallet/bwtest/mock"
 	"github.com/btcsuite/btcwallet/waddrmgr"
@@ -113,6 +115,88 @@ func TestCreateTxDuplicateReturnsStoreError(t *testing.T) {
 	require.ErrorIs(t, err, db.ErrTxAlreadyExists)
 }
 
+// TestCreateTxCreditAddrMismatch verifies that crediting an output with an
+// address that the output script does not pay to is rejected, so a caller
+// cannot corrupt UTXO ownership by mislabeling a credit.
+func TestCreateTxCreditAddrMismatch(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	newAddrmgrNamespace(t, dbConn)
+	txStore := newTxStore(t, dbConn)
+
+	// The output pays to one address, but the credit claims otherAddr,
+	// which the output script does not contain.
+	_, script := newTestAddressScript(t)
+	otherAddr, _ := newTestAddressScript(t)
+
+	addrStore := &bwmock.AddrStore{}
+	addrStore.On("ChainParams").Return(&chaincfg.RegressionNetParams)
+	store := NewStore(dbConn, txStore, addrStore)
+
+	txMsg := &wire.MsgTx{Version: 1}
+	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{63},
+	}})
+	txMsg.AddTxOut(&wire.TxOut{Value: 7_000, PkScript: script})
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: 0,
+		Tx:       txMsg,
+		Received: time.Unix(1710003200, 0),
+		Status:   db.TxStatusPublished,
+		Credits:  map[uint32]btcutil.Address{0: otherAddr},
+	})
+	require.ErrorIs(t, err, db.ErrInvalidParam)
+}
+
+// TestCreateTxCreditBareMultisigMember verifies that crediting a bare-multisig
+// output with one of its member pubkeys is accepted. Membership, not equality,
+// is required so a wallet that owns one key in a multisig script still records
+// the credit.
+func TestCreateTxCreditBareMultisigMember(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	newAddrmgrNamespace(t, dbConn)
+	txStore := newTxStore(t, dbConn)
+
+	// Build a 1-of-2 bare-multisig script and credit it with the first
+	// member's pubkey address.
+	memberAddr, multiSigScript := newMultisigScript(t)
+
+	managedAddr := &bwmock.ManagedAddress{}
+	managedAddr.On("Internal").Return(false).Maybe()
+
+	addrStore := &bwmock.AddrStore{}
+	addrStore.On("ChainParams").Return(&chaincfg.RegressionNetParams)
+	addrStore.On("Address", mock.Anything, mock.Anything).
+		Return(managedAddr, nil)
+	addrStore.On("MarkUsed", mock.Anything, mock.Anything).Return(nil)
+	store := NewStore(dbConn, txStore, addrStore)
+
+	txMsg := &wire.MsgTx{Version: 1}
+	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{65},
+	}})
+	txMsg.AddTxOut(&wire.TxOut{Value: 5_000, PkScript: multiSigScript})
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: 0,
+		Tx:       txMsg,
+		Received: time.Unix(1710003400, 0),
+		Status:   db.TxStatusPublished,
+		Credits:  map[uint32]btcutil.Address{0: memberAddr},
+	})
+	require.NoError(t, err)
+
+	addrStore.AssertCalled(t, "MarkUsed", mock.Anything, mock.Anything)
+}
+
 // TestCreateTxCreditlessSucceeds verifies that a credit-less (sweep) tx is
 // recorded even without the address-manager namespace, since the namespace is
 // only consulted when recording credits.
@@ -154,6 +238,69 @@ func TestCreateTxCreditlessSucceeds(t *testing.T) {
 		return nil
 	})
 	require.NoError(t, err)
+}
+
+// TestCreateTxCreditNilFallback verifies that a nil credit address records the
+// credit via the output's own script, matching the documented
+// CreateTxParams.Credits fallback and the SQL backends. The nil path must not
+// consult the address manager (no Address/MarkUsed lookup) and must not panic.
+func TestCreateTxCreditNilFallback(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	// The addrmgr namespace is still required because the credit set is
+	// non-empty, even though the nil credit itself never reads an address.
+	newAddrmgrNamespace(t, dbConn)
+	txStore := newTxStore(t, dbConn)
+
+	_, script := newTestAddressScript(t)
+
+	// A non-nil addrStore is required by CreateTx whenever there are
+	// credits, but the nil-credit path must only read ChainParams and never
+	// resolve or mark an address. Register no Address/MarkUsed expectations
+	// so a regression that consults the address manager surfaces here.
+	addrStore := &bwmock.AddrStore{}
+	addrStore.On("ChainParams").Return(&chaincfg.RegressionNetParams)
+	store := NewStore(dbConn, txStore, addrStore)
+
+	txMsg := &wire.MsgTx{Version: 1}
+	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{66},
+	}})
+	txMsg.AddTxOut(&wire.TxOut{Value: 4_000, PkScript: script})
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: 0,
+		Tx:       txMsg,
+		Received: time.Unix(1710003500, 0),
+		Status:   db.TxStatusPublished,
+		Credits:  map[uint32]btcutil.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	// The credit is recorded from the output index alone, with change
+	// cleared because there is no resolved derivation branch.
+	txid := txMsg.TxHash()
+	err = walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(wtxmgrNamespaceKey)
+		require.NotNil(t, ns)
+
+		details, err := txStore.TxDetails(ns, &txid)
+		require.NoError(t, err)
+		require.NotNil(t, details)
+		require.Len(t, details.Credits, 1)
+		require.Equal(t, uint32(0), details.Credits[0].Index)
+		require.False(t, details.Credits[0].Change)
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	// The address manager must not have been consulted for a nil credit.
+	addrStore.AssertNotCalled(t, "Address", mock.Anything, mock.Anything)
+	addrStore.AssertNotCalled(t, "MarkUsed", mock.Anything, mock.Anything)
 }
 
 // TestUpdateTxLabelOnlySuccess verifies that kvdb.Store can apply a label-only
@@ -685,4 +832,34 @@ func insertSpendChain(t *testing.T, dbConn walletdb.DB,
 	require.NoError(t, err)
 
 	return fundingRec, spendRec
+}
+
+// newMultisigScript builds a 1-of-2 bare-multisig output script and returns the
+// first member's pubkey address along with the script.
+func newMultisigScript(t *testing.T) (btcutil.Address, []byte) {
+	t.Helper()
+
+	firstKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	secondKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	memberAddr, err := btcutil.NewAddressPubKey(
+		firstKey.PubKey().SerializeCompressed(),
+		&chaincfg.RegressionNetParams,
+	)
+	require.NoError(t, err)
+
+	builder := txscript.NewScriptBuilder()
+	builder.AddInt64(1)
+	builder.AddData(firstKey.PubKey().SerializeCompressed())
+	builder.AddData(secondKey.PubKey().SerializeCompressed())
+	builder.AddInt64(2)
+	builder.AddOp(txscript.OP_CHECKMULTISIG)
+
+	script, err := builder.Script()
+	require.NoError(t, err)
+
+	return memberAddr, script
 }

--- a/wallet/internal/db/kvdb/txstore_test.go
+++ b/wallet/internal/db/kvdb/txstore_test.go
@@ -303,6 +303,75 @@ func TestCreateTxCreditNilFallback(t *testing.T) {
 	addrStore.AssertNotCalled(t, "MarkUsed", mock.Anything, mock.Anything)
 }
 
+// TestInvalidateUnminedTxSuccess verifies that kvdb.Store removes one unmined
+// transaction through the legacy transaction store.
+func TestInvalidateUnminedTxSuccess(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore, nil)
+
+	txMsg := &wire.MsgTx{Version: 1}
+	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{62},
+	}})
+	txMsg.AddTxOut(&wire.TxOut{Value: 9_000, PkScript: []byte{0x51}})
+	rec, err := wtxmgr.NewTxRecordFromMsgTx(txMsg, time.Now())
+	require.NoError(t, err)
+
+	err = walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+		require.NotNil(t, ns)
+
+		return txStore.InsertTx(ns, rec, nil)
+	})
+	require.NoError(t, err)
+
+	err = store.InvalidateUnminedTx(
+		t.Context(), db.InvalidateUnminedTxParams{
+			WalletID: 0,
+			Txid:     rec.Hash,
+		},
+	)
+	require.NoError(t, err)
+
+	err = walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(wtxmgrNamespaceKey)
+		require.NotNil(t, ns)
+
+		details, err := txStore.TxDetails(ns, &rec.Hash)
+		require.NoError(t, err)
+		require.Nil(t, details)
+
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// TestInvalidateUnminedTxRejectsConfirmed verifies that confirmed transactions
+// cannot be invalidated through the unmined-only kvdb path.
+func TestInvalidateUnminedTxRejectsConfirmed(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore, nil)
+	rec := insertConfirmedTx(t, dbConn, txStore, 144)
+
+	err := store.InvalidateUnminedTx(
+		t.Context(), db.InvalidateUnminedTxParams{
+			WalletID: 0,
+			Txid:     rec.Hash,
+		},
+	)
+	require.ErrorIs(t, err, db.ErrInvalidateTx)
+}
+
 // TestUpdateTxLabelOnlySuccess verifies that kvdb.Store can apply a label-only
 // UpdateTx patch through the legacy label path.
 func TestUpdateTxLabelOnlySuccess(t *testing.T) {

--- a/wallet/internal/db/kvdb/txstore_test.go
+++ b/wallet/internal/db/kvdb/txstore_test.go
@@ -5,13 +5,156 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+	bwmock "github.com/btcsuite/btcwallet/bwtest/mock"
+	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+// TestCreateTxUnminedWithCreditSuccess verifies that kvdb.Store records an
+// unmined transaction, label, credit, and address-used state through wtxmgr.
+func TestCreateTxUnminedWithCreditSuccess(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	newAddrmgrNamespace(t, dbConn)
+	txStore := newTxStore(t, dbConn)
+
+	addr, script := newTestAddressScript(t)
+	managedAddr := &bwmock.ManagedAddress{}
+	managedAddr.On("Internal").Return(true).Maybe()
+	managedAddr.On("Address").Return(addr).Maybe()
+	managedAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Maybe()
+	managedAddr.On("Imported").Return(false).Maybe()
+	managedAddr.On("InternalAccount").Return(uint32(0)).Maybe()
+	managedAddr.On("Compressed").Return(true).Maybe()
+	managedAddr.On("AddrHash").Return([]byte(nil)).Maybe()
+	managedAddr.On("Used", mock.Anything).Return(false).Maybe()
+
+	addrStore := &bwmock.AddrStore{}
+	addrStore.On("ChainParams").Return(&chaincfg.RegressionNetParams)
+	addrStore.On("Address", mock.Anything, mock.Anything).
+		Return(managedAddr, nil)
+	addrStore.On("MarkUsed", mock.Anything, mock.Anything).Return(nil)
+	store := NewStore(dbConn, txStore, addrStore)
+
+	txMsg := &wire.MsgTx{Version: 1}
+	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{60},
+	}})
+	txMsg.AddTxOut(&wire.TxOut{Value: 7_000, PkScript: script})
+
+	label := "published"
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: 0,
+		Tx:       txMsg,
+		Received: time.Unix(1710003000, 0),
+		Status:   db.TxStatusPublished,
+		Label:    label,
+		Credits:  map[uint32]btcutil.Address{0: addr},
+	})
+	require.NoError(t, err)
+
+	txid := txMsg.TxHash()
+	err = walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(wtxmgrNamespaceKey)
+		require.NotNil(t, ns)
+
+		details, err := txStore.TxDetails(ns, &txid)
+		require.NoError(t, err)
+		require.NotNil(t, details)
+		require.Equal(t, label, details.Label)
+		require.Len(t, details.Credits, 1)
+		require.Equal(t, uint32(0), details.Credits[0].Index)
+		require.True(t, details.Credits[0].Change)
+
+		return nil
+	})
+	require.NoError(t, err)
+	addrStore.AssertCalled(t, "MarkUsed", mock.Anything, mock.Anything)
+}
+
+// TestCreateTxDuplicateReturnsStoreError verifies that duplicate unmined tx
+// inserts are translated to db.ErrTxAlreadyExists.
+func TestCreateTxDuplicateReturnsStoreError(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	newAddrmgrNamespace(t, dbConn)
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore, nil)
+
+	txMsg := &wire.MsgTx{Version: 1}
+	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{61},
+	}})
+	txMsg.AddTxOut(&wire.TxOut{Value: 8_000, PkScript: []byte{0x51}})
+
+	params := db.CreateTxParams{
+		WalletID: 0,
+		Tx:       txMsg,
+		Received: time.Unix(1710003100, 0),
+		Status:   db.TxStatusPublished,
+	}
+	err := store.CreateTx(t.Context(), params)
+	require.NoError(t, err)
+
+	err = store.CreateTx(t.Context(), params)
+	require.ErrorIs(t, err, db.ErrTxAlreadyExists)
+}
+
+// TestCreateTxCreditlessSucceeds verifies that a credit-less (sweep) tx is
+// recorded even without the address-manager namespace, since the namespace is
+// only consulted when recording credits.
+func TestCreateTxCreditlessSucceeds(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	// Deliberately omit newAddrmgrNamespace: a credit-less tx must not
+	// require the address-manager bucket.
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore, nil)
+
+	txMsg := &wire.MsgTx{Version: 1}
+	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{64},
+	}})
+	txMsg.AddTxOut(&wire.TxOut{Value: 6_000, PkScript: []byte{0x51}})
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: 0,
+		Tx:       txMsg,
+		Received: time.Unix(1710003300, 0),
+		Status:   db.TxStatusPublished,
+	})
+	require.NoError(t, err)
+
+	txid := txMsg.TxHash()
+	err = walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(wtxmgrNamespaceKey)
+		require.NotNil(t, ns)
+
+		details, err := txStore.TxDetails(ns, &txid)
+		require.NoError(t, err)
+		require.NotNil(t, details)
+		require.Empty(t, details.Credits)
+
+		return nil
+	})
+	require.NoError(t, err)
+}
 
 // TestUpdateTxLabelOnlySuccess verifies that kvdb.Store can apply a label-only
 // UpdateTx patch through the legacy label path.

--- a/wallet/internal/db/kvdb/utils_test.go
+++ b/wallet/internal/db/kvdb/utils_test.go
@@ -5,7 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/walletdb"
 	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
@@ -62,4 +66,34 @@ func newTxStore(t *testing.T, dbConn walletdb.DB) *wtxmgr.Store {
 	require.NoError(t, err)
 
 	return txStore
+}
+
+// newAddrmgrNamespace creates the top-level waddrmgr bucket expected by kvdb
+// address-related tests.
+func newAddrmgrNamespace(t *testing.T, dbConn walletdb.DB) {
+	t.Helper()
+
+	err := walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		_, err := tx.CreateTopLevelBucket(waddrmgr.NamespaceKey)
+		return err
+	})
+	require.NoError(t, err)
+}
+
+// newTestAddressScript returns a test address and its payment script.
+func newTestAddressScript(t *testing.T) (btcutil.Address, []byte) {
+	t.Helper()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	addr, err := btcutil.NewAddressPubKey(
+		privKey.PubKey().SerializeCompressed(), &chaincfg.RegressionNetParams,
+	)
+	require.NoError(t, err)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	return addr, pkScript
 }

--- a/wallet/internal/db/pg/addresses.go
+++ b/wallet/internal/db/pg/addresses.go
@@ -47,6 +47,47 @@ func (s *Store) GetAddress(ctx context.Context,
 	return info, nil
 }
 
+// ResolveOwnedAddresses resolves a batch of script pubkeys to the wallet-owned
+// subset using a single query.
+func (s *Store) ResolveOwnedAddresses(ctx context.Context,
+	query db.ResolveOwnedAddressesQuery) (map[string]*db.AddressInfo, error) {
+
+	owned := make(map[string]*db.AddressInfo)
+
+	// An empty request resolves to an empty result without issuing a query.
+	if len(query.ScriptPubKeys) == 0 {
+		return owned, nil
+	}
+
+	err := s.execRead(ctx, func(q *sqlc.Queries) error {
+		rows, err := q.ListAddressesByScriptPubKeys(
+			ctx, sqlc.ListAddressesByScriptPubKeysParams{
+				WalletID:      int64(query.WalletID),
+				ScriptPubKeys: query.ScriptPubKeys,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("list addresses by scripts: %w", err)
+		}
+
+		for _, row := range rows {
+			info, err := addressRowToInfo(row)
+			if err != nil {
+				return fmt.Errorf("map address row: %w", err)
+			}
+
+			owned[string(info.ScriptPubKey)] = info
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return owned, nil
+}
+
 // ListAddresses returns a page of addresses matching the given query.
 func (s *Store) ListAddresses(ctx context.Context,
 	query db.ListAddressesQuery) (page.Result[db.AddressInfo, uint32], error) {
@@ -394,7 +435,8 @@ func addressSecretRowToSecret(
 // generic conversion function to handle all address query result types.
 type addressInfoRow interface {
 	sqlc.GetAddressByScriptPubKeyRow |
-		sqlc.ListAddressesByAccountRow
+		sqlc.ListAddressesByAccountRow |
+		sqlc.ListAddressesByScriptPubKeysRow
 }
 
 // addressRowToInfo converts a PostgreSQL address row to an AddressInfo struct.

--- a/wallet/internal/db/pg/txstore_createtx.go
+++ b/wallet/internal/db/pg/txstore_createtx.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 )
@@ -297,6 +298,54 @@ func (o *createTxOps) InsertReplacementEdges(
 	return nil
 }
 
+// creditLookupScript returns the script_pub_key used to resolve the owning
+// address row for the credited output at the given index.
+//
+// When the caller supplied a resolved credit address, ownership is keyed on
+// that address's own script (PayToAddrScript). This mirrors the kvdb backend,
+// which validates the credit as a member of the output script and then looks
+// the address up directly: a bare-multisig output the wallet partly owns is
+// stored against the wallet-owned member rather than the full multisig script,
+// which no address row would ever match. For a single-address output the
+// member script equals the output script, so the lookup is unchanged.
+//
+// When the credit address is nil the caller has no resolved owner, so the
+// on-chain output script is used directly, preserving the store's original
+// behavior.
+//
+// NOTE: This only selects the address-ownership lookup key. The stored UTXO
+// always records the on-chain output script (TxOut[index].PkScript) via
+// InsertUtxo's amount/output-index, never the member script.
+func creditLookupScript(params db.CreateTxParams, index uint32) ([]byte,
+	error) {
+
+	creditAddr := params.Credits[index]
+	if creditAddr == nil {
+		return params.Tx.TxOut[index].PkScript, nil
+	}
+
+	// A non-nil credit address is authoritative for ownership, so reject it
+	// unless the output it claims to credit actually pays to it. Without this
+	// check a caller could point output N at any wallet address and have the
+	// store record a UTXO owned by an address the output never pays,
+	// corrupting ownership. Membership (not equality) keeps bare-multisig
+	// member credits valid.
+	err := db.ValidateCreditAddrMembership(
+		creditAddr, params.Tx.TxOut[index].PkScript,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("credit output %d: %w", index, err)
+	}
+
+	lookupScript, err := txscript.PayToAddrScript(creditAddr)
+	if err != nil {
+		return nil, fmt.Errorf("credit output %d: build address script: "+
+			"%w", index, err)
+	}
+
+	return lookupScript, nil
+}
+
 // insertCredits inserts one wallet-owned UTXO row for each credited output of
 // the transaction being stored.
 func insertCredits(ctx context.Context, qtx *sqlc.Queries,
@@ -314,11 +363,14 @@ func insertCredits(ctx context.Context, qtx *sqlc.Queries,
 			continue
 		}
 
-		pkScript := params.Tx.TxOut[index].PkScript
+		lookupScript, err := creditLookupScript(params, index)
+		if err != nil {
+			return err
+		}
 
 		addrRow, err := qtx.GetAddressByScriptPubKey(
 			ctx, sqlc.GetAddressByScriptPubKeyParams{
-				ScriptPubKey: pkScript,
+				ScriptPubKey: lookupScript,
 				WalletID:     int64(params.WalletID),
 			},
 		)

--- a/wallet/internal/db/sqlite/addresses.go
+++ b/wallet/internal/db/sqlite/addresses.go
@@ -47,6 +47,47 @@ func (s *Store) GetAddress(ctx context.Context,
 	return info, nil
 }
 
+// ResolveOwnedAddresses resolves a batch of script pubkeys to the wallet-owned
+// subset using a single query.
+func (s *Store) ResolveOwnedAddresses(ctx context.Context,
+	query db.ResolveOwnedAddressesQuery) (map[string]*db.AddressInfo, error) {
+
+	owned := make(map[string]*db.AddressInfo)
+
+	// An empty request resolves to an empty result without issuing a query.
+	if len(query.ScriptPubKeys) == 0 {
+		return owned, nil
+	}
+
+	err := s.execRead(ctx, func(q *sqlc.Queries) error {
+		rows, err := q.ListAddressesByScriptPubKeys(
+			ctx, sqlc.ListAddressesByScriptPubKeysParams{
+				WalletID:      int64(query.WalletID),
+				ScriptPubKeys: query.ScriptPubKeys,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("list addresses by scripts: %w", err)
+		}
+
+		for _, row := range rows {
+			info, err := addressRowToInfo(row)
+			if err != nil {
+				return fmt.Errorf("map address row: %w", err)
+			}
+
+			owned[string(info.ScriptPubKey)] = info
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return owned, nil
+}
+
 // ListAddresses returns a page of addresses matching the given query.
 func (s *Store) ListAddresses(ctx context.Context,
 	query db.ListAddressesQuery) (page.Result[db.AddressInfo, uint32], error) {
@@ -391,7 +432,8 @@ func addressSecretRowToSecret(
 // single generic conversion function to handle all address query result types.
 type addressInfoRow interface {
 	sqlc.GetAddressByScriptPubKeyRow |
-		sqlc.ListAddressesByAccountRow
+		sqlc.ListAddressesByAccountRow |
+		sqlc.ListAddressesByScriptPubKeysRow
 }
 
 // addressRowToInfo converts a SQLite address row to an AddressInfo struct.

--- a/wallet/internal/db/sqlite/txstore_createtx.go
+++ b/wallet/internal/db/sqlite/txstore_createtx.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 )
@@ -295,6 +296,54 @@ func (o *createTxOps) InsertReplacementEdges(
 	return nil
 }
 
+// creditLookupScript returns the script_pub_key used to resolve the owning
+// address row for the credited output at the given index.
+//
+// When the caller supplied a resolved credit address, ownership is keyed on
+// that address's own script (PayToAddrScript). This mirrors the kvdb backend,
+// which validates the credit as a member of the output script and then looks
+// the address up directly: a bare-multisig output the wallet partly owns is
+// stored against the wallet-owned member rather than the full multisig script,
+// which no address row would ever match. For a single-address output the
+// member script equals the output script, so the lookup is unchanged.
+//
+// When the credit address is nil the caller has no resolved owner, so the
+// on-chain output script is used directly, preserving the store's original
+// behavior.
+//
+// NOTE: This only selects the address-ownership lookup key. The stored UTXO
+// always records the on-chain output script (TxOut[index].PkScript) via
+// InsertUtxo's amount/output-index, never the member script.
+func creditLookupScript(params db.CreateTxParams, index uint32) ([]byte,
+	error) {
+
+	creditAddr := params.Credits[index]
+	if creditAddr == nil {
+		return params.Tx.TxOut[index].PkScript, nil
+	}
+
+	// A non-nil credit address is authoritative for ownership, so reject it
+	// unless the output it claims to credit actually pays to it. Without this
+	// check a caller could point output N at any wallet address and have the
+	// store record a UTXO owned by an address the output never pays,
+	// corrupting ownership. Membership (not equality) keeps bare-multisig
+	// member credits valid.
+	err := db.ValidateCreditAddrMembership(
+		creditAddr, params.Tx.TxOut[index].PkScript,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("credit output %d: %w", index, err)
+	}
+
+	lookupScript, err := txscript.PayToAddrScript(creditAddr)
+	if err != nil {
+		return nil, fmt.Errorf("credit output %d: build address script: "+
+			"%w", index, err)
+	}
+
+	return lookupScript, nil
+}
+
 // insertCredits inserts one wallet-owned UTXO row for each credited
 // output of the transaction being stored.
 func insertCredits(ctx context.Context, qtx *sqlc.Queries,
@@ -312,11 +361,14 @@ func insertCredits(ctx context.Context, qtx *sqlc.Queries,
 			continue
 		}
 
-		pkScript := params.Tx.TxOut[index].PkScript
+		lookupScript, err := creditLookupScript(params, index)
+		if err != nil {
+			return err
+		}
 
 		addrRow, err := qtx.GetAddressByScriptPubKey(
 			ctx, sqlc.GetAddressByScriptPubKeyParams{
-				ScriptPubKey: pkScript,
+				ScriptPubKey: lookupScript,
 				WalletID:     int64(params.WalletID),
 			},
 		)

--- a/wallet/internal/db/tx_store_common.go
+++ b/wallet/internal/db/tx_store_common.go
@@ -10,7 +10,9 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 )
 
@@ -583,6 +585,93 @@ func validateCreateTxParams(params CreateTxParams) error {
 	}
 
 	return nil
+}
+
+// ValidateCreditAddrMembership verifies that a caller-supplied credit address
+// is actually paid by the output script it claims to credit. A bad caller
+// could otherwise label output N with any wallet address even when TxOut[N]
+// pays elsewhere, and the SQL backends would record the output as owned by
+// that unrelated address, corrupting UTXO ownership. The kvdb backend already
+// enforces the same rule via its own validateCreditAddr, so this keeps the
+// backends consistent.
+//
+// Membership, not strict equality, is required so bare-multisig outputs the
+// wallet partly owns still validate: such an output is credited to one of its
+// member pubkey addresses, whose own script never equals the full multisig
+// output script.
+//
+// The check is intentionally script-based and chain-parameter free. For a
+// single-address output the member's standard script equals the output script
+// outright. For a bare-multisig output the member's pubkey is one of the
+// script's member operands, and ScriptAddress() exposes that pubkey directly
+// without re-deriving a network-encoded address, so no chaincfg.Params is
+// needed (the SQL stores do not carry one).
+//
+// The bare-multisig fallback is gated on the output script actually being a
+// standard bare-multisig script (txscript.MultiSigTy). Without that gate any
+// script that merely pushes the same bytes - for example a non-paying
+// OP_RETURN <pubkey> - would pass, after which InsertUtxo would record that
+// unrelated script as wallet-owned. The gate is what distinguishes "a pubkey
+// appears somewhere in the script" from "the script pays through bare multisig
+// and this pubkey is a member": in a MultiSigTy script the only non-empty data
+// pushes are the member pubkey operands (the threshold and key-count small
+// integers and OP_CHECKMULTISIG carry no push data), so a data-push match
+// against a MultiSigTy script can only be a genuine member.
+func ValidateCreditAddrMembership(creditAddr btcutil.Address,
+	outputScript []byte) error {
+
+	creditScript, err := txscript.PayToAddrScript(creditAddr)
+	if err != nil {
+		return fmt.Errorf("%w: build credit address script: %w",
+			ErrInvalidParam, err)
+	}
+
+	// A single-address output is credited to the very address its script
+	// pays, so the member's standard script equals the output script.
+	if bytes.Equal(creditScript, outputScript) {
+		return nil
+	}
+
+	// Otherwise the only supported shape is a standard bare-multisig output
+	// the wallet partly owns, credited to one of its member pubkeys. Require
+	// the output script to classify as bare multisig before trusting any
+	// pushed-member match, so a non-multisig script that happens to push the
+	// pubkey bytes (such as OP_RETURN <pubkey>) is rejected rather than
+	// recorded as wallet-owned.
+	if txscript.GetScriptClass(outputScript) != txscript.MultiSigTy {
+		return fmt.Errorf("%w: credit address %s is not paid by the "+
+			"output script", ErrInvalidParam, creditAddr.EncodeAddress())
+	}
+
+	// The output is a bare-multisig script, whose only data pushes are its
+	// member pubkey operands, so the credited pubkey must appear as one of
+	// those pushes to be a member.
+	memberPubKey := creditAddr.ScriptAddress()
+	if len(memberPubKey) != 0 && scriptPushesData(outputScript, memberPubKey) {
+		return nil
+	}
+
+	return fmt.Errorf("%w: credit address %s is not a member of the "+
+		"bare-multisig output script", ErrInvalidParam,
+		creditAddr.EncodeAddress())
+}
+
+// scriptPushesData reports whether script contains a data push equal to want.
+// It is used to detect a bare-multisig member pubkey inside a multisig output
+// script without depending on chain parameters.
+func scriptPushesData(script, want []byte) bool {
+	const scriptVersion = 0
+
+	tokenizer := txscript.MakeScriptTokenizer(scriptVersion, script)
+	for tokenizer.Next() {
+		if bytes.Equal(tokenizer.Data(), want) {
+			return true
+		}
+	}
+
+	// A malformed or non-matching script yields no match; the caller then
+	// rejects the credit as a non-member rather than trusting it.
+	return false
 }
 
 // validateCreateTxStatus checks the status/block combinations that CreateTx may

--- a/wallet/internal/db/tx_store_common_test.go
+++ b/wallet/internal/db/tx_store_common_test.go
@@ -8,8 +8,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -2001,6 +2004,113 @@ func TestValidateUpdateTxState(t *testing.T) {
 			err := validateUpdateTxState(test.state, test.isCoinbase)
 			if test.wantErr != nil {
 				require.ErrorIs(t, err, test.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestValidateCreditAddrMembership verifies the chain-free credit membership
+// check used by the SQL CreateTx path. A single-address output must validate
+// by script equality, a bare-multisig member must validate by membership, and
+// any other shape that merely pushes the pubkey bytes (notably a non-paying
+// OP_RETURN <pubkey>) must be rejected with ErrInvalidParam so InsertUtxo never
+// records an unrelated script as wallet-owned.
+func TestValidateCreditAddrMembership(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: a wallet-owned pubkey address plus a foreign pubkey that
+	// shares a 1-of-2 bare-multisig output with it. ScriptAddress() is the
+	// chain-free serialized pubkey the check matches against.
+	params := &chaincfg.RegressionNetParams
+
+	memberKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	memberAddr, err := btcutil.NewAddressPubKey(
+		memberKey.PubKey().SerializeCompressed(), params,
+	)
+	require.NoError(t, err)
+
+	foreignKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	foreignAddr, err := btcutil.NewAddressPubKey(
+		foreignKey.PubKey().SerializeCompressed(), params,
+	)
+	require.NoError(t, err)
+
+	// An unrelated wallet-owned pubkey that is not part of the multisig.
+	outsiderKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	outsiderAddr, err := btcutil.NewAddressPubKey(
+		outsiderKey.PubKey().SerializeCompressed(), params,
+	)
+	require.NoError(t, err)
+
+	// The member's own standard P2PK script (single-address output).
+	memberScript, err := txscript.PayToAddrScript(memberAddr)
+	require.NoError(t, err)
+
+	// A 1-of-2 bare-multisig output built from the member plus the foreign
+	// key. The full multisig script is never a single wallet address.
+	multiSigScript, err := txscript.MultiSigScript(
+		[]*btcutil.AddressPubKey{memberAddr, foreignAddr}, 1,
+	)
+	require.NoError(t, err)
+
+	// A non-paying OP_RETURN that pushes the wallet-owned member pubkey. It
+	// pushes the same bytes the multisig check looks for but pays nobody.
+	opReturnScript, err := txscript.NullDataScript(memberAddr.ScriptAddress())
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name         string
+		creditAddr   btcutil.Address
+		outputScript []byte
+		wantErr      bool
+	}{
+		{
+			name:         "single address script equality",
+			creditAddr:   memberAddr,
+			outputScript: memberScript,
+		},
+		{
+			name:         "bare multisig member",
+			creditAddr:   memberAddr,
+			outputScript: multiSigScript,
+		},
+		{
+			// The regression: an OP_RETURN that pushes the
+			// wallet-owned pubkey is not a bare-multisig payment, so
+			// it must be rejected even though the bytes are present.
+			name:         "op_return pushes member pubkey",
+			creditAddr:   memberAddr,
+			outputScript: opReturnScript,
+			wantErr:      true,
+		},
+		{
+			// A pubkey that is not one of the multisig members must
+			// be rejected even though the output is bare multisig.
+			name:         "bare multisig non member",
+			creditAddr:   outsiderAddr,
+			outputScript: multiSigScript,
+			wantErr:      true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Act.
+			err := ValidateCreditAddrMembership(
+				tc.creditAddr, tc.outputScript,
+			)
+
+			// Assert.
+			if tc.wantErr {
+				require.ErrorIs(t, err, ErrInvalidParam)
 				return
 			}
 

--- a/wallet/internal/sql/pg/queries/addresses.sql
+++ b/wallet/internal/sql/pg/queries/addresses.sql
@@ -41,6 +41,42 @@ INNER JOIN wallets AS w ON a.wallet_id = w.id
 LEFT JOIN address_secrets AS s ON a.id = s.address_id
 WHERE a.script_pub_key = $1 AND a.wallet_id = $2;
 
+-- name: ListAddressesByScriptPubKeys :many
+-- Resolves a batch of script pubkeys to the wallet-owned address rows in a
+-- single query. Returns one row per matching script; scripts with no matching
+-- address are simply absent from the result. The Go caller is responsible for
+-- short-circuiting an empty script set before issuing this query.
+SELECT
+    a.id,
+    a.account_id,
+    acc.account_number,
+    acc.account_name,
+    ks.purpose,
+    ks.coin_type,
+    a.type_id,
+    a.address_branch,
+    a.address_index,
+    a.script_pub_key,
+    a.pub_key,
+    a.created_at,
+    acc.origin_id,
+    acc.master_fingerprint,
+    w.is_watch_only AS wallet_is_watch_only,
+    (s.encrypted_script IS NOT NULL)::BOOLEAN AS has_script,
+    exists(
+        SELECT 1
+        FROM utxos AS u
+        WHERE u.address_id = a.id
+    ) AS is_used
+FROM addresses AS a
+INNER JOIN accounts AS acc ON a.account_id = acc.id
+INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN address_secrets AS s ON a.id = s.address_id
+WHERE
+    a.wallet_id = sqlc.arg('wallet_id')
+    AND a.script_pub_key = any(sqlc.arg('script_pub_keys')::BYTEA []);
+
 -- name: GetAddressSecret :one
 -- Retrieves secret information for an address. Uses LEFT JOIN to distinguish:
 -- - Address exists with secret: returns full row

--- a/wallet/internal/sql/pg/sqlc/addresses.sql.go
+++ b/wallet/internal/sql/pg/sqlc/addresses.sql.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"database/sql"
 	"time"
+
+	"github.com/lib/pq"
 )
 
 const CreateDerivedAddress = `-- name: CreateDerivedAddress :one
@@ -331,6 +333,109 @@ func (q *Queries) ListAddressesByAccount(ctx context.Context, arg ListAddressesB
 	var items []ListAddressesByAccountRow
 	for rows.Next() {
 		var i ListAddressesByAccountRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.AccountID,
+			&i.AccountNumber,
+			&i.AccountName,
+			&i.Purpose,
+			&i.CoinType,
+			&i.TypeID,
+			&i.AddressBranch,
+			&i.AddressIndex,
+			&i.ScriptPubKey,
+			&i.PubKey,
+			&i.CreatedAt,
+			&i.OriginID,
+			&i.MasterFingerprint,
+			&i.WalletIsWatchOnly,
+			&i.HasScript,
+			&i.IsUsed,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const ListAddressesByScriptPubKeys = `-- name: ListAddressesByScriptPubKeys :many
+SELECT
+    a.id,
+    a.account_id,
+    acc.account_number,
+    acc.account_name,
+    ks.purpose,
+    ks.coin_type,
+    a.type_id,
+    a.address_branch,
+    a.address_index,
+    a.script_pub_key,
+    a.pub_key,
+    a.created_at,
+    acc.origin_id,
+    acc.master_fingerprint,
+    w.is_watch_only AS wallet_is_watch_only,
+    (s.encrypted_script IS NOT NULL)::BOOLEAN AS has_script,
+    exists(
+        SELECT 1
+        FROM utxos AS u
+        WHERE u.address_id = a.id
+    ) AS is_used
+FROM addresses AS a
+INNER JOIN accounts AS acc ON a.account_id = acc.id
+INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN address_secrets AS s ON a.id = s.address_id
+WHERE
+    a.wallet_id = $1
+    AND a.script_pub_key = any($2::BYTEA [])
+`
+
+type ListAddressesByScriptPubKeysParams struct {
+	WalletID      int64
+	ScriptPubKeys [][]byte
+}
+
+type ListAddressesByScriptPubKeysRow struct {
+	ID                int64
+	AccountID         int64
+	AccountNumber     sql.NullInt64
+	AccountName       string
+	Purpose           int64
+	CoinType          int64
+	TypeID            int16
+	AddressBranch     sql.NullInt16
+	AddressIndex      sql.NullInt64
+	ScriptPubKey      []byte
+	PubKey            []byte
+	CreatedAt         time.Time
+	OriginID          int16
+	MasterFingerprint sql.NullInt64
+	WalletIsWatchOnly bool
+	HasScript         bool
+	IsUsed            bool
+}
+
+// Resolves a batch of script pubkeys to the wallet-owned address rows in a
+// single query. Returns one row per matching script; scripts with no matching
+// address are simply absent from the result. The Go caller is responsible for
+// short-circuiting an empty script set before issuing this query.
+func (q *Queries) ListAddressesByScriptPubKeys(ctx context.Context, arg ListAddressesByScriptPubKeysParams) ([]ListAddressesByScriptPubKeysRow, error) {
+	rows, err := q.query(ctx, q.listAddressesByScriptPubKeysStmt, ListAddressesByScriptPubKeys, arg.WalletID, pq.Array(arg.ScriptPubKeys))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListAddressesByScriptPubKeysRow
+	for rows.Next() {
+		var i ListAddressesByScriptPubKeysRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.AccountID,

--- a/wallet/internal/sql/pg/sqlc/db.go
+++ b/wallet/internal/sql/pg/sqlc/db.go
@@ -210,6 +210,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.listAddressesByAccountStmt, err = db.PrepareContext(ctx, ListAddressesByAccount); err != nil {
 		return nil, fmt.Errorf("error preparing query ListAddressesByAccount: %w", err)
 	}
+	if q.listAddressesByScriptPubKeysStmt, err = db.PrepareContext(ctx, ListAddressesByScriptPubKeys); err != nil {
+		return nil, fmt.Errorf("error preparing query ListAddressesByScriptPubKeys: %w", err)
+	}
 	if q.listKeyScopesByWalletStmt, err = db.PrepareContext(ctx, ListKeyScopesByWallet); err != nil {
 		return nil, fmt.Errorf("error preparing query ListKeyScopesByWallet: %w", err)
 	}
@@ -597,6 +600,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing listAddressesByAccountStmt: %w", cerr)
 		}
 	}
+	if q.listAddressesByScriptPubKeysStmt != nil {
+		if cerr := q.listAddressesByScriptPubKeysStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listAddressesByScriptPubKeysStmt: %w", cerr)
+		}
+	}
 	if q.listKeyScopesByWalletStmt != nil {
 		if cerr := q.listKeyScopesByWalletStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing listKeyScopesByWalletStmt: %w", cerr)
@@ -818,6 +826,7 @@ type Queries struct {
 	listActiveUtxoLeasesStmt                    *sql.Stmt
 	listAddressTypesStmt                        *sql.Stmt
 	listAddressesByAccountStmt                  *sql.Stmt
+	listAddressesByScriptPubKeysStmt            *sql.Stmt
 	listKeyScopesByWalletStmt                   *sql.Stmt
 	listOwnedInputPrevOutputsByTxHashesStmt     *sql.Stmt
 	listOwnedOutputsByTxIDsStmt                 *sql.Stmt
@@ -910,6 +919,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		listActiveUtxoLeasesStmt:                    q.listActiveUtxoLeasesStmt,
 		listAddressTypesStmt:                        q.listAddressTypesStmt,
 		listAddressesByAccountStmt:                  q.listAddressesByAccountStmt,
+		listAddressesByScriptPubKeysStmt:            q.listAddressesByScriptPubKeysStmt,
 		listKeyScopesByWalletStmt:                   q.listKeyScopesByWalletStmt,
 		listOwnedInputPrevOutputsByTxHashesStmt:     q.listOwnedInputPrevOutputsByTxHashesStmt,
 		listOwnedOutputsByTxIDsStmt:                 q.listOwnedOutputsByTxIDsStmt,

--- a/wallet/internal/sql/pg/sqlc/querier.go
+++ b/wallet/internal/sql/pg/sqlc/querier.go
@@ -355,6 +355,11 @@ type Querier interface {
 	// When cursor_id is provided, only rows strictly after that address ID are
 	// returned. Returns up to page_limit rows.
 	ListAddressesByAccount(ctx context.Context, arg ListAddressesByAccountParams) ([]ListAddressesByAccountRow, error)
+	// Resolves a batch of script pubkeys to the wallet-owned address rows in a
+	// single query. Returns one row per matching script; scripts with no matching
+	// address are simply absent from the result. The Go caller is responsible for
+	// short-circuiting an empty script set before issuing this query.
+	ListAddressesByScriptPubKeys(ctx context.Context, arg ListAddressesByScriptPubKeysParams) ([]ListAddressesByScriptPubKeysRow, error)
 	// Lists all key scopes for a wallet, ordered by ID.
 	ListKeyScopesByWallet(ctx context.Context, walletID int64) ([]ListKeyScopesByWalletRow, error)
 	// ListOwnedInputPrevOutputsByTxHashes lists wallet-owned previous outputs that

--- a/wallet/internal/sql/sqlite/queries/addresses.sql
+++ b/wallet/internal/sql/sqlite/queries/addresses.sql
@@ -43,6 +43,44 @@ INNER JOIN wallets AS w ON a.wallet_id = w.id
 LEFT JOIN address_secrets AS s ON a.id = s.address_id
 WHERE a.script_pub_key = ? AND a.wallet_id = ?;
 
+-- name: ListAddressesByScriptPubKeys :many
+-- Resolves a batch of script pubkeys to the wallet-owned address rows in a
+-- single query. Returns one row per matching script; scripts with no matching
+-- address are simply absent from the result. The Go caller is responsible for
+-- short-circuiting an empty script set before issuing this query.
+SELECT
+    a.id,
+    a.account_id,
+    acc.account_number,
+    acc.account_name,
+    ks.purpose,
+    ks.coin_type,
+    a.type_id,
+    a.address_branch,
+    a.address_index,
+    a.script_pub_key,
+    a.pub_key,
+    a.created_at,
+    acc.origin_id,
+    acc.master_fingerprint,
+    w.is_watch_only AS wallet_is_watch_only,
+    cast(
+        EXISTS (
+            SELECT 1
+            FROM utxos AS u
+            WHERE u.address_id = a.id
+        ) AS BOOLEAN
+    ) AS is_used,
+    s.encrypted_script IS NOT NULL AS has_script
+FROM addresses AS a
+INNER JOIN accounts AS acc ON a.account_id = acc.id
+INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN address_secrets AS s ON a.id = s.address_id
+WHERE
+    a.wallet_id = ?
+    AND a.script_pub_key IN (sqlc.slice('script_pub_keys'));
+
 -- name: GetAddressSecret :one
 -- Retrieves secret information for an address. Uses LEFT JOIN to distinguish:
 -- - Address exists with secret: returns full row

--- a/wallet/internal/sql/sqlite/sqlc/addresses.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/addresses.sql.go
@@ -8,6 +8,7 @@ package sqlc
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"time"
 )
 
@@ -335,6 +336,122 @@ func (q *Queries) ListAddressesByAccount(ctx context.Context, arg ListAddressesB
 	var items []ListAddressesByAccountRow
 	for rows.Next() {
 		var i ListAddressesByAccountRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.AccountID,
+			&i.AccountNumber,
+			&i.AccountName,
+			&i.Purpose,
+			&i.CoinType,
+			&i.TypeID,
+			&i.AddressBranch,
+			&i.AddressIndex,
+			&i.ScriptPubKey,
+			&i.PubKey,
+			&i.CreatedAt,
+			&i.OriginID,
+			&i.MasterFingerprint,
+			&i.WalletIsWatchOnly,
+			&i.IsUsed,
+			&i.HasScript,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const ListAddressesByScriptPubKeys = `-- name: ListAddressesByScriptPubKeys :many
+SELECT
+    a.id,
+    a.account_id,
+    acc.account_number,
+    acc.account_name,
+    ks.purpose,
+    ks.coin_type,
+    a.type_id,
+    a.address_branch,
+    a.address_index,
+    a.script_pub_key,
+    a.pub_key,
+    a.created_at,
+    acc.origin_id,
+    acc.master_fingerprint,
+    w.is_watch_only AS wallet_is_watch_only,
+    cast(
+        EXISTS (
+            SELECT 1
+            FROM utxos AS u
+            WHERE u.address_id = a.id
+        ) AS BOOLEAN
+    ) AS is_used,
+    s.encrypted_script IS NOT NULL AS has_script
+FROM addresses AS a
+INNER JOIN accounts AS acc ON a.account_id = acc.id
+INNER JOIN key_scopes AS ks ON acc.scope_id = ks.id
+INNER JOIN wallets AS w ON a.wallet_id = w.id
+LEFT JOIN address_secrets AS s ON a.id = s.address_id
+WHERE
+    a.wallet_id = ?
+    AND a.script_pub_key IN (/*SLICE:script_pub_keys*/?)
+`
+
+type ListAddressesByScriptPubKeysParams struct {
+	WalletID      int64
+	ScriptPubKeys [][]byte
+}
+
+type ListAddressesByScriptPubKeysRow struct {
+	ID                int64
+	AccountID         int64
+	AccountNumber     sql.NullInt64
+	AccountName       string
+	Purpose           int64
+	CoinType          int64
+	TypeID            int64
+	AddressBranch     sql.NullInt64
+	AddressIndex      sql.NullInt64
+	ScriptPubKey      []byte
+	PubKey            []byte
+	CreatedAt         time.Time
+	OriginID          int64
+	MasterFingerprint sql.NullInt64
+	WalletIsWatchOnly bool
+	IsUsed            bool
+	HasScript         bool
+}
+
+// Resolves a batch of script pubkeys to the wallet-owned address rows in a
+// single query. Returns one row per matching script; scripts with no matching
+// address are simply absent from the result. The Go caller is responsible for
+// short-circuiting an empty script set before issuing this query.
+func (q *Queries) ListAddressesByScriptPubKeys(ctx context.Context, arg ListAddressesByScriptPubKeysParams) ([]ListAddressesByScriptPubKeysRow, error) {
+	query := ListAddressesByScriptPubKeys
+	var queryParams []interface{}
+	queryParams = append(queryParams, arg.WalletID)
+	if len(arg.ScriptPubKeys) > 0 {
+		for _, v := range arg.ScriptPubKeys {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:script_pub_keys*/?", strings.Repeat(",?", len(arg.ScriptPubKeys))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:script_pub_keys*/?", "NULL", 1)
+	}
+	rows, err := q.query(ctx, nil, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListAddressesByScriptPubKeysRow
+	for rows.Next() {
+		var i ListAddressesByScriptPubKeysRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.AccountID,

--- a/wallet/internal/sql/sqlite/sqlc/db.go
+++ b/wallet/internal/sql/sqlite/sqlc/db.go
@@ -210,6 +210,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.listAddressesByAccountStmt, err = db.PrepareContext(ctx, ListAddressesByAccount); err != nil {
 		return nil, fmt.Errorf("error preparing query ListAddressesByAccount: %w", err)
 	}
+	if q.listAddressesByScriptPubKeysStmt, err = db.PrepareContext(ctx, ListAddressesByScriptPubKeys); err != nil {
+		return nil, fmt.Errorf("error preparing query ListAddressesByScriptPubKeys: %w", err)
+	}
 	if q.listKeyScopesByWalletStmt, err = db.PrepareContext(ctx, ListKeyScopesByWallet); err != nil {
 		return nil, fmt.Errorf("error preparing query ListKeyScopesByWallet: %w", err)
 	}
@@ -597,6 +600,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing listAddressesByAccountStmt: %w", cerr)
 		}
 	}
+	if q.listAddressesByScriptPubKeysStmt != nil {
+		if cerr := q.listAddressesByScriptPubKeysStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listAddressesByScriptPubKeysStmt: %w", cerr)
+		}
+	}
 	if q.listKeyScopesByWalletStmt != nil {
 		if cerr := q.listKeyScopesByWalletStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing listKeyScopesByWalletStmt: %w", cerr)
@@ -818,6 +826,7 @@ type Queries struct {
 	listActiveUtxoLeasesStmt                    *sql.Stmt
 	listAddressTypesStmt                        *sql.Stmt
 	listAddressesByAccountStmt                  *sql.Stmt
+	listAddressesByScriptPubKeysStmt            *sql.Stmt
 	listKeyScopesByWalletStmt                   *sql.Stmt
 	listOwnedInputPrevOutputsByTxHashesStmt     *sql.Stmt
 	listOwnedOutputsByTxIDsStmt                 *sql.Stmt
@@ -910,6 +919,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		listActiveUtxoLeasesStmt:                    q.listActiveUtxoLeasesStmt,
 		listAddressTypesStmt:                        q.listAddressTypesStmt,
 		listAddressesByAccountStmt:                  q.listAddressesByAccountStmt,
+		listAddressesByScriptPubKeysStmt:            q.listAddressesByScriptPubKeysStmt,
 		listKeyScopesByWalletStmt:                   q.listKeyScopesByWalletStmt,
 		listOwnedInputPrevOutputsByTxHashesStmt:     q.listOwnedInputPrevOutputsByTxHashesStmt,
 		listOwnedOutputsByTxIDsStmt:                 q.listOwnedOutputsByTxIDsStmt,

--- a/wallet/internal/sql/sqlite/sqlc/querier.go
+++ b/wallet/internal/sql/sqlite/sqlc/querier.go
@@ -352,6 +352,11 @@ type Querier interface {
 	// When cursor_id is provided, only rows strictly after that address ID are
 	// returned. Returns up to page_limit rows.
 	ListAddressesByAccount(ctx context.Context, arg ListAddressesByAccountParams) ([]ListAddressesByAccountRow, error)
+	// Resolves a batch of script pubkeys to the wallet-owned address rows in a
+	// single query. Returns one row per matching script; scripts with no matching
+	// address are simply absent from the result. The Go caller is responsible for
+	// short-circuiting an empty script set before issuing this query.
+	ListAddressesByScriptPubKeys(ctx context.Context, arg ListAddressesByScriptPubKeysParams) ([]ListAddressesByScriptPubKeysRow, error)
 	// Lists all key scopes for a wallet, ordered by ID.
 	ListKeyScopesByWallet(ctx context.Context, walletID int64) ([]ListKeyScopesByWalletRow, error)
 	// ListOwnedInputPrevOutputsByTxHashes lists wallet-owned previous outputs that

--- a/wallet/tx_publisher.go
+++ b/wallet/tx_publisher.go
@@ -24,8 +24,6 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
-	"github.com/btcsuite/btcwallet/walletdb"
-	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/davecgh/go-spew/spew"
 )
 
@@ -126,14 +124,18 @@ func (w *Wallet) Broadcast(ctx context.Context, tx *wire.MsgTx,
 	// First, we'll attempt to add the tx to our wallet's DB. This will
 	// allow us to track the tx's confirmation status, and also
 	// re-broadcast it upon startup. If any of the subsequent steps fail,
-	// this tx must be removed.
-	ourAddrs, err := w.addTxToWallet(ctx, tx, label)
+	// this tx is invalidated via InvalidateUnminedTx.
+	//
+	// recorded reports whether a tx row was actually written; it gates the
+	// invalidation below so a wallet-unrelated tx (never recorded) is not
+	// invalidated, which would clobber the publish error with ErrTxNotFound.
+	ourAddrs, recorded, err := w.addTxToWallet(ctx, tx, label)
 	if err != nil {
 		return err
 	}
 
 	// Now, we'll attempt to publish the tx. On successful attempt, we
-	// return immediately. On any failures, we remove it from the tx store
+	// return immediately. On any failures, we invalidate it in the tx store
 	// to prevent subsequent attempts with stale transaction data.
 	err = w.publishTx(tx, ourAddrs)
 	if err == nil {
@@ -143,17 +145,24 @@ func (w *Wallet) Broadcast(ctx context.Context, tx *wire.MsgTx,
 	txid := tx.TxHash()
 	log.Errorf("%v: broadcast failed: %v", txid, err)
 
-	// If the tx was rejected for any other reason, then we'll remove it
+	// If we never recorded this tx (it is wallet-unrelated), there is
+	// nothing to invalidate, so we return the original publish error as-is
+	// rather than overwriting it with cleanup context.
+	if !recorded {
+		return err
+	}
+
+	// If the tx was rejected for any other reason, then we'll invalidate it
 	// from the tx store, as otherwise, we'll attempt to continually
 	// re-broadcast it, and the UTXO state of the wallet won't be accurate.
-	removeErr := w.removeUnminedTx(tx)
+	removeErr := w.invalidateUnminedTx(ctx, tx)
 	if removeErr != nil {
-		log.Warnf("Unable to remove tx %v after broadcast failed: %v",
+		log.Warnf("Unable to invalidate tx %v after broadcast failed: %v",
 			txid, removeErr)
 
 		// Return a wrapped error to give the caller full context.
 		return fmt.Errorf("broadcast failed: %w; and failed to "+
-			"remove from wallet: %v", err, removeErr)
+			"invalidate in wallet: %v", err, removeErr)
 	}
 
 	return err
@@ -264,8 +273,13 @@ type ownedAddrInfo struct {
 // transaction. This transaction contains no business logic and only performs
 // the necessary database writes, ensuring that the exclusive database lock is
 // held for the shortest possible time.
+//
+// It returns the wallet-owned output addresses and a recorded flag reporting
+// whether a tx row was actually written to the store. The flag is required
+// because a debit-only sweep records a row yet returns zero addresses, so
+// callers cannot infer recording from the address slice alone.
 func (w *Wallet) addTxToWallet(ctx context.Context, tx *wire.MsgTx,
-	label string) ([]btcutil.Address, error) {
+	label string) ([]btcutil.Address, bool, error) {
 
 	// Stage 1: Extract potential addresses from all transaction outputs.
 	// This is a CPU-intensive operation that is performed entirely in
@@ -276,7 +290,7 @@ func (w *Wallet) addTxToWallet(ctx context.Context, tx *wire.MsgTx,
 	// by the wallet.
 	ownedAddrs, err := w.filterOwnedAddresses(ctx, txOutAddrs)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	// If the transaction has no outputs relevant to us, it may still be a
@@ -285,23 +299,25 @@ func (w *Wallet) addTxToWallet(ctx context.Context, tx *wire.MsgTx,
 	if len(ownedAddrs) == 0 {
 		spendsOurs, err := w.spendsWalletOutput(ctx, tx)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 
 		// Neither outputs nor inputs are wallet-relevant, so we can
-		// safely exit without recording anything.
+		// safely exit without recording anything. recorded is false so
+		// the caller does not invalidate a tx that was never written.
 		if !spendsOurs {
-			return nil, nil
+			return nil, false, nil
 		}
 
 		// The tx spends a wallet output but credits none, so record it
-		// with an empty credit set.
+		// with an empty credit set. It is now tracked, so recorded is
+		// true even though no addresses are returned.
 		err = w.recordTxAndCredits(ctx, tx, label, nil)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 
-		return nil, nil
+		return nil, true, nil
 	}
 
 	// Stage 3: Prepare a definitive "write plan". This plan is created in
@@ -338,10 +354,10 @@ func (w *Wallet) addTxToWallet(ctx context.Context, tx *wire.MsgTx,
 	// fast as possible, containing no business logic.
 	err = w.recordTxAndCredits(ctx, tx, label, creditsToWrite)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
-	return ourAddrs, nil
+	return ourAddrs, true, nil
 }
 
 // recordTxAndCredits performs a single atomic database transaction to execute a
@@ -690,26 +706,24 @@ func (w *Wallet) publishTx(tx *wire.MsgTx, ourAddrs []btcutil.Address) error {
 	return rpcErr
 }
 
-// removeUnminedTx removes a tx from the unconfirmed store.
-func (w *Wallet) removeUnminedTx(tx *wire.MsgTx) error {
+// invalidateUnminedTx marks a tx as failed in the unconfirmed store.
+func (w *Wallet) invalidateUnminedTx(ctx context.Context,
+	tx *wire.MsgTx) error {
+
 	txHash := tx.TxHash()
 
-	dbErr := walletdb.Update(w.cfg.DB, func(dbTx walletdb.ReadWriteTx) error {
-		txmgrNs := dbTx.ReadWriteBucket(wtxmgrNamespaceKey)
-
-		txRec, err := wtxmgr.NewTxRecordFromMsgTx(tx, time.Now())
-		if err != nil {
-			return err
-		}
-
-		return w.txStore.RemoveUnminedTx(txmgrNs, txRec)
+	dbErr := w.store.InvalidateUnminedTx(ctx, db.InvalidateUnminedTxParams{
+		WalletID: w.id,
+		Txid:     txHash,
 	})
 	if dbErr != nil {
-		log.Warnf("Unable to remove invalid tx %v: %v", txHash, dbErr)
+		log.Warnf("Unable to invalidate invalid tx %v: %v", txHash,
+			dbErr)
+
 		return dbErr
 	}
 
-	log.Infof("Removed invalid tx: %v", txHash)
+	log.Infof("Invalidated invalid tx: %v", txHash)
 
 	// The serialized tx is for logging only, don't fail on the error.
 	var txRaw bytes.Buffer
@@ -719,12 +733,12 @@ func (w *Wallet) removeUnminedTx(tx *wire.MsgTx) error {
 	// Optionally log the tx in debug when the size is manageable.
 	const maxTxSizeForLog = 1_000_000
 	if txRaw.Len() < maxTxSizeForLog {
-		log.Debugf("Removed invalid tx: %v \n hex=%x",
+		log.Debugf("Invalidated invalid tx: %v \n hex=%x",
 			newLogClosure(func() string {
 				return spew.Sdump(tx)
 			}), txRaw.Bytes())
 	} else {
-		log.Debugf("Removed invalid tx %v due to its size "+
+		log.Debugf("Invalidated invalid tx %v due to its size "+
 			"being too large", txHash)
 	}
 

--- a/wallet/tx_publisher.go
+++ b/wallet/tx_publisher.go
@@ -708,19 +708,29 @@ func (w *Wallet) publishTx(tx *wire.MsgTx, ourAddrs []btcutil.Address) error {
 	// If the tx was rejected, we need to determine why and act
 	// accordingly.
 	//
-	// NOTE: This check for ErrTxAlreadyInMempool should only be triggered
-	// if the wallet is running without mempool acceptance checks (e.g.,
-	// with an older version of the chain backend or with Neutrino).
-	// Otherwise, this condition should have been caught earlier by the
-	// `checkMempool` function.
-	if errors.Is(rpcErr, chain.ErrTxAlreadyInMempool) {
-		log.Infof("%v: tx already in mempool", txid)
+	// NOTE: These already-broadcast checks should only be triggered if the
+	// wallet is running without mempool acceptance checks (e.g., with an
+	// older version of the chain backend or with Neutrino). Otherwise, this
+	// condition should have been caught earlier by the `checkMempool`
+	// function, which treats the same set of errors as already broadcast.
+	switch {
+	case errors.Is(rpcErr, chain.ErrTxAlreadyInMempool),
+		errors.Is(rpcErr, chain.ErrTxAlreadyKnown),
+		errors.Is(rpcErr, chain.ErrTxAlreadyConfirmed):
+
+		// The tx is already known, confirmed, or in the mempool, so it
+		// was accepted by the network. Treat this as a successful
+		// publish so the recorded tx keeps being tracked rather than
+		// invalidated by the caller.
+		log.Infof("%v: tx already known/confirmed/in mempool", txid)
+
 		return nil
-	}
 
 	// If the tx was rejected for any other reason, then we'll return the
 	// error and let the caller handle the cleanup.
-	return rpcErr
+	default:
+		return rpcErr
+	}
 }
 
 // invalidateUnminedTx marks a tx as failed in the unconfirmed store.

--- a/wallet/tx_publisher.go
+++ b/wallet/tx_publisher.go
@@ -18,11 +18,13 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/davecgh/go-spew/spew"
@@ -468,6 +470,105 @@ func (w *Wallet) filterOwnedAddresses(
 	}
 
 	return ownedAddrs, nil
+}
+
+// spendsWalletOutput reports whether the transaction spends at least one output
+// owned by the wallet, so a sweep that pays no wallet-owned outputs is still
+// recognized as ours.
+//
+// Wallet relevance cannot rely on current-UTXO membership alone. GetUtxo only
+// sees the current unspent set, so a no-change tx that re-spends a wallet
+// output already consumed by another unmined wallet tx (a fee-bump / RBF /
+// sweep replacement) would miss on GetUtxo and be wrongly classified as
+// wallet-unrelated. Such a tx must still be treated as ours so it is recorded
+// and the store-level input-conflict path can arbitrate the double-spend before
+// it broadcasts unrecorded. We therefore also consult the parent transaction's
+// wallet-owned outputs, which persist in the store even after the output is
+// spent, instead of treating an absent current UTXO as proof of
+// non-ownership.
+func (w *Wallet) spendsWalletOutput(ctx context.Context,
+	tx *wire.MsgTx) (bool, error) {
+
+	// Cache parent-tx ownership lookups so several inputs spending the same
+	// parent only cost one GetTxDetail call.
+	ownedParents := make(map[chainhash.Hash]map[uint32]struct{})
+
+	for _, txIn := range tx.TxIn {
+		outPoint := txIn.PreviousOutPoint
+
+		_, err := w.store.GetUtxo(ctx, db.GetUtxoQuery{
+			WalletID: w.id,
+			OutPoint: outPoint,
+		})
+		if err == nil {
+			// The output is a current wallet UTXO, so the tx clearly
+			// spends our funds.
+			return true, nil
+		}
+
+		if !errors.Is(err, db.ErrUtxoNotFound) {
+			return false, err
+		}
+
+		// The output is not a current UTXO. It may still be a wallet
+		// output already spent by another unmined wallet tx, which the
+		// parent's recorded owned outputs reveal.
+		ownedOutputs, err := w.walletOwnedOutputs(
+			ctx, outPoint.Hash, ownedParents,
+		)
+		if err != nil {
+			return false, err
+		}
+
+		if _, ok := ownedOutputs[outPoint.Index]; ok {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// walletOwnedOutputs returns the set of output indexes that the wallet owns in
+// the transaction identified by txHash, memoizing the per-parent lookup in
+// cache. A parent the wallet does not record contributes an empty set, so its
+// outputs are treated as not wallet-owned.
+func (w *Wallet) walletOwnedOutputs(ctx context.Context,
+	txHash chainhash.Hash,
+	cache map[chainhash.Hash]map[uint32]struct{}) (map[uint32]struct{},
+	error) {
+
+	if owned, ok := cache[txHash]; ok {
+		return owned, nil
+	}
+
+	detail, err := w.store.GetTxDetail(ctx, db.GetTxDetailQuery{
+		WalletID: w.id,
+		Txid:     txHash,
+	})
+
+	// A parent the wallet never recorded cannot have contributed a
+	// wallet-owned output, so it spends none of our funds. Memoize a
+	// non-nil empty set so a later cache hit returns the same value and the
+	// caller can index the result without a nil check.
+	if errors.Is(err, db.ErrTxNotFound) {
+		empty := make(map[uint32]struct{})
+		cache[txHash] = empty
+
+		return empty, nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	owned := make(map[uint32]struct{}, len(detail.OwnedOutputs))
+	for _, output := range detail.OwnedOutputs {
+		owned[output.Index] = struct{}{}
+	}
+
+	cache[txHash] = owned
+
+	return owned, nil
 }
 
 // publishTx is a helper function that handles the process of broadcasting a

--- a/wallet/tx_publisher.go
+++ b/wallet/tx_publisher.go
@@ -505,8 +505,9 @@ func (w *Wallet) extractTxAddrs(tx *wire.MsgTx) map[uint32][]btcutil.Address {
 // the wallet needs to act on.
 //
 // The function is optimized to handle transactions with multiple outputs paying
-// to the same address. It internally de-duplicates the addresses to ensure that
-// the expensive database lookup is performed only once for each unique address.
+// to the same address. It internally de-duplicates the addresses and resolves
+// wallet ownership for the entire set with a single batched Store lookup,
+// rather than one lookup per address.
 func (w *Wallet) filterOwnedAddresses(ctx context.Context,
 	txOutAddrs map[uint32][]btcutil.Address) (
 	map[string]ownedAddrInfo, error) {
@@ -529,34 +530,50 @@ func (w *Wallet) filterOwnedAddresses(ctx context.Context,
 		}
 	}
 
+	// Resolve each unique address by its own script rather than the whole
+	// output script. For a single-address output these are identical, but
+	// for a bare-multisig output it correctly resolves the wallet-owned
+	// member, which the multisig script itself would never match.
+	//
+	// The scripts are gathered up front so the wallet-ownership question is
+	// answered with a single batched Store lookup instead of one lookup per
+	// address.
+	scriptToKey := make(map[string]string, len(uniqueAddrs))
+	scripts := make([][]byte, 0, len(uniqueAddrs))
+
 	for key, info := range uniqueAddrs {
-		// Look the address up by its own script rather than the whole
-		// output script. For a single-address output these are
-		// identical, but for a bare-multisig output it correctly
-		// resolves the wallet-owned member, which the multisig script
-		// itself would never match.
 		ownScript, err := txscript.PayToAddrScript(info.addr)
 		if err != nil {
 			return nil, err
 		}
 
-		_, err = w.store.GetAddress(ctx, db.GetAddressQuery{
-			WalletID:     w.id,
-			ScriptPubKey: ownScript,
-		})
-
-		// If the address is not found, it simply means it does not
-		// belong to the wallet. This is the expected case for most
-		// addresses, so we can safely continue to the next one.
-		if errors.Is(err, db.ErrAddressNotFound) {
+		scriptKey := string(ownScript)
+		if _, ok := scriptToKey[scriptKey]; ok {
 			continue
 		}
 
-		if err != nil {
-			return nil, err
-		}
+		scriptToKey[scriptKey] = key
 
-		ownedAddrs[key] = info
+		scripts = append(scripts, ownScript)
+	}
+
+	// Ask the Store which of the gathered scripts are wallet-owned in one
+	// operation. A script present in the result map is owned; an absent one
+	// simply does not belong to the wallet, which is the expected case for
+	// most addresses.
+	owned, err := w.store.ResolveOwnedAddresses(
+		ctx, db.ResolveOwnedAddressesQuery{
+			WalletID:      w.id,
+			ScriptPubKeys: scripts,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	for scriptKey := range owned {
+		key := scriptToKey[scriptKey]
+		ownedAddrs[key] = uniqueAddrs[key]
 	}
 
 	return ownedAddrs, nil

--- a/wallet/tx_publisher.go
+++ b/wallet/tx_publisher.go
@@ -23,7 +23,6 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcwallet/chain"
-	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
@@ -128,7 +127,7 @@ func (w *Wallet) Broadcast(ctx context.Context, tx *wire.MsgTx,
 	// allow us to track the tx's confirmation status, and also
 	// re-broadcast it upon startup. If any of the subsequent steps fail,
 	// this tx must be removed.
-	ourAddrs, err := w.addTxToWallet(tx, label)
+	ourAddrs, err := w.addTxToWallet(ctx, tx, label)
 	if err != nil {
 		return err
 	}
@@ -168,6 +167,13 @@ var (
 	// ErrTxCannotBeNil is returned when a nil transaction is passed to a
 	// function.
 	ErrTxCannotBeNil = errors.New("tx cannot be nil")
+
+	// ErrTxRetainedInvalid is returned when a tx cannot be recorded for
+	// publishing because the store already retains a row for the same hash in
+	// a terminal invalid state (failed or replaced). The record-before-publish
+	// step refuses to report success in that case so the caller does not
+	// publish a tx whose only stored row is invalid and untracked.
+	ErrTxRetainedInvalid = errors.New("tx exists in a retained invalid state")
 )
 
 // checkMempool is a helper function that checks if a tx is acceptable to the
@@ -220,9 +226,6 @@ type creditInfo struct {
 	// index is the output index of the credit.
 	index uint32
 
-	// ma is the managed address of the credit.
-	ma waddrmgr.ManagedAddress
-
 	// addr is the address of the credit.
 	addr btcutil.Address
 }
@@ -230,8 +233,8 @@ type creditInfo struct {
 // ownedAddrInfo holds information about a wallet-owned address and the
 // transaction output indices that pay to it.
 type ownedAddrInfo struct {
-	// managedAddr represents the managed address.
-	managedAddr waddrmgr.ManagedAddress
+	// addr is the wallet-owned address.
+	addr btcutil.Address
 
 	// outputIndices contains the transaction output indices that contain
 	// this address. The indices are not guaranteed to be sorted in any
@@ -248,10 +251,9 @@ type ownedAddrInfo struct {
 // This is done outside of any database transaction to avoid holding locks
 // during computationally expensive work.
 //
-// 2. Filter: Second, it uses a fast, read-only database transaction to
-// filter the large list of potential addresses down to the small set that is
-// actually owned by the wallet. This minimizes the time spent in the final,
-// more expensive write transaction.
+// 2. Filter: Second, it uses Store address lookups to filter the large list of
+// potential addresses down to the small set that is actually owned by the
+// wallet. This minimizes the time spent in the final, more expensive write.
 //
 // 3. Plan: Third, it prepares a definitive "write plan" in memory. This plan
 // is a simple slice of structs that contains all the information needed to
@@ -262,13 +264,8 @@ type ownedAddrInfo struct {
 // transaction. This transaction contains no business logic and only performs
 // the necessary database writes, ensuring that the exclusive database lock is
 // held for the shortest possible time.
-func (w *Wallet) addTxToWallet(tx *wire.MsgTx,
+func (w *Wallet) addTxToWallet(ctx context.Context, tx *wire.MsgTx,
 	label string) ([]btcutil.Address, error) {
-
-	txRec, err := wtxmgr.NewTxRecordFromMsgTx(tx, time.Now())
-	if err != nil {
-		return nil, err
-	}
 
 	// Stage 1: Extract potential addresses from all transaction outputs.
 	// This is a CPU-intensive operation that is performed entirely in
@@ -276,15 +273,34 @@ func (w *Wallet) addTxToWallet(tx *wire.MsgTx,
 	txOutAddrs := w.extractTxAddrs(tx)
 
 	// Stage 2: Filter the extracted addresses to find which ones are owned
-	// by the wallet. This is done in a fast, read-only database
-	// transaction to minimize contention.
-	ownedAddrs, err := w.filterOwnedAddresses(txOutAddrs)
+	// by the wallet.
+	ownedAddrs, err := w.filterOwnedAddresses(ctx, txOutAddrs)
 	if err != nil {
 		return nil, err
 	}
 
-	// If the transaction has no outputs relevant to us, we can exit early.
+	// If the transaction has no outputs relevant to us, it may still be a
+	// sweep that spends our own coins. We check the input side before
+	// giving up so the tx is still tracked (and can later be invalidated).
 	if len(ownedAddrs) == 0 {
+		spendsOurs, err := w.spendsWalletOutput(ctx, tx)
+		if err != nil {
+			return nil, err
+		}
+
+		// Neither outputs nor inputs are wallet-relevant, so we can
+		// safely exit without recording anything.
+		if !spendsOurs {
+			return nil, nil
+		}
+
+		// The tx spends a wallet output but credits none, so record it
+		// with an empty credit set.
+		err = w.recordTxAndCredits(ctx, tx, label, nil)
+		if err != nil {
+			return nil, err
+		}
+
 		return nil, nil
 	}
 
@@ -306,22 +322,21 @@ func (w *Wallet) addTxToWallet(tx *wire.MsgTx,
 	// Iterate directly over owned addresses and their pre-computed output
 	// indices. This correctly handles the edge case where a single
 	// transaction has multiple outputs paying to the same address.
-	for addr, info := range ownedAddrs {
+	for _, info := range ownedAddrs {
 		for _, index := range info.outputIndices {
 			creditsToWrite = append(creditsToWrite, creditInfo{
 				index: index,
-				ma:    info.managedAddr,
-				addr:  addr,
+				addr:  info.addr,
 			})
 		}
 
-		ourAddrs = append(ourAddrs, addr)
+		ourAddrs = append(ourAddrs, info.addr)
 	}
 
 	// Stage 4: Atomically execute the write plan. This is the only stage
 	// that takes an exclusive database lock, and it is designed to be as
 	// fast as possible, containing no business logic.
-	err = w.recordTxAndCredits(txRec, label, creditsToWrite)
+	err = w.recordTxAndCredits(ctx, tx, label, creditsToWrite)
 	if err != nil {
 		return nil, err
 	}
@@ -331,59 +346,113 @@ func (w *Wallet) addTxToWallet(tx *wire.MsgTx,
 
 // recordTxAndCredits performs a single atomic database transaction to execute a
 // pre-computed "write plan" for a transaction.
-func (w *Wallet) recordTxAndCredits(txRec *wtxmgr.TxRecord, label string,
-	creditsToWrite []creditInfo) error {
+func (w *Wallet) recordTxAndCredits(ctx context.Context, tx *wire.MsgTx,
+	label string, creditsToWrite []creditInfo) error {
 
-	return walletdb.Update(w.cfg.DB, func(dbTx walletdb.ReadWriteTx) error {
-		addrmgrNs := dbTx.ReadWriteBucket(waddrmgrNamespaceKey)
-		txmgrNs := dbTx.ReadWriteBucket(wtxmgrNamespaceKey)
+	// The Store contract records exactly one credit per output index
+	// (CreateTxParams.Credits is keyed by index, so "duplicate credited
+	// outputs are impossible by construction"). A bare-multisig output the
+	// wallet partly owns can yield more than one owned member address for
+	// the same index, so the write plan may carry several creditInfo entries
+	// that collapse onto one key. Pick the lexicographically smallest
+	// EncodeAddress() as the canonical owner instead of letting whichever
+	// entry happens to be visited last win: a map-iteration-order-dependent
+	// choice would record a nondeterministic owner across runs. The only
+	// effect not captured for the dropped members is marking an imported
+	// multisig member's address used, which does not feed gap-limit
+	// derivation, so a single canonical owner is sufficient here.
+	credits := make(map[uint32]btcutil.Address, len(creditsToWrite))
+	for _, credit := range creditsToWrite {
+		existing, ok := credits[credit.index]
+		if !ok ||
+			credit.addr.EncodeAddress() < existing.EncodeAddress() {
 
-		// If there is a label we should write, get the namespace key
-		// and record it in the tx store.
-		if len(label) != 0 {
-			txHash := txRec.MsgTx.TxHash()
-
-			err := w.txStore.PutTxLabel(txmgrNs, txHash, label)
-			if err != nil {
-				return err
-			}
+			credits[credit.index] = credit.addr
 		}
+	}
 
-		// At the moment all notified txs are assumed to actually be
-		// relevant. This assumption will not hold true when SPV
-		// support is added, but until then, simply insert the tx
-		// because there should either be one or more relevant inputs
-		// or outputs.
-		exists, err := w.txStore.InsertTxCheckIfExists(
-			txmgrNs, txRec, nil,
-		)
-		if err != nil {
-			return err
-		}
+	txHash := tx.TxHash()
 
-		// If the tx has already been recorded, we can return early.
-		if exists {
-			return nil
-		}
+	err := w.store.CreateTx(ctx, db.CreateTxParams{
+		WalletID: w.id,
+		Tx:       tx,
+		Received: time.Now(),
+		Status:   db.TxStatusPublished,
+		Label:    label,
+		Credits:  credits,
+	})
+	if err == nil {
+		return nil
+	}
 
-		// Now, execute the write plan.
-		for _, credit := range creditsToWrite {
-			err := w.txStore.AddCredit(
-				txmgrNs, txRec, nil, credit.index,
-				credit.ma.Internal(),
-			)
-			if err != nil {
-				return err
-			}
+	if !errors.Is(err, db.ErrTxAlreadyExists) {
+		return err
+	}
 
-			err = w.addrStore.MarkUsed(addrmgrNs, credit.addr)
-			if err != nil {
-				return err
-			}
+	// A row already exists for this tx hash; reconcile against its stored
+	// status instead of assuming the duplicate is a live, tracked tx.
+	return w.handleExistingTx(ctx, txHash, label)
+}
+
+// handleExistingTx reconciles a record-before-publish duplicate for txHash
+// against the stored row's status. Failed and replaced rows are now RETAINED
+// (not deleted) by InvalidateUnminedTx, so a hash collision here no longer
+// implies the stored row is still a live, tracked transaction. If a prior
+// Broadcast recorded this tx, publishTx failed, and cleanup invalidated the row
+// (now TxStatusFailed/TxStatusReplaced, with its wallet-owned spend edges
+// already cleared), treating the duplicate as an idempotent success would let
+// the caller publish a tx whose only stored row is invalid and untracked,
+// leaving the live tx unrebroadcast and its spend edges unclaimed. The
+// record-before-publish step is therefore authoritative: only treat the
+// duplicate as success when the row is still live for the publish flow.
+func (w *Wallet) handleExistingTx(ctx context.Context, txHash chainhash.Hash,
+	label string) error {
+
+	existing, err := w.store.GetTx(ctx, db.GetTxQuery{
+		WalletID: w.id,
+		Txid:     txHash,
+	})
+	if err != nil {
+		return err
+	}
+
+	// A retained-invalid row cannot be safely revived through this path: the
+	// spend edges InvalidateUnminedTx cleared would need to be re-claimed as a
+	// graph-affecting lifecycle change. Return a clear error before publishing
+	// against a stale, untracked row.
+	if !db.IsUnminedStatus(existing.Status) {
+		return fmt.Errorf("%w: tx %v exists with status %v",
+			ErrTxRetainedInvalid, txHash, existing.Status)
+	}
+
+	// The existing row is still live, so recording is idempotent: its credits
+	// and spend edges are already claimed. If another workflow inserted the
+	// duplicate as pending, promote it to match the published state this
+	// record-before-publish path uses for new rows.
+	if len(label) == 0 {
+		if existing.Status == db.TxStatusPending {
+			state := db.UpdateTxState{Status: db.TxStatusPublished}
+
+			return w.store.UpdateTx(ctx, db.UpdateTxParams{
+				WalletID: w.id,
+				Txid:     txHash,
+				State:    &state,
+			})
 		}
 
 		return nil
-	})
+	}
+
+	params := db.UpdateTxParams{
+		WalletID: w.id,
+		Txid:     txHash,
+		Label:    &label,
+	}
+	if existing.Status == db.TxStatusPending {
+		params.State = &db.UpdateTxState{Status: db.TxStatusPublished}
+	}
+
+	return w.store.UpdateTx(ctx, params)
 }
 
 // extractTxAddrs extracts all potential addresses from a transaction's outputs.
@@ -419,54 +488,59 @@ func (w *Wallet) extractTxAddrs(tx *wire.MsgTx) map[uint32][]btcutil.Address {
 // filters a potentially large set of addresses down to the small subset that
 // the wallet needs to act on.
 //
-// The function is optimized to handle transactions with multiple outputs
-// paying to the same address. It internally de-duplicates the addresses to
-// ensure that the expensive database lookup (`w.addrStore.Address`) is
-// performed only once for each unique address.
-func (w *Wallet) filterOwnedAddresses(
+// The function is optimized to handle transactions with multiple outputs paying
+// to the same address. It internally de-duplicates the addresses to ensure that
+// the expensive database lookup is performed only once for each unique address.
+func (w *Wallet) filterOwnedAddresses(ctx context.Context,
 	txOutAddrs map[uint32][]btcutil.Address) (
-	map[btcutil.Address]ownedAddrInfo, error) {
+	map[string]ownedAddrInfo, error) {
 
-	ownedAddrs := make(map[btcutil.Address]ownedAddrInfo)
+	ownedAddrs := make(map[string]ownedAddrInfo)
 
-	// Pre-deduplicate addresses outside the DB transaction.
-	uniqueAddrs := make(map[btcutil.Address][]uint32)
+	// Pre-deduplicate addresses outside the Store write path.
+	uniqueAddrs := make(map[string]ownedAddrInfo)
 	for index, addrs := range txOutAddrs {
 		for _, addr := range addrs {
-			uniqueAddrs[addr] = append(uniqueAddrs[addr], index)
+			key := addr.EncodeAddress()
+			info := uniqueAddrs[key]
+
+			if info.addr == nil {
+				info.addr = addr
+			}
+
+			info.outputIndices = append(info.outputIndices, index)
+			uniqueAddrs[key] = info
 		}
 	}
 
-	err := walletdb.View(w.cfg.DB, func(dbTx walletdb.ReadTx) error {
-		addrmgrNs := dbTx.ReadBucket(waddrmgrNamespaceKey)
-
-		for addr, indices := range uniqueAddrs {
-			ma, err := w.addrStore.Address(addrmgrNs, addr)
-
-			// If the address is not found, it simply means
-			// it does not belong to the wallet. This is
-			// the expected case for most addresses, so we
-			// can safely continue to the next one.
-			if waddrmgr.IsError(
-				err, waddrmgr.ErrAddressNotFound) {
-
-				continue
-			}
-
-			if err != nil {
-				return err
-			}
-
-			ownedAddrs[addr] = ownedAddrInfo{
-				managedAddr:   ma,
-				outputIndices: indices,
-			}
+	for key, info := range uniqueAddrs {
+		// Look the address up by its own script rather than the whole
+		// output script. For a single-address output these are
+		// identical, but for a bare-multisig output it correctly
+		// resolves the wallet-owned member, which the multisig script
+		// itself would never match.
+		ownScript, err := txscript.PayToAddrScript(info.addr)
+		if err != nil {
+			return nil, err
 		}
 
-		return nil
-	})
-	if err != nil {
-		return nil, err
+		_, err = w.store.GetAddress(ctx, db.GetAddressQuery{
+			WalletID:     w.id,
+			ScriptPubKey: ownScript,
+		})
+
+		// If the address is not found, it simply means it does not
+		// belong to the wallet. This is the expected case for most
+		// addresses, so we can safely continue to the next one.
+		if errors.Is(err, db.ErrAddressNotFound) {
+			continue
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		ownedAddrs[key] = info
 	}
 
 	return ownedAddrs, nil

--- a/wallet/tx_publisher_benchmark_test.go
+++ b/wallet/tx_publisher_benchmark_test.go
@@ -5,13 +5,19 @@
 package wallet
 
 import (
+	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	bwmock "github.com/btcsuite/btcwallet/bwtest/mock"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,7 +35,8 @@ import (
 //
 // The API is optimized with a 4-stage pipeline:
 //  1. Extract: O(n) - CPU-intensive address extraction (no DB locks)
-//  2. Filter: O(m·log(k)) - Read-only DB transaction to filter owned addresses
+//  2. Filter: O(m·log(k)) - Single batched read-only store lookup that resolves
+//     all m unique scripts to the owned subset in one DB operation
 //  3. Plan: O(n·m) - In-memory write plan preparation (typically O(n) as m≈1-2)
 //  4. Execute: O(c) - Atomic write transaction
 //     (c = owned outputs, typically c << n)
@@ -243,7 +250,8 @@ func BenchmarkBroadcastAPI(b *testing.B) {
 //
 // The 4-stage pipeline design provides excellent concurrent performance:
 //  1. Extract: O(n) - Parallel CPU work, no contention
-//  2. Filter: O(m·log(k)) - Read-only transactions, minimal lock contention
+//  2. Filter: O(m·log(k)) - Single batched read-only store lookup per tx,
+//     minimal lock contention
 //  3. Plan: O(n·m) - Parallel in-memory work, no contention
 //  4. Execute: O(c) - Short write transactions reduce lock contention
 //
@@ -419,4 +427,105 @@ func assertBroadcastAPIsEquivalent(b *testing.B,
 		"PublishTransaction and Broadcast APIs should produce "+
 			"equivalent mempool state",
 	)
+}
+
+// countingAddrStore is a minimal db.Store whose only purpose is to count how
+// many times ResolveOwnedAddresses is invoked, so a benchmark can assert that
+// the output-ownership filter issues a single batched lookup regardless of how
+// many outputs a transaction has. Every other Store method is intentionally
+// left unimplemented because filterOwnedAddresses only calls
+// ResolveOwnedAddresses; the embedded nil interface is therefore never
+// dereferenced.
+type countingAddrStore struct {
+	db.Store
+
+	// owned is the set of wallet-owned scripts, keyed by string(script).
+	owned map[string]*db.AddressInfo
+
+	// calls counts the number of ResolveOwnedAddresses invocations.
+	calls atomic.Int64
+}
+
+// ResolveOwnedAddresses records the call and returns the owned subset of the
+// requested scripts in a single operation, mirroring the real backends'
+// contract.
+func (c *countingAddrStore) ResolveOwnedAddresses(_ context.Context,
+	query db.ResolveOwnedAddressesQuery) (map[string]*db.AddressInfo, error) {
+
+	c.calls.Add(1)
+
+	result := make(map[string]*db.AddressInfo)
+	for _, script := range query.ScriptPubKeys {
+		if info, ok := c.owned[string(script)]; ok {
+			result[string(script)] = info
+		}
+	}
+
+	return result, nil
+}
+
+// BenchmarkFilterOwnedAddresses measures the output-ownership filter on a tx
+// with a growing number of distinct output addresses (half wallet-owned). It
+// reports a store_ops/op metric to demonstrate that the batched lookup keeps
+// the filter stage at a single store operation per transaction (N -> 1),
+// independent of the output count N.
+func BenchmarkFilterOwnedAddresses(b *testing.B) {
+	outputCounts := []int{1, 8, 64, 256, 1024}
+
+	for _, n := range outputCounts {
+		b.Run(fmt.Sprintf("Outputs-%04d", n), func(b *testing.B) {
+			// Build n distinct output addresses; every other one is
+			// wallet-owned.
+			txOutAddrs := make(map[uint32][]btcutil.Address, n)
+			owned := make(map[string]*db.AddressInfo)
+
+			for i := range n {
+				privKey, err := btcec.NewPrivateKey()
+				require.NoError(b, err)
+
+				addr, err := btcutil.NewAddressPubKey(
+					privKey.PubKey().SerializeCompressed(),
+					&chainParams,
+				)
+				require.NoError(b, err)
+
+				txOutAddrs[uint32(i)] = []btcutil.Address{addr}
+
+				if i%2 != 0 {
+					continue
+				}
+
+				script, err := txscript.PayToAddrScript(addr)
+				require.NoError(b, err)
+
+				owned[string(script)] = &db.AddressInfo{
+					ScriptPubKey: script,
+				}
+			}
+
+			store := &countingAddrStore{owned: owned}
+			w := &Wallet{store: store}
+			w.cache = newStoreRuntimeCache(store)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				_, err := w.filterOwnedAddresses(
+					b.Context(), txOutAddrs,
+				)
+				require.NoError(b, err)
+			}
+
+			b.StopTimer()
+
+			// The filter must issue exactly one store lookup per
+			// call, no matter how many outputs the tx has.
+			opsPerCall := float64(store.calls.Load()) /
+				float64(b.N)
+			require.InDelta(b, 1.0, opsPerCall, 1e-9,
+				"filter stage must be a single store op per tx")
+			b.ReportMetric(opsPerCall, "store_ops/op")
+		})
+	}
 }

--- a/wallet/tx_publisher_test.go
+++ b/wallet/tx_publisher_test.go
@@ -9,7 +9,6 @@ import (
 	"crypto/sha256"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcjson"
@@ -20,9 +19,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	bwmock "github.com/btcsuite/btcwallet/bwtest/mock"
 	"github.com/btcsuite/btcwallet/chain"
-	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
-	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -73,16 +70,37 @@ func addressCreditsEqual(a, b map[uint32]btcutil.Address) bool {
 	return true
 }
 
-// matchUpdateTxLabelParams returns a matcher for Store label updates.
-func matchUpdateTxLabelParams(walletID uint32, txid chainhash.Hash,
-	label string) any {
+// matchUpdateTxParams returns a matcher for Store tx metadata updates. The
+// nil-handling branches for the optional label and state fields are inherent to
+// the matcher and read clearer inline than split across helpers.
+//
+//nolint:cyclop // Inline nil-handling for optional matcher fields.
+func matchUpdateTxParams(walletID uint32, txid chainhash.Hash,
+	label *string, state *db.UpdateTxState) any {
 
 	return mock.MatchedBy(func(params db.UpdateTxParams) bool {
-		return params.WalletID == walletID &&
-			params.Txid == txid &&
-			params.Label != nil &&
-			*params.Label == label &&
-			params.State == nil
+		if params.WalletID != walletID || params.Txid != txid {
+			return false
+		}
+
+		if label == nil {
+			if params.Label != nil {
+				return false
+			}
+		} else if params.Label == nil || *params.Label != *label {
+			return false
+		}
+
+		if state == nil {
+			return params.State == nil
+		}
+
+		if params.State == nil {
+			return false
+		}
+
+		return params.State.Status == state.Status &&
+			params.State.Block == nil && state.Block == nil
 	})
 }
 
@@ -319,56 +337,110 @@ func TestExtractTxAddrs(t *testing.T) {
 }
 
 // TestFilterOwnedAddresses tests the filterOwnedAddresses method to ensure it
-// correctly identifies owned addresses and handles de-duplication.
+// correctly identifies owned addresses, handles de-duplication, and recognizes
+// a wallet-owned member of a bare-multisig output.
 func TestFilterOwnedAddresses(t *testing.T) {
 	t.Parallel()
 
-	// Create a new test wallet with mocks.
-	w, mocks := createStartedWalletWithMocks(t)
+	t.Run("dedup single-address outputs", func(t *testing.T) {
+		t.Parallel()
 
-	// Create two addresses, one owned and one not.
-	ownedPrivKey, err := btcec.NewPrivateKey()
+		w, mocks := createStartedWalletWithMocks(t)
+
+		// Create two addresses, one owned and one not.
+		ownedAddr := mustNewPubKeyAddr(t, w)
+		unownedAddr := mustNewPubKeyAddr(t, w)
+
+		ownedScript := mustPayToAddrScript(ownedAddr)
+		unownedScript := mustPayToAddrScript(unownedAddr)
+
+		// Create an input map with both addresses, with the owned
+		// address appearing twice.
+		txOutAddrs := map[uint32][]btcutil.Address{
+			0: {ownedAddr},
+			1: {unownedAddr},
+			2: {ownedAddr}, // Duplicate
+		}
+
+		// Each address is looked up by its own script, which for a
+		// single-address output equals the output script.
+		mocks.store.On("GetAddress", mock.Anything,
+			matchGetAddressQuery(w.id, ownedScript),
+		).Return(&db.AddressInfo{ScriptPubKey: ownedScript}, nil).Once()
+		mocks.store.On("GetAddress", mock.Anything,
+			matchGetAddressQuery(w.id, unownedScript),
+		).Return(nil, db.ErrAddressNotFound).Once()
+
+		// Filter the addresses.
+		ownedAddrs, err := w.filterOwnedAddresses(
+			t.Context(), txOutAddrs,
+		)
+		require.NoError(t, err)
+
+		// Check that the result contains only the owned address.
+		require.Len(t, ownedAddrs, 1)
+		info, ok := ownedAddrs[ownedAddr.EncodeAddress()]
+		require.True(t, ok)
+		require.ElementsMatch(t, []uint32{uint32(0), uint32(2)},
+			info.outputIndices)
+	})
+
+	t.Run("bare multisig owned member", func(t *testing.T) {
+		t.Parallel()
+
+		w, mocks := createStartedWalletWithMocks(t)
+
+		// A bare 1-of-2 multisig output yields two pubkey addresses;
+		// the wallet owns only the first one.
+		ownedAddr := mustNewPubKeyAddr(t, w)
+		otherAddr := mustNewPubKeyAddr(t, w)
+
+		// The extractor surfaces both members for the same output.
+		txOutAddrs := map[uint32][]btcutil.Address{
+			0: {ownedAddr, otherAddr},
+		}
+
+		// Ownership is resolved by each member's own script, never the
+		// whole multisig output script, which would match no address
+		// row.
+		ownedScript := mustPayToAddrScript(ownedAddr)
+		otherScript := mustPayToAddrScript(otherAddr)
+
+		mocks.store.On("GetAddress", mock.Anything,
+			matchGetAddressQuery(w.id, ownedScript),
+		).Return(&db.AddressInfo{ScriptPubKey: ownedScript}, nil).Once()
+		mocks.store.On("GetAddress", mock.Anything,
+			matchGetAddressQuery(w.id, otherScript),
+		).Return(nil, db.ErrAddressNotFound).Once()
+
+		ownedAddrs, err := w.filterOwnedAddresses(
+			t.Context(), txOutAddrs,
+		)
+		require.NoError(t, err)
+
+		// Only the owned member is recognized, mapped to output 0.
+		require.Len(t, ownedAddrs, 1)
+		info, ok := ownedAddrs[ownedAddr.EncodeAddress()]
+		require.True(t, ok)
+		require.ElementsMatch(t, []uint32{uint32(0)},
+			info.outputIndices)
+	})
+}
+
+// mustNewPubKeyAddr returns a fresh P2PK address on the wallet's chain. It
+// fails the test on error.
+func mustNewPubKeyAddr(t *testing.T, w *Wallet) *btcutil.AddressPubKey {
+	t.Helper()
+
+	privKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
-	ownedAddr, err := btcutil.NewAddressPubKey(
-		ownedPrivKey.PubKey().SerializeCompressed(), w.cfg.ChainParams,
+
+	addr, err := btcutil.NewAddressPubKey(
+		privKey.PubKey().SerializeCompressed(), w.cfg.ChainParams,
 	)
 	require.NoError(t, err)
 
-	unownedPrivKey, err := btcec.NewPrivateKey()
-	require.NoError(t, err)
-	unownedAddr, err := btcutil.NewAddressPubKey(
-		unownedPrivKey.PubKey().SerializeCompressed(),
-		w.cfg.ChainParams,
-	)
-	require.NoError(t, err)
-
-	// Create an input map with both addresses, with the owned address
-	// appearing twice.
-	txOutAddrs := map[uint32][]btcutil.Address{
-		0: {ownedAddr},
-		1: {unownedAddr},
-		2: {ownedAddr}, // Duplicate
-	}
-
-	// Set up the mock for the address store.
-	mockManagedAddr := &bwmock.ManagedAddress{}
-	errAddrNotFound := waddrmgr.ManagerError{
-		ErrorCode: waddrmgr.ErrAddressNotFound,
-	}
-
-	mocks.addrStore.On("Address", mock.Anything, ownedAddr).
-		Return(mockManagedAddr, nil).Once()
-	mocks.addrStore.On("Address", mock.Anything, unownedAddr).
-		Return(nil, errAddrNotFound).Once()
-
-	// Filter the addresses.
-	ownedAddrs, err := w.filterOwnedAddresses(txOutAddrs)
-	require.NoError(t, err)
-
-	// Check that the result contains only the owned address.
-	require.Len(t, ownedAddrs, 1)
-	_, ok := ownedAddrs[ownedAddr]
-	require.True(t, ok)
+	return addr
 }
 
 // mustNewStandalonePubKeyAddr returns a fresh P2PK address on the test chain
@@ -392,14 +464,12 @@ func mustNewStandalonePubKeyAddr(t *testing.T) *btcutil.AddressPubKey {
 func TestRecordTxAndCredits(t *testing.T) {
 	t.Parallel()
 
-	// Create a sample TxRecord from a transaction with one input and one
-	// output with a value of 10000.
+	// Create a sample transaction with one input and one output with a value
+	// of 10000.
 	tx := &wire.MsgTx{
 		TxIn:  []*wire.TxIn{{}},
 		TxOut: []*wire.TxOut{{Value: 10000}},
 	}
-	txRec, err := wtxmgr.NewTxRecordFromMsgTx(tx, time.Now())
-	require.NoError(t, err)
 
 	// Create a sample credit for a P2PK address.
 	privKey, err := btcec.NewPrivateKey()
@@ -411,31 +481,70 @@ func TestRecordTxAndCredits(t *testing.T) {
 
 	mockManagedAddr := &bwmock.ManagedAddress{}
 	mockManagedAddr.On("Internal").Return(false)
+
 	credits := []creditInfo{{
 		index: 0,
-		ma:    mockManagedAddr,
 		addr:  addr,
 	}}
+	expectedCredits := map[uint32]btcutil.Address{0: addr}
 
 	testCases := []struct {
-		name      string
-		withLabel bool
-		txExists  bool
+		name        string
+		withLabel   bool
+		createErr   error
+		updateLabel bool
+		updateState bool
+
+		// existingStatus, when set via existingSet, is the status the
+		// store reports for the colliding row on ErrTxAlreadyExists.
+		existingStatus db.TxStatus
+		existingSet    bool
+
+		// wantErr is the sentinel the call must return, if any.
+		wantErr error
 	}{
 		{
 			name:      "new tx with label",
 			withLabel: true,
-			txExists:  false,
 		},
 		{
-			name:      "existing tx",
+			name:        "existing live tx",
+			withLabel:   true,
+			createErr:   db.ErrTxAlreadyExists,
+			updateLabel: true,
+
+			existingStatus: db.TxStatusPublished,
+			existingSet:    true,
+		},
+		{
+			name:        "existing pending tx",
+			withLabel:   true,
+			createErr:   db.ErrTxAlreadyExists,
+			updateLabel: true,
+			updateState: true,
+
+			existingStatus: db.TxStatusPending,
+			existingSet:    true,
+		},
+		{
+			name:      "existing failed tx",
 			withLabel: true,
-			txExists:  true,
+			createErr: db.ErrTxAlreadyExists,
+
+			existingStatus: db.TxStatusFailed,
+			existingSet:    true,
+			wantErr:        ErrTxRetainedInvalid,
 		},
 		{
-			name:      "no label",
-			withLabel: false,
-			txExists:  false,
+			name:      "existing replaced tx",
+			createErr: db.ErrTxAlreadyExists,
+
+			existingStatus: db.TxStatusReplaced,
+			existingSet:    true,
+			wantErr:        ErrTxRetainedInvalid,
+		},
+		{
+			name: "no label",
 		},
 	}
 
@@ -451,27 +560,116 @@ func TestRecordTxAndCredits(t *testing.T) {
 				label = testTxLabel
 			}
 
-			mocks.txStore.On("InsertTxCheckIfExists",
-				mock.Anything, txRec, mock.Anything,
-			).Return(tc.txExists, nil).Once()
+			mocks.store.On("CreateTx", mock.Anything,
+				matchCreateTxParams(
+					w.id, tx, label, expectedCredits,
+				),
+			).Return(tc.createErr).Once()
 
-			if tc.withLabel {
-				mocks.txStore.On("PutTxLabel",
-					mock.Anything, txid, label,
+			// On a duplicate, recordTxAndCredits reads the
+			// existing row's status to decide whether the
+			// collision is a live idempotent duplicate or a
+			// retained-invalid row it must refuse.
+			if tc.existingSet {
+				mocks.store.On("GetTx", mock.Anything,
+					db.GetTxQuery{WalletID: w.id, Txid: txid},
+				).Return(&db.TxInfo{
+					Hash:   txid,
+					Status: tc.existingStatus,
+				}, nil).Once()
+			}
+
+			if tc.updateLabel || tc.updateState {
+				var labelPtr *string
+				if tc.updateLabel {
+					labelPtr = &label
+				}
+
+				var state *db.UpdateTxState
+				if tc.updateState {
+					state = &db.UpdateTxState{
+						Status: db.TxStatusPublished,
+					}
+				}
+
+				mocks.store.On("UpdateTx", mock.Anything,
+					matchUpdateTxParams(w.id, txid, labelPtr, state),
 				).Return(nil).Once()
 			}
 
-			if !tc.txExists {
-				mocks.txStore.On("AddCredit",
-					mock.Anything, txRec, mock.Anything,
-					uint32(0), false,
-				).Return(nil).Once()
-				mocks.addrStore.On("MarkUsed",
-					mock.Anything, addr,
-				).Return(nil).Once()
+			err := w.recordTxAndCredits(
+				t.Context(), tx, label, credits,
+			)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
 			}
 
-			err := w.recordTxAndCredits(txRec, label, credits)
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestRecordTxAndCreditsDeterministicMultiOwned verifies that when a single
+// output index carries more than one wallet-owned credit address (as a
+// bare-multisig output the wallet partly owns can), recordTxAndCredits records
+// the lexicographically smallest EncodeAddress() as the canonical owner. The
+// selection must not depend on credit slice or map iteration order.
+func TestRecordTxAndCreditsDeterministicMultiOwned(t *testing.T) {
+	t.Parallel()
+
+	tx := &wire.MsgTx{
+		TxIn:  []*wire.TxIn{{}},
+		TxOut: []*wire.TxOut{{Value: 10000}},
+	}
+
+	// Build two distinct wallet-owned addresses and order them by encoded
+	// form so the expected canonical (smallest) owner is unambiguous.
+	addrA := mustNewStandalonePubKeyAddr(t)
+	addrB := mustNewStandalonePubKeyAddr(t)
+
+	smaller, larger := addrA, addrB
+	if larger.EncodeAddress() < smaller.EncodeAddress() {
+		smaller, larger = larger, smaller
+	}
+
+	expectedCredits := map[uint32]btcutil.Address{0: smaller}
+
+	// Feed the two owned members for the same output index in both orders;
+	// the canonical pick must be the smaller-encoded address either way.
+	testCases := []struct {
+		name    string
+		credits []creditInfo
+	}{
+		{
+			name: "smaller first",
+			credits: []creditInfo{
+				{index: 0, addr: smaller},
+				{index: 0, addr: larger},
+			},
+		},
+		{
+			name: "larger first",
+			credits: []creditInfo{
+				{index: 0, addr: larger},
+				{index: 0, addr: smaller},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			w, mocks := createStartedWalletWithMocks(t)
+
+			mocks.store.On("CreateTx", mock.Anything,
+				matchCreateTxParams(w.id, tx, "", expectedCredits),
+			).Return(nil).Once()
+
+			err := w.recordTxAndCredits(
+				t.Context(), tx, "", tc.credits,
+			)
 			require.NoError(t, err)
 		})
 	}
@@ -497,6 +695,8 @@ func TestAddTxToWallet(t *testing.T) {
 		unownedPrivKey.PubKey().SerializeCompressed(), &chainParams,
 	)
 	require.NoError(t, err)
+	ownedScript := mustPayToAddrScript(ownedAddr)
+	unownedScript := mustPayToAddrScript(unownedAddr)
 
 	// Create a transaction with outputs to both owned and unowned
 	// addresses.
@@ -505,19 +705,18 @@ func TestAddTxToWallet(t *testing.T) {
 		TxOut: []*wire.TxOut{
 			{
 				Value:    10000,
-				PkScript: mustPayToAddrScript(ownedAddr),
+				PkScript: ownedScript,
 			},
 			{
 				Value:    20000,
-				PkScript: mustPayToAddrScript(unownedAddr),
+				PkScript: unownedScript,
 			},
 			{
 				Value:    30000,
-				PkScript: mustPayToAddrScript(ownedAddr),
+				PkScript: ownedScript,
 			},
 		},
 	}
-	txid := tx.TxHash()
 	label := testTxLabel
 
 	t.Run("tx with owned outputs", func(t *testing.T) {
@@ -530,57 +729,30 @@ func TestAddTxToWallet(t *testing.T) {
 		// the wallet to identify these outputs, record the
 		// transaction, and credit the wallet with the new UTXOs.
 		//
-		// Set up the mock for the address store.
-		mockManagedAddr := &bwmock.ManagedAddress{}
-		mockManagedAddr.On("Internal").Return(false)
+		m.store.On("GetAddress", mock.Anything,
+			matchGetAddressQuery(w.id, ownedScript),
+		).Return(&db.AddressInfo{ScriptPubKey: ownedScript}, nil).Once()
+		m.store.On("GetAddress", mock.Anything,
+			matchGetAddressQuery(w.id, unownedScript),
+		).Return(nil, db.ErrAddressNotFound).Once()
 
-		errAddrNotFound := waddrmgr.ManagerError{
-			ErrorCode: waddrmgr.ErrAddressNotFound,
+		expectedCredits := map[uint32]btcutil.Address{
+			0: ownedAddr,
+			2: ownedAddr,
 		}
-
-		m.addrStore.On("Address",
-			mock.Anything, ownedAddr,
-		).Return(mockManagedAddr, nil)
-		m.addrStore.On("Address",
-			mock.Anything, unownedAddr,
-		).Return(nil, errAddrNotFound)
-
-		// Set up the mocks for the transaction store.
-		m.txStore.On("PutTxLabel",
-			mock.Anything, txid, label,
+		m.store.On("CreateTx", mock.Anything,
+			matchCreateTxParams(w.id, tx, label, expectedCredits),
 		).Return(nil).Once()
-		m.txStore.On("InsertTxCheckIfExists",
-			mock.Anything, mock.Anything,
-			mock.Anything,
-		).Return(false, nil).Once()
-
-		// We expect two credits to be added for the two owned
-		// outputs.
-		m.txStore.On("AddCredit",
-			mock.Anything, mock.Anything,
-			mock.Anything, uint32(0), false,
-		).Return(nil).Once()
-		m.txStore.On("AddCredit",
-			mock.Anything, mock.Anything,
-			mock.Anything, uint32(2), false,
-		).Return(nil).Once()
-		m.addrStore.On("MarkUsed",
-			mock.Anything, ownedAddr,
-		).Return(nil).Twice()
 
 		// Add the transaction to the wallet.
-		ourAddrs, err := w.addTxToWallet(tx, label)
+		ourAddrs, err := w.addTxToWallet(t.Context(), tx, label)
 		require.NoError(t, err)
 
 		// Check that the returned addresses are correct.
-		require.Len(t, ourAddrs, 2)
+		require.Len(t, ourAddrs, 1)
 		require.Equal(
 			t, ownedAddr.String(),
 			ourAddrs[0].String(),
-		)
-		require.Equal(
-			t, ownedAddr.String(),
-			ourAddrs[1].String(),
 		)
 	})
 
@@ -590,28 +762,81 @@ func TestAddTxToWallet(t *testing.T) {
 		w, m := createStartedWalletWithMocks(t)
 
 		// This test case simulates the scenario where the
-		// transaction has no outputs owned by the wallet. We
-		// expect the wallet to identify this and exit early
-		// without recording the transaction.
+		// transaction has neither outputs nor inputs owned by the
+		// wallet. We expect the wallet to identify this and exit
+		// early without recording the transaction.
 		//
-		// Set up the mock for the address store to own no
+		// Set up the mock for the Store to own no
 		// addresses.
-		errAddrNotFound := waddrmgr.ManagerError{
-			ErrorCode: waddrmgr.ErrAddressNotFound,
-		}
-		m.addrStore.On("Address",
-			mock.Anything, ownedAddr,
-		).Return(nil, errAddrNotFound)
-		m.addrStore.On("Address",
-			mock.Anything, unownedAddr,
-		).Return(nil, errAddrNotFound)
+		m.store.On("GetAddress", mock.Anything,
+			matchGetAddressQuery(w.id, ownedScript),
+		).Return(nil, db.ErrAddressNotFound).Once()
+		m.store.On("GetAddress", mock.Anything,
+			matchGetAddressQuery(w.id, unownedScript),
+		).Return(nil, db.ErrAddressNotFound).Once()
+
+		// With no owned outputs, addTxToWallet falls back to checking
+		// the input side. The single input does not spend a current
+		// wallet UTXO, so GetUtxo reports not-found.
+		m.store.On("GetUtxo", mock.Anything, db.GetUtxoQuery{
+			WalletID: w.id,
+			OutPoint: tx.TxIn[0].PreviousOutPoint,
+		}).Return((*db.UtxoInfo)(nil), db.ErrUtxoNotFound).Once()
+
+		// The input's parent is not a wallet transaction either, so it
+		// spends no already-spent wallet output and the tx is genuinely
+		// wallet-unrelated.
+		m.store.On("GetTxDetail", mock.Anything, db.GetTxDetailQuery{
+			WalletID: w.id,
+			Txid:     tx.TxIn[0].PreviousOutPoint.Hash,
+		}).Return((*db.TxDetailInfo)(nil), db.ErrTxNotFound).Once()
 
 		// Add the transaction to the wallet.
-		ourAddrs, err := w.addTxToWallet(tx, label)
+		ourAddrs, err := w.addTxToWallet(t.Context(), tx, label)
 		require.NoError(t, err)
 
 		// We expect no addresses to be returned and no calls to the
 		// transaction store.
+		require.Nil(t, ourAddrs)
+	})
+
+	t.Run("sweep tx (owned input, no owned outputs)", func(t *testing.T) {
+		t.Parallel()
+
+		w, m := createStartedWalletWithMocks(t)
+
+		// A sweep pays no wallet-owned outputs but spends a wallet
+		// UTXO, so it must still be recorded (with an empty credit
+		// set) so it can be tracked and later invalidated.
+		m.store.On("GetAddress", mock.Anything,
+			matchGetAddressQuery(w.id, ownedScript),
+		).Return(nil, db.ErrAddressNotFound).Once()
+		m.store.On("GetAddress", mock.Anything,
+			matchGetAddressQuery(w.id, unownedScript),
+		).Return(nil, db.ErrAddressNotFound).Once()
+
+		// The single input spends a wallet output, so GetUtxo returns
+		// a UTXO.
+		m.store.On("GetUtxo", mock.Anything, db.GetUtxoQuery{
+			WalletID: w.id,
+			OutPoint: tx.TxIn[0].PreviousOutPoint,
+		}).Return(&db.UtxoInfo{
+			OutPoint: tx.TxIn[0].PreviousOutPoint,
+		}, nil).Once()
+
+		// The tx is recorded with an empty credit map.
+		m.store.On("CreateTx", mock.Anything,
+			matchCreateTxParams(
+				w.id, tx, label,
+				map[uint32]btcutil.Address{},
+			),
+		).Return(nil).Once()
+
+		ourAddrs, err := w.addTxToWallet(t.Context(), tx, label)
+		require.NoError(t, err)
+
+		// A debit-only sweep credits no wallet outputs, so no
+		// addresses are returned even though the tx was recorded.
 		require.Nil(t, ourAddrs)
 	})
 }
@@ -869,23 +1094,13 @@ func TestBroadcastSuccess(t *testing.T) {
 		mock.Anything, mock.Anything,
 	).Return([]*btcjson.TestMempoolAcceptResult{{Allowed: true}}, nil)
 
-	// Mock addTxToWallet to succeed.
-	mockManagedAddr := &bwmock.ManagedAddress{}
-	mockManagedAddr.On("Internal").Return(false)
-	m.addrStore.On("Address",
-		mock.Anything, ownedAddr,
-	).Return(mockManagedAddr, nil).Once()
-	m.txStore.On("PutTxLabel",
-		mock.Anything, tx.TxHash(), label,
-	).Return(nil).Once()
-	m.txStore.On("InsertTxCheckIfExists",
-		mock.Anything, mock.Anything, mock.Anything,
-	).Return(false, nil).Once()
-	m.txStore.On("AddCredit",
-		mock.Anything, mock.Anything, mock.Anything, uint32(0), false,
-	).Return(nil).Once()
-	m.addrStore.On("MarkUsed",
-		mock.Anything, ownedAddr,
+	m.store.On("GetAddress", mock.Anything,
+		matchGetAddressQuery(w.id, pkScript),
+	).Return(&db.AddressInfo{ScriptPubKey: pkScript}, nil).Once()
+	m.store.On("CreateTx", mock.Anything,
+		matchCreateTxParams(w.id, tx, label, map[uint32]btcutil.Address{
+			0: ownedAddr,
+		}),
 	).Return(nil).Once()
 
 	// Mock publishTx to succeed.
@@ -947,23 +1162,13 @@ func TestBroadcastPublishFailsRemoveSucceeds(t *testing.T) {
 		mock.Anything, mock.Anything,
 	).Return([]*btcjson.TestMempoolAcceptResult{{Allowed: true}}, nil)
 
-	// Mock addTxToWallet to succeed.
-	mockManagedAddr := &bwmock.ManagedAddress{}
-	mockManagedAddr.On("Internal").Return(false)
-	m.addrStore.On("Address",
-		mock.Anything, ownedAddr,
-	).Return(mockManagedAddr, nil).Once()
-	m.txStore.On("PutTxLabel",
-		mock.Anything, tx.TxHash(), label,
-	).Return(nil).Once()
-	m.txStore.On("InsertTxCheckIfExists",
-		mock.Anything, mock.Anything, mock.Anything,
-	).Return(false, nil).Once()
-	m.txStore.On("AddCredit",
-		mock.Anything, mock.Anything, mock.Anything, uint32(0), false,
-	).Return(nil).Once()
-	m.addrStore.On("MarkUsed",
-		mock.Anything, ownedAddr,
+	m.store.On("GetAddress", mock.Anything,
+		matchGetAddressQuery(w.id, pkScript),
+	).Return(&db.AddressInfo{ScriptPubKey: pkScript}, nil).Once()
+	m.store.On("CreateTx", mock.Anything,
+		matchCreateTxParams(w.id, tx, label, map[uint32]btcutil.Address{
+			0: ownedAddr,
+		}),
 	).Return(nil).Once()
 
 	// Mock publishTx to fail.
@@ -1009,27 +1214,13 @@ func TestBroadcastPublishFailsRemoveFails(t *testing.T) {
 		mock.Anything, mock.Anything,
 	).Return([]*btcjson.TestMempoolAcceptResult{{Allowed: true}}, nil)
 
-	// Mock addTxToWallet to succeed.
-	mockManagedAddr := &bwmock.ManagedAddress{}
-	mockManagedAddr.On("Internal").Return(false)
-
-	// Mock addrStore to succeed.
-	m.addrStore.On("Address",
-		mock.Anything, ownedAddr,
-	).Return(mockManagedAddr, nil).Once()
-	m.addrStore.On("MarkUsed",
-		mock.Anything, ownedAddr,
-	).Return(nil).Once()
-
-	// Mock txStore to succeed.
-	m.txStore.On("PutTxLabel",
-		mock.Anything, tx.TxHash(), label,
-	).Return(nil).Once()
-	m.txStore.On("InsertTxCheckIfExists",
-		mock.Anything, mock.Anything, mock.Anything,
-	).Return(false, nil).Once()
-	m.txStore.On("AddCredit",
-		mock.Anything, mock.Anything, mock.Anything, uint32(0), false,
+	m.store.On("GetAddress", mock.Anything,
+		matchGetAddressQuery(w.id, pkScript),
+	).Return(&db.AddressInfo{ScriptPubKey: pkScript}, nil).Once()
+	m.store.On("CreateTx", mock.Anything,
+		matchCreateTxParams(w.id, tx, label, map[uint32]btcutil.Address{
+			0: ownedAddr,
+		}),
 	).Return(nil).Once()
 
 	// Mock publishTx to fail.

--- a/wallet/tx_publisher_test.go
+++ b/wallet/tx_publisher_test.go
@@ -695,6 +695,7 @@ func TestAddTxToWallet(t *testing.T) {
 		unownedPrivKey.PubKey().SerializeCompressed(), &chainParams,
 	)
 	require.NoError(t, err)
+
 	ownedScript := mustPayToAddrScript(ownedAddr)
 	unownedScript := mustPayToAddrScript(unownedAddr)
 
@@ -745,8 +746,13 @@ func TestAddTxToWallet(t *testing.T) {
 		).Return(nil).Once()
 
 		// Add the transaction to the wallet.
-		ourAddrs, err := w.addTxToWallet(t.Context(), tx, label)
+		ourAddrs, recorded, err := w.addTxToWallet(
+			t.Context(), tx, label,
+		)
 		require.NoError(t, err)
+
+		// The tx was written, so recorded is true.
+		require.True(t, recorded)
 
 		// Check that the returned addresses are correct.
 		require.Len(t, ourAddrs, 1)
@@ -792,12 +798,16 @@ func TestAddTxToWallet(t *testing.T) {
 		}).Return((*db.TxDetailInfo)(nil), db.ErrTxNotFound).Once()
 
 		// Add the transaction to the wallet.
-		ourAddrs, err := w.addTxToWallet(t.Context(), tx, label)
+		ourAddrs, recorded, err := w.addTxToWallet(
+			t.Context(), tx, label,
+		)
 		require.NoError(t, err)
 
-		// We expect no addresses to be returned and no calls to the
-		// transaction store.
+		// We expect no addresses to be returned, no calls to the
+		// transaction store, and recorded to be false because nothing
+		// was written.
 		require.Nil(t, ourAddrs)
+		require.False(t, recorded)
 	})
 
 	t.Run("sweep tx (owned input, no owned outputs)", func(t *testing.T) {
@@ -832,12 +842,16 @@ func TestAddTxToWallet(t *testing.T) {
 			),
 		).Return(nil).Once()
 
-		ourAddrs, err := w.addTxToWallet(t.Context(), tx, label)
+		ourAddrs, recorded, err := w.addTxToWallet(
+			t.Context(), tx, label,
+		)
 		require.NoError(t, err)
 
 		// A debit-only sweep credits no wallet outputs, so no
-		// addresses are returned even though the tx was recorded.
+		// addresses are returned, yet recorded is true because the tx
+		// row was written.
 		require.Nil(t, ourAddrs)
+		require.True(t, recorded)
 	})
 }
 
@@ -903,9 +917,9 @@ func mustPayToAddrScript(addr btcutil.Address) []byte {
 	return pkScript
 }
 
-// TestRemoveUnminedTx tests the removeUnminedTx method to ensure it correctly
-// removes a transaction from the unconfirmed store.
-func TestRemoveUnminedTx(t *testing.T) {
+// TestInvalidateUnminedTx tests the invalidateUnminedTx method to ensure it
+// correctly marks a transaction failed in the unconfirmed store.
+func TestInvalidateUnminedTx(t *testing.T) {
 	t.Parallel()
 
 	w, mocks := createStartedWalletWithMocks(t)
@@ -918,13 +932,14 @@ func TestRemoveUnminedTx(t *testing.T) {
 		}},
 	}
 
-	// Set up the mock for the transaction store.
-	mocks.txStore.On(
-		"RemoveUnminedTx", mock.Anything, mock.Anything,
+	txid := tx.TxHash()
+	mocks.store.On(
+		"InvalidateUnminedTx", mock.Anything,
+		matchInvalidateUnminedTxParams(w.id, txid),
 	).Return(nil).Once()
 
 	// Call the method under test.
-	err := w.removeUnminedTx(tx)
+	err := w.invalidateUnminedTx(t.Context(), tx)
 	require.NoError(t, err)
 }
 
@@ -1177,13 +1192,150 @@ func TestBroadcastPublishFailsRemoveSucceeds(t *testing.T) {
 		mock.Anything, mock.Anything,
 	).Return(nil, errPublish)
 
-	// Mock removeUnminedTx to succeed.
-	m.txStore.On("RemoveUnminedTx",
-		mock.Anything, mock.Anything,
+	m.store.On("InvalidateUnminedTx", mock.Anything,
+		matchInvalidateUnminedTxParams(w.id, tx.TxHash()),
 	).Return(nil).Once()
 
 	err = w.Broadcast(t.Context(), tx, label)
 	require.ErrorIs(t, err, errPublish)
+}
+
+// TestBroadcastSweepPublishFailsInvalidateSucceeds tests that a sweep tx (no
+// owned outputs but an owned input) is recorded, and that when publishing fails
+// the recorded tx is invalidated rather than hitting ErrTxNotFound.
+func TestBroadcastSweepPublishFailsInvalidateSucceeds(t *testing.T) {
+	t.Parallel()
+
+	label := testTxLabel
+	w, m := createStartedWalletWithMocks(t)
+
+	// Create a tx whose only output pays an address the wallet does not
+	// own, so it has no owned outputs.
+	unownedPrivKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	unownedAddr, err := btcutil.NewAddressPubKey(
+		unownedPrivKey.PubKey().SerializeCompressed(), &chainParams,
+	)
+	require.NoError(t, err)
+	pkScript, err := txscript.PayToAddrScript(unownedAddr)
+	require.NoError(t, err)
+
+	prevOut := wire.OutPoint{Hash: chainhash.Hash{0xaa}, Index: 0}
+	tx := &wire.MsgTx{
+		TxIn:  []*wire.TxIn{{PreviousOutPoint: prevOut}},
+		TxOut: []*wire.TxOut{{Value: 10000, PkScript: pkScript}},
+	}
+
+	// Mock checkMempool to succeed.
+	m.chain.On("TestMempoolAccept",
+		mock.Anything, mock.Anything,
+	).Return([]*btcjson.TestMempoolAcceptResult{{Allowed: true}}, nil)
+
+	// The output is unowned.
+	m.store.On("GetAddress", mock.Anything,
+		matchGetAddressQuery(w.id, pkScript),
+	).Return(nil, db.ErrAddressNotFound).Once()
+
+	// The input spends a wallet UTXO, marking the tx as ours.
+	m.store.On("GetUtxo", mock.Anything, db.GetUtxoQuery{
+		WalletID: w.id,
+		OutPoint: prevOut,
+	}).Return(&db.UtxoInfo{OutPoint: prevOut}, nil).Once()
+
+	// The sweep is recorded with no credits.
+	m.store.On("CreateTx", mock.Anything,
+		matchCreateTxParams(
+			w.id, tx, label, map[uint32]btcutil.Address{},
+		),
+	).Return(nil).Once()
+
+	// Mock publishTx to fail.
+	m.chain.On("NotifyReceived", mock.Anything).Return(nil)
+	m.chain.On("SendRawTransaction",
+		mock.Anything, mock.Anything,
+	).Return(nil, errPublish)
+
+	// The recorded sweep can be invalidated because a row exists.
+	m.store.On("InvalidateUnminedTx", mock.Anything,
+		matchInvalidateUnminedTxParams(w.id, tx.TxHash()),
+	).Return(nil).Once()
+
+	err = w.Broadcast(t.Context(), tx, label)
+	require.ErrorIs(t, err, errPublish)
+}
+
+// TestBroadcastUnrelatedPublishFailsNoInvalidate tests that when a
+// wallet-unrelated tx (no owned outputs and no owned inputs) fails to publish,
+// Broadcast does not attempt to invalidate it and returns the original publish
+// error unchanged. Invalidating a never-recorded tx would surface
+// db.ErrTxNotFound and clobber the real broadcast error.
+func TestBroadcastUnrelatedPublishFailsNoInvalidate(t *testing.T) {
+	t.Parallel()
+
+	label := testTxLabel
+	w, m := createStartedWalletWithMocks(t)
+
+	// Create a tx whose only output pays an address the wallet does not
+	// own, so it has no owned outputs.
+	unownedPrivKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	unownedAddr, err := btcutil.NewAddressPubKey(
+		unownedPrivKey.PubKey().SerializeCompressed(), &chainParams,
+	)
+	require.NoError(t, err)
+	pkScript, err := txscript.PayToAddrScript(unownedAddr)
+	require.NoError(t, err)
+
+	prevOut := wire.OutPoint{Hash: chainhash.Hash{0xbb}, Index: 0}
+	tx := &wire.MsgTx{
+		TxIn:  []*wire.TxIn{{PreviousOutPoint: prevOut}},
+		TxOut: []*wire.TxOut{{Value: 10000, PkScript: pkScript}},
+	}
+
+	// Mock checkMempool to succeed.
+	m.chain.On("TestMempoolAccept",
+		mock.Anything, mock.Anything,
+	).Return([]*btcjson.TestMempoolAcceptResult{{Allowed: true}}, nil)
+
+	// The output is unowned.
+	m.store.On("GetAddress", mock.Anything,
+		matchGetAddressQuery(w.id, pkScript),
+	).Return(nil, db.ErrAddressNotFound).Once()
+
+	// The input does not spend a wallet UTXO, so the tx is wallet-unrelated
+	// and is never recorded.
+	m.store.On("GetUtxo", mock.Anything, db.GetUtxoQuery{
+		WalletID: w.id,
+		OutPoint: prevOut,
+	}).Return((*db.UtxoInfo)(nil), db.ErrUtxoNotFound).Once()
+
+	// The input's parent is not a wallet transaction either, so the output
+	// is not a wallet-owned output that is merely already spent. The tx is
+	// therefore genuinely wallet-unrelated.
+	m.store.On("GetTxDetail", mock.Anything, db.GetTxDetailQuery{
+		WalletID: w.id,
+		Txid:     prevOut.Hash,
+	}).Return((*db.TxDetailInfo)(nil), db.ErrTxNotFound).Once()
+
+	// Mock publishTx to fail.
+	m.chain.On("NotifyReceived", mock.Anything).Return(nil)
+	m.chain.On("SendRawTransaction",
+		mock.Anything, mock.Anything,
+	).Return(nil, errPublish)
+
+	// We deliberately register no InvalidateUnminedTx expectation: it must
+	// not be called for a never-recorded tx.
+
+	err = w.Broadcast(t.Context(), tx, label)
+
+	// The original publish error must be preserved and not clobbered with
+	// cleanup context such as db.ErrTxNotFound.
+	require.ErrorIs(t, err, errPublish)
+	require.NotErrorIs(t, err, db.ErrTxNotFound)
+
+	// No invalidation must have been attempted for the unrecorded tx.
+	m.store.AssertNotCalled(t, "InvalidateUnminedTx", mock.Anything,
+		mock.Anything)
 }
 
 // TestBroadcastPublishFailsRemoveFails tests the Broadcast method when both
@@ -1229,9 +1381,8 @@ func TestBroadcastPublishFailsRemoveFails(t *testing.T) {
 		mock.Anything, mock.Anything,
 	).Return(nil, errPublish)
 
-	// Mock removeUnminedTx to fail.
-	m.txStore.On("RemoveUnminedTx",
-		mock.Anything, mock.Anything,
+	m.store.On("InvalidateUnminedTx", mock.Anything,
+		matchInvalidateUnminedTxParams(w.id, tx.TxHash()),
 	).Return(errRemove).Once()
 
 	err = w.Broadcast(t.Context(), tx, label)

--- a/wallet/tx_publisher_test.go
+++ b/wallet/tx_publisher_test.go
@@ -5,6 +5,7 @@
 package wallet
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"errors"
 	"testing"
@@ -13,12 +14,14 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	bwmock "github.com/btcsuite/btcwallet/bwtest/mock"
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -33,6 +36,71 @@ var (
 )
 
 const testTxLabel = "test-tx"
+
+// matchCreateTxParams returns a matcher for Store CreateTx parameters.
+func matchCreateTxParams(walletID uint32, tx *wire.MsgTx, label string,
+	credits map[uint32]btcutil.Address) any {
+
+	return mock.MatchedBy(func(params db.CreateTxParams) bool {
+		return params.WalletID == walletID &&
+			params.Tx == tx &&
+			!params.Received.IsZero() &&
+			params.Block == nil &&
+			params.Status == db.TxStatusPublished &&
+			params.Label == label &&
+			addressCreditsEqual(params.Credits, credits)
+	})
+}
+
+// addressCreditsEqual reports whether two credit maps contain the same encoded
+// addresses for the same output indexes.
+func addressCreditsEqual(a, b map[uint32]btcutil.Address) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for index, addr := range a {
+		otherAddr, ok := b[index]
+		if !ok {
+			return false
+		}
+
+		if addr.EncodeAddress() != otherAddr.EncodeAddress() {
+			return false
+		}
+	}
+
+	return true
+}
+
+// matchUpdateTxLabelParams returns a matcher for Store label updates.
+func matchUpdateTxLabelParams(walletID uint32, txid chainhash.Hash,
+	label string) any {
+
+	return mock.MatchedBy(func(params db.UpdateTxParams) bool {
+		return params.WalletID == walletID &&
+			params.Txid == txid &&
+			params.Label != nil &&
+			*params.Label == label &&
+			params.State == nil
+	})
+}
+
+// matchGetAddressQuery returns a matcher for Store address lookups.
+func matchGetAddressQuery(walletID uint32, scriptPubKey []byte) any {
+	return mock.MatchedBy(func(query db.GetAddressQuery) bool {
+		return query.WalletID == walletID &&
+			bytes.Equal(query.ScriptPubKey, scriptPubKey)
+	})
+}
+
+// matchInvalidateUnminedTxParams returns a matcher for Store invalidation
+// requests.
+func matchInvalidateUnminedTxParams(walletID uint32, txid chainhash.Hash) any {
+	return mock.MatchedBy(func(params db.InvalidateUnminedTxParams) bool {
+		return params.WalletID == walletID && params.Txid == txid
+	})
+}
 
 // TestCheckMempoolAcceptance tests the CheckMempoolAcceptance method.
 func TestCheckMempoolAcceptance(t *testing.T) {

--- a/wallet/tx_publisher_test.go
+++ b/wallet/tx_publisher_test.go
@@ -1128,6 +1128,18 @@ func TestPublishTx(t *testing.T) {
 			sendErr:     chain.ErrTxAlreadyInMempool,
 			expectedErr: nil,
 		},
+		{
+			name:        "already known",
+			notifyErr:   nil,
+			sendErr:     chain.ErrTxAlreadyKnown,
+			expectedErr: nil,
+		},
+		{
+			name:        "already confirmed",
+			notifyErr:   nil,
+			sendErr:     chain.ErrTxAlreadyConfirmed,
+			expectedErr: nil,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1197,6 +1209,90 @@ func TestBroadcastSuccess(t *testing.T) {
 
 	err = w.Broadcast(t.Context(), tx, label)
 	require.NoError(t, err)
+}
+
+// TestBroadcastAlreadyBroadcastedAtPublish tests that Broadcast treats an
+// already-known or already-confirmed SendRawTransaction error as a successful
+// publish: it returns nil and must not invalidate the recorded tx. This guards
+// the path where mempool acceptance is unavailable, so the duplicate is only
+// detected at publish time.
+func TestBroadcastAlreadyBroadcastedAtPublish(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		sendErr error
+	}{
+		{
+			name:    "already known",
+			sendErr: chain.ErrTxAlreadyKnown,
+		},
+		{
+			name:    "already confirmed",
+			sendErr: chain.ErrTxAlreadyConfirmed,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			label := testTxLabel
+			w, m := createStartedWalletWithMocks(t)
+
+			// Create a tx with an owned output so it is recorded
+			// before publishing.
+			ownedPrivKey, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+			ownedAddr, err := btcutil.NewAddressPubKey(
+				ownedPrivKey.PubKey().SerializeCompressed(),
+				&chainParams,
+			)
+			require.NoError(t, err)
+			pkScript, err := txscript.PayToAddrScript(ownedAddr)
+			require.NoError(t, err)
+
+			tx := &wire.MsgTx{
+				TxIn: []*wire.TxIn{{}},
+				TxOut: []*wire.TxOut{
+					{Value: 10000, PkScript: pkScript},
+				},
+			}
+
+			// Mempool acceptance is unavailable, so checkMempool
+			// falls through to a direct publish.
+			m.chain.On("TestMempoolAccept",
+				mock.Anything, mock.Anything,
+			).Return(
+				[]*btcjson.TestMempoolAcceptResult(nil),
+				chain.ErrUnimplemented,
+			)
+
+			m.store.On("ResolveOwnedAddresses", mock.Anything,
+				matchResolveOwnedAddressesQuery(w.id, pkScript),
+			).Return(ownedAddrsResult(pkScript), nil).Once()
+			m.store.On("CreateTx", mock.Anything,
+				matchCreateTxParams(w.id, tx, label,
+					map[uint32]btcutil.Address{0: ownedAddr},
+				),
+			).Return(nil).Once()
+
+			// publishTx sees the duplicate only at send time.
+			m.chain.On("NotifyReceived",
+				mock.Anything).Return(nil)
+			m.chain.On("SendRawTransaction",
+				mock.Anything, mock.Anything,
+			).Return(nil, tc.sendErr)
+
+			err = w.Broadcast(t.Context(), tx, label)
+
+			// The already-broadcast tx must be treated as a
+			// success and kept tracked, never invalidated.
+			require.NoError(t, err)
+			m.store.AssertNotCalled(t, "InvalidateUnminedTx",
+				mock.Anything, mock.Anything)
+		})
+	}
 }
 
 // TestBroadcastAlreadyBroadcasted tests the Broadcast method when the

--- a/wallet/tx_publisher_test.go
+++ b/wallet/tx_publisher_test.go
@@ -5,7 +5,6 @@
 package wallet
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"errors"
 	"testing"
@@ -104,12 +103,43 @@ func matchUpdateTxParams(walletID uint32, txid chainhash.Hash,
 	})
 }
 
-// matchGetAddressQuery returns a matcher for Store address lookups.
-func matchGetAddressQuery(walletID uint32, scriptPubKey []byte) any {
-	return mock.MatchedBy(func(query db.GetAddressQuery) bool {
-		return query.WalletID == walletID &&
-			bytes.Equal(query.ScriptPubKey, scriptPubKey)
+// matchResolveOwnedAddressesQuery returns a matcher for the batched Store
+// address lookup. The wallet builds the script set from a map, so the order is
+// not deterministic; the matcher compares the scripts as a set.
+func matchResolveOwnedAddressesQuery(walletID uint32, scripts ...[]byte) any {
+	want := make(map[string]struct{}, len(scripts))
+	for _, script := range scripts {
+		want[string(script)] = struct{}{}
+	}
+
+	return mock.MatchedBy(func(query db.ResolveOwnedAddressesQuery) bool {
+		if query.WalletID != walletID {
+			return false
+		}
+
+		if len(query.ScriptPubKeys) != len(want) {
+			return false
+		}
+
+		for _, script := range query.ScriptPubKeys {
+			if _, ok := want[string(script)]; !ok {
+				return false
+			}
+		}
+
+		return true
 	})
+}
+
+// ownedAddrsResult builds the owned-subset map returned by the batched Store
+// address lookup, keyed by string(script) as the contract requires.
+func ownedAddrsResult(scripts ...[]byte) map[string]*db.AddressInfo {
+	owned := make(map[string]*db.AddressInfo, len(scripts))
+	for _, script := range scripts {
+		owned[string(script)] = &db.AddressInfo{ScriptPubKey: script}
+	}
+
+	return owned
 }
 
 // matchInvalidateUnminedTxParams returns a matcher for Store invalidation
@@ -362,14 +392,12 @@ func TestFilterOwnedAddresses(t *testing.T) {
 			2: {ownedAddr}, // Duplicate
 		}
 
-		// Each address is looked up by its own script, which for a
-		// single-address output equals the output script.
-		mocks.store.On("GetAddress", mock.Anything,
-			matchGetAddressQuery(w.id, ownedScript),
-		).Return(&db.AddressInfo{ScriptPubKey: ownedScript}, nil).Once()
-		mocks.store.On("GetAddress", mock.Anything,
-			matchGetAddressQuery(w.id, unownedScript),
-		).Return(nil, db.ErrAddressNotFound).Once()
+		// All addresses are resolved by their own scripts in a single
+		// batched lookup; for a single-address output a script equals
+		// the output script. Only the owned script comes back.
+		mocks.store.On("ResolveOwnedAddresses", mock.Anything,
+			matchResolveOwnedAddressesQuery(w.id, ownedScript, unownedScript),
+		).Return(ownedAddrsResult(ownedScript), nil).Once()
 
 		// Filter the addresses.
 		ownedAddrs, err := w.filterOwnedAddresses(
@@ -406,12 +434,9 @@ func TestFilterOwnedAddresses(t *testing.T) {
 		ownedScript := mustPayToAddrScript(ownedAddr)
 		otherScript := mustPayToAddrScript(otherAddr)
 
-		mocks.store.On("GetAddress", mock.Anything,
-			matchGetAddressQuery(w.id, ownedScript),
-		).Return(&db.AddressInfo{ScriptPubKey: ownedScript}, nil).Once()
-		mocks.store.On("GetAddress", mock.Anything,
-			matchGetAddressQuery(w.id, otherScript),
-		).Return(nil, db.ErrAddressNotFound).Once()
+		mocks.store.On("ResolveOwnedAddresses", mock.Anything,
+			matchResolveOwnedAddressesQuery(w.id, ownedScript, otherScript),
+		).Return(ownedAddrsResult(ownedScript), nil).Once()
 
 		ownedAddrs, err := w.filterOwnedAddresses(
 			t.Context(), txOutAddrs,
@@ -424,6 +449,61 @@ func TestFilterOwnedAddresses(t *testing.T) {
 		require.True(t, ok)
 		require.ElementsMatch(t, []uint32{uint32(0)},
 			info.outputIndices)
+	})
+
+	t.Run("single batched lookup for many outputs", func(t *testing.T) {
+		t.Parallel()
+
+		w, mocks := createStartedWalletWithMocks(t)
+
+		// Build a many-output tx with distinct addresses, every other
+		// one wallet-owned, to show the filter resolves the whole set
+		// with a single Store lookup (N outputs -> 1 op).
+		const numOutputs = 32
+
+		txOutAddrs := make(map[uint32][]btcutil.Address, numOutputs)
+		scripts := make([][]byte, 0, numOutputs)
+		ownedScripts := make([][]byte, 0, numOutputs/2)
+		ownedKeys := make(map[string]struct{}, numOutputs/2)
+
+		for i := range numOutputs {
+			addr := mustNewPubKeyAddr(t, w)
+			script := mustPayToAddrScript(addr)
+
+			txOutAddrs[uint32(i)] = []btcutil.Address{addr}
+
+			scripts = append(scripts, script)
+
+			// Mark every other address as wallet-owned.
+			if i%2 != 0 {
+				continue
+			}
+
+			ownedScripts = append(ownedScripts, script)
+			ownedKeys[addr.EncodeAddress()] = struct{}{}
+		}
+
+		// The whole script set is resolved in exactly one call, which
+		// .Once() plus AssertExpectations enforce.
+		mocks.store.On("ResolveOwnedAddresses", mock.Anything,
+			matchResolveOwnedAddressesQuery(w.id, scripts...),
+		).Return(ownedAddrsResult(ownedScripts...), nil).Once()
+
+		ownedAddrs, err := w.filterOwnedAddresses(
+			t.Context(), txOutAddrs,
+		)
+		require.NoError(t, err)
+
+		// Exactly the owned half is returned, and the filter issued a
+		// single batched Store lookup regardless of the output count.
+		require.Len(t, ownedAddrs, len(ownedKeys))
+
+		for key := range ownedAddrs {
+			_, ok := ownedKeys[key]
+			require.True(t, ok)
+		}
+
+		mocks.store.AssertNumberOfCalls(t, "ResolveOwnedAddresses", 1)
 	})
 }
 
@@ -730,12 +810,9 @@ func TestAddTxToWallet(t *testing.T) {
 		// the wallet to identify these outputs, record the
 		// transaction, and credit the wallet with the new UTXOs.
 		//
-		m.store.On("GetAddress", mock.Anything,
-			matchGetAddressQuery(w.id, ownedScript),
-		).Return(&db.AddressInfo{ScriptPubKey: ownedScript}, nil).Once()
-		m.store.On("GetAddress", mock.Anything,
-			matchGetAddressQuery(w.id, unownedScript),
-		).Return(nil, db.ErrAddressNotFound).Once()
+		m.store.On("ResolveOwnedAddresses", mock.Anything,
+			matchResolveOwnedAddressesQuery(w.id, ownedScript, unownedScript),
+		).Return(ownedAddrsResult(ownedScript), nil).Once()
 
 		expectedCredits := map[uint32]btcutil.Address{
 			0: ownedAddr,
@@ -774,12 +851,9 @@ func TestAddTxToWallet(t *testing.T) {
 		//
 		// Set up the mock for the Store to own no
 		// addresses.
-		m.store.On("GetAddress", mock.Anything,
-			matchGetAddressQuery(w.id, ownedScript),
-		).Return(nil, db.ErrAddressNotFound).Once()
-		m.store.On("GetAddress", mock.Anything,
-			matchGetAddressQuery(w.id, unownedScript),
-		).Return(nil, db.ErrAddressNotFound).Once()
+		m.store.On("ResolveOwnedAddresses", mock.Anything,
+			matchResolveOwnedAddressesQuery(w.id, ownedScript, unownedScript),
+		).Return(ownedAddrsResult(), nil).Once()
 
 		// With no owned outputs, addTxToWallet falls back to checking
 		// the input side. The single input does not spend a current
@@ -818,12 +892,9 @@ func TestAddTxToWallet(t *testing.T) {
 		// A sweep pays no wallet-owned outputs but spends a wallet
 		// UTXO, so it must still be recorded (with an empty credit
 		// set) so it can be tracked and later invalidated.
-		m.store.On("GetAddress", mock.Anything,
-			matchGetAddressQuery(w.id, ownedScript),
-		).Return(nil, db.ErrAddressNotFound).Once()
-		m.store.On("GetAddress", mock.Anything,
-			matchGetAddressQuery(w.id, unownedScript),
-		).Return(nil, db.ErrAddressNotFound).Once()
+		m.store.On("ResolveOwnedAddresses", mock.Anything,
+			matchResolveOwnedAddressesQuery(w.id, ownedScript, unownedScript),
+		).Return(ownedAddrsResult(), nil).Once()
 
 		// The single input spends a wallet output, so GetUtxo returns
 		// a UTXO.
@@ -1109,9 +1180,9 @@ func TestBroadcastSuccess(t *testing.T) {
 		mock.Anything, mock.Anything,
 	).Return([]*btcjson.TestMempoolAcceptResult{{Allowed: true}}, nil)
 
-	m.store.On("GetAddress", mock.Anything,
-		matchGetAddressQuery(w.id, pkScript),
-	).Return(&db.AddressInfo{ScriptPubKey: pkScript}, nil).Once()
+	m.store.On("ResolveOwnedAddresses", mock.Anything,
+		matchResolveOwnedAddressesQuery(w.id, pkScript),
+	).Return(ownedAddrsResult(pkScript), nil).Once()
 	m.store.On("CreateTx", mock.Anything,
 		matchCreateTxParams(w.id, tx, label, map[uint32]btcutil.Address{
 			0: ownedAddr,
@@ -1177,9 +1248,9 @@ func TestBroadcastPublishFailsRemoveSucceeds(t *testing.T) {
 		mock.Anything, mock.Anything,
 	).Return([]*btcjson.TestMempoolAcceptResult{{Allowed: true}}, nil)
 
-	m.store.On("GetAddress", mock.Anything,
-		matchGetAddressQuery(w.id, pkScript),
-	).Return(&db.AddressInfo{ScriptPubKey: pkScript}, nil).Once()
+	m.store.On("ResolveOwnedAddresses", mock.Anything,
+		matchResolveOwnedAddressesQuery(w.id, pkScript),
+	).Return(ownedAddrsResult(pkScript), nil).Once()
 	m.store.On("CreateTx", mock.Anything,
 		matchCreateTxParams(w.id, tx, label, map[uint32]btcutil.Address{
 			0: ownedAddr,
@@ -1232,9 +1303,9 @@ func TestBroadcastSweepPublishFailsInvalidateSucceeds(t *testing.T) {
 	).Return([]*btcjson.TestMempoolAcceptResult{{Allowed: true}}, nil)
 
 	// The output is unowned.
-	m.store.On("GetAddress", mock.Anything,
-		matchGetAddressQuery(w.id, pkScript),
-	).Return(nil, db.ErrAddressNotFound).Once()
+	m.store.On("ResolveOwnedAddresses", mock.Anything,
+		matchResolveOwnedAddressesQuery(w.id, pkScript),
+	).Return(ownedAddrsResult(), nil).Once()
 
 	// The input spends a wallet UTXO, marking the tx as ours.
 	m.store.On("GetUtxo", mock.Anything, db.GetUtxoQuery{
@@ -1298,9 +1369,9 @@ func TestBroadcastUnrelatedPublishFailsNoInvalidate(t *testing.T) {
 	).Return([]*btcjson.TestMempoolAcceptResult{{Allowed: true}}, nil)
 
 	// The output is unowned.
-	m.store.On("GetAddress", mock.Anything,
-		matchGetAddressQuery(w.id, pkScript),
-	).Return(nil, db.ErrAddressNotFound).Once()
+	m.store.On("ResolveOwnedAddresses", mock.Anything,
+		matchResolveOwnedAddressesQuery(w.id, pkScript),
+	).Return(ownedAddrsResult(), nil).Once()
 
 	// The input does not spend a wallet UTXO, so the tx is wallet-unrelated
 	// and is never recorded.
@@ -1366,9 +1437,9 @@ func TestBroadcastPublishFailsRemoveFails(t *testing.T) {
 		mock.Anything, mock.Anything,
 	).Return([]*btcjson.TestMempoolAcceptResult{{Allowed: true}}, nil)
 
-	m.store.On("GetAddress", mock.Anything,
-		matchGetAddressQuery(w.id, pkScript),
-	).Return(&db.AddressInfo{ScriptPubKey: pkScript}, nil).Once()
+	m.store.On("ResolveOwnedAddresses", mock.Anything,
+		matchResolveOwnedAddressesQuery(w.id, pkScript),
+	).Return(ownedAddrsResult(pkScript), nil).Once()
 	m.store.On("CreateTx", mock.Anything,
 		matchCreateTxParams(w.id, tx, label, map[uint32]btcutil.Address{
 			0: ownedAddr,
@@ -1401,4 +1472,124 @@ func TestBroadcastNilTx(t *testing.T) {
 
 	err := w.Broadcast(t.Context(), nil, label)
 	require.ErrorIs(t, err, ErrTxCannotBeNil)
+}
+
+// TestBroadcastRetryRetainedInvalidDoesNotPublish verifies the retained-invalid
+// guard added in "wallet: route tx recording and ownership filtering through
+// store": when a prior Broadcast recorded a tx, its publish failed, and cleanup
+// invalidated the row, a later retry with the same tx hash hits
+// ErrTxAlreadyExists in CreateTx. Because the only stored row is now in a
+// terminal failed state, Broadcast must refuse to report the record step a
+// success and must NOT publish the tx. The store's retained failed row is the
+// source of truth; SendRawTransaction is never reached.
+func TestBroadcastRetryRetainedInvalidDoesNotPublish(t *testing.T) {
+	t.Parallel()
+
+	label := testTxLabel
+	w, m := createStartedWalletWithMocks(t)
+
+	// Create a transaction with an owned output so it is classified as ours
+	// and recording is attempted.
+	ownedPrivKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	ownedAddr, err := btcutil.NewAddressPubKey(
+		ownedPrivKey.PubKey().SerializeCompressed(), &chainParams,
+	)
+	require.NoError(t, err)
+	pkScript, err := txscript.PayToAddrScript(ownedAddr)
+	require.NoError(t, err)
+
+	tx := &wire.MsgTx{
+		TxIn:  []*wire.TxIn{{}},
+		TxOut: []*wire.TxOut{{Value: 10000, PkScript: pkScript}},
+	}
+	txid := tx.TxHash()
+
+	// Mock checkMempool to succeed so the flow reaches recording.
+	m.chain.On("TestMempoolAccept",
+		mock.Anything, mock.Anything,
+	).Return([]*btcjson.TestMempoolAcceptResult{{Allowed: true}}, nil)
+
+	m.store.On("ResolveOwnedAddresses", mock.Anything,
+		matchResolveOwnedAddressesQuery(w.id, pkScript),
+	).Return(ownedAddrsResult(pkScript), nil).Once()
+
+	// The prior attempt already inserted this tx, so CreateTx reports the
+	// duplicate.
+	m.store.On("CreateTx", mock.Anything,
+		matchCreateTxParams(w.id, tx, label, map[uint32]btcutil.Address{
+			0: ownedAddr,
+		}),
+	).Return(db.ErrTxAlreadyExists).Once()
+
+	// The retained row was invalidated by the prior cleanup and is now
+	// failed, so the record step must refuse the duplicate.
+	m.store.On("GetTx", mock.Anything,
+		db.GetTxQuery{WalletID: w.id, Txid: txid},
+	).Return(&db.TxInfo{Hash: txid, Status: db.TxStatusFailed}, nil).Once()
+
+	// We deliberately register NO SendRawTransaction (and no NotifyReceived)
+	// expectation: publishing must not happen while the only stored row is
+	// failed. AssertExpectations would flag an unexpected publish call.
+	err = w.Broadcast(t.Context(), tx, label)
+	require.ErrorIs(t, err, ErrTxRetainedInvalid)
+}
+
+// TestBroadcastRetryLiveDuplicateIdempotent verifies the complementary case:
+// when CreateTx reports a duplicate but the stored row is still live
+// (TxStatusPublished), Broadcast treats the record step as an idempotent
+// success and proceeds to (re)publish the tx, leaving the live row tracked.
+func TestBroadcastRetryLiveDuplicateIdempotent(t *testing.T) {
+	t.Parallel()
+
+	label := testTxLabel
+	w, m := createStartedWalletWithMocks(t)
+
+	ownedPrivKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	ownedAddr, err := btcutil.NewAddressPubKey(
+		ownedPrivKey.PubKey().SerializeCompressed(), &chainParams,
+	)
+	require.NoError(t, err)
+	pkScript, err := txscript.PayToAddrScript(ownedAddr)
+	require.NoError(t, err)
+
+	tx := &wire.MsgTx{
+		TxIn:  []*wire.TxIn{{}},
+		TxOut: []*wire.TxOut{{Value: 10000, PkScript: pkScript}},
+	}
+	txid := tx.TxHash()
+
+	m.chain.On("TestMempoolAccept",
+		mock.Anything, mock.Anything,
+	).Return([]*btcjson.TestMempoolAcceptResult{{Allowed: true}}, nil)
+
+	m.store.On("ResolveOwnedAddresses", mock.Anything,
+		matchResolveOwnedAddressesQuery(w.id, pkScript),
+	).Return(ownedAddrsResult(pkScript), nil).Once()
+
+	m.store.On("CreateTx", mock.Anything,
+		matchCreateTxParams(w.id, tx, label, map[uint32]btcutil.Address{
+			0: ownedAddr,
+		}),
+	).Return(db.ErrTxAlreadyExists).Once()
+
+	// The existing row is still live, so the duplicate is idempotent.
+	m.store.On("GetTx", mock.Anything,
+		db.GetTxQuery{WalletID: w.id, Txid: txid},
+	).Return(&db.TxInfo{Hash: txid, Status: db.TxStatusPublished}, nil).Once()
+
+	// A non-empty label still patches the stored label on the live row.
+	m.store.On("UpdateTx", mock.Anything,
+		matchUpdateTxParams(w.id, txid, &label, nil),
+	).Return(nil).Once()
+
+	// Recording succeeded idempotently, so publishing proceeds as normal.
+	m.chain.On("NotifyReceived", mock.Anything).Return(nil)
+	m.chain.On("SendRawTransaction",
+		mock.Anything, mock.Anything,
+	).Return(nil, nil)
+
+	err = w.Broadcast(t.Context(), tx, label)
+	require.NoError(t, err)
 }

--- a/wallet/tx_publisher_test.go
+++ b/wallet/tx_publisher_test.go
@@ -371,6 +371,22 @@ func TestFilterOwnedAddresses(t *testing.T) {
 	require.True(t, ok)
 }
 
+// mustNewStandalonePubKeyAddr returns a fresh P2PK address on the test chain
+// without needing a wallet instance. It fails the test on error.
+func mustNewStandalonePubKeyAddr(t *testing.T) *btcutil.AddressPubKey {
+	t.Helper()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	addr, err := btcutil.NewAddressPubKey(
+		privKey.PubKey().SerializeCompressed(), &chainParams,
+	)
+	require.NoError(t, err)
+
+	return addr
+}
+
 // TestRecordTxAndCredits tests the recordTxAndCredits method to ensure it
 // correctly records transactions and credits in the database.
 func TestRecordTxAndCredits(t *testing.T) {
@@ -598,6 +614,57 @@ func TestAddTxToWallet(t *testing.T) {
 		// transaction store.
 		require.Nil(t, ourAddrs)
 	})
+}
+
+// TestSpendsWalletOutputConflictingNoChangeSpend is the task-173 regression:
+// a no-change transaction re-spends a wallet output that is already consumed by
+// another unmined wallet transaction. That output is no longer in the current
+// UTXO set, so GetUtxo misses it, but it remains a wallet-owned output of its
+// recorded parent transaction.
+//
+// spendsWalletOutput must therefore derive wallet relevance from the parent's
+// owned outputs, not from current-UTXO membership, and report the spend as
+// ours. That is what keeps addTxToWallet from taking its wallet-unrelated
+// early-out: the tx is instead recorded, and for SQL backends the store-level
+// CreateTx / MarkInputsSpent path then arbitrates the double-spend before it
+// can broadcast unrecorded.
+func TestSpendsWalletOutputConflictingNoChangeSpend(t *testing.T) {
+	t.Parallel()
+
+	w, m := createStartedWalletWithMocks(t)
+
+	// The no-change tx pays a single output to an address the wallet does
+	// not own, and spends one prior outpoint O.
+	unownedAddr := mustNewStandalonePubKeyAddr(t)
+	unownedScript := mustPayToAddrScript(unownedAddr)
+
+	spentOutPoint := wire.OutPoint{Hash: chainhash.Hash{0xcc}, Index: 1}
+	tx := &wire.MsgTx{
+		TxIn:  []*wire.TxIn{{PreviousOutPoint: spentOutPoint}},
+		TxOut: []*wire.TxOut{{Value: 10000, PkScript: unownedScript}},
+	}
+
+	// O is already spent by another unmined wallet tx, so it is not a
+	// current UTXO and GetUtxo misses it.
+	m.store.On("GetUtxo", mock.Anything, db.GetUtxoQuery{
+		WalletID: w.id,
+		OutPoint: spentOutPoint,
+	}).Return((*db.UtxoInfo)(nil), db.ErrUtxoNotFound).Once()
+
+	// O's parent is a recorded wallet tx that owns output index 1, so the
+	// wallet still owns the now-spent output.
+	m.store.On("GetTxDetail", mock.Anything, db.GetTxDetailQuery{
+		WalletID: w.id,
+		Txid:     spentOutPoint.Hash,
+	}).Return(&db.TxDetailInfo{
+		OwnedOutputs: []db.TxOwnedOutput{{Index: 1, Amount: 5000}},
+	}, nil).Once()
+
+	spendsOurs, err := w.spendsWalletOutput(t.Context(), tx)
+	require.NoError(t, err)
+
+	// The conflicting spend must not be classified as wallet-unrelated.
+	require.True(t, spendsOurs)
 }
 
 // mustPayToAddrScript is a helper function to create a PkScript for a given


### PR DESCRIPTION
## Summary

Route the wallet's tx publisher path through `db.Store`: kvdb
implements `CreateTx` and `InvalidateUnminedTx`, and wallet code
records transactions, filters owned addresses, and cleans up
invalid txs through the store boundary instead of legacy
wtxmgr calls. Migrates the kvdb test fixtures from the legacy
`testManagedAddress` type to the consolidated
`bwmock.ManagedAddress` so downstream branches can reuse the
shared mock surface.

Stack position: **#6** of the kvdb-migration stack. Split out
from #1230 per
[Task 145](.lgtm/tasks/145-split-impl-tx-creator-store.md);
stacks on #1230 because the downstream chain (PSBT + runtime)
needs both PR 1's tx-creator surface AND PR 2's
`bwmock.ManagedAddress` migration to compile.

## Changes

- `kvdb.Store.CreateTx` — records a transaction record + credits
  in one walletdb update; new test helpers extend the legacy
  txstore fixture for the new write path.
- `kvdb.Store.InvalidateUnminedTx` — removes one unmined tx via
  the legacy txstore.
- `Wallet.ProcessTransaction` (tx recording), owned-address
  filtering, and invalid-tx cleanup route through `db.Store`
  instead of direct legacy txstore reads.
- New `tx publisher store matchers` test helpers + mock
  expectations.
- `kvdb` tests migrate from `testManagedAddress` to
  `bwmock.ManagedAddress` (the consolidated mock from Task 119)
  so downstream branches inherit a single canonical
  ManagedAddress mock surface.

## Test plan

- [ ] `GOWORK=off go test ./wallet/internal/db/kvdb -run 'Test(CreateTx|InvalidateUnminedTx)'`
- [ ] `GOWORK=off go test ./wallet -run 'Test.*TxPublisher|Test.*Record|Test.*Invalid'`
- [ ] `GOWORK=off go test ./wallet/internal/db/kvdb ./wallet`
- [ ] CI green on Format / compilation / lint check