### PR TITLE
wallet: route runtime startup, sync-tip, and rewind through the Store

### DIFF
--- a/wallet/common_test.go
+++ b/wallet/common_test.go
@@ -219,24 +219,14 @@ func createStartedWalletWithID(t *testing.T, walletID uint32) (*Wallet,
 		Maybe()
 	deps.addrStore.On("WatchOnly").Return(false).Maybe()
 
-	// Mock account loading.
-	deps.addrStore.On("ActiveScopedKeyManagers").
-		Return([]waddrmgr.AccountStore{deps.accountManager}).
+	// Mock account loading through the store (runtime startup).
+	deps.store.On("ListAccounts", mock.Anything,
+		mock.AnythingOfType("db.ListAccountsQuery")).
+		Return([]db.AccountInfo(nil), nil).
 		Once()
 
-	deps.accountManager.On("LastAccount", mock.Anything).
-		Return(uint32(0), nil).
-		Once()
-
-	deps.accountManager.On("AccountProperties", mock.Anything, uint32(0)).
-		Return(&waddrmgr.AccountProperties{
-			AccountNumber: 0,
-			AccountName:   "default",
-		}, nil).
-		Once()
-
-	// Mock expired lock deletion.
-	deps.txStore.On("DeleteExpiredLockedOutputs", mock.Anything).
+	// Mock expired-lease cleanup (runtime startup).
+	deps.store.On("DeleteExpiredLeases", mock.Anything, mock.Anything).
 		Return(nil).
 		Once()
 

--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -273,7 +273,8 @@ func (w *Wallet) waitForBackoff(startTime time.Time, backoff time.Duration,
 
 // performRuntimeSetup executes the synchronous initialization tasks required
 // before the wallet's main loops can start. This includes sanity checking the
-// birthday block, loading accounts into memory, and cleaning up expired locks.
+// birthday block, fail-fast verifying that the wallet's accounts can be read
+// from the store, and cleaning up expired locks.
 func (w *Wallet) performRuntimeSetup(startCtx context.Context) error {
 	// Perform the birthday sanity check synchronously to ensure we are
 	// connected and our status is valid before starting the main loop.
@@ -285,15 +286,26 @@ func (w *Wallet) performRuntimeSetup(startCtx context.Context) error {
 		return err
 	}
 
-	// Ensure all accounts are loaded into memory so we can efficiently
-	// access them during the scan loop without database lookups.
-	err = w.DBGetAllAccounts(startCtx)
+	// Fail fast on store connectivity by reading the wallet's accounts
+	// before entering the main loop. The result is intentionally discarded:
+	// the read itself surfaces a broken or unreachable store as a startup
+	// error rather than a mid-scan failure.
+	_, err = w.cache.ListAccounts(
+		startCtx, db.ListAccountsQuery{
+			WalletID: w.id,
+		},
+	)
 	if err != nil {
-		return err
+		return fmt.Errorf("list accounts: %w", err)
 	}
 
 	// Cleanup any expired output locks.
-	return w.DBDeleteExpiredLockedOutputs(startCtx)
+	err = w.store.DeleteExpiredLeases(startCtx, w.id)
+	if err != nil {
+		return fmt.Errorf("delete expired leases: %w", err)
+	}
+
+	return nil
 }
 
 // Stop signals all wallet background processes to shutdown and blocks until

--- a/wallet/controller_test.go
+++ b/wallet/controller_test.go
@@ -9,12 +9,39 @@ import (
 
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
-	bwmock "github.com/btcsuite/btcwallet/bwtest/mock"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+// TestPerformRuntimeSetupRoutesStoreStartup verifies that startup setup uses
+// the runtime store paths for account loading and lease cleanup.
+func TestPerformRuntimeSetupRoutesStoreStartup(t *testing.T) {
+	t.Parallel()
+
+	w, deps := createTestWalletWithMocks(t)
+	w.id = 51
+	birthdayBlock := &db.Block{
+		Hash:      chainhash.Hash{51},
+		Height:    100,
+		Timestamp: time.Unix(1710003700, 0),
+	}
+	accountNumber0 := uint32(0)
+
+	deps.store.On("GetWallet", mock.Anything, "").Return(&db.WalletInfo{
+		Name:          "",
+		BirthdayBlock: birthdayBlock,
+	}, nil).Once()
+	deps.store.On("ListAccounts", mock.Anything, db.ListAccountsQuery{
+		WalletID: w.id,
+	}).Return([]db.AccountInfo{{AccountNumber: &accountNumber0}}, nil).Once()
+	deps.store.On("DeleteExpiredLeases", mock.Anything, w.id).Return(nil).
+		Once()
+
+	err := w.performRuntimeSetup(t.Context())
+	require.NoError(t, err)
+}
 
 // TestHandleUnlockReq verifies that the handleUnlockReq method correctly
 // processes an unlock request by invoking the address manager's Unlock method
@@ -255,15 +282,14 @@ func TestControllerStart(t *testing.T) {
 
 	// 2. Mock DBGetAllAccounts: Expect a call to load active account
 	//    managers.
-	deps.addrStore.On(
-		"ActiveScopedKeyManagers",
-	).Return([]waddrmgr.AccountStore(nil)).Once()
+	deps.store.On("ListAccounts", mock.Anything,
+		mock.AnythingOfType("db.ListAccountsQuery")).
+		Return([]db.AccountInfo(nil), nil).Once()
 
-	// 3. Mock deleteExpiredLockedOutputs: Expect a call to cleanup expired
-	//    locks in the transaction store.
-	deps.txStore.On(
-		"DeleteExpiredLockedOutputs", mock.Anything,
-	).Return(nil).Once()
+	// 3. Mock deleteExpiredLeases: Expect a call to cleanup expired
+	//    leases through the store.
+	deps.store.On("DeleteExpiredLeases", mock.Anything,
+		mock.Anything).Return(nil).Once()
 
 	// 4. Mock syncer.run: Expect the syncer to be started.
 	deps.syncer.On(
@@ -537,12 +563,11 @@ func TestControllerStop(t *testing.T) {
 	// Setup mocks for the startup sequence.
 	deps.store.On("GetWallet", mock.Anything, mock.Anything).Return(
 		&db.WalletInfo{BirthdayBlock: &db.Block{}}, nil).Once()
-	deps.addrStore.On(
-		"ActiveScopedKeyManagers",
-	).Return([]waddrmgr.AccountStore(nil)).Once()
-	deps.txStore.On(
-		"DeleteExpiredLockedOutputs", mock.Anything,
-	).Return(nil).Once()
+	deps.store.On("ListAccounts", mock.Anything,
+		mock.AnythingOfType("db.ListAccountsQuery")).
+		Return([]db.AccountInfo(nil), nil).Once()
+	deps.store.On("DeleteExpiredLeases", mock.Anything,
+		mock.Anything).Return(nil).Once()
 
 	// Mock syncer.run to simulate a long-running process that exits when
 	// the context is cancelled.
@@ -584,12 +609,11 @@ func TestControllerLock(t *testing.T) {
 	// Setup mocks for startup.
 	deps.store.On("GetWallet", mock.Anything, mock.Anything).Return(
 		&db.WalletInfo{BirthdayBlock: &db.Block{}}, nil).Once()
-	deps.addrStore.On(
-		"ActiveScopedKeyManagers",
-	).Return([]waddrmgr.AccountStore(nil)).Once()
-	deps.txStore.On(
-		"DeleteExpiredLockedOutputs", mock.Anything,
-	).Return(nil).Once()
+	deps.store.On("ListAccounts", mock.Anything,
+		mock.AnythingOfType("db.ListAccountsQuery")).
+		Return([]db.AccountInfo(nil), nil).Once()
+	deps.store.On("DeleteExpiredLeases", mock.Anything,
+		mock.Anything).Return(nil).Once()
 	deps.syncer.On("run", mock.Anything).Return(nil).Once()
 
 	require.NoError(t, w.Start(t.Context()))
@@ -625,12 +649,11 @@ func TestControllerUnlock(t *testing.T) {
 	// Setup mocks for startup.
 	deps.store.On("GetWallet", mock.Anything, mock.Anything).Return(
 		&db.WalletInfo{BirthdayBlock: &db.Block{}}, nil).Once()
-	deps.addrStore.On(
-		"ActiveScopedKeyManagers",
-	).Return([]waddrmgr.AccountStore(nil)).Once()
-	deps.txStore.On(
-		"DeleteExpiredLockedOutputs", mock.Anything,
-	).Return(nil).Once()
+	deps.store.On("ListAccounts", mock.Anything,
+		mock.AnythingOfType("db.ListAccountsQuery")).
+		Return([]db.AccountInfo(nil), nil).Once()
+	deps.store.On("DeleteExpiredLeases", mock.Anything,
+		mock.Anything).Return(nil).Once()
 	deps.syncer.On("run", mock.Anything).Return(nil).Once()
 
 	require.NoError(t, w.Start(t.Context()))
@@ -666,12 +689,11 @@ func TestControllerChangePassphrase(t *testing.T) {
 	// Setup mocks for startup.
 	deps.store.On("GetWallet", mock.Anything, mock.Anything).Return(
 		&db.WalletInfo{BirthdayBlock: &db.Block{}}, nil).Once()
-	deps.addrStore.On(
-		"ActiveScopedKeyManagers",
-	).Return([]waddrmgr.AccountStore(nil)).Once()
-	deps.txStore.On(
-		"DeleteExpiredLockedOutputs", mock.Anything,
-	).Return(nil).Once()
+	deps.store.On("ListAccounts", mock.Anything,
+		mock.AnythingOfType("db.ListAccountsQuery")).
+		Return([]db.AccountInfo(nil), nil).Once()
+	deps.store.On("DeleteExpiredLeases", mock.Anything,
+		mock.Anything).Return(nil).Once()
 	deps.syncer.On("run", mock.Anything).Return(nil).Once()
 
 	require.NoError(t, w.Start(t.Context()))
@@ -791,28 +813,22 @@ func TestControllerStart_WithAccounts(t *testing.T) {
 
 	// Arrange: Setup a wallet with existing accounts in the address store.
 	w, deps := createTestWalletWithMocks(t)
+	accountNumber0 := uint32(0)
+	accountNumber1 := uint32(1)
 
 	deps.store.On("GetWallet", mock.Anything, mock.Anything).Return(
 		&db.WalletInfo{BirthdayBlock: &db.Block{Height: 100}}, nil,
 	).Once()
 
-	scopedMgr := &bwmock.AccountStore{}
-	deps.addrStore.On(
-		"ActiveScopedKeyManagers",
-	).Return([]waddrmgr.AccountStore{scopedMgr}).Once()
+	deps.store.On("ListAccounts", mock.Anything,
+		mock.AnythingOfType("db.ListAccountsQuery")).
+		Return([]db.AccountInfo{
+			{AccountNumber: &accountNumber0},
+			{AccountNumber: &accountNumber1},
+		}, nil).Once()
 
-	scopedMgr.On("LastAccount", mock.Anything).Return(uint32(1), nil).Once()
-	scopedMgr.On("Scope").Return(waddrmgr.KeyScopeBIP0084).Maybe()
-	scopedMgr.On(
-		"AccountProperties", mock.Anything, uint32(0),
-	).Return(&waddrmgr.AccountProperties{AccountNumber: 0}, nil).Once()
-	scopedMgr.On(
-		"AccountProperties", mock.Anything, uint32(1),
-	).Return(&waddrmgr.AccountProperties{AccountNumber: 1}, nil).Once()
-
-	deps.txStore.On(
-		"DeleteExpiredLockedOutputs", mock.Anything,
-	).Return(nil).Once()
+	deps.store.On("DeleteExpiredLeases", mock.Anything,
+		mock.Anything).Return(nil).Once()
 	deps.syncer.On("run", mock.Anything).Return(nil).Once()
 
 	// Act: Start the wallet.
@@ -1185,12 +1201,11 @@ func TestControllerInfo(t *testing.T) {
 		&db.WalletInfo{
 			BirthdayBlock: &db.Block{Height: 100},
 		}, nil).Once()
-	deps.addrStore.On(
-		"ActiveScopedKeyManagers",
-	).Return([]waddrmgr.AccountStore(nil)).Once()
-	deps.txStore.On(
-		"DeleteExpiredLockedOutputs", mock.Anything,
-	).Return(nil).Once()
+	deps.store.On("ListAccounts", mock.Anything,
+		mock.AnythingOfType("db.ListAccountsQuery")).
+		Return([]db.AccountInfo(nil), nil).Once()
+	deps.store.On("DeleteExpiredLeases", mock.Anything,
+		mock.Anything).Return(nil).Once()
 	deps.syncer.On("run", mock.Anything).Return(nil).Once()
 
 	// Mock the chain backend to return a specific name.
@@ -1339,14 +1354,9 @@ func TestControllerStart_DBGetAllAccountsFail(t *testing.T) {
 		"GetWallet", mock.Anything, mock.Anything,
 	).Return(&db.WalletInfo{BirthdayBlock: &db.Block{}}, nil).Once()
 
-	mockScopedMgr := &bwmock.AccountStore{}
-	deps.addrStore.On(
-		"ActiveScopedKeyManagers",
-	).Return([]waddrmgr.AccountStore{mockScopedMgr}).Once()
-
-	mockScopedMgr.On(
-		"LastAccount", mock.Anything,
-	).Return(uint32(0), errDBMock).Once()
+	deps.store.On("ListAccounts", mock.Anything,
+		mock.AnythingOfType("db.ListAccountsQuery")).
+		Return([]db.AccountInfo(nil), errDBMock).Once()
 
 	// Act: Attempt to start the wallet.
 	err := w.Start(t.Context())
@@ -1389,12 +1399,11 @@ func TestControllerStart_BirthdayNotSet(t *testing.T) {
 		}),
 	).Return(nil).Once()
 
-	deps.addrStore.On(
-		"ActiveScopedKeyManagers",
-	).Return([]waddrmgr.AccountStore(nil)).Once()
-	deps.txStore.On(
-		"DeleteExpiredLockedOutputs", mock.Anything,
-	).Return(nil).Once()
+	deps.store.On("ListAccounts", mock.Anything,
+		mock.AnythingOfType("db.ListAccountsQuery")).
+		Return([]db.AccountInfo(nil), nil).Once()
+	deps.store.On("DeleteExpiredLeases", mock.Anything,
+		mock.Anything).Return(nil).Once()
 	deps.syncer.On("run", mock.Anything).Return(nil).Once()
 
 	// Act: Start the wallet.
@@ -1455,11 +1464,13 @@ func TestControllerStart_DeleteExpiredFail(t *testing.T) {
 
 	deps.store.On("GetWallet", mock.Anything, mock.Anything).Return(
 		&db.WalletInfo{BirthdayBlock: &db.Block{}}, nil).Once()
-	deps.addrStore.On("ActiveScopedKeyManagers").Return(
-		[]waddrmgr.AccountStore(nil)).Once()
 
-	deps.txStore.On("DeleteExpiredLockedOutputs", mock.Anything).Return(
-		errDBMock).Once()
+	deps.store.On("ListAccounts", mock.Anything,
+		mock.AnythingOfType("db.ListAccountsQuery")).Return(
+		[]db.AccountInfo(nil), nil).Once()
+
+	deps.store.On("DeleteExpiredLeases", mock.Anything, mock.Anything).
+		Return(errDBMock).Once()
 
 	// Act: Attempt to start.
 	err := w.Start(t.Context())

--- a/wallet/db_ops.go
+++ b/wallet/db_ops.go
@@ -501,9 +501,20 @@ func (s *syncer) DBGetSyncedBlocks(_ context.Context, startHeight,
 func (s *syncer) DBPutRewind(_ context.Context,
 	bs waddrmgr.BlockStamp) error {
 
+	var preRewindTip waddrmgr.BlockStamp
+
 	err := walletdb.Update(s.cfg.DB, func(tx walletdb.ReadWriteTx) error {
 		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
 		txmgrNs := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+
+		// SetSyncedTo below writes the addrmgr bucket and advances the live
+		// manager's in-memory synced tip immediately. If the subsequent
+		// Rollback fails, walletdb rolls the bucket write back but the
+		// in-memory tip stays rewound to a fork point that was never
+		// persisted. Snapshot the pre-rewind tip inside this write transaction,
+		// immediately before the rewind, so a failed update restores the latest
+		// committed live tip.
+		preRewindTip = s.addrStore.SyncedTo()
 
 		err := s.addrStore.SetSyncedTo(addrmgrNs, &bs)
 		if err != nil {
@@ -513,6 +524,12 @@ func (s *syncer) DBPutRewind(_ context.Context,
 		return s.txStore.Rollback(txmgrNs, bs.Height+1)
 	})
 	if err != nil {
+		// walletdb rolled the addrmgr bucket back, but any synced-tip
+		// advance from SetSyncedTo survives in memory. Restore the
+		// pre-rewind tip only if the live manager still points at the
+		// rolled-back rewind target.
+		s.addrStore.RestoreSyncedToIfCurrent(preRewindTip, bs)
+
 		return fmt.Errorf("rollback wallet: %w", err)
 	}
 

--- a/wallet/db_ops_test.go
+++ b/wallet/db_ops_test.go
@@ -566,6 +566,10 @@ func TestDBPutRewind(t *testing.T) {
 
 	bs := waddrmgr.BlockStamp{Height: 100, Hash: chainhash.Hash{0x01}}
 
+	// DBPutRewind snapshots the synced tip inside the update so it can
+	// restore it on failure; the successful path never restores.
+	preRewindTip := waddrmgr.BlockStamp{Height: 50, Hash: chainhash.Hash{0x09}}
+	mocks.addrStore.On("SyncedTo").Return(preRewindTip).Once()
 	mocks.addrStore.On("SetSyncedTo", mock.Anything, &bs).Return(nil).Once()
 	mocks.txStore.On("Rollback",
 		mock.Anything, int32(101),
@@ -574,8 +578,47 @@ func TestDBPutRewind(t *testing.T) {
 	// Act: Rewind the wallet state to the specified block height.
 	err := s.DBPutRewind(t.Context(), bs)
 
-	// Assert: Verify that the rewind operation succeeded.
+	// Assert: Verify that the rewind operation succeeded. The mock's
+	// AssertExpectations confirms RestoreSyncedTo was not called.
 	require.NoError(t, err)
+}
+
+// TestDBPutRewind_RollbackFailureRestoresTip verifies that when SetSyncedTo
+// succeeds and advances the in-memory synced tip but the subsequent
+// txStore.Rollback fails, DBPutRewind conditionally restores the in-memory tip
+// to the pre-rewind value. SetSyncedTo writes the bucket and advances the live
+// manager's tip immediately, so a rolled-back update would otherwise leave the
+// tip rewound to a fork point that was never persisted.
+func TestDBPutRewind_RollbackFailureRestoresTip(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: SetSyncedTo succeeds (advancing the in-memory tip) and then
+	// Rollback fails, forcing the restore path.
+	w, mocks := createTestWalletWithMocks(t)
+	s := newSyncer(w.cfg, w.addrStore, w.txStore, nil)
+
+	bs := waddrmgr.BlockStamp{Height: 100, Hash: chainhash.Hash{0x01}}
+
+	preRewindTip := waddrmgr.BlockStamp{
+		Height: 150, Hash: chainhash.Hash{0x42},
+	}
+	mocks.addrStore.On("SyncedTo").Return(preRewindTip).Once()
+	mocks.addrStore.On("SetSyncedTo", mock.Anything, &bs).Return(nil).Once()
+	mocks.txStore.On("Rollback",
+		mock.Anything, int32(101),
+	).Return(errRollbackFail).Once()
+	mocks.addrStore.On("RestoreSyncedToIfCurrent", preRewindTip, bs).
+		Return(true).Once()
+
+	// Act: Rewind the wallet state, expecting the rollback to fail.
+	err := s.DBPutRewind(t.Context(), bs)
+
+	// Assert: The error propagates and the pre-rewind tip is restored if the
+	// live tip still points at the rewound fork point. The mock's
+	// AssertExpectations confirms the conditional restore was called with the
+	// snapshotted pre-rewind tip and the rewind target.
+	require.ErrorIs(t, err, errRollbackFail)
+	mocks.addrStore.AssertExpectations(t)
 }
 
 // TestDBPutBirthdayBlock_Error verifies that DBPutBirthdayBlock correctly
@@ -1296,12 +1339,23 @@ func TestDBPutRewind_Error(t *testing.T) {
 	mockAddrStore := &bwmock.AddrStore{}
 	s := newSyncer(Config{DB: db}, mockAddrStore, nil, nil)
 
+	// The synced tip is snapshotted before the update and conditionally
+	// restored after the update fails so the in-memory tip is not left at
+	// the never-persisted fork point.
+	preRewindTip := waddrmgr.BlockStamp{Height: 50, Hash: chainhash.Hash{0x09}}
+	rewindTip := waddrmgr.BlockStamp{}
+
+	mockAddrStore.On("SyncedTo").Return(preRewindTip).Once()
 	mockAddrStore.On("SetSyncedTo",
 		mock.Anything, mock.Anything).Return(errSetSync).Once()
+	mockAddrStore.On(
+		"RestoreSyncedToIfCurrent", preRewindTip, rewindTip,
+	).Return(false).Once()
 
 	// Act: Perform DBPutRewind.
 	err := s.DBPutRewind(t.Context(), waddrmgr.BlockStamp{})
 
-	// Assert: Verify failure.
+	// Assert: Verify failure and that the pre-rewind tip was restored.
 	require.ErrorIs(t, err, errSetSync)
+	mockAddrStore.AssertExpectations(t)
 }

--- a/wallet/db_ops_test.go
+++ b/wallet/db_ops_test.go
@@ -530,6 +530,68 @@ func TestDBGetScanData(t *testing.T) {
 	require.Empty(t, initialUnspent)
 }
 
+// TestLoadWalletScanDataKeepsImportedXpubHorizons verifies that full-scan setup
+// builds its horizon targets from the legacy address manager's active accounts.
+// Imported xpub accounts have real waddrmgr account numbers that must remain in
+// the lookahead set even though SQL account metadata may not expose a BIP44
+// account number for them.
+func TestLoadWalletScanDataKeepsImportedXpubHorizons(t *testing.T) {
+	t.Parallel()
+
+	w, mocks := createTestWalletWithMocks(t)
+	s := newSyncer(w.cfg, w.addrStore, w.txStore, nil)
+
+	const importedAccount = uint32(9)
+
+	scope := waddrmgr.KeyScopeBIP0084
+	props := &waddrmgr.AccountProperties{
+		AccountNumber:    importedAccount,
+		AccountName:      "imported-xpub",
+		ExternalKeyCount: 5,
+		InternalKeyCount: 2,
+		KeyScope:         scope,
+		IsWatchOnly:      true,
+	}
+
+	scopedMgr := &bwmock.AccountStore{}
+	mocks.addrStore.On("ActiveScopedKeyManagers").Return(
+		[]waddrmgr.AccountStore{scopedMgr},
+	).Once()
+
+	scopedMgr.On("ActiveAccounts").Return([]uint32{importedAccount}).Once()
+	scopedMgr.On("Scope").Return(scope).Once()
+
+	mocks.addrStore.On("FetchScopedKeyManager", scope).Return(
+		scopedMgr, nil,
+	).Once()
+
+	scopedMgr.On("AccountProperties", mock.Anything, importedAccount).Return(
+		props, nil,
+	).Once()
+
+	mocks.addrStore.On("ForEachRelevantActiveAddress", mock.Anything,
+		mock.Anything,
+	).Return(nil).Once()
+
+	mocks.txStore.On("OutputsToWatch", mock.Anything).Return(
+		[]wtxmgr.Credit(nil), nil,
+	).Once()
+
+	horizonData, initialAddrs, initialUnspent, err := s.loadWalletScanData(
+		t.Context(),
+	)
+
+	require.NoError(t, err)
+	require.Len(t, horizonData, 1)
+	require.Equal(t, props, horizonData[0])
+	require.Equal(t, importedAccount, horizonData[0].AccountNumber)
+	require.Empty(t, initialAddrs)
+	require.Empty(t, initialUnspent)
+
+	mocks.addrStore.AssertExpectations(t)
+	scopedMgr.AssertExpectations(t)
+}
+
 // TestDBGetSyncedBlocks verifies that the wallet can successfully retrieve a
 // range of block hashes from its internal index.
 func TestDBGetSyncedBlocks(t *testing.T) {
@@ -1353,7 +1415,7 @@ func TestDBPutRewind_Error(t *testing.T) {
 	).Return(false).Once()
 
 	// Act: Perform DBPutRewind.
-	err := s.DBPutRewind(t.Context(), waddrmgr.BlockStamp{})
+	err := s.DBPutRewind(t.Context(), rewindTip)
 
 	// Assert: Verify failure and that the pre-rewind tip was restored.
 	require.ErrorIs(t, err, errSetSync)

--- a/wallet/internal/bwtest/mock/store.go
+++ b/wallet/internal/bwtest/mock/store.go
@@ -440,6 +440,15 @@ func (m *Store) ApplyScanBatch(ctx context.Context,
 	return args.Error(0)
 }
 
+// RewindWallet implements the db.TxStore interface.
+func (m *Store) RewindWallet(ctx context.Context,
+	params db.RewindWalletParams) error {
+
+	args := m.Called(ctx, params)
+
+	return args.Error(0)
+}
+
 // GetTx implements the db.TxStore interface.
 func (m *Store) GetTx(ctx context.Context,
 	query db.GetTxQuery) (*db.TxInfo, error) {

--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -1092,6 +1092,23 @@ type CreateTxParams struct {
 	// UTXO always records the on-chain output script, never the member
 	// script.
 	Credits map[uint32]address.Address
+
+	// CreditCandidates maps output indexes to addresses extracted from the
+	// output script that may make the output wallet-owned.
+	//
+	// Unlike Credits, candidates are not trusted ownership assertions. Batch
+	// writers resolve them inside the same write transaction that records the
+	// transaction, then copy only owned outputs into Credits before the normal
+	// CreateTx validation and insert path runs. This is used by notification
+	// paths where ownership can change between parsing a chain notification and
+	// committing the batch.
+	//
+	// If the output script itself is wallet-owned, the batch writer records a
+	// nil credit for that index so ownership is keyed on the on-chain script.
+	// Only when the output script is not owned does it try the candidate
+	// addresses, which supports bare-multisig outputs owned through one member
+	// pubkey.
+	CreditCandidates map[uint32][]address.Address
 }
 
 // TxBatchParams contains a wallet transaction batch and optional sync-tip

--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -1108,6 +1108,17 @@ type TxBatchParams struct {
 	SyncedTo *Block
 }
 
+// RewindWalletParams contains the wallet-scoped rewind target for a manual
+// rescan. The block is the new synced tip for the wallet after transactions at
+// and above the next height are detached from confirmed history.
+type RewindWalletParams struct {
+	// WalletID is the ID of the wallet to rewind.
+	WalletID uint32
+
+	// Block is the wallet's new synced-to block after the rewind.
+	Block Block
+}
+
 // ScanHorizon records the highest recovered address index for one account
 // branch.
 type ScanHorizon struct {

--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -423,6 +423,13 @@ type TxStore interface {
 	// ApplyScanBatch atomically records recovery scan writes for one wallet.
 	ApplyScanBatch(ctx context.Context, params ScanBatchParams) error
 
+	// RewindWallet atomically detaches one wallet's confirmed transactions at
+	// and above the block after params.Block, and updates only that wallet's
+	// synced tip to params.Block. Unlike RollbackToBlock, this method is
+	// wallet-scoped and must not delete shared block rows or mutate other
+	// wallets' sync states.
+	RewindWallet(ctx context.Context, params RewindWalletParams) error
+
 	// GetTx retrieves a transaction record by its hash. It takes a context
 	// and GetTxQuery, returning a TxInfo struct or an error if the
 	// transaction is not found.

--- a/wallet/internal/db/itest/scan_batch_conformance_test.go
+++ b/wallet/internal/db/itest/scan_batch_conformance_test.go
@@ -605,6 +605,93 @@ func TestApplyScanBatchResolvesHorizonByAccountID(t *testing.T) {
 		"failed batch must not extend the derived account")
 }
 
+// TestApplyScanBatchRejectsWrongWalletHorizonAccountID verifies that a SQL scan
+// horizon cannot target an account row owned by a different wallet. The foreign
+// account is first advanced so the old unscoped lookup would have accepted the
+// wallet-A batch as a no-op before any wallet ownership check on inserted
+// addresses could run.
+func TestApplyScanBatchRejectsWrongWalletHorizonAccountID(t *testing.T) {
+	t.Parallel()
+
+	scope := db.KeyScopeBIP0084
+	fixture := newKVDBScanFixture(t)
+	store := NewTestStoreWithDerive(t, realAddressDeriveFunc())
+
+	deriveAccount := func(_ context.Context, _ db.KeyScope, _ uint32,
+		watchOnly bool) (*db.DerivedAccountData, error) {
+
+		data := &db.DerivedAccountData{
+			PublicKey:            []byte(fixture.accountXPub),
+			MasterKeyFingerprint: 0x01020304,
+		}
+		if !watchOnly {
+			data.EncryptedPrivateKey = RandomBytes(48)
+		}
+
+		return data, nil
+	}
+
+	walletA := newWallet(t, store, "wallet-scan-wrong-owner-a")
+	walletB := newWallet(t, store, "wallet-scan-wrong-owner-b")
+
+	accountA, err := store.CreateDerivedAccount(
+		t.Context(), db.CreateDerivedAccountParams{
+			WalletID: walletA,
+			Scope:    scope,
+			Name:     "wallet-a-account",
+		}, deriveAccount,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, accountA.AccountID)
+
+	accountB, err := store.CreateDerivedAccount(
+		t.Context(), db.CreateDerivedAccountParams{
+			WalletID: walletB,
+			Scope:    scope,
+			Name:     "wallet-b-account",
+		}, deriveAccount,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, accountB.AccountID)
+
+	err = store.ApplyScanBatch(t.Context(), db.ScanBatchParams{
+		WalletID: walletB,
+		Horizons: []db.ScanHorizon{{
+			AccountID:   accountB.AccountID,
+			Scope:       scope,
+			Account:     0,
+			AccountName: "wallet-b-account",
+			Branch:      0,
+			Index:       3,
+		}},
+	})
+	require.NoError(t, err)
+
+	account := getAccountByName(t, store, walletB, scope, "wallet-b-account")
+	require.Equal(t, uint32(4), account.ExternalKeyCount)
+
+	err = store.ApplyScanBatch(t.Context(), db.ScanBatchParams{
+		WalletID: walletA,
+		Horizons: []db.ScanHorizon{{
+			AccountID:   accountB.AccountID,
+			Scope:       scope,
+			Account:     0,
+			AccountName: "wallet-b-account",
+			Branch:      0,
+			Index:       1,
+		}},
+	})
+	require.ErrorIs(t, err, db.ErrAccountNotFound)
+
+	account = getAccountByName(t, store, walletA, scope, "wallet-a-account")
+	require.Equal(t, uint32(0), account.ExternalKeyCount,
+		"wallet A must not accept wallet B's account ID")
+
+	account = getAccountByName(t, store, walletB, scope, "wallet-b-account")
+	require.Equal(t, uint32(4), account.ExternalKeyCount,
+		"failed wallet A batch must not mutate wallet B")
+}
+
 // TestApplyScanBatchSkipsInvalidChild verifies that the SQL horizon extension
 // skips an HD-invalid child index instead of failing, matching the kvdb
 // ScopedKeyManager.ExtendAddresses behaviour. kvdb cannot be coerced into an

--- a/wallet/internal/db/itest/txstore_utxostore_test.go
+++ b/wallet/internal/db/itest/txstore_utxostore_test.go
@@ -2201,6 +2201,117 @@ func TestRollbackToBlockRewindsSyncToStoredLowerBlock(t *testing.T) {
 	require.Equal(t, forkBlock.Hash, walletInfo.SyncedTo.Hash)
 }
 
+// TestRewindWalletLeavesOtherWalletState verifies manual rescan rewind is
+// wallet-scoped. It must detach only the selected wallet's confirmed
+// transactions and sync tip, leaving another wallet that shares the same Store
+// at the same block height untouched.
+func TestRewindWalletLeavesOtherWalletState(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+
+	const (
+		walletAName = "wallet-rewind-scoped-a"
+		walletBName = "wallet-rewind-scoped-b"
+	)
+
+	walletA := newWallet(t, store, walletAName)
+	walletB := newWallet(t, store, walletBName)
+
+	rewindBlock := db.Block{
+		Hash:      chainhash.Hash{100},
+		Height:    100,
+		Timestamp: time.Unix(1710006100, 0),
+	}
+	tipBlock := db.Block{
+		Hash:      chainhash.Hash{101},
+		Height:    101,
+		Timestamp: time.Unix(1710006110, 0),
+	}
+
+	txA := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 1000}},
+	)
+	txB := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 2000}},
+	)
+
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: walletA,
+		Transactions: []db.CreateTxParams{{
+			WalletID: walletA,
+			Tx:       txA,
+			Received: time.Unix(1710006120, 0),
+			Block:    &tipBlock,
+			Status:   db.TxStatusPublished,
+		}},
+		SyncedTo: &tipBlock,
+	})
+	require.NoError(t, err)
+
+	err = store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: walletB,
+		Transactions: []db.CreateTxParams{{
+			WalletID: walletB,
+			Tx:       txB,
+			Received: time.Unix(1710006130, 0),
+			Block:    &tipBlock,
+			Status:   db.TxStatusPublished,
+		}},
+		SyncedTo: &tipBlock,
+	})
+	require.NoError(t, err)
+
+	err = store.RewindWallet(t.Context(), db.RewindWalletParams{
+		WalletID: walletA,
+		Block:    rewindBlock,
+	})
+	require.NoError(t, err)
+
+	infoA, err := store.GetWallet(t.Context(), walletAName)
+	require.NoError(t, err)
+	require.NotNil(t, infoA.SyncedTo)
+	require.Equal(t, rewindBlock.Height, infoA.SyncedTo.Height)
+	require.Equal(t, rewindBlock.Hash, infoA.SyncedTo.Hash)
+
+	infoB, err := store.GetWallet(t.Context(), walletBName)
+	require.NoError(t, err)
+	require.NotNil(t, infoB.SyncedTo)
+	require.Equal(t, tipBlock.Height, infoB.SyncedTo.Height)
+	require.Equal(t, tipBlock.Hash, infoB.SyncedTo.Hash)
+
+	confirmedA, err := store.ListTxns(t.Context(), db.ListTxnsQuery{
+		WalletID:    walletA,
+		StartHeight: tipBlock.Height,
+		EndHeight:   tipBlock.Height,
+	})
+	require.NoError(t, err)
+	require.Empty(t, confirmedA)
+
+	unminedA, err := store.ListTxns(t.Context(), db.ListTxnsQuery{
+		WalletID:    walletA,
+		UnminedOnly: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, unminedA, 1)
+	require.Equal(t, txA.TxHash(), unminedA[0].Hash)
+	require.Nil(t, unminedA[0].Block)
+	require.Equal(t, db.TxStatusPublished, unminedA[0].Status)
+
+	confirmedB, err := store.ListTxns(t.Context(), db.ListTxnsQuery{
+		WalletID:    walletB,
+		StartHeight: tipBlock.Height,
+		EndHeight:   tipBlock.Height,
+	})
+	require.NoError(t, err)
+	require.Len(t, confirmedB, 1)
+	require.Equal(t, txB.TxHash(), confirmedB[0].Hash)
+	require.NotNil(t, confirmedB[0].Block)
+	require.Equal(t, tipBlock.Height, confirmedB[0].Block.Height)
+}
+
 // TestCreateTxReconfirmsOrphanedCoinbase verifies that CreateTx can restore an
 // orphaned coinbase row to confirmed history when the same coinbase hash later
 // re-enters the best chain.

--- a/wallet/internal/db/itest/txstore_utxostore_test.go
+++ b/wallet/internal/db/itest/txstore_utxostore_test.go
@@ -3638,6 +3638,53 @@ func TestApplyTxBatchChildBeforeParent(t *testing.T) {
 	}))
 }
 
+// TestApplyTxBatchResolvesCreditCandidates verifies ApplyTxBatch resolves
+// notification credit candidates inside the batch write transaction before it
+// records transaction credits.
+func TestApplyTxBatchResolvesCreditCandidates(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWatchOnlyWallet(
+		t, store, "wallet-apply-tx-batch-candidates",
+	)
+
+	memberAddr, memberScript, multiSigScript := newMultisigScript(t)
+	_, err := store.NewImportedAddress(
+		t.Context(), db.NewImportedAddressParams{
+			WalletID:        walletID,
+			AddressType:     db.RawPubKey,
+			PubKey:          memberAddr.ScriptAddress(),
+			ScriptPubKey:    memberScript,
+			EncryptedScript: RandomBytes(48),
+		},
+	)
+	require.NoError(t, err)
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 7000, PkScript: multiSigScript}},
+	)
+
+	err = store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: walletID,
+		Transactions: []db.CreateTxParams{{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710000190, 0),
+			Status:   db.TxStatusPending,
+			CreditCandidates: map[uint32][]address.Address{
+				0: {memberAddr},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	require.True(t, walletUtxoExists(t, store, walletID, wire.OutPoint{
+		Hash: tx.TxHash(), Index: 0,
+	}))
+}
+
 // TestApplyScanBatchChildBeforeParent verifies that ApplyScanBatch records the
 // parent->child spend edge even when the child transaction is listed before the
 // in-batch parent whose output it spends.
@@ -4008,6 +4055,56 @@ func TestApplyTxBatchDuplicateUnminedKeepsConfirmed(t *testing.T) {
 	require.NotNil(t, txInfo.Block)
 	require.Equal(t, block.Height, txInfo.Block.Height)
 	require.Equal(t, block.Hash, txInfo.Block.Hash)
+}
+
+// TestApplyTxBatchPromotesPendingDuplicate verifies that an unmined mempool
+// notification can promote a locally-created pending transaction to published
+// without replacing the existing label.
+func TestApplyTxBatchPromotesPendingDuplicate(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-apply-tx-batch-publish-dupe")
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 7000, PkScript: RandomBytes(22)}},
+	)
+
+	const originalLabel = "original"
+
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: walletID,
+		Transactions: []db.CreateTxParams{{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710000165, 0),
+			Status:   db.TxStatusPending,
+			Label:    originalLabel,
+		}},
+	})
+	require.NoError(t, err)
+
+	err = store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: walletID,
+		Transactions: []db.CreateTxParams{{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710000166, 0),
+			Status:   db.TxStatusPublished,
+			Label:    "ignored",
+		}},
+	})
+	require.NoError(t, err)
+
+	txInfo, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     tx.TxHash(),
+	})
+	require.NoError(t, err)
+	require.Nil(t, txInfo.Block)
+	require.Equal(t, db.TxStatusPublished, txInfo.Status)
+	require.Equal(t, originalLabel, txInfo.Label)
 }
 
 // TestApplyTxBatchDuplicateConfirmedChecksTimestamp verifies that an otherwise

