### PR TITLE
db: cover ApplyScanBatch conformance and RollbackToBlock atomicity

### DIFF
--- a/wallet/internal/db/itest/pg_test.go
+++ b/wallet/internal/db/itest/pg_test.go
@@ -434,3 +434,25 @@ func walletUtxoSpent(t *testing.T, store *pg.Store,
 
 	return spentBy.SpentByTxID.Valid
 }
+
+// clearUtxosSpentByTxID clears all UTXO spend edges claimed by one transaction.
+func clearUtxosSpentByTxID(t *testing.T, store *pg.Store,
+	walletID uint32, txHash chainhash.Hash) {
+
+	t.Helper()
+
+	txID, ok := txIDByHash(t, store, walletID, txHash)
+	require.True(t, ok)
+
+	rows, err := store.Queries().ClearUtxosSpentByTxID(
+		t.Context(), sqlc.ClearUtxosSpentByTxIDParams{
+			WalletID: int64(walletID),
+			SpentByTxID: sql.NullInt64{
+				Int64: txID,
+				Valid: true,
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rows)
+}

--- a/wallet/internal/db/itest/scan_batch_conformance_test.go
+++ b/wallet/internal/db/itest/scan_batch_conformance_test.go
@@ -1,0 +1,299 @@
+//go:build itest
+
+package itest
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/addresstype"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/db/kvdb"
+	"github.com/btcsuite/btcwallet/wallet/internal/db/page"
+	"github.com/btcsuite/btcwallet/walletdb"
+	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+	"github.com/stretchr/testify/require"
+)
+
+// scanBatchChainParams is the network the conformance backends share so the
+// kvdb address manager and the SQL derivation callback build identical
+// scripts.
+var scanBatchChainParams = &chaincfg.RegressionNetParams
+
+// scanBatchSeed is a fixed BIP32 seed used to build a deterministic kvdb
+// address manager, so the derived account public key (and therefore every
+// derived address) is reproducible across runs and backends.
+var scanBatchSeed = []byte{
+	0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+	0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+	0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+	0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+}
+
+// realAddressDeriveFunc returns an AddressDerivationFunc that derives BIP32
+// child addresses from the account-level extended public key, building the
+// script exactly like the production wallet (and therefore the kvdb address
+// manager) does. This is what lets the SQL backends reproduce kvdb's stored
+// scripts byte-for-byte.
+func realAddressDeriveFunc() db.AddressDerivationFunc {
+	return func(_ context.Context,
+		params db.AddressDerivationParams) (*db.DerivedAddressData, error) {
+
+		accountKey, err := hdkeychain.NewKeyFromString(
+			string(params.AccountPubKey),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		branchKey, err := accountKey.Derive(params.Branch)
+		if err != nil {
+			return nil, err
+		}
+
+		addrKey, err := branchKey.Derive(params.Index)
+		if err != nil {
+			return nil, err
+		}
+
+		pubKey, err := addrKey.ECPubKey()
+		if err != nil {
+			return nil, err
+		}
+
+		pubKeyBytes := pubKey.SerializeCompressed()
+
+		walletAddrType, err := addresstype.ToWallet(params.AddrType, false)
+		if err != nil {
+			return nil, err
+		}
+
+		addr, err := walletAddrType.AddrFromPubKeyBytes(
+			pubKeyBytes, scanBatchChainParams,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		scriptPubKey, err := txscript.PayToAddrScript(addr)
+		if err != nil {
+			return nil, err
+		}
+
+		return &db.DerivedAddressData{
+			ScriptPubKey: scriptPubKey,
+			PubKey:       pubKeyBytes,
+		}, nil
+	}
+}
+
+// kvdbScanFixture bundles a real kvdb store together with the account material
+// a parallel SQL store needs to derive identical addresses.
+type kvdbScanFixture struct {
+	store       db.Store
+	scope       db.KeyScope
+	accountName string
+	accountXPub string
+}
+
+// newKVDBScanFixture builds a kvdb store backed by a real waddrmgr address
+// manager and wtxmgr transaction store seeded from scanBatchSeed. It returns
+// the store and the BIP0084 default account's name and extended public key so
+// the SQL backends can mirror the same derivation.
+func newKVDBScanFixture(t *testing.T) kvdbScanFixture {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "kvdb-scan.db")
+	dbConn, err := walletdb.Create(
+		"bdb", dbPath, true, 10*time.Second, false,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = dbConn.Close()
+	})
+
+	rootKey, err := hdkeychain.NewMaster(scanBatchSeed, scanBatchChainParams)
+	require.NoError(t, err)
+
+	pubPass := []byte("public")
+	privPass := []byte("private")
+
+	addrmgrKey := []byte("waddrmgr")
+	txmgrKey := []byte("wtxmgr")
+
+	err = walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		addrmgrNs, err := tx.CreateTopLevelBucket(addrmgrKey)
+		if err != nil {
+			return err
+		}
+
+		txmgrNs, err := tx.CreateTopLevelBucket(txmgrKey)
+		if err != nil {
+			return err
+		}
+
+		err = waddrmgr.Create(
+			addrmgrNs, rootKey, pubPass, privPass,
+			scanBatchChainParams, &waddrmgr.FastScryptOptions,
+			time.Time{},
+		)
+		if err != nil {
+			return err
+		}
+
+		return wtxmgr.Create(txmgrNs)
+	})
+	require.NoError(t, err)
+
+	var (
+		addrMgr *waddrmgr.Manager
+		txStore *wtxmgr.Store
+	)
+
+	err = walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		addrmgrNs := tx.ReadWriteBucket(addrmgrKey)
+		txmgrNs := tx.ReadWriteBucket(txmgrKey)
+
+		addrMgr, err = waddrmgr.Open(
+			addrmgrNs, pubPass, scanBatchChainParams,
+		)
+		if err != nil {
+			return err
+		}
+
+		txStore, err = wtxmgr.Open(txmgrNs, scanBatchChainParams)
+
+		return err
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		addrMgr.Close()
+	})
+
+	scope := waddrmgr.KeyScopeBIP0084
+
+	scopedMgr, err := addrMgr.FetchScopedKeyManager(scope)
+	require.NoError(t, err)
+
+	var props *waddrmgr.AccountProperties
+
+	err = walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(addrmgrKey)
+		props, err = scopedMgr.AccountProperties(
+			ns, waddrmgr.DefaultAccountNum,
+		)
+
+		return err
+	})
+	require.NoError(t, err)
+	require.NotNil(t, props.AccountPubKey)
+
+	return kvdbScanFixture{
+		store:       kvdb.NewStore(dbConn, txStore, addrMgr),
+		scope:       db.KeyScope(scope),
+		accountName: props.AccountName,
+		accountXPub: props.AccountPubKey.String(),
+	}
+}
+
+// derivedAddressKey identifies a derived address by its branch and index, the
+// stable coordinates both backends agree on.
+type derivedAddressKey struct {
+	branch uint32
+	index  uint32
+}
+
+// collectDerivedScripts returns the branch/index -> script_pub_key map for
+// every derived address the store has recorded for the account.
+func collectDerivedScripts(t *testing.T, store db.Store, walletID uint32,
+	scope db.KeyScope, accountName string) map[derivedAddressKey][]byte {
+
+	t.Helper()
+
+	req, err := page.NewRequest[uint32](64)
+	require.NoError(t, err)
+
+	query := db.ListAddressesQuery{
+		WalletID: walletID,
+		Scope:    &scope,
+		Page:     req,
+	}
+	if accountName != db.DefaultImportedAccountName {
+		query.AccountName = &accountName
+	} else {
+		query.Scope = nil
+	}
+
+	scripts := make(map[derivedAddressKey][]byte)
+	for addr, err := range store.IterAddresses(t.Context(), query) {
+		require.NoError(t, err)
+
+		if !addr.HasDerivationPath {
+			continue
+		}
+
+		key := derivedAddressKey{
+			branch: addr.Branch,
+			index:  addr.Index,
+		}
+		scripts[key] = addr.ScriptPubKey
+	}
+
+	return scripts
+}
+
+// listedAddress captures the listed coordinates of an address plus the
+// HasDerivationPath signal, so a test can assert both the path and whether the
+// row is HD-derived (a real path) versus a raw single import (no path).
+type listedAddress struct {
+	branch            uint32
+	index             uint32
+	hasDerivationPath bool
+}
+
+// collectAddressPaths returns the listed coordinates of every address the store
+// lists for the account, in IterAddresses order. Unlike collectDerivedScripts
+// it does not filter by origin, so it surfaces an imported-xpub account's
+// HD-derived rows whose origin is ImportedAccount yet carry a real path, and it
+// reports HasDerivationPath so the caller can tell those apart from raw single
+// imports.
+func collectAddressPaths(t *testing.T, store db.Store, walletID uint32,
+	scope db.KeyScope, accountName string) []listedAddress {
+
+	t.Helper()
+
+	req, err := page.NewRequest[uint32](64)
+	require.NoError(t, err)
+
+	query := db.ListAddressesQuery{
+		WalletID: walletID,
+		Scope:    &scope,
+		Page:     req,
+	}
+	if accountName != db.DefaultImportedAccountName {
+		query.AccountName = &accountName
+	} else {
+		query.Scope = nil
+	}
+
+	//nolint:prealloc // Iterator yields an unknown count.
+	var paths []listedAddress
+	for addr, err := range store.IterAddresses(t.Context(), query) {
+		require.NoError(t, err)
+
+		paths = append(paths, listedAddress{
+			branch:            addr.Branch,
+			index:             addr.Index,
+			hasDerivationPath: addr.HasDerivationPath,
+		})
+	}
+
+	return paths
+}

--- a/wallet/internal/db/itest/scan_batch_conformance_test.go
+++ b/wallet/internal/db/itest/scan_batch_conformance_test.go
@@ -297,3 +297,378 @@ func collectAddressPaths(t *testing.T, store db.Store, walletID uint32,
 
 	return paths
 }
