### PR TITLE
wallet: readd create max account number itest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,12 +67,17 @@ DOCKER_TOOLS = docker run \
   $(GIT_VOLUME) \
   btcwallet-tools
 
+# Pin the sqlfluff image by digest to keep linting results stable across
+# environments and over time. The tag alone is mutable, so it could later point
+# to a different build with changed rules or behavior. This digest currently
+# corresponds to sqlfluff 4.2.1 on Docker Hub:
+# https://hub.docker.com/layers/sqlfluff/sqlfluff/4.2.1
 SQLFLUFF = docker run \
 	--rm \
 	--user $$(id -u):$$(id -g) \
     -v $$(pwd):/sql \
     -w /sql \
-    sqlfluff/sqlfluff
+    sqlfluff/sqlfluff@sha256:0b1f131e3e9b4ac10bf45f1b2cb8680e67f74e63f8e6db9f0f0207dbbe3c71d2
 
 GREEN := "\\033[0;32m"
 NC := "\\033[0m"

--- a/wallet/internal/db/itest/accountstore_createderived_test.go
+++ b/wallet/internal/db/itest/accountstore_createderived_test.go
@@ -325,6 +325,51 @@ func TestCreateDerivedAccountSequentialNumbers(t *testing.T) {
 	}
 }
 
+// TestCreateDerivedAccountMaxAccountNumber verifies that CreateDerivedAccount
+// allocates the last valid account number and then reports overflow on the
+// next allocation.
+func TestCreateDerivedAccountMaxAccountNumber(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	queries := store.Queries()
+	walletID := newWallet(t, store, "max-account-wallet")
+
+	// Arrange: create a derived account and seed the scope near the limit.
+	createDerivedAccount(
+		t, store, walletID, db.KeyScopeBIP0084, "seed-derived-account",
+	)
+	scopeID := GetKeyScopeID(t, queries, walletID, db.KeyScopeBIP0084)
+	CreateAccountWithNumber(
+		t, queries, scopeID, db.MaxAccountNumber-1, "account-max-minus-one",
+	)
+	UpdateKeyScopeNextAccountNumber(t, store.DB(), scopeID, db.MaxAccountNumber)
+
+	// Act: allocate the last valid account number.
+	info, err := store.CreateDerivedAccount(
+		t.Context(), db.CreateDerivedAccountParams{
+			WalletID: walletID,
+			Scope:    db.KeyScopeBIP0084,
+			Name:     "account-max",
+		},
+		SpendableDeriveFn(),
+	)
+
+	// Assert: the max allocation succeeds, and the next one fails.
+	require.NoError(t, err)
+	require.Equal(t, db.MaxAccountNumber, info.AccountNumber)
+
+	_, err = store.CreateDerivedAccount(
+		t.Context(), db.CreateDerivedAccountParams{
+			WalletID: walletID,
+			Scope:    db.KeyScopeBIP0084,
+			Name:     "account-overflow",
+		},
+		SpendableDeriveFn(),
+	)
+	require.ErrorIs(t, err, db.ErrMaxAccountNumberReached)
+}
+
 // TestCreateDerivedAccountConcurrent verifies that concurrent account creation
 // yields unique, sequential account numbers without errors.
 func TestCreateDerivedAccountConcurrent(t *testing.T) {


### PR DESCRIPTION
Just re-added an item removed in the last big PR https://github.com/btcsuite/btcwallet/pull/1260.

Also:
> Looks like SQLfluff got an update, and the version is not locked in the Docker image.

so we are pinning it too.