--- a/wallet/internal/db/kvdb/txstore.go
+++ b/wallet/internal/db/kvdb/txstore.go
@@ -380,7 +380,7 @@ func batchNeedsAddrStore(params db.TxBatchParams) bool {
 	}
 
 	for _, tx := range params.Transactions {
-		if len(tx.Credits) > 0 {
+		if len(tx.Credits) > 0 || len(tx.CreditCandidates) > 0 {
 			return true
 		}
 	}
@@ -461,7 +461,14 @@ func (s *Store) applyLegacyTxBatch(addrmgrNs walletdb.ReadWriteBucket,
 	txmgrNs walletdb.ReadWriteBucket, transactions []db.CreateTxParams) error {
 
 	for i := range transactions {
-		req, err := db.NewCreateTxRequest(transactions[i])
+		params, err := s.resolveLegacyCreditCandidates(
+			addrmgrNs, transactions[i],
+		)
+		if err != nil {
+			return fmt.Errorf("resolve credit candidates %d: %w", i, err)
+		}
+
+		req, err := db.NewCreateTxRequest(params)
 		if err != nil {
 			return fmt.Errorf("validate tx %d: %w", i, err)
 		}
@@ -473,6 +480,122 @@ func (s *Store) applyLegacyTxBatch(addrmgrNs walletdb.ReadWriteBucket,
 	}
 
 	return nil
+}
+
+// resolveLegacyCreditCandidates promotes wallet-owned notification credit
+// candidates into Credits while the surrounding walletdb write transaction is
+// open.
+func (s *Store) resolveLegacyCreditCandidates(
+	addrmgrNs walletdb.ReadWriteBucket,
+	params db.CreateTxParams) (db.CreateTxParams, error) {
+
+	if len(params.CreditCandidates) == 0 {
+		return params, nil
+	}
+
+	credits := make(
+		map[uint32]address.Address,
+		len(params.Credits)+len(params.CreditCandidates),
+	)
+	for index, addr := range params.Credits {
+		credits[index] = addr
+	}
+
+	for index, candidates := range params.CreditCandidates {
+		if _, ok := credits[index]; ok {
+			continue
+		}
+
+		if uint64(index) >= uint64(len(params.Tx.TxOut)) {
+			return params, fmt.Errorf("%w: credit candidate index %d: %w",
+				db.ErrInvalidParam, index, db.ErrIndexOutOfRange)
+		}
+
+		ownedAddr, err := s.ownedLegacyCreditCandidate(
+			addrmgrNs, params, index, candidates,
+		)
+		if err != nil {
+			return params, fmt.Errorf("lookup candidate %d: %w", index, err)
+		}
+
+		if ownedAddr != nil {
+			credits[index] = ownedAddr
+			continue
+		}
+
+		owned, err := s.legacyCreditScriptOwned(
+			addrmgrNs, params.Tx.TxOut[index].PkScript,
+		)
+		if err != nil {
+			return params, fmt.Errorf("lookup output script %d: %w", index,
+				err)
+		}
+
+		if owned {
+			credits[index] = nil
+		}
+	}
+
+	params.Credits = credits
+	params.CreditCandidates = nil
+
+	return params, nil
+}
+
+// ownedLegacyCreditCandidate returns the first candidate address owned by the
+// legacy address manager.
+func (s *Store) ownedLegacyCreditCandidate(
+	addrmgrNs walletdb.ReadBucket, params db.CreateTxParams, index uint32,
+	candidates []address.Address) (address.Address, error) {
+
+	chainParams := s.addrStore.ChainParams()
+	for _, candidate := range candidates {
+		if candidate == nil {
+			return nil, fmt.Errorf("%w: nil credit candidate",
+				db.ErrInvalidParam)
+		}
+
+		err := validateCreditAddr(
+			*params.Tx, index, candidate, chainParams,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = s.addrStore.Address(addrmgrNs, candidate)
+		if waddrmgr.IsError(err, waddrmgr.ErrAddressNotFound) {
+			continue
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("lookup candidate address: %w", err)
+		}
+
+		return candidate, nil
+	}
+
+	return nil, nil //nolint:nilnil // A nil address means no candidate matched.
+}
+
+// legacyCreditScriptOwned reports whether script resolves to a wallet address.
+func (s *Store) legacyCreditScriptOwned(addrmgrNs walletdb.ReadBucket,
+	script []byte) (bool, error) {
+
+	addr := addressFromScript(script, s.addrStore.ChainParams())
+	if addr == nil {
+		return false, nil
+	}
+
+	_, err := s.addrStore.Address(addrmgrNs, addr)
+	if waddrmgr.IsError(err, waddrmgr.ErrAddressNotFound) {
+		return false, nil
+	}
+
+	if err != nil {
+		return false, fmt.Errorf("lookup script address: %w", err)
+	}
+
+	return true, nil
 }
 
 // applyLegacyTxNotification records one relevant transaction notification using
@@ -640,7 +763,7 @@ func (s *Store) applyUnconfirmedLegacyTx(
 // applyUnconfirmedDuplicate handles an unmined batch notification for a
 // transaction hash already present in the legacy store.
 func (s *Store) applyUnconfirmedDuplicate(
-	addrmgrNs walletdb.ReadBucket, txmgrNs walletdb.ReadBucket,
+	addrmgrNs walletdb.ReadBucket, txmgrNs walletdb.ReadWriteBucket,
 	existing *wtxmgr.TxDetails, txHash chainhash.Hash,
 	req db.CreateTxRequest) error {
 
@@ -651,6 +774,17 @@ func (s *Store) applyUnconfirmedDuplicate(
 	status, err := readLegacyTxStatus(txmgrNs, txHash)
 	if err != nil {
 		return fmt.Errorf("read duplicate tx status: %w", err)
+	}
+
+	promoted, err := s.promoteUnconfirmedDuplicate(
+		addrmgrNs, txmgrNs, existing, txHash, status, req,
+	)
+	if err != nil {
+		return err
+	}
+
+	if promoted {
+		return nil
 	}
 
 	matches, err := s.legacyDuplicateMatches(
@@ -665,6 +799,38 @@ func (s *Store) applyUnconfirmedDuplicate(
 	}
 
 	return fmt.Errorf("tx %s: %w", txHash, db.ErrTxAlreadyExists)
+}
+
+// promoteUnconfirmedDuplicate marks a matching pending duplicate as published
+// while preserving its existing label.
+func (s *Store) promoteUnconfirmedDuplicate(
+	addrmgrNs walletdb.ReadBucket, txmgrNs walletdb.ReadWriteBucket,
+	existing *wtxmgr.TxDetails, txHash chainhash.Hash, status db.TxStatus,
+	req db.CreateTxRequest) (bool, error) {
+
+	if req.Params.Status != db.TxStatusPublished ||
+		status != db.TxStatusPending {
+
+		return false, nil
+	}
+
+	creditsMatch, err := s.legacyCreditsMatch(
+		addrmgrNs, existing.Credits, req,
+	)
+	if err != nil {
+		return false, err
+	}
+
+	if !creditsMatch {
+		return false, nil
+	}
+
+	err = putLegacyTxStatus(txmgrNs, txHash, db.TxStatusPublished)
+	if err != nil {
+		return false, fmt.Errorf("promote duplicate tx status: %w", err)
+	}
+
+	return true, nil
 }
 
 // legacyDuplicateMatches reports whether a duplicate batch notification's

--- a/wallet/internal/db/kvdb/txstore.go
+++ b/wallet/internal/db/kvdb/txstore.go
@@ -1143,6 +1143,59 @@ func (s *Store) InvalidateUnminedTx(_ context.Context,
 	return nil
 }
 
+// RewindWallet atomically rewinds the single kvdb wallet to the requested
+// manual-rescan sync tip and detaches transactions confirmed above it.
+func (s *Store) RewindWallet(_ context.Context,
+	params db.RewindWalletParams) error {
+
+	block, err := db.BlockStampFromBlock(&params.Block)
+	if err != nil {
+		return fmt.Errorf("kvdb.Store.RewindWallet: block: %w", err)
+	}
+
+	rollbackHeight, err := db.Int64ToInt32(int64(params.Block.Height) + 1)
+	if err != nil {
+		return fmt.Errorf("kvdb.Store.RewindWallet: rollback height: %w",
+			err)
+	}
+
+	var preRewindTip waddrmgr.BlockStamp
+
+	// Hold the Store write lock through the commit-failure restore below. This
+	// keeps the cache restore ordered before a following Store write can commit
+	// the same tip and create an ABA match.
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	err = walletdb.Update(s.db, func(tx walletdb.ReadWriteTx) error {
+		addrmgrNs := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+		if addrmgrNs == nil {
+			return errMissingAddrmgrNamespace
+		}
+
+		txmgrNs := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+		if txmgrNs == nil {
+			return errMissingTxmgrNamespace
+		}
+
+		preRewindTip = s.addrStore.SyncedTo()
+
+		err := s.addrStore.SetSyncedTo(addrmgrNs, &block)
+		if err != nil {
+			return fmt.Errorf("set synced to: %w", err)
+		}
+
+		return s.txStore.Rollback(txmgrNs, rollbackHeight)
+	})
+	if err != nil {
+		s.addrStore.RestoreSyncedToIfCurrent(preRewindTip, block)
+
+		return fmt.Errorf("kvdb.Store.RewindWallet: %w", err)
+	}
+
+	return nil
+}
+
 // RollbackToBlock atomically rolls legacy transaction state back to the
 // provided height and rewinds wallet sync metadata to the same fork point in
 // one walletdb update, mirroring the legacy SetSyncedTo + wtxmgr Rollback

--- a/wallet/internal/db/kvdb/txstore_test.go
+++ b/wallet/internal/db/kvdb/txstore_test.go
@@ -1925,6 +1925,61 @@ func TestApplyTxBatchConfirmedDuplicatePreservesUnminedLabel(t *testing.T) {
 	require.Equal(t, originalLabel, txInfo.Label)
 }
 
+// TestApplyTxBatchPromotesPendingDuplicate verifies that a mempool echo can
+// promote a locally-created pending transaction to published without replacing
+// the existing label.
+func TestApplyTxBatchPromotesPendingDuplicate(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	newAddrmgrNamespace(t, dbConn)
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore, nil)
+
+	txMsg := &wire.MsgTx{Version: 1}
+	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{71},
+	}})
+	txMsg.AddTxOut(&wire.TxOut{Value: 10_000, PkScript: []byte{0x51}})
+
+	const originalLabel = "original"
+
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: 0,
+		Transactions: []db.CreateTxParams{{
+			WalletID: 0,
+			Tx:       txMsg,
+			Received: time.Unix(1710004100, 0),
+			Status:   db.TxStatusPending,
+			Label:    originalLabel,
+		}},
+	})
+	require.NoError(t, err)
+
+	err = store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: 0,
+		Transactions: []db.CreateTxParams{{
+			WalletID: 0,
+			Tx:       txMsg,
+			Received: time.Unix(1710004200, 0),
+			Status:   db.TxStatusPublished,
+			Label:    "ignored",
+		}},
+	})
+	require.NoError(t, err)
+
+	txInfo, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: 0,
+		Txid:     txMsg.TxHash(),
+	})
+	require.NoError(t, err)
+	require.Nil(t, txInfo.Block)
+	require.Equal(t, db.TxStatusPublished, txInfo.Status)
+	require.Equal(t, originalLabel, txInfo.Label)
+}
+
 // TestApplyTxBatchDuplicateConfirmedRejectsBlockMismatch verifies that a
 // confirmed duplicate for the same transaction hash cannot be recorded in a
 // second block.
@@ -1992,8 +2047,8 @@ func TestApplyTxBatchDuplicateConfirmedRejectsBlockMismatch(t *testing.T) {
 }
 
 // TestApplyTxBatchDuplicateUnminedRejectsMutation verifies that a duplicate
-// unconfirmed batch member cannot mutate status, label, or credit metadata for
-// a transaction already stored as unconfirmed.
+// unconfirmed batch member cannot mutate label or credit metadata for a
+// transaction already stored as unconfirmed.
 func TestApplyTxBatchDuplicateUnminedRejectsMutation(t *testing.T) {
 	t.Parallel()
 
@@ -2032,7 +2087,7 @@ func TestApplyTxBatchDuplicateUnminedRejectsMutation(t *testing.T) {
 			WalletID: 0,
 			Tx:       txMsg,
 			Received: time.Unix(1710003500, 0),
-			Status:   db.TxStatusPublished,
+			Status:   db.TxStatusPending,
 			Label:    "mutated",
 		}},
 	})
@@ -2141,6 +2196,74 @@ func TestApplyTxBatchRecordsTxAndSyncedTo(t *testing.T) {
 			return bs.Height == int32(syncedTo.Height)
 		}),
 	)
+}
+
+// TestApplyTxBatchResolvesCreditCandidates verifies kvdb resolves notification
+// credit candidates inside the batch write before recording credits.
+func TestApplyTxBatchResolvesCreditCandidates(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	newAddrmgrNamespace(t, dbConn)
+	txStore := newTxStore(t, dbConn)
+
+	addr, script := newTestAddressScript(t)
+	managedAddr := &bwmock.ManagedAddress{}
+	managedAddr.On("Internal").Return(true).Maybe()
+	managedAddr.On("Address").Return(addr).Maybe()
+	managedAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Maybe()
+	managedAddr.On("Imported").Return(false).Maybe()
+	managedAddr.On("InternalAccount").Return(uint32(0)).Maybe()
+	managedAddr.On("Compressed").Return(true).Maybe()
+	managedAddr.On("AddrHash").Return([]byte(nil)).Maybe()
+	managedAddr.On("Used", mock.Anything).Return(false).Maybe()
+
+	addrStore := &bwmock.AddrStore{}
+	addrStore.On("ChainParams").Return(&chaincfg.RegressionNetParams)
+	addrStore.On("Address", mock.Anything, addr).Return(
+		managedAddr, nil,
+	).Twice()
+	addrStore.On("MarkUsed", mock.Anything, addr).Return(nil).Once()
+	store := NewStore(dbConn, txStore, addrStore)
+
+	txMsg := &wire.MsgTx{Version: 1}
+	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{65},
+	}})
+	txMsg.AddTxOut(&wire.TxOut{Value: 10_000, PkScript: script})
+
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: 0,
+		Transactions: []db.CreateTxParams{{
+			WalletID: 0,
+			Tx:       txMsg,
+			Received: time.Unix(1710003110, 0),
+			Status:   db.TxStatusPublished,
+			CreditCandidates: map[uint32][]address.Address{
+				0: {addr},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	txid := txMsg.TxHash()
+	err = walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(wtxmgrNamespaceKey)
+		require.NotNil(t, ns)
+
+		details, err := txStore.TxDetails(ns, &txid)
+		require.NoError(t, err)
+		require.NotNil(t, details)
+		require.Len(t, details.Credits, 1)
+		require.True(t, details.Credits[0].Change)
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	addrStore.AssertExpectations(t)
 }
 
 // TestApplyTxBatchRestoresSyncedToOnFailure verifies that a batch failure after

--- a/wallet/internal/db/pg/txstore_batch.go
+++ b/wallet/internal/db/pg/txstore_batch.go
@@ -2,8 +2,12 @@ package pg
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 
+	"github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 )
@@ -59,6 +63,11 @@ func (s *Store) ApplyTxBatch(ctx context.Context,
 func applyBatchTransaction(ctx context.Context, qtx *sqlc.Queries,
 	params db.CreateTxParams) error {
 
+	params, err := resolveCreditCandidates(ctx, qtx, params)
+	if err != nil {
+		return fmt.Errorf("resolve credit candidates: %w", err)
+	}
+
 	req, err := db.NewCreateTxRequest(params)
 	if err != nil {
 		return fmt.Errorf("validate tx: %w", err)
@@ -84,7 +93,218 @@ func applyBatchTransaction(ctx context.Context, qtx *sqlc.Queries,
 		}
 	}
 
-	return db.CreateTxWithOps(ctx, req, ops)
+	err = db.CreateTxWithOps(ctx, req, ops)
+
+	return promoteBatchDuplicate(ctx, qtx, req, ops, err)
+}
+
+// resolveCreditCandidates resolves notification credit candidates inside the
+// batch write transaction and promotes owned outputs into Credits.
+func resolveCreditCandidates(ctx context.Context, qtx *sqlc.Queries,
+	params db.CreateTxParams) (db.CreateTxParams, error) {
+
+	if len(params.CreditCandidates) == 0 {
+		return params, nil
+	}
+
+	credits := make(
+		map[uint32]address.Address,
+		len(params.Credits)+len(params.CreditCandidates),
+	)
+	for index, addr := range params.Credits {
+		credits[index] = addr
+	}
+
+	for index, candidates := range params.CreditCandidates {
+		if _, ok := credits[index]; ok {
+			continue
+		}
+
+		if uint64(index) >= uint64(len(params.Tx.TxOut)) {
+			return params, fmt.Errorf("%w: credit candidate index %d: %w",
+				db.ErrInvalidParam, index, db.ErrIndexOutOfRange)
+		}
+
+		outputScript := params.Tx.TxOut[index].PkScript
+
+		owned, err := creditScriptOwned(
+			ctx, qtx, params.WalletID, outputScript,
+		)
+		if err != nil {
+			return params, fmt.Errorf("lookup output script %d: %w", index,
+				err)
+		}
+
+		if owned {
+			credits[index] = nil
+			continue
+		}
+
+		ownedAddr, err := ownedCreditCandidate(
+			ctx, qtx, params.WalletID, outputScript, candidates,
+		)
+		if err != nil {
+			return params, fmt.Errorf("lookup candidate %d: %w", index, err)
+		}
+
+		if ownedAddr != nil {
+			credits[index] = ownedAddr
+		}
+	}
+
+	params.Credits = credits
+	params.CreditCandidates = nil
+
+	return params, nil
+}
+
+// ownedCreditCandidate returns the first candidate address owned by the wallet.
+func ownedCreditCandidate(ctx context.Context, qtx *sqlc.Queries,
+	walletID uint32, outputScript []byte,
+	candidates []address.Address) (address.Address, error) {
+
+	for _, candidate := range candidates {
+		if candidate == nil {
+			return nil, fmt.Errorf("%w: nil credit candidate",
+				db.ErrInvalidParam)
+		}
+
+		err := db.ValidateCreditAddrMembership(candidate, outputScript)
+		if err != nil {
+			return nil, err
+		}
+
+		candidateScript, err := txscript.PayToAddrScript(candidate)
+		if err != nil {
+			return nil, fmt.Errorf("candidate script: %w", err)
+		}
+
+		owned, err := creditScriptOwned(
+			ctx, qtx, walletID, candidateScript,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		if owned {
+			return candidate, nil
+		}
+	}
+
+	return nil, nil //nolint:nilnil // A nil address means no candidate matched.
+}
+
+// creditScriptOwned reports whether walletID has an address row for script.
+func creditScriptOwned(ctx context.Context, qtx *sqlc.Queries, walletID uint32,
+	script []byte) (bool, error) {
+
+	_, err := qtx.GetAddressByScriptPubKey(
+		ctx, sqlc.GetAddressByScriptPubKeyParams{
+			ScriptPubKey: script,
+			WalletID:     int64(walletID),
+		},
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// promoteBatchDuplicate promotes a pending unmined duplicate to published when
+// the shared create flow rejected that non-idempotent state transition.
+func promoteBatchDuplicate(ctx context.Context, qtx *sqlc.Queries,
+	req db.CreateTxRequest, ops db.CreateTxOps, createErr error) error {
+
+	txID, ok, err := promotableBatchDuplicate(ctx, qtx, req, createErr)
+	if err != nil {
+		return err
+	}
+
+	if !ok {
+		return createErr
+	}
+
+	rows, err := qtx.UpdateTransactionStatusByIDs(
+		ctx, sqlc.UpdateTransactionStatusByIDsParams{
+			WalletID: int64(req.Params.WalletID),
+			Status:   int16(db.TxStatusPublished),
+			TxIds:    []int64{txID},
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("promote duplicate tx status: %w", err)
+	}
+
+	if rows == 0 {
+		return fmt.Errorf("promote duplicate tx %s: %w", req.TxHash,
+			db.ErrTxNotFound)
+	}
+
+	err = ops.InsertCredits(ctx, req, txID)
+	if err != nil {
+		return fmt.Errorf("record promoted duplicate tx credits: %w", err)
+	}
+
+	err = ops.MarkInputsSpent(ctx, req, txID)
+	if err != nil {
+		return fmt.Errorf("record promoted duplicate tx spends: %w", err)
+	}
+
+	return nil
+}
+
+// promotableBatchDuplicate returns the existing tx id when createErr is a
+// pending-unmined duplicate that this batch may promote to published state.
+func promotableBatchDuplicate(ctx context.Context, qtx *sqlc.Queries,
+	req db.CreateTxRequest, createErr error) (int64, bool, error) {
+
+	if createErr == nil || !errors.Is(createErr, db.ErrTxAlreadyExists) {
+		return 0, false, nil
+	}
+
+	row, err := qtx.GetTransactionByHash(
+		ctx, sqlc.GetTransactionByHashParams{
+			WalletID: int64(req.Params.WalletID),
+			TxHash:   req.TxHash[:],
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, false, nil
+		}
+
+		return 0, false, fmt.Errorf("get duplicate tx: %w", err)
+	}
+
+	status, err := db.ParseTxStatus(int64(row.TxStatus))
+	if err != nil {
+		return 0, false, fmt.Errorf("parse duplicate tx status: %w", err)
+	}
+
+	var block *db.Block
+	if row.BlockHeight.Valid {
+		block, err = buildBlock(
+			row.BlockHeight, row.BlockHash, row.BlockTimestamp,
+		)
+		if err != nil {
+			return 0, false, fmt.Errorf("build duplicate tx block: %w",
+				err)
+		}
+	}
+
+	if !db.CanPromoteUnminedCreateTxDuplicate(
+		req, status, row.IsCoinbase, block,
+	) {
+
+		return 0, false, nil
+	}
+
+	return row.ID, true, nil
 }
 
 // applyBatchSyncTip applies the optional sync-tip update within a batch.

--- a/wallet/internal/db/pg/txstore_rollback.go
+++ b/wallet/internal/db/pg/txstore_rollback.go
@@ -10,6 +10,95 @@ import (
 	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 )
 
+const maxSQLBlockHeight = int32(1<<31 - 1)
+
+// RewindWallet atomically rewinds one wallet for a manual rescan without
+// deleting shared block rows or mutating other wallets' sync states.
+func (s *Store) RewindWallet(ctx context.Context,
+	params db.RewindWalletParams) error {
+
+	return s.execWrite(ctx, func(qtx *sqlc.Queries) error {
+		err := rewindWalletTransactions(ctx, qtx, params)
+		if err != nil {
+			return err
+		}
+
+		err = db.UpdateWalletWithOps(ctx, db.UpdateWalletParams{
+			WalletID: params.WalletID,
+			SyncedTo: &params.Block,
+		}, updateWalletOps{q: qtx})
+		if err != nil {
+			return fmt.Errorf("update wallet sync tip: %w", err)
+		}
+
+		return nil
+	})
+}
+
+// rewindWalletTransactions detaches one wallet's confirmed transactions above
+// the manual-rescan rewind point while preserving shared block rows.
+func rewindWalletTransactions(ctx context.Context, qtx *sqlc.Queries,
+	params db.RewindWalletParams) error {
+
+	startHeight, err := db.Int64ToInt32(int64(params.Block.Height) + 1)
+	if err != nil {
+		return fmt.Errorf("rewind start height: %w", err)
+	}
+
+	rows, err := qtx.ListTransactionsByHeightRange(
+		ctx, sqlc.ListTransactionsByHeightRangeParams{
+			WalletID:    int64(params.WalletID),
+			StartHeight: startHeight,
+			EndHeight:   maxSQLBlockHeight,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("list wallet rewind txs: %w", err)
+	}
+
+	coinbaseRoots := make([]chainhash.Hash, 0)
+	for _, row := range rows {
+		txHash, err := chainhash.NewHash(row.TxHash)
+		if err != nil {
+			return fmt.Errorf("rewind tx hash: %w", err)
+		}
+
+		status := db.TxStatusPublished
+		if row.IsCoinbase {
+			status = db.TxStatusOrphaned
+
+			coinbaseRoots = append(coinbaseRoots, *txHash)
+		}
+
+		updated, err := qtx.UpdateTransactionStateByHash(
+			ctx, sqlc.UpdateTransactionStateByHashParams{
+				BlockHeight: sql.NullInt32{},
+				Status:      int16(status),
+				WalletID:    int64(params.WalletID),
+				TxHash:      row.TxHash,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("detach rewind tx %s: %w", txHash, err)
+		}
+
+		if updated == 0 {
+			return fmt.Errorf("rewind tx %s: %w", txHash,
+				db.ErrTxNotFound)
+		}
+	}
+
+	if len(coinbaseRoots) == 0 {
+		return nil
+	}
+
+	return db.InvalidateRollbackDescendants(
+		ctx, map[uint32][]chainhash.Hash{
+			params.WalletID: coinbaseRoots,
+		}, rollbackToBlockOps{qtx: qtx},
+	)
+}
+
 // RollbackToBlock atomically removes every block at or above the provided
 // height and rewrites wallet sync-state references so the block delete can
 // succeed.

--- a/wallet/internal/db/sqlite/txstore_batch.go
+++ b/wallet/internal/db/sqlite/txstore_batch.go
@@ -2,8 +2,12 @@ package sqlite
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 
+	"github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 )
@@ -59,6 +63,11 @@ func (s *Store) ApplyTxBatch(ctx context.Context,
 func applyBatchTransaction(ctx context.Context, qtx *sqlc.Queries,
 	params db.CreateTxParams) error {
 
+	params, err := resolveCreditCandidates(ctx, qtx, params)
+	if err != nil {
+		return fmt.Errorf("resolve credit candidates: %w", err)
+	}
+
 	req, err := db.NewCreateTxRequest(params)
 	if err != nil {
 		return fmt.Errorf("validate tx: %w", err)
@@ -84,7 +93,218 @@ func applyBatchTransaction(ctx context.Context, qtx *sqlc.Queries,
 		}
 	}
 
-	return db.CreateTxWithOps(ctx, req, ops)
+	err = db.CreateTxWithOps(ctx, req, ops)
+
+	return promoteBatchDuplicate(ctx, qtx, req, ops, err)
+}
+
+// resolveCreditCandidates resolves notification credit candidates inside the
+// batch write transaction and promotes owned outputs into Credits.
+func resolveCreditCandidates(ctx context.Context, qtx *sqlc.Queries,
+	params db.CreateTxParams) (db.CreateTxParams, error) {
+
+	if len(params.CreditCandidates) == 0 {
+		return params, nil
+	}
+
+	credits := make(
+		map[uint32]address.Address,
+		len(params.Credits)+len(params.CreditCandidates),
+	)
+	for index, addr := range params.Credits {
+		credits[index] = addr
+	}
+
+	for index, candidates := range params.CreditCandidates {
+		if _, ok := credits[index]; ok {
+			continue
+		}
+
+		if uint64(index) >= uint64(len(params.Tx.TxOut)) {
+			return params, fmt.Errorf("%w: credit candidate index %d: %w",
+				db.ErrInvalidParam, index, db.ErrIndexOutOfRange)
+		}
+
+		outputScript := params.Tx.TxOut[index].PkScript
+
+		owned, err := creditScriptOwned(
+			ctx, qtx, params.WalletID, outputScript,
+		)
+		if err != nil {
+			return params, fmt.Errorf("lookup output script %d: %w", index,
+				err)
+		}
+
+		if owned {
+			credits[index] = nil
+			continue
+		}
+
+		ownedAddr, err := ownedCreditCandidate(
+			ctx, qtx, params.WalletID, outputScript, candidates,
+		)
+		if err != nil {
+			return params, fmt.Errorf("lookup candidate %d: %w", index, err)
+		}
+
+		if ownedAddr != nil {
+			credits[index] = ownedAddr
+		}
+	}
+
+	params.Credits = credits
+	params.CreditCandidates = nil
+
+	return params, nil
+}
+
+// ownedCreditCandidate returns the first candidate address owned by the wallet.
+func ownedCreditCandidate(ctx context.Context, qtx *sqlc.Queries,
+	walletID uint32, outputScript []byte,
+	candidates []address.Address) (address.Address, error) {
+
+	for _, candidate := range candidates {
+		if candidate == nil {
+			return nil, fmt.Errorf("%w: nil credit candidate",
+				db.ErrInvalidParam)
+		}
+
+		err := db.ValidateCreditAddrMembership(candidate, outputScript)
+		if err != nil {
+			return nil, err
+		}
+
+		candidateScript, err := txscript.PayToAddrScript(candidate)
+		if err != nil {
+			return nil, fmt.Errorf("candidate script: %w", err)
+		}
+
+		owned, err := creditScriptOwned(
+			ctx, qtx, walletID, candidateScript,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		if owned {
+			return candidate, nil
+		}
+	}
+
+	return nil, nil //nolint:nilnil // A nil address means no candidate matched.
+}
+
+// creditScriptOwned reports whether walletID has an address row for script.
+func creditScriptOwned(ctx context.Context, qtx *sqlc.Queries, walletID uint32,
+	script []byte) (bool, error) {
+
+	_, err := qtx.GetAddressByScriptPubKey(
+		ctx, sqlc.GetAddressByScriptPubKeyParams{
+			ScriptPubKey: script,
+			WalletID:     int64(walletID),
+		},
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// promoteBatchDuplicate promotes a pending unmined duplicate to published when
+// the shared create flow rejected that non-idempotent state transition.
+func promoteBatchDuplicate(ctx context.Context, qtx *sqlc.Queries,
+	req db.CreateTxRequest, ops db.CreateTxOps, createErr error) error {
+
+	txID, ok, err := promotableBatchDuplicate(ctx, qtx, req, createErr)
+	if err != nil {
+		return err
+	}
+
+	if !ok {
+		return createErr
+	}
+
+	rows, err := qtx.UpdateTransactionStatusByIDs(
+		ctx, sqlc.UpdateTransactionStatusByIDsParams{
+			WalletID: int64(req.Params.WalletID),
+			Status:   int64(db.TxStatusPublished),
+			TxIds:    []int64{txID},
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("promote duplicate tx status: %w", err)
+	}
+
+	if rows == 0 {
+		return fmt.Errorf("promote duplicate tx %s: %w", req.TxHash,
+			db.ErrTxNotFound)
+	}
+
+	err = ops.InsertCredits(ctx, req, txID)
+	if err != nil {
+		return fmt.Errorf("record promoted duplicate tx credits: %w", err)
+	}
+
+	err = ops.MarkInputsSpent(ctx, req, txID)
+	if err != nil {
+		return fmt.Errorf("record promoted duplicate tx spends: %w", err)
+	}
+
+	return nil
+}
+
+// promotableBatchDuplicate returns the existing tx id when createErr is a
+// pending-unmined duplicate that this batch may promote to published state.
+func promotableBatchDuplicate(ctx context.Context, qtx *sqlc.Queries,
+	req db.CreateTxRequest, createErr error) (int64, bool, error) {
+
+	if createErr == nil || !errors.Is(createErr, db.ErrTxAlreadyExists) {
+		return 0, false, nil
+	}
+
+	row, err := qtx.GetTransactionByHash(
+		ctx, sqlc.GetTransactionByHashParams{
+			WalletID: int64(req.Params.WalletID),
+			TxHash:   req.TxHash[:],
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, false, nil
+		}
+
+		return 0, false, fmt.Errorf("get duplicate tx: %w", err)
+	}
+
+	status, err := db.ParseTxStatus(row.TxStatus)
+	if err != nil {
+		return 0, false, fmt.Errorf("parse duplicate tx status: %w", err)
+	}
+
+	var block *db.Block
+	if row.BlockHeight.Valid {
+		block, err = buildBlock(
+			row.BlockHeight, row.BlockHash, row.BlockTimestamp,
+		)
+		if err != nil {
+			return 0, false, fmt.Errorf("build duplicate tx block: %w",
+				err)
+		}
+	}
+
+	if !db.CanPromoteUnminedCreateTxDuplicate(
+		req, status, row.IsCoinbase, block,
+	) {
+
+		return 0, false, nil
+	}
+
+	return row.ID, true, nil
 }
 
 // applyBatchSyncTip applies the optional sync-tip update within a batch.

--- a/wallet/internal/db/sqlite/txstore_rollback.go
+++ b/wallet/internal/db/sqlite/txstore_rollback.go
@@ -10,6 +10,95 @@ import (
 	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 )
 
+const maxSQLBlockHeight = int64(1<<31 - 1)
+
+// RewindWallet atomically rewinds one wallet for a manual rescan without
+// deleting shared block rows or mutating other wallets' sync states.
+func (s *Store) RewindWallet(ctx context.Context,
+	params db.RewindWalletParams) error {
+
+	return s.execWrite(ctx, func(qtx *sqlc.Queries) error {
+		err := rewindWalletTransactions(ctx, qtx, params)
+		if err != nil {
+			return err
+		}
+
+		err = db.UpdateWalletWithOps(ctx, db.UpdateWalletParams{
+			WalletID: params.WalletID,
+			SyncedTo: &params.Block,
+		}, updateWalletOps{q: qtx})
+		if err != nil {
+			return fmt.Errorf("update wallet sync tip: %w", err)
+		}
+
+		return nil
+	})
+}
+
+// rewindWalletTransactions detaches one wallet's confirmed transactions above
+// the manual-rescan rewind point while preserving shared block rows.
+func rewindWalletTransactions(ctx context.Context, qtx *sqlc.Queries,
+	params db.RewindWalletParams) error {
+
+	startHeight, err := db.Int64ToInt32(int64(params.Block.Height) + 1)
+	if err != nil {
+		return fmt.Errorf("rewind start height: %w", err)
+	}
+
+	rows, err := qtx.ListTransactionsByHeightRange(
+		ctx, sqlc.ListTransactionsByHeightRangeParams{
+			WalletID:    int64(params.WalletID),
+			StartHeight: int64(startHeight),
+			EndHeight:   maxSQLBlockHeight,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("list wallet rewind txs: %w", err)
+	}
+
+	coinbaseRoots := make([]chainhash.Hash, 0)
+	for _, row := range rows {
+		txHash, err := chainhash.NewHash(row.TxHash)
+		if err != nil {
+			return fmt.Errorf("rewind tx hash: %w", err)
+		}
+
+		status := db.TxStatusPublished
+		if row.IsCoinbase {
+			status = db.TxStatusOrphaned
+
+			coinbaseRoots = append(coinbaseRoots, *txHash)
+		}
+
+		updated, err := qtx.UpdateTransactionStateByHash(
+			ctx, sqlc.UpdateTransactionStateByHashParams{
+				BlockHeight: sql.NullInt64{},
+				Status:      int64(status),
+				WalletID:    int64(params.WalletID),
+				TxHash:      row.TxHash,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("detach rewind tx %s: %w", txHash, err)
+		}
+
+		if updated == 0 {
+			return fmt.Errorf("rewind tx %s: %w", txHash,
+				db.ErrTxNotFound)
+		}
+	}
+
+	if len(coinbaseRoots) == 0 {
+		return nil
+	}
+
+	return db.InvalidateRollbackDescendants(
+		ctx, map[uint32][]chainhash.Hash{
+			params.WalletID: coinbaseRoots,
+		}, rollbackToBlockOps{qtx: qtx},
+	)
+}
+
 // RollbackToBlock atomically removes every block at or above the provided
 // height and rewrites wallet sync-state references so the block delete can
 // succeed.

--- a/wallet/internal/db/txstore_common.go
+++ b/wallet/internal/db/txstore_common.go
@@ -564,6 +564,11 @@ func validateCreateTxParams(params CreateTxParams) error {
 		}
 	}
 
+	if len(params.CreditCandidates) > 0 {
+		return fmt.Errorf("%w: unresolved credit candidates",
+			ErrInvalidParam)
+	}
+
 	// Coinbase transactions only enter wallet history once a block already
 	// anchors them, so CreateTx requires the caller to provide that block up
 	// front instead of storing a fake unmined intermediate row first.
@@ -971,6 +976,27 @@ func canIgnoreUnminedConfirmedDuplicate(req CreateTxRequest,
 	existing CreateTxExistingTarget) bool {
 
 	return req.Params.Block == nil && existing.HasBlock
+}
+
+// CanPromoteUnminedCreateTxDuplicate reports whether an unmined duplicate
+// observation may promote an existing pending row to published. The caller must
+// preserve the existing row label while applying this transition.
+func CanPromoteUnminedCreateTxDuplicate(req CreateTxRequest, status TxStatus,
+	isCoinbase bool, block *Block) bool {
+
+	if req.Params.Block != nil || block != nil {
+		return false
+	}
+
+	if req.Params.Status != TxStatusPublished {
+		return false
+	}
+
+	if status != TxStatusPending {
+		return false
+	}
+
+	return req.IsCoinbase == isCoinbase
 }
 
 // loadCreateTxExisting resolves any wallet-scoped row already stored for the

--- a/wallet/internal/db/txstore_common.go
+++ b/wallet/internal/db/txstore_common.go
@@ -1733,6 +1733,16 @@ func invalidateRollbackDescendants(ctx context.Context,
 	return nil
 }
 
+// InvalidateRollbackDescendants clears spend edges and fails unmined
+// descendants rooted in disconnected coinbase transactions. Wallet-scoped
+// rewind paths use this without deleting shared block rows.
+func InvalidateRollbackDescendants(ctx context.Context,
+	rootHashesByWallet map[uint32][]chainhash.Hash,
+	ops RollbackToBlockOps) error {
+
+	return invalidateRollbackDescendants(ctx, rootHashesByWallet, ops)
+}
+
 // MarkTxRootsOrphaned rewrites every disconnected coinbase root to the
 // orphaned state before descendant invalidation completes.
 func MarkTxRootsOrphaned(ctx context.Context,

--- a/wallet/internal/db/txstore_common_test.go
+++ b/wallet/internal/db/txstore_common_test.go
@@ -2446,3 +2446,75 @@ func TestValidateBatchTransactionsTx(t *testing.T) {
 		require.ErrorIs(t, err, ErrInvalidParam)
 	})
 }
+
+// TestCanPromoteUnminedCreateTxDuplicate verifies that only a pending unmined
+// duplicate can be promoted to the published unmined state.
+func TestCanPromoteUnminedCreateTxDuplicate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		reqBlock    *Block
+		reqStatus   TxStatus
+		rowStatus   TxStatus
+		reqCoinbase bool
+		rowCoinbase bool
+		rowBlock    *Block
+		wantPromote bool
+	}{
+		{
+			name:        "pending to published",
+			reqStatus:   TxStatusPublished,
+			rowStatus:   TxStatusPending,
+			wantPromote: true,
+		},
+		{
+			name:      "request pending",
+			reqStatus: TxStatusPending,
+			rowStatus: TxStatusPending,
+		},
+		{
+			name:      "row already published",
+			reqStatus: TxStatusPublished,
+			rowStatus: TxStatusPublished,
+		},
+		{
+			name:      "row has block",
+			reqStatus: TxStatusPublished,
+			rowStatus: TxStatusPending,
+			rowBlock:  testBlock(107),
+		},
+		{
+			name:      "request has block",
+			reqBlock:  testBlock(108),
+			reqStatus: TxStatusPublished,
+			rowStatus: TxStatusPending,
+		},
+		{
+			name:        "coinbase mismatch",
+			reqStatus:   TxStatusPublished,
+			rowStatus:   TxStatusPending,
+			reqCoinbase: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := CreateTxRequest{
+				Params: CreateTxParams{
+					Block:  tc.reqBlock,
+					Status: tc.reqStatus,
+				},
+				IsCoinbase: tc.reqCoinbase,
+			}
+
+			canPromote := CanPromoteUnminedCreateTxDuplicate(
+				req, tc.rowStatus, tc.rowCoinbase, tc.rowBlock,
+			)
+
+			require.Equal(t, tc.wantPromote, canPromote)
+		})
+	}
+}

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -353,7 +353,12 @@ func (m *Manager) Load(cfg Config) (*Wallet, error) {
 		isWatchOnly:       addrMgr.WatchOnly(),
 	}
 
-	w.sync = newSyncer(cfg, w.addrStore, w.txStore, w)
+	w.sync = newSyncer(
+		cfg, w.addrStore, w.txStore, w, syncerStoreConfig{
+			store:    w.store,
+			walletID: w.id,
+		},
+	)
 	w.state = newWalletState(w.sync)
 
 	// Register the wallet.

--- a/wallet/syncer.go
+++ b/wallet/syncer.go
@@ -349,7 +349,7 @@ func (s *syncer) checkRollback(ctx context.Context) error {
 		startHeight := max(0, endHeight-batchSize+1)
 
 		// Fetch Local Batch (from wallet's database).
-		localHashes, err = s.DBGetSyncedBlocks(
+		localHashes, err = s.syncedBlockHashes(
 			ctx, startHeight, endHeight,
 		)
 		if err != nil {
@@ -412,6 +412,69 @@ func (s *syncer) checkRollback(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// syncedBlockHashes returns the wallet's synced block hashes for the inclusive
+// height range.
+func (s *syncer) syncedBlockHashes(ctx context.Context, startHeight,
+	endHeight int32) ([]*chainhash.Hash, error) {
+
+	if s.store == nil {
+		return s.DBGetSyncedBlocks(ctx, startHeight, endHeight)
+	}
+
+	start, err := db.Int64ToUint32(int64(startHeight))
+	if err != nil {
+		return nil, fmt.Errorf("start height %d: %w", startHeight, err)
+	}
+
+	end, err := db.Int64ToUint32(int64(endHeight))
+	if err != nil {
+		return nil, fmt.Errorf("end height %d: %w", endHeight, err)
+	}
+
+	blocks, err := s.store.ListSyncedBlocks(
+		ctx, db.ListSyncedBlocksQuery{
+			StartHeight: start,
+			EndHeight:   end,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list synced blocks: %w", err)
+	}
+
+	hashes := make([]*chainhash.Hash, len(blocks))
+	for i := range blocks {
+		hashes[i] = &blocks[i].Hash
+	}
+
+	return hashes, nil
+}
+
+// syncedTo returns the wallet's current sync tip from the active runtime
+// backend.
+func (s *syncer) syncedTo(ctx context.Context) (waddrmgr.BlockStamp, error) {
+	if s.store == nil {
+		return s.addrStore.SyncedTo(), nil
+	}
+
+	walletInfo, err := s.store.GetWallet(ctx, s.cfg.Name)
+	if err != nil {
+		return waddrmgr.BlockStamp{}, fmt.Errorf("get wallet sync tip: %w",
+			err)
+	}
+
+	if walletInfo.SyncedTo == nil {
+		return waddrmgr.BlockStamp{}, nil
+	}
+
+	syncedTo, err := db.BlockStampFromBlock(walletInfo.SyncedTo)
+	if err != nil {
+		return waddrmgr.BlockStamp{}, fmt.Errorf("decode wallet sync tip: %w",
+			err)
+	}
+
+	return syncedTo, nil
 }
 
 // findForkPoint compares local and remote block hashes to find the last

--- a/wallet/syncer.go
+++ b/wallet/syncer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 )
 
@@ -188,6 +189,12 @@ type syncer struct {
 	// txStore is the transaction manager.
 	txStore wtxmgr.TxStore
 
+	// store is the transitional database store used by migrated runtime paths.
+	store db.Store
+
+	// walletID is the database wallet identifier used by store-backed paths.
+	walletID uint32
+
 	// state tracks the chain synchronization status.
 	state atomic.Uint32
 
@@ -202,17 +209,34 @@ type syncer struct {
 	publisher TxPublisher
 }
 
+// syncerStoreConfig contains store-backed runtime options for the syncer.
+type syncerStoreConfig struct {
+	// store is the transitional database store used by migrated runtime paths.
+	store db.Store
+
+	// walletID is the database wallet identifier used by store-backed paths.
+	walletID uint32
+}
+
 // newSyncer creates a new syncer instance.
 func newSyncer(cfg Config, addrStore waddrmgr.AddrStore,
-	txStore wtxmgr.TxStore, publisher TxPublisher) *syncer {
+	txStore wtxmgr.TxStore, publisher TxPublisher,
+	storeConfigs ...syncerStoreConfig) *syncer {
 
-	return &syncer{
+	s := &syncer{
 		cfg:         cfg,
 		addrStore:   addrStore,
 		txStore:     txStore,
 		scanReqChan: make(chan *scanReq, 1),
 		publisher:   publisher,
 	}
+
+	if len(storeConfigs) > 0 {
+		s.store = storeConfigs[0].store
+		s.walletID = storeConfigs[0].walletID
+	}
+
+	return s
 }
 
 // syncState returns the current synchronization state of the wallet.

--- a/wallet/syncer.go
+++ b/wallet/syncer.go
@@ -399,7 +399,7 @@ func (s *syncer) checkRollback(ctx context.Context) error {
 			}
 
 			// Perform the rollback.
-			return s.DBPutRewind(ctx, waddrmgr.BlockStamp{
+			return s.rewindToBlock(ctx, waddrmgr.BlockStamp{
 				Height:    forkHeight,
 				Hash:      *forkHash,
 				Timestamp: header.Timestamp,
@@ -412,6 +412,96 @@ func (s *syncer) checkRollback(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// rewindToBlock rewinds wallet sync and transaction state to the given fork
+// point.
+func (s *syncer) rewindToBlock(ctx context.Context,
+	block waddrmgr.BlockStamp) error {
+
+	if s.store == nil {
+		return s.DBPutRewind(ctx, block)
+	}
+
+	rollbackBoundary := int64(block.Height) + 1
+
+	rollbackHeight, err := db.Int64ToUint32(rollbackBoundary)
+	if err != nil {
+		return fmt.Errorf("rollback height %d: %w", rollbackBoundary, err)
+	}
+
+	// Roll transaction state back and rewind the wallet sync tip to the same
+	// fork point in one atomic store call so a failure cannot leave the sync
+	// tip rewound while transaction state still references the abandoned
+	// chain. RollbackToBlock derives the new sync tip from the stored
+	// fork-point block, so the caller only supplies the rollback boundary.
+	err = s.store.RollbackToBlock(ctx, rollbackHeight)
+	if err != nil {
+		return fmt.Errorf("rollback to block: %w", err)
+	}
+
+	return nil
+}
+
+// rewindWallet rewinds this wallet's sync and transaction state for a manual
+// rescan without requiring a DB-wide block rollback.
+func (s *syncer) rewindWallet(ctx context.Context,
+	block waddrmgr.BlockStamp) error {
+
+	if s.store == nil {
+		return s.DBPutRewind(ctx, block)
+	}
+
+	storeBlock, err := s.resolveRewindBlock(block)
+	if err != nil {
+		return fmt.Errorf("rewind wallet block: %w", err)
+	}
+
+	err = s.store.RewindWallet(ctx, db.RewindWalletParams{
+		WalletID: s.walletID,
+		Block:    *storeBlock,
+	})
+	if err != nil {
+		return fmt.Errorf("rewind wallet: %w", err)
+	}
+
+	return nil
+}
+
+// resolveRewindBlock resolves the requested manual-rewind height into the
+// canonical block metadata recorded as the wallet's new synced tip.
+func (s *syncer) resolveRewindBlock(
+	block waddrmgr.BlockStamp) (*db.Block, error) {
+
+	if block.Hash != (chainhash.Hash{}) && !block.Timestamp.IsZero() {
+		storeBlock, err := db.BlockFromBlockStamp(block)
+		if err != nil {
+			return nil, fmt.Errorf("convert rewind block: %w", err)
+		}
+
+		return storeBlock, nil
+	}
+
+	hash, err := s.cfg.Chain.GetBlockHash(int64(block.Height))
+	if err != nil {
+		return nil, fmt.Errorf("get rewind block hash: %w", err)
+	}
+
+	header, err := s.cfg.Chain.GetBlockHeader(hash)
+	if err != nil {
+		return nil, fmt.Errorf("get rewind block header: %w", err)
+	}
+
+	storeBlock, err := db.BlockFromBlockStamp(waddrmgr.BlockStamp{
+		Height:    block.Height,
+		Hash:      *hash,
+		Timestamp: header.Timestamp,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("convert resolved rewind block: %w", err)
+	}
+
+	return storeBlock, nil
 }
 
 // syncedBlockHashes returns the wallet's synced block hashes for the inclusive
@@ -1343,7 +1433,15 @@ func (s *syncer) waitForEvent(ctx context.Context) error {
 // scanWithRewind rewinds the wallet's sync status to the requested start
 // block.
 func (s *syncer) scanWithRewind(ctx context.Context, req *scanReq) error {
-	current := s.addrStore.SyncedTo()
+	// Read the synced tip through syncedTo so a Store-backed backend uses
+	// the Store's tip rather than the legacy addrStore tip. A backend that
+	// does not mirror ApplyScanBatch/RewindWallet into the legacy manager
+	// would otherwise compare against a stale legacy height and could
+	// wrongly conclude there is nothing to rewind for a full rescan.
+	current, err := s.syncedTo(ctx)
+	if err != nil {
+		return err
+	}
 
 	if req.startBlock.Height >= current.Height {
 		// Requested start is ahead of or equal to current sync.
@@ -1354,8 +1452,7 @@ func (s *syncer) scanWithRewind(ctx context.Context, req *scanReq) error {
 	log.Infof("Rewinding sync status from %d to %d for rescan",
 		current.Height, req.startBlock.Height)
 
-	// Rewind the database status.
-	err := s.DBPutRewind(ctx, req.startBlock)
+	err = s.rewindWallet(ctx, req.startBlock)
 	if err != nil {
 		log.Errorf("Failed to rewind sync status: %v", err)
 

--- a/wallet/syncer.go
+++ b/wallet/syncer.go
@@ -1,6 +1,7 @@
 package wallet
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -658,7 +659,7 @@ func (s *syncer) requestScan(ctx context.Context, req *scanReq) error {
 // broadcastUnminedTxns retrieves all unmined transactions from the wallet and
 // attempts to re-broadcast them to the network.
 func (s *syncer) broadcastUnminedTxns(ctx context.Context) error {
-	txs, err := s.DBGetUnminedTxns(ctx)
+	txs, err := s.unminedTxns(ctx)
 	if err != nil {
 		log.Errorf("Unable to retrieve unconfirmed transactions to "+
 			"resend: %v", err)
@@ -675,6 +676,45 @@ func (s *syncer) broadcastUnminedTxns(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// unminedTxns returns transactions that are still active in the wallet's
+// unmined set.
+func (s *syncer) unminedTxns(ctx context.Context) ([]*wire.MsgTx, error) {
+	if s.store == nil {
+		return s.DBGetUnminedTxns(ctx)
+	}
+
+	infos, err := s.store.ListTxns(
+		ctx, db.ListTxnsQuery{
+			WalletID:    s.walletID,
+			UnminedOnly: true,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list unmined txns: %w", err)
+	}
+
+	txSet := make(map[chainhash.Hash]*wire.MsgTx, len(infos))
+	for i := range infos {
+		info := infos[i]
+		if info.Status != db.TxStatusPublished {
+			continue
+		}
+
+		var tx wire.MsgTx
+
+		err := tx.Deserialize(bytes.NewReader(info.SerializedTx))
+		if err != nil {
+			return nil, fmt.Errorf("deserialize unmined tx %v: %w",
+				info.Hash, err)
+		}
+
+		txHash := tx.TxHash()
+		txSet[txHash] = &tx
+	}
+
+	return wtxmgr.DependencySort(txSet), nil
 }
 
 // updateSyncTip records the latest synced block for store-backed runtime paths.

--- a/wallet/syncer.go
+++ b/wallet/syncer.go
@@ -524,6 +524,47 @@ func (s *syncer) broadcastUnminedTxns(ctx context.Context) error {
 	return nil
 }
 
+// updateSyncTip records the latest synced block for store-backed runtime paths.
+func (s *syncer) updateSyncTip(ctx context.Context,
+	block wtxmgr.BlockMeta) error {
+
+	if s.store == nil {
+		return s.DBPutSyncTip(ctx, block)
+	}
+
+	storeBlock, err := storeBlockFromBlockMeta(block)
+	if err != nil {
+		return err
+	}
+
+	err = s.store.UpdateWallet(
+		ctx, db.UpdateWalletParams{
+			WalletID: s.walletID,
+			SyncedTo: storeBlock,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("update sync tip: %w", err)
+	}
+
+	return nil
+}
+
+// storeBlockFromBlockMeta converts chain notification block metadata into the
+// store block shape.
+func storeBlockFromBlockMeta(block wtxmgr.BlockMeta) (*db.Block, error) {
+	height, err := db.Int64ToUint32(int64(block.Height))
+	if err != nil {
+		return nil, fmt.Errorf("block height %d: %w", block.Height, err)
+	}
+
+	return &db.Block{
+		Hash:      block.Hash,
+		Height:    height,
+		Timestamp: block.Time,
+	}, nil
+}
+
 // scanBatchHeadersOnly performs a lightweight scan by only fetching block
 // headers. This is used when the wallet has no addresses or outpoints to
 // watch, allowing it to fast-forward its sync state.
@@ -1126,7 +1167,7 @@ func (s *syncer) handleChainUpdate(ctx context.Context, n any) error {
 func (s *syncer) processChainUpdate(ctx context.Context, update any) error {
 	switch n := update.(type) {
 	case chain.BlockConnected:
-		return s.DBPutSyncTip(ctx, wtxmgr.BlockMeta(n))
+		return s.updateSyncTip(ctx, wtxmgr.BlockMeta(n))
 
 	// A block was disconnected. We use checkRollback to safely verify our
 	// chain state against the backend and rewind if necessary. This

--- a/wallet/syncer.go
+++ b/wallet/syncer.go
@@ -334,7 +334,11 @@ func (s *syncer) checkRollback(ctx context.Context) error {
 	// requests lightweight.
 	const batchSize = 10
 
-	syncedTo := s.addrStore.SyncedTo()
+	syncedTo, err := s.syncedTo(ctx)
+	if err != nil {
+		return err
+	}
+
 	syncedHeight := syncedTo.Height
 
 	var (
@@ -741,6 +745,108 @@ func (s *syncer) updateSyncTip(ctx context.Context,
 	}
 
 	return nil
+}
+
+// putTxNotifications records relevant transaction notifications through the
+// store when configured, falling back to the legacy walletdb path otherwise.
+func (s *syncer) putTxNotifications(ctx context.Context,
+	matches TxEntries, blockMeta *wtxmgr.BlockMeta) error {
+
+	if s.store == nil {
+		return s.DBPutTxns(ctx, matches, blockMeta)
+	}
+
+	var block *db.Block
+	if blockMeta != nil {
+		var err error
+
+		block, err = storeBlockFromBlockMeta(*blockMeta)
+		if err != nil {
+			return err
+		}
+	}
+
+	transactions := make([]db.CreateTxParams, 0, len(matches))
+	for i := range matches {
+		match := matches[i]
+		creditCandidates := make(
+			map[uint32][]address.Address, len(match.Entries),
+		)
+
+		for _, entry := range match.Entries {
+			index := entry.Credit.Index
+			if uint64(index) >= uint64(len(match.Rec.MsgTx.TxOut)) {
+				return fmt.Errorf("credit output %d: %w", index,
+					db.ErrInvalidParam)
+			}
+
+			creditCandidates[index] = append(
+				creditCandidates[index], entry.Address,
+			)
+		}
+
+		status, label, err := s.txNotificationState(
+			ctx, match.Rec.Hash, block,
+		)
+		if err != nil {
+			return err
+		}
+
+		transactions = append(transactions, db.CreateTxParams{
+			WalletID:         s.walletID,
+			Tx:               &match.Rec.MsgTx,
+			Received:         match.Rec.Received,
+			Block:            block,
+			Status:           status,
+			Label:            label,
+			CreditCandidates: creditCandidates,
+		})
+	}
+
+	err := s.store.ApplyTxBatch(
+		ctx, db.TxBatchParams{
+			WalletID:     s.walletID,
+			Transactions: transactions,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("apply tx notifications: %w", err)
+	}
+
+	return nil
+}
+
+// txNotificationState returns the status and label to use for a relevant tx
+// notification recorded through the Store path.
+func (s *syncer) txNotificationState(ctx context.Context,
+	txHash chainhash.Hash, block *db.Block) (db.TxStatus, string, error) {
+
+	const (
+		label  = ""
+		status = db.TxStatusPublished
+	)
+
+	if block != nil {
+		return status, label, nil
+	}
+
+	info, err := s.store.GetTx(ctx, db.GetTxQuery{
+		WalletID: s.walletID,
+		Txid:     txHash,
+	})
+	switch {
+	case errors.Is(err, db.ErrTxNotFound):
+		return status, label, nil
+
+	case err != nil:
+		return 0, "", fmt.Errorf("get tx %v: %w", txHash, err)
+	}
+
+	if info.Block != nil || !db.IsUnminedStatus(info.Status) {
+		return status, label, nil
+	}
+
+	return status, info.Label, nil
 }
 
 // storeBlockFromBlockMeta converts chain notification block metadata into the
@@ -1249,7 +1355,9 @@ func (s *syncer) advanceChainSync(ctx context.Context) (bool, error) {
 			err)
 	}
 
-	// Determine our current sync state.
+	// Determine our current sync state from the same backend scanBatch writes
+	// below. Store-backed scan commits are introduced in a later stack commit;
+	// until then, regular chain sync must continue reading the legacy tip.
 	syncedTo := s.addrStore.SyncedTo()
 
 	// If the wallet is caught up to the best known tip, log this and
@@ -1373,7 +1481,7 @@ func (s *syncer) processChainUpdate(ctx context.Context, update any) error {
 	// handled atomically via FilteredBlockConnected.
 	case chain.RelevantTx:
 		matches := s.prepareTxMatches([]*wtxmgr.TxRecord{n.TxRecord})
-		return s.DBPutTxns(ctx, matches, n.Block)
+		return s.putTxNotifications(ctx, matches, n.Block)
 
 	case chain.FilteredBlockConnected:
 		matches := s.prepareTxMatches(n.RelevantTxs)

--- a/wallet/syncer_test.go
+++ b/wallet/syncer_test.go
@@ -161,14 +161,14 @@ func TestCheckRollbackNoReorg(t *testing.T) {
 	t.Parallel()
 
 	// Arrange: Initialize a syncer with a test database and mock chain.
-	db, cleanup := setupTestDB(t)
+	dbConn, cleanup := setupTestDB(t)
 	defer cleanup()
 
 	mockAddrStore := &bwmock.AddrStore{}
 	mockChain := &bwmock.Chain{}
 
 	s := newSyncer(
-		Config{Chain: mockChain, DB: db}, mockAddrStore, nil, nil,
+		Config{Chain: mockChain, DB: dbConn}, mockAddrStore, nil, nil,
 	)
 
 	tip := waddrmgr.BlockStamp{Height: 100, Hash: chainhash.Hash{0x01}}
@@ -205,7 +205,7 @@ func TestCheckRollbackDetected(t *testing.T) {
 
 	// Arrange: Initialize a syncer with a test database and mocks to
 	// simulate a chain reorganization.
-	db, cleanup := setupTestDB(t)
+	dbConn, cleanup := setupTestDB(t)
 	defer cleanup()
 
 	mockAddrStore := &bwmock.AddrStore{}
@@ -214,7 +214,7 @@ func TestCheckRollbackDetected(t *testing.T) {
 	mockPublisher := &mockTxPublisher{}
 
 	s := newSyncer(
-		Config{Chain: mockChain, DB: db}, mockAddrStore, mockTxStore,
+		Config{Chain: mockChain, DB: dbConn}, mockAddrStore, mockTxStore,
 		mockPublisher,
 	)
 
@@ -332,7 +332,7 @@ func TestSyncerLoadScanState(t *testing.T) {
 
 	// Arrange: Initialize a syncer with a test database and set up complex
 	// mock expectations for loading wallet scan data.
-	db, cleanup := setupTestDB(t)
+	dbConn, cleanup := setupTestDB(t)
 	defer cleanup()
 
 	mockAddrStore := &bwmock.AddrStore{}
@@ -341,7 +341,7 @@ func TestSyncerLoadScanState(t *testing.T) {
 
 	s := newSyncer(
 		Config{
-			DB:             db,
+			DB:             dbConn,
 			RecoveryWindow: 10,
 			ChainParams:    &chainParams,
 		},
@@ -441,14 +441,14 @@ func TestScanBatchWithCFilters(t *testing.T) {
 	t.Parallel()
 
 	// Arrange: Initialize a syncer and set up a recovery state.
-	db, cleanup := setupTestDB(t)
+	dbConn, cleanup := setupTestDB(t)
 	defer cleanup()
 
 	mockChain := &bwmock.Chain{}
 	mockPublisher := &mockTxPublisher{}
 
 	s := newSyncer(
-		Config{Chain: mockChain, DB: db}, nil, nil, mockPublisher,
+		Config{Chain: mockChain, DB: dbConn}, nil, nil, mockPublisher,
 	)
 
 	mockAddrStore := &bwmock.AddrStore{}
@@ -860,39 +860,76 @@ func TestExtractAddrEntries(t *testing.T) {
 	require.Equal(t, uint32(0), entries[0].Credit.Index)
 }
 
+// matchRewindWalletParams returns a matcher for one wallet-scoped manual
+// rescan rewind target.
+func matchRewindWalletParams(walletID uint32,
+	block waddrmgr.BlockStamp) any {
+
+	return mock.MatchedBy(func(params db.RewindWalletParams) bool {
+		if block.Height < 0 {
+			return false
+		}
+
+		return params.WalletID == walletID &&
+			params.Block.Height == uint32(block.Height) &&
+			params.Block.Hash == block.Hash &&
+			params.Block.Timestamp.Equal(block.Timestamp.UTC())
+	})
+}
+
 // TestHandleScanReq verifies scan request handling.
 func TestHandleScanReq(t *testing.T) {
 	t.Parallel()
 
 	// Arrange: Initialize a syncer with a test database and mocks to
 	// test handling of different scan request types.
-	db, cleanup := setupTestDB(t)
+	dbConn, cleanup := setupTestDB(t)
 	defer cleanup()
 
 	mockAddrStore := &bwmock.AddrStore{}
+	mockChain := &bwmock.Chain{}
 	mockPublisher := &mockTxPublisher{}
+	mockTxStore := &bwmock.TxStore{}
+	store := &walletmock.Store{}
 
 	s := newSyncer(
-		Config{DB: db}, mockAddrStore, nil, mockPublisher,
+		Config{DB: dbConn, Chain: mockChain}, mockAddrStore,
+		mockTxStore, mockPublisher,
+		syncerStoreConfig{store: store, walletID: 0},
 	)
 
-	// Case 1: Test handling of a rewind scan request.
+	// Case 1: Test handling of a rewind scan request. The current tip is at
+	// height 100, so rewinding to height 50 uses the wallet-scoped Store
+	// rewind while the decision also comes from the Store tip.
+	start := waddrmgr.BlockStamp{Height: 50}
 	req := &scanReq{
 		typ:        scanTypeRewind,
-		startBlock: waddrmgr.BlockStamp{Height: 50},
+		startBlock: start,
 	}
-	mockAddrStore.On("SyncedTo").Return(
-		waddrmgr.BlockStamp{Height: 100},
+
+	rewindHash := chainhash.Hash{50}
+	rewindHeader := &wire.BlockHeader{
+		Timestamp: time.Unix(50, 0).UTC(),
+	}
+	rewindBlock := waddrmgr.BlockStamp{
+		Height:    start.Height,
+		Hash:      rewindHash,
+		Timestamp: rewindHeader.Timestamp,
+	}
+
+	store.On("GetWallet", mock.Anything, mock.Anything).Return(
+		&db.WalletInfo{SyncedTo: &db.Block{Height: 100}}, nil,
 	).Once()
-
-	// Expect sync state update and transaction rollback for the rewind.
-	mockAddrStore.On(
-		"SetSyncedTo", mock.Anything, mock.Anything,
+	mockChain.On("GetBlockHash", int64(start.Height)).Return(
+		&rewindHash, nil,
+	).Once()
+	mockChain.On("GetBlockHeader", &rewindHash).Return(
+		rewindHeader, nil,
+	).Once()
+	store.On(
+		"RewindWallet", mock.Anything,
+		matchRewindWalletParams(0, rewindBlock),
 	).Return(nil).Once()
-
-	mockTxStore := &bwmock.TxStore{}
-	s.txStore = mockTxStore
-	mockTxStore.On("Rollback", mock.Anything, int32(51)).Return(nil).Once()
 
 	// Act & Assert: Verify that a rewind scan request is correctly handled.
 	err := s.handleScanReq(t.Context(), req)
@@ -904,7 +941,7 @@ func TestHandleScanReq(t *testing.T) {
 		startBlock: waddrmgr.BlockStamp{Height: 100},
 		targets:    []waddrmgr.AccountScope{{Account: 1}},
 	}
-	mockChain := &bwmock.Chain{}
+	mockChain = &bwmock.Chain{}
 	s.cfg.Chain = mockChain
 	mockChain.On("GetBestBlock").Return(
 		&chainhash.Hash{}, int32(101), nil,
@@ -2700,6 +2737,95 @@ func TestSyncedBlockHashesRoutesStore(t *testing.T) {
 	store.AssertExpectations(t)
 }
 
+// TestRewindToBlockRoutesStore verifies the store rewind path issues a single
+// atomic RollbackToBlock for the rollback boundary, which rewinds the wallet
+// sync tip and rolls transaction state back together, rather than two
+// independent sync-tip and rollback writes.
+func TestRewindToBlockRoutesStore(t *testing.T) {
+	t.Parallel()
+
+	store := &walletmock.Store{}
+	s := newSyncer(Config{}, nil, nil, nil)
+	s.store = store
+	s.walletID = 99
+
+	fork := waddrmgr.BlockStamp{
+		Hash:      chainhash.Hash{99},
+		Height:    100,
+		Timestamp: time.Unix(1710003900, 0),
+	}
+
+	store.On(
+		"RollbackToBlock", mock.Anything, uint32(101),
+	).Return(nil).Once()
+
+	err := s.rewindToBlock(t.Context(), fork)
+	require.NoError(t, err)
+	store.AssertExpectations(t)
+}
+
+// TestScanWithRewindRoutesStoreRewind verifies manual rescans route through
+// the wallet-scoped Store rewind API when Store-backed sync reads are enabled.
+func TestScanWithRewindRoutesStoreRewind(t *testing.T) {
+	t.Parallel()
+
+	const walletName = "manual-rewind-wallet"
+
+	store := &walletmock.Store{}
+	s := newSyncer(
+		Config{Name: walletName}, nil, nil, nil,
+		syncerStoreConfig{store: store, walletID: 100},
+	)
+
+	current := &db.Block{Hash: chainhash.Hash{100}, Height: 100}
+	store.On("GetWallet", mock.Anything, walletName).Return(
+		&db.WalletInfo{SyncedTo: current}, nil,
+	).Once()
+
+	start := waddrmgr.BlockStamp{
+		Hash:      chainhash.Hash{50},
+		Height:    50,
+		Timestamp: time.Unix(1710004100, 0),
+	}
+
+	store.On(
+		"RewindWallet", mock.Anything,
+		matchRewindWalletParams(100, start),
+	).Return(nil).Once()
+
+	err := s.scanWithRewind(t.Context(), &scanReq{
+		typ:        scanTypeRewind,
+		startBlock: start,
+	})
+	require.NoError(t, err)
+
+	store.AssertExpectations(t)
+}
+
+// TestRewindToBlockFallsBackToLegacy verifies that, when no runtime store is
+// configured, rewindToBlock still routes through the legacy DBPutRewind path
+// (SetSyncedTo + wtxmgr Rollback) rather than the store.
+func TestRewindToBlockFallsBackToLegacy(t *testing.T) {
+	t.Parallel()
+
+	w, mocks := createTestWalletWithMocks(t)
+	s := newSyncer(w.cfg, w.addrStore, w.txStore, nil)
+	require.Nil(t, s.store)
+
+	bs := waddrmgr.BlockStamp{Height: 100, Hash: chainhash.Hash{0x01}}
+
+	mocks.addrStore.On("SetSyncedTo", mock.Anything, &bs).Return(nil).Once()
+	mocks.txStore.On("Rollback",
+		mock.Anything, int32(101),
+	).Return(nil).Once()
+
+	err := s.rewindToBlock(t.Context(), bs)
+	require.NoError(t, err)
+
+	mocks.addrStore.AssertExpectations(t)
+	mocks.txStore.AssertExpectations(t)
+}
+
 // TestHandleChainUpdate_SpecialNotifs verifies RescanProgress and
 // RescanFinished.
 func TestHandleChainUpdate_SpecialNotifs(t *testing.T) {
@@ -3129,34 +3255,40 @@ func TestLoadFullScanState_Error(t *testing.T) {
 	require.ErrorContains(t, err, "db error")
 }
 
-// TestScanWithRewind_Error verifies error propagation from DBPutRewind.
+// TestScanWithRewind_Error verifies error propagation from the Store rewind.
 func TestScanWithRewind_Error(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Setup mock expectations for a rewind scan where a database
-	// rollback failure occurs.
-	db, cleanup := setupTestDB(t)
-	defer cleanup()
+	// Arrange: Setup a store-backed syncer for a rewind scan where the Store
+	// rewind fails.
+	store := &walletmock.Store{}
+	s := newSyncer(
+		Config{}, nil, nil, nil,
+		syncerStoreConfig{store: store, walletID: 0},
+	)
 
-	mockTxStore := &bwmock.TxStore{}
-	mockAddrStore := &bwmock.AddrStore{}
-	s := newSyncer(Config{DB: db}, mockAddrStore, mockTxStore, nil)
-	mockAddrStore.On("SyncedTo").Return(
-		waddrmgr.BlockStamp{Height: 100}).Maybe()
+	rewindTip := waddrmgr.BlockStamp{
+		Height:    90,
+		Hash:      chainhash.Hash{90},
+		Timestamp: time.Unix(90, 0).UTC(),
+	}
 
-	mockAddrStore.On("SetSyncedTo", mock.Anything,
-		mock.Anything).Return(nil).Maybe()
-	mockTxStore.On("Rollback", mock.Anything, mock.Anything).Return(
-		errRollbackFail).Once()
+	store.On("GetWallet", mock.Anything, "").Return(
+		&db.WalletInfo{SyncedTo: &db.Block{Height: 100}}, nil,
+	).Once()
+	store.On(
+		"RewindWallet", mock.Anything,
+		matchRewindWalletParams(0, rewindTip),
+	).Return(errRollbackFail).Once()
 
 	// Act: Attempt to perform a scan with rewind.
 	err := s.scanWithRewind(
 		t.Context(), &scanReq{
-			startBlock: waddrmgr.BlockStamp{Height: 90},
+			startBlock: rewindTip,
 		},
 	)
 
-	// Assert: Verify rollback failure is propagated.
+	// Assert: Verify the rewind failure is propagated.
 	require.ErrorContains(t, err, "rollback fail")
 }
 

--- a/wallet/syncer_test.go
+++ b/wallet/syncer_test.go
@@ -1,6 +1,7 @@
 package wallet
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"testing"
@@ -2708,6 +2709,163 @@ func TestProcessChainUpdateRoutesSyncTip(t *testing.T) {
 	err := s.processChainUpdate(t.Context(), chain.BlockConnected(block))
 	require.NoError(t, err)
 	store.AssertExpectations(t)
+}
+
+// TestAdvanceChainSyncUsesLegacySyncedToWithStore verifies regular chain sync
+// keeps reading the legacy sync tip while scanBatch still writes through the
+// legacy walletdb path, even when a runtime store is configured.
+func TestAdvanceChainSyncUsesLegacySyncedToWithStore(t *testing.T) {
+	t.Parallel()
+
+	const (
+		walletID   uint32 = 78
+		walletName        = "legacy-sync-tip"
+	)
+
+	store := &walletmock.Store{}
+	addrStore := &bwmock.AddrStore{}
+	chain := &bwmock.Chain{}
+	syncedTo := waddrmgr.BlockStamp{
+		Hash:      chainhash.Hash{78},
+		Height:    144,
+		Timestamp: time.Unix(1710003900, 0),
+	}
+
+	s := newSyncer(
+		Config{Name: walletName, Chain: chain}, addrStore, nil, nil,
+		syncerStoreConfig{store: store, walletID: walletID},
+	)
+
+	chain.On("GetBestBlock").Return(
+		&syncedTo.Hash, syncedTo.Height, nil,
+	).Once()
+	addrStore.On("SyncedTo").Return(syncedTo).Once()
+
+	syncFinished, err := s.advanceChainSync(t.Context())
+	require.NoError(t, err)
+	require.True(t, syncFinished)
+	chain.AssertExpectations(t)
+	addrStore.AssertExpectations(t)
+	store.AssertExpectations(t)
+}
+
+// TestBroadcastUnminedTxnsRoutesStore verifies rebroadcast reads active unmined
+// transactions from the runtime store and publishes the decoded transaction.
+func TestBroadcastUnminedTxnsRoutesStore(t *testing.T) {
+	t.Parallel()
+
+	store := &walletmock.Store{}
+	publisher := &mockTxPublisher{}
+	s := newSyncer(Config{}, nil, nil, publisher)
+	s.store = store
+	s.walletID = 66
+
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{66},
+	}})
+	tx.AddTxOut(&wire.TxOut{Value: 1000, PkScript: []byte{0x51}})
+
+	var txBytes bytes.Buffer
+
+	err := tx.Serialize(&txBytes)
+	require.NoError(t, err)
+
+	store.On("ListTxns", mock.Anything, db.ListTxnsQuery{
+		WalletID:    s.walletID,
+		UnminedOnly: true,
+	}).Return([]db.TxInfo{
+		{
+			Hash:         tx.TxHash(),
+			Status:       db.TxStatusPublished,
+			SerializedTx: txBytes.Bytes(),
+		},
+		{
+			Hash:         chainhash.Hash{67},
+			Status:       db.TxStatusPending,
+			SerializedTx: txBytes.Bytes(),
+		},
+	}, nil).Once()
+	publisher.On("Broadcast", mock.Anything, mock.MatchedBy(
+		func(got *wire.MsgTx) bool {
+			return got.TxHash() == tx.TxHash()
+		},
+	), "").Return(nil).Once()
+
+	err = s.broadcastUnminedTxns(t.Context())
+	require.NoError(t, err)
+	store.AssertExpectations(t)
+	publisher.AssertExpectations(t)
+}
+
+// TestBroadcastUnminedTxnsStoreSortsDependencies verifies store-backed
+// rebroadcast publishes an unmined parent before its in-store child even when
+// the store query returns the child first.
+func TestBroadcastUnminedTxnsStoreSortsDependencies(t *testing.T) {
+	t.Parallel()
+
+	store := &walletmock.Store{}
+	publisher := &mockTxPublisher{}
+	s := newSyncer(Config{}, nil, nil, publisher)
+	s.store = store
+	s.walletID = 67
+
+	parent := wire.NewMsgTx(2)
+	parent.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{67}, Index: 0,
+	}})
+	parent.AddTxOut(&wire.TxOut{Value: 1000, PkScript: []byte{0x51}})
+
+	child := wire.NewMsgTx(2)
+	child.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: parent.TxHash(), Index: 0,
+	}})
+	child.AddTxOut(&wire.TxOut{Value: 900, PkScript: []byte{0x51}})
+
+	var parentBytes bytes.Buffer
+
+	err := parent.Serialize(&parentBytes)
+	require.NoError(t, err)
+
+	var childBytes bytes.Buffer
+
+	err = child.Serialize(&childBytes)
+	require.NoError(t, err)
+
+	store.On("ListTxns", mock.Anything, db.ListTxnsQuery{
+		WalletID:    s.walletID,
+		UnminedOnly: true,
+	}).Return([]db.TxInfo{
+		{
+			Hash:         child.TxHash(),
+			Status:       db.TxStatusPublished,
+			SerializedTx: childBytes.Bytes(),
+		},
+		{
+			Hash:         parent.TxHash(),
+			Status:       db.TxStatusPublished,
+			SerializedTx: parentBytes.Bytes(),
+		},
+	}, nil).Once()
+
+	var published []chainhash.Hash
+	publisher.On(
+		"Broadcast", mock.Anything, mock.AnythingOfType("*wire.MsgTx"), "",
+	).Return(nil).Run(func(args mock.Arguments) {
+		tx, ok := args.Get(1).(*wire.MsgTx)
+		require.True(t, ok)
+
+		published = append(published, tx.TxHash())
+	}).Twice()
+
+	err = s.broadcastUnminedTxns(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, []chainhash.Hash{
+		parent.TxHash(), child.TxHash(),
+	}, published)
+
+	store.AssertExpectations(t)
+	publisher.AssertExpectations(t)
 }
 
 // TestSyncedBlockHashesRoutesStore verifies rollback reads consult the runtime

--- a/wallet/syncer_test.go
+++ b/wallet/syncer_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil/v2/gcs"
 	"github.com/btcsuite/btcd/btcutil/v2/gcs/builder"
 	"github.com/btcsuite/btcd/chainhash/v2"
@@ -829,6 +830,243 @@ func TestHandleChainUpdate(t *testing.T) {
 	// processed.
 	err = s.handleChainUpdate(t.Context(), chain.RelevantTx{TxRecord: rec})
 	require.NoError(t, err)
+}
+
+// newBareMultisigCreditScript returns one member address, that member's own
+// P2PK script, and a bare-multisig output script containing that member.
+func newBareMultisigCreditScript(t *testing.T) (
+	*address.AddressPubKey, []byte, []byte) {
+
+	t.Helper()
+
+	memberKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	foreignKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	memberAddr, err := address.NewAddressPubKey(
+		memberKey.PubKey().SerializeCompressed(), &chainParams,
+	)
+	require.NoError(t, err)
+
+	memberScript, err := txscript.PayToAddrScript(memberAddr)
+	require.NoError(t, err)
+
+	multiSigScript, err := txscript.NewScriptBuilder().
+		AddInt64(1).
+		AddData(memberKey.PubKey().SerializeCompressed()).
+		AddData(foreignKey.PubKey().SerializeCompressed()).
+		AddInt64(2).
+		AddOp(txscript.OP_CHECKMULTISIG).
+		Script()
+	require.NoError(t, err)
+
+	return memberAddr, memberScript, multiSigScript
+}
+
+// matchRelevantTxParams reports whether the single batched transaction carries
+// the expected wallet, hash, receive time, credit candidate, status, and label.
+// Block confirmation is validated separately by the caller.
+func matchRelevantTxParams(txParams db.CreateTxParams, walletID uint32,
+	tx *wire.MsgTx, addr address.Address, received time.Time,
+	status db.TxStatus, label string) bool {
+
+	if len(txParams.Credits) != 0 || txParams.Tx == nil {
+		return false
+	}
+
+	var hasCandidate bool
+	for _, candidate := range txParams.CreditCandidates[0] {
+		if candidate.EncodeAddress() == addr.EncodeAddress() {
+			hasCandidate = true
+			break
+		}
+	}
+
+	if !hasCandidate {
+		return false
+	}
+
+	return txParams.WalletID == walletID &&
+		txParams.Tx.TxHash() == tx.TxHash() &&
+		txParams.Received.Equal(received) &&
+		txParams.Status == status &&
+		txParams.Label == label
+}
+
+// matchUnminedTxBatchState returns a matcher asserting an unmined relevant
+// transaction is written as a single store batch with the expected metadata.
+func matchUnminedTxBatchState(walletID uint32, tx *wire.MsgTx,
+	addr address.Address, received time.Time, status db.TxStatus,
+	label string) any {
+
+	return mock.MatchedBy(func(params db.TxBatchParams) bool {
+		if params.WalletID != walletID ||
+			len(params.Transactions) != 1 {
+
+			return false
+		}
+
+		txParams := params.Transactions[0]
+		if txParams.Block != nil {
+			return false
+		}
+
+		return matchRelevantTxParams(
+			txParams, walletID, tx, addr, received, status, label,
+		)
+	})
+}
+
+// matchUnminedTxBatch returns a matcher asserting an unmined relevant
+// transaction is written as a single store batch with the expected credit and
+// no confirming block.
+func matchUnminedTxBatch(walletID uint32, tx *wire.MsgTx,
+	addr address.Address, received time.Time) any {
+
+	return matchUnminedTxBatchState(
+		walletID, tx, addr, received, db.TxStatusPublished, "",
+	)
+}
+
+// TestProcessRelevantTxUsesStore verifies that relevant transaction
+// notifications are routed through the store when store wiring is available.
+func TestProcessRelevantTxUsesStore(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a syncer with store wiring and a transaction paying to a
+	// wallet-owned address.
+	const walletID uint32 = 7
+
+	store := &walletmock.Store{}
+	publisher := &mockTxPublisher{}
+	s := newSyncer(
+		Config{ChainParams: &chainParams}, nil, nil, publisher,
+		syncerStoreConfig{store: store, walletID: walletID},
+	)
+
+	addr, err := address.NewAddressPubKeyHash(
+		make([]byte, 20), &chainParams,
+	)
+	require.NoError(t, err)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	tx := wire.NewMsgTx(1)
+	tx.AddTxOut(&wire.TxOut{Value: 1000, PkScript: pkScript})
+
+	received := time.Unix(123, 0).UTC()
+	rec, err := wtxmgr.NewTxRecordFromMsgTx(tx, received)
+	require.NoError(t, err)
+
+	store.On("GetTx", mock.Anything, db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     rec.Hash,
+	}).Return(nil, db.ErrTxNotFound).Once()
+
+	store.On("ApplyTxBatch", mock.Anything,
+		matchUnminedTxBatch(walletID, tx, addr, received),
+	).Return(nil).Once()
+
+	// Act: Process an unconfirmed relevant transaction notification.
+	err = s.processChainUpdate(t.Context(), chain.RelevantTx{TxRecord: rec})
+
+	// Assert: The notification was written through the store batch API.
+	require.NoError(t, err)
+	store.AssertExpectations(t)
+}
+
+// TestProcessRelevantTxPreservesUnminedMetadata verifies that a mempool echo of
+// an already-recorded local transaction promotes it to published while
+// preserving the existing label when replayed through ApplyTxBatch.
+func TestProcessRelevantTxPreservesUnminedMetadata(t *testing.T) {
+	t.Parallel()
+
+	const walletID uint32 = 9
+
+	store := &walletmock.Store{}
+	s := newSyncer(
+		Config{ChainParams: &chainParams}, nil, nil, nil,
+		syncerStoreConfig{store: store, walletID: walletID},
+	)
+
+	addr, err := address.NewAddressPubKeyHash(
+		make([]byte, 20), &chainParams,
+	)
+	require.NoError(t, err)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	tx := wire.NewMsgTx(1)
+	tx.AddTxOut(&wire.TxOut{Value: 1000, PkScript: pkScript})
+
+	received := time.Unix(456, 0).UTC()
+	rec, err := wtxmgr.NewTxRecordFromMsgTx(tx, received)
+	require.NoError(t, err)
+
+	const label = "pending label"
+
+	store.On("GetTx", mock.Anything, db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     rec.Hash,
+	}).Return(&db.TxInfo{
+		Hash:   rec.Hash,
+		Status: db.TxStatusPending,
+		Label:  label,
+	}, nil).Once()
+
+	store.On("ApplyTxBatch", mock.Anything,
+		matchUnminedTxBatchState(
+			walletID, tx, addr, received, db.TxStatusPublished, label,
+		),
+	).Return(nil).Once()
+
+	err = s.processChainUpdate(t.Context(), chain.RelevantTx{TxRecord: rec})
+
+	require.NoError(t, err)
+	store.AssertExpectations(t)
+}
+
+// TestProcessRelevantTxUsesBareMultisigMember verifies store-backed relevant
+// transaction notifications keep bare-multisig credits when the wallet owns a
+// member pubkey address but not the full multisig output script.
+func TestProcessRelevantTxUsesBareMultisigMember(t *testing.T) {
+	t.Parallel()
+
+	const walletID uint32 = 8
+
+	store := &walletmock.Store{}
+	s := newSyncer(
+		Config{ChainParams: &chainParams}, nil, nil, nil,
+		syncerStoreConfig{store: store, walletID: walletID},
+	)
+
+	memberAddr, memberScript, multiSigScript :=
+		newBareMultisigCreditScript(t)
+	require.NotEqual(t, memberScript, multiSigScript)
+
+	tx := wire.NewMsgTx(1)
+	tx.AddTxOut(&wire.TxOut{Value: 1000, PkScript: multiSigScript})
+
+	received := time.Unix(124, 0).UTC()
+	rec, err := wtxmgr.NewTxRecordFromMsgTx(tx, received)
+	require.NoError(t, err)
+
+	store.On("GetTx", mock.Anything, db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     rec.Hash,
+	}).Return(nil, db.ErrTxNotFound).Once()
+
+	store.On("ApplyTxBatch", mock.Anything,
+		matchUnminedTxBatch(walletID, tx, memberAddr, received),
+	).Return(nil).Once()
+
+	err = s.processChainUpdate(t.Context(), chain.RelevantTx{TxRecord: rec})
+	require.NoError(t, err)
+	store.AssertExpectations(t)
 }
 
 // TestExtractAddrEntries verifies address extraction from outputs.

--- a/wallet/syncer_test.go
+++ b/wallet/syncer_test.go
@@ -15,6 +15,8 @@ import (
 	bwmock "github.com/btcsuite/btcwallet/bwtest/mock"
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	walletmock "github.com/btcsuite/btcwallet/wallet/internal/bwtest/mock"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -2637,6 +2639,38 @@ func TestProcessChainUpdate(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+// TestProcessChainUpdateRoutesSyncTip verifies connected block notifications
+// update the runtime store sync tip when the store is available.
+func TestProcessChainUpdateRoutesSyncTip(t *testing.T) {
+	t.Parallel()
+
+	store := &walletmock.Store{}
+	s := newSyncer(Config{}, nil, nil, nil)
+	s.store = store
+	s.walletID = 77
+
+	block := wtxmgr.BlockMeta{
+		Block: wtxmgr.Block{
+			Hash:   chainhash.Hash{77},
+			Height: 144,
+		},
+		Time: time.Unix(1710003800, 0),
+	}
+	store.On("UpdateWallet", mock.Anything, mock.MatchedBy(
+		func(params db.UpdateWalletParams) bool {
+			return params.WalletID == s.walletID &&
+				params.SyncedTo != nil &&
+				params.SyncedTo.Hash == block.Hash &&
+				params.SyncedTo.Height == uint32(block.Height) &&
+				params.SyncedTo.Timestamp.Equal(block.Time)
+		},
+	)).Return(nil).Once()
+
+	err := s.processChainUpdate(t.Context(), chain.BlockConnected(block))
+	require.NoError(t, err)
+	store.AssertExpectations(t)
 }
 
 // TestHandleChainUpdate_SpecialNotifs verifies RescanProgress and

--- a/wallet/syncer_test.go
+++ b/wallet/syncer_test.go
@@ -2814,6 +2814,14 @@ func TestRewindToBlockFallsBackToLegacy(t *testing.T) {
 
 	bs := waddrmgr.BlockStamp{Height: 100, Hash: chainhash.Hash{0x01}}
 
+	// DBPutRewind snapshots the live synced tip before the rollback so it
+	// can restore it on failure, so SyncedTo is consulted first. The
+	// rollback here succeeds, so the snapshot is never restored; a valid
+	// pre-rewind tip just satisfies the read.
+	preRewindTip := waddrmgr.BlockStamp{
+		Height: 200, Hash: chainhash.Hash{0x02},
+	}
+	mocks.addrStore.On("SyncedTo").Return(preRewindTip).Once()
 	mocks.addrStore.On("SetSyncedTo", mock.Anything, &bs).Return(nil).Once()
 	mocks.txStore.On("Rollback",
 		mock.Anything, int32(101),

--- a/wallet/syncer_test.go
+++ b/wallet/syncer_test.go
@@ -2673,6 +2673,33 @@ func TestProcessChainUpdateRoutesSyncTip(t *testing.T) {
 	store.AssertExpectations(t)
 }
 
+// TestSyncedBlockHashesRoutesStore verifies rollback reads consult the runtime
+// store when it is available.
+func TestSyncedBlockHashesRoutesStore(t *testing.T) {
+	t.Parallel()
+
+	store := &walletmock.Store{}
+	s := newSyncer(Config{}, nil, nil, nil)
+	s.store = store
+	s.walletID = 88
+
+	blocks := []db.Block{{Hash: chainhash.Hash{88}, Height: 100}, {
+		Hash:   chainhash.Hash{89},
+		Height: 101,
+	}}
+	store.On("ListSyncedBlocks", mock.Anything, db.ListSyncedBlocksQuery{
+		StartHeight: 100,
+		EndHeight:   101,
+	}).Return(blocks, nil).Once()
+
+	hashes, err := s.syncedBlockHashes(t.Context(), 100, 101)
+	require.NoError(t, err)
+	require.Len(t, hashes, 2)
+	require.Equal(t, blocks[0].Hash, *hashes[0])
+	require.Equal(t, blocks[1].Hash, *hashes[1])
+	store.AssertExpectations(t)
+}
+
 // TestHandleChainUpdate_SpecialNotifs verifies RescanProgress and
 // RescanFinished.
 func TestHandleChainUpdate_SpecialNotifs(t *testing.T) {


### PR DESCRIPTION
Routes the wallet's runtime startup and sync-tip/rollback paths through the runtime `db.Store`, and wires the runtime store into the syncer.

- Startup: route runtime startup setup and pass the runtime store into the syncer.
- Sync tip and rollback: route sync-tip updates and rollback block reads; route manual rewinds through the Store and restore the in-memory synced tip on a failed rewind.
- Wallet-scoped rewind: add `RewindWallet` to the store interface, implemented in `kvdb`, `pg`, and `sqlite`, so a manual rescan can rewind one wallet without deleting shared block rows; also promotes unmined tx duplicates.
- Relevant transactions: route relevant-tx notifications and unmined rebroadcast reads through the Store.