+
+// TestApplyScanBatchHorizonsConformance proves that a non-empty Horizons batch
+// derives an identical set of addresses on kvdb and the SQL backend under
+// test. Each SQL backend (sqlite or postgres, selected by build tag) is
+// compared against an in-process kvdb store seeded from the same account key,
+// so green runs on both tags establish kvdb == sqlite == postgres parity.
+func TestApplyScanBatchHorizonsConformance(t *testing.T) {
+	t.Parallel()
+
+	fixture := newKVDBScanFixture(t)
+
+	// Build the SQL store with the same real BIP32 derivation kvdb uses.
+	sqlStore := NewTestStoreWithDerive(t, realAddressDeriveFunc())
+
+	walletID := newWallet(t, sqlStore, "wallet-scan-conformance")
+
+	// Recreate the kvdb default account inside the SQL store with the exact
+	// same account extended public key so both derive identical scripts.
+	deriveAccount := func(_ context.Context, _ db.KeyScope, _ uint32,
+		watchOnly bool) (*db.DerivedAccountData, error) {
+
+		data := &db.DerivedAccountData{
+			PublicKey:            []byte(fixture.accountXPub),
+			MasterKeyFingerprint: 0x01020304,
+		}
+		if !watchOnly {
+			data.EncryptedPrivateKey = RandomBytes(48)
+		}
+
+		return data, nil
+	}
+
+	sqlAccount, err := sqlStore.CreateDerivedAccount(
+		t.Context(), db.CreateDerivedAccountParams{
+			WalletID: walletID,
+			Scope:    fixture.scope,
+			Name:     fixture.accountName,
+		}, deriveAccount,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sqlAccount.AccountID)
+
+	// A batch that extends both branches well past index 0 forces real
+	// multi-address derivation on each backend.
+	kvdbHorizons := []db.ScanHorizon{
+		{
+			Scope:       fixture.scope,
+			Account:     waddrmgr.DefaultAccountNum,
+			AccountName: fixture.accountName,
+			Branch:      0,
+			Index:       8,
+		},
+		{
+			Scope:       fixture.scope,
+			Account:     waddrmgr.DefaultAccountNum,
+			AccountName: fixture.accountName,
+			Branch:      1,
+			Index:       3,
+		},
+	}
+	sqlHorizons := make([]db.ScanHorizon, len(kvdbHorizons))
+	copy(sqlHorizons, kvdbHorizons)
+
+	for i := range sqlHorizons {
+		sqlHorizons[i].AccountID = sqlAccount.AccountID
+	}
+
+	kvdbParams := db.ScanBatchParams{
+		WalletID: 0,
+		Horizons: kvdbHorizons,
+	}
+	sqlParams := db.ScanBatchParams{
+		WalletID: walletID,
+		Horizons: sqlHorizons,
+	}
+
+	require.NoError(t, fixture.store.ApplyScanBatch(t.Context(), kvdbParams))
+	require.NoError(t, sqlStore.ApplyScanBatch(t.Context(), sqlParams))
+
+	kvdbScripts := collectDerivedScripts(
+		t, fixture.store, 0, fixture.scope, fixture.accountName,
+	)
+	sqlScripts := collectDerivedScripts(
+		t, sqlStore, walletID, fixture.scope, fixture.accountName,
+	)
+
+	// Branch 0 derives indices 0..8 (9 addresses) and branch 1 derives
+	// indices 0..3 (4 addresses) for a total of 13 derived addresses.
+	require.Len(t, kvdbScripts, 13)
+	require.Equal(t, kvdbScripts, sqlScripts,
+		"kvdb and SQL must derive identical address scripts")
+
+	// Replaying the same batch must be a no-op on both backends: the
+	// horizon early-returns once the discovered index is below the next
+	// index, so no duplicate rows are inserted.
+	require.NoError(t, fixture.store.ApplyScanBatch(t.Context(), kvdbParams))
+	require.NoError(t, sqlStore.ApplyScanBatch(t.Context(), sqlParams))
+
+	kvdbReplay := collectDerivedScripts(
+		t, fixture.store, 0, fixture.scope, fixture.accountName,
+	)
+	sqlReplay := collectDerivedScripts(
+		t, sqlStore, walletID, fixture.scope, fixture.accountName,
+	)
+	require.Equal(t, kvdbScripts, kvdbReplay)
+	require.Equal(t, sqlScripts, sqlReplay)
+}
+
+// TestApplyScanBatchResolvesHorizonByAccountID proves the SQL backend resolves
+// a scan horizon's owning account by its durable account row ID, not by mutable
+// account name or masked account number. An imported-xpub account stores a NULL
+// account_number that the AccountInfo contract masks to 0, the same number the
+// default derived account uses, so a by-number resolution would extend the
+// wrong account. The test creates both accounts in one scope and asserts the
+// imported account ID is the one extended even when the horizon carries stale
+// name metadata, a derived account still resolves by ID, and a missing ID fails
+// the batch instead of silently extending the default account 0.
+//
+// Extension is verified two ways. The advanced next-index counters are the
+// direct evidence of which account the extension targeted, the same signal the
+// sibling invalid-child tests assert. The listing assertions then prove the
+// imported-xpub account's HD-derived rows are listable: an imported-xpub
+// account is HD, so its derived rows carry a real branch/index that
+// IterAddresses must surface (origin ImportedAccount with a populated path),
+// not reject as it once did.
+func TestApplyScanBatchResolvesHorizonByAccountID(t *testing.T) {
+	t.Parallel()
+
+	// A watch-only wallet is required because an imported-xpub account is
+	// public-only and the ADR 0012 spendable-wallet invariant rejects it on
+	// a spendable wallet.
+	const (
+		derivedAccount  = "derived-account"
+		importedAccount = "imported-xpub-account"
+	)
+
+	scope := db.KeyScopeBIP0084
+
+	store := NewTestStoreWithDerive(t, realAddressDeriveFunc())
+	walletID := newWatchOnlyWallet(t, store, "wallet-scan-by-name")
+
+	// A real account extended public key so the horizon extension can derive
+	// valid child addresses from the imported account's xpub. The mock derive
+	// callback ignores the key, but CreateDerivedAccount stores it verbatim
+	// and the imported xpub below must parse, so a real key keeps both paths
+	// consistent.
+	fixture := newKVDBScanFixture(t)
+
+	importedKey, err := hdkeychain.NewKeyFromString(fixture.accountXPub)
+	require.NoError(t, err)
+
+	importedKey, err = importedKey.Derive(0)
+	require.NoError(t, err)
+
+	importedXPub := importedKey.String()
+
+	// The default derived account allocates account number 0; an
+	// imported-xpub account stores a NULL number that masks to 0 too, so
+	// both share the by-number fast-path identity and only AccountName can
+	// disambiguate them.
+	deriveAccount := func(_ context.Context, _ db.KeyScope, _ uint32,
+		_ bool) (*db.DerivedAccountData, error) {
+
+		return &db.DerivedAccountData{
+			PublicKey:            []byte(fixture.accountXPub),
+			MasterKeyFingerprint: 0x01020304,
+		}, nil
+	}
+
+	derivedInfo, err := store.CreateDerivedAccount(
+		t.Context(), db.CreateDerivedAccountParams{
+			WalletID: walletID,
+			Scope:    scope,
+			Name:     derivedAccount,
+		}, deriveAccount,
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint32Ptr(0), derivedInfo.AccountNumber)
+	require.NotNil(t, derivedInfo.AccountID)
+
+	importedInfo, err := store.CreateImportedAccount(
+		t.Context(), db.CreateImportedAccountParams{
+			WalletID:  walletID,
+			Name:      importedAccount,
+			Scope:     scope,
+			PublicKey: []byte(importedXPub),
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, importedInfo.AccountID)
+
+	// Emit a horizon for the imported account: Account is masked to 0 (the
+	// default derived account's number) and AccountName is stale metadata, so
+	// only AccountID resolves the intended target.
+	err = store.ApplyScanBatch(t.Context(), db.ScanBatchParams{
+		WalletID: walletID,
+		Horizons: []db.ScanHorizon{{
+			AccountID:   importedInfo.AccountID,
+			Scope:       scope,
+			Account:     0,
+			AccountName: "stale-imported-name",
+			Branch:      0,
+			Index:       3,
+		}},
+	})
+	require.NoError(t, err)
+
+	// The imported account's external next index must advance to 4 (indices
+	// 0..3 derived); the default derived account (also number 0) must stay at
+	// 0, proving the horizon resolved by ID and not by mutable name metadata or
+	// the masked number.
+	imported := getAccountByName(t, store, walletID, scope, importedAccount)
+	require.Equal(t, uint32(4), imported.ExternalKeyCount,
+		"imported account ID must be the one extended")
+
+	derived := getAccountByName(t, store, walletID, scope, derivedAccount)
+	require.Equal(t, uint32(0), derived.ExternalKeyCount,
+		"default derived account must not be extended by an imported "+
+			"account ID horizon")
+
+	// The extended imported-xpub account is HD, so its derived rows must be
+	// listable with their branch/index, not rejected as a branch/index path on
+	// an imported account. IterAddresses surfaces them with the account's
+	// ImportedAccount origin and the external branch the horizon extended.
+	// Each row is HD-derived, so HasDerivationPath must be true: this is what
+	// lets the wallet-layer mapper tell an imported-xpub child at (0, 0) apart
+	// from a raw single import at the same zero coordinates.
+	paths := collectAddressPaths(
+		t, store, walletID, scope, importedAccount,
+	)
+	require.Equal(t, []listedAddress{
+		{branch: 0, index: 0, hasDerivationPath: true},
+		{branch: 0, index: 1, hasDerivationPath: true},
+		{branch: 0, index: 2, hasDerivationPath: true},
+		{branch: 0, index: 3, hasDerivationPath: true},
+	}, paths, "imported-xpub HD addresses must list with their path")
+
+	// A raw single import is the contrasting shape: it lands in the keyless
+	// "imported" bucket with no chain position, so it must read back with no
+	// path and HasDerivationPath false, the inverse of the imported-xpub HD
+	// children above. This is the signal's whole reason to exist, since both
+	// shapes share the ImportedAccount origin.
+	rawImport, err := store.NewImportedAddress(
+		t.Context(), db.NewImportedAddressParams{
+			WalletID:     walletID,
+			AddressType:  db.WitnessPubKey,
+			PubKey:       RandomBytes(33),
+			ScriptPubKey: RandomBytes(32),
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, rawImport.IsImported)
+	require.False(t, rawImport.HasDerivationPath,
+		"a raw single import must not carry a derivation path")
+
+	rawPaths := collectAddressPaths(
+		t, store, walletID, scope, db.DefaultImportedAccountName,
+	)
+	require.Equal(t, []listedAddress{
+		{branch: 0, index: 0, hasDerivationPath: false},
+	}, rawPaths, "raw import must list with no path and "+
+		"HasDerivationPath false")
+
+	// A horizon carrying the derived account ID still resolves and extends only
+	// the derived account, regardless of its AccountName metadata.
+	err = store.ApplyScanBatch(t.Context(), db.ScanBatchParams{
+		WalletID: walletID,
+		Horizons: []db.ScanHorizon{{
+			AccountID:   derivedInfo.AccountID,
+			Scope:       scope,
+			Account:     0,
+			AccountName: "stale-derived-name",
+			Branch:      0,
+			Index:       1,
+		}},
+	})
+	require.NoError(t, err)
+
+	derived = getAccountByName(t, store, walletID, scope, derivedAccount)
+	require.Equal(t, uint32(2), derived.ExternalKeyCount,
+		"derived account ID must resolve and extend")
+
+	// A horizon without an account ID must fail the batch outright. The
+	// fail-safe forbids falling back to mutable names or the default account 0.
+	err = store.ApplyScanBatch(t.Context(), db.ScanBatchParams{
+		WalletID: walletID,
+		Horizons: []db.ScanHorizon{{
+			Scope:       scope,
+			Account:     0,
+			AccountName: importedAccount,
+			Branch:      0,
+			Index:       5,
+		}},
+	})
+	require.ErrorIs(t, err, db.ErrInvalidParam)
+
+	// The failed batch must not have extended either account.
+	imported = getAccountByName(t, store, walletID, scope, importedAccount)
+	require.Equal(t, uint32(4), imported.ExternalKeyCount,
+		"failed batch must not extend the imported account")
+
+	derived = getAccountByName(t, store, walletID, scope, derivedAccount)
+	require.Equal(t, uint32(2), derived.ExternalKeyCount,
+		"failed batch must not extend the derived account")
+}
+
+// TestApplyScanBatchSkipsInvalidChild verifies that the SQL horizon extension
+// skips an HD-invalid child index instead of failing, matching the kvdb
+// ScopedKeyManager.ExtendAddresses behaviour. kvdb cannot be coerced into an
+// invalid child at a chosen low index, so the skip is exercised directly
+// against the SQL backend with a derivation callback that reports
+// hdkeychain.ErrInvalidChild for one index.
+func TestApplyScanBatchSkipsInvalidChild(t *testing.T) {
+	t.Parallel()
+
+	const invalidIndex = 2
+
+	scope := db.KeyScopeBIP0084
+	accountName := "skip-account"
+
+	// The callback errors with ErrInvalidChild only for the chosen index and
+	// otherwise returns a deterministic script derived from the coordinates.
+	derive := func(_ context.Context,
+		params db.AddressDerivationParams) (*db.DerivedAddressData, error) {
+
+		if params.Branch == 0 && params.Index == invalidIndex {
+			return nil, hdkeychain.ErrInvalidChild
+		}
+
+		script := make([]byte, 22)
+		script[0] = 0x00
+		script[1] = 0x14
+		script[2] = byte(params.Branch)
+		script[3] = byte(params.Index)
+
+		return &db.DerivedAddressData{ScriptPubKey: script}, nil
+	}
+
+	store := NewTestStoreWithDerive(t, derive)
+	walletID := newWallet(t, store, "wallet-scan-skip")
+	createDerivedAccount(t, store, walletID, scope, accountName)
+	accountInfo := getAccountByName(t, store, walletID, scope, accountName)
+	require.NotNil(t, accountInfo.AccountID)
+
+	err := store.ApplyScanBatch(t.Context(), db.ScanBatchParams{
+		WalletID: walletID,
+		Horizons: []db.ScanHorizon{{
+			AccountID:   accountInfo.AccountID,
+			Scope:       scope,
+			Account:     0,
+			AccountName: accountName,
+			Branch:      0,
+			Index:       4,
+		}},
+	})
+	require.NoError(t, err)
+
+	scripts := collectDerivedScripts(t, store, walletID, scope, accountName)
+
+	// Indices 0,1,3,4 must be derived; index 2 is skipped as invalid.
+	require.Len(t, scripts, 4)
+
+	for _, idx := range []uint32{0, 1, 3, 4} {
+		_, ok := scripts[derivedAddressKey{branch: 0, index: idx}]
+		require.Truef(t, ok, "expected derived index %d", idx)
+	}
+
+	_, skipped := scripts[derivedAddressKey{branch: 0, index: invalidIndex}]
+	require.False(t, skipped, "invalid child index must be skipped")
+
+	// The next external index must advance past the discovered horizon so a
+	// subsequent allocation does not collide with the derived range.
+	account := getAccountByName(t, store, walletID, scope, accountName)
+	require.Equal(t, uint32(5), account.ExternalKeyCount)
+}

--- a/wallet/internal/db/itest/scan_batch_conformance_test.go
+++ b/wallet/internal/db/itest/scan_batch_conformance_test.go
@@ -8,9 +8,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/address/v2"
 	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/addresstype"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
@@ -669,6 +671,265 @@ func TestApplyScanBatchSkipsInvalidChild(t *testing.T) {
 
 	// The next external index must advance past the discovered horizon so a
 	// subsequent allocation does not collide with the derived range.
+	account := getAccountByName(t, store, walletID, scope, accountName)
+	require.Equal(t, uint32(5), account.ExternalKeyCount)
+}
+
+// deriveScanAddress derives the BIP0084 P2WPKH address and its script for the
+// given branch and index from the account extended public key, matching both
+// the kvdb address manager and the SQL derivation callback.
+func deriveScanAddress(t *testing.T, accountXPub string, branch uint32,
+	index uint32) (address.Address, []byte) {
+
+	t.Helper()
+
+	accountKey, err := hdkeychain.NewKeyFromString(accountXPub)
+	require.NoError(t, err)
+
+	branchKey, err := accountKey.Derive(branch)
+	require.NoError(t, err)
+
+	addrKey, err := branchKey.Derive(index)
+	require.NoError(t, err)
+
+	pubKey, err := addrKey.ECPubKey()
+	require.NoError(t, err)
+
+	addr, err := address.NewAddressWitnessPubKeyHash(
+		address.Hash160(pubKey.SerializeCompressed()), scanBatchChainParams,
+	)
+	require.NoError(t, err)
+
+	script, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	return addr, script
+}
+
+// watchOutPoints returns the set of outpoints a store reports as needing to be
+// watched during recovery.
+func watchOutPoints(t *testing.T, store db.Store,
+	walletID uint32) map[wire.OutPoint]struct{} {
+
+	t.Helper()
+
+	utxos, err := store.ListOutputsToWatch(t.Context(), walletID)
+	require.NoError(t, err)
+
+	out := make(map[wire.OutPoint]struct{}, len(utxos))
+	for _, utxo := range utxos {
+		out[utxo.OutPoint] = struct{}{}
+	}
+
+	return out
+}
+
+// TestListOutputsToWatchConformance proves that kvdb and the SQL backend under
+// test report the same recovery watch set for an identical transaction history
+// covering an unspent credit, a credit spent by an unmined transaction, and a
+// leased credit. Comparing each SQL backend against an in-process kvdb store
+// (and exercising both build tags) establishes kvdb == sqlite == postgres.
+func TestListOutputsToWatchConformance(t *testing.T) {
+	t.Parallel()
+
+	fixture := newKVDBScanFixture(t)
+
+	sqlStore := NewTestStoreWithDerive(t, realAddressDeriveFunc())
+	walletID := newWallet(t, sqlStore, "wallet-watch-conformance")
+
+	deriveAccount := func(_ context.Context, _ db.KeyScope, _ uint32,
+		watchOnly bool) (*db.DerivedAccountData, error) {
+
+		data := &db.DerivedAccountData{
+			PublicKey:            []byte(fixture.accountXPub),
+			MasterKeyFingerprint: 0x01020304,
+		}
+		if !watchOnly {
+			data.EncryptedPrivateKey = RandomBytes(48)
+		}
+
+		return data, nil
+	}
+
+	sqlAccount, err := sqlStore.CreateDerivedAccount(
+		t.Context(), db.CreateDerivedAccountParams{
+			WalletID: walletID,
+			Scope:    fixture.scope,
+			Name:     fixture.accountName,
+		}, deriveAccount,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sqlAccount.AccountID)
+
+	// Extend the external branch on both backends so the credited addresses
+	// below are owned by each store.
+	kvdbHorizon := []db.ScanHorizon{{
+		Scope:       fixture.scope,
+		Account:     waddrmgr.DefaultAccountNum,
+		AccountName: fixture.accountName,
+		Branch:      0,
+		Index:       5,
+	}}
+	sqlHorizon := []db.ScanHorizon{{
+		AccountID:   sqlAccount.AccountID,
+		Scope:       fixture.scope,
+		Account:     waddrmgr.DefaultAccountNum,
+		AccountName: fixture.accountName,
+		Branch:      0,
+		Index:       5,
+	}}
+	require.NoError(t, fixture.store.ApplyScanBatch(t.Context(),
+		db.ScanBatchParams{WalletID: 0, Horizons: kvdbHorizon}))
+	require.NoError(t, sqlStore.ApplyScanBatch(t.Context(),
+		db.ScanBatchParams{WalletID: walletID, Horizons: sqlHorizon}))
+
+	// addrKept funds an output that stays unspent; addrSpent funds an output
+	// that a later unmined transaction spends.
+	addrKept, scriptKept := deriveScanAddress(t, fixture.accountXPub, 0, 0)
+	addrSpent, scriptSpent := deriveScanAddress(t, fixture.accountXPub, 0, 1)
+
+	fundingTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{
+			{Value: 6000, PkScript: scriptKept},
+			{Value: 7000, PkScript: scriptSpent},
+		},
+	)
+	fundingHash := fundingTx.TxHash()
+
+	// An unmined transaction that spends the second funding output. The
+	// spent-by-unmined output must still be watched on both backends.
+	spendTx := newRegularTx(
+		[]wire.OutPoint{{Hash: fundingHash, Index: 1}},
+		[]*wire.TxOut{{Value: 6500, PkScript: scriptKept}},
+	)
+
+	apply := func(store db.Store, id uint32) {
+		err := store.CreateTx(t.Context(), db.CreateTxParams{
+			WalletID: id,
+			Tx:       fundingTx,
+			Received: time.Unix(1710000200, 0),
+			Status:   db.TxStatusPublished,
+			Credits: map[uint32]address.Address{
+				0: addrKept,
+				1: addrSpent,
+			},
+		})
+		require.NoError(t, err)
+
+		err = store.CreateTx(t.Context(), db.CreateTxParams{
+			WalletID: id,
+			Tx:       spendTx,
+			Received: time.Unix(1710000300, 0),
+			Status:   db.TxStatusPublished,
+			Credits:  map[uint32]address.Address{0: addrKept},
+		})
+		require.NoError(t, err)
+	}
+
+	apply(fixture.store, 0)
+	apply(sqlStore, walletID)
+
+	// Lease the still-unspent funding output on both backends; leased outputs
+	// must remain in the watch set.
+	leaseID := db.LockID{0x07}
+
+	keptOutPoint := wire.OutPoint{Hash: fundingHash, Index: 0}
+	for _, lease := range []struct {
+		store db.Store
+		id    uint32
+	}{{fixture.store, 0}, {sqlStore, walletID}} {
+		_, err := lease.store.LeaseOutput(t.Context(), db.LeaseOutputParams{
+			WalletID: lease.id,
+			ID:       leaseID,
+			OutPoint: keptOutPoint,
+			Duration: time.Hour,
+		})
+		require.NoError(t, err)
+	}
+
+	kvdbWatch := watchOutPoints(t, fixture.store, 0)
+	sqlWatch := watchOutPoints(t, sqlStore, walletID)
+
+	// Expected watch set: the leased unspent output (funding:0), the
+	// spent-by-unmined output (funding:1), and the unmined spend's own
+	// credit (spend:0).
+	expected := map[wire.OutPoint]struct{}{
+		{Hash: fundingHash, Index: 0}:      {},
+		{Hash: fundingHash, Index: 1}:      {},
+		{Hash: spendTx.TxHash(), Index: 0}: {},
+	}
+	require.Equal(t, expected, kvdbWatch)
+	require.Equal(t, expected, sqlWatch)
+	require.Equal(t, kvdbWatch, sqlWatch,
+		"kvdb and SQL must report the same recovery watch set")
+}
+
+// TestApplyScanBatchSkipsInvalidLastChild verifies that when the discovered
+// horizon index itself is HD-invalid, the SQL extension keeps deriving past it
+// to the next valid child and stores that address, matching the legacy
+// extendAddresses nested loop (which derives one index beyond an invalid
+// terminal index).
+func TestApplyScanBatchSkipsInvalidLastChild(t *testing.T) {
+	t.Parallel()
+
+	const invalidIndex = 3
+
+	scope := db.KeyScopeBIP0084
+	accountName := "skip-last-account"
+
+	derive := func(_ context.Context,
+		params db.AddressDerivationParams) (*db.DerivedAddressData, error) {
+
+		if params.Branch == 0 && params.Index == invalidIndex {
+			return nil, hdkeychain.ErrInvalidChild
+		}
+
+		script := make([]byte, 22)
+		script[0] = 0x00
+		script[1] = 0x14
+		script[2] = byte(params.Branch)
+		script[3] = byte(params.Index)
+
+		return &db.DerivedAddressData{ScriptPubKey: script}, nil
+	}
+
+	store := NewTestStoreWithDerive(t, derive)
+	walletID := newWallet(t, store, "wallet-scan-skip-last")
+	createDerivedAccount(t, store, walletID, scope, accountName)
+	accountInfo := getAccountByName(t, store, walletID, scope, accountName)
+	require.NotNil(t, accountInfo.AccountID)
+
+	// The discovered horizon index (3) is itself invalid.
+	err := store.ApplyScanBatch(t.Context(), db.ScanBatchParams{
+		WalletID: walletID,
+		Horizons: []db.ScanHorizon{{
+			AccountID:   accountInfo.AccountID,
+			Scope:       scope,
+			Account:     0,
+			AccountName: accountName,
+			Branch:      0,
+			Index:       invalidIndex,
+		}},
+	})
+	require.NoError(t, err)
+
+	scripts := collectDerivedScripts(t, store, walletID, scope, accountName)
+
+	// Indices 0,1,2 derive normally; index 3 is invalid so derivation
+	// continues to index 4 and stores it, matching the legacy nested loop.
+	require.Len(t, scripts, 4)
+
+	for _, idx := range []uint32{0, 1, 2, 4} {
+		_, ok := scripts[derivedAddressKey{branch: 0, index: idx}]
+		require.Truef(t, ok, "expected derived index %d", idx)
+	}
+
+	_, skipped := scripts[derivedAddressKey{branch: 0, index: invalidIndex}]
+	require.False(t, skipped, "invalid terminal index must be skipped")
+
+	// The next external index advances to one past the address derived
+	// beyond the invalid terminal index (index 4 -> next index 5).
 	account := getAccountByName(t, store, walletID, scope, accountName)
 	require.Equal(t, uint32(5), account.ExternalKeyCount)
 }

--- a/wallet/internal/db/itest/sqlite_test.go
+++ b/wallet/internal/db/itest/sqlite_test.go
@@ -179,3 +179,25 @@ func walletUtxoSpent(t *testing.T, store *sqlite.Store,
 
 	return spentBy.SpentByTxID.Valid
 }
+
+// clearUtxosSpentByTxID clears all UTXO spend edges claimed by one transaction.
+func clearUtxosSpentByTxID(t *testing.T, store *sqlite.Store,
+	walletID uint32, txHash chainhash.Hash) {
+
+	t.Helper()
+
+	txID, ok := txIDByHash(t, store, walletID, txHash)
+	require.True(t, ok)
+
+	rows, err := store.Queries().ClearUtxosSpentByTxID(
+		t.Context(), sqlc.ClearUtxosSpentByTxIDParams{
+			WalletID: int64(walletID),
+			SpentByTxID: sql.NullInt64{
+				Int64: txID,
+				Valid: true,
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rows)
+}

--- a/wallet/internal/db/itest/tx_corruption_pg_test.go
+++ b/wallet/internal/db/itest/tx_corruption_pg_test.go
@@ -80,6 +80,26 @@ func corruptTransactionHash(t *testing.T, store *pg.Store,
 	require.EqualValues(t, 1, rows)
 }
 
+// forceRollbackBlockDeleteFailure installs a trigger that fails the rollback
+// block-deletion stage after sync-state rewind has run.
+func forceRollbackBlockDeleteFailure(t *testing.T, store *pg.Store) {
+	t.Helper()
+
+	statements := []string{
+		"CREATE OR REPLACE FUNCTION fail_rollback_block_delete() " +
+			"RETURNS trigger LANGUAGE plpgsql AS $$ " +
+			"BEGIN RAISE EXCEPTION " +
+			"'forced rollback block delete failure'; END; $$",
+		"CREATE TRIGGER fail_rollback_block_delete " +
+			"BEFORE DELETE ON blocks FOR EACH ROW EXECUTE FUNCTION " +
+			"fail_rollback_block_delete()",
+	}
+	for _, stmt := range statements {
+		_, err := store.DB().ExecContext(t.Context(), stmt)
+		require.NoError(t, err)
+	}
+}
+
 // corruptTransactionBlockHeight writes an invalid block height after dropping
 // the non-negative height check and creating a matching block row. The
 // corruption itests use this to verify that reads reject impossible

--- a/wallet/internal/db/itest/tx_corruption_sqlite_test.go
+++ b/wallet/internal/db/itest/tx_corruption_sqlite_test.go
@@ -98,6 +98,21 @@ func corruptTransactionHash(t *testing.T, store *sqlite.Store,
 	require.NoError(t, tx.Commit())
 }
 
+// forceRollbackBlockDeleteFailure installs a trigger that fails the rollback
+// block-deletion stage after sync-state rewind has run.
+func forceRollbackBlockDeleteFailure(t *testing.T, store *sqlite.Store) {
+	t.Helper()
+
+	_, err := store.DB().ExecContext(
+		t.Context(),
+		"CREATE TRIGGER fail_rollback_block_delete "+
+			"BEFORE DELETE ON blocks "+
+			"BEGIN SELECT RAISE(FAIL, "+
+			"'forced rollback block delete failure'); END",
+	)
+	require.NoError(t, err)
+}
+
 // corruptTransactionBlockHeight writes an invalid block height after first
 // creating a matching block row in sqlite. The corruption itests use this to
 // verify that reads reject impossible confirmation metadata.

--- a/wallet/internal/db/itest/tx_store_rollback_test.go
+++ b/wallet/internal/db/itest/tx_store_rollback_test.go
@@ -1,0 +1,149 @@
+//go:build itest
+
+package itest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRollbackToBlockAtomicRollsBackSyncTipOnFailure proves that
+// RollbackToBlock rewinds the wallet sync tip and rolls back transaction state
+// inside one backend transaction: when the rollback step fails, the sync-tip
+// rewind is discarded rather than committed on its own.
+//
+// The scenario forces a mid-rollback failure with a backend trigger that fails
+// block deletion. RollbackToBlock rewinds the wallet sync state to the fork
+// point, then fails while deleting block rows. Because both effects share one
+// transaction, the wallet's persisted sync tip must remain at its original
+// block.
+//
+// This test is non-tautological: a sync-state rewind committed in a separate
+// transaction from the block rollback would leave the wallet pointed below the
+// coinbase block even though the rollback failed, failing the final assertion.
+func TestRollbackToBlockAtomicRollsBackSyncTipOnFailure(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletName := "wallet-rollback-atomic"
+	walletID := newWallet(t, store, walletName)
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+	queries := store.Queries()
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+
+	// The fork block survives the rollback; the sync tip would rewind to it.
+	forkBlock := CreateBlockFixture(t, queries, 419)
+
+	// Confirm a coinbase transaction at the next block and point the wallet
+	// sync tip at it, so a successful rollback would visibly move the tip back
+	// to the fork block.
+	coinbaseBlock := CreateBlockFixture(t, queries, 420)
+	coinbaseTx := newCoinbaseTx(addr.ScriptPubKey)
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       coinbaseTx,
+		Received: time.Unix(1710004200, 0),
+		Block:    &coinbaseBlock,
+		Status:   db.TxStatusPublished,
+		Credits:  map[uint32]address.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	err = store.UpdateWallet(t.Context(), db.UpdateWalletParams{
+		WalletID: walletID,
+		SyncedTo: &coinbaseBlock,
+	})
+	require.NoError(t, err)
+
+	// Confirm the starting sync tip is the coinbase block.
+	before, err := store.GetWallet(t.Context(), walletName)
+	require.NoError(t, err)
+	require.NotNil(t, before.SyncedTo)
+	require.Equal(t, coinbaseBlock.Height, before.SyncedTo.Height)
+
+	// Force the block deletion stage to fail after rollback has rewound the
+	// wallet sync state inside the same transaction.
+	forceRollbackBlockDeleteFailure(t, store)
+
+	// The rollback (boundary = coinbase height) must fail while deleting the
+	// rollback block after rewinding the sync state to the fork point.
+	err = store.RollbackToBlock(t.Context(), coinbaseBlock.Height)
+	require.ErrorContains(t, err, "delete blocks at or above height")
+
+	// The sync tip must be unchanged: the failed rollback rolled the sync-tip
+	// rewind back with it, so the wallet still points at the coinbase block.
+	after, err := store.GetWallet(t.Context(), walletName)
+	require.NoError(t, err)
+	require.NotNil(t, after.SyncedTo)
+	require.Equal(t, coinbaseBlock.Height, after.SyncedTo.Height)
+	require.NotEqual(t, forkBlock.Height, after.SyncedTo.Height)
+}
+
+// TestRollbackToBlockRewindsSyncTipAndRollsBack proves the happy path: a
+// rollback to a block height both rewinds the wallet sync tip to the fork point
+// at height-1 and disconnects the orphaned block's transactions in one
+// transaction.
+func TestRollbackToBlockRewindsSyncTipAndRollsBack(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletName := "wallet-rollback-happy"
+	walletID := newWallet(t, store, walletName)
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+	queries := store.Queries()
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+
+	// The fork block at height-1 survives the rollback and becomes the new
+	// sync tip.
+	forkBlock := CreateBlockFixture(t, queries, 439)
+
+	confirmedBlock := CreateBlockFixture(t, queries, 440)
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 6000, PkScript: addr.ScriptPubKey}},
+	)
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       tx,
+		Received: time.Unix(1710004300, 0),
+		Block:    &confirmedBlock,
+		Status:   db.TxStatusPublished,
+		Credits:  map[uint32]address.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	err = store.UpdateWallet(t.Context(), db.UpdateWalletParams{
+		WalletID: walletID,
+		SyncedTo: &confirmedBlock,
+	})
+	require.NoError(t, err)
+
+	err = store.RollbackToBlock(t.Context(), confirmedBlock.Height)
+	require.NoError(t, err)
+
+	// The sync tip moved back to the fork point at height-1.
+	after, err := store.GetWallet(t.Context(), walletName)
+	require.NoError(t, err)
+	require.NotNil(t, after.SyncedTo)
+	require.Equal(t, forkBlock.Height, after.SyncedTo.Height)
+	require.Equal(t, forkBlock.Hash, after.SyncedTo.Hash)
+
+	// The previously confirmed transaction is now unmined.
+	txInfo, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     tx.TxHash(),
+	})
+	require.NoError(t, err)
+	require.Nil(t, txInfo.Block)
+}

--- a/wallet/internal/db/itest/txstore_utxostore_test.go
+++ b/wallet/internal/db/itest/txstore_utxostore_test.go
@@ -3638,6 +3638,38 @@ func TestApplyTxBatchStoresTxAndSyncTip(t *testing.T) {
 		walletInfo.SyncedTo.Timestamp.Unix())
 }
 
+// TestApplyTxBatchRejectsStaleDuplicateTx verifies that a duplicate batch
+// observation is not skipped when the existing row is terminal history. A blind
+// ErrTxAlreadyExists skip would leave the failed row in place while reporting a
+// successful batch application.
+func TestApplyTxBatchRejectsStaleDuplicateTx(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-apply-tx-batch-stale")
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 7000, PkScript: RandomBytes(22)}},
+	)
+	params := db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       tx,
+		Received: time.Unix(1710000155, 0),
+		Status:   db.TxStatusPending,
+	}
+
+	err := store.CreateTx(t.Context(), params)
+	require.NoError(t, err)
+	setTxStatus(t, store, walletID, tx.TxHash(), db.TxStatusFailed)
+
+	err = store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID:     walletID,
+		Transactions: []db.CreateTxParams{params},
+	})
+	require.ErrorIs(t, err, db.ErrTxAlreadyExists)
+}
+
 // TestApplyTxBatchConfirmsTxInSameBlock verifies that a batch can record a
 // transaction confirmed in the very block the same batch introduces as the new
 // sync tip. The confirming block row does not exist before the batch, so the
@@ -4136,4 +4168,395 @@ func TestApplyTxBatchRejectsNilTx(t *testing.T) {
 		Txid:     tx.TxHash(),
 	})
 	require.ErrorIs(t, err, db.ErrTxNotFound)
+}
+
+// TestApplyScanBatchConfirmsTxInNewBlock verifies that a scan batch can record
+// relevant transactions confirmed in blocks the same batch newly connects. The
+// confirming block rows do not exist before the batch, so the batch must
+// connect the synced blocks before recording the confirmed transactions;
+// otherwise the confirmed inserts fail with ErrBlockNotFound.
+func TestApplyScanBatchConfirmsTxInNewBlock(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletName := "wallet-apply-scan-batch-confirmed"
+	walletID := newWallet(t, store, walletName)
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addrEarly := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	addrLate := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+
+	// Two newly discovered synced blocks, neither inserted ahead of time.
+	earlyBlock := NewBlockFixture(220)
+	lateBlock := NewBlockFixture(221)
+
+	// One relevant transaction confirmed in each newly synced block.
+	earlyTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 6000, PkScript: addrEarly.ScriptPubKey}},
+	)
+	lateTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 9000, PkScript: addrLate.ScriptPubKey}},
+	)
+
+	err := store.ApplyScanBatch(t.Context(), db.ScanBatchParams{
+		WalletID: walletID,
+		Transactions: []db.CreateTxParams{{
+			WalletID: walletID,
+			Tx:       earlyTx,
+			Received: time.Unix(1710000400, 0),
+			Block:    &earlyBlock,
+			Status:   db.TxStatusPublished,
+			Credits:  map[uint32]address.Address{0: nil},
+		}, {
+			WalletID: walletID,
+			Tx:       lateTx,
+			Received: time.Unix(1710000500, 0),
+			Block:    &lateBlock,
+			Status:   db.TxStatusPublished,
+			Credits:  map[uint32]address.Address{0: nil},
+		}},
+		SyncedBlocks: []db.Block{earlyBlock, lateBlock},
+	})
+	require.NoError(t, err)
+
+	// Both transactions are recorded as confirmed in their respective newly
+	// connected blocks, with their credited outputs in the UTXO set.
+	earlyInfo, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     earlyTx.TxHash(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, earlyInfo.Block)
+	require.Equal(t, earlyBlock.Height, earlyInfo.Block.Height)
+	require.True(t, walletUtxoExists(t, store, walletID, wire.OutPoint{
+		Hash: earlyTx.TxHash(), Index: 0,
+	}))
+
+	lateInfo, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     lateTx.TxHash(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, lateInfo.Block)
+	require.Equal(t, lateBlock.Height, lateInfo.Block.Height)
+	require.True(t, walletUtxoExists(t, store, walletID, wire.OutPoint{
+		Hash: lateTx.TxHash(), Index: 0,
+	}))
+
+	// The sync tip advanced to the final synced block.
+	walletInfo, err := store.GetWallet(t.Context(), walletName)
+	require.NoError(t, err)
+	require.NotNil(t, walletInfo.SyncedTo)
+	require.Equal(t, lateBlock.Height, walletInfo.SyncedTo.Height)
+	require.Equal(t, lateBlock.Hash, walletInfo.SyncedTo.Hash)
+}
+
+// TestApplyScanBatchRejectsMismatchedWalletID verifies that a scan batch is
+// rejected when any transaction is owned by a wallet other than the batch
+// wallet, and that the rejection commits nothing: the synced block is not
+// connected, the sync tip is not advanced, and no transaction row is written.
+func TestApplyScanBatchRejectsMismatchedWalletID(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletName := "wallet-apply-scan-batch-mismatch"
+	walletID := newWallet(t, store, walletName)
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 7000, PkScript: addr.ScriptPubKey}},
+	)
+	syncedBlock := NewBlockFixture(222)
+
+	// The batch targets walletID and carries a synced block, but the lone
+	// transaction claims a different wallet. The whole batch must be rejected
+	// before any synced-block or transaction write.
+	err := store.ApplyScanBatch(t.Context(), db.ScanBatchParams{
+		WalletID: walletID,
+		Transactions: []db.CreateTxParams{{
+			WalletID: walletID + 99,
+			Tx:       tx,
+			Received: time.Unix(1710000600, 0),
+			Block:    &syncedBlock,
+			Status:   db.TxStatusPublished,
+			Credits:  map[uint32]address.Address{0: nil},
+		}},
+		SyncedBlocks: []db.Block{syncedBlock},
+	})
+	require.ErrorIs(t, err, db.ErrInvalidParam)
+
+	// The synced block was not connected: the wallet sync tip is unchanged.
+	walletInfo, err := store.GetWallet(t.Context(), walletName)
+	require.NoError(t, err)
+	require.Nil(t, walletInfo.SyncedTo)
+
+	// No transaction row was written for either wallet.
+	_, err = store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     tx.TxHash(),
+	})
+	require.ErrorIs(t, err, db.ErrTxNotFound)
+}
+
+// TestApplyTxBatchConfirmed verifies that a runtime batch can record a
+// transaction confirmed in a block that did not exist before the batch, even
+// when the batch carries no sync-tip update (SyncedTo is nil). This is the
+// standalone relevant-tx notification path: applyBatchTransaction must ensure
+// the confirming block row exists before CreateTxWithOps validates it,
+// otherwise the confirmed insert fails with ErrBlockNotFound. The wallet sync
+// tip must not advance, because only the sync-tip update path may move it.
+func TestApplyTxBatchConfirmed(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletName := "wallet-apply-tx-batch-confirmed-no-tip"
+	walletID := newWallet(t, store, walletName)
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 7000, PkScript: addr.ScriptPubKey}},
+	)
+
+	// The confirming block does not exist before the batch and the batch
+	// carries no sync-tip update, so the transaction path itself must create
+	// the block row.
+	block := NewBlockFixture(214)
+
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: walletID,
+		Transactions: []db.CreateTxParams{{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710000170, 0),
+			Block:    &block,
+			Status:   db.TxStatusPublished,
+			Credits:  map[uint32]address.Address{0: nil},
+		}},
+	})
+	require.NoError(t, err)
+
+	// The transaction is recorded as confirmed in the batch's block with its
+	// credited output in the wallet UTXO set.
+	txInfo, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     tx.TxHash(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, db.TxStatusPublished, txInfo.Status)
+	require.NotNil(t, txInfo.Block)
+	require.Equal(t, block.Height, txInfo.Block.Height)
+	require.Equal(t, block.Hash, txInfo.Block.Hash)
+	require.True(t, walletUtxoExists(t, store, walletID, wire.OutPoint{
+		Hash: tx.TxHash(), Index: 0,
+	}))
+
+	// The wallet sync tip must not have advanced: a standalone confirmed
+	// notification ensures only the tx's own block row, never the sync tip.
+	walletInfo, err := store.GetWallet(t.Context(), walletName)
+	require.NoError(t, err)
+	require.Nil(t, walletInfo.SyncedTo)
+}
+
+// TestApplyTxBatchDuplicate verifies that a duplicate batch transaction whose
+// stored row shape matches the new observation does not silently skip while
+// leaving wallet-owned edges unrecorded. CreateTxWithOps returns
+// ErrTxAlreadyExists before writing credits or marking wallet-input spends, so
+// a duplicate that newly carries a credit or a wallet-input spend must replay
+// those edges. An exact duplicate that already has every edge may still be
+// skipped without error.
+func TestApplyTxBatchDuplicate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("later credit is recorded", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange: Insert the tx row first with no credits, so the wallet
+		// owns no output for it yet.
+		store := NewTestStore(t)
+		walletID := newWallet(t, store, "wallet-dup-later-credit")
+		createDerivedAccount(
+			t, store, walletID, db.KeyScopeBIP0084, "default",
+		)
+
+		addr := newDerivedAddress(
+			t, store, walletID, db.KeyScopeBIP0084, "default", false,
+		)
+		tx := newRegularTx(
+			[]wire.OutPoint{randomOutPoint()},
+			[]*wire.TxOut{{Value: 7000, PkScript: addr.ScriptPubKey}},
+		)
+
+		err := store.CreateTx(t.Context(), db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710000180, 0),
+			Status:   db.TxStatusPending,
+		})
+		require.NoError(t, err)
+
+		creditOutPoint := wire.OutPoint{Hash: tx.TxHash(), Index: 0}
+		require.False(
+			t, walletUtxoExists(t, store, walletID, creditOutPoint),
+		)
+
+		// Act: Re-observe the same tx through a batch that now carries the
+		// wallet credit. The stored row shape matches, so the old skip path
+		// would drop the credit.
+		err = store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+			WalletID: walletID,
+			Transactions: []db.CreateTxParams{{
+				WalletID: walletID,
+				Tx:       tx,
+				Received: time.Unix(1710000180, 0),
+				Status:   db.TxStatusPending,
+				Credits:  map[uint32]address.Address{0: nil},
+			}},
+		})
+		require.NoError(t, err)
+
+		// Assert: The duplicate batch recorded the previously missing credit.
+		require.True(
+			t, walletUtxoExists(t, store, walletID, creditOutPoint),
+		)
+	})
+
+	t.Run("later wallet-input spend is recorded", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange: Record the child tx first while the parent output it
+		// spends is not yet wallet-owned, so no spend edge is created.
+		store := NewTestStore(t)
+		walletID := newWallet(t, store, "wallet-dup-later-spend")
+		createDerivedAccount(
+			t, store, walletID, db.KeyScopeBIP0084, "default",
+		)
+
+		addr := newDerivedAddress(
+			t, store, walletID, db.KeyScopeBIP0084, "default", false,
+		)
+
+		// Build the parent funding tx first so its hash is known, then have
+		// the child spend the parent's output 0. The parent is not recorded
+		// yet, so when the child is created its input is not wallet-owned and
+		// no spend edge is written.
+		parentTx := newRegularTx(
+			[]wire.OutPoint{randomOutPoint()},
+			[]*wire.TxOut{{Value: 9000, PkScript: addr.ScriptPubKey}},
+		)
+		parentOutPoint := wire.OutPoint{Hash: parentTx.TxHash(), Index: 0}
+		childTx := newRegularTx(
+			[]wire.OutPoint{parentOutPoint},
+			[]*wire.TxOut{{Value: 4000, PkScript: RandomBytes(22)}},
+		)
+		childParams := db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       childTx,
+			Received: time.Unix(1710000190, 0),
+			Status:   db.TxStatusPending,
+		}
+		err := store.CreateTx(t.Context(), childParams)
+		require.NoError(t, err)
+
+		// Now record the parent funding tx with a wallet credit at output 0.
+		err = store.CreateTx(t.Context(), db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       parentTx,
+			Received: time.Unix(1710000191, 0),
+			Status:   db.TxStatusPending,
+			Credits:  map[uint32]address.Address{0: nil},
+		})
+		require.NoError(t, err)
+		require.True(t, walletUtxoSpent(t, store, walletID, parentOutPoint))
+
+		// Creating the parent credit reconciles the already-stored child. Clear
+		// the edge directly to model a partially replayed duplicate where the
+		// child row exists but its spend edge is still missing.
+		clearUtxosSpentByTxID(t, store, walletID, childTx.TxHash())
+		require.False(t, walletUtxoSpent(t, store, walletID, parentOutPoint))
+
+		// Act: Re-observe the child through a batch. The stored row matches,
+		// so the old skip path would leave the now-wallet-owned parent
+		// unspent.
+		err = store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+			WalletID:     walletID,
+			Transactions: []db.CreateTxParams{childParams},
+		})
+		require.NoError(t, err)
+
+		// Assert: The parent output is now spent by the child. A competing
+		// transaction spending the same parent output must therefore be
+		// rejected as a conflict, which only holds once the spend edge from
+		// the replayed child exists.
+		conflictTx := newRegularTx(
+			[]wire.OutPoint{parentOutPoint},
+			[]*wire.TxOut{{Value: 3000, PkScript: RandomBytes(22)}},
+		)
+		err = store.CreateTx(t.Context(), db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       conflictTx,
+			Received: time.Unix(1710000192, 0),
+			Status:   db.TxStatusPending,
+		})
+		require.ErrorIs(t, err, db.ErrTxInputConflict)
+	})
+
+	t.Run("exact duplicate may skip", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange: Record the tx with its wallet credit already present.
+		store := NewTestStore(t)
+		walletID := newWallet(t, store, "wallet-dup-exact")
+		createDerivedAccount(
+			t, store, walletID, db.KeyScopeBIP0084, "default",
+		)
+
+		addr := newDerivedAddress(
+			t, store, walletID, db.KeyScopeBIP0084, "default", false,
+		)
+		tx := newRegularTx(
+			[]wire.OutPoint{randomOutPoint()},
+			[]*wire.TxOut{{Value: 7000, PkScript: addr.ScriptPubKey}},
+		)
+		params := db.CreateTxParams{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710000200, 0),
+			Status:   db.TxStatusPending,
+			Credits:  map[uint32]address.Address{0: nil},
+		}
+		err := store.CreateTx(t.Context(), params)
+		require.NoError(t, err)
+
+		creditOutPoint := wire.OutPoint{Hash: tx.TxHash(), Index: 0}
+		require.True(
+			t, walletUtxoExists(t, store, walletID, creditOutPoint),
+		)
+
+		// Act: Re-observe the identical tx through a batch.
+		err = store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+			WalletID:     walletID,
+			Transactions: []db.CreateTxParams{params},
+		})
+
+		// Assert: The exact duplicate is accepted and the credit is still
+		// present exactly once.
+		require.NoError(t, err)
+		require.True(
+			t, walletUtxoExists(t, store, walletID, creditOutPoint),
+		)
+	})
 }

--- a/wallet/internal/db/kvdb/txstore_test.go
+++ b/wallet/internal/db/kvdb/txstore_test.go
@@ -3947,12 +3947,8 @@ func TestRollbackToBlockAtomicRollsBackSyncTipOnRollbackError(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Fail the rollback step that runs after the sync-tip rewind.
+	// Fail the transaction rollback before the live sync tip is rewound.
 	mockTxStore := &bwmock.TxStore{}
-	mockTxStore.On(
-		"RangeTransactions", mock.Anything, int32(forkHeight),
-		int32(forkHeight), mock.Anything,
-	).Return(nil).Once()
 	mockTxStore.On("Rollback", mock.Anything, int32(rollbackHeight)).
 		Return(errForcedRollback).Once()
 
@@ -3962,7 +3958,8 @@ func TestRollbackToBlockAtomicRollsBackSyncTipOnRollbackError(t *testing.T) {
 	require.ErrorIs(t, err, errForcedRollback)
 
 	// The persisted and live sync tips must remain at the original height: the
-	// rewind rolled back atomically with the failed transaction rollback.
+	// store does not rewind wallet metadata until the transaction rollback
+	// succeeds.
 	require.EqualValues(t, initialHeight, persistedSyncedHeight(t, dbConn))
 	require.EqualValues(t, initialHeight, addrMgr.SyncedTo().Height)
 	require.Equal(t, tipStamp.Hash, addrMgr.SyncedTo().Hash)

--- a/wallet/internal/db/kvdb/txstore_test.go
+++ b/wallet/internal/db/kvdb/txstore_test.go
@@ -565,6 +565,8 @@ func TestRollbackToBlockHeightZeroResetsSyncTip(t *testing.T) {
 	// The address manager reports a synced tip above genesis so the rollback
 	// to zero has a stale tip to clear. SetSyncedTo(nil) is the reset to the
 	// start block; the rollback must invoke it rather than skip the rewind.
+	// SyncedTo is also read once to snapshot the pre-rollback tip for the
+	// failed-rollback restore path, which this success case does not exercise.
 	addrStore := &bwmock.AddrStore{}
 	mockNoBirthdayBlock(addrStore)
 	addrStore.On("SyncedTo").Return(waddrmgr.BlockStamp{
@@ -3797,4 +3799,172 @@ func TestApplyScanBatchHorizonMissingNameErrors(t *testing.T) {
 	require.Zero(t, externalKeyCount(
 		t, dbConn, scopedMgr, waddrmgr.DefaultAccountNum,
 	))
+}
+
+// errForcedRollback is a static error injected by the rollback atomicity test
+// to fail the transaction rollback step after the sync-tip rewind has run.
+var errForcedRollback = errors.New("forced rollback failure")
+
+// rewindAddrManagerSeed is a fixed BIP32 seed used to build a real waddrmgr
+// address manager for the rollback atomicity test, so SetSyncedTo writes to a
+// real namespace that bbolt can roll back.
+var rewindAddrManagerSeed = []byte{
+	0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27,
+	0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f,
+	0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+	0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f,
+}
+
+// newRealAddrManager creates the waddrmgr namespace and a real address manager
+// in the test database, returning the opened manager. The manager is used by
+// the rollback atomicity test because, unlike the mock address store, its
+// SetSyncedTo performs a real namespace write that bbolt reverts on rollback.
+func newRealAddrManager(t *testing.T,
+	dbConn walletdb.DB) *waddrmgr.Manager {
+
+	t.Helper()
+
+	rootKey, err := hdkeychain.NewMaster(
+		rewindAddrManagerSeed, &chaincfg.RegressionNetParams,
+	)
+	require.NoError(t, err)
+
+	pubPass := []byte("public")
+	privPass := []byte("private")
+
+	err = walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns, err := tx.CreateTopLevelBucket(waddrmgr.NamespaceKey)
+		if err != nil {
+			return err
+		}
+
+		return waddrmgr.Create(
+			ns, rootKey, pubPass, privPass,
+			&chaincfg.RegressionNetParams, &waddrmgr.FastScryptOptions,
+			time.Time{},
+		)
+	})
+	require.NoError(t, err)
+
+	var mgr *waddrmgr.Manager
+
+	err = walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+		mgr, err = waddrmgr.Open(ns, pubPass, &chaincfg.RegressionNetParams)
+
+		return err
+	})
+	require.NoError(t, err)
+	t.Cleanup(mgr.Close)
+
+	return mgr
+}
+
+// persistedSyncedHeight re-opens the address manager from disk and returns its
+// persisted synced-to height, bypassing the in-memory cache so the value
+// reflects what bbolt actually committed.
+func persistedSyncedHeight(t *testing.T, dbConn walletdb.DB) int32 {
+	t.Helper()
+
+	var height int32
+
+	err := walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgr.NamespaceKey)
+		require.NotNil(t, ns)
+
+		fresh, err := waddrmgr.Open(
+			ns, []byte("public"), &chaincfg.RegressionNetParams,
+		)
+		if err != nil {
+			return err
+		}
+		defer fresh.Close()
+
+		height = fresh.SyncedTo().Height
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	return height
+}
+
+// TestRollbackToBlockAtomicRollsBackSyncTipOnRollbackError verifies that
+// kvdb.Store.RollbackToBlock discards the sync-tip rewind when the transaction
+// rollback fails, proving both effects share one walletdb transaction.
+//
+// The address manager is real so SetSyncedTo persists, while the transaction
+// store is a mock that fails Rollback. A two-write rollback (SetSyncedTo then a
+// separate Rollback) would already have committed the rewound sync tip when the
+// rollback failed; the single-transaction implementation instead reverts it, so
+// the persisted and live sync tips must remain at their original height.
+func TestRollbackToBlockAtomicRollsBackSyncTipOnRollbackError(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	addrMgr := newRealAddrManager(t, dbConn)
+
+	// Seed a contiguous fork->tip chain so the rollback can derive the fork
+	// block hash at height-1, and so the synced tip starts at the rollback
+	// boundary and must survive a failed rollback.
+	const (
+		forkHeight     = 49
+		initialHeight  = 50
+		rollbackHeight = initialHeight
+	)
+
+	forkStamp := &waddrmgr.BlockStamp{
+		Height: forkHeight,
+		Hash:   chainhash.Hash{0xaa},
+	}
+	tipStamp := &waddrmgr.BlockStamp{
+		Height: initialHeight,
+		Hash:   chainhash.Hash{0xbb},
+	}
+	err := walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+
+		err := addrMgr.SetSyncedTo(ns, forkStamp)
+		if err != nil {
+			return err
+		}
+
+		return addrMgr.SetSyncedTo(ns, tipStamp)
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, initialHeight, persistedSyncedHeight(t, dbConn))
+
+	// The wtxmgr namespace must exist for the rollback transaction to find it.
+	err = walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns, err := tx.CreateTopLevelBucket(wtxmgrNamespaceKey)
+		if err != nil {
+			return err
+		}
+
+		return wtxmgr.Create(ns)
+	})
+	require.NoError(t, err)
+
+	// Fail the rollback step that runs after the sync-tip rewind.
+	mockTxStore := &bwmock.TxStore{}
+	mockTxStore.On(
+		"RangeTransactions", mock.Anything, int32(forkHeight),
+		int32(forkHeight), mock.Anything,
+	).Return(nil).Once()
+	mockTxStore.On("Rollback", mock.Anything, int32(rollbackHeight)).
+		Return(errForcedRollback).Once()
+
+	store := NewStore(dbConn, mockTxStore, addrMgr)
+
+	err = store.RollbackToBlock(t.Context(), rollbackHeight)
+	require.ErrorIs(t, err, errForcedRollback)
+
+	// The persisted and live sync tips must remain at the original height: the
+	// rewind rolled back atomically with the failed transaction rollback.
+	require.EqualValues(t, initialHeight, persistedSyncedHeight(t, dbConn))
+	require.EqualValues(t, initialHeight, addrMgr.SyncedTo().Height)
+	require.Equal(t, tipStamp.Hash, addrMgr.SyncedTo().Hash)
+	mockTxStore.AssertExpectations(t)
 }

--- a/wallet/internal/db/kvdb/txstore_test.go
+++ b/wallet/internal/db/kvdb/txstore_test.go
@@ -3397,3 +3397,164 @@ func (r *recordEvictAddrStore) FetchScopedKeyManager(
 
 	return r.spy, nil
 }
+
+// TestApplyScanBatchRollbackEvictsThroughAdvancedNextIndex verifies that when a
+// horizon extension advances the branch's next index past horizon.Index+1 (as
+// when ExtendAddresses skips HD-invalid children), a failed batch evicts every
+// derived child through the actual advanced next index, not just the requested
+// horizon child. The rollback must re-read the post-extension next index rather
+// than assuming horizon.Index+1.
+func TestApplyScanBatchRollbackEvictsThroughAdvancedNextIndex(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	mgr := newSpendableAddrMgr(t, dbConn)
+	t.Cleanup(func() {
+		_ = mgr.Lock()
+		mgr.Close()
+	})
+
+	err := walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgr.NamespaceKey)
+
+		return mgr.Unlock(ns, testPrivPass)
+	})
+	require.NoError(t, err)
+
+	const (
+		account      = waddrmgr.DefaultAccountNum
+		horizonIndex = 5
+
+		// The post-extension next index lands two past horizon.Index+1,
+		// emulating ExtendAddresses skipping HD-invalid children at
+		// indices 6 and 7 before settling on 8.
+		advancedNextIndex = horizonIndex + 3
+	)
+
+	// Wrap the real manager so the post-extension AccountProperties re-read
+	// reports the advanced next index and the eviction range is recorded.
+	spy := &recordEvictScopedMgr{
+		branch:           waddrmgr.ExternalBranch,
+		postExtNextIndex: advancedNextIndex,
+	}
+	addrStore := &recordEvictAddrStore{AddrStore: mgr, spy: spy}
+
+	scope := waddrmgr.KeyScopeBIP0084
+
+	// A synced block whose height overflows the legacy int32 height domain
+	// fails the batch after the horizon extension has already advanced the
+	// manager's in-memory address state, forcing the rollback path.
+	overflowBlock := db.Block{
+		Hash:      chainhash.Hash{0xCD},
+		Height:    uint32(math.MaxInt32) + 1,
+		Timestamp: time.Unix(1_700_000_000, 0),
+	}
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore, addrStore)
+
+	err = store.ApplyScanBatch(t.Context(), db.ScanBatchParams{
+		WalletID: 0,
+		Horizons: []db.ScanHorizon{{
+			Scope:       db.KeyScope(scope),
+			Account:     account,
+			AccountName: waddrmgr.DefaultAccountName,
+			Branch:      waddrmgr.ExternalBranch,
+			Index:       horizonIndex,
+		}},
+		SyncedBlocks: []db.Block{overflowBlock},
+	})
+	require.Error(t, err)
+
+	// The rollback must have evicted from the pre-extension next index (0)
+	// through the advanced post-extension next index, covering the invalid-
+	// child-skip children, not just horizon.Index+1.
+	require.True(t, spy.evicted)
+	require.Equal(t, uint32(0), spy.evictFrom)
+	require.Equal(t, uint32(advancedNextIndex), spy.evictTo)
+	require.Greater(t, spy.evictTo, uint32(horizonIndex+1))
+}
+
+// TestApplyScanBatchRejectsInvalidBranch verifies that ApplyScanBatch rejects a
+// horizon whose branch is neither external nor internal, mirroring the SQL
+// backend's ExtendScanHorizon, and that the malformed branch does not extend
+// either the external or internal horizon state.
+func TestApplyScanBatchRejectsInvalidBranch(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	mgr := newSpendableAddrMgr(t, dbConn)
+	t.Cleanup(func() {
+		_ = mgr.Lock()
+		mgr.Close()
+	})
+
+	err := walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgr.NamespaceKey)
+
+		return mgr.Unlock(ns, testPrivPass)
+	})
+	require.NoError(t, err)
+
+	const account = waddrmgr.DefaultAccountNum
+
+	scope := waddrmgr.KeyScopeBIP0084
+	scopedMgr, err := mgr.FetchScopedKeyManager(scope)
+	require.NoError(t, err)
+
+	require.Zero(t, externalKeyCount(t, dbConn, scopedMgr, account))
+	require.Zero(t, internalKeyCount(t, dbConn, scopedMgr, account))
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore, mgr)
+
+	// Branch 2 is neither external (0) nor internal (1); the legacy
+	// ExtendAddresses would coerce it to external, but the store must reject
+	// it as an invalid param instead.
+	err = store.ApplyScanBatch(t.Context(), db.ScanBatchParams{
+		WalletID: 0,
+		Horizons: []db.ScanHorizon{{
+			Scope:       db.KeyScope(scope),
+			Account:     account,
+			AccountName: waddrmgr.DefaultAccountName,
+			Branch:      2,
+			Index:       9,
+		}},
+	})
+	require.ErrorIs(t, err, db.ErrInvalidParam)
+
+	// Neither branch's horizon state may have advanced.
+	require.Zero(t, externalKeyCount(t, dbConn, scopedMgr, account))
+	require.Zero(t, internalKeyCount(t, dbConn, scopedMgr, account))
+}
+
+// internalKeyCount reports the number of internal keys the scoped manager
+// considers derived for the account, read through the live manager so any
+// unpersisted in-memory advance would be observable.
+func internalKeyCount(t *testing.T, dbConn walletdb.DB,
+	scopedMgr waddrmgr.AccountStore, account uint32) uint32 {
+
+	t.Helper()
+
+	var count uint32
+
+	err := walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgr.NamespaceKey)
+
+		props, err := scopedMgr.AccountProperties(ns, account)
+		if err != nil {
+			return err
+		}
+
+		count = props.InternalKeyCount
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	return count
+}

--- a/wallet/internal/db/kvdb/txstore_test.go
+++ b/wallet/internal/db/kvdb/txstore_test.go
@@ -2943,3 +2943,84 @@ func TestApplyTxBatchCreditNilFallback(t *testing.T) {
 	addrStore.AssertNotCalled(t, "Address", mock.Anything, mock.Anything)
 	addrStore.AssertNotCalled(t, "MarkUsed", mock.Anything, mock.Anything)
 }
+
+// TestApplyScanBatchRecordsTxAndSyncedBlocks verifies that kvdb.Store applies
+// scan-discovered transactions and connected sync blocks in one write batch.
+func TestApplyScanBatchRecordsTxAndSyncedBlocks(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	newAddrmgrNamespace(t, dbConn)
+	txStore := newTxStore(t, dbConn)
+
+	addr, script := newTestAddressScript(t)
+	managedAddr := &bwmock.ManagedAddress{}
+	managedAddr.On("Internal").Return(false).Maybe()
+	managedAddr.On("Address").Return(addr).Maybe()
+	managedAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Maybe()
+	managedAddr.On("Imported").Return(false).Maybe()
+	managedAddr.On("InternalAccount").Return(uint32(0)).Maybe()
+	managedAddr.On("Compressed").Return(true).Maybe()
+	managedAddr.On("AddrHash").Return([]byte(nil)).Maybe()
+	managedAddr.On("Used", mock.Anything).Return(false).Maybe()
+
+	addrStore := &bwmock.AddrStore{}
+	addrStore.On("ChainParams").Return(&chaincfg.RegressionNetParams)
+	addrStore.On("Address", mock.Anything, mock.Anything).
+		Return(managedAddr, nil)
+	addrStore.On("MarkUsed", mock.Anything, mock.Anything).Return(nil)
+	addrStore.On("SetSyncedTo", mock.Anything, mock.Anything).Return(nil)
+	addrStore.On("SyncedTo").Return(waddrmgr.BlockStamp{}).Maybe()
+	store := NewStore(dbConn, txStore, addrStore)
+
+	txMsg := &wire.MsgTx{Version: 1}
+	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{65},
+	}})
+	txMsg.AddTxOut(&wire.TxOut{Value: 11_000, PkScript: script})
+
+	syncedBlocks := []db.Block{{
+		Hash:      chainhash.Hash{66},
+		Height:    145,
+		Timestamp: time.Unix(1710003300, 0),
+	}, {
+		Hash:      chainhash.Hash{67},
+		Height:    146,
+		Timestamp: time.Unix(1710003400, 0),
+	}}
+	err := store.ApplyScanBatch(t.Context(), db.ScanBatchParams{
+		WalletID: 0,
+		Transactions: []db.CreateTxParams{{
+			WalletID: 0,
+			Tx:       txMsg,
+			Received: time.Unix(1710003350, 0),
+			Status:   db.TxStatusPublished,
+			Credits:  map[uint32]address.Address{0: addr},
+		}},
+		SyncedBlocks: syncedBlocks,
+	})
+	require.NoError(t, err)
+
+	txid := txMsg.TxHash()
+	err = walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(wtxmgrNamespaceKey)
+		require.NotNil(t, ns)
+
+		details, err := txStore.TxDetails(ns, &txid)
+		require.NoError(t, err)
+		require.NotNil(t, details)
+		require.Len(t, details.Credits, 1)
+
+		return nil
+	})
+	require.NoError(t, err)
+	addrStore.AssertCalled(t, "MarkUsed", mock.Anything, mock.Anything)
+	addrStore.AssertCalled(
+		t, "SetSyncedTo", mock.Anything,
+		mock.MatchedBy(func(bs *waddrmgr.BlockStamp) bool {
+			return bs.Height == int32(146)
+		}),
+	)
+}

--- a/wallet/internal/db/kvdb/txstore_test.go
+++ b/wallet/internal/db/kvdb/txstore_test.go
@@ -2,6 +2,7 @@ package kvdb
 
 import (
 	"errors"
+	"math"
 	"testing"
 	"time"
 
@@ -3023,4 +3024,376 @@ func TestApplyScanBatchRecordsTxAndSyncedBlocks(t *testing.T) {
 			return bs.Height == int32(146)
 		}),
 	)
+}
+
+// TestApplyScanBatchHorizonRollbackSafety verifies that when a recovery scan
+// batch fails after its horizon extension has already advanced the scoped
+// manager's in-memory address state, the live manager does not keep reporting
+// the unpersisted horizon advance once walletdb rolls the batch back.
+func TestApplyScanBatchHorizonRollbackSafety(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	// newSpendableAddrMgr creates the addrmgr namespace and a real manager
+	// with the default account already present on every default scope.
+	addrStore := newSpendableAddrMgr(t, dbConn)
+	t.Cleanup(func() {
+		_ = addrStore.Lock()
+		addrStore.Close()
+	})
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore, addrStore)
+
+	err := walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgr.NamespaceKey)
+
+		return addrStore.Unlock(ns, testPrivPass)
+	})
+	require.NoError(t, err)
+
+	const account = waddrmgr.DefaultAccountNum
+
+	scope := waddrmgr.KeyScopeBIP0084
+	scopedMgr, err := addrStore.FetchScopedKeyManager(scope)
+	require.NoError(t, err)
+
+	// The fresh default account has not derived any external addresses yet.
+	require.Zero(t, externalKeyCount(t, dbConn, scopedMgr, account))
+
+	const horizonIndex = 9
+
+	horizon := db.ScanHorizon{
+		Scope:   db.KeyScope(scope),
+		Account: account,
+		// AccountName carries the account's durable identity; it is
+		// always set, even for the default account, so resolution never
+		// has to guess whether the masked Account number is trustworthy.
+		AccountName: waddrmgr.DefaultAccountName,
+		Branch:      waddrmgr.ExternalBranch,
+		Index:       horizonIndex,
+	}
+
+	// A synced block whose height overflows the legacy int32 height domain
+	// fails the synced-block step, which runs after the horizon extension
+	// has already mutated the manager's in-memory address state.
+	overflowBlock := db.Block{
+		Hash:      chainhash.Hash{0xAB},
+		Height:    uint32(math.MaxInt32) + 1,
+		Timestamp: time.Unix(1_700_000_000, 0),
+	}
+
+	err = store.ApplyScanBatch(t.Context(), db.ScanBatchParams{
+		WalletID:     0,
+		Horizons:     []db.ScanHorizon{horizon},
+		SyncedBlocks: []db.Block{overflowBlock},
+	})
+	require.Error(t, err)
+
+	// The live manager must not observe the rolled-back horizon advance, and
+	// the persisted addrmgr bucket must not record any derived external
+	// addresses either.
+	require.Zero(t, externalKeyCount(t, dbConn, scopedMgr, account))
+
+	// As a positive control, the same horizon extension applied without the
+	// failing block must succeed and advance the external next index past the
+	// recovered child, proving the rollback path above did not simply skip the
+	// extension and that the invalidated cache reloads cleanly.
+	err = store.ApplyScanBatch(t.Context(), db.ScanBatchParams{
+		WalletID: 0,
+		Horizons: []db.ScanHorizon{horizon},
+	})
+	require.NoError(t, err)
+	require.Equal(
+		t, uint32(horizonIndex+1),
+		externalKeyCount(t, dbConn, scopedMgr, account),
+	)
+}
+
+// externalKeyCount reports the number of external keys the scoped manager
+// considers derived for the account, read through the live manager so any
+// unpersisted in-memory advance would be observable.
+func externalKeyCount(t *testing.T, dbConn walletdb.DB,
+	scopedMgr waddrmgr.AccountStore, account uint32) uint32 {
+
+	t.Helper()
+
+	var count uint32
+
+	err := walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgr.NamespaceKey)
+
+		props, err := scopedMgr.AccountProperties(ns, account)
+		if err != nil {
+			return err
+		}
+
+		count = props.ExternalKeyCount
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	return count
+}
+
+// failOnSyncedBlockStore wraps a real address manager and fails the SetSyncedTo
+// call at index failAt (zero-based), delegating every other call to the
+// embedded manager. This lets a scan-batch test commit some real in-memory
+// state and then fail mid-batch so the rollback path can be exercised against a
+// genuine manager rather than a mock.
+type failOnSyncedBlockStore struct {
+	*waddrmgr.Manager
+
+	failAt int
+	calls  int
+}
+
+// SetSyncedTo delegates to the real manager until the configured failure index,
+// at which point it returns an induced error without writing.
+func (f *failOnSyncedBlockStore) SetSyncedTo(ns walletdb.ReadWriteBucket,
+	bs *waddrmgr.BlockStamp) error {
+
+	defer func() { f.calls++ }()
+
+	if f.calls == f.failAt {
+		return errInducedFailure
+	}
+
+	return f.Manager.SetSyncedTo(ns, bs)
+}
+
+// TestApplyScanBatchRollsBackDerivedAddressCache verifies that when a scan
+// batch extends an address horizon and then fails later in the same update, the
+// rolled-back scan-derived address is neither observable through the live
+// manager's account next-index nor returned by Address, even though the horizon
+// extension had already mutated the manager's in-memory state.
+func TestApplyScanBatchRollsBackDerivedAddressCache(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	mgr := newSpendableAddrMgr(t, dbConn)
+	t.Cleanup(func() {
+		_ = mgr.Lock()
+		mgr.Close()
+	})
+
+	err := walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgr.NamespaceKey)
+
+		return mgr.Unlock(ns, testPrivPass)
+	})
+	require.NoError(t, err)
+
+	const account = waddrmgr.DefaultAccountNum
+
+	scope := waddrmgr.KeyScopeBIP0084
+	scopedMgr, err := mgr.FetchScopedKeyManager(scope)
+	require.NoError(t, err)
+
+	// The fresh default account has not derived any external addresses yet.
+	require.Zero(t, externalKeyCount(t, dbConn, scopedMgr, account))
+
+	// Re-derive the address the horizon extension below would cache so the
+	// test can assert it is unreachable after the rolled-back batch.
+	const horizonIndex = 6
+
+	scanAddr, _, err := scopedMgr.DeriveAddr(
+		account, waddrmgr.ExternalBranch, horizonIndex,
+	)
+	require.NoError(t, err)
+
+	// The first synced block fails, so the batch unwinds after the horizon
+	// extension has already advanced the manager's in-memory state.
+	addrStore := &failOnSyncedBlockStore{Manager: mgr, failAt: 0}
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore, addrStore)
+
+	err = store.ApplyScanBatch(t.Context(), db.ScanBatchParams{
+		WalletID: 0,
+		Horizons: []db.ScanHorizon{{
+			Scope:       db.KeyScope(scope),
+			Account:     account,
+			AccountName: waddrmgr.DefaultAccountName,
+			Branch:      waddrmgr.ExternalBranch,
+			Index:       horizonIndex,
+		}},
+		SyncedBlocks: []db.Block{*someBlock(t, 100)},
+	})
+	require.Error(t, err)
+
+	// The persisted next index must reload to zero, proving the horizon
+	// advance did not survive the rollback.
+	require.Zero(t, externalKeyCount(t, dbConn, scopedMgr, account))
+
+	// The rolled-back scan-derived address must not be returned by Address.
+	// Address consults the in-memory cache before the bucket, so a stale
+	// cache entry would surface here even though the bucket was rolled back.
+	err = walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgr.NamespaceKey)
+
+		_, err := mgr.Address(ns, scanAddr)
+
+		return err
+	})
+	require.Error(t, err)
+}
+
+// TestApplyScanBatchRollsBackSyncedTip verifies that a multi-block scan batch
+// that advances one synced block and then fails on a later block leaves both
+// the persisted synced tip and the live manager's in-memory SyncedTo at the
+// pre-batch value. A fully-successful batch must still advance SyncedTo.
+func TestApplyScanBatchRollsBackSyncedTip(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	mgr := newSpendableAddrMgr(t, dbConn)
+	t.Cleanup(func() {
+		_ = mgr.Lock()
+		mgr.Close()
+	})
+
+	txStore := newTxStore(t, dbConn)
+
+	preBatchTip := mgr.SyncedTo()
+
+	firstBlock := someBlock(t, 200)
+	secondBlock := someBlock(t, 201)
+
+	// The second synced block fails, after the first has already advanced
+	// both the bucket and the in-memory tip.
+	failStore := &failOnSyncedBlockStore{Manager: mgr, failAt: 1}
+	store := NewStore(dbConn, txStore, failStore)
+
+	err := store.ApplyScanBatch(t.Context(), db.ScanBatchParams{
+		WalletID:     0,
+		SyncedBlocks: []db.Block{*firstBlock, *secondBlock},
+	})
+	require.Error(t, err)
+
+	// The in-memory tip must be restored to the pre-batch value, not left at
+	// the first block whose bucket write was rolled back.
+	require.Equal(t, preBatchTip, mgr.SyncedTo())
+
+	// The persisted tip must also match the pre-batch value. Open a fresh
+	// manager on the same database so the synced tip is read straight from
+	// the rolled-back bucket rather than from the live manager's memory.
+	var reopened *waddrmgr.Manager
+
+	err = walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgr.NamespaceKey)
+
+		var oerr error
+
+		reopened, oerr = waddrmgr.Open(
+			ns, []byte("pub"), &chaincfg.SimNetParams,
+		)
+
+		return oerr
+	})
+	require.NoError(t, err)
+	t.Cleanup(reopened.Close)
+
+	require.Equal(t, preBatchTip.Height, reopened.SyncedTo().Height)
+	require.Equal(t, preBatchTip.Hash, reopened.SyncedTo().Hash)
+
+	// As a positive control, a fully-successful batch through the real
+	// manager must advance SyncedTo to the final block.
+	successStore := NewStore(dbConn, txStore, mgr)
+	err = successStore.ApplyScanBatch(t.Context(), db.ScanBatchParams{
+		WalletID:     0,
+		SyncedBlocks: []db.Block{*firstBlock, *secondBlock},
+	})
+	require.NoError(t, err)
+	require.Equal(t, secondBlock.Height, uint32(mgr.SyncedTo().Height))
+	require.Equal(t, secondBlock.Hash, mgr.SyncedTo().Hash)
+}
+
+// recordEvictScopedMgr wraps a real AccountStore so a scan-batch test can both
+// observe the index range passed to EvictDerivedAddresses and simulate a
+// post-extension next index that advanced past the requested horizon (as
+// happens when ExtendAddresses skips HD-invalid children). The first
+// AccountProperties read (the pre-extension snapshot) is delegated unchanged;
+// the second read (the post-extension re-read) reports postExtNextIndex so the
+// rollback range under test is forced to extend beyond horizon.Index+1.
+type recordEvictScopedMgr struct {
+	waddrmgr.AccountStore
+
+	branch           uint32
+	postExtNextIndex uint32
+
+	propCalls int
+
+	evictFrom uint32
+	evictTo   uint32
+	evicted   bool
+}
+
+// AccountProperties delegates the pre-extension read to the real manager and
+// overrides the external/internal key count on the post-extension re-read so
+// the test can assert the rollback range tracks the advanced next index.
+func (r *recordEvictScopedMgr) AccountProperties(ns walletdb.ReadBucket,
+	account uint32) (*waddrmgr.AccountProperties, error) {
+
+	props, err := r.AccountStore.AccountProperties(ns, account)
+	if err != nil {
+		return nil, err
+	}
+
+	r.propCalls++
+
+	// The first call is the pre-extension snapshot; leave it untouched. The
+	// second call is the post-extension re-read the fix relies on.
+	if r.propCalls >= 2 {
+		if r.branch == waddrmgr.InternalBranch {
+			props.InternalKeyCount = r.postExtNextIndex
+		} else {
+			props.ExternalKeyCount = r.postExtNextIndex
+		}
+	}
+
+	return props, nil
+}
+
+// EvictDerivedAddresses records the half-open range the rollback evicts so the
+// test can assert it covers the advanced next index, not horizon.Index+1.
+func (r *recordEvictScopedMgr) EvictDerivedAddresses(account, branch, fromIndex,
+	toIndex uint32) {
+
+	r.evicted = true
+	r.evictFrom = fromIndex
+	r.evictTo = toIndex
+
+	r.AccountStore.EvictDerivedAddresses(
+		account, branch, fromIndex, toIndex,
+	)
+}
+
+// recordEvictAddrStore wraps a real AddrStore and returns the same
+// recordEvictScopedMgr spy from FetchScopedKeyManager so a scan-batch test can
+// inspect the rollback eviction range.
+type recordEvictAddrStore struct {
+	waddrmgr.AddrStore
+
+	spy *recordEvictScopedMgr
+}
+
+// FetchScopedKeyManager returns the recording spy wrapping the real scoped
+// manager so the test observes the eviction range the rollback uses.
+func (r *recordEvictAddrStore) FetchScopedKeyManager(
+	scope waddrmgr.KeyScope) (waddrmgr.AccountStore, error) {
+
+	realMgr, err := r.AddrStore.FetchScopedKeyManager(scope)
+	if err != nil {
+		return nil, err
+	}
+
+	r.spy.AccountStore = realMgr
+
+	return r.spy, nil
 }

--- a/wallet/internal/db/kvdb/txstore_test.go
+++ b/wallet/internal/db/kvdb/txstore_test.go
@@ -1,6 +1,7 @@
 package kvdb
 
 import (
+	"bytes"
 	"errors"
 	"math"
 	"testing"
@@ -9,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/address/v2"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
@@ -3557,4 +3559,242 @@ func internalKeyCount(t *testing.T, dbConn walletdb.DB,
 	require.NoError(t, err)
 
 	return count
+}
+
+// importWatchOnlyXpubAccount imports a watch-only ("imported xpub") account
+// onto the given scope and returns its real waddrmgr account number. The
+// account key is derived from an independent master seed so the imported
+// account is distinct from the wallet's own derived accounts; what matters for
+// the scan-horizon path is only that it is a valid, child-derivable account
+// xpub the manager can extend.
+func importWatchOnlyXpubAccount(t *testing.T, dbConn walletdb.DB,
+	mgr *waddrmgr.Manager, scope waddrmgr.KeyScope,
+	name string) uint32 {
+
+	t.Helper()
+
+	// Derive m/scope.Purpose'/scope.Coin'/0' from a distinct seed and
+	// neuter it so the manager stores a watch-only account public key.
+	seed := bytes.Repeat([]byte{0xC3}, hdkeychain.RecommendedSeedLen)
+	master, err := hdkeychain.NewMaster(seed, &chaincfg.SimNetParams)
+	require.NoError(t, err)
+
+	purposeKey, err := master.DeriveNonStandard(
+		scope.Purpose + hdkeychain.HardenedKeyStart,
+	)
+	require.NoError(t, err)
+
+	coinKey, err := purposeKey.DeriveNonStandard(
+		scope.Coin + hdkeychain.HardenedKeyStart,
+	)
+	require.NoError(t, err)
+
+	acctKey, err := coinKey.DeriveNonStandard(hdkeychain.HardenedKeyStart)
+	require.NoError(t, err)
+
+	acctPub, err := acctKey.Neuter()
+	require.NoError(t, err)
+
+	scopedMgr, err := mgr.FetchScopedKeyManager(scope)
+	require.NoError(t, err)
+
+	var account uint32
+
+	err = walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+
+		account, err = scopedMgr.NewAccountWatchingOnly(
+			ns, name, acctPub, 0, nil,
+		)
+
+		return err
+	})
+	require.NoError(t, err)
+
+	return account
+}
+
+// TestApplyScanBatchHorizonResolvesImportedAccountByName verifies that a
+// horizon emitted for an imported account, whose Account number has been masked
+// to 0 (the default derived account's number), is resolved by its durable
+// AccountName and extends the imported account's branch rather than the default
+// account's.
+func TestApplyScanBatchHorizonResolvesImportedAccountByName(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	mgr := newSpendableAddrMgr(t, dbConn)
+	t.Cleanup(func() {
+		_ = mgr.Lock()
+		mgr.Close()
+	})
+
+	scope := waddrmgr.KeyScopeBIP0084
+	scopedMgr, err := mgr.FetchScopedKeyManager(scope)
+	require.NoError(t, err)
+
+	// Import a watch-only account; it receives a real, non-zero waddrmgr
+	// number, but the AccountInfo contract masks imported numbers to 0.
+	const importedName = "imported-xpub"
+
+	importedAccount := importWatchOnlyXpubAccount(
+		t, dbConn, mgr, scope, importedName,
+	)
+	require.NotEqual(t, uint32(waddrmgr.DefaultAccountNum), importedAccount)
+
+	// Neither the default nor the imported account has derived an external
+	// address yet.
+	require.Zero(t, externalKeyCount(
+		t, dbConn, scopedMgr, waddrmgr.DefaultAccountNum,
+	))
+	require.Zero(t, externalKeyCount(t, dbConn, scopedMgr, importedAccount))
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore, mgr)
+
+	const horizonIndex = 4
+
+	// The horizon mirrors what the AccountInfo contract emits for an
+	// imported account: Account masked to 0, identity carried by name.
+	err = store.ApplyScanBatch(t.Context(), db.ScanBatchParams{
+		WalletID: 0,
+		Horizons: []db.ScanHorizon{{
+			Scope:       db.KeyScope(scope),
+			Account:     0,
+			AccountName: importedName,
+			Branch:      waddrmgr.ExternalBranch,
+			Index:       horizonIndex,
+		}},
+	})
+	require.NoError(t, err)
+
+	// The imported account's branch must have advanced past the recovered
+	// child, while the default account (number 0) must remain untouched:
+	// resolving the masked number 0 directly would have extended it.
+	require.Equal(t, uint32(horizonIndex+1), externalKeyCount(
+		t, dbConn, scopedMgr, importedAccount,
+	))
+	require.Zero(t, externalKeyCount(
+		t, dbConn, scopedMgr, waddrmgr.DefaultAccountNum,
+	))
+}
+
+// TestApplyScanBatchHorizonResolvesDerivedAccountByNumber verifies that a
+// horizon for a derived account whose name matches its real account number
+// extends that derived account, confirming the name resolution agrees with the
+// number fast path for non-imported accounts.
+func TestApplyScanBatchHorizonResolvesDerivedAccountByNumber(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	mgr := newSpendableAddrMgr(t, dbConn)
+	t.Cleanup(func() {
+		_ = mgr.Lock()
+		mgr.Close()
+	})
+
+	err := walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgr.NamespaceKey)
+
+		return mgr.Unlock(ns, testPrivPass)
+	})
+	require.NoError(t, err)
+
+	scope := waddrmgr.KeyScopeBIP0084
+	scopedMgr, err := mgr.FetchScopedKeyManager(scope)
+	require.NoError(t, err)
+
+	// Create a second derived account so resolution must distinguish it from
+	// the default account by both its non-zero number and its name.
+	const derivedName = "derived-1"
+
+	props := createLegacyAccount(t, dbConn, mgr, scope, derivedName)
+	derivedAccount := props.AccountNumber
+	require.NotEqual(t, uint32(waddrmgr.DefaultAccountNum), derivedAccount)
+
+	require.Zero(t, externalKeyCount(t, dbConn, scopedMgr, derivedAccount))
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore, mgr)
+
+	const horizonIndex = 3
+
+	err = store.ApplyScanBatch(t.Context(), db.ScanBatchParams{
+		WalletID: 0,
+		Horizons: []db.ScanHorizon{{
+			Scope:       db.KeyScope(scope),
+			Account:     derivedAccount,
+			AccountName: derivedName,
+			Branch:      waddrmgr.ExternalBranch,
+			Index:       horizonIndex,
+		}},
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, uint32(horizonIndex+1), externalKeyCount(
+		t, dbConn, scopedMgr, derivedAccount,
+	))
+	// The default account must not have been touched.
+	require.Zero(t, externalKeyCount(
+		t, dbConn, scopedMgr, waddrmgr.DefaultAccountNum,
+	))
+}
+
+// TestApplyScanBatchHorizonMissingNameErrors verifies that a horizon naming an
+// account that no longer exists (e.g. a rename racing the scan) fails the batch
+// instead of silently extending the default account, which shares the masked
+// Account number 0.
+func TestApplyScanBatchHorizonMissingNameErrors(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	mgr := newSpendableAddrMgr(t, dbConn)
+	t.Cleanup(func() {
+		_ = mgr.Lock()
+		mgr.Close()
+	})
+
+	err := walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgr.NamespaceKey)
+
+		return mgr.Unlock(ns, testPrivPass)
+	})
+	require.NoError(t, err)
+
+	scope := waddrmgr.KeyScopeBIP0084
+	scopedMgr, err := mgr.FetchScopedKeyManager(scope)
+	require.NoError(t, err)
+
+	require.Zero(t, externalKeyCount(
+		t, dbConn, scopedMgr, waddrmgr.DefaultAccountNum,
+	))
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore, mgr)
+
+	// The horizon carries a name no account holds and the masked number 0.
+	// Resolution must surface the lookup miss instead of extending the
+	// default account that happens to own number 0.
+	err = store.ApplyScanBatch(t.Context(), db.ScanBatchParams{
+		WalletID: 0,
+		Horizons: []db.ScanHorizon{{
+			Scope:       db.KeyScope(scope),
+			Account:     0,
+			AccountName: "does-not-exist",
+			Branch:      waddrmgr.ExternalBranch,
+			Index:       7,
+		}},
+	})
+	require.Error(t, err)
+
+	// The default account (number 0) must not have absorbed the extension.
+	require.Zero(t, externalKeyCount(
+		t, dbConn, scopedMgr, waddrmgr.DefaultAccountNum,
+	))
 }


### PR DESCRIPTION
Adds unit and cross-backend conformance test coverage for the `ApplyScanBatch` scan engine and `RollbackToBlock` sync-tip atomicity. Test-only — no production changes.

- `kvdb` unit tests: tx and synced-block writes, synced-tip rollback, rollback through skipped indices, account-name resolution, and sync-tip restoration on a failed `RollbackToBlock`.
- itests: an `ApplyScanBatch` conformance fixture run against `kvdb`, `pg`, and `sqlite` (horizon and watch-set conformance; scan/tx batch duplicate and new-block cases), plus `RollbackToBlock` sync-tip atomicity.
