### PR TITLE
wallet: SQL-only signer account-secret fallback

### DIFF
--- a/wallet/cache.go
+++ b/wallet/cache.go
@@ -21,6 +21,12 @@ type runtimeCache interface {
 	GetAccount(ctx context.Context,
 		query db.GetAccountQuery) (*db.AccountInfo, error)
 
+	// GetAccountSecret returns encrypted account-level signing material.
+	// The result mirrors the underlying db.AccountStore.GetAccountSecret
+	// contract and never contains plaintext key material.
+	GetAccountSecret(ctx context.Context,
+		query db.GetAccountSecretQuery) (*db.AccountSecret, error)
+
 	// ListAccounts returns accounts matching the given query. The result
 	// mirrors the underlying db.AccountStore.ListAccounts contract.
 	ListAccounts(ctx context.Context,
@@ -72,6 +78,20 @@ func (c *storeRuntimeCache) GetAccount(ctx context.Context,
 	query db.GetAccountQuery) (*db.AccountInfo, error) {
 
 	return c.store.GetAccount(ctx, query)
+}
+
+// GetAccountSecret delegates to the underlying db.Store.
+//
+// NOTE: pass-through today. See storeRuntimeCache's TODO(yy).
+//
+// TODO(yy): drop the wrapcheck exemption once the cache layer wraps
+// store errors with its own typed errors.
+//
+//nolint:wrapcheck
+func (c *storeRuntimeCache) GetAccountSecret(ctx context.Context,
+	query db.GetAccountSecretQuery) (*db.AccountSecret, error) {
+
+	return c.store.GetAccountSecret(ctx, query)
 }
 
 // ListAccounts delegates to the underlying db.Store.

--- a/wallet/internal/bwtest/mock/store.go
+++ b/wallet/internal/bwtest/mock/store.go
@@ -265,6 +265,18 @@ func (m *Store) GetAddressSecret(ctx context.Context,
 	return args.Get(0).(*db.AddressSecret), args.Error(1)
 }
 
+// GetAccountSecret implements the db.AccountStore interface.
+func (m *Store) GetAccountSecret(ctx context.Context,
+	query db.GetAccountSecretQuery) (*db.AccountSecret, error) {
+
+	args := m.Called(ctx, query)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*db.AccountSecret), args.Error(1)
+}
+
 // ListAddressTypes implements the db.AddressStore interface.
 func (m *Store) ListAddressTypes(ctx context.Context) (
 	[]db.AddressTypeInfo, error) {

--- a/wallet/internal/db/accounts_common.go
+++ b/wallet/internal/db/accounts_common.go
@@ -33,6 +33,12 @@ var (
 	// reports success but does not return any derived account material.
 	ErrNilDerivedAccountData = errors.New("derived account data is nil")
 
+	// ErrAccountSecretUnavailable is returned when a backend does not expose
+	// store-side account secret material through AccountStore.
+	ErrAccountSecretUnavailable = errors.New(
+		"account secret unavailable",
+	)
+
 	// errMissingDerivedPublicKey is returned when the derivation callback
 	// returns data with an empty public key. Every derived account must
 	// have a public key.
@@ -58,6 +64,20 @@ var (
 func (params *CreateDerivedAccountParams) Validate() error {
 	if params.Name == "" {
 		return ErrMissingAccountName
+	}
+
+	return nil
+}
+
+// Validate checks whether a GetAccountSecretQuery identifies exactly one
+// account selector.
+func (query GetAccountSecretQuery) Validate() error {
+	if query.Name == nil && query.AccountNumber == nil {
+		return ErrInvalidAccountQuery
+	}
+
+	if query.Name != nil && query.AccountNumber != nil {
+		return ErrInvalidAccountQuery
 	}
 
 	return nil

--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -443,6 +443,37 @@ type AccountInfo struct {
 	rowID int64
 }
 
+// AccountSecret holds the encrypted account-level key material used by signing
+// operations. The encrypted private key must be decrypted by the caller through
+// the wallet key vault. This type intentionally carries no plaintext key
+// material.
+type AccountSecret struct {
+	// WalletID is the ID of the wallet that owns the account.
+	WalletID uint32
+
+	// Scope is the key scope the account belongs to.
+	Scope KeyScope
+
+	// AccountNumber is the BIP44 account index for derived accounts. Imported
+	// accounts have no account number and leave this field at zero.
+	AccountNumber uint32
+
+	// AccountName is the human-readable account name.
+	AccountName string
+
+	// PublicKey is the account-level extended public key in plaintext.
+	PublicKey []byte
+
+	// EncryptedPrivateKey is the account-level extended private key encrypted
+	// by the wallet's key vault. A nil value means the account has no private
+	// account material and cannot sign derived child keys.
+	EncryptedPrivateKey []byte
+
+	// MasterKeyFingerprint is the fingerprint of the root master key
+	// corresponding to the account key.
+	MasterKeyFingerprint uint32
+}
+
 // ScopeAddrSchema is the address schema of a particular KeyScope. It is
 // persisted on the key_scopes row and consulted when deriving any keys
 // for a particular scope to know how to encode the public keys as
@@ -563,6 +594,25 @@ type GetAccountQuery struct {
 	// coinbase maturity, locked-output exclusion) use Store.Balance with
 	// BalanceParams instead.
 	SkipBalance bool
+}
+
+// GetAccountSecretQuery contains the parameters for querying account-level
+// signing material. The query must specify either the account name or the
+// account number within the provided wallet and scope.
+type GetAccountSecretQuery struct {
+	// WalletID is the ID of the wallet to query.
+	WalletID uint32
+
+	// Scope is the key scope of the account.
+	Scope KeyScope
+
+	// Name is the name of the account to query. If nil, the query uses
+	// AccountNumber.
+	Name *string
+
+	// AccountNumber is the account number to query. If nil, the query uses
+	// Name.
+	AccountNumber *uint32
 }
 
 // ListAccountsQuery holds the set of options for a ListAccounts query.

--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -227,6 +227,13 @@ type AccountStore interface {
 	GetAccount(ctx context.Context, query GetAccountQuery) (
 		*AccountInfo, error)
 
+	// GetAccountSecret retrieves encrypted account-level signing material for
+	// one account. The returned EncryptedPrivateKey is still ciphertext;
+	// callers must decrypt it through the wallet key vault before deriving
+	// private child keys.
+	GetAccountSecret(ctx context.Context, query GetAccountSecretQuery) (
+		*AccountSecret, error)
+
 	// ListAccounts returns a slice of AccountInfo for all accounts,
 	// optionally filtered by name or key scope. It returns an empty slice
 	// if no accounts are found.

--- a/wallet/internal/db/itest/account_store_test.go
+++ b/wallet/internal/db/itest/account_store_test.go
@@ -887,6 +887,88 @@ func TestGetAccount(t *testing.T) {
 	}
 }
 
+// TestGetAccountSecret verifies that GetAccountSecret returns account rows
+// with encrypted private key material, watch-only nil material, and not-found
+// errors as distinct outcomes.
+func TestGetAccountSecret(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-get-account-secret")
+	scope := db.KeyScopeBIP0084
+	pubKey := []byte("derived-account-pubkey")
+	privKey := []byte("encrypted-account-privkey")
+
+	const fingerprint = uint32(0xAABBCCDD)
+
+	derived, err := store.CreateDerivedAccount(
+		t.Context(), db.CreateDerivedAccountParams{
+			WalletID: walletID,
+			Scope:    scope,
+			Name:     "derived",
+		}, func(_ context.Context, _ db.KeyScope, _ uint32,
+			walletIsWatchOnly bool) (*db.DerivedAccountData, error) {
+
+			require.False(t, walletIsWatchOnly)
+
+			return &db.DerivedAccountData{
+				PublicKey:            pubKey,
+				EncryptedPrivateKey:  privKey,
+				MasterKeyFingerprint: fingerprint,
+			}, nil
+		},
+	)
+	require.NoError(t, err)
+
+	secret, err := store.GetAccountSecret(
+		t.Context(), db.GetAccountSecretQuery{
+			WalletID:      walletID,
+			Scope:         scope,
+			AccountNumber: &derived.AccountNumber,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, walletID, secret.WalletID)
+	require.Equal(t, scope, secret.Scope)
+	require.Equal(t, derived.AccountNumber, secret.AccountNumber)
+	require.Equal(t, "derived", secret.AccountName)
+	require.Equal(t, pubKey, secret.PublicKey)
+	require.Equal(t, privKey, secret.EncryptedPrivateKey)
+	require.Equal(t, fingerprint, secret.MasterKeyFingerprint)
+
+	watchOnlyName := "watch-only-import"
+	_, err = store.CreateImportedAccount(
+		t.Context(), db.CreateImportedAccountParams{
+			WalletID:  walletID,
+			Name:      watchOnlyName,
+			Scope:     scope,
+			PublicKey: []byte("watch-only-pubkey"),
+		},
+	)
+	require.NoError(t, err)
+
+	secret, err = store.GetAccountSecret(
+		t.Context(), db.GetAccountSecretQuery{
+			WalletID: walletID,
+			Scope:    scope,
+			Name:     &watchOnlyName,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, watchOnlyName, secret.AccountName)
+	require.Nil(t, secret.EncryptedPrivateKey)
+
+	missing := uint32(999)
+	_, err = store.GetAccountSecret(
+		t.Context(), db.GetAccountSecretQuery{
+			WalletID:      walletID,
+			Scope:         scope,
+			AccountNumber: &missing,
+		},
+	)
+	require.ErrorIs(t, err, db.ErrAccountNotFound)
+}
+
 // TestGetAccountWatchOnlyMapping verifies that GetAccount preserves
 // representative watch-only flags on read.
 func TestGetAccountWatchOnlyMapping(t *testing.T) {

--- a/wallet/internal/db/kvdb/accountstore.go
+++ b/wallet/internal/db/kvdb/accountstore.go
@@ -519,6 +519,19 @@ func (s *Store) GetAccount(_ context.Context,
 	return info, nil
 }
 
+// GetAccountSecret reports that kvdb account secrets are not exposed through
+// the store-side account-secret contract.
+func (s *Store) GetAccountSecret(_ context.Context,
+	query db.GetAccountSecretQuery) (*db.AccountSecret, error) {
+
+	err := query.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, db.ErrAccountSecretUnavailable
+}
+
 // lookupAccount performs the per-transaction work of GetAccount: scope
 // resolution, account-number lookup, AccountInfo build, contract
 // enforcement, and optional balance attachment.

--- a/wallet/internal/db/pg/accounts.go
+++ b/wallet/internal/db/pg/accounts.go
@@ -43,6 +43,41 @@ func (s *Store) GetAccount(ctx context.Context,
 	return account, nil
 }
 
+// GetAccountSecret retrieves encrypted account-level signing material for one
+// account.
+func (s *Store) GetAccountSecret(ctx context.Context,
+	query db.GetAccountSecretQuery) (*db.AccountSecret, error) {
+
+	err := query.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	var secret *db.AccountSecret
+
+	err = s.execRead(ctx, func(q *sqlc.Queries) error {
+		row, err := q.GetAccountSecret(ctx, sqlc.GetAccountSecretParams{
+			WalletID:      int64(query.WalletID),
+			Purpose:       int64(query.Scope.Purpose),
+			CoinType:      int64(query.Scope.Coin),
+			AccountNumber: db.NullableUint32ToSQLInt64(query.AccountNumber),
+			AccountName:   db.NullableStringToSQLNullString(query.Name),
+		})
+		if err != nil {
+			return mapGetAccountSecretErr(err, query)
+		}
+
+		secret, err = accountSecretRowToInfo(row)
+
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return secret, nil
+}
+
 // ListAccounts returns a slice of AccountInfo for all accounts, optionally
 // filtered by name or key scope.
 func (s *Store) ListAccounts(ctx context.Context,
@@ -473,6 +508,55 @@ func accountRowToInfo[T accountInfoRow](row T) (*db.AccountInfo, error) {
 	)
 }
 
+// accountSecretRowToInfo converts a PostgreSQL account-secret row to the
+// backend-independent AccountSecret shape.
+func accountSecretRowToInfo(
+	row sqlc.GetAccountSecretRow) (*db.AccountSecret, error) {
+
+	walletID, err := db.Int64ToUint32(row.WalletID)
+	if err != nil {
+		return nil, fmt.Errorf("wallet ID: %w", err)
+	}
+
+	purpose, err := db.Int64ToUint32(row.Purpose)
+	if err != nil {
+		return nil, fmt.Errorf("scope purpose: %w", err)
+	}
+
+	coin, err := db.Int64ToUint32(row.CoinType)
+	if err != nil {
+		return nil, fmt.Errorf("scope coin type: %w", err)
+	}
+
+	var accountNumber uint32
+	if row.AccountNumber.Valid {
+		accountNumber, err = db.Int64ToUint32(row.AccountNumber.Int64)
+		if err != nil {
+			return nil, fmt.Errorf("account number: %w", err)
+		}
+	}
+
+	var masterFingerprint uint32
+	if row.MasterFingerprint.Valid {
+		masterFingerprint, err = db.Int64ToUint32(
+			row.MasterFingerprint.Int64,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("master fingerprint: %w", err)
+		}
+	}
+
+	return &db.AccountSecret{
+		WalletID:             walletID,
+		Scope:                db.KeyScope{Purpose: purpose, Coin: coin},
+		AccountNumber:        accountNumber,
+		AccountName:          row.AccountName,
+		PublicKey:            row.PublicKey,
+		EncryptedPrivateKey:  row.EncryptedPrivateKey,
+		MasterKeyFingerprint: masterFingerprint,
+	}, nil
+}
+
 // accountListQueries groups PostgreSQL account listing query methods.
 type accountListQueries struct {
 	q *sqlc.Queries
@@ -695,6 +779,26 @@ func (p accountGetQueries) attachBalance(ctx context.Context,
 func mapGetAccountErr(err error, query db.GetAccountQuery) error {
 	if !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("get account: %w", err)
+	}
+
+	if query.Name != nil {
+		return fmt.Errorf("account %q in scope %d/%d: %w", *query.Name,
+			query.Scope.Purpose, query.Scope.Coin,
+			db.ErrAccountNotFound)
+	}
+
+	return fmt.Errorf("account %d in scope %d/%d: %w",
+		*query.AccountNumber, query.Scope.Purpose, query.Scope.Coin,
+		db.ErrAccountNotFound)
+}
+
+// mapGetAccountSecretErr returns the typed ErrAccountNotFound when err is
+// sql.ErrNoRows, falling back to a wrapped form otherwise.
+func mapGetAccountSecretErr(err error,
+	query db.GetAccountSecretQuery) error {
+
+	if !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("get account secret: %w", err)
 	}
 
 	if query.Name != nil {

--- a/wallet/internal/db/sqlite/accounts.go
+++ b/wallet/internal/db/sqlite/accounts.go
@@ -43,6 +43,41 @@ func (s *Store) GetAccount(ctx context.Context,
 	return account, nil
 }
 
+// GetAccountSecret retrieves encrypted account-level signing material for one
+// account.
+func (s *Store) GetAccountSecret(ctx context.Context,
+	query db.GetAccountSecretQuery) (*db.AccountSecret, error) {
+
+	err := query.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	var secret *db.AccountSecret
+
+	err = s.execRead(ctx, func(q *sqlc.Queries) error {
+		row, err := q.GetAccountSecret(ctx, sqlc.GetAccountSecretParams{
+			WalletID:      int64(query.WalletID),
+			Purpose:       int64(query.Scope.Purpose),
+			CoinType:      int64(query.Scope.Coin),
+			AccountNumber: db.NullableUint32ToSQLInt64(query.AccountNumber),
+			AccountName:   db.NullableStringToSQLNullString(query.Name),
+		})
+		if err != nil {
+			return mapGetAccountSecretErr(err, query)
+		}
+
+		secret, err = accountSecretRowToInfo(row)
+
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return secret, nil
+}
+
 // ListAccounts returns a slice of AccountInfo for all accounts, optionally
 // filtered by name or key scope.
 func (s *Store) ListAccounts(ctx context.Context,
@@ -475,6 +510,55 @@ func accountRowToInfo[T accountInfoRow](row T) (*db.AccountInfo,
 	})
 }
 
+// accountSecretRowToInfo converts a SQLite account-secret row to the
+// backend-independent AccountSecret shape.
+func accountSecretRowToInfo(
+	row sqlc.GetAccountSecretRow) (*db.AccountSecret, error) {
+
+	walletID, err := db.Int64ToUint32(row.WalletID)
+	if err != nil {
+		return nil, fmt.Errorf("wallet ID: %w", err)
+	}
+
+	purpose, err := db.Int64ToUint32(row.Purpose)
+	if err != nil {
+		return nil, fmt.Errorf("scope purpose: %w", err)
+	}
+
+	coin, err := db.Int64ToUint32(row.CoinType)
+	if err != nil {
+		return nil, fmt.Errorf("scope coin type: %w", err)
+	}
+
+	var accountNumber uint32
+	if row.AccountNumber.Valid {
+		accountNumber, err = db.Int64ToUint32(row.AccountNumber.Int64)
+		if err != nil {
+			return nil, fmt.Errorf("account number: %w", err)
+		}
+	}
+
+	var masterFingerprint uint32
+	if row.MasterFingerprint.Valid {
+		masterFingerprint, err = db.Int64ToUint32(
+			row.MasterFingerprint.Int64,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("master fingerprint: %w", err)
+		}
+	}
+
+	return &db.AccountSecret{
+		WalletID:             walletID,
+		Scope:                db.KeyScope{Purpose: purpose, Coin: coin},
+		AccountNumber:        accountNumber,
+		AccountName:          row.AccountName,
+		PublicKey:            row.PublicKey,
+		EncryptedPrivateKey:  row.EncryptedPrivateKey,
+		MasterKeyFingerprint: masterFingerprint,
+	}, nil
+}
+
 // accountListQueries groups SQLite account listing query methods.
 type accountListQueries struct {
 	q *sqlc.Queries
@@ -697,6 +781,26 @@ func (s accountGetQueries) attachBalance(ctx context.Context,
 func mapGetAccountErr(err error, query db.GetAccountQuery) error {
 	if !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("get account: %w", err)
+	}
+
+	if query.Name != nil {
+		return fmt.Errorf("account %q in scope %d/%d: %w", *query.Name,
+			query.Scope.Purpose, query.Scope.Coin,
+			db.ErrAccountNotFound)
+	}
+
+	return fmt.Errorf("account %d in scope %d/%d: %w",
+		*query.AccountNumber, query.Scope.Purpose, query.Scope.Coin,
+		db.ErrAccountNotFound)
+}
+
+// mapGetAccountSecretErr returns the typed ErrAccountNotFound when err is
+// sql.ErrNoRows, falling back to a wrapped form otherwise.
+func mapGetAccountSecretErr(err error,
+	query db.GetAccountSecretQuery) error {
+
+	if !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("get account secret: %w", err)
 	}
 
 	if query.Name != nil {

--- a/wallet/internal/sql/pg/queries/accounts.sql
+++ b/wallet/internal/sql/pg/queries/accounts.sql
@@ -56,6 +56,37 @@ INSERT INTO account_secrets (
     $1, $2
 );
 
+-- name: GetAccountSecret :one
+-- Returns account-level key material for signing. The account row is returned
+-- even when no account_secrets row exists so callers can distinguish a
+-- watch-only account from an absent account.
+SELECT
+    a.wallet_id,
+    ks.purpose,
+    ks.coin_type,
+    a.account_number,
+    a.account_name,
+    a.public_key,
+    acs.encrypted_private_key,
+    a.master_fingerprint
+FROM accounts AS a
+INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
+WHERE
+    a.wallet_id = sqlc.arg('wallet_id')
+    AND ks.purpose = sqlc.arg('purpose')
+    AND ks.coin_type = sqlc.arg('coin_type')
+    AND (
+        (
+            sqlc.narg('account_number')::BIGINT IS NOT NULL
+            AND a.account_number = sqlc.narg('account_number')::BIGINT
+        )
+        OR (
+            sqlc.narg('account_name')::TEXT IS NOT NULL
+            AND a.account_name = sqlc.narg('account_name')::TEXT
+        )
+    );
+
 -- name: GetAccountByScopeAndName :one
 -- Returns a single account by scope id and account name.
 SELECT

--- a/wallet/internal/sql/pg/sqlc/accounts.sql.go
+++ b/wallet/internal/sql/pg/sqlc/accounts.sql.go
@@ -715,6 +715,79 @@ func (q *Queries) GetAccountPropsById(ctx context.Context, id int64) (GetAccount
 	return i, err
 }
 
+const GetAccountSecret = `-- name: GetAccountSecret :one
+SELECT
+    a.wallet_id,
+    ks.purpose,
+    ks.coin_type,
+    a.account_number,
+    a.account_name,
+    a.public_key,
+    acs.encrypted_private_key,
+    a.master_fingerprint
+FROM accounts AS a
+INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
+WHERE
+    a.wallet_id = $1
+    AND ks.purpose = $2
+    AND ks.coin_type = $3
+    AND (
+        (
+            $4::BIGINT IS NOT NULL
+            AND a.account_number = $4::BIGINT
+        )
+        OR (
+            $5::TEXT IS NOT NULL
+            AND a.account_name = $5::TEXT
+        )
+    )
+`
+
+type GetAccountSecretParams struct {
+	WalletID      int64
+	Purpose       int64
+	CoinType      int64
+	AccountNumber sql.NullInt64
+	AccountName   sql.NullString
+}
+
+type GetAccountSecretRow struct {
+	WalletID            int64
+	Purpose             int64
+	CoinType            int64
+	AccountNumber       sql.NullInt64
+	AccountName         string
+	PublicKey           []byte
+	EncryptedPrivateKey []byte
+	MasterFingerprint   sql.NullInt64
+}
+
+// Returns account-level key material for signing. The account row is returned
+// even when no account_secrets row exists so callers can distinguish a
+// watch-only account from an absent account.
+func (q *Queries) GetAccountSecret(ctx context.Context, arg GetAccountSecretParams) (GetAccountSecretRow, error) {
+	row := q.queryRow(ctx, q.getAccountSecretStmt, GetAccountSecret,
+		arg.WalletID,
+		arg.Purpose,
+		arg.CoinType,
+		arg.AccountNumber,
+		arg.AccountName,
+	)
+	var i GetAccountSecretRow
+	err := row.Scan(
+		&i.WalletID,
+		&i.Purpose,
+		&i.CoinType,
+		&i.AccountNumber,
+		&i.AccountName,
+		&i.PublicKey,
+		&i.EncryptedPrivateKey,
+		&i.MasterFingerprint,
+	)
+	return i, err
+}
+
 const GetAndIncrementNextExternalIndex = `-- name: GetAndIncrementNextExternalIndex :one
 UPDATE accounts
 SET next_external_index = next_external_index + 1

--- a/wallet/internal/sql/pg/sqlc/db.go
+++ b/wallet/internal/sql/pg/sqlc/db.go
@@ -99,6 +99,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getAccountPropsByIdStmt, err = db.PrepareContext(ctx, GetAccountPropsById); err != nil {
 		return nil, fmt.Errorf("error preparing query GetAccountPropsById: %w", err)
 	}
+	if q.getAccountSecretStmt, err = db.PrepareContext(ctx, GetAccountSecret); err != nil {
+		return nil, fmt.Errorf("error preparing query GetAccountSecret: %w", err)
+	}
 	if q.getActiveUtxoLeaseLockIDStmt, err = db.PrepareContext(ctx, GetActiveUtxoLeaseLockID); err != nil {
 		return nil, fmt.Errorf("error preparing query GetActiveUtxoLeaseLockID: %w", err)
 	}
@@ -407,6 +410,11 @@ func (q *Queries) Close() error {
 	if q.getAccountPropsByIdStmt != nil {
 		if cerr := q.getAccountPropsByIdStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getAccountPropsByIdStmt: %w", cerr)
+		}
+	}
+	if q.getAccountSecretStmt != nil {
+		if cerr := q.getAccountSecretStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getAccountSecretStmt: %w", cerr)
 		}
 	}
 	if q.getActiveUtxoLeaseLockIDStmt != nil {
@@ -773,6 +781,7 @@ type Queries struct {
 	getAccountByWalletScopeAndNameStmt          *sql.Stmt
 	getAccountByWalletScopeAndNumberStmt        *sql.Stmt
 	getAccountPropsByIdStmt                     *sql.Stmt
+	getAccountSecretStmt                        *sql.Stmt
 	getActiveUtxoLeaseLockIDStmt                *sql.Stmt
 	getAddressByScriptPubKeyStmt                *sql.Stmt
 	getAddressSecretStmt                        *sql.Stmt
@@ -864,6 +873,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getAccountByWalletScopeAndNameStmt:          q.getAccountByWalletScopeAndNameStmt,
 		getAccountByWalletScopeAndNumberStmt:        q.getAccountByWalletScopeAndNumberStmt,
 		getAccountPropsByIdStmt:                     q.getAccountPropsByIdStmt,
+		getAccountSecretStmt:                        q.getAccountSecretStmt,
 		getActiveUtxoLeaseLockIDStmt:                q.getActiveUtxoLeaseLockIDStmt,
 		getAddressByScriptPubKeyStmt:                q.getAddressByScriptPubKeyStmt,
 		getAddressSecretStmt:                        q.getAddressSecretStmt,

--- a/wallet/internal/sql/pg/sqlc/querier.go
+++ b/wallet/internal/sql/pg/sqlc/querier.go
@@ -152,6 +152,10 @@ type Querier interface {
 	GetAccountByWalletScopeAndNumber(ctx context.Context, arg GetAccountByWalletScopeAndNumberParams) (GetAccountByWalletScopeAndNumberRow, error)
 	// Returns full account properties by account id.
 	GetAccountPropsById(ctx context.Context, id int64) (GetAccountPropsByIdRow, error)
+	// Returns account-level key material for signing. The account row is returned
+	// even when no account_secrets row exists so callers can distinguish a
+	// watch-only account from an absent account.
+	GetAccountSecret(ctx context.Context, arg GetAccountSecretParams) (GetAccountSecretRow, error)
 	// Returns the lock ID for the current active lease on a UTXO ID.
 	//
 	// How:

--- a/wallet/internal/sql/sqlite/queries/accounts.sql
+++ b/wallet/internal/sql/sqlite/queries/accounts.sql
@@ -56,6 +56,39 @@ INSERT INTO account_secrets (
     ?, ?
 );
 
+-- name: GetAccountSecret :one
+-- Returns account-level key material for signing. The account row is returned
+-- even when no account_secrets row exists so callers can distinguish a
+-- watch-only account from an absent account.
+SELECT
+    a.wallet_id,
+    ks.purpose,
+    ks.coin_type,
+    a.account_number,
+    a.account_name,
+    a.public_key,
+    acs.encrypted_private_key,
+    a.master_fingerprint
+FROM accounts AS a
+INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
+WHERE
+    a.wallet_id = sqlc.arg('wallet_id')
+    AND ks.purpose = sqlc.arg('purpose')
+    AND ks.coin_type = sqlc.arg('coin_type')
+    AND (
+        (
+            cast(sqlc.narg('account_number') AS INTEGER) IS NOT NULL
+            AND a.account_number = cast(
+                sqlc.narg('account_number') AS INTEGER
+            )
+        )
+        OR (
+            cast(sqlc.narg('account_name') AS TEXT) IS NOT NULL
+            AND a.account_name = cast(sqlc.narg('account_name') AS TEXT)
+        )
+    );
+
 -- name: GetAccountByScopeAndName :one
 -- Returns a single account by scope id and account name.
 SELECT

--- a/wallet/internal/sql/sqlite/sqlc/accounts.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/accounts.sql.go
@@ -725,6 +725,81 @@ func (q *Queries) GetAccountPropsById(ctx context.Context, id int64) (GetAccount
 	return i, err
 }
 
+const GetAccountSecret = `-- name: GetAccountSecret :one
+SELECT
+    a.wallet_id,
+    ks.purpose,
+    ks.coin_type,
+    a.account_number,
+    a.account_name,
+    a.public_key,
+    acs.encrypted_private_key,
+    a.master_fingerprint
+FROM accounts AS a
+INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
+WHERE
+    a.wallet_id = ?1
+    AND ks.purpose = ?2
+    AND ks.coin_type = ?3
+    AND (
+        (
+            cast(?4 AS INTEGER) IS NOT NULL
+            AND a.account_number = cast(
+                ?4 AS INTEGER
+            )
+        )
+        OR (
+            cast(?5 AS TEXT) IS NOT NULL
+            AND a.account_name = cast(?5 AS TEXT)
+        )
+    )
+`
+
+type GetAccountSecretParams struct {
+	WalletID      int64
+	Purpose       int64
+	CoinType      int64
+	AccountNumber sql.NullInt64
+	AccountName   sql.NullString
+}
+
+type GetAccountSecretRow struct {
+	WalletID            int64
+	Purpose             int64
+	CoinType            int64
+	AccountNumber       sql.NullInt64
+	AccountName         string
+	PublicKey           []byte
+	EncryptedPrivateKey []byte
+	MasterFingerprint   sql.NullInt64
+}
+
+// Returns account-level key material for signing. The account row is returned
+// even when no account_secrets row exists so callers can distinguish a
+// watch-only account from an absent account.
+func (q *Queries) GetAccountSecret(ctx context.Context, arg GetAccountSecretParams) (GetAccountSecretRow, error) {
+	row := q.queryRow(ctx, q.getAccountSecretStmt, GetAccountSecret,
+		arg.WalletID,
+		arg.Purpose,
+		arg.CoinType,
+		arg.AccountNumber,
+		arg.AccountName,
+	)
+	var i GetAccountSecretRow
+	err := row.Scan(
+		&i.WalletID,
+		&i.Purpose,
+		&i.CoinType,
+		&i.AccountNumber,
+		&i.AccountName,
+		&i.PublicKey,
+		&i.EncryptedPrivateKey,
+		&i.MasterFingerprint,
+	)
+	return i, err
+}
+
 const GetAndIncrementNextExternalIndex = `-- name: GetAndIncrementNextExternalIndex :one
 UPDATE accounts
 SET next_external_index = next_external_index + 1

--- a/wallet/internal/sql/sqlite/sqlc/db.go
+++ b/wallet/internal/sql/sqlite/sqlc/db.go
@@ -99,6 +99,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getAccountPropsByIdStmt, err = db.PrepareContext(ctx, GetAccountPropsById); err != nil {
 		return nil, fmt.Errorf("error preparing query GetAccountPropsById: %w", err)
 	}
+	if q.getAccountSecretStmt, err = db.PrepareContext(ctx, GetAccountSecret); err != nil {
+		return nil, fmt.Errorf("error preparing query GetAccountSecret: %w", err)
+	}
 	if q.getActiveUtxoLeaseLockIDStmt, err = db.PrepareContext(ctx, GetActiveUtxoLeaseLockID); err != nil {
 		return nil, fmt.Errorf("error preparing query GetActiveUtxoLeaseLockID: %w", err)
 	}
@@ -407,6 +410,11 @@ func (q *Queries) Close() error {
 	if q.getAccountPropsByIdStmt != nil {
 		if cerr := q.getAccountPropsByIdStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getAccountPropsByIdStmt: %w", cerr)
+		}
+	}
+	if q.getAccountSecretStmt != nil {
+		if cerr := q.getAccountSecretStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getAccountSecretStmt: %w", cerr)
 		}
 	}
 	if q.getActiveUtxoLeaseLockIDStmt != nil {
@@ -773,6 +781,7 @@ type Queries struct {
 	getAccountByWalletScopeAndNameStmt          *sql.Stmt
 	getAccountByWalletScopeAndNumberStmt        *sql.Stmt
 	getAccountPropsByIdStmt                     *sql.Stmt
+	getAccountSecretStmt                        *sql.Stmt
 	getActiveUtxoLeaseLockIDStmt                *sql.Stmt
 	getAddressByScriptPubKeyStmt                *sql.Stmt
 	getAddressSecretStmt                        *sql.Stmt
@@ -864,6 +873,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getAccountByWalletScopeAndNameStmt:          q.getAccountByWalletScopeAndNameStmt,
 		getAccountByWalletScopeAndNumberStmt:        q.getAccountByWalletScopeAndNumberStmt,
 		getAccountPropsByIdStmt:                     q.getAccountPropsByIdStmt,
+		getAccountSecretStmt:                        q.getAccountSecretStmt,
 		getActiveUtxoLeaseLockIDStmt:                q.getActiveUtxoLeaseLockIDStmt,
 		getAddressByScriptPubKeyStmt:                q.getAddressByScriptPubKeyStmt,
 		getAddressSecretStmt:                        q.getAddressSecretStmt,

--- a/wallet/internal/sql/sqlite/sqlc/querier.go
+++ b/wallet/internal/sql/sqlite/sqlc/querier.go
@@ -150,6 +150,10 @@ type Querier interface {
 	GetAccountByWalletScopeAndNumber(ctx context.Context, arg GetAccountByWalletScopeAndNumberParams) (GetAccountByWalletScopeAndNumberRow, error)
 	// Returns full account properties by account id.
 	GetAccountPropsById(ctx context.Context, id int64) (GetAccountPropsByIdRow, error)
+	// Returns account-level key material for signing. The account row is returned
+	// even when no account_secrets row exists so callers can distinguish a
+	// watch-only account from an absent account.
+	GetAccountSecret(ctx context.Context, arg GetAccountSecretParams) (GetAccountSecretRow, error)
 	// Returns the lock ID for the current active lease on a UTXO ID.
 	//
 	// How:

--- a/wallet/signer.go
+++ b/wallet/signer.go
@@ -13,8 +13,10 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcwallet/internal/zero"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/keyvault"
 	"github.com/btcsuite/btcwallet/walletdb"
 )
 
@@ -34,6 +36,14 @@ var (
 	// ErrInvalidSignParam is returned when the parameters for the signing
 	// operation are invalid.
 	ErrInvalidSignParam = errors.New("invalid signing parameters")
+
+	// ErrWatchOnlyAccount is returned when account metadata exists but has no
+	// private key material available for signing.
+	ErrWatchOnlyAccount = errors.New("account is watch-only")
+
+	// ErrAccountNotInStore is returned when neither legacy waddrmgr nor the
+	// durable store can resolve the signing account.
+	ErrAccountNotInStore = errors.New("account not in store")
 )
 
 // Signer provides an interface for common, safe cryptographic operations,
@@ -698,7 +708,7 @@ func (w *Wallet) ComputeUnlockingScript(ctx context.Context,
 		return nil, err
 	}
 
-	privKey, err := w.privKeyForOutput(scriptInfo)
+	privKey, err := w.privKeyForOutput(ctx, scriptInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -720,11 +730,12 @@ func (w *Wallet) ComputeUnlockingScript(ctx context.Context,
 
 // privKeyForOutput returns the private key needed to sign for the given
 // wallet-controlled output.
-func (w *Wallet) privKeyForOutput(scriptInfo OutputScriptInfo) (
+func (w *Wallet) privKeyForOutput(ctx context.Context,
+	scriptInfo OutputScriptInfo) (
 	*btcec.PrivateKey, error) {
 
 	if canUseAddressInfoDerivation(scriptInfo.AddressInfo) {
-		return w.privKeyForAddressInfo(scriptInfo.AddressInfo)
+		return w.privKeyForAddressInfo(ctx, scriptInfo.AddressInfo)
 	}
 
 	pubKeyAddr, err := w.loadManagedPubKeyAddr(scriptInfo.Addr)
@@ -732,7 +743,7 @@ func (w *Wallet) privKeyForOutput(scriptInfo OutputScriptInfo) (
 		return nil, err
 	}
 
-	return w.resolvePrivKey(pubKeyAddr)
+	return w.resolvePrivKey(ctx, pubKeyAddr)
 }
 
 // canUseAddressInfoDerivation reports whether address metadata contains enough
@@ -747,7 +758,8 @@ func canUseAddressInfoDerivation(addressInfo AddressInfo) bool {
 
 // privKeyForAddressInfo derives the private key described by store-backed
 // address metadata.
-func (w *Wallet) privKeyForAddressInfo(addressInfo AddressInfo) (
+func (w *Wallet) privKeyForAddressInfo(ctx context.Context,
+	addressInfo AddressInfo) (
 	*btcec.PrivateKey, error) {
 
 	derivation := addressInfo.Derivation
@@ -764,7 +776,9 @@ func (w *Wallet) privKeyForAddressInfo(addressInfo AddressInfo) (
 		MasterKeyFingerprint: derivation.MasterKeyFingerprint,
 	}
 
-	return w.resolveDerivedPathPrivKey(derivation.KeyScope, derivationPath)
+	return w.resolveDerivedPathPrivKey(
+		ctx, derivation.KeyScope, derivationPath,
+	)
 }
 
 // loadManagedPubKeyAddr loads a managed pubkey address for signer-private key
@@ -801,7 +815,8 @@ func (w *Wallet) loadManagedPubKeyAddr(addr btcutil.Address) (
 
 // resolvePrivKey resolves the private key for a managed pubkey address without
 // using output-script inspection as the private-key lookup seam.
-func (w *Wallet) resolvePrivKey(pubKeyAddr waddrmgr.ManagedPubKeyAddress) (
+func (w *Wallet) resolvePrivKey(ctx context.Context,
+	pubKeyAddr waddrmgr.ManagedPubKeyAddress) (
 	*btcec.PrivateKey, error) {
 
 	// Imported spendable keys have no derivation path, so we fall back to the
@@ -821,12 +836,13 @@ func (w *Wallet) resolvePrivKey(pubKeyAddr waddrmgr.ManagedPubKeyAddress) (
 			pubKeyAddr.Address())
 	}
 
-	return w.resolveDerivedPathPrivKey(keyScope, derivationPath)
+	return w.resolveDerivedPathPrivKey(ctx, keyScope, derivationPath)
 }
 
 // resolveDerivedPathPrivKey resolves one derived private key through the scoped
 // manager cache or the database-backed fallback.
-func (w *Wallet) resolveDerivedPathPrivKey(keyScope waddrmgr.KeyScope,
+func (w *Wallet) resolveDerivedPathPrivKey(ctx context.Context,
+	keyScope waddrmgr.KeyScope,
 	derivationPath waddrmgr.DerivationPath) (*btcec.PrivateKey, error) {
 
 	// TODO(yy): SQL-only accounts (created via Store.CreateDerivedAccount
@@ -840,6 +856,22 @@ func (w *Wallet) resolveDerivedPathPrivKey(keyScope waddrmgr.KeyScope,
 	// AccountPubKey plumbing on the public-key side.
 	accountManager, err := w.addrStore.FetchScopedKeyManager(keyScope)
 	if err != nil {
+		if isWaddrmgrAccountClassError(
+			err, waddrmgr.ErrScopeNotFound,
+			waddrmgr.ErrAccountNotFound,
+		) {
+
+			privKey, storeErr := w.resolveDerivedPrivKeyFromStore(
+				ctx, keyScope, derivationPath,
+			)
+			if storeErr != nil {
+				return nil, fmt.Errorf("store account fallback after "+
+					"legacy scope miss: %w: %w", err, storeErr)
+			}
+
+			return privKey, nil
+		}
+
 		return nil, fmt.Errorf("fetch scoped key manager: %w", err)
 	}
 
@@ -851,11 +883,28 @@ func (w *Wallet) resolveDerivedPathPrivKey(keyScope waddrmgr.KeyScope,
 	// Only a cold account cache warrants the slower DB-backed fallback. Other
 	// derivation errors are real failures that re-running through the database
 	// will not repair.
-	if !waddrmgr.IsError(err, waddrmgr.ErrAccountNotCached) {
+	if !isWaddrmgrAccountClassError(err, waddrmgr.ErrAccountNotCached) {
 		return nil, fmt.Errorf("derive private key from cache: %w", err)
 	}
 
-	return w.resolveDerivedPrivKey(accountManager, derivationPath)
+	privKey, err = w.resolveDerivedPrivKey(accountManager, derivationPath)
+	if err == nil {
+		return privKey, nil
+	}
+
+	if !isWaddrmgrAccountClassError(err, waddrmgr.ErrAccountNotFound) {
+		return nil, err
+	}
+
+	privKey, storeErr := w.resolveDerivedPrivKeyFromStore(
+		ctx, keyScope, derivationPath,
+	)
+	if storeErr != nil {
+		return nil, fmt.Errorf("store account fallback after legacy "+
+			"account miss: %w: %w", err, storeErr)
+	}
+
+	return privKey, nil
 }
 
 // resolveDerivedPrivKey resolves one derived private key through the normal
@@ -893,6 +942,105 @@ func (w *Wallet) resolveDerivedPrivKey(accountManager waddrmgr.AccountStore,
 	}
 
 	return privKey, nil
+}
+
+// resolveDerivedPrivKeyFromStore resolves one derived private key from the
+// account-level encrypted secret stored behind the wallet store.
+func (w *Wallet) resolveDerivedPrivKeyFromStore(ctx context.Context,
+	keyScope waddrmgr.KeyScope,
+	path waddrmgr.DerivationPath) (*btcec.PrivateKey, error) {
+
+	if w.cache == nil {
+		return nil, fmt.Errorf("%w: cache", ErrMissingParam)
+	}
+
+	secret, err := w.cache.GetAccountSecret(ctx, db.GetAccountSecretQuery{
+		WalletID:      w.id,
+		Scope:         db.KeyScope(keyScope),
+		AccountNumber: &path.InternalAccount,
+	})
+	switch {
+	case errors.Is(err, db.ErrAccountSecretUnavailable),
+		errors.Is(err, db.ErrAccountNotFound):
+
+		return nil, ErrAccountNotInStore
+
+	case err != nil:
+		return nil, fmt.Errorf("fetch account secret: %w", err)
+	}
+
+	if len(secret.EncryptedPrivateKey) == 0 {
+		return nil, ErrWatchOnlyAccount
+	}
+
+	if w.keyVault == nil {
+		return nil, fmt.Errorf("%w: keyVault", ErrMissingParam)
+	}
+
+	return deriveStoredAccountChildKey(
+		w.keyVault, secret.EncryptedPrivateKey, path,
+	)
+}
+
+// deriveStoredAccountChildKey decrypts an account's encrypted private
+// key with the wallet's keyVault and walks the branch + index
+// derivation to produce the leaf private key. The intermediate hd keys
+// are zeroed via defer so the plaintext does not outlive the call.
+func deriveStoredAccountChildKey(vault keyvault.Vault,
+	encryptedAccountPriv []byte,
+	path waddrmgr.DerivationPath) (*btcec.PrivateKey, error) {
+
+	plaintext, err := vault.Decrypt(
+		waddrmgr.CKTPrivate, encryptedAccountPriv,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt account priv: %w", err)
+	}
+	defer zero.Bytes(plaintext)
+
+	acctPriv, err := hdkeychain.NewKeyFromString(string(plaintext))
+	if err != nil {
+		return nil, fmt.Errorf("parse account priv: %w", err)
+	}
+	defer acctPriv.Zero()
+
+	branchKey, err := deriveChildKey(acctPriv, path.Branch)
+	if err != nil {
+		return nil, fmt.Errorf("derive branch: %w", err)
+	}
+	defer branchKey.Zero()
+
+	addrKey, err := deriveChildKey(branchKey, path.Index)
+	if err != nil {
+		return nil, fmt.Errorf("derive index: %w", err)
+	}
+	defer addrKey.Zero()
+
+	privKey, err := addrKey.ECPrivKey()
+	if err != nil {
+		return nil, fmt.Errorf("derive private key: %w", err)
+	}
+
+	return privKey, nil
+}
+
+// isWaddrmgrAccountClassError reports whether err wraps a waddrmgr
+// ManagerError whose code belongs to the supplied set.
+func isWaddrmgrAccountClassError(err error,
+	codes ...waddrmgr.ErrorCode) bool {
+
+	var mErr waddrmgr.ManagerError
+	if !errors.As(err, &mErr) {
+		return false
+	}
+
+	for _, code := range codes {
+		if mErr.ErrorCode == code {
+			return true
+		}
+	}
+
+	return false
 }
 
 // signAndAssembleScript is a helper function that performs the final signing
@@ -1064,7 +1212,7 @@ func (w *Wallet) GetPrivKeyForAddress(ctx context.Context, a btcutil.Address) (
 	info, err := w.GetAddressInfo(ctx, a)
 	switch {
 	case err == nil && canUseAddressInfoDerivation(info):
-		return w.privKeyForAddressInfo(info)
+		return w.privKeyForAddressInfo(ctx, info)
 
 	case err == nil:
 		// Store record exists but no usable derivation info

--- a/wallet/signer_test.go
+++ b/wallet/signer_test.go
@@ -945,6 +945,109 @@ func TestComputeUnlockingScriptSQLDerivedAddress(t *testing.T) {
 	require.NoError(t, vm.Execute(), "script execution failed")
 }
 
+// TestComputeUnlockingScriptSQLOnlyAccount verifies that signing can derive a
+// private key from SQL account secrets when the account does not exist in
+// legacy waddrmgr.
+func TestComputeUnlockingScriptSQLOnlyAccount(t *testing.T) {
+	t.Parallel()
+
+	w, chain := newSQLAddressSigningWallet(t)
+	_, err := w.NewAccount(
+		t.Context(), waddrmgr.KeyScopeBIP0084, "secondary",
+	)
+	require.NoError(t, err)
+
+	chain.On(
+		"NotifyReceived",
+		mock.MatchedBy(func(addrs []btcutil.Address) bool {
+			return len(addrs) == 1
+		}),
+	).Return(nil).Once()
+
+	addr, err := w.NewAddress(
+		t.Context(), "secondary", waddrmgr.WitnessPubKey, false,
+	)
+	require.NoError(t, err)
+
+	_, err = w.loadManagedPubKeyAddr(addr)
+	require.Error(t, err)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	prevOut, tx := createDummyTestTx(pkScript)
+	fetcher := txscript.NewCannedPrevOutputFetcher(
+		prevOut.PkScript, prevOut.Value,
+	)
+	sigHashes := txscript.NewTxSigHashes(tx, fetcher)
+	params := &UnlockingScriptParams{
+		Tx:         tx,
+		InputIndex: 0,
+		Output:     prevOut,
+		SigHashes:  sigHashes,
+		HashType:   txscript.SigHashAll,
+	}
+
+	script, err := w.ComputeUnlockingScript(t.Context(), params)
+	require.NoError(t, err)
+	require.Nil(t, script.SigScript)
+	require.NotNil(t, script.Witness)
+
+	tx.TxIn[0].Witness = script.Witness
+	vm, err := txscript.NewEngine(
+		prevOut.PkScript, tx, 0, txscript.StandardVerifyFlags, nil,
+		sigHashes, prevOut.Value, fetcher,
+	)
+	require.NoError(t, err)
+	require.NoError(t, vm.Execute(), "script execution failed")
+}
+
+// TestResolveDerivedPrivKeyFromStoreRejectsWatchOnly verifies that the
+// store-only signer branch returns a precise error for accounts without
+// encrypted private key material.
+func TestResolveDerivedPrivKeyFromStoreRejectsWatchOnly(t *testing.T) {
+	t.Parallel()
+
+	w, mocks := createStartedWalletWithMocks(t)
+	path := waddrmgr.DerivationPath{InternalAccount: 3}
+	query := db.GetAccountSecretQuery{
+		WalletID:      w.id,
+		Scope:         db.KeyScope(waddrmgr.KeyScopeBIP0084),
+		AccountNumber: &path.InternalAccount,
+	}
+	mocks.store.On("GetAccountSecret", mock.Anything, query).Return(
+		&db.AccountSecret{AccountNumber: path.InternalAccount}, nil,
+	).Once()
+
+	_, err := w.resolveDerivedPrivKeyFromStore(
+		t.Context(), waddrmgr.KeyScopeBIP0084, path,
+	)
+	require.ErrorIs(t, err, ErrWatchOnlyAccount)
+}
+
+// TestResolveDerivedPrivKeyFromStoreAbsentAccount verifies that a missing
+// account row terminates the store-only signer branch with
+// ErrAccountNotInStore.
+func TestResolveDerivedPrivKeyFromStoreAbsentAccount(t *testing.T) {
+	t.Parallel()
+
+	w, mocks := createStartedWalletWithMocks(t)
+	path := waddrmgr.DerivationPath{InternalAccount: 7}
+	query := db.GetAccountSecretQuery{
+		WalletID:      w.id,
+		Scope:         db.KeyScope(waddrmgr.KeyScopeBIP0084),
+		AccountNumber: &path.InternalAccount,
+	}
+	mocks.store.On("GetAccountSecret", mock.Anything, query).Return(
+		(*db.AccountSecret)(nil), db.ErrAccountNotFound,
+	).Once()
+
+	_, err := w.resolveDerivedPrivKeyFromStore(
+		t.Context(), waddrmgr.KeyScopeBIP0084, path,
+	)
+	require.ErrorIs(t, err, ErrAccountNotInStore)
+}
+
 // TestGetPrivKeyForAddressSQLDerivedAddress verifies that GetPrivKeyForAddress
 // recovers the private key for an address whose only persistent record lives
 // in the SQL store.
@@ -1159,7 +1262,7 @@ func TestResolvePrivKeyFallsBackAfterCacheMiss(t *testing.T) {
 	mocks.pubKeyAddr.On("PrivKey").Return(privKey, nil).Once()
 
 	// Act: Resolve the private key for the managed pubkey address.
-	resolvedPrivKey, err := w.resolvePrivKey(mocks.pubKeyAddr)
+	resolvedPrivKey, err := w.resolvePrivKey(t.Context(), mocks.pubKeyAddr)
 	require.NoError(t, err)
 
 	// Assert: The fallback path returns the same private key bytes.
@@ -1335,10 +1438,22 @@ func newSQLAddressSigningWallet(t *testing.T) (*Wallet, *bwmock.Chain) {
 	legacyDB, cleanup := setupTestDB(t)
 	t.Cleanup(cleanup)
 
-	addrStore := newSpendableAddressManager(t, legacyDB)
+	addrStore, rootKey := newSpendableAddressManager(t, legacyDB)
 	t.Cleanup(func() {
 		addrStore.Close()
 	})
+	t.Cleanup(rootKey.Zero)
+
+	masterFingerprint, err := masterKeyFingerprint(rootKey)
+	require.NoError(t, err)
+
+	encryptedRoot, err := addrStore.Encrypt(
+		waddrmgr.CKTPrivate, []byte(rootKey.String()),
+	)
+	require.NoError(t, err)
+
+	rootPub, err := rootKey.Neuter()
+	require.NoError(t, err)
 
 	var w *Wallet
 
@@ -1361,8 +1476,8 @@ func newSQLAddressSigningWallet(t *testing.T) (*Wallet, *bwmock.Chain) {
 		t.Context(), db.CreateWalletParams{
 			Name:                     "sql-signing",
 			ManagerVersion:           1,
-			EncryptedMasterPrivKey:   []byte{1},
-			MasterPubKey:             []byte{2},
+			EncryptedMasterPrivKey:   encryptedRoot,
+			MasterPubKey:             []byte(rootPub.String()),
 			MasterKeyPrivParams:      []byte{3},
 			EncryptedCryptoPrivKey:   []byte{4},
 			EncryptedCryptoScriptKey: []byte{5},
@@ -1375,16 +1490,18 @@ func newSQLAddressSigningWallet(t *testing.T) (*Wallet, *bwmock.Chain) {
 			WalletID: walletInfo.ID,
 			Scope:    db.KeyScope(waddrmgr.KeyScopeBIP0084),
 			Name:     "default",
-		}, testAccountDerivationFunc(),
+		}, newAccountDeriveFn(rootKey, addrStore, masterFingerprint),
 	)
 	require.NoError(t, err)
 
 	chain := &bwmock.Chain{}
 	w = &Wallet{
-		addrStore: addrStore,
-		store:     store,
-		keyVault:  addrStore,
-		state:     newWalletState(nil),
+		addrStore:         addrStore,
+		store:             store,
+		cache:             newStoreRuntimeCache(store),
+		keyVault:          addrStore,
+		state:             newWalletState(nil),
+		masterFingerprint: masterFingerprint,
 		cfg: Config{
 			DB:          legacyDB,
 			Chain:       chain,
@@ -1405,9 +1522,9 @@ func newSQLAddressSigningWallet(t *testing.T) (*Wallet, *bwmock.Chain) {
 }
 
 // newSpendableAddressManager creates and unlocks a deterministic legacy
-// waddrmgr manager for signer integration tests.
+// waddrmgr manager and returns its root key for signer integration tests.
 func newSpendableAddressManager(t *testing.T,
-	dbConn walletdb.DB) *waddrmgr.Manager {
+	dbConn walletdb.DB) (*waddrmgr.Manager, *hdkeychain.ExtendedKey) {
 
 	t.Helper()
 
@@ -1452,7 +1569,7 @@ func newSpendableAddressManager(t *testing.T,
 	})
 	require.NoError(t, err)
 
-	return mgr
+	return mgr, rootKey
 }
 
 // testAccountDerivationFunc returns minimal spendable account material for SQL


### PR DESCRIPTION
## Summary

Read encrypted account private keys through `db.Store` and let
the signer derive child private keys for SQL-only accounts
(accounts that exist on the SQL store but have no legacy
waddrmgr counterpart). Adds the
`GetAccountSecret` contract on `AccountStore` so wallet signers
can resolve a derived address back to its account-level key
material through the store API instead of reaching into the
legacy waddrmgr directly.

Stack position: **#11** of the kvdb-migration stack — a
**sibling** of the main UTXO chain. Stacks directly on #1229
(impl-wallet-metadata-store); no other branch in the stack
depends on this work. Verified: zero references to
`GetAccountSecret` / `keyVault` / `AccountSecret` symbols across
the 9 other branches in the stack.

## Changes

- `db.AccountStore.GetAccountSecret` — new contract that
  resolves an account's encrypted master private key + chain
  code. pg/sqlite implement the lookup via a new sqlc query;
  kvdb implements it through legacy waddrmgr.
- `Wallet.cache` exposes the per-account encrypted secret so the
  signer can derive child keys without rereading the store on
  every signing call.
- `Wallet.signer` derives SQL-only private keys through a small
  `keyVault` wrapper that handles the decrypt + child-derivation
  path; the legacy waddrmgr path stays in place for accounts
  that have it.
- New cross-backend `TestGetAccountSecret` itests on pg, sqlite,
  and kvdb verify the contract.

## Test plan

- [ ] `make sqlc`
- [ ] `GOWORK=off go test ./wallet -run 'Test(ComputeUnlockingScriptSQL|GetPrivKeyForAddressSQL|ResolveDerivedPrivKeyFromStore)'`
- [ ] `GOWORK=off go test ./wallet/internal/db ./wallet/internal/db/sqlite ./wallet/internal/db/pg`
- [ ] `GOWORK=off make itest-db db=sqlite case=TestGetAccountSecret verbose=1`
- [ ] `GOWORK=off make itest-db db=postgres case=TestGetAccountSecret verbose=1`
- [ ] CI green on Format / compilation / lint check