### PR TITLE
db+waddrmgr: add scan-batch scaffolding and rollback support

### DIFF
--- a/wallet/internal/bwtest/mock/store.go
+++ b/wallet/internal/bwtest/mock/store.go
@@ -422,6 +422,15 @@ func (m *Store) UpdateTx(ctx context.Context,
 	return args.Error(0)
 }
 
+// ApplyTxBatch implements the db.TxStore interface.
+func (m *Store) ApplyTxBatch(ctx context.Context,
+	params db.TxBatchParams) error {
+
+	args := m.Called(ctx, params)
+
+	return args.Error(0)
+}
+
 // GetTx implements the db.TxStore interface.
 func (m *Store) GetTx(ctx context.Context,
 	query db.GetTxQuery) (*db.TxInfo, error) {

--- a/wallet/internal/bwtest/mock/store.go
+++ b/wallet/internal/bwtest/mock/store.go
@@ -380,6 +380,18 @@ func (m *Store) DeleteExpiredLeases(ctx context.Context,
 	return args.Error(0)
 }
 
+// ListOutputsToWatch implements the db.UTXOStore interface.
+func (m *Store) ListOutputsToWatch(ctx context.Context,
+	walletID uint32) ([]db.UtxoInfo, error) {
+
+	args := m.Called(ctx, walletID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).([]db.UtxoInfo), args.Error(1)
+}
+
 // Balance implements the db.UTXOStore interface.
 func (m *Store) Balance(ctx context.Context,
 	params db.BalanceParams) (db.BalanceResult, error) {

--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -1078,6 +1078,20 @@ type CreateTxParams struct {
 	Credits map[uint32]address.Address
 }
 
+// TxBatchParams contains a wallet transaction batch and optional sync-tip
+// update that should be applied atomically.
+type TxBatchParams struct {
+	// WalletID is the ID of the wallet receiving the batch.
+	WalletID uint32
+
+	// Transactions contains the transaction records to apply.
+	Transactions []CreateTxParams
+
+	// SyncedTo optionally records the wallet's new chain sync tip as part of
+	// the same batch.
+	SyncedTo *Block
+}
+
 // UpdateTxState contains one requested transaction-state change.
 type UpdateTxState struct {
 	// Block records the transaction as confirmed in the provided block.

--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -411,6 +411,10 @@ type TxStore interface {
 	// graph-affecting lifecycle changes.
 	UpdateTx(ctx context.Context, params UpdateTxParams) error
 
+	// ApplyTxBatch atomically records a batch of transaction records and an
+	// optional wallet sync-tip update.
+	ApplyTxBatch(ctx context.Context, params TxBatchParams) error
+
 	// GetTx retrieves a transaction record by its hash. It takes a context
 	// and GetTxQuery, returning a TxInfo struct or an error if the
 	// transaction is not found.

--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -517,6 +517,10 @@ type UTXOStore interface {
 	// DeleteExpiredLeases removes expired UTXO lease records for the wallet.
 	DeleteExpiredLeases(ctx context.Context, walletID uint32) error
 
+	// ListOutputsToWatch returns UTXOs that recovery scans should watch.
+	ListOutputsToWatch(ctx context.Context, walletID uint32) ([]UtxoInfo,
+		error)
+
 	// Balance returns a wallet-scoped balance view for the current unspent UTXO
 	// set after applying any optional caller-supplied filters.
 	//

--- a/wallet/internal/db/itest/pg_test.go
+++ b/wallet/internal/db/itest/pg_test.go
@@ -408,3 +408,29 @@ func walletUtxoExists(t *testing.T, store *pg.Store,
 
 	return true
 }
+
+// walletUtxoSpent reports whether one wallet-scoped outpoint exists and is
+// recorded as spent, i.e. its spend edge points at a spending transaction.
+func walletUtxoSpent(t *testing.T, store *pg.Store,
+	walletID uint32,
+	outPoint wire.OutPoint) bool {
+
+	t.Helper()
+
+	spentBy, err := store.Queries().GetUtxoSpendByOutpoint(
+		t.Context(), sqlc.GetUtxoSpendByOutpointParams{
+			WalletID:    int64(walletID),
+			TxHash:      outPoint.Hash[:],
+			OutputIndex: int32(outPoint.Index),
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false
+		}
+
+		require.NoError(t, err)
+	}
+
+	return spentBy.Valid
+}

--- a/wallet/internal/db/itest/pg_test.go
+++ b/wallet/internal/db/itest/pg_test.go
@@ -432,5 +432,5 @@ func walletUtxoSpent(t *testing.T, store *pg.Store,
 		require.NoError(t, err)
 	}
 
-	return spentBy.Valid
+	return spentBy.SpentByTxID.Valid
 }

--- a/wallet/internal/db/itest/sqlite_test.go
+++ b/wallet/internal/db/itest/sqlite_test.go
@@ -153,3 +153,29 @@ func walletUtxoExists(t *testing.T, store *sqlite.Store,
 
 	return true
 }
+
+// walletUtxoSpent reports whether one wallet-scoped outpoint exists and is
+// recorded as spent, i.e. its spend edge points at a spending transaction.
+func walletUtxoSpent(t *testing.T, store *sqlite.Store,
+	walletID uint32,
+	outPoint wire.OutPoint) bool {
+
+	t.Helper()
+
+	spentBy, err := store.Queries().GetUtxoSpendByOutpoint(
+		t.Context(), sqlc.GetUtxoSpendByOutpointParams{
+			WalletID:    int64(walletID),
+			TxHash:      outPoint.Hash[:],
+			OutputIndex: int64(outPoint.Index),
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false
+		}
+
+		require.NoError(t, err)
+	}
+
+	return spentBy.Valid
+}

--- a/wallet/internal/db/itest/sqlite_test.go
+++ b/wallet/internal/db/itest/sqlite_test.go
@@ -177,5 +177,5 @@ func walletUtxoSpent(t *testing.T, store *sqlite.Store,
 		require.NoError(t, err)
 	}
 
-	return spentBy.Valid
+	return spentBy.SpentByTxID.Valid
 }

--- a/wallet/internal/db/itest/txstore_create_edge_cases_test.go
+++ b/wallet/internal/db/itest/txstore_create_edge_cases_test.go
@@ -66,9 +66,9 @@ func TestCreateTxRejectsInvalidParams(t *testing.T) {
 	require.ErrorContains(t, err, "tx is required")
 }
 
-// TestCreateTxRejectsDuplicateConfirmedTransaction verifies that duplicate
-// confirmed inserts fail instead of silently creating a second row.
-func TestCreateTxRejectsDuplicateConfirmedTransaction(t *testing.T) {
+// TestCreateTxSkipsDuplicateConfirmedTransaction verifies that an exact
+// duplicate confirmed insert is idempotent instead of creating a second row.
+func TestCreateTxSkipsDuplicateConfirmedTransaction(t *testing.T) {
 	t.Parallel()
 
 	store := NewTestStore(t)
@@ -98,7 +98,7 @@ func TestCreateTxRejectsDuplicateConfirmedTransaction(t *testing.T) {
 	require.NoError(t, err)
 
 	err = store.CreateTx(t.Context(), params)
-	require.ErrorIs(t, err, db.ErrTxAlreadyExists)
+	require.NoError(t, err)
 }
 
 // TestCreateTxRejectsMissingConfirmingBlockForExistingUnminedRow verifies that

--- a/wallet/internal/db/itest/txstore_utxostore_test.go
+++ b/wallet/internal/db/itest/txstore_utxostore_test.go
@@ -3057,3 +3057,226 @@ func TestApplyTxBatchChildBeforeParent(t *testing.T) {
 		Hash: parentTx.TxHash(), Index: 0,
 	}))
 }
+
+// TestApplyTxBatchStoresTxAndSyncTip verifies that a runtime batch can persist
+// transaction history and advance the wallet sync tip atomically.
+func TestApplyTxBatchStoresTxAndSyncTip(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletName := "wallet-apply-tx-batch"
+	walletID := newWallet(t, store, walletName)
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 7000, PkScript: addr.ScriptPubKey}},
+	)
+	syncedTo := NewBlockFixture(212)
+
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: walletID,
+		Transactions: []db.CreateTxParams{{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710000150, 0),
+			Status:   db.TxStatusPending,
+			Credits:  map[uint32]address.Address{0: nil},
+		}},
+		SyncedTo: &syncedTo,
+	})
+	require.NoError(t, err)
+
+	txInfo, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     tx.TxHash(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, db.TxStatusPending, txInfo.Status)
+	require.Nil(t, txInfo.Block)
+	require.True(t, walletUtxoExists(t, store, walletID, wire.OutPoint{
+		Hash: tx.TxHash(), Index: 0,
+	}))
+
+	walletInfo, err := store.GetWallet(t.Context(), walletName)
+	require.NoError(t, err)
+	require.NotNil(t, walletInfo.SyncedTo)
+	require.Equal(t, syncedTo.Hash, walletInfo.SyncedTo.Hash)
+	require.Equal(t, syncedTo.Height, walletInfo.SyncedTo.Height)
+	require.Equal(t, syncedTo.Timestamp.Unix(),
+		walletInfo.SyncedTo.Timestamp.Unix())
+}
+
+// TestApplyTxBatchConfirmsTxInSameBlock verifies that a batch can record a
+// transaction confirmed in the very block the same batch introduces as the new
+// sync tip. The confirming block row does not exist before the batch, so the
+// batch must create the sync-tip block before recording the confirmed
+// transaction; otherwise the confirmed insert fails with ErrBlockNotFound.
+func TestApplyTxBatchConfirmsTxInSameBlock(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletName := "wallet-apply-tx-batch-confirmed"
+	walletID := newWallet(t, store, walletName)
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 7000, PkScript: addr.ScriptPubKey}},
+	)
+
+	// The confirming block is also the batch's new sync tip. It is not
+	// inserted ahead of time, so the batch itself must create it before the
+	// confirmed transaction is recorded.
+	block := NewBlockFixture(213)
+
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: walletID,
+		Transactions: []db.CreateTxParams{{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710000160, 0),
+			Block:    &block,
+			Status:   db.TxStatusPublished,
+			Credits:  map[uint32]address.Address{0: nil},
+		}},
+		SyncedTo: &block,
+	})
+	require.NoError(t, err)
+
+	// The transaction is recorded as confirmed in the batch's block and its
+	// credited output is in the wallet UTXO set.
+	txInfo, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     tx.TxHash(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, db.TxStatusPublished, txInfo.Status)
+	require.NotNil(t, txInfo.Block)
+	require.Equal(t, block.Height, txInfo.Block.Height)
+	require.Equal(t, block.Hash, txInfo.Block.Hash)
+	require.True(t, walletUtxoExists(t, store, walletID, wire.OutPoint{
+		Hash: tx.TxHash(), Index: 0,
+	}))
+
+	// The sync tip advanced to the same block.
+	walletInfo, err := store.GetWallet(t.Context(), walletName)
+	require.NoError(t, err)
+	require.NotNil(t, walletInfo.SyncedTo)
+	require.Equal(t, block.Height, walletInfo.SyncedTo.Height)
+	require.Equal(t, block.Hash, walletInfo.SyncedTo.Hash)
+}
+
+// TestApplyTxBatchRejectsMismatchedWalletID verifies that a batch is rejected
+// when any transaction is owned by a wallet other than the batch wallet, and
+// that the rejection commits nothing: the sync tip is not advanced and no
+// transaction row is written.
+func TestApplyTxBatchRejectsMismatchedWalletID(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletName := "wallet-apply-tx-batch-mismatch"
+	walletID := newWallet(t, store, walletName)
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 7000, PkScript: addr.ScriptPubKey}},
+	)
+	syncedTo := NewBlockFixture(214)
+
+	// The batch targets walletID, but the lone transaction claims a different
+	// wallet. The whole batch must be rejected before any write.
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: walletID,
+		Transactions: []db.CreateTxParams{{
+			WalletID: walletID + 99,
+			Tx:       tx,
+			Received: time.Unix(1710000170, 0),
+			Status:   db.TxStatusPending,
+			Credits:  map[uint32]address.Address{0: nil},
+		}},
+		SyncedTo: &syncedTo,
+	})
+	require.ErrorIs(t, err, db.ErrInvalidParam)
+
+	// The sync tip was not advanced: the wallet is still unsynced.
+	walletInfo, err := store.GetWallet(t.Context(), walletName)
+	require.NoError(t, err)
+	require.Nil(t, walletInfo.SyncedTo)
+
+	// No transaction row was written for either wallet.
+	_, err = store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     tx.TxHash(),
+	})
+	require.ErrorIs(t, err, db.ErrTxNotFound)
+}
+
+// TestApplyTxBatchRejectsNilTx verifies that a multi-transaction batch with one
+// nil Tx is rejected with ErrInvalidParam rather than panicking. ApplyTxBatch
+// reorders the batch parents-first before applying it, and that sort
+// dereferences each transaction's Tx, so a nil member must be caught up front;
+// the rejection must also commit nothing.
+func TestApplyTxBatchRejectsNilTx(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletName := "wallet-apply-tx-batch-nil-tx"
+	walletID := newWallet(t, store, walletName)
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 7000, PkScript: addr.ScriptPubKey}},
+	)
+	syncedTo := NewBlockFixture(215)
+
+	// The batch carries a valid transaction and a second one with a nil Tx.
+	// The parents-first sort runs before per-tx request validation, so the nil
+	// member must be rejected by the up-front guard rather than panicking.
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: walletID,
+		Transactions: []db.CreateTxParams{
+			{
+				WalletID: walletID,
+				Tx:       tx,
+				Received: time.Unix(1710000210, 0),
+				Status:   db.TxStatusPending,
+				Credits:  map[uint32]address.Address{0: nil},
+			},
+			{
+				WalletID: walletID,
+				Tx:       nil,
+				Received: time.Unix(1710000211, 0),
+				Status:   db.TxStatusPending,
+			},
+		},
+		SyncedTo: &syncedTo,
+	})
+	require.ErrorIs(t, err, db.ErrInvalidParam)
+
+	// The sync tip was not advanced and the valid transaction was not written:
+	// the whole batch is rejected before any write.
+	walletInfo, err := store.GetWallet(t.Context(), walletName)
+	require.NoError(t, err)
+	require.Nil(t, walletInfo.SyncedTo)
+
+	_, err = store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     tx.TxHash(),
+	})
+	require.ErrorIs(t, err, db.ErrTxNotFound)
+}

--- a/wallet/internal/db/itest/txstore_utxostore_test.go
+++ b/wallet/internal/db/itest/txstore_utxostore_test.go
@@ -2901,3 +2901,74 @@ func txDetailHashes(infos []db.TxDetailInfo) []chainhash.Hash {
 
 	return hashes
 }
+
+// TestListOutputsToWatchBareMultisigUsesOutputScript verifies that the recovery
+// watch set reports the actual on-chain output script for a bare-multisig
+// output the wallet partly owns, rather than the member address's own script.
+//
+// A bare-multisig output is credited to one of its member pubkey addresses, so
+// the stored UTXO resolves to that member address. The member's own script
+// (PayToAddrScript) differs from the full multisig output script. A rescan must
+// watch the output script the chain actually carries, so ListOutputsToWatch
+// must derive the watch script from the funding transaction's
+// TxOut[output_index].PkScript, not from the credited address row. This locks
+// in parity with the kvdb backend, whose credit walk records the on-chain
+// output script.
+//
+// Without the fix, the query returns addresses.script_pub_key (the member's
+// P2PK script), so the rescan would watch a script the multisig output never
+// pays, and a recovered spend would be missed.
+func TestListOutputsToWatchBareMultisigUsesOutputScript(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+
+	// A script-only import (no private key) requires a watch-only wallet per
+	// the ADR 0012 spendable-wallet invariant.
+	walletID := newWatchOnlyWallet(t, store, "wallet-watch-bare-multisig")
+
+	// memberScript is the member's own P2PK script (registered as the wallet
+	// address); multiSigScript is the full on-chain output script, which is
+	// never registered as an address.
+	memberAddr, memberScript, multiSigScript := newMultisigScript(t)
+	require.NotEqual(t, memberScript, multiSigScript)
+
+	_, err := store.NewImportedAddress(
+		t.Context(), db.NewImportedAddressParams{
+			WalletID:        walletID,
+			AddressType:     db.RawPubKey,
+			PubKey:          memberAddr.ScriptAddress(),
+			ScriptPubKey:    memberScript,
+			EncryptedScript: RandomBytes(48),
+		},
+	)
+	require.NoError(t, err)
+
+	// The funding transaction pays the bare-multisig output; Credits[0]
+	// carries the resolved member address exactly as the publisher supplies
+	// it after filtering ownership by the member script.
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 7000, PkScript: multiSigScript}},
+	)
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       tx,
+		Received: time.Unix(1710004500, 0),
+		Status:   db.TxStatusPublished,
+		Credits:  map[uint32]address.Address{0: memberAddr},
+	})
+	require.NoError(t, err)
+
+	utxos, err := store.ListOutputsToWatch(t.Context(), walletID)
+	require.NoError(t, err)
+	require.Len(t, utxos, 1)
+
+	outPoint := wire.OutPoint{Hash: tx.TxHash(), Index: 0}
+	require.Equal(t, outPoint, utxos[0].OutPoint)
+
+	// The watch script must be the on-chain multisig output script, not the
+	// member address's own script that the UTXO row resolves to.
+	require.Equal(t, multiSigScript, utxos[0].PkScript)
+	require.NotEqual(t, memberScript, utxos[0].PkScript)
+}

--- a/wallet/internal/db/itest/txstore_utxostore_test.go
+++ b/wallet/internal/db/itest/txstore_utxostore_test.go
@@ -152,6 +152,109 @@ func TestCreateTxCreditBareMultisigMember(t *testing.T) {
 	require.Equal(t, db.RawPubKey, utxo.AddrType)
 }
 
+// TestCreateTxDuplicateCreditBareMultisigMemberMismatch verifies that an
+// idempotent duplicate cannot change the wallet-owned member address recorded
+// for a bare-multisig credit.
+//
+// Scenario:
+//   - The wallet imports both members of a 1-of-2 bare-multisig output.
+//   - The first CreateTx records the output as owned by the first member.
+//   - A duplicate CreateTx call reports the same transaction and output, but
+//     claims ownership through the second member.
+//
+// Assertions:
+//   - The duplicate is rejected with ErrTxAlreadyExists because it is not an
+//     exact replay of the stored ownership metadata.
+func TestCreateTxDuplicateCreditBareMultisigMemberMismatch(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWatchOnlyWallet(
+		t, store, "wallet-bare-multisig-duplicate-mismatch",
+	)
+
+	firstKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	secondKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	firstAddr, err := address.NewAddressPubKey(
+		firstKey.PubKey().SerializeCompressed(),
+		&chaincfg.RegressionNetParams,
+	)
+	require.NoError(t, err)
+
+	secondAddr, err := address.NewAddressPubKey(
+		secondKey.PubKey().SerializeCompressed(),
+		&chaincfg.RegressionNetParams,
+	)
+	require.NoError(t, err)
+
+	firstScript, err := txscript.PayToAddrScript(firstAddr)
+	require.NoError(t, err)
+
+	secondScript, err := txscript.PayToAddrScript(secondAddr)
+	require.NoError(t, err)
+
+	for _, member := range []struct {
+		addr   *address.AddressPubKey
+		script []byte
+	}{
+		{
+			addr:   firstAddr,
+			script: firstScript,
+		},
+		{
+			addr:   secondAddr,
+			script: secondScript,
+		},
+	} {
+		_, err := store.NewImportedAddress(
+			t.Context(), db.NewImportedAddressParams{
+				WalletID:        walletID,
+				AddressType:     db.RawPubKey,
+				PubKey:          member.addr.ScriptAddress(),
+				ScriptPubKey:    member.script,
+				EncryptedScript: RandomBytes(48),
+			},
+		)
+		require.NoError(t, err)
+	}
+
+	multiSigScript, err := txscript.NewScriptBuilder().
+		AddInt64(1).
+		AddData(firstKey.PubKey().SerializeCompressed()).
+		AddData(secondKey.PubKey().SerializeCompressed()).
+		AddInt64(2).
+		AddOp(txscript.OP_CHECKMULTISIG).
+		Script()
+	require.NoError(t, err)
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 7000, PkScript: multiSigScript}},
+	)
+
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       tx,
+		Received: time.Unix(1710004400, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]address.Address{0: firstAddr},
+	})
+	require.NoError(t, err)
+
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       tx,
+		Received: time.Unix(1710004401, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]address.Address{0: secondAddr},
+	})
+	require.ErrorIs(t, err, db.ErrTxAlreadyExists)
+}
+
 // TestCreateTxCreditAddrMismatch verifies that CreateTx rejects a non-nil
 // credit address that the credited output does not pay to, instead of
 // recording a UTXO owned by an unrelated address.
@@ -408,8 +511,8 @@ func TestCreateTxRejectsSecondPendingSpend(t *testing.T) {
 	require.False(t, ok)
 }
 
-// TestCreateTxRejectsDuplicateTx verifies that CreateTx inserts one wallet-
-// scoped transaction row only once.
+// TestCreateTxSkipsDuplicateTx verifies that CreateTx inserts one wallet-
+// scoped transaction row only once for an idempotent duplicate.
 //
 // Scenario:
 //   - One wallet transaction hash is already present in the store.
@@ -421,9 +524,9 @@ func TestCreateTxRejectsSecondPendingSpend(t *testing.T) {
 //   - Attempt to insert the same transaction hash again.
 //
 // Assertions:
-//   - CreateTx returns ErrTxAlreadyExists.
+//   - CreateTx treats the duplicate as a no-op.
 //   - The original row remains stored once.
-func TestCreateTxRejectsDuplicateTx(t *testing.T) {
+func TestCreateTxSkipsDuplicateTx(t *testing.T) {
 	t.Parallel()
 
 	store := NewTestStore(t)
@@ -448,10 +551,376 @@ func TestCreateTxRejectsDuplicateTx(t *testing.T) {
 		Received: time.Unix(1710000590, 0),
 		Status:   db.TxStatusPending,
 	})
-	require.ErrorIs(t, err, db.ErrTxAlreadyExists)
+	require.NoError(t, err)
 
 	_, ok := txIDByHash(t, store, walletID, tx.TxHash())
 	require.True(t, ok)
+}
+
+// TestCreateTxReplaysDuplicateCredit verifies that an idempotent duplicate
+// transaction observation still records newly supplied wallet credit edges.
+func TestCreateTxReplaysDuplicateCredit(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-create-tx-replay-credit")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 5000, PkScript: addr.ScriptPubKey}},
+	)
+	params := db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       tx,
+		Received: time.Unix(1710000580, 0),
+		Status:   db.TxStatusPending,
+	}
+
+	err := store.CreateTx(t.Context(), params)
+	require.NoError(t, err)
+
+	outPoint := wire.OutPoint{Hash: tx.TxHash(), Index: 0}
+	require.False(t, walletUtxoExists(t, store, walletID, outPoint))
+
+	params.Credits = map[uint32]address.Address{0: nil}
+	err = store.CreateTx(t.Context(), params)
+	require.NoError(t, err)
+	require.True(t, walletUtxoExists(t, store, walletID, outPoint))
+}
+
+// TestCreateTxReplayedCreditMarksExistingChildSpent verifies that replaying a
+// parent credit also reconciles an already-stored child that spends it.
+func TestCreateTxReplayedCreditMarksExistingChildSpent(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-create-tx-replay-spent")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	parentAddr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	childAddr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+
+	parentTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 5000, PkScript: parentAddr.ScriptPubKey}},
+	)
+	parentParams := db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       parentTx,
+		Received: time.Unix(1710000580, 0),
+		Status:   db.TxStatusPending,
+	}
+
+	err := store.CreateTx(t.Context(), parentParams)
+	require.NoError(t, err)
+
+	parentOutPoint := wire.OutPoint{Hash: parentTx.TxHash(), Index: 0}
+	require.False(t, walletUtxoExists(t, store, walletID, parentOutPoint))
+
+	childTx := newRegularTx(
+		[]wire.OutPoint{parentOutPoint},
+		[]*wire.TxOut{{Value: 4000, PkScript: childAddr.ScriptPubKey}},
+	)
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       childTx,
+		Received: time.Unix(1710000590, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]address.Address{0: nil},
+	})
+	require.NoError(t, err)
+	require.False(t, walletUtxoExists(t, store, walletID, parentOutPoint))
+
+	parentParams.Credits = map[uint32]address.Address{0: nil}
+	err = store.CreateTx(t.Context(), parentParams)
+	require.NoError(t, err)
+	require.True(t, walletUtxoSpent(t, store, walletID, parentOutPoint))
+}
+
+// TestCreateTxReplayedCreditConfirmedChildReplacesUnmined verifies that a
+// late-discovered parent credit reconciles already-stored conflicting children
+// before recording the parent spend edge.
+func TestCreateTxReplayedCreditConfirmedChildReplacesUnmined(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-create-tx-replay-replace")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	parentAddr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	unminedAddr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	confirmedAddr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+
+	parentTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 5000, PkScript: parentAddr.ScriptPubKey}},
+	)
+	parentParams := db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       parentTx,
+		Received: time.Unix(1710000600, 0),
+		Status:   db.TxStatusPending,
+	}
+
+	err := store.CreateTx(t.Context(), parentParams)
+	require.NoError(t, err)
+
+	parentOutPoint := wire.OutPoint{Hash: parentTx.TxHash(), Index: 0}
+	require.False(t, walletUtxoExists(t, store, walletID, parentOutPoint))
+
+	unminedChild := newRegularTx(
+		[]wire.OutPoint{parentOutPoint},
+		[]*wire.TxOut{{Value: 4000, PkScript: unminedAddr.ScriptPubKey}},
+	)
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       unminedChild,
+		Received: time.Unix(1710000610, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]address.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	confirmedChild := newRegularTx(
+		[]wire.OutPoint{parentOutPoint},
+		[]*wire.TxOut{{Value: 3000, PkScript: confirmedAddr.ScriptPubKey}},
+	)
+	confirmedBlock := CreateBlockFixture(t, store.Queries(), 262)
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       confirmedChild,
+		Received: time.Unix(1710000620, 0),
+		Block:    &confirmedBlock,
+		Status:   db.TxStatusPublished,
+		Credits:  map[uint32]address.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	parentParams.Credits = map[uint32]address.Address{0: nil}
+	err = store.CreateTx(t.Context(), parentParams)
+	require.NoError(t, err)
+
+	confirmedID, ok := txIDByHash(
+		t, store, walletID, confirmedChild.TxHash(),
+	)
+	require.True(t, ok)
+	require.Equal(
+		t, []int64{confirmedID},
+		childSpendingTxIDs(t, store, walletID, parentTx.TxHash()),
+	)
+
+	unminedInfo, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     unminedChild.TxHash(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, db.TxStatusReplaced, unminedInfo.Status)
+
+	confirmedInfo, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     confirmedChild.TxHash(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, db.TxStatusPublished, confirmedInfo.Status)
+	require.NotNil(t, confirmedInfo.Block)
+	require.Equal(t, confirmedBlock.Height, confirmedInfo.Block.Height)
+}
+
+// TestCreateTxReplayedCreditSkipsReplacedChildSnapshot verifies that replaying
+// a parent credit does not reattach a child spend from a stale active-child
+// snapshot after that child has already been replaced.
+func TestCreateTxReplayedCreditSkipsReplacedChildSnapshot(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-create-tx-replay-stale-child")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	parentAddr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	unminedAddr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	confirmedAddr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+
+	parentTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{
+			{Value: 5000, PkScript: parentAddr.ScriptPubKey},
+			{Value: 6000, PkScript: parentAddr.ScriptPubKey},
+		},
+	)
+	parentParams := db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       parentTx,
+		Received: time.Unix(1710000630, 0),
+		Status:   db.TxStatusPending,
+	}
+
+	err := store.CreateTx(t.Context(), parentParams)
+	require.NoError(t, err)
+
+	firstOutPoint := wire.OutPoint{Hash: parentTx.TxHash(), Index: 0}
+	secondOutPoint := wire.OutPoint{Hash: parentTx.TxHash(), Index: 1}
+	unminedChild := newRegularTx(
+		[]wire.OutPoint{firstOutPoint, secondOutPoint},
+		[]*wire.TxOut{{Value: 4000, PkScript: unminedAddr.ScriptPubKey}},
+	)
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       unminedChild,
+		Received: time.Unix(1710000640, 0),
+		Status:   db.TxStatusPending,
+		Credits:  map[uint32]address.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	confirmedChild := newRegularTx(
+		[]wire.OutPoint{firstOutPoint},
+		[]*wire.TxOut{{Value: 3000, PkScript: confirmedAddr.ScriptPubKey}},
+	)
+	confirmedBlock := CreateBlockFixture(t, store.Queries(), 263)
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       confirmedChild,
+		Received: time.Unix(1710000650, 0),
+		Block:    &confirmedBlock,
+		Status:   db.TxStatusPublished,
+		Credits:  map[uint32]address.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	parentParams.Credits = map[uint32]address.Address{0: nil, 1: nil}
+	err = store.CreateTx(t.Context(), parentParams)
+	require.NoError(t, err)
+
+	confirmedID, ok := txIDByHash(
+		t, store, walletID, confirmedChild.TxHash(),
+	)
+	require.True(t, ok)
+	require.Equal(
+		t, []int64{confirmedID},
+		childSpendingTxIDs(t, store, walletID, parentTx.TxHash()),
+	)
+	require.True(t, walletUtxoSpent(t, store, walletID, firstOutPoint))
+	require.False(t, walletUtxoSpent(t, store, walletID, secondOutPoint))
+
+	unminedInfo, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     unminedChild.TxHash(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, db.TxStatusReplaced, unminedInfo.Status)
+}
+
+// TestCreateTxReplayedCreditPreplansConfirmedReplacements verifies that late
+// parent-credit replay computes confirmed child replacements across all newly
+// discovered credits before enforcing the single-unmined-spender rule.
+func TestCreateTxReplayedCreditPreplansConfirmedReplacements(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-create-tx-replay-preplan")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	parentAddr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	parentTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{
+			{Value: 5000, PkScript: parentAddr.ScriptPubKey},
+			{Value: 6000, PkScript: parentAddr.ScriptPubKey},
+		},
+	)
+	parentParams := db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       parentTx,
+		Received: time.Unix(1710000660, 0),
+		Status:   db.TxStatusPending,
+	}
+
+	err := store.CreateTx(t.Context(), parentParams)
+	require.NoError(t, err)
+
+	firstOutPoint := wire.OutPoint{Hash: parentTx.TxHash(), Index: 0}
+	secondOutPoint := wire.OutPoint{Hash: parentTx.TxHash(), Index: 1}
+	staleChild := newRegularTx(
+		[]wire.OutPoint{firstOutPoint, secondOutPoint},
+		[]*wire.TxOut{{Value: 4000, PkScript: []byte{0x51}}},
+	)
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       staleChild,
+		Received: time.Unix(1710000670, 0),
+		Status:   db.TxStatusPending,
+	})
+	require.NoError(t, err)
+
+	activeChild := newRegularTx(
+		[]wire.OutPoint{firstOutPoint},
+		[]*wire.TxOut{{Value: 3000, PkScript: []byte{0x52}}},
+	)
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       activeChild,
+		Received: time.Unix(1710000680, 0),
+		Status:   db.TxStatusPending,
+	})
+	require.NoError(t, err)
+
+	confirmedChild := newRegularTx(
+		[]wire.OutPoint{secondOutPoint},
+		[]*wire.TxOut{{Value: 2000, PkScript: []byte{0x53}}},
+	)
+	confirmedBlock := CreateBlockFixture(t, store.Queries(), 264)
+	err = store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: walletID,
+		Tx:       confirmedChild,
+		Received: time.Unix(1710000690, 0),
+		Block:    &confirmedBlock,
+		Status:   db.TxStatusPublished,
+	})
+	require.NoError(t, err)
+
+	parentParams.Credits = map[uint32]address.Address{0: nil, 1: nil}
+	err = store.CreateTx(t.Context(), parentParams)
+	require.NoError(t, err)
+
+	activeID, ok := txIDByHash(t, store, walletID, activeChild.TxHash())
+	require.True(t, ok)
+	confirmedID, ok := txIDByHash(t, store, walletID, confirmedChild.TxHash())
+	require.True(t, ok)
+	require.ElementsMatch(
+		t, []int64{activeID, confirmedID},
+		childSpendingTxIDs(t, store, walletID, parentTx.TxHash()),
+	)
+	require.True(t, walletUtxoSpent(t, store, walletID, firstOutPoint))
+	require.True(t, walletUtxoSpent(t, store, walletID, secondOutPoint))
+
+	staleInfo, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     staleChild.TxHash(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, db.TxStatusReplaced, staleInfo.Status)
 }
 
 // TestCreateTxConfirmsExistingUnminedRow verifies that CreateTx reuses one live
@@ -3171,6 +3640,279 @@ func TestApplyTxBatchConfirmsTxInSameBlock(t *testing.T) {
 	require.NotNil(t, walletInfo.SyncedTo)
 	require.Equal(t, block.Height, walletInfo.SyncedTo.Height)
 	require.Equal(t, block.Hash, walletInfo.SyncedTo.Hash)
+}
+
+// TestApplyTxBatchConfirmsTxBeforeSyncTip verifies that a batch can record a
+// transaction confirmed before the same batch's final synced block. The
+// transaction's confirming block row does not exist before the batch, so the
+// batch must create it independently of the synced-to block.
+func TestApplyTxBatchConfirmsTxBeforeSyncTip(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletName := "wallet-apply-tx-batch-confirm-before-tip"
+	walletID := newWallet(t, store, walletName)
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 7000, PkScript: addr.ScriptPubKey}},
+	)
+
+	block := NewBlockFixture(212)
+	syncedTo := NewBlockFixture(213)
+
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: walletID,
+		Transactions: []db.CreateTxParams{{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710000160, 0),
+			Block:    &block,
+			Status:   db.TxStatusPublished,
+			Credits:  map[uint32]address.Address{0: nil},
+		}},
+		SyncedTo: &syncedTo,
+	})
+	require.NoError(t, err)
+
+	txInfo, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     tx.TxHash(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, db.TxStatusPublished, txInfo.Status)
+	require.NotNil(t, txInfo.Block)
+	require.Equal(t, block.Height, txInfo.Block.Height)
+	require.Equal(t, block.Hash, txInfo.Block.Hash)
+
+	walletInfo, err := store.GetWallet(t.Context(), walletName)
+	require.NoError(t, err)
+	require.NotNil(t, walletInfo.SyncedTo)
+	require.Equal(t, syncedTo.Height, walletInfo.SyncedTo.Height)
+	require.Equal(t, syncedTo.Hash, walletInfo.SyncedTo.Hash)
+}
+
+// TestApplyTxBatchConfirmsExistingTx verifies that ApplyTxBatch reconciles a
+// pending transaction when the same transaction is later observed confirmed.
+func TestApplyTxBatchConfirmsExistingTx(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletName := "wallet-apply-tx-batch-confirm-existing"
+	walletID := newWallet(t, store, walletName)
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 7000, PkScript: addr.ScriptPubKey}},
+	)
+
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: walletID,
+		Transactions: []db.CreateTxParams{{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710000161, 0),
+			Status:   db.TxStatusPending,
+			Credits:  map[uint32]address.Address{0: nil},
+		}},
+	})
+	require.NoError(t, err)
+
+	block := NewBlockFixture(216)
+	err = store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: walletID,
+		Transactions: []db.CreateTxParams{{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710000162, 0),
+			Block:    &block,
+			Status:   db.TxStatusPublished,
+			Credits:  map[uint32]address.Address{0: nil},
+		}},
+		SyncedTo: &block,
+	})
+	require.NoError(t, err)
+
+	txInfo, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     tx.TxHash(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, db.TxStatusPublished, txInfo.Status)
+	require.NotNil(t, txInfo.Block)
+	require.Equal(t, block.Height, txInfo.Block.Height)
+	require.Equal(t, block.Hash, txInfo.Block.Hash)
+
+	walletInfo, err := store.GetWallet(t.Context(), walletName)
+	require.NoError(t, err)
+	require.NotNil(t, walletInfo.SyncedTo)
+	require.Equal(t, block.Height, walletInfo.SyncedTo.Height)
+	require.Equal(t, block.Hash, walletInfo.SyncedTo.Hash)
+}
+
+// TestApplyTxBatchDuplicateUnminedKeepsConfirmed verifies that an unmined batch
+// notification for an already-confirmed transaction is a no-op, matching the
+// legacy kvdb behavior for rescan observations.
+func TestApplyTxBatchDuplicateUnminedKeepsConfirmed(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-apply-tx-batch-unmined-dupe")
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 7000, PkScript: RandomBytes(22)}},
+	)
+	block := NewBlockFixture(217)
+
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: walletID,
+		Transactions: []db.CreateTxParams{{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710000163, 0),
+			Block:    &block,
+			Status:   db.TxStatusPublished,
+		}},
+		SyncedTo: &block,
+	})
+	require.NoError(t, err)
+
+	err = store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: walletID,
+		Transactions: []db.CreateTxParams{{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710000164, 0),
+			Status:   db.TxStatusPending,
+		}},
+	})
+	require.NoError(t, err)
+
+	txInfo, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     tx.TxHash(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, db.TxStatusPublished, txInfo.Status)
+	require.NotNil(t, txInfo.Block)
+	require.Equal(t, block.Height, txInfo.Block.Height)
+	require.Equal(t, block.Hash, txInfo.Block.Hash)
+}
+
+// TestApplyTxBatchDuplicateConfirmedChecksTimestamp verifies that an otherwise
+// idempotent confirmed duplicate still validates the caller's block timestamp.
+func TestApplyTxBatchDuplicateConfirmedChecksTimestamp(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-apply-tx-batch-ts-dupe")
+
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 7000, PkScript: RandomBytes(22)}},
+	)
+	block := NewBlockFixture(218)
+
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: walletID,
+		Transactions: []db.CreateTxParams{{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710000165, 0),
+			Block:    &block,
+			Status:   db.TxStatusPublished,
+		}},
+		SyncedTo: &block,
+	})
+	require.NoError(t, err)
+
+	mismatchedBlock := block
+	mismatchedBlock.Timestamp = block.Timestamp.Add(time.Second)
+	err = store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: walletID,
+		Transactions: []db.CreateTxParams{{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710000166, 0),
+			Block:    &mismatchedBlock,
+			Status:   db.TxStatusPublished,
+		}},
+	})
+	require.ErrorIs(t, err, db.ErrBlockMismatch)
+}
+
+// TestApplyTxBatchRejectsDuplicateStateMismatch verifies that a non-idempotent
+// duplicate does not let the batch advance the sync tip.
+func TestApplyTxBatchRejectsDuplicateStateMismatch(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletName := "wallet-apply-tx-batch-duplicate-mismatch"
+	walletID := newWallet(t, store, walletName)
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	addr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	tx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 7000, PkScript: addr.ScriptPubKey}},
+	)
+
+	firstBlock := NewBlockFixture(217)
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: walletID,
+		Transactions: []db.CreateTxParams{{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710000163, 0),
+			Block:    &firstBlock,
+			Status:   db.TxStatusPublished,
+			Credits:  map[uint32]address.Address{0: nil},
+		}},
+		SyncedTo: &firstBlock,
+	})
+	require.NoError(t, err)
+
+	secondBlock := NewBlockFixture(218)
+	err = store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: walletID,
+		Transactions: []db.CreateTxParams{{
+			WalletID: walletID,
+			Tx:       tx,
+			Received: time.Unix(1710000164, 0),
+			Block:    &secondBlock,
+			Status:   db.TxStatusPublished,
+			Credits:  map[uint32]address.Address{0: nil},
+		}},
+		SyncedTo: &secondBlock,
+	})
+	require.ErrorIs(t, err, db.ErrTxAlreadyExists)
+
+	txInfo, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     tx.TxHash(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, db.TxStatusPublished, txInfo.Status)
+	require.NotNil(t, txInfo.Block)
+	require.Equal(t, firstBlock.Height, txInfo.Block.Height)
+	require.Equal(t, firstBlock.Hash, txInfo.Block.Hash)
+
+	walletInfo, err := store.GetWallet(t.Context(), walletName)
+	require.NoError(t, err)
+	require.NotNil(t, walletInfo.SyncedTo)
+	require.Equal(t, firstBlock.Height, walletInfo.SyncedTo.Height)
+	require.Equal(t, firstBlock.Hash, walletInfo.SyncedTo.Hash)
 }
 
 // TestApplyTxBatchRejectsMismatchedWalletID verifies that a batch is rejected

--- a/wallet/internal/db/itest/txstore_utxostore_test.go
+++ b/wallet/internal/db/itest/txstore_utxostore_test.go
@@ -2972,3 +2972,88 @@ func TestListOutputsToWatchBareMultisigUsesOutputScript(t *testing.T) {
 	require.Equal(t, multiSigScript, utxos[0].PkScript)
 	require.NotEqual(t, memberScript, utxos[0].PkScript)
 }
+
+// TestApplyTxBatchChildBeforeParent verifies that ApplyTxBatch records the
+// parent->child spend edge even when the child transaction is listed before
+// the in-batch parent whose output it spends. Each transaction claims its spent
+// parent inputs by updating the parent credit's UTXO row, so a child applied
+// before its parent would update no row and, finding no conflicting spend,
+// silently drop the spend edge while still succeeding. ApplyTxBatch must apply
+// the batch parents-first so the parent credit ends up marked spent regardless
+// of caller order.
+func TestApplyTxBatchChildBeforeParent(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-apply-tx-batch-child-first")
+	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0084, "default")
+
+	parentAddr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+	childAddr := newDerivedAddress(
+		t, store, walletID, db.KeyScopeBIP0084, "default", false,
+	)
+
+	// The parent spends an external input and credits the wallet at output 0.
+	parentTx := newRegularTx(
+		[]wire.OutPoint{randomOutPoint()},
+		[]*wire.TxOut{{Value: 7000, PkScript: parentAddr.ScriptPubKey}},
+	)
+
+	// The child spends the parent's wallet-owned output and credits the wallet
+	// at its own output 0.
+	childTx := newRegularTx(
+		[]wire.OutPoint{{Hash: parentTx.TxHash(), Index: 0}},
+		[]*wire.TxOut{{Value: 6000, PkScript: childAddr.ScriptPubKey}},
+	)
+
+	// Deliberately list the child before its in-batch parent. A caller-order
+	// apply would record the child first, drop its spend of the not-yet-stored
+	// parent output, and leave the parent credit unspent.
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: walletID,
+		Transactions: []db.CreateTxParams{
+			{
+				WalletID: walletID,
+				Tx:       childTx,
+				Received: time.Unix(1710000180, 0),
+				Status:   db.TxStatusPending,
+				Credits:  map[uint32]address.Address{0: nil},
+			},
+			{
+				WalletID: walletID,
+				Tx:       parentTx,
+				Received: time.Unix(1710000181, 0),
+				Status:   db.TxStatusPending,
+				Credits:  map[uint32]address.Address{0: nil},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Both transactions are recorded.
+	_, err = store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     parentTx.TxHash(),
+	})
+	require.NoError(t, err)
+	_, err = store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: walletID,
+		Txid:     childTx.TxHash(),
+	})
+	require.NoError(t, err)
+
+	// The child's own credit is recorded as a wallet UTXO.
+	require.True(t, walletUtxoExists(t, store, walletID, wire.OutPoint{
+		Hash: childTx.TxHash(), Index: 0,
+	}))
+
+	// The parent credit must be marked spent: the in-batch child's spend edge
+	// was recorded even though the child was applied first. Without the
+	// parents-first ordering this edge is silently dropped and the assertion
+	// fails.
+	require.True(t, walletUtxoSpent(t, store, walletID, wire.OutPoint{
+		Hash: parentTx.TxHash(), Index: 0,
+	}))
+}

--- a/wallet/internal/db/kvdb/txstore.go
+++ b/wallet/internal/db/kvdb/txstore.go
@@ -289,6 +289,95 @@ func (s *Store) UpdateTx(_ context.Context, params db.UpdateTxParams) error {
 	return nil
 }
 
+// legacyCreditEntries converts db-native credit addresses into legacy credit
+// entries and marks resolved addresses as used.
+//
+// Each non-nil credit is validated against the output script it claims to
+// credit using the same membership check the CreateTx path applies in
+// addCreateTxCredit, so the batch path cannot record a UTXO owned by an
+// address the output does not pay. A nil credit means the caller has no
+// resolved owner, so ownership is keyed on the output's own script: the entry
+// is recorded from the output index alone, with no address-manager lookup or
+// used-marking, matching CreateTx and the SQL backends.
+func (s *Store) legacyCreditEntries(addrmgrNs walletdb.ReadWriteBucket,
+	req db.CreateTxRequest) ([]wtxmgr.CreditEntry, error) {
+
+	chainParams := s.addrStore.ChainParams()
+
+	credits := make([]wtxmgr.CreditEntry, 0, len(req.Params.Credits))
+	for index, addr := range req.Params.Credits {
+		// A nil credit address has no owner to resolve, so key the
+		// credit on the output's own script: record it from the index
+		// with change cleared, skipping the address-manager lookup and
+		// the membership check that has no caller address to validate.
+		if addr == nil {
+			if int(index) >= len(req.Params.Tx.TxOut) {
+				return nil, fmt.Errorf("credit output %d: %w: "+
+					"index out of range", index,
+					db.ErrInvalidParam)
+			}
+
+			credits = append(credits, wtxmgr.CreditEntry{
+				Index:  index,
+				Change: false,
+			})
+
+			continue
+		}
+
+		// Validate the caller-supplied credit against the actual output
+		// script before trusting it, rejecting a mismatch with the same
+		// error CreateTx uses.
+		err := validateCreditAddr(
+			*req.Params.Tx, index, addr, chainParams,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		managedAddr, err := s.addrStore.Address(addrmgrNs, addr)
+		if waddrmgr.IsError(err, waddrmgr.ErrAddressNotFound) {
+			return nil, fmt.Errorf("credit output %d: %w", index,
+				db.ErrAddressNotFound)
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("lookup credit address %d: %w",
+				index, err)
+		}
+
+		credits = append(credits, wtxmgr.CreditEntry{
+			Index:  index,
+			Change: managedAddr.Internal(),
+		})
+
+		err = s.addrStore.MarkUsed(addrmgrNs, addr)
+		if err != nil {
+			return nil, fmt.Errorf("mark credit address used %d: %w",
+				index, err)
+		}
+	}
+
+	return credits, nil
+}
+
+// kvdbTxBlockMeta converts store block metadata into legacy transaction block
+// metadata.
+func kvdbTxBlockMeta(block *db.Block) (*wtxmgr.BlockMeta, error) {
+	height, err := db.Uint32ToInt32(block.Height)
+	if err != nil {
+		return nil, fmt.Errorf("convert block height: %w", err)
+	}
+
+	return &wtxmgr.BlockMeta{
+		Block: wtxmgr.Block{
+			Hash:   block.Hash,
+			Height: height,
+		},
+		Time: block.Timestamp,
+	}, nil
+}
+
 // GetTx retrieves one wallet-scoped transaction snapshot through the legacy
 // wtxmgr query path.
 func (s *Store) GetTx(_ context.Context, query db.GetTxQuery) (

--- a/wallet/internal/db/kvdb/txstore.go
+++ b/wallet/internal/db/kvdb/txstore.go
@@ -25,6 +25,18 @@ var _ db.TxStore = (*Store)(nil)
 // signed legacy wtxmgr height domain.
 var errLegacyHeightOverflow = errors.New("legacy height overflows int32")
 
+// kvdbTxStatusBucketKey is a kvdb-owned side bucket under the legacy wtxmgr
+// namespace that records transaction statuses wtxmgr cannot represent.
+var kvdbTxStatusBucketKey = []byte("db-tx-status")
+
+// legacyTxStatusValueLen is the byte width of one encoded db.TxStatus value.
+const legacyTxStatusValueLen = 1
+
+// errLegacyTxStatusUnexpectedSize reports a corrupt status side-bucket value.
+var errLegacyTxStatusUnexpectedSize = errors.New(
+	"legacy tx status bucket value has unexpected byte width",
+)
+
 // CreateTx records an unmined transaction through the legacy wtxmgr path.
 //
 // Unlike the SQL backends, kvdb does NOT route through the shared
@@ -103,6 +115,11 @@ func (s *Store) createTxWithTx(tx walletdb.ReadWriteTx,
 
 	if exists {
 		return db.ErrTxAlreadyExists
+	}
+
+	err = putLegacyTxStatus(txmgrNs, txRec.Hash, params.Status)
+	if err != nil {
+		return fmt.Errorf("put tx status: %w", err)
 	}
 
 	if len(params.Label) != 0 {
@@ -289,6 +306,518 @@ func (s *Store) UpdateTx(_ context.Context, params db.UpdateTxParams) error {
 	return nil
 }
 
+// ApplyTxBatch atomically records transactions and an optional sync-tip update
+// through the legacy walletdb managers.
+func (s *Store) ApplyTxBatch(_ context.Context,
+	params db.TxBatchParams) error {
+
+	// A batch with no transactions and no sync-tip update has nothing to
+	// persist. Return before the addrStore guard and walletdb.Update so an
+	// empty batch neither requires an address manager nor opens a write
+	// transaction.
+	if len(params.Transactions) == 0 && params.SyncedTo == nil {
+		return nil
+	}
+
+	err := db.ValidateBatchTransactionsWalletID(
+		params.WalletID, params.Transactions,
+	)
+	if err != nil {
+		return fmt.Errorf("validate batch wallet ids: %w", err)
+	}
+
+	// Reject a nil-Tx member before the parents-first sort below
+	// dereferences each transaction; the per-tx NewCreateTxRequest check in
+	// the apply loop runs only after the sort.
+	err = db.ValidateBatchTransactionsTx(params.Transactions)
+	if err != nil {
+		return fmt.Errorf("validate batch transactions: %w", err)
+	}
+
+	// Record any in-batch parent before its children. The confirmed path
+	// records a debit only against an already-inserted parent credit, so a
+	// confirmed child applied before its in-batch parent would find no credit
+	// to spend and silently leave the parent output unspent. Sorting parents
+	// first makes the batch order-independent; an already parents-first or
+	// dependency-free batch is returned unchanged.
+	params.Transactions = db.SortTxBatchParentsFirst(params.Transactions)
+
+	if batchNeedsAddrStore(params) && s.addrStore == nil {
+		return fmt.Errorf("kvdb.Store.ApplyTxBatch: %w",
+			errMissingAddrStore)
+	}
+
+	var syncTipRestore batchSyncTipRestore
+
+	// Hold the Store write lock through the commit-failure restore below. This
+	// keeps the cache restore ordered before a following Store write can commit
+	// the same tip and create an ABA match.
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	err = walletdb.Update(s.db, func(tx walletdb.ReadWriteTx) error {
+		return s.applyLegacyBatchUpdate(tx, params, &syncTipRestore)
+	})
+	if err != nil {
+		if syncTipRestore.snapshotTaken {
+			s.addrStore.RestoreSyncedToIfCurrent(
+				syncTipRestore.previous,
+				syncTipRestore.attempted,
+			)
+		}
+
+		return fmt.Errorf("kvdb.Store.ApplyTxBatch: %w", err)
+	}
+
+	return nil
+}
+
+// batchNeedsAddrStore reports whether a transaction batch needs the address
+// manager namespace or live address store.
+func batchNeedsAddrStore(params db.TxBatchParams) bool {
+	if params.SyncedTo != nil {
+		return true
+	}
+
+	for _, tx := range params.Transactions {
+		if len(tx.Credits) > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+// batchSyncTipRestore tracks the live sync tip to restore when a batch update
+// fails after the address manager has changed its in-memory synced-to block.
+type batchSyncTipRestore struct {
+	previous  waddrmgr.BlockStamp
+	attempted waddrmgr.BlockStamp
+
+	snapshotTaken bool
+}
+
+// applyLegacyBatchUpdate performs the namespace lookups and write operations of
+// a transaction batch within a legacy walletdb write transaction, recording any
+// transactions and applying the optional sync-tip update.
+func (s *Store) applyLegacyBatchUpdate(tx walletdb.ReadWriteTx,
+	params db.TxBatchParams, syncTipRestore *batchSyncTipRestore) error {
+
+	var addrmgrNs walletdb.ReadWriteBucket
+	if batchNeedsAddrStore(params) {
+		addrmgrNs = tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+		if addrmgrNs == nil {
+			return errMissingAddrmgrNamespace
+		}
+	}
+
+	if len(params.Transactions) > 0 {
+		txmgrNs := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+		if txmgrNs == nil {
+			return errMissingTxmgrNamespace
+		}
+
+		err := s.applyLegacyTxBatch(
+			addrmgrNs, txmgrNs, params.Transactions,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	return s.applyLegacyBatchSyncTip(
+		addrmgrNs, params, syncTipRestore,
+	)
+}
+
+// applyLegacyBatchSyncTip applies the optional sync-tip update for a legacy
+// transaction batch.
+func (s *Store) applyLegacyBatchSyncTip(ns walletdb.ReadWriteBucket,
+	params db.TxBatchParams, syncTipRestore *batchSyncTipRestore) error {
+
+	if params.SyncedTo == nil {
+		return nil
+	}
+
+	block, err := db.BlockStampFromBlock(params.SyncedTo)
+	if err != nil {
+		return err
+	}
+
+	syncTipRestore.previous = s.addrStore.SyncedTo()
+	syncTipRestore.attempted = block
+	syncTipRestore.snapshotTaken = true
+
+	err = s.addrStore.SetSyncedTo(ns, &block)
+	if err != nil {
+		return fmt.Errorf("set synced tip: %w", err)
+	}
+
+	return nil
+}
+
+// applyLegacyTxBatch records one batch of relevant transaction notifications.
+func (s *Store) applyLegacyTxBatch(addrmgrNs walletdb.ReadWriteBucket,
+	txmgrNs walletdb.ReadWriteBucket, transactions []db.CreateTxParams) error {
+
+	for i := range transactions {
+		req, err := db.NewCreateTxRequest(transactions[i])
+		if err != nil {
+			return fmt.Errorf("validate tx %d: %w", i, err)
+		}
+
+		err = s.applyLegacyTxNotification(addrmgrNs, txmgrNs, req)
+		if err != nil {
+			return fmt.Errorf("apply tx %d: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
+// applyLegacyTxNotification records one relevant transaction notification using
+// legacy wtxmgr semantics.
+func (s *Store) applyLegacyTxNotification(addrmgrNs walletdb.ReadWriteBucket,
+	txmgrNs walletdb.ReadWriteBucket, req db.CreateTxRequest) error {
+
+	txRec, err := wtxmgr.NewTxRecordFromMsgTx(
+		req.Params.Tx, req.Received,
+	)
+	if err != nil {
+		return fmt.Errorf("build tx record: %w", err)
+	}
+
+	if req.Params.Block == nil {
+		return s.applyUnconfirmedLegacyTx(addrmgrNs, txmgrNs, txRec, req)
+	}
+
+	block, err := kvdbTxBlockMeta(req.Params.Block)
+	if err != nil {
+		return err
+	}
+
+	handled, err := s.applyConfirmedDuplicate(
+		addrmgrNs, txmgrNs, txRec.Hash, block, req,
+	)
+	if err != nil {
+		return err
+	}
+
+	if handled {
+		return nil
+	}
+
+	label, err := s.confirmedBatchLabel(txmgrNs, txRec.Hash, req)
+	if err != nil {
+		return err
+	}
+
+	credits, err := s.legacyCreditEntries(addrmgrNs, req)
+	if err != nil {
+		return err
+	}
+
+	err = s.txStore.InsertConfirmedTx(txmgrNs, txRec, block, credits)
+	if err != nil {
+		return fmt.Errorf("insert confirmed tx: %w", err)
+	}
+
+	err = putLegacyTxStatus(txmgrNs, txRec.Hash, req.Params.Status)
+	if err != nil {
+		return fmt.Errorf("put tx status: %w", err)
+	}
+
+	return s.putLegacyTxLabel(txmgrNs, txRec, label)
+}
+
+// confirmedBatchLabel returns the label to keep after storing a confirmed batch
+// notification.
+func (s *Store) confirmedBatchLabel(txmgrNs walletdb.ReadBucket,
+	txHash chainhash.Hash, req db.CreateTxRequest) (string, error) {
+
+	existing, err := s.txStore.TxDetails(txmgrNs, &txHash)
+	if err != nil {
+		return "", fmt.Errorf("lookup existing tx label: %w", err)
+	}
+
+	if existing == nil || existing.Block.Height >= 0 {
+		return req.Params.Label, nil
+	}
+
+	return existing.Label, nil
+}
+
+// applyConfirmedDuplicate handles a confirmed batch notification for a
+// transaction hash already present in the legacy store.
+func (s *Store) applyConfirmedDuplicate(
+	addrmgrNs walletdb.ReadBucket, txmgrNs walletdb.ReadBucket,
+	txHash chainhash.Hash, block *wtxmgr.BlockMeta,
+	req db.CreateTxRequest) (bool, error) {
+
+	existing, err := s.txStore.TxDetails(txmgrNs, &txHash)
+	if err != nil {
+		return false, fmt.Errorf("lookup existing tx: %w", err)
+	}
+
+	if existing == nil || existing.Block.Height < 0 {
+		return false, nil
+	}
+
+	matches, err := s.legacyConfirmedDuplicateMatches(
+		addrmgrNs, txmgrNs, existing, txHash, block, req,
+	)
+	if err != nil {
+		return false, err
+	}
+
+	if matches {
+		return true, nil
+	}
+
+	return true, fmt.Errorf("tx %s: %w", txHash, db.ErrTxAlreadyExists)
+}
+
+// legacyConfirmedDuplicateMatches reports whether a confirmed duplicate batch
+// notification is already fully reflected by the legacy store.
+func (s *Store) legacyConfirmedDuplicateMatches(
+	addrmgrNs walletdb.ReadBucket, txmgrNs walletdb.ReadBucket,
+	existing *wtxmgr.TxDetails, txHash chainhash.Hash,
+	block *wtxmgr.BlockMeta, req db.CreateTxRequest) (bool, error) {
+
+	if existing.Block.Height != block.Height ||
+		existing.Block.Hash != block.Hash ||
+		!existing.Block.Time.Equal(block.Time) {
+
+		return false, nil
+	}
+
+	status, err := readLegacyTxStatus(txmgrNs, txHash)
+	if err != nil {
+		return false, fmt.Errorf("read duplicate tx status: %w", err)
+	}
+
+	return s.legacyDuplicateMatches(addrmgrNs, existing, status, req)
+}
+
+// applyUnconfirmedLegacyTx records an unmined transaction through the legacy
+// wtxmgr path. A duplicate unmined notification for a transaction the store
+// already has confirmed is a no-op: InsertUnconfirmedTx no-ops the record write
+// for an existing transaction, but the status write would otherwise mark the
+// confirmed transaction pending.
+func (s *Store) applyUnconfirmedLegacyTx(
+	addrmgrNs walletdb.ReadWriteBucket, txmgrNs walletdb.ReadWriteBucket,
+	txRec *wtxmgr.TxRecord, req db.CreateTxRequest) error {
+
+	existing, err := s.txStore.TxDetails(txmgrNs, &txRec.Hash)
+	if err != nil {
+		return fmt.Errorf("lookup existing tx: %w", err)
+	}
+
+	if existing != nil {
+		return s.applyUnconfirmedDuplicate(
+			addrmgrNs, txmgrNs, existing, txRec.Hash, req,
+		)
+	}
+
+	credits, err := s.legacyCreditEntries(addrmgrNs, req)
+	if err != nil {
+		return err
+	}
+
+	err = s.txStore.InsertUnconfirmedTx(txmgrNs, txRec, credits)
+	if err != nil {
+		return fmt.Errorf("insert unconfirmed tx: %w", err)
+	}
+
+	err = putLegacyTxStatus(txmgrNs, txRec.Hash, req.Params.Status)
+	if err != nil {
+		return fmt.Errorf("put tx status: %w", err)
+	}
+
+	return s.putLegacyTxLabel(txmgrNs, txRec, req.Params.Label)
+}
+
+// applyUnconfirmedDuplicate handles an unmined batch notification for a
+// transaction hash already present in the legacy store.
+func (s *Store) applyUnconfirmedDuplicate(
+	addrmgrNs walletdb.ReadBucket, txmgrNs walletdb.ReadBucket,
+	existing *wtxmgr.TxDetails, txHash chainhash.Hash,
+	req db.CreateTxRequest) error {
+
+	if existing.Block.Height >= 0 {
+		return nil
+	}
+
+	status, err := readLegacyTxStatus(txmgrNs, txHash)
+	if err != nil {
+		return fmt.Errorf("read duplicate tx status: %w", err)
+	}
+
+	matches, err := s.legacyDuplicateMatches(
+		addrmgrNs, existing, status, req,
+	)
+	if err != nil {
+		return err
+	}
+
+	if matches {
+		return nil
+	}
+
+	return fmt.Errorf("tx %s: %w", txHash, db.ErrTxAlreadyExists)
+}
+
+// legacyDuplicateMatches reports whether a duplicate batch notification's
+// wallet metadata is already fully reflected by the legacy store.
+func (s *Store) legacyDuplicateMatches(
+	addrmgrNs walletdb.ReadBucket, existing *wtxmgr.TxDetails,
+	status db.TxStatus, req db.CreateTxRequest) (bool, error) {
+
+	if status != req.Params.Status {
+		return false, nil
+	}
+
+	if existing.Label != req.Params.Label {
+		return false, nil
+	}
+
+	return s.legacyCreditsMatch(addrmgrNs, existing.Credits, req)
+}
+
+// legacyCreditsMatch reports whether requested credit ownership exactly matches
+// the legacy credit records already stored for an unconfirmed transaction.
+func (s *Store) legacyCreditsMatch(addrmgrNs walletdb.ReadBucket,
+	existing []wtxmgr.CreditRecord, req db.CreateTxRequest) (bool, error) {
+
+	if len(existing) != len(req.Params.Credits) {
+		return false, nil
+	}
+
+	existingCredits := make(map[uint32]bool, len(existing))
+	for _, credit := range existing {
+		existingCredits[credit.Index] = credit.Change
+	}
+
+	for index, addr := range req.Params.Credits {
+		existingChange, ok := existingCredits[index]
+		if !ok {
+			return false, nil
+		}
+
+		expectedChange := false
+		if addr != nil {
+			chainParams := s.addrStore.ChainParams()
+
+			err := validateCreditAddr(*req.Params.Tx, index, addr, chainParams)
+			if err != nil {
+				return false, err
+			}
+
+			managedAddr, err := s.addrStore.Address(addrmgrNs, addr)
+			if waddrmgr.IsError(err, waddrmgr.ErrAddressNotFound) {
+				return false, nil
+			}
+
+			if err != nil {
+				return false, fmt.Errorf("lookup credit address %d: %w",
+					index, err)
+			}
+
+			expectedChange = managedAddr.Internal()
+		}
+
+		if existingChange != expectedChange {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// putLegacyTxStatus writes or clears the kvdb status side-bucket entry for one
+// legacy transaction.
+func putLegacyTxStatus(txmgrNs walletdb.ReadWriteBucket,
+	txid chainhash.Hash, status db.TxStatus) error {
+
+	if status == db.TxStatusPublished {
+		return deleteLegacyTxStatus(txmgrNs, txid)
+	}
+
+	if status != db.TxStatusPending {
+		return fmt.Errorf("legacy tx status %s: %w", status,
+			db.ErrInvalidStatus)
+	}
+
+	statusBucket, err := txmgrNs.CreateBucketIfNotExists(
+		kvdbTxStatusBucketKey,
+	)
+	if err != nil {
+		return fmt.Errorf("create tx status bucket: %w", err)
+	}
+
+	return statusBucket.Put(txid[:], []byte{byte(status)})
+}
+
+// deleteLegacyTxStatus clears the kvdb status side-bucket entry for one legacy
+// transaction.
+func deleteLegacyTxStatus(txmgrNs walletdb.ReadWriteBucket,
+	txid chainhash.Hash) error {
+
+	statusBucket := txmgrNs.NestedReadWriteBucket(kvdbTxStatusBucketKey)
+	if statusBucket == nil {
+		return nil
+	}
+
+	return statusBucket.Delete(txid[:])
+}
+
+// readLegacyTxStatus reads the kvdb status side-bucket entry for one legacy
+// transaction. Missing entries mean wtxmgr's native published status.
+func readLegacyTxStatus(txmgrNs walletdb.ReadBucket,
+	txid chainhash.Hash) (db.TxStatus, error) {
+
+	statusBucket := txmgrNs.NestedReadBucket(kvdbTxStatusBucketKey)
+	if statusBucket == nil {
+		return db.TxStatusPublished, nil
+	}
+
+	raw := statusBucket.Get(txid[:])
+	if raw == nil {
+		return db.TxStatusPublished, nil
+	}
+
+	if len(raw) != legacyTxStatusValueLen {
+		return db.TxStatus(0), fmt.Errorf(
+			"%w: txid=%s: expected %d bytes, got %d",
+			errLegacyTxStatusUnexpectedSize, txid,
+			legacyTxStatusValueLen, len(raw),
+		)
+	}
+
+	status, err := db.ParseTxStatus(int64(raw[0]))
+	if err != nil {
+		return db.TxStatus(0), err
+	}
+
+	return status, nil
+}
+
+// putLegacyTxLabel records one non-empty transaction label through wtxmgr.
+func (s *Store) putLegacyTxLabel(txmgrNs walletdb.ReadWriteBucket,
+	txRec *wtxmgr.TxRecord, label string) error {
+
+	if len(label) == 0 {
+		return nil
+	}
+
+	err := s.txStore.PutTxLabel(txmgrNs, txRec.Hash, label)
+	if err != nil {
+		return fmt.Errorf("put transaction label: %w", err)
+	}
+
+	return nil
+}
+
 // legacyCreditEntries converts db-native credit addresses into legacy credit
 // entries and marks resolved addresses as used.
 //
@@ -301,6 +830,10 @@ func (s *Store) UpdateTx(_ context.Context, params db.UpdateTxParams) error {
 // used-marking, matching CreateTx and the SQL backends.
 func (s *Store) legacyCreditEntries(addrmgrNs walletdb.ReadWriteBucket,
 	req db.CreateTxRequest) ([]wtxmgr.CreditEntry, error) {
+
+	if len(req.Params.Credits) == 0 {
+		return nil, nil
+	}
 
 	chainParams := s.addrStore.ChainParams()
 
@@ -378,12 +911,15 @@ func kvdbTxBlockMeta(block *db.Block) (*wtxmgr.BlockMeta, error) {
 	}, nil
 }
 
-// GetTx retrieves one wallet-scoped transaction snapshot through the legacy
-// wtxmgr query path.
-func (s *Store) GetTx(_ context.Context, query db.GetTxQuery) (
-	*db.TxInfo, error) {
+// fetchTxDetailsWithStatus loads the wtxmgr details and legacy status for a
+// transaction within a single read transaction.
+func (s *Store) fetchTxDetailsWithStatus(txid *chainhash.Hash) (
+	*wtxmgr.TxDetails, db.TxStatus, error) {
 
-	var info *db.TxInfo
+	var (
+		details *wtxmgr.TxDetails
+		status  db.TxStatus
+	)
 
 	err := walletdb.View(s.db, func(tx walletdb.ReadTx) error {
 		ns := tx.ReadBucket(wtxmgrNamespaceKey)
@@ -393,24 +929,40 @@ func (s *Store) GetTx(_ context.Context, query db.GetTxQuery) (
 			)
 		}
 
-		details, err := s.txStore.TxDetails(ns, &query.Txid)
+		txDetails, err := s.txStore.TxDetails(ns, txid)
 		if err != nil {
 			return fmt.Errorf("lookup transaction details: %w", err)
 		}
 
-		if details == nil {
+		if txDetails == nil {
 			return db.ErrTxNotFound
 		}
 
-		info = kvdbTxInfo(details)
+		txStatus, err := readLegacyTxStatus(ns, txDetails.Hash)
+		if err != nil {
+			return fmt.Errorf("read tx status: %w", err)
+		}
+
+		details = txDetails
+		status = txStatus
 
 		return nil
 	})
+
+	return details, status, err
+}
+
+// GetTx retrieves one wallet-scoped transaction snapshot through the legacy
+// wtxmgr query path.
+func (s *Store) GetTx(_ context.Context, query db.GetTxQuery) (
+	*db.TxInfo, error) {
+
+	details, status, err := s.fetchTxDetailsWithStatus(&query.Txid)
 	if err != nil {
 		return nil, fmt.Errorf("kvdb.Store.GetTx: %w", err)
 	}
 
-	return info, nil
+	return kvdbTxInfo(details, status), nil
 }
 
 // ListTxns lists wallet-scoped transaction summaries through the legacy wtxmgr
@@ -464,7 +1016,16 @@ func (s *Store) listTxnsRange(ns walletdb.ReadBucket, begin, end int32,
 		ns, begin, end,
 		func(txDetails []wtxmgr.TxDetails) (bool, error) {
 			for i := range txDetails {
-				infos = append(infos, *kvdbTxInfo(&txDetails[i]))
+				status, err := readLegacyTxStatus(
+					ns, txDetails[i].Hash,
+				)
+				if err != nil {
+					return false, fmt.Errorf("read tx status: %w", err)
+				}
+
+				infos = append(
+					infos, *kvdbTxInfo(&txDetails[i], status),
+				)
 			}
 
 			return false, nil
@@ -482,34 +1043,12 @@ func (s *Store) listTxnsRange(ns walletdb.ReadBucket, begin, end int32,
 func (s *Store) GetTxDetail(_ context.Context, query db.GetTxDetailQuery) (
 	*db.TxDetailInfo, error) {
 
-	var detail *db.TxDetailInfo
-
-	err := walletdb.View(s.db, func(tx walletdb.ReadTx) error {
-		ns := tx.ReadBucket(wtxmgrNamespaceKey)
-		if ns == nil {
-			return fmt.Errorf(
-				"wtxmgr namespace: %w", walletdb.ErrBucketNotFound,
-			)
-		}
-
-		txDetails, err := s.txStore.TxDetails(ns, &query.Txid)
-		if err != nil {
-			return fmt.Errorf("lookup transaction details: %w", err)
-		}
-
-		if txDetails == nil {
-			return db.ErrTxNotFound
-		}
-
-		detail = kvdbTxDetailInfo(txDetails)
-
-		return nil
-	})
+	details, status, err := s.fetchTxDetailsWithStatus(&query.Txid)
 	if err != nil {
 		return nil, fmt.Errorf("kvdb.Store.GetTxDetail: %w", err)
 	}
 
-	return detail, nil
+	return kvdbTxDetailInfo(details, status), nil
 }
 
 // ListTxDetails lists detailed wallet-scoped transaction views through the
@@ -531,8 +1070,18 @@ func (s *Store) ListTxDetails(_ context.Context, query db.ListTxDetailsQuery) (
 			ns, query.StartHeight, query.EndHeight,
 			func(txDetails []wtxmgr.TxDetails) (bool, error) {
 				for i := range txDetails {
+					status, err := readLegacyTxStatus(
+						ns, txDetails[i].Hash,
+					)
+					if err != nil {
+						return false, fmt.Errorf(
+							"read tx status: %w", err,
+						)
+					}
+
 					details = append(
-						details, *kvdbTxDetailInfo(&txDetails[i]),
+						details,
+						*kvdbTxDetailInfo(&txDetails[i], status),
 					)
 				}
 
@@ -580,7 +1129,12 @@ func (s *Store) InvalidateUnminedTx(_ context.Context,
 				db.ErrInvalidateTx)
 		}
 
-		return s.txStore.RemoveUnminedTx(ns, &details.TxRecord)
+		err = s.txStore.RemoveUnminedTx(ns, &details.TxRecord)
+		if err != nil {
+			return err
+		}
+
+		return deleteLegacyTxStatus(ns, params.Txid)
 	})
 	if err != nil {
 		return fmt.Errorf("kvdb.Store.InvalidateUnminedTx: %w", err)
@@ -1122,7 +1676,7 @@ func validateUpdateTxParams(params db.UpdateTxParams) (*string, error) {
 
 // kvdbTxInfo maps legacy wtxmgr detail data into the lightweight db-native
 // transaction summary model.
-func kvdbTxInfo(details *wtxmgr.TxDetails) *db.TxInfo {
+func kvdbTxInfo(details *wtxmgr.TxDetails, status db.TxStatus) *db.TxInfo {
 	var block *db.Block
 	if details.Block.Height >= 0 {
 		block = &db.Block{
@@ -1138,16 +1692,16 @@ func kvdbTxInfo(details *wtxmgr.TxDetails) *db.TxInfo {
 		Received:     details.Received.UTC(),
 		Block:        block,
 
-		// Legacy wtxmgr only exposes transactions it still treats as valid,
-		// and it does not persist pending/replaced/failed/orphaned state.
-		Status: db.TxStatusPublished,
+		Status: status,
 		Label:  details.Label,
 	}
 }
 
 // kvdbTxDetailInfo maps legacy wtxmgr detail data into the db-native
 // transaction detail model used by wallet tx-reader code.
-func kvdbTxDetailInfo(details *wtxmgr.TxDetails) *db.TxDetailInfo {
+func kvdbTxDetailInfo(details *wtxmgr.TxDetails,
+	status db.TxStatus) *db.TxDetailInfo {
+
 	var block *db.Block
 	if details.Block.Height >= 0 {
 		block = &db.Block{
@@ -1182,9 +1736,7 @@ func kvdbTxDetailInfo(details *wtxmgr.TxDetails) *db.TxDetailInfo {
 		Received:     details.Received.UTC(),
 		Block:        block,
 
-		// Legacy wtxmgr only exposes transactions it still treats as valid,
-		// and it does not persist pending/replaced/failed/orphaned state.
-		Status:       db.TxStatusPublished,
+		Status:       status,
 		Label:        details.Label,
 		OwnedInputs:  ownedInputs,
 		OwnedOutputs: ownedOutputs,

--- a/wallet/internal/db/kvdb/txstore_test.go
+++ b/wallet/internal/db/kvdb/txstore_test.go
@@ -21,6 +21,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// failingRollbackTxStore injects a Rollback failure while delegating all other
+// transaction-store methods to the embedded implementation.
+type failingRollbackTxStore struct {
+	wtxmgr.TxStore
+
+	err error
+}
+
+// Rollback injects the configured rollback failure.
+func (f failingRollbackTxStore) Rollback(walletdb.ReadWriteBucket,
+	int32) error {
+
+	return f.err
+}
+
 // TestCreateTxUnminedWithCreditSuccess verifies that kvdb.Store records an
 // unmined transaction, label, credit, and address-used state through wtxmgr.
 func TestCreateTxUnminedWithCreditSuccess(t *testing.T) {
@@ -115,6 +130,67 @@ func TestCreateTxDuplicateReturnsStoreError(t *testing.T) {
 
 	err = store.CreateTx(t.Context(), params)
 	require.ErrorIs(t, err, db.ErrTxAlreadyExists)
+}
+
+// TestCreateTxPersistsPendingStatus verifies kvdb round-trips pending
+// transactions through its status side bucket.
+func TestCreateTxPersistsPendingStatus(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	newAddrmgrNamespace(t, dbConn)
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore, nil)
+
+	txMsg := &wire.MsgTx{Version: 1}
+	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{77},
+	}})
+	txMsg.AddTxOut(&wire.TxOut{Value: 8_000, PkScript: []byte{0x51}})
+
+	err := store.CreateTx(t.Context(), db.CreateTxParams{
+		WalletID: 0,
+		Tx:       txMsg,
+		Received: time.Unix(1710004300, 0),
+		Status:   db.TxStatusPending,
+	})
+	require.NoError(t, err)
+
+	txid := txMsg.TxHash()
+	info, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: 0,
+		Txid:     txid,
+	})
+	require.NoError(t, err)
+	require.Equal(t, db.TxStatusPending, info.Status)
+
+	detail, err := store.GetTxDetail(t.Context(), db.GetTxDetailQuery{
+		WalletID: 0,
+		Txid:     txid,
+	})
+	require.NoError(t, err)
+	require.Equal(t, db.TxStatusPending, detail.Status)
+
+	infos, err := store.ListTxns(t.Context(), db.ListTxnsQuery{
+		WalletID:    0,
+		UnminedOnly: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, infos, 1)
+	require.Equal(t, db.TxStatusPending, infos[0].Status)
+
+	details, err := store.ListTxDetails(
+		t.Context(), db.ListTxDetailsQuery{
+			WalletID:    0,
+			StartHeight: -1,
+			EndHeight:   -1,
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, details, 1)
+	require.Equal(t, db.TxStatusPending, details[0].Status)
 }
 
 // TestCreateTxCreditAddrMismatch verifies that crediting an output with an
@@ -870,6 +946,52 @@ func TestRollbackToBlockRestoresResetSyncTipOnCommitFailure(t *testing.T) {
 	require.ErrorIs(t, err, errInjectedCommit)
 }
 
+// TestRollbackToBlockFailureKeepsSyncTip verifies a transaction rollback
+// failure does not leave the live address-manager sync tip rewound.
+func TestRollbackToBlockFailureKeepsSyncTip(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	addrStore := newAddrStore(t, dbConn)
+	t.Cleanup(addrStore.Close)
+	txStore := newTxStore(t, dbConn)
+
+	forkTip := waddrmgr.BlockStamp{
+		Hash:      chainhash.Hash{9},
+		Height:    9,
+		Timestamp: time.Unix(1710004100, 0),
+	}
+	currentTip := waddrmgr.BlockStamp{
+		Hash:      chainhash.Hash{10},
+		Height:    10,
+		Timestamp: time.Unix(1710004700, 0),
+	}
+	err := walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		addrmgrNs := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+		require.NotNil(t, addrmgrNs)
+
+		err := addrStore.SetSyncedTo(addrmgrNs, &forkTip)
+		if err != nil {
+			return err
+		}
+
+		return addrStore.SetSyncedTo(addrmgrNs, &currentTip)
+	})
+	require.NoError(t, err)
+
+	store := NewStore(
+		dbConn, failingRollbackTxStore{
+			TxStore: txStore,
+			err:     errInducedFailure,
+		}, addrStore,
+	)
+	err = store.RollbackToBlock(t.Context(), 10)
+	require.ErrorIs(t, err, errInducedFailure)
+	require.Equal(t, currentTip, addrStore.SyncedTo())
+}
+
 // TestUpdateTxLabelOnlySuccess verifies that kvdb.Store can apply a label-only
 // UpdateTx patch through the legacy label path.
 func TestUpdateTxLabelOnlySuccess(t *testing.T) {
@@ -1587,4 +1709,545 @@ func matchAddress(addr address.Address) interface{} {
 	return mock.MatchedBy(func(got address.Address) bool {
 		return got.EncodeAddress() == addr.EncodeAddress()
 	})
+}
+
+// TestApplyTxBatchDuplicateUnminedKeepsConfirmed verifies that a duplicate
+// unmined notification for an already-confirmed transaction is a no-op and does
+// not downgrade the recorded confirmed status to pending.
+func TestApplyTxBatchDuplicateUnminedKeepsConfirmed(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	newAddrmgrNamespace(t, dbConn)
+	txStore := newTxStore(t, dbConn)
+
+	addr, script := newTestAddressScript(t)
+	managedAddr := &bwmock.ManagedAddress{}
+	managedAddr.On("Internal").Return(true).Maybe()
+	managedAddr.On("Address").Return(addr).Maybe()
+	managedAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Maybe()
+	managedAddr.On("Imported").Return(false).Maybe()
+	managedAddr.On("InternalAccount").Return(uint32(0)).Maybe()
+	managedAddr.On("Compressed").Return(true).Maybe()
+	managedAddr.On("AddrHash").Return([]byte(nil)).Maybe()
+	managedAddr.On("Used", mock.Anything).Return(false).Maybe()
+
+	addrStore := &bwmock.AddrStore{}
+	addrStore.On("ChainParams").Return(&chaincfg.RegressionNetParams)
+	addrStore.On("Address", mock.Anything, mock.Anything).
+		Return(managedAddr, nil)
+	addrStore.On("MarkUsed", mock.Anything, mock.Anything).Return(nil)
+	addrStore.On("SetSyncedTo", mock.Anything, mock.Anything).Return(nil)
+	addrStore.On("SyncedTo").Return(waddrmgr.BlockStamp{}).Maybe()
+	store := NewStore(dbConn, txStore, addrStore)
+
+	txMsg := &wire.MsgTx{Version: 1}
+	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{63},
+	}})
+	txMsg.AddTxOut(&wire.TxOut{Value: 10_000, PkScript: script})
+
+	block := &db.Block{
+		Hash:      chainhash.Hash{64},
+		Height:    144,
+		Timestamp: time.Unix(1710003200, 0),
+	}
+
+	// Record the transaction as confirmed.
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: 0,
+		Transactions: []db.CreateTxParams{{
+			WalletID: 0,
+			Tx:       txMsg,
+			Received: time.Unix(1710003100, 0),
+			Block:    block,
+			Status:   db.TxStatusPublished,
+			Credits:  map[uint32]address.Address{0: addr},
+		}},
+		SyncedTo: block,
+	})
+	require.NoError(t, err)
+
+	// A later duplicate unmined notification for the same transaction must
+	// not downgrade its confirmed status to pending.
+	err = store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: 0,
+		Transactions: []db.CreateTxParams{{
+			WalletID: 0,
+			Tx:       txMsg,
+			Received: time.Unix(1710003300, 0),
+			Status:   db.TxStatusPending,
+			Credits:  map[uint32]address.Address{0: addr},
+		}},
+	})
+	require.NoError(t, err)
+
+	txInfo, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: 0,
+		Txid:     txMsg.TxHash(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, txInfo.Block)
+	require.Equal(t, db.TxStatusPublished, txInfo.Status)
+}
+
+// TestApplyTxBatchRecordsTxAndSyncedTo verifies that kvdb.Store applies
+// transaction notifications and sync-tip updates atomically.
+func TestApplyTxBatchRecordsTxAndSyncedTo(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	newAddrmgrNamespace(t, dbConn)
+	txStore := newTxStore(t, dbConn)
+
+	addr, script := newTestAddressScript(t)
+	managedAddr := &bwmock.ManagedAddress{}
+	managedAddr.On("Internal").Return(true).Maybe()
+	managedAddr.On("Address").Return(addr).Maybe()
+	managedAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Maybe()
+	managedAddr.On("Imported").Return(false).Maybe()
+	managedAddr.On("InternalAccount").Return(uint32(0)).Maybe()
+	managedAddr.On("Compressed").Return(true).Maybe()
+	managedAddr.On("AddrHash").Return([]byte(nil)).Maybe()
+	managedAddr.On("Used", mock.Anything).Return(false).Maybe()
+
+	addrStore := &bwmock.AddrStore{}
+	addrStore.On("ChainParams").Return(&chaincfg.RegressionNetParams)
+	addrStore.On("Address", mock.Anything, mock.Anything).
+		Return(managedAddr, nil)
+	addrStore.On("MarkUsed", mock.Anything, mock.Anything).Return(nil)
+	addrStore.On("SetSyncedTo", mock.Anything, mock.Anything).Return(nil)
+	store := NewStore(dbConn, txStore, addrStore)
+
+	txMsg := &wire.MsgTx{Version: 1}
+	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{63},
+	}})
+	txMsg.AddTxOut(&wire.TxOut{Value: 10_000, PkScript: script})
+
+	syncedTo := &db.Block{
+		Hash:      chainhash.Hash{64},
+		Height:    144,
+		Timestamp: time.Unix(1710003200, 0),
+	}
+	label := "batch label"
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: 0,
+		Transactions: []db.CreateTxParams{{
+			WalletID: 0,
+			Tx:       txMsg,
+			Received: time.Unix(1710003100, 0),
+			Status:   db.TxStatusPublished,
+			Label:    label,
+			Credits:  map[uint32]address.Address{0: addr},
+		}},
+		SyncedTo: syncedTo,
+	})
+	require.NoError(t, err)
+
+	txid := txMsg.TxHash()
+	err = walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(wtxmgrNamespaceKey)
+		require.NotNil(t, ns)
+
+		details, err := txStore.TxDetails(ns, &txid)
+		require.NoError(t, err)
+		require.NotNil(t, details)
+		require.Equal(t, label, details.Label)
+		require.Len(t, details.Credits, 1)
+		require.True(t, details.Credits[0].Change)
+
+		return nil
+	})
+	require.NoError(t, err)
+	addrStore.AssertCalled(t, "MarkUsed", mock.Anything, mock.Anything)
+	addrStore.AssertCalled(
+		t, "SetSyncedTo", mock.Anything,
+		mock.MatchedBy(func(bs *waddrmgr.BlockStamp) bool {
+			return bs.Height == int32(syncedTo.Height)
+		}),
+	)
+}
+
+// TestApplyTxBatchEmptyNoAddrStore verifies that a batch with no transactions
+// and no sync-tip update returns nil without an address manager and without
+// opening a write transaction. The store is built with a nil addrStore and the
+// db has no namespaces, so any attempt to open the addrmgr bucket would fail;
+// a nil error therefore proves the empty batch short-circuits before
+// walletdb.Update.
+func TestApplyTxBatchEmptyNoAddrStore(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	// Deliberately create no namespaces and pass a nil addrStore: an empty
+	// batch must touch neither.
+	store := NewStore(dbConn, nil, nil)
+
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{WalletID: 0})
+	require.NoError(t, err)
+}
+
+// TestApplyTxBatchSyncTipOnlyDoesNotRequireTxStore verifies a sync-tip-only
+// batch does not require the legacy wtxmgr namespace.
+func TestApplyTxBatchSyncTipOnlyDoesNotRequireTxStore(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	newAddrmgrNamespace(t, dbConn)
+
+	syncedTo := &db.Block{
+		Hash:      chainhash.Hash{78},
+		Height:    144,
+		Timestamp: time.Unix(1710004400, 0),
+	}
+	addrStore := &bwmock.AddrStore{}
+	addrStore.On("SetSyncedTo", mock.Anything, mock.MatchedBy(
+		func(bs *waddrmgr.BlockStamp) bool {
+			return bs.Height == int32(syncedTo.Height) &&
+				bs.Hash == syncedTo.Hash
+		},
+	)).Return(nil)
+	store := NewStore(dbConn, nil, addrStore)
+
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: 0,
+		SyncedTo: syncedTo,
+	})
+	require.NoError(t, err)
+	addrStore.AssertExpectations(t)
+}
+
+// TestApplyTxBatchRejectsMismatchedWalletID verifies kvdb enforces the shared
+// batch wallet-id invariant before opening a write transaction.
+func TestApplyTxBatchRejectsMismatchedWalletID(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	store := NewStore(dbConn, nil, nil)
+	txMsg := &wire.MsgTx{Version: 1}
+	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{75},
+	}})
+	txMsg.AddTxOut(&wire.TxOut{Value: 1_000, PkScript: []byte{0x51}})
+
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: 0,
+		Transactions: []db.CreateTxParams{{
+			WalletID: 1,
+			Tx:       txMsg,
+			Received: time.Unix(1710004000, 0),
+			Status:   db.TxStatusPublished,
+		}},
+	})
+	require.ErrorIs(t, err, db.ErrInvalidParam)
+}
+
+// TestApplyTxBatchRejectsNilTx verifies that a multi-transaction batch
+// containing a nil Tx is rejected with ErrInvalidParam instead of panicking.
+// ApplyTxBatch reorders the batch parents-first before applying it, and that
+// sort dereferences each transaction's Tx; without an up-front nil check the
+// sort would panic on the nil member rather than returning a validation error.
+func TestApplyTxBatchRejectsNilTx(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	store := NewStore(dbConn, nil, nil)
+
+	validTx := &wire.MsgTx{Version: 1}
+	validTx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{77},
+	}})
+	validTx.AddTxOut(&wire.TxOut{Value: 1_000, PkScript: []byte{0x51}})
+
+	// The batch carries two transactions but the second has a nil Tx. The
+	// parents-first sort runs before the per-tx request validation, so this
+	// must be caught by the up-front guard rather than panicking.
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: 0,
+		Transactions: []db.CreateTxParams{
+			{
+				WalletID: 0,
+				Tx:       validTx,
+				Received: time.Unix(1710004100, 0),
+				Status:   db.TxStatusPublished,
+			},
+			{
+				WalletID: 0,
+				Tx:       nil,
+				Received: time.Unix(1710004101, 0),
+				Status:   db.TxStatusPublished,
+			},
+		},
+	})
+	require.ErrorIs(t, err, db.ErrInvalidParam)
+}
+
+// TestApplyTxBatchConfirmedChildBeforeParentSpendsParent verifies that a batch
+// listing a confirmed child before its in-batch confirmed parent still records
+// the child's spend of the parent's wallet-owned output. The confirmed write
+// path records a debit only against an already-inserted parent credit, so
+// applying the child first would find no credit to spend and silently leave the
+// parent output unspent. ApplyTxBatch sorts the batch parents-first to close
+// that gap.
+func TestApplyTxBatchConfirmedChildBeforeParentSpendsParent(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	newAddrmgrNamespace(t, dbConn)
+	txStore := newTxStore(t, dbConn)
+
+	addr, script := newTestAddressScript(t)
+	managedAddr := &bwmock.ManagedAddress{}
+	managedAddr.On("Internal").Return(true).Maybe()
+	managedAddr.On("Address").Return(addr).Maybe()
+	managedAddr.On("AddrType").Return(waddrmgr.WitnessPubKey).Maybe()
+	managedAddr.On("Imported").Return(false).Maybe()
+	managedAddr.On("InternalAccount").Return(uint32(0)).Maybe()
+	managedAddr.On("Compressed").Return(true).Maybe()
+	managedAddr.On("AddrHash").Return([]byte(nil)).Maybe()
+	managedAddr.On("Used", mock.Anything).Return(false).Maybe()
+
+	addrStore := &bwmock.AddrStore{}
+	addrStore.On("ChainParams").Return(&chaincfg.RegressionNetParams)
+	addrStore.On("Address", mock.Anything, mock.Anything).
+		Return(managedAddr, nil)
+	addrStore.On("MarkUsed", mock.Anything, mock.Anything).Return(nil)
+	addrStore.On("SetSyncedTo", mock.Anything, mock.Anything).Return(nil)
+	addrStore.On("SyncedTo").Return(waddrmgr.BlockStamp{}).Maybe()
+	store := NewStore(dbConn, txStore, addrStore)
+
+	// The parent spends an external input and credits the wallet at output 0.
+	parentTx := &wire.MsgTx{Version: 1}
+	parentTx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{91},
+	}})
+	parentTx.AddTxOut(&wire.TxOut{Value: 10_000, PkScript: script})
+	parentOutPoint := wire.OutPoint{Hash: parentTx.TxHash(), Index: 0}
+
+	// The child spends the parent's wallet-owned output and credits the wallet
+	// at its own output 0.
+	childTx := &wire.MsgTx{Version: 1}
+	childTx.AddTxIn(&wire.TxIn{PreviousOutPoint: parentOutPoint})
+	childTx.AddTxOut(&wire.TxOut{Value: 9_000, PkScript: script})
+	childOutPoint := wire.OutPoint{Hash: childTx.TxHash(), Index: 0}
+
+	block := &db.Block{
+		Hash:      chainhash.Hash{92},
+		Height:    200,
+		Timestamp: time.Unix(1710005000, 0),
+	}
+
+	// Deliberately list the confirmed child before its in-batch confirmed
+	// parent. A caller-order apply would record the child first and drop its
+	// spend of the not-yet-stored parent output.
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: 0,
+		Transactions: []db.CreateTxParams{
+			{
+				WalletID: 0,
+				Tx:       childTx,
+				Received: time.Unix(1710005100, 0),
+				Block:    block,
+				Status:   db.TxStatusPublished,
+				Credits:  map[uint32]address.Address{0: addr},
+			},
+			{
+				WalletID: 0,
+				Tx:       parentTx,
+				Received: time.Unix(1710005101, 0),
+				Block:    block,
+				Status:   db.TxStatusPublished,
+				Credits:  map[uint32]address.Address{0: addr},
+			},
+		},
+		SyncedTo: block,
+	})
+	require.NoError(t, err)
+
+	// The parent output must be spent and the child output unspent: only the
+	// child's own credit should remain in the unspent set. Without the
+	// parents-first ordering the parent output would be left unspent and both
+	// outputs would appear in the unspent set.
+	err = walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(wtxmgrNamespaceKey)
+		require.NotNil(t, ns)
+
+		unspent, err := txStore.UnspentOutputs(ns)
+		require.NoError(t, err)
+
+		unspentSet := make(map[wire.OutPoint]struct{}, len(unspent))
+		for _, credit := range unspent {
+			unspentSet[credit.OutPoint] = struct{}{}
+		}
+
+		require.NotContains(t, unspentSet, parentOutPoint)
+		require.Contains(t, unspentSet, childOutPoint)
+
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// TestApplyTxBatchPersistsPendingStatus verifies kvdb batch writes round-trip
+// pending transactions through the status side bucket.
+func TestApplyTxBatchPersistsPendingStatus(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	newAddrmgrNamespace(t, dbConn)
+	txStore := newTxStore(t, dbConn)
+	addrStore := &bwmock.AddrStore{}
+	addrStore.On("ChainParams").Return(&chaincfg.RegressionNetParams).Maybe()
+	store := NewStore(dbConn, txStore, addrStore)
+
+	txMsg := &wire.MsgTx{Version: 1}
+	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{76},
+	}})
+	txMsg.AddTxOut(&wire.TxOut{Value: 1_000, PkScript: []byte{0x51}})
+
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: 0,
+		Transactions: []db.CreateTxParams{{
+			WalletID: 0,
+			Tx:       txMsg,
+			Received: time.Unix(1710004200, 0),
+			Status:   db.TxStatusPending,
+		}},
+	})
+	require.NoError(t, err)
+
+	info, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: 0,
+		Txid:     txMsg.TxHash(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, db.TxStatusPending, info.Status)
+}
+
+// TestApplyTxBatchCreditAddrMismatch verifies that the batch credit path
+// rejects a credit whose address the output script does not pay, with the same
+// ErrInvalidParam the CreateTx path returns. This guards against recording a
+// UTXO owned by an unrelated address.
+func TestApplyTxBatchCreditAddrMismatch(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	newAddrmgrNamespace(t, dbConn)
+	txStore := newTxStore(t, dbConn)
+
+	// The output pays to one address, but the credit claims otherAddr,
+	// which the output script does not contain.
+	_, script := newTestAddressScript(t)
+	otherAddr, _ := newTestAddressScript(t)
+
+	// Register no Address/MarkUsed expectations: validation must reject the
+	// mismatch before the address manager is consulted.
+	addrStore := &bwmock.AddrStore{}
+	addrStore.On("ChainParams").Return(&chaincfg.RegressionNetParams)
+	store := NewStore(dbConn, txStore, addrStore)
+
+	txMsg := &wire.MsgTx{Version: 1}
+	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{67},
+	}})
+	txMsg.AddTxOut(&wire.TxOut{Value: 7_000, PkScript: script})
+
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: 0,
+		Transactions: []db.CreateTxParams{{
+			WalletID: 0,
+			Tx:       txMsg,
+			Received: time.Unix(1710003600, 0),
+			Status:   db.TxStatusPublished,
+			Credits:  map[uint32]address.Address{0: otherAddr},
+		}},
+	})
+	require.ErrorIs(t, err, db.ErrInvalidParam)
+
+	// The mismatch must be caught before any address-manager access.
+	addrStore.AssertNotCalled(t, "Address", mock.Anything, mock.Anything)
+	addrStore.AssertNotCalled(t, "MarkUsed", mock.Anything, mock.Anything)
+}
+
+// TestApplyTxBatchCreditNilFallback verifies that a nil credit address in the
+// batch path records the credit via the output's own script, matching the
+// CreateTx fallback and the SQL backends. The nil path must not consult the
+// address manager (no Address/MarkUsed lookup) and must not panic.
+func TestApplyTxBatchCreditNilFallback(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	newAddrmgrNamespace(t, dbConn)
+	txStore := newTxStore(t, dbConn)
+
+	_, script := newTestAddressScript(t)
+
+	// A non-nil addrStore is required because the batch is non-empty, but
+	// the nil-credit path must only read ChainParams and never resolve or
+	// mark an address. Register no Address/MarkUsed expectations so a
+	// regression that consults the address manager surfaces here.
+	addrStore := &bwmock.AddrStore{}
+	addrStore.On("ChainParams").Return(&chaincfg.RegressionNetParams)
+	store := NewStore(dbConn, txStore, addrStore)
+
+	txMsg := &wire.MsgTx{Version: 1}
+	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{68},
+	}})
+	txMsg.AddTxOut(&wire.TxOut{Value: 4_000, PkScript: script})
+
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: 0,
+		Transactions: []db.CreateTxParams{{
+			WalletID: 0,
+			Tx:       txMsg,
+			Received: time.Unix(1710003700, 0),
+			Status:   db.TxStatusPublished,
+			Credits:  map[uint32]address.Address{0: nil},
+		}},
+	})
+	require.NoError(t, err)
+
+	// The credit is recorded from the output index alone, with change
+	// cleared because there is no resolved derivation branch.
+	txid := txMsg.TxHash()
+	err = walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(wtxmgrNamespaceKey)
+		require.NotNil(t, ns)
+
+		details, err := txStore.TxDetails(ns, &txid)
+		require.NoError(t, err)
+		require.NotNil(t, details)
+		require.Len(t, details.Credits, 1)
+		require.Equal(t, uint32(0), details.Credits[0].Index)
+		require.False(t, details.Credits[0].Change)
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	// The address manager must not have been consulted for a nil credit.
+	addrStore.AssertNotCalled(t, "Address", mock.Anything, mock.Anything)
+	addrStore.AssertNotCalled(t, "MarkUsed", mock.Anything, mock.Anything)
 }

--- a/wallet/internal/db/kvdb/txstore_test.go
+++ b/wallet/internal/db/kvdb/txstore_test.go
@@ -36,6 +36,43 @@ func (f failingRollbackTxStore) Rollback(walletdb.ReadWriteBucket,
 	return f.err
 }
 
+// succeedThenFailSyncedAddrStore writes the synced-to block through the real
+// manager, then reports an induced failure so the walletdb transaction rolls
+// back after the manager's in-memory tip has already advanced.
+type succeedThenFailSyncedAddrStore struct {
+	*waddrmgr.Manager
+
+	beforeRestore func()
+}
+
+// SetSyncedTo writes the synced-to block before injecting the configured
+// post-write failure.
+func (s *succeedThenFailSyncedAddrStore) SetSyncedTo(
+	ns walletdb.ReadWriteBucket, bs *waddrmgr.BlockStamp) error {
+
+	err := s.Manager.SetSyncedTo(ns, bs)
+	if err != nil {
+		return err
+	}
+
+	return errInducedFailure
+}
+
+// RestoreSyncedToIfCurrent runs an optional hook before delegating the
+// conditional restore to the wrapped manager.
+func (s *succeedThenFailSyncedAddrStore) RestoreSyncedToIfCurrent(
+	previous, current waddrmgr.BlockStamp) bool {
+
+	if s.beforeRestore != nil {
+		beforeRestore := s.beforeRestore
+		s.beforeRestore = nil
+
+		beforeRestore()
+	}
+
+	return s.Manager.RestoreSyncedToIfCurrent(previous, current)
+}
+
 // TestCreateTxUnminedWithCreditSuccess verifies that kvdb.Store records an
 // unmined transaction, label, credit, and address-used state through wtxmgr.
 func TestCreateTxUnminedWithCreditSuccess(t *testing.T) {
@@ -1493,6 +1530,29 @@ func mockNoBirthdayBlock(addrStore *bwmock.AddrStore) {
 	).Maybe()
 }
 
+// beforeUpdateDB wraps a walletdb.DB and runs one hook immediately before the
+// next Update starts its underlying write transaction.
+type beforeUpdateDB struct {
+	walletdb.DB
+
+	before func()
+}
+
+// Update runs the configured pre-update hook before delegating to the embedded
+// DB implementation.
+func (db *beforeUpdateDB) Update(f func(walletdb.ReadWriteTx) error,
+	reset func()) error {
+
+	if db.before != nil {
+		before := db.before
+		db.before = nil
+
+		before()
+	}
+
+	return db.DB.Update(f, reset)
+}
+
 // writeSyncedTo persists a sync tip through the real address manager.
 func writeSyncedTo(t *testing.T, dbConn walletdb.DB,
 	mgr *waddrmgr.Manager, tip waddrmgr.BlockStamp) {
@@ -1793,6 +1853,206 @@ func TestApplyTxBatchDuplicateUnminedKeepsConfirmed(t *testing.T) {
 	require.Equal(t, db.TxStatusPublished, txInfo.Status)
 }
 
+// TestApplyTxBatchConfirmedDuplicatePreservesUnminedLabel verifies that a
+// confirmed notification for an already-stored unmined transaction preserves
+// the existing user label instead of replacing it with the batch label.
+func TestApplyTxBatchConfirmedDuplicatePreservesUnminedLabel(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	newAddrmgrNamespace(t, dbConn)
+	txStore := newTxStore(t, dbConn)
+	addrStore := &bwmock.AddrStore{}
+	addrStore.On("ChainParams").Return(&chaincfg.RegressionNetParams).Maybe()
+	store := NewStore(dbConn, txStore, addrStore)
+
+	txMsg := &wire.MsgTx{Version: 1}
+	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{69},
+	}})
+	txMsg.AddTxOut(&wire.TxOut{Value: 10_000, PkScript: []byte{0x51}})
+
+	const originalLabel = "original"
+
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: 0,
+		Transactions: []db.CreateTxParams{{
+			WalletID: 0,
+			Tx:       txMsg,
+			Received: time.Unix(1710003800, 0),
+			Status:   db.TxStatusPending,
+			Label:    originalLabel,
+		}},
+	})
+	require.NoError(t, err)
+
+	block := &db.Block{
+		Hash:      chainhash.Hash{70},
+		Height:    147,
+		Timestamp: time.Unix(1710003900, 0),
+	}
+	err = store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: 0,
+		Transactions: []db.CreateTxParams{{
+			WalletID: 0,
+			Tx:       txMsg,
+			Received: time.Unix(1710004000, 0),
+			Block:    block,
+			Status:   db.TxStatusPublished,
+			Label:    "ignored",
+		}},
+	})
+	require.NoError(t, err)
+
+	txInfo, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: 0,
+		Txid:     txMsg.TxHash(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, txInfo.Block)
+	require.Equal(t, block.Height, txInfo.Block.Height)
+	require.Equal(t, db.TxStatusPublished, txInfo.Status)
+	require.Equal(t, originalLabel, txInfo.Label)
+}
+
+// TestApplyTxBatchDuplicateConfirmedRejectsBlockMismatch verifies that a
+// confirmed duplicate for the same transaction hash cannot be recorded in a
+// second block.
+func TestApplyTxBatchDuplicateConfirmedRejectsBlockMismatch(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	newAddrmgrNamespace(t, dbConn)
+	txStore := newTxStore(t, dbConn)
+	addrStore := &bwmock.AddrStore{}
+	addrStore.On("ChainParams").Return(&chaincfg.RegressionNetParams).Maybe()
+	store := NewStore(dbConn, txStore, addrStore)
+
+	txMsg := &wire.MsgTx{Version: 1}
+	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{65},
+	}})
+	txMsg.AddTxOut(&wire.TxOut{Value: 10_000, PkScript: []byte{0x51}})
+
+	firstBlock := &db.Block{
+		Hash:      chainhash.Hash{66},
+		Height:    145,
+		Timestamp: time.Unix(1710003400, 0),
+	}
+	secondBlock := &db.Block{
+		Hash:      chainhash.Hash{67},
+		Height:    146,
+		Timestamp: time.Unix(1710003500, 0),
+	}
+
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: 0,
+		Transactions: []db.CreateTxParams{{
+			WalletID: 0,
+			Tx:       txMsg,
+			Received: time.Unix(1710003300, 0),
+			Block:    firstBlock,
+			Status:   db.TxStatusPublished,
+		}},
+	})
+	require.NoError(t, err)
+
+	err = store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: 0,
+		Transactions: []db.CreateTxParams{{
+			WalletID: 0,
+			Tx:       txMsg,
+			Received: time.Unix(1710003600, 0),
+			Block:    secondBlock,
+			Status:   db.TxStatusPublished,
+		}},
+	})
+	require.ErrorIs(t, err, db.ErrTxAlreadyExists)
+
+	txInfo, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: 0,
+		Txid:     txMsg.TxHash(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, txInfo.Block)
+	require.Equal(t, firstBlock.Height, txInfo.Block.Height)
+	require.Equal(t, firstBlock.Hash, txInfo.Block.Hash)
+}
+
+// TestApplyTxBatchDuplicateUnminedRejectsMutation verifies that a duplicate
+// unconfirmed batch member cannot mutate status, label, or credit metadata for
+// a transaction already stored as unconfirmed.
+func TestApplyTxBatchDuplicateUnminedRejectsMutation(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	newAddrmgrNamespace(t, dbConn)
+	txStore := newTxStore(t, dbConn)
+	addrStore := &bwmock.AddrStore{}
+	addrStore.On("ChainParams").Return(&chaincfg.RegressionNetParams).Maybe()
+	store := NewStore(dbConn, txStore, addrStore)
+
+	txMsg := &wire.MsgTx{Version: 1}
+	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{65},
+	}})
+	txMsg.AddTxOut(&wire.TxOut{Value: 10_000, PkScript: []byte{0x51}})
+
+	const originalLabel = "original"
+
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: 0,
+		Transactions: []db.CreateTxParams{{
+			WalletID: 0,
+			Tx:       txMsg,
+			Received: time.Unix(1710003400, 0),
+			Status:   db.TxStatusPending,
+			Label:    originalLabel,
+		}},
+	})
+	require.NoError(t, err)
+
+	err = store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: 0,
+		Transactions: []db.CreateTxParams{{
+			WalletID: 0,
+			Tx:       txMsg,
+			Received: time.Unix(1710003500, 0),
+			Status:   db.TxStatusPublished,
+			Label:    "mutated",
+		}},
+	})
+	require.ErrorIs(t, err, db.ErrTxAlreadyExists)
+
+	err = store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: 0,
+		Transactions: []db.CreateTxParams{{
+			WalletID: 0,
+			Tx:       txMsg,
+			Received: time.Unix(1710003600, 0),
+			Status:   db.TxStatusPending,
+			Label:    originalLabel,
+			Credits:  map[uint32]address.Address{0: nil},
+		}},
+	})
+	require.ErrorIs(t, err, db.ErrTxAlreadyExists)
+
+	txInfo, err := store.GetTx(t.Context(), db.GetTxQuery{
+		WalletID: 0,
+		Txid:     txMsg.TxHash(),
+	})
+	require.NoError(t, err)
+	require.Nil(t, txInfo.Block)
+	require.Equal(t, db.TxStatusPending, txInfo.Status)
+	require.Equal(t, originalLabel, txInfo.Label)
+}
+
 // TestApplyTxBatchRecordsTxAndSyncedTo verifies that kvdb.Store applies
 // transaction notifications and sync-tip updates atomically.
 func TestApplyTxBatchRecordsTxAndSyncedTo(t *testing.T) {
@@ -1820,6 +2080,7 @@ func TestApplyTxBatchRecordsTxAndSyncedTo(t *testing.T) {
 	addrStore.On("Address", mock.Anything, mock.Anything).
 		Return(managedAddr, nil)
 	addrStore.On("MarkUsed", mock.Anything, mock.Anything).Return(nil)
+	addrStore.On("SyncedTo").Return(waddrmgr.BlockStamp{}).Maybe()
 	addrStore.On("SetSyncedTo", mock.Anything, mock.Anything).Return(nil)
 	store := NewStore(dbConn, txStore, addrStore)
 
@@ -1873,6 +2134,164 @@ func TestApplyTxBatchRecordsTxAndSyncedTo(t *testing.T) {
 	)
 }
 
+// TestApplyTxBatchRestoresSyncedToOnFailure verifies that a batch failure after
+// SetSyncedTo restores the address manager's in-memory synced tip to match the
+// rolled-back walletdb state.
+func TestApplyTxBatchRestoresSyncedToOnFailure(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	mgr := newSpendableAddrMgr(t, dbConn)
+	t.Cleanup(mgr.Close)
+
+	preBatchTip := waddrmgr.BlockStamp{
+		Height:    100,
+		Hash:      chainhash.Hash{71},
+		Timestamp: time.Unix(1710004100, 0),
+	}
+	err := walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		addrmgrNs := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+		require.NotNil(t, addrmgrNs)
+
+		return mgr.SetSyncedTo(addrmgrNs, &preBatchTip)
+	})
+	require.NoError(t, err)
+	require.Equal(t, preBatchTip, mgr.SyncedTo())
+
+	addrStore := &succeedThenFailSyncedAddrStore{Manager: mgr}
+	store := NewStore(dbConn, nil, addrStore)
+	syncedTo := &db.Block{
+		Hash:      chainhash.Hash{72},
+		Height:    101,
+		Timestamp: time.Unix(1710004200, 0),
+	}
+
+	err = store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: 0,
+		SyncedTo: syncedTo,
+	})
+	require.ErrorIs(t, err, errInducedFailure)
+	require.Equal(t, preBatchTip, mgr.SyncedTo())
+
+	var reopenedTip waddrmgr.BlockStamp
+
+	err = walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		addrmgrNs := tx.ReadBucket(waddrmgr.NamespaceKey)
+		require.NotNil(t, addrmgrNs)
+
+		reopened, err := waddrmgr.Open(
+			addrmgrNs, []byte("pub"), &chaincfg.SimNetParams,
+		)
+		if err != nil {
+			return err
+		}
+		defer reopened.Close()
+
+		reopenedTip = reopened.SyncedTo()
+
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, preBatchTip.Height, reopenedTip.Height)
+	require.Equal(t, preBatchTip.Hash, reopenedTip.Hash)
+}
+
+// TestApplyTxBatchRestoresWriteLockedSyncedToOnFailure verifies that a failed
+// batch restores the sync tip snapshot captured inside the walletdb write
+// transaction, not a stale tip observed before another writer commits.
+func TestApplyTxBatchRestoresWriteLockedSyncedToOnFailure(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	mgr := newSpendableAddrMgr(t, dbConn)
+	t.Cleanup(mgr.Close)
+
+	preBatchTip := waddrmgr.BlockStamp{
+		Height:    100,
+		Hash:      chainhash.Hash{81},
+		Timestamp: time.Unix(1710004300, 0),
+	}
+	writeSyncedTo(t, dbConn, mgr, preBatchTip)
+	require.Equal(t, preBatchTip, mgr.SyncedTo())
+
+	writeLockedTip := waddrmgr.BlockStamp{
+		Height:    101,
+		Hash:      chainhash.Hash{82},
+		Timestamp: time.Unix(1710004400, 0),
+	}
+	failDB := &beforeUpdateDB{
+		DB: dbConn,
+		before: func() {
+			writeSyncedTo(t, dbConn, mgr, writeLockedTip)
+		},
+	}
+
+	addrStore := &succeedThenFailSyncedAddrStore{Manager: mgr}
+	store := NewStore(failDB, nil, addrStore)
+	syncedTo := &db.Block{
+		Hash:      chainhash.Hash{83},
+		Height:    102,
+		Timestamp: time.Unix(1710004500, 0),
+	}
+
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: 0,
+		SyncedTo: syncedTo,
+	})
+	require.ErrorIs(t, err, errInducedFailure)
+	require.Equal(t, writeLockedTip, mgr.SyncedTo())
+}
+
+// TestApplyTxBatchSkipsStaleSyncedToRestore verifies that the failed-batch
+// restore path does not overwrite a newer live tip committed after the failed
+// update has returned.
+func TestApplyTxBatchSkipsStaleSyncedToRestore(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	mgr := newSpendableAddrMgr(t, dbConn)
+	t.Cleanup(mgr.Close)
+
+	preBatchTip := waddrmgr.BlockStamp{
+		Height:    100,
+		Hash:      chainhash.Hash{84},
+		Timestamp: time.Unix(1710004600, 0),
+	}
+	writeSyncedTo(t, dbConn, mgr, preBatchTip)
+	require.Equal(t, preBatchTip, mgr.SyncedTo())
+
+	newerTip := waddrmgr.BlockStamp{
+		Height:    101,
+		Hash:      chainhash.Hash{85},
+		Timestamp: time.Unix(1710004700, 0),
+	}
+	addrStore := &succeedThenFailSyncedAddrStore{
+		Manager: mgr,
+		beforeRestore: func() {
+			writeSyncedTo(t, dbConn, mgr, newerTip)
+		},
+	}
+	store := NewStore(dbConn, nil, addrStore)
+	syncedTo := &db.Block{
+		Hash:      chainhash.Hash{86},
+		Height:    102,
+		Timestamp: time.Unix(1710004800, 0),
+	}
+
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: 0,
+		SyncedTo: syncedTo,
+	})
+	require.ErrorIs(t, err, errInducedFailure)
+	require.Equal(t, newerTip, mgr.SyncedTo())
+}
+
 // TestApplyTxBatchEmptyNoAddrStore verifies that a batch with no transactions
 // and no sync-tip update returns nil without an address manager and without
 // opening a write transaction. The store is built with a nil addrStore and the
@@ -1893,6 +2312,50 @@ func TestApplyTxBatchEmptyNoAddrStore(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestApplyTxBatchCreditlessNoAddrStore verifies that a transaction-only batch
+// with no credits records through wtxmgr without an address manager or addrmgr
+// namespace.
+func TestApplyTxBatchCreditlessNoAddrStore(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore, nil)
+
+	txMsg := &wire.MsgTx{Version: 1}
+	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{87},
+	}})
+	txMsg.AddTxOut(&wire.TxOut{Value: 1_000, PkScript: []byte{0x51}})
+	txHash := txMsg.TxHash()
+
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: 0,
+		Transactions: []db.CreateTxParams{{
+			WalletID: 0,
+			Tx:       txMsg,
+			Received: time.Unix(1710004900, 0),
+			Status:   db.TxStatusPublished,
+		}},
+	})
+	require.NoError(t, err)
+
+	err = walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
+		require.NotNil(t, txmgrNs)
+
+		details, err := txStore.TxDetails(txmgrNs, &txHash)
+		require.NoError(t, err)
+		require.NotNil(t, details)
+		require.Empty(t, details.Credits)
+
+		return nil
+	})
+	require.NoError(t, err)
+}
+
 // TestApplyTxBatchSyncTipOnlyDoesNotRequireTxStore verifies a sync-tip-only
 // batch does not require the legacy wtxmgr namespace.
 func TestApplyTxBatchSyncTipOnlyDoesNotRequireTxStore(t *testing.T) {
@@ -1909,6 +2372,7 @@ func TestApplyTxBatchSyncTipOnlyDoesNotRequireTxStore(t *testing.T) {
 		Timestamp: time.Unix(1710004400, 0),
 	}
 	addrStore := &bwmock.AddrStore{}
+	addrStore.On("SyncedTo").Return(waddrmgr.BlockStamp{}).Maybe()
 	addrStore.On("SetSyncedTo", mock.Anything, mock.MatchedBy(
 		func(bs *waddrmgr.BlockStamp) bool {
 			return bs.Height == int32(syncedTo.Height) &&

--- a/wallet/internal/db/kvdb/utxostore.go
+++ b/wallet/internal/db/kvdb/utxostore.go
@@ -186,6 +186,42 @@ func (s *Store) ListUTXOs(_ context.Context,
 	return utxos, nil
 }
 
+// ListOutputsToWatch lists outputs that recovery scans should monitor through
+// the legacy wtxmgr query path.
+func (s *Store) ListOutputsToWatch(_ context.Context,
+	_ uint32) ([]db.UtxoInfo, error) {
+
+	var utxos []db.UtxoInfo
+
+	err := walletdb.View(s.db, func(tx walletdb.ReadTx) error {
+		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
+		if txmgrNs == nil {
+			return errMissingTxmgrNamespace
+		}
+
+		credits, err := s.txStore.OutputsToWatch(txmgrNs)
+		if err != nil {
+			return fmt.Errorf("outputs to watch: %w", err)
+		}
+
+		utxos = make([]db.UtxoInfo, len(credits))
+		for i := range credits {
+			utxos[i] = *utxoInfoBase(&credits[i])
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("kvdb.Store.ListOutputsToWatch: %w", err)
+	}
+
+	if len(utxos) == 0 {
+		return []db.UtxoInfo{}, nil
+	}
+
+	return utxos, nil
+}
+
 // LeaseOutput locks one known wallet UTXO through the legacy wtxmgr lease
 // path.
 func (s *Store) LeaseOutput(_ context.Context,

--- a/wallet/internal/db/kvdb/utxostore_test.go
+++ b/wallet/internal/db/kvdb/utxostore_test.go
@@ -313,6 +313,37 @@ func TestDeleteExpiredLeases(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestListOutputsToWatchReturnsLockedCredit verifies that recovery watch lists
+// include credits even when they are currently leased.
+func TestListOutputsToWatchReturnsLockedCredit(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore, nil)
+
+	pkScript := []byte{0x51, 0x21}
+	outPoint := insertKnownCredit(t, dbConn, txStore, pkScript, 3000, 4)
+
+	err := walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+		_, err := txStore.LockOutput(
+			ns, wtxmgr.LockID{3}, outPoint, time.Hour,
+		)
+
+		return err
+	})
+	require.NoError(t, err)
+
+	utxos, err := store.ListOutputsToWatch(t.Context(), 0)
+	require.NoError(t, err)
+	require.Len(t, utxos, 1)
+	require.Equal(t, outPoint, utxos[0].OutPoint)
+	require.Equal(t, pkScript, utxos[0].PkScript)
+}
+
 // TestGetUtxoSuccess verifies that kvdb.Store adapts one wallet-owned legacy
 // credit into the db-native UTXO shape.
 func TestGetUtxoSuccess(t *testing.T) {

--- a/wallet/internal/db/pg/backend_error_test.go
+++ b/wallet/internal/db/pg/backend_error_test.go
@@ -180,7 +180,7 @@ func TestPgBackendHelpersRejectOverflow(t *testing.T) {
 	)
 	require.ErrorContains(t, err, "convert input outpoint index 0")
 
-	_, err = creditExists(t.Context(), nil, 1, chainhash.Hash{1}, ^uint32(0))
+	_, _, err = creditExists(t.Context(), nil, 1, chainhash.Hash{1}, ^uint32(0))
 	require.ErrorContains(t, err, "convert credit index")
 
 	err = markInputsSpent(t.Context(), nil, db.CreateTxParams{

--- a/wallet/internal/db/pg/backend_rows_test.go
+++ b/wallet/internal/db/pg/backend_rows_test.go
@@ -154,7 +154,7 @@ func TestPgCreateTxOpsAdditionalBranches(t *testing.T) {
 	conflictOps := &createTxOps{
 		invalidateUnminedTxOps: invalidateUnminedTxOps{
 			qtx: sqlc.New(rowDBTX{
-				row:      newSQLiteRow(t, "SELECT ?", int64(5)),
+				row:      newSQLiteRow(t, "SELECT ?, ?", int64(5), []byte{1}),
 				queryErr: errDummy,
 			}),
 		},

--- a/wallet/internal/db/pg/txstore_batch.go
+++ b/wallet/internal/db/pg/txstore_batch.go
@@ -1,0 +1,126 @@
+package pg
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+)
+
+// ApplyTxBatch atomically records transactions and an optional sync-tip update.
+func (s *Store) ApplyTxBatch(ctx context.Context,
+	params db.TxBatchParams) error {
+
+	// Reject a batch that mixes wallets before opening the write transaction:
+	// the sync tip is updated for params.WalletID, so a transaction owned by a
+	// different wallet must not ride along in the same atomic batch.
+	err := db.ValidateBatchTransactionsWalletID(
+		params.WalletID, params.Transactions,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Reject a nil-Tx member before SortTxBatchParentsFirst dereferences each
+	// transaction below; the per-tx NewCreateTxRequest check in
+	// applyBatchTransaction runs only after the sort.
+	err = db.ValidateBatchTransactionsTx(params.Transactions)
+	if err != nil {
+		return err
+	}
+
+	return s.execWrite(ctx, func(qtx *sqlc.Queries) error {
+		// CreateTxWithOps needs each confirming block row during
+		// PrepareBlock, so materialize all batch transaction blocks before
+		// any transaction is created.
+		err := ensureBatchTxBlocks(ctx, qtx, params.Transactions)
+		if err != nil {
+			return err
+		}
+
+		err = applyBatchSyncTip(ctx, qtx, params)
+		if err != nil {
+			return err
+		}
+
+		// Record any in-batch parent before its children. Each tx claims
+		// its spent parent inputs by updating the parent credit's UTXO row,
+		// so a child applied before its in-batch parent would update no row
+		// and silently drop the spend edge. Sorting parents first makes the
+		// batch order-independent; an already parents-first or
+		// dependency-free batch is returned unchanged.
+		txs := db.SortTxBatchParentsFirst(params.Transactions)
+
+		for i := range txs {
+			req, err := db.NewCreateTxRequest(txs[i])
+			if err != nil {
+				return fmt.Errorf("validate tx %d: %w", i, err)
+			}
+
+			err = db.CreateTxWithOps(ctx, req, &createTxOps{
+				invalidateUnminedTxOps: invalidateUnminedTxOps{
+					qtx: qtx,
+				},
+			})
+			if err != nil {
+				return fmt.Errorf("create tx %d: %w", i, err)
+			}
+		}
+
+		return nil
+	})
+}
+
+// ensureBatchTxBlocks materializes every confirming block referenced by a batch
+// transaction before the transaction rows are created.
+func ensureBatchTxBlocks(ctx context.Context, qtx *sqlc.Queries,
+	txs []db.CreateTxParams) error {
+
+	for i := range txs {
+		if txs[i].Block == nil {
+			continue
+		}
+
+		err := ensureBlockExists(ctx, qtx, txs[i].Block)
+		if err != nil {
+			return fmt.Errorf("tx %d block: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
+// applyBatchSyncTip applies the optional sync-tip update within a batch.
+func applyBatchSyncTip(ctx context.Context, qtx *sqlc.Queries,
+	params db.TxBatchParams) error {
+
+	if params.SyncedTo == nil {
+		return nil
+	}
+
+	err := ensureBlockExists(ctx, qtx, params.SyncedTo)
+	if err != nil {
+		return fmt.Errorf("ensure synced block: %w", err)
+	}
+
+	syncParams, err := buildUpdateSyncParams(db.UpdateWalletParams{
+		WalletID: params.WalletID,
+		SyncedTo: params.SyncedTo,
+	})
+	if err != nil {
+		return err
+	}
+
+	rowsAffected, err := qtx.UpdateWalletSyncState(ctx, syncParams)
+	if err != nil {
+		return fmt.Errorf("update wallet sync state: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return fmt.Errorf("wallet sync state for wallet %d: %w",
+			params.WalletID, db.ErrWalletNotFound)
+	}
+
+	return nil
+}

--- a/wallet/internal/db/pg/txstore_createtx.go
+++ b/wallet/internal/db/pg/txstore_createtx.go
@@ -1,14 +1,17 @@
 package pg
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 )
@@ -52,9 +55,9 @@ var _ db.CreateTxOps = (*createTxOps)(nil)
 func (o *createTxOps) LoadExisting(ctx context.Context,
 	req db.CreateTxRequest) (*db.CreateTxExistingTarget, error) {
 
-	meta, err := o.qtx.GetTransactionMetaByHash(
+	row, err := o.qtx.GetTransactionByHash(
 		ctx,
-		sqlc.GetTransactionMetaByHashParams{
+		sqlc.GetTransactionByHashParams{
 			WalletID: int64(req.Params.WalletID),
 			TxHash:   req.TxHash[:],
 		},
@@ -67,16 +70,38 @@ func (o *createTxOps) LoadExisting(ctx context.Context,
 		return nil, fmt.Errorf("get tx metadata: %w", err)
 	}
 
-	status, err := db.ParseTxStatus(int64(meta.TxStatus))
+	status, err := db.ParseTxStatus(int64(row.TxStatus))
 	if err != nil {
 		return nil, err
 	}
 
+	var (
+		blockHeight *uint32
+		blockHash   *chainhash.Hash
+	)
+	if row.BlockHeight.Valid {
+		block, err := buildBlock(
+			row.BlockHeight, row.BlockHash, row.BlockTimestamp,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		height := block.Height
+		blockHeight = &height
+
+		hash := block.Hash
+		blockHash = &hash
+	}
+
 	return &db.CreateTxExistingTarget{
-		ID:         meta.ID,
-		Status:     status,
-		HasBlock:   meta.BlockHeight.Valid,
-		IsCoinbase: meta.IsCoinbase,
+		ID:          row.ID,
+		Status:      status,
+		HasBlock:    row.BlockHeight.Valid,
+		BlockHeight: blockHeight,
+		BlockHash:   blockHash,
+		IsCoinbase:  row.IsCoinbase,
+		Label:       row.TxLabel,
 	}, nil
 }
 
@@ -169,7 +194,7 @@ func collectConflictRootIDs(ctx context.Context, qtx *sqlc.Queries,
 				inputIndex, err)
 		}
 
-		spentByTxID, err := qtx.GetUtxoSpendByOutpoint(
+		spend, err := qtx.GetUtxoSpendByOutpoint(
 			ctx, sqlc.GetUtxoSpendByOutpointParams{
 				WalletID:    int64(req.Params.WalletID),
 				TxHash:      txIn.PreviousOutPoint.Hash[:],
@@ -185,11 +210,11 @@ func collectConflictRootIDs(ctx context.Context, qtx *sqlc.Queries,
 				err)
 		}
 
-		if !spentByTxID.SpentByTxID.Valid {
+		if !spend.SpentByTxID.Valid {
 			continue
 		}
 
-		rootIDs[spentByTxID.SpentByTxID.Int64] = struct{}{}
+		rootIDs[spend.SpentByTxID.Int64] = struct{}{}
 	}
 
 	return rootIDs, nil
@@ -246,7 +271,7 @@ func (o *createTxOps) Insert(ctx context.Context,
 func (o *createTxOps) InsertCredits(ctx context.Context,
 	req db.CreateTxRequest, txID int64) error {
 
-	return insertCredits(ctx, o.qtx, req.Params, txID)
+	return insertCredits(ctx, o, req.Params, txID)
 }
 
 // MarkInputsSpent records wallet-owned inputs spent by the transaction.
@@ -346,75 +371,491 @@ func creditLookupScript(params db.CreateTxParams, index uint32) ([]byte,
 	return lookupScript, nil
 }
 
+// existingChildSpend describes one already-stored active transaction input that
+// spends an output whose wallet ownership was discovered later.
+type existingChildSpend struct {
+	// id is the stored child transaction row ID.
+	id int64
+
+	// hash is the child transaction hash used for descendant discovery.
+	hash chainhash.Hash
+
+	// confirmed reports whether the child row has confirming block metadata.
+	confirmed bool
+
+	// inputIndex is the input index that spends prevOut.
+	inputIndex int
+
+	// prevOut is the parent output spent by the child input.
+	prevOut wire.OutPoint
+}
+
 // insertCredits inserts one wallet-owned UTXO row for each credited output of
 // the transaction being stored.
-func insertCredits(ctx context.Context, qtx *sqlc.Queries,
+func insertCredits(ctx context.Context, ops *createTxOps,
 	params db.CreateTxParams, txID int64) error {
 
 	for index := range params.Credits {
-		creditExists, err := creditExists(
-			ctx, qtx, params.WalletID, params.Tx.TxHash(), index,
+		err := insertCredit(ctx, ops.qtx, params, txID, index)
+		if err != nil {
+			return err
+		}
+	}
+
+	err := markExistingChildSpends(ctx, ops, params, txID)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// insertCredit inserts or validates one wallet-owned UTXO row for a credited
+// output.
+func insertCredit(ctx context.Context, qtx *sqlc.Queries,
+	params db.CreateTxParams, txID int64, index uint32) error {
+
+	lookupScript, err := creditLookupScript(params, index)
+	if err != nil {
+		return err
+	}
+
+	creditExists, existingScript, err := creditExists(
+		ctx, qtx, params.WalletID, params.Tx.TxHash(), index,
+	)
+	if err != nil {
+		return err
+	}
+
+	if creditExists {
+		if !bytes.Equal(existingScript, lookupScript) {
+			return fmt.Errorf("credit output %d owner mismatch: %w",
+				index, db.ErrTxAlreadyExists)
+		}
+
+		return nil
+	}
+
+	addrRow, err := qtx.GetAddressByScriptPubKey(
+		ctx, sqlc.GetAddressByScriptPubKeyParams{
+			ScriptPubKey: lookupScript,
+			WalletID:     int64(params.WalletID),
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("credit output %d: %w", index,
+				db.ErrAddressNotFound)
+		}
+
+		return fmt.Errorf("resolve credit address %d: %w", index, err)
+	}
+
+	outputIndex, err := db.Uint32ToInt32(index)
+	if err != nil {
+		return fmt.Errorf("convert credit index %d: %w", index, err)
+	}
+
+	_, err = qtx.InsertUtxo(ctx, sqlc.InsertUtxoParams{
+		WalletID:    int64(params.WalletID),
+		TxID:        txID,
+		OutputIndex: outputIndex,
+		Amount:      params.Tx.TxOut[index].Value,
+		AddressID:   addrRow.ID,
+	})
+	if err != nil {
+		return fmt.Errorf("insert credit output %d: %w", index, err)
+	}
+
+	return nil
+}
+
+// markExistingChildSpends attaches already-stored active child transaction
+// inputs to any credited outputs created by params.Tx.
+func markExistingChildSpends(ctx context.Context, ops *createTxOps,
+	params db.CreateTxParams, txID int64) error {
+
+	if len(params.Credits) == 0 {
+		return nil
+	}
+
+	qtx := ops.qtx
+
+	rows, err := qtx.ListActiveTransactionRaws(ctx, int64(params.WalletID))
+	if err != nil {
+		return fmt.Errorf("list active txns: %w", err)
+	}
+
+	parentHash := params.Tx.TxHash()
+
+	childSpends, err := collectExistingChildSpends(
+		rows, parentHash, params, txID,
+	)
+	if err != nil {
+		return err
+	}
+
+	outPoints := make([]wire.OutPoint, 0, len(childSpends))
+	for outPoint := range childSpends {
+		outPoints = append(outPoints, outPoint)
+	}
+
+	sort.Slice(outPoints, func(i, j int) bool {
+		return outPoints[i].Index < outPoints[j].Index
+	})
+
+	activeSpends := make(map[wire.OutPoint][]existingChildSpend, len(outPoints))
+	for _, outPoint := range outPoints {
+		spends, err := activeExistingChildSpends(
+			ctx, qtx, params.WalletID, childSpends[outPoint],
 		)
 		if err != nil {
 			return err
 		}
 
-		if creditExists {
-			continue
-		}
+		activeSpends[outPoint] = spends
+	}
 
-		lookupScript, err := creditLookupScript(params, index)
-		if err != nil {
-			return err
-		}
+	scheduledReplacements, err := validateExistingChildSpendGroups(
+		activeSpends,
+	)
+	if err != nil {
+		return err
+	}
 
-		addrRow, err := qtx.GetAddressByScriptPubKey(
-			ctx, sqlc.GetAddressByScriptPubKeyParams{
-				ScriptPubKey: lookupScript,
-				WalletID:     int64(params.WalletID),
-			},
+	appliedReplacements := make(map[int64]struct{}, len(scheduledReplacements))
+	for _, outPoint := range outPoints {
+		spends := activeSpends[outPoint]
+
+		err = reconcileExistingChildSpends(
+			ctx, ops, params, spends, scheduledReplacements,
+			appliedReplacements,
 		)
 		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return fmt.Errorf("credit output %d: %w", index,
-					db.ErrAddressNotFound)
-			}
-
-			return fmt.Errorf("resolve credit address %d: %w", index, err)
-		}
-
-		outputIndex, err := db.Uint32ToInt32(index)
-		if err != nil {
-			return fmt.Errorf("convert credit index %d: %w", index, err)
-		}
-
-		_, err = qtx.InsertUtxo(ctx, sqlc.InsertUtxoParams{
-			WalletID:    int64(params.WalletID),
-			TxID:        txID,
-			OutputIndex: outputIndex,
-			Amount:      params.Tx.TxOut[index].Value,
-			AddressID:   addrRow.ID,
-		})
-		if err != nil {
-			return fmt.Errorf("insert credit output %d: %w", index, err)
+			return err
 		}
 	}
 
 	return nil
 }
 
-// creditExists reports whether the wallet already has a UTXO row for the
-// given credited output, even if that output is now spent by a child tx.
+// validateExistingChildSpendGroups validates every credited-output spend group
+// before reconciliation mutates any spend edges.
+func validateExistingChildSpendGroups(
+	groups map[wire.OutPoint][]existingChildSpend) (map[int64]struct{}, error) {
+
+	scheduledReplacements := make(map[int64]struct{})
+	for _, spends := range groups {
+		confirmed, unmined := splitExistingChildSpends(spends)
+		if len(confirmed) > 1 {
+			return nil, db.ErrTxInputConflict
+		}
+
+		if len(confirmed) == 0 {
+			continue
+		}
+
+		for _, spend := range unmined {
+			scheduledReplacements[spend.id] = struct{}{}
+		}
+	}
+
+	for _, spends := range groups {
+		confirmed, unmined := splitExistingChildSpends(spends)
+		if len(confirmed) != 0 {
+			continue
+		}
+
+		unmined = filterExistingChildSpendsByID(
+			unmined, scheduledReplacements,
+		)
+		if len(unmined) > 1 {
+			return nil, db.ErrTxInputConflict
+		}
+	}
+
+	return scheduledReplacements, nil
+}
+
+// filterExistingChildSpendsByID removes spends whose child transaction ID is in
+// the skip set.
+func filterExistingChildSpendsByID(spends []existingChildSpend,
+	skip map[int64]struct{}) []existingChildSpend {
+
+	filtered := spends[:0]
+	for _, spend := range spends {
+		if _, ok := skip[spend.id]; ok {
+			continue
+		}
+
+		filtered = append(filtered, spend)
+	}
+
+	return filtered
+}
+
+// collectExistingChildSpends groups active children by the credited parent
+// outpoint they spend.
+func collectExistingChildSpends(rows []sqlc.ListActiveTransactionRawsRow,
+	parentHash chainhash.Hash, params db.CreateTxParams, txID int64) (
+	map[wire.OutPoint][]existingChildSpend, error) {
+
+	spends := make(map[wire.OutPoint][]existingChildSpend)
+	for _, row := range rows {
+		if row.ID == txID {
+			continue
+		}
+
+		txHash, err := chainhash.NewHash(row.TxHash)
+		if err != nil {
+			return nil, fmt.Errorf("active child tx hash %d: %w", row.ID,
+				err)
+		}
+
+		childTx, err := deserializeActiveTx(row.ID, row.RawTx)
+		if err != nil {
+			return nil, err
+		}
+
+		addChildInputSpends(
+			spends, childTx, parentHash, params, row.ID, *txHash,
+			row.BlockHeight.Valid,
+		)
+	}
+
+	return spends, nil
+}
+
+// activeExistingChildSpends filters one snapshot group to children that still
+// belong to the active spend set.
+func activeExistingChildSpends(ctx context.Context, qtx *sqlc.Queries,
+	walletID uint32, spends []existingChildSpend) ([]existingChildSpend,
+	error) {
+
+	active := make([]existingChildSpend, 0, len(spends))
+	for _, spend := range spends {
+		row, err := qtx.GetTransactionByHash(
+			ctx, sqlc.GetTransactionByHashParams{
+				WalletID: int64(walletID),
+				TxHash:   spend.hash[:],
+			},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("refresh existing child %d: %w",
+				spend.id, err)
+		}
+
+		status, err := db.ParseTxStatus(int64(row.TxStatus))
+		if err != nil {
+			return nil, fmt.Errorf("refresh existing child %d: %w",
+				spend.id, err)
+		}
+
+		if !db.IsUnminedStatus(status) {
+			continue
+		}
+
+		spend.confirmed = row.BlockHeight.Valid
+		active = append(active, spend)
+	}
+
+	return active, nil
+}
+
+// addChildInputSpends appends child inputs that spend credited parent outputs.
+func addChildInputSpends(spends map[wire.OutPoint][]existingChildSpend,
+	childTx *wire.MsgTx, parentHash chainhash.Hash, params db.CreateTxParams,
+	childTxID int64, childHash chainhash.Hash, confirmed bool) {
+
+	for inputIndex, txIn := range childTx.TxIn {
+		prevOut := txIn.PreviousOutPoint
+		if prevOut.Hash != parentHash {
+			continue
+		}
+
+		if _, ok := params.Credits[prevOut.Index]; !ok {
+			continue
+		}
+
+		spends[prevOut] = append(spends[prevOut], existingChildSpend{
+			id:         childTxID,
+			hash:       childHash,
+			confirmed:  confirmed,
+			inputIndex: inputIndex,
+			prevOut:    prevOut,
+		})
+	}
+}
+
+// deserializeActiveTx deserializes one active transaction row.
+func deserializeActiveTx(txID int64, rawTx []byte) (*wire.MsgTx, error) {
+	var msgTx wire.MsgTx
+
+	err := msgTx.Deserialize(bytes.NewReader(rawTx))
+	if err != nil {
+		return nil, fmt.Errorf("deserialize active tx %d: %w", txID, err)
+	}
+
+	return &msgTx, nil
+}
+
+// reconcileExistingChildSpends reconciles all active children that spend one
+// newly discovered parent credit before any spend edge is mutated.
+func reconcileExistingChildSpends(ctx context.Context, ops *createTxOps,
+	params db.CreateTxParams, spends []existingChildSpend,
+	scheduledReplacements, appliedReplacements map[int64]struct{}) error {
+
+	confirmed, unmined := splitExistingChildSpends(spends)
+	if len(confirmed) > 1 {
+		return db.ErrTxInputConflict
+	}
+
+	if len(confirmed) == 0 {
+		unmined = filterExistingChildSpendsByID(
+			unmined, scheduledReplacements,
+		)
+		if len(unmined) == 0 {
+			return nil
+		}
+
+		if len(unmined) != 1 {
+			return db.ErrTxInputConflict
+		}
+
+		return markChildInputSpent(ctx, ops.qtx, params, unmined[0])
+	}
+
+	confirmedSpend := confirmed[0]
+
+	unmined = filterExistingChildSpendsByID(unmined, appliedReplacements)
+	if len(unmined) > 0 {
+		err := replaceUnminedChildSpends(
+			ctx, ops, params, confirmedSpend.id, unmined,
+		)
+		if err != nil {
+			return err
+		}
+
+		for _, spend := range unmined {
+			appliedReplacements[spend.id] = struct{}{}
+		}
+	}
+
+	return markChildInputSpent(ctx, ops.qtx, params, confirmedSpend)
+}
+
+// splitExistingChildSpends separates confirmed child spends from unmined child
+// spends.
+func splitExistingChildSpends(spends []existingChildSpend) (
+	[]existingChildSpend, []existingChildSpend) {
+
+	confirmed := make([]existingChildSpend, 0, len(spends))
+	unmined := make([]existingChildSpend, 0, len(spends))
+
+	for _, spend := range spends {
+		if spend.confirmed {
+			confirmed = append(confirmed, spend)
+
+			continue
+		}
+
+		unmined = append(unmined, spend)
+	}
+
+	return confirmed, unmined
+}
+
+// replaceUnminedChildSpends marks unmined child spends replaced by a confirmed
+// child spend.
+func replaceUnminedChildSpends(ctx context.Context, ops *createTxOps,
+	params db.CreateTxParams, confirmedTxID int64,
+	unmined []existingChildSpend) error {
+
+	rootIDs := make([]int64, 0, len(unmined))
+	rootHashes := make([]chainhash.Hash, 0, len(unmined))
+
+	for _, spend := range unmined {
+		rootIDs = append(rootIDs, spend.id)
+		rootHashes = append(rootHashes, spend.hash)
+	}
+
+	err := db.ReplaceUnminedTxConflicts(
+		ctx, int64(params.WalletID), rootIDs, rootHashes, confirmedTxID,
+		ops,
+	)
+	if err != nil {
+		return fmt.Errorf("replace existing child spends: %w", err)
+	}
+
+	return nil
+}
+
+// markChildInputSpent attaches one child input to its credited parent output.
+func markChildInputSpent(ctx context.Context, qtx *sqlc.Queries,
+	params db.CreateTxParams, spend existingChildSpend) error {
+
+	outputIndex, err := db.Uint32ToInt32(spend.prevOut.Index)
+	if err != nil {
+		return fmt.Errorf("convert child outpoint index %d: %w",
+			spend.inputIndex, err)
+	}
+
+	spentInputIndex, err := db.Int64ToInt32(int64(spend.inputIndex))
+	if err != nil {
+		return fmt.Errorf("convert child input index %d: %w",
+			spend.inputIndex, err)
+	}
+
+	rowsAffected, err := qtx.MarkUtxoSpent(
+		ctx, sqlc.MarkUtxoSpentParams{
+			WalletID:    int64(params.WalletID),
+			TxHash:      spend.prevOut.Hash[:],
+			OutputIndex: outputIndex,
+			SpentByTxID: sql.NullInt64{
+				Int64: spend.id,
+				Valid: true,
+			},
+			SpentInputIndex: sql.NullInt32{
+				Int32: spentInputIndex,
+				Valid: true,
+			},
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("mark existing child %d input %d: %w",
+			spend.id, spend.inputIndex, err)
+	}
+
+	if rowsAffected != 0 {
+		return nil
+	}
+
+	err = ensureSpendConflict(
+		ctx, qtx, params.WalletID, spend.prevOut.Hash, outputIndex,
+		spend.id,
+	)
+	if err != nil {
+		return fmt.Errorf("mark existing child %d input %d: %w",
+			spend.id, spend.inputIndex, err)
+	}
+
+	return nil
+}
+
+// creditExists reports whether the wallet already has a UTXO row for the given
+// credited output, even if that output is now spent by a child tx. When the row
+// exists, it also returns the script used to resolve the owner address.
 func creditExists(ctx context.Context, qtx *sqlc.Queries,
-	walletID uint32, txHash chainhash.Hash, outputIndex uint32) (bool, error) {
+	walletID uint32, txHash chainhash.Hash, outputIndex uint32) (bool, []byte,
+	error) {
 
 	convertedIndex, err := db.Uint32ToInt32(outputIndex)
 	if err != nil {
-		return false, fmt.Errorf("convert credit index %d: %w", outputIndex,
-			err)
+		return false, nil, fmt.Errorf("convert credit index %d: %w",
+			outputIndex, err)
 	}
 
-	_, err = qtx.GetUtxoSpendByOutpoint(
+	row, err := qtx.GetUtxoSpendByOutpoint(
 		ctx, sqlc.GetUtxoSpendByOutpointParams{
 			WalletID:    int64(walletID),
 			TxHash:      txHash[:],
@@ -423,14 +864,14 @@ func creditExists(ctx context.Context, qtx *sqlc.Queries,
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return false, nil
+			return false, nil, nil
 		}
 
-		return false, fmt.Errorf("lookup credit output %d: %w", outputIndex,
-			err)
+		return false, nil, fmt.Errorf("lookup credit output %d: %w",
+			outputIndex, err)
 	}
 
-	return true, nil
+	return true, row.ScriptPubKey, nil
 }
 
 // markInputsSpent attaches wallet-owned outpoints spent by the stored
@@ -493,7 +934,7 @@ func ensureSpendConflict(ctx context.Context, qtx *sqlc.Queries,
 	walletID uint32, txHash chainhash.Hash, outputIndex int32,
 	txID int64) error {
 
-	spendByTxID, err := qtx.GetUtxoSpendByOutpoint(
+	spend, err := qtx.GetUtxoSpendByOutpoint(
 		ctx, sqlc.GetUtxoSpendByOutpointParams{
 			WalletID:    int64(walletID),
 			TxHash:      txHash[:],
@@ -510,8 +951,7 @@ func ensureSpendConflict(ctx context.Context, qtx *sqlc.Queries,
 		return fmt.Errorf("check spend conflict: %w", err)
 	}
 
-	if spendByTxID.SpentByTxID.Valid &&
-		spendByTxID.SpentByTxID.Int64 != txID {
+	if spend.SpentByTxID.Valid && spend.SpentByTxID.Int64 != txID {
 		return db.ErrTxInputConflict
 	}
 

--- a/wallet/internal/db/pg/txstore_createtx.go
+++ b/wallet/internal/db/pg/txstore_createtx.go
@@ -185,11 +185,11 @@ func collectConflictRootIDs(ctx context.Context, qtx *sqlc.Queries,
 				err)
 		}
 
-		if !spentByTxID.Valid {
+		if !spentByTxID.SpentByTxID.Valid {
 			continue
 		}
 
-		rootIDs[spentByTxID.Int64] = struct{}{}
+		rootIDs[spentByTxID.SpentByTxID.Int64] = struct{}{}
 	}
 
 	return rootIDs, nil
@@ -510,7 +510,8 @@ func ensureSpendConflict(ctx context.Context, qtx *sqlc.Queries,
 		return fmt.Errorf("check spend conflict: %w", err)
 	}
 
-	if spendByTxID.Valid && spendByTxID.Int64 != txID {
+	if spendByTxID.SpentByTxID.Valid &&
+		spendByTxID.SpentByTxID.Int64 != txID {
 		return db.ErrTxInputConflict
 	}
 

--- a/wallet/internal/db/pg/utxostore_listoutputstowatch.go
+++ b/wallet/internal/db/pg/utxostore_listoutputstowatch.go
@@ -1,0 +1,51 @@
+package pg
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+)
+
+// ListOutputsToWatch returns UTXOs that recovery scans should watch.
+//
+// The result mirrors the legacy wtxmgr OutputsToWatch contract: it returns
+// every known output (unspent, locked, or spent only by an unmined
+// transaction) but populates just the OutPoint and PkScript, since those are
+// the only fields a rescan consumes.
+func (s *Store) ListOutputsToWatch(ctx context.Context,
+	walletID uint32) ([]db.UtxoInfo, error) {
+
+	var utxos []db.UtxoInfo
+
+	err := s.execRead(ctx, func(q *sqlc.Queries) error {
+		rows, err := q.ListOutputsToWatch(ctx, int64(walletID))
+		if err != nil {
+			return fmt.Errorf("list outputs to watch: %w", err)
+		}
+
+		utxos = make([]db.UtxoInfo, len(rows))
+		for i, row := range rows {
+			utxo, err := db.WatchOutputFromRow(
+				row.TxHash, int64(row.OutputIndex), row.RawTx,
+			)
+			if err != nil {
+				return err
+			}
+
+			utxos[i] = *utxo
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(utxos) == 0 {
+		return []db.UtxoInfo{}, nil
+	}
+
+	return utxos, nil
+}

--- a/wallet/internal/db/sqlite/backend_rows_test.go
+++ b/wallet/internal/db/sqlite/backend_rows_test.go
@@ -66,7 +66,7 @@ func TestCreateTxOpsAdditionalBranches(t *testing.T) {
 	conflictOps := &createTxOps{
 		invalidateUnminedTxOps: invalidateUnminedTxOps{
 			qtx: sqlc.New(rowDBTX{
-				row:      newRow(t, "SELECT ?", int64(5)),
+				row:      newRow(t, "SELECT ?, ?", int64(5), []byte{1}),
 				queryErr: errDummy,
 			}),
 		},

--- a/wallet/internal/db/sqlite/txstore_batch.go
+++ b/wallet/internal/db/sqlite/txstore_batch.go
@@ -1,0 +1,123 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+)
+
+// ApplyTxBatch atomically records transactions and an optional sync-tip update.
+func (s *Store) ApplyTxBatch(ctx context.Context,
+	params db.TxBatchParams) error {
+
+	// Reject a batch that mixes wallets before opening the write transaction:
+	// the sync tip is updated for params.WalletID, so a transaction owned by a
+	// different wallet must not ride along in the same atomic batch.
+	err := db.ValidateBatchTransactionsWalletID(
+		params.WalletID, params.Transactions,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Reject a nil-Tx member before SortTxBatchParentsFirst dereferences each
+	// transaction below; the per-tx NewCreateTxRequest check in
+	// applyBatchTransaction runs only after the sort.
+	err = db.ValidateBatchTransactionsTx(params.Transactions)
+	if err != nil {
+		return err
+	}
+
+	return s.execWrite(ctx, func(qtx *sqlc.Queries) error {
+		// CreateTxWithOps needs each confirming block row during
+		// PrepareBlock, so materialize all batch transaction blocks before
+		// any transaction is created.
+		err := ensureBatchTxBlocks(ctx, qtx, params.Transactions)
+		if err != nil {
+			return err
+		}
+
+		err = applyBatchSyncTip(ctx, qtx, params)
+		if err != nil {
+			return err
+		}
+
+		// Record any in-batch parent before its children. Each tx claims
+		// its spent parent inputs by updating the parent credit's UTXO row,
+		// so a child applied before its in-batch parent would update no row
+		// and silently drop the spend edge. Sorting parents first makes the
+		// batch order-independent; an already parents-first or
+		// dependency-free batch is returned unchanged.
+		txs := db.SortTxBatchParentsFirst(params.Transactions)
+
+		for i := range txs {
+			req, err := db.NewCreateTxRequest(txs[i])
+			if err != nil {
+				return fmt.Errorf("validate tx %d: %w", i, err)
+			}
+
+			err = db.CreateTxWithOps(ctx, req, &createTxOps{
+				invalidateUnminedTxOps: invalidateUnminedTxOps{
+					qtx: qtx,
+				},
+			})
+			if err != nil {
+				return fmt.Errorf("create tx %d: %w", i, err)
+			}
+		}
+
+		return nil
+	})
+}
+
+// ensureBatchTxBlocks materializes every confirming block referenced by a batch
+// transaction before the transaction rows are created.
+func ensureBatchTxBlocks(ctx context.Context, qtx *sqlc.Queries,
+	txs []db.CreateTxParams) error {
+
+	for i := range txs {
+		if txs[i].Block == nil {
+			continue
+		}
+
+		err := ensureBlockExists(ctx, qtx, txs[i].Block)
+		if err != nil {
+			return fmt.Errorf("tx %d block: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
+// applyBatchSyncTip applies the optional sync-tip update within a batch.
+func applyBatchSyncTip(ctx context.Context, qtx *sqlc.Queries,
+	params db.TxBatchParams) error {
+
+	if params.SyncedTo == nil {
+		return nil
+	}
+
+	err := ensureBlockExists(ctx, qtx, params.SyncedTo)
+	if err != nil {
+		return fmt.Errorf("ensure synced block: %w", err)
+	}
+
+	syncParams := buildUpdateSyncParams(db.UpdateWalletParams{
+		WalletID: params.WalletID,
+		SyncedTo: params.SyncedTo,
+	})
+
+	rowsAffected, err := qtx.UpdateWalletSyncState(ctx, syncParams)
+	if err != nil {
+		return fmt.Errorf("update wallet sync state: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return fmt.Errorf("wallet sync state for wallet %d: %w",
+			params.WalletID, db.ErrWalletNotFound)
+	}
+
+	return nil
+}

--- a/wallet/internal/db/sqlite/txstore_createtx.go
+++ b/wallet/internal/db/sqlite/txstore_createtx.go
@@ -1,14 +1,17 @@
 package sqlite
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 )
@@ -52,9 +55,9 @@ var _ db.CreateTxOps = (*createTxOps)(nil)
 func (o *createTxOps) LoadExisting(ctx context.Context,
 	req db.CreateTxRequest) (*db.CreateTxExistingTarget, error) {
 
-	meta, err := o.qtx.GetTransactionMetaByHash(
+	row, err := o.qtx.GetTransactionByHash(
 		ctx,
-		sqlc.GetTransactionMetaByHashParams{
+		sqlc.GetTransactionByHashParams{
 			WalletID: int64(req.Params.WalletID),
 			TxHash:   req.TxHash[:],
 		},
@@ -67,16 +70,38 @@ func (o *createTxOps) LoadExisting(ctx context.Context,
 		return nil, fmt.Errorf("get tx metadata: %w", err)
 	}
 
-	status, err := db.ParseTxStatus(meta.TxStatus)
+	status, err := db.ParseTxStatus(row.TxStatus)
 	if err != nil {
 		return nil, err
 	}
 
+	var (
+		blockHeight *uint32
+		blockHash   *chainhash.Hash
+	)
+	if row.BlockHeight.Valid {
+		block, err := buildBlock(
+			row.BlockHeight, row.BlockHash, row.BlockTimestamp,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		height := block.Height
+		blockHeight = &height
+
+		hash := block.Hash
+		blockHash = &hash
+	}
+
 	return &db.CreateTxExistingTarget{
-		ID:         meta.ID,
-		Status:     status,
-		HasBlock:   meta.BlockHeight.Valid,
-		IsCoinbase: meta.IsCoinbase,
+		ID:          row.ID,
+		Status:      status,
+		HasBlock:    row.BlockHeight.Valid,
+		BlockHeight: blockHeight,
+		BlockHash:   blockHash,
+		IsCoinbase:  row.IsCoinbase,
+		Label:       row.TxLabel,
 	}, nil
 }
 
@@ -164,7 +189,7 @@ func collectConflictRootIDs(ctx context.Context,
 
 	rootIDs := make(map[int64]struct{}, len(req.Params.Tx.TxIn))
 	for inputIndex, txIn := range req.Params.Tx.TxIn {
-		spentByTxID, err := qtx.GetUtxoSpendByOutpoint(
+		spend, err := qtx.GetUtxoSpendByOutpoint(
 			ctx, sqlc.GetUtxoSpendByOutpointParams{
 				WalletID:    int64(req.Params.WalletID),
 				TxHash:      txIn.PreviousOutPoint.Hash[:],
@@ -180,11 +205,11 @@ func collectConflictRootIDs(ctx context.Context,
 				err)
 		}
 
-		if !spentByTxID.SpentByTxID.Valid {
+		if !spend.SpentByTxID.Valid {
 			continue
 		}
 
-		rootIDs[spentByTxID.SpentByTxID.Int64] = struct{}{}
+		rootIDs[spend.SpentByTxID.Int64] = struct{}{}
 	}
 
 	return rootIDs, nil
@@ -244,7 +269,7 @@ func (o *createTxOps) Insert(ctx context.Context,
 func (o *createTxOps) InsertCredits(ctx context.Context,
 	req db.CreateTxRequest, txID int64) error {
 
-	return insertCredits(ctx, o.qtx, req.Params, txID)
+	return insertCredits(ctx, o, req.Params, txID)
 }
 
 // MarkInputsSpent records wallet-owned inputs spent by the transaction.
@@ -344,64 +369,470 @@ func creditLookupScript(params db.CreateTxParams, index uint32) ([]byte,
 	return lookupScript, nil
 }
 
+// existingChildSpend describes one already-stored active transaction input that
+// spends an output whose wallet ownership was discovered later.
+type existingChildSpend struct {
+	// id is the stored child transaction row ID.
+	id int64
+
+	// hash is the child transaction hash used for descendant discovery.
+	hash chainhash.Hash
+
+	// confirmed reports whether the child row has confirming block metadata.
+	confirmed bool
+
+	// inputIndex is the input index that spends prevOut.
+	inputIndex int
+
+	// prevOut is the parent output spent by the child input.
+	prevOut wire.OutPoint
+}
+
 // insertCredits inserts one wallet-owned UTXO row for each credited
 // output of the transaction being stored.
-func insertCredits(ctx context.Context, qtx *sqlc.Queries,
+func insertCredits(ctx context.Context, ops *createTxOps,
 	params db.CreateTxParams, txID int64) error {
 
 	for index := range params.Credits {
-		creditExists, err := creditExists(
-			ctx, qtx, params.WalletID, params.Tx.TxHash(), index,
+		err := insertCredit(ctx, ops.qtx, params, txID, index)
+		if err != nil {
+			return err
+		}
+	}
+
+	err := markExistingChildSpends(ctx, ops, params, txID)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// insertCredit inserts or validates one wallet-owned UTXO row for a credited
+// output.
+func insertCredit(ctx context.Context, qtx *sqlc.Queries,
+	params db.CreateTxParams, txID int64, index uint32) error {
+
+	lookupScript, err := creditLookupScript(params, index)
+	if err != nil {
+		return err
+	}
+
+	creditExists, existingScript, err := creditExists(
+		ctx, qtx, params.WalletID, params.Tx.TxHash(), index,
+	)
+	if err != nil {
+		return err
+	}
+
+	if creditExists {
+		if !bytes.Equal(existingScript, lookupScript) {
+			return fmt.Errorf("credit output %d owner mismatch: %w",
+				index, db.ErrTxAlreadyExists)
+		}
+
+		return nil
+	}
+
+	addrRow, err := qtx.GetAddressByScriptPubKey(
+		ctx, sqlc.GetAddressByScriptPubKeyParams{
+			ScriptPubKey: lookupScript,
+			WalletID:     int64(params.WalletID),
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("credit output %d: %w", index,
+				db.ErrAddressNotFound)
+		}
+
+		return fmt.Errorf("resolve credit address %d: %w", index, err)
+	}
+
+	_, err = qtx.InsertUtxo(ctx, sqlc.InsertUtxoParams{
+		WalletID:    int64(params.WalletID),
+		TxID:        txID,
+		OutputIndex: int64(index),
+		Amount:      params.Tx.TxOut[index].Value,
+		AddressID:   addrRow.ID,
+	})
+	if err != nil {
+		return fmt.Errorf("insert credit output %d: %w", index, err)
+	}
+
+	return nil
+}
+
+// markExistingChildSpends attaches already-stored active child transaction
+// inputs to any credited outputs created by params.Tx.
+func markExistingChildSpends(ctx context.Context, ops *createTxOps,
+	params db.CreateTxParams, txID int64) error {
+
+	if len(params.Credits) == 0 {
+		return nil
+	}
+
+	qtx := ops.qtx
+
+	rows, err := qtx.ListActiveTransactionRaws(ctx, int64(params.WalletID))
+	if err != nil {
+		return fmt.Errorf("list active txns: %w", err)
+	}
+
+	parentHash := params.Tx.TxHash()
+
+	childSpends, err := collectExistingChildSpends(
+		rows, parentHash, params, txID,
+	)
+	if err != nil {
+		return err
+	}
+
+	outPoints := make([]wire.OutPoint, 0, len(childSpends))
+	for outPoint := range childSpends {
+		outPoints = append(outPoints, outPoint)
+	}
+
+	sort.Slice(outPoints, func(i, j int) bool {
+		return outPoints[i].Index < outPoints[j].Index
+	})
+
+	activeSpends := make(map[wire.OutPoint][]existingChildSpend, len(outPoints))
+	for _, outPoint := range outPoints {
+		spends, err := activeExistingChildSpends(
+			ctx, qtx, params.WalletID, childSpends[outPoint],
 		)
 		if err != nil {
 			return err
 		}
 
-		if creditExists {
-			continue
-		}
+		activeSpends[outPoint] = spends
+	}
 
-		lookupScript, err := creditLookupScript(params, index)
-		if err != nil {
-			return err
-		}
+	scheduledReplacements, err := validateExistingChildSpendGroups(
+		activeSpends,
+	)
+	if err != nil {
+		return err
+	}
 
-		addrRow, err := qtx.GetAddressByScriptPubKey(
-			ctx, sqlc.GetAddressByScriptPubKeyParams{
-				ScriptPubKey: lookupScript,
-				WalletID:     int64(params.WalletID),
-			},
+	appliedReplacements := make(map[int64]struct{}, len(scheduledReplacements))
+	for _, outPoint := range outPoints {
+		spends := activeSpends[outPoint]
+
+		err = reconcileExistingChildSpends(
+			ctx, ops, params, spends, scheduledReplacements,
+			appliedReplacements,
 		)
 		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return fmt.Errorf("credit output %d: %w", index,
-					db.ErrAddressNotFound)
-			}
-
-			return fmt.Errorf("resolve credit address %d: %w", index, err)
-		}
-
-		_, err = qtx.InsertUtxo(ctx, sqlc.InsertUtxoParams{
-			WalletID:    int64(params.WalletID),
-			TxID:        txID,
-			OutputIndex: int64(index),
-			Amount:      params.Tx.TxOut[index].Value,
-			AddressID:   addrRow.ID,
-		})
-		if err != nil {
-			return fmt.Errorf("insert credit output %d: %w", index, err)
+			return err
 		}
 	}
 
 	return nil
 }
 
-// creditExists reports whether the wallet already has a UTXO row for the
-// given credited output, even if that output is now spent by a child tx.
-func creditExists(ctx context.Context, qtx *sqlc.Queries,
-	walletID uint32, txHash chainhash.Hash, outputIndex uint32) (bool, error) {
+// validateExistingChildSpendGroups validates every credited-output spend group
+// before reconciliation mutates any spend edges.
+func validateExistingChildSpendGroups(
+	groups map[wire.OutPoint][]existingChildSpend) (map[int64]struct{}, error) {
 
-	_, err := qtx.GetUtxoSpendByOutpoint(
+	scheduledReplacements := make(map[int64]struct{})
+	for _, spends := range groups {
+		confirmed, unmined := splitExistingChildSpends(spends)
+		if len(confirmed) > 1 {
+			return nil, db.ErrTxInputConflict
+		}
+
+		if len(confirmed) == 0 {
+			continue
+		}
+
+		for _, spend := range unmined {
+			scheduledReplacements[spend.id] = struct{}{}
+		}
+	}
+
+	for _, spends := range groups {
+		confirmed, unmined := splitExistingChildSpends(spends)
+		if len(confirmed) != 0 {
+			continue
+		}
+
+		unmined = filterExistingChildSpendsByID(
+			unmined, scheduledReplacements,
+		)
+		if len(unmined) > 1 {
+			return nil, db.ErrTxInputConflict
+		}
+	}
+
+	return scheduledReplacements, nil
+}
+
+// filterExistingChildSpendsByID removes spends whose child transaction ID is in
+// the skip set.
+func filterExistingChildSpendsByID(spends []existingChildSpend,
+	skip map[int64]struct{}) []existingChildSpend {
+
+	filtered := spends[:0]
+	for _, spend := range spends {
+		if _, ok := skip[spend.id]; ok {
+			continue
+		}
+
+		filtered = append(filtered, spend)
+	}
+
+	return filtered
+}
+
+// collectExistingChildSpends groups active children by the credited parent
+// outpoint they spend.
+func collectExistingChildSpends(rows []sqlc.ListActiveTransactionRawsRow,
+	parentHash chainhash.Hash, params db.CreateTxParams, txID int64) (
+	map[wire.OutPoint][]existingChildSpend, error) {
+
+	spends := make(map[wire.OutPoint][]existingChildSpend)
+	for _, row := range rows {
+		if row.ID == txID {
+			continue
+		}
+
+		txHash, err := chainhash.NewHash(row.TxHash)
+		if err != nil {
+			return nil, fmt.Errorf("active child tx hash %d: %w", row.ID,
+				err)
+		}
+
+		childTx, err := deserializeActiveTx(row.ID, row.RawTx)
+		if err != nil {
+			return nil, err
+		}
+
+		addChildInputSpends(
+			spends, childTx, parentHash, params, row.ID, *txHash,
+			row.BlockHeight.Valid,
+		)
+	}
+
+	return spends, nil
+}
+
+// activeExistingChildSpends filters one snapshot group to children that still
+// belong to the active spend set.
+func activeExistingChildSpends(ctx context.Context, qtx *sqlc.Queries,
+	walletID uint32, spends []existingChildSpend) ([]existingChildSpend,
+	error) {
+
+	active := make([]existingChildSpend, 0, len(spends))
+	for _, spend := range spends {
+		row, err := qtx.GetTransactionByHash(
+			ctx, sqlc.GetTransactionByHashParams{
+				WalletID: int64(walletID),
+				TxHash:   spend.hash[:],
+			},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("refresh existing child %d: %w",
+				spend.id, err)
+		}
+
+		status, err := db.ParseTxStatus(row.TxStatus)
+		if err != nil {
+			return nil, fmt.Errorf("refresh existing child %d: %w",
+				spend.id, err)
+		}
+
+		if !db.IsUnminedStatus(status) {
+			continue
+		}
+
+		spend.confirmed = row.BlockHeight.Valid
+		active = append(active, spend)
+	}
+
+	return active, nil
+}
+
+// addChildInputSpends appends child inputs that spend credited parent outputs.
+func addChildInputSpends(spends map[wire.OutPoint][]existingChildSpend,
+	childTx *wire.MsgTx, parentHash chainhash.Hash, params db.CreateTxParams,
+	childTxID int64, childHash chainhash.Hash, confirmed bool) {
+
+	for inputIndex, txIn := range childTx.TxIn {
+		prevOut := txIn.PreviousOutPoint
+		if prevOut.Hash != parentHash {
+			continue
+		}
+
+		if _, ok := params.Credits[prevOut.Index]; !ok {
+			continue
+		}
+
+		spends[prevOut] = append(spends[prevOut], existingChildSpend{
+			id:         childTxID,
+			hash:       childHash,
+			confirmed:  confirmed,
+			inputIndex: inputIndex,
+			prevOut:    prevOut,
+		})
+	}
+}
+
+// deserializeActiveTx deserializes one active transaction row.
+func deserializeActiveTx(txID int64, rawTx []byte) (*wire.MsgTx, error) {
+	var msgTx wire.MsgTx
+
+	err := msgTx.Deserialize(bytes.NewReader(rawTx))
+	if err != nil {
+		return nil, fmt.Errorf("deserialize active tx %d: %w", txID, err)
+	}
+
+	return &msgTx, nil
+}
+
+// reconcileExistingChildSpends reconciles all active children that spend one
+// newly discovered parent credit before any spend edge is mutated.
+func reconcileExistingChildSpends(ctx context.Context, ops *createTxOps,
+	params db.CreateTxParams, spends []existingChildSpend,
+	scheduledReplacements, appliedReplacements map[int64]struct{}) error {
+
+	confirmed, unmined := splitExistingChildSpends(spends)
+	if len(confirmed) > 1 {
+		return db.ErrTxInputConflict
+	}
+
+	if len(confirmed) == 0 {
+		unmined = filterExistingChildSpendsByID(
+			unmined, scheduledReplacements,
+		)
+		if len(unmined) == 0 {
+			return nil
+		}
+
+		if len(unmined) != 1 {
+			return db.ErrTxInputConflict
+		}
+
+		return markChildInputSpent(ctx, ops.qtx, params, unmined[0])
+	}
+
+	confirmedSpend := confirmed[0]
+
+	unmined = filterExistingChildSpendsByID(unmined, appliedReplacements)
+	if len(unmined) > 0 {
+		err := replaceUnminedChildSpends(
+			ctx, ops, params, confirmedSpend.id, unmined,
+		)
+		if err != nil {
+			return err
+		}
+
+		for _, spend := range unmined {
+			appliedReplacements[spend.id] = struct{}{}
+		}
+	}
+
+	return markChildInputSpent(ctx, ops.qtx, params, confirmedSpend)
+}
+
+// splitExistingChildSpends separates confirmed child spends from unmined child
+// spends.
+func splitExistingChildSpends(spends []existingChildSpend) (
+	[]existingChildSpend, []existingChildSpend) {
+
+	confirmed := make([]existingChildSpend, 0, len(spends))
+	unmined := make([]existingChildSpend, 0, len(spends))
+
+	for _, spend := range spends {
+		if spend.confirmed {
+			confirmed = append(confirmed, spend)
+
+			continue
+		}
+
+		unmined = append(unmined, spend)
+	}
+
+	return confirmed, unmined
+}
+
+// replaceUnminedChildSpends marks unmined child spends replaced by a confirmed
+// child spend.
+func replaceUnminedChildSpends(ctx context.Context, ops *createTxOps,
+	params db.CreateTxParams, confirmedTxID int64,
+	unmined []existingChildSpend) error {
+
+	rootIDs := make([]int64, 0, len(unmined))
+	rootHashes := make([]chainhash.Hash, 0, len(unmined))
+
+	for _, spend := range unmined {
+		rootIDs = append(rootIDs, spend.id)
+		rootHashes = append(rootHashes, spend.hash)
+	}
+
+	err := db.ReplaceUnminedTxConflicts(
+		ctx, int64(params.WalletID), rootIDs, rootHashes, confirmedTxID,
+		ops,
+	)
+	if err != nil {
+		return fmt.Errorf("replace existing child spends: %w", err)
+	}
+
+	return nil
+}
+
+// markChildInputSpent attaches one child input to its credited parent output.
+func markChildInputSpent(ctx context.Context, qtx *sqlc.Queries,
+	params db.CreateTxParams, spend existingChildSpend) error {
+
+	spentInputIndex := sql.NullInt64{
+		Int64: int64(spend.inputIndex),
+		Valid: true,
+	}
+
+	rowsAffected, err := qtx.MarkUtxoSpent(
+		ctx, sqlc.MarkUtxoSpentParams{
+			WalletID:    int64(params.WalletID),
+			TxHash:      spend.prevOut.Hash[:],
+			OutputIndex: int64(spend.prevOut.Index),
+			SpentByTxID: sql.NullInt64{
+				Int64: spend.id,
+				Valid: true,
+			},
+			SpentInputIndex: spentInputIndex,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("mark existing child %d input %d: %w",
+			spend.id, spend.inputIndex, err)
+	}
+
+	if rowsAffected != 0 {
+		return nil
+	}
+
+	err = ensureSpendConflict(
+		ctx, qtx, params.WalletID, spend.prevOut.Hash,
+		int64(spend.prevOut.Index), spend.id,
+	)
+	if err != nil {
+		return fmt.Errorf("mark existing child %d input %d: %w",
+			spend.id, spend.inputIndex, err)
+	}
+
+	return nil
+}
+
+// creditExists reports whether the wallet already has a UTXO row for the given
+// credited output, even if that output is now spent by a child tx. When the row
+// exists, it also returns the script used to resolve the owner address.
+func creditExists(ctx context.Context, qtx *sqlc.Queries,
+	walletID uint32, txHash chainhash.Hash, outputIndex uint32) (bool, []byte,
+	error) {
+
+	row, err := qtx.GetUtxoSpendByOutpoint(
 		ctx, sqlc.GetUtxoSpendByOutpointParams{
 			WalletID:    int64(walletID),
 			TxHash:      txHash[:],
@@ -410,14 +841,14 @@ func creditExists(ctx context.Context, qtx *sqlc.Queries,
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return false, nil
+			return false, nil, nil
 		}
 
-		return false, fmt.Errorf("lookup credit output %d: %w", outputIndex,
-			err)
+		return false, nil, fmt.Errorf("lookup credit output %d: %w",
+			outputIndex, err)
 	}
 
-	return true, nil
+	return true, row.ScriptPubKey, nil
 }
 
 // markInputsSpent attaches wallet-owned outpoints spent by the stored
@@ -472,7 +903,7 @@ func ensureSpendConflict(ctx context.Context,
 	qtx *sqlc.Queries, walletID uint32, txHash chainhash.Hash,
 	outputIndex int64, txID int64) error {
 
-	spendByTxID, err := qtx.GetUtxoSpendByOutpoint(
+	spend, err := qtx.GetUtxoSpendByOutpoint(
 		ctx, sqlc.GetUtxoSpendByOutpointParams{
 			WalletID:    int64(walletID),
 			TxHash:      txHash[:],
@@ -489,8 +920,7 @@ func ensureSpendConflict(ctx context.Context,
 		return fmt.Errorf("check spend conflict: %w", err)
 	}
 
-	if spendByTxID.SpentByTxID.Valid &&
-		spendByTxID.SpentByTxID.Int64 != txID {
+	if spend.SpentByTxID.Valid && spend.SpentByTxID.Int64 != txID {
 		return db.ErrTxInputConflict
 	}
 

--- a/wallet/internal/db/sqlite/txstore_createtx.go
+++ b/wallet/internal/db/sqlite/txstore_createtx.go
@@ -180,11 +180,11 @@ func collectConflictRootIDs(ctx context.Context,
 				err)
 		}
 
-		if !spentByTxID.Valid {
+		if !spentByTxID.SpentByTxID.Valid {
 			continue
 		}
 
-		rootIDs[spentByTxID.Int64] = struct{}{}
+		rootIDs[spentByTxID.SpentByTxID.Int64] = struct{}{}
 	}
 
 	return rootIDs, nil
@@ -489,7 +489,8 @@ func ensureSpendConflict(ctx context.Context,
 		return fmt.Errorf("check spend conflict: %w", err)
 	}
 
-	if spendByTxID.Valid && spendByTxID.Int64 != txID {
+	if spendByTxID.SpentByTxID.Valid &&
+		spendByTxID.SpentByTxID.Int64 != txID {
 		return db.ErrTxInputConflict
 	}
 

--- a/wallet/internal/db/sqlite/utxostore_listoutputstowatch.go
+++ b/wallet/internal/db/sqlite/utxostore_listoutputstowatch.go
@@ -1,0 +1,51 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+)
+
+// ListOutputsToWatch returns UTXOs that recovery scans should watch.
+//
+// The result mirrors the legacy wtxmgr OutputsToWatch contract: it returns
+// every known output (unspent, locked, or spent only by an unmined
+// transaction) but populates just the OutPoint and PkScript, since those are
+// the only fields a rescan consumes.
+func (s *Store) ListOutputsToWatch(ctx context.Context,
+	walletID uint32) ([]db.UtxoInfo, error) {
+
+	var utxos []db.UtxoInfo
+
+	err := s.execRead(ctx, func(q *sqlc.Queries) error {
+		rows, err := q.ListOutputsToWatch(ctx, int64(walletID))
+		if err != nil {
+			return fmt.Errorf("list outputs to watch: %w", err)
+		}
+
+		utxos = make([]db.UtxoInfo, len(rows))
+		for i, row := range rows {
+			utxo, err := db.WatchOutputFromRow(
+				row.TxHash, row.OutputIndex, row.RawTx,
+			)
+			if err != nil {
+				return err
+			}
+
+			utxos[i] = *utxo
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(utxos) == 0 {
+		return []db.UtxoInfo{}, nil
+	}
+
+	return utxos, nil
+}

--- a/wallet/internal/db/txstore_common.go
+++ b/wallet/internal/db/txstore_common.go
@@ -1815,3 +1815,200 @@ func IsUnminedStatus(status TxStatus) bool {
 		return false
 	}
 }
+
+// ValidateBatchTransactionsWalletID rejects a batch whose transactions are not
+// all owned by batchWalletID. A batch applies sync state (sync tip or scan
+// horizons) to batchWalletID but records each transaction under that
+// transaction's own WalletID, so a mismatched member would let one wallet's
+// sync state advance atomically with another wallet's transaction write. The
+// check runs before any backend write so the batch invariant is enforced
+// up front, before horizon derivation or synced-block work is wasted.
+func ValidateBatchTransactionsWalletID(batchWalletID uint32,
+	txs []CreateTxParams) error {
+
+	for i := range txs {
+		if txs[i].WalletID == batchWalletID {
+			continue
+		}
+
+		return fmt.Errorf("%w: transaction %d wallet id %d does not "+
+			"match batch wallet id %d", ErrInvalidParam, i,
+			txs[i].WalletID, batchWalletID)
+	}
+
+	return nil
+}
+
+// ValidateBatchTransactionsTx rejects a batch in which any transaction has a
+// nil Tx. A batch is reordered parents-first by SortTxBatchParentsFirst before
+// it is applied, and that sort dereferences each transaction's Tx to read its
+// hash and inputs. Per-transaction NewCreateTxRequest validation would catch a
+// nil Tx, but only inside the apply loop that runs after the sort, so a nil Tx
+// would panic during reordering. Running this check up front, before the sort,
+// turns that into the same ErrInvalidParam every backend returns uniformly.
+func ValidateBatchTransactionsTx(txs []CreateTxParams) error {
+	for i := range txs {
+		if txs[i].Tx != nil {
+			continue
+		}
+
+		return fmt.Errorf("%w: transaction %d tx is required",
+			ErrInvalidParam, i)
+	}
+
+	return nil
+}
+
+// SortTxBatchParentsFirst returns the batch transactions reordered so that any
+// transaction creating an output another batch member spends is positioned
+// before that spending member, regardless of the caller's original order.
+//
+// The SQL backends record a transaction's wallet-owned credits and then claim
+// its spent parent inputs in the same per-transaction step. Claiming a spent
+// input is an UPDATE on the parent credit's UTXO row, so the parent credit must
+// already exist when the child is recorded; otherwise the UPDATE matches no row
+// and, finding no conflicting spend either, silently drops the spend edge and
+// leaves the parent credit unspent. Applying a batch in caller order is
+// therefore unsafe whenever a child is listed before its in-batch parent.
+//
+// This makes ApplyTxBatch order-independent: it stably topologically sorts the
+// batch so every in-batch parent precedes its children while preserving the
+// caller's relative order among transactions that have no in-batch dependency.
+// A batch that is already parents-first, has a single transaction, or has no
+// in-batch parent/child edges is returned unchanged. Edges to outpoints created
+// outside the batch impose no ordering, since those parent rows either already
+// exist or never will.
+//
+// The returned slice is a fresh reordering of the same CreateTxParams values;
+// the input slice is not mutated.
+func SortTxBatchParentsFirst(txs []CreateTxParams) []CreateTxParams {
+	// Nothing to reorder: a single transaction (or none) cannot list a
+	// child ahead of an in-batch parent.
+	if len(txs) <= 1 {
+		return txs
+	}
+
+	children, inDegree := buildTxBatchDependencyGraph(txs)
+	order := topoSortTxBatchOrder(children, inDegree)
+
+	ordered := make([]CreateTxParams, 0, len(txs))
+	for _, idx := range order {
+		ordered = append(ordered, txs[idx])
+	}
+
+	return ordered
+}
+
+// buildTxBatchDependencyGraph builds the parent->child dependency edges of a
+// transaction batch. children[p] lists the positions of the batch transactions
+// spending an output of txs[p], and inDegree[c] counts the distinct in-batch
+// parents of txs[c]. Outpoints created outside the batch contribute no edge.
+func buildTxBatchDependencyGraph(txs []CreateTxParams) ([][]int, []int) {
+	// Map every in-batch transaction hash to its position so input lookups
+	// can tell an in-batch parent from an external outpoint. A hash that
+	// repeats in the batch keeps its first position; a later duplicate is
+	// rejected by CreateTxWithOps regardless of order, so the dependency
+	// edge only needs to point at one occurrence.
+	indexByHash := make(map[chainhash.Hash]int, len(txs))
+	for i := range txs {
+		hash := txs[i].Tx.TxHash()
+		if _, ok := indexByHash[hash]; !ok {
+			indexByHash[hash] = i
+		}
+	}
+
+	children := make([][]int, len(txs))
+
+	inDegree := make([]int, len(txs))
+	for child := range txs {
+		// Deduplicate parents within one child so a child spending two
+		// outputs of the same in-batch parent only adds one edge, which
+		// keeps the in-degree bookkeeping exact.
+		seen := make(map[int]struct{})
+		for _, txIn := range txs[child].Tx.TxIn {
+			parent, ok := indexByHash[txIn.PreviousOutPoint.Hash]
+			if !ok || parent == child {
+				continue
+			}
+
+			if _, dup := seen[parent]; dup {
+				continue
+			}
+
+			seen[parent] = struct{}{}
+			children[parent] = append(children[parent], child)
+			inDegree[child]++
+		}
+	}
+
+	return children, inDegree
+}
+
+// topoSortTxBatchOrder returns batch transaction positions in a stable
+// parents-first topological order using Kahn's algorithm with an
+// ascending-index ready set: among transactions whose in-batch parents are all
+// already emitted, the one with the lowest original position goes next. That
+// keeps the caller's relative order for independent transactions and leaves an
+// already parents-first batch unchanged.
+//
+// A dependency cycle is impossible for real transactions, since an output
+// cannot be spent before the transaction creating it exists. If a malformed
+// batch still encodes one, the cyclic members never reach the ready set; they
+// are appended in their original order so no transaction is dropped and
+// CreateTxWithOps can reject the bad input downstream.
+func topoSortTxBatchOrder(children [][]int, inDegree []int) []int {
+	total := len(inDegree)
+
+	ready := make([]int, 0, total)
+	for i := range inDegree {
+		if inDegree[i] == 0 {
+			ready = append(ready, i)
+		}
+	}
+
+	order := make([]int, 0, total)
+
+	emitted := make([]bool, total)
+	for len(ready) > 0 {
+		node := popLowestIndex(&ready)
+		order = append(order, node)
+		emitted[node] = true
+
+		for _, child := range children[node] {
+			inDegree[child]--
+			if inDegree[child] == 0 {
+				ready = append(ready, child)
+			}
+		}
+	}
+
+	// Append any cyclic leftover in original order.
+	if len(order) != total {
+		for i := range total {
+			if !emitted[i] {
+				order = append(order, i)
+			}
+		}
+	}
+
+	return order
+}
+
+// popLowestIndex removes and returns the smallest value from ready, preserving
+// the order of the remaining elements.
+func popLowestIndex(ready *[]int) int {
+	r := *ready
+
+	lowest := 0
+	for i := 1; i < len(r); i++ {
+		if r[i] < r[lowest] {
+			lowest = i
+		}
+	}
+
+	node := r[lowest]
+	r = append(r[:lowest], r[lowest+1:]...)
+	*ready = r
+
+	return node
+}

--- a/wallet/internal/db/txstore_common.go
+++ b/wallet/internal/db/txstore_common.go
@@ -780,8 +780,17 @@ type CreateTxExistingTarget struct {
 	// HasBlock reports whether the row already has confirming block metadata.
 	HasBlock bool
 
+	// BlockHeight is the confirmed block height when HasBlock is true.
+	BlockHeight *uint32
+
+	// BlockHash is the confirmed block hash when HasBlock is true.
+	BlockHash *chainhash.Hash
+
 	// IsCoinbase reports whether the row records coinbase history.
 	IsCoinbase bool
+
+	// Label is the stored user-visible transaction label.
+	Label string
 }
 
 // ErrCreateTxExistingNotFound reports that CreateTx found no existing row.
@@ -896,6 +905,72 @@ func checkReuseCreateTx(req CreateTxRequest,
 	}
 
 	return true
+}
+
+// createTxBlockMatches reports whether a stored row carries the same block
+// assignment as the incoming CreateTx observation.
+func createTxBlockMatches(req CreateTxRequest,
+	existing CreateTxExistingTarget) bool {
+
+	if req.Params.Block == nil {
+		return !existing.HasBlock
+	}
+
+	if !existing.HasBlock || existing.BlockHeight == nil ||
+		existing.BlockHash == nil {
+
+		return false
+	}
+
+	return *existing.BlockHeight == req.Params.Block.Height &&
+		*existing.BlockHash == req.Params.Block.Hash
+}
+
+// checkIdempotentCreateTx reports whether the incoming CreateTx observation is
+// already fully reflected by the stored row.
+func checkIdempotentCreateTx(req CreateTxRequest,
+	existing CreateTxExistingTarget) bool {
+
+	if req.Params.Status != existing.Status {
+		return false
+	}
+
+	if req.IsCoinbase != existing.IsCoinbase {
+		return false
+	}
+
+	if req.Params.Label != existing.Label {
+		return false
+	}
+
+	return createTxBlockMatches(req, existing)
+}
+
+// validateCreateTxCreditRequests validates every caller-supplied credit before
+// an existing tx row is treated as an idempotent duplicate.
+func validateCreateTxCreditRequests(req CreateTxRequest) error {
+	for index, addr := range req.Params.Credits {
+		if addr == nil {
+			continue
+		}
+
+		err := ValidateCreditAddrMembership(
+			addr, req.Params.Tx.TxOut[index].PkScript,
+		)
+		if err != nil {
+			return fmt.Errorf("credit output %d: %w", index, err)
+		}
+	}
+
+	return nil
+}
+
+// canIgnoreUnminedConfirmedDuplicate reports whether an unmined observation may
+// be ignored because the same transaction is already recorded as confirmed.
+func canIgnoreUnminedConfirmedDuplicate(req CreateTxRequest,
+	existing CreateTxExistingTarget) bool {
+
+	return req.Params.Block == nil && existing.HasBlock
 }
 
 // loadCreateTxExisting resolves any wallet-scoped row already stored for the
@@ -1047,6 +1122,48 @@ func handleTxConflicts(ctx context.Context, req CreateTxRequest,
 	return nil
 }
 
+// ReplaceUnminedTxConflicts rewrites direct unmined conflict roots displaced by
+// the provided replacement transaction.
+//
+// Callers use this when the direct conflict roots were discovered outside the
+// normal spend-edge lookup path, such as when a parent credit is learned after
+// its children have already been stored as external-input spends. The function
+// preserves the standard replacement ordering: discover descendants from a
+// stable graph snapshot, mark direct roots replaced, then mark dependent
+// descendants failed.
+func ReplaceUnminedTxConflicts(ctx context.Context, walletID int64,
+	rootIDs []int64, rootHashes []chainhash.Hash, replacementTxID int64,
+	ops CreateTxOps) error {
+
+	if len(rootIDs) == 0 {
+		return nil
+	}
+
+	if len(rootIDs) != len(rootHashes) {
+		return fmt.Errorf("%w: conflict roots and hashes differ",
+			ErrInvalidParam)
+	}
+
+	descendantIDs, err := collectConflictDescendants(
+		ctx, walletID, rootHashes, rootIDs, ops,
+	)
+	if err != nil {
+		return err
+	}
+
+	err = handleRootTxns(ctx, walletID, rootIDs, replacementTxID, ops)
+	if err != nil {
+		return err
+	}
+
+	err = handleTxDescendants(ctx, walletID, descendantIDs, ops)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // insertCreateTx completes the fresh-Insert CreateTx path.
 //
 // The order is important:
@@ -1075,21 +1192,93 @@ func insertCreateTx(ctx context.Context, req CreateTxRequest,
 		return err
 	}
 
-	// Credits only describe outputs created by the new tx itself, so they do
-	// not interfere with conflict discovery. Keep them after replacement
-	// handling so the branch rewrite stays grouped with the shared-input
-	// reconciliation.
-	err = ops.InsertCredits(ctx, req, txID)
+	err = recordCreateTxEdges(ctx, req, txID, ops)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// recordCreateTxEdges records wallet-owned credits and spent-input edges for a
+// transaction row that already exists in the backend.
+func recordCreateTxEdges(ctx context.Context, req CreateTxRequest, txID int64,
+	ops CreateTxOps) error {
+
+	// Credits only describe outputs created by the tx itself, so they do not
+	// interfere with conflict discovery. Keep them after replacement handling
+	// so the branch rewrite stays grouped with the shared-input reconciliation.
+	err := ops.InsertCredits(ctx, req, txID)
 	if err != nil {
 		return fmt.Errorf("create tx credits: %w", err)
 	}
 
-	// Claim wallet-owned parent inputs last. This is the write that makes the
-	// new tx the recorded spender of the shared parents, so doing it earlier
-	// would hide the displaced unmined branch from the replacement walk.
+	// Claim wallet-owned parent inputs last. This is the write that makes this
+	// tx the recorded spender of the shared parents, so doing it earlier would
+	// hide a displaced unmined branch from the replacement walk.
 	err = ops.MarkInputsSpent(ctx, req, txID)
 	if err != nil {
 		return fmt.Errorf("create tx spends: %w", err)
+	}
+
+	return nil
+}
+
+// handleExistingCreateTx handles a CreateTx request for a transaction hash that
+// already has a wallet-scoped row.
+func handleExistingCreateTx(ctx context.Context, req CreateTxRequest,
+	existing CreateTxExistingTarget, ops CreateTxOps) error {
+
+	if canIgnoreUnminedConfirmedDuplicate(req, existing) {
+		return nil
+	}
+
+	if checkIdempotentCreateTx(req, existing) {
+		return replayIdempotentCreateTx(ctx, req, existing, ops)
+	}
+
+	if !checkReuseCreateTx(req, existing) {
+		return fmt.Errorf("tx %s: %w", req.TxHash, ErrTxAlreadyExists)
+	}
+
+	err := ops.ConfirmExisting(ctx, req, existing)
+	if err != nil {
+		return fmt.Errorf("confirm existing tx: %w", err)
+	}
+
+	err = handleTxConflicts(ctx, req, existing.ID, ops)
+	if err != nil {
+		return err
+	}
+
+	err = recordCreateTxEdges(ctx, req, existing.ID, ops)
+	if err != nil {
+		return fmt.Errorf("replay confirmed tx edges: %w", err)
+	}
+
+	return nil
+}
+
+// replayIdempotentCreateTx validates and records any edge writes that an
+// idempotent duplicate transaction notification may still need.
+func replayIdempotentCreateTx(ctx context.Context, req CreateTxRequest,
+	existing CreateTxExistingTarget, ops CreateTxOps) error {
+
+	err := validateCreateTxCreditRequests(req)
+	if err != nil {
+		return err
+	}
+
+	if req.Params.Block != nil {
+		err = ops.PrepareBlock(ctx, req)
+		if err != nil {
+			return fmt.Errorf("prepare duplicate block assignment: %w", err)
+		}
+	}
+
+	err = recordCreateTxEdges(ctx, req, existing.ID, ops)
+	if err != nil {
+		return fmt.Errorf("replay duplicate tx edges: %w", err)
 	}
 
 	return nil
@@ -1110,25 +1299,16 @@ func CreateTxWithOps(ctx context.Context, req CreateTxRequest,
 		return err
 	}
 
-	if foundExisting {
-		if !checkReuseCreateTx(req, *existing) {
-			return fmt.Errorf("tx %s: %w", req.TxHash, ErrTxAlreadyExists)
-		}
-
-		err = ops.ConfirmExisting(ctx, req, *existing)
+	if !foundExisting {
+		err = ops.PrepareBlock(ctx, req)
 		if err != nil {
-			return fmt.Errorf("confirm existing tx: %w", err)
+			return fmt.Errorf("prepare create block assignment: %w", err)
 		}
 
-		return nil
+		return insertCreateTx(ctx, req, ops)
 	}
 
-	err = ops.PrepareBlock(ctx, req)
-	if err != nil {
-		return fmt.Errorf("prepare create block assignment: %w", err)
-	}
-
-	return insertCreateTx(ctx, req, ops)
+	return handleExistingCreateTx(ctx, req, *existing, ops)
 }
 
 // validateUpdateTxParams checks that UpdateTx received at least one mutable

--- a/wallet/internal/db/txstore_common_test.go
+++ b/wallet/internal/db/txstore_common_test.go
@@ -762,10 +762,159 @@ func TestCreateTxWithOpsDuplicate(t *testing.T) {
 	})
 
 	ops.On("LoadExisting", mock.Anything, req).Return(
-		&CreateTxExistingTarget{ID: 4}, nil).Once()
+		&CreateTxExistingTarget{
+			ID:     4,
+			Status: TxStatusPublished,
+		}, nil,
+	).Once()
 
 	err := CreateTxWithOps(context.Background(), req, ops)
 	require.ErrorIs(t, err, ErrTxAlreadyExists)
+}
+
+// TestCreateTxWithOpsIdempotentDuplicate verifies that the shared CreateTx
+// helper replays edge writes for an exact duplicate observation.
+func TestCreateTxWithOpsIdempotentDuplicate(t *testing.T) {
+	t.Parallel()
+
+	req := testCreateTxRequest(t)
+	existing := CreateTxExistingTarget{
+		ID:         4,
+		Status:     req.Params.Status,
+		IsCoinbase: req.IsCoinbase,
+		Label:      req.Params.Label,
+	}
+
+	ops := &mockCreateTxOps{}
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
+
+	ops.On("LoadExisting", mock.Anything, req).Return(&existing, nil).Once()
+	ops.On("InsertCredits", mock.Anything, req, int64(4)).Return(nil).Once()
+	ops.On("MarkInputsSpent", mock.Anything, req, int64(4)).Return(nil).Once()
+
+	err := CreateTxWithOps(context.Background(), req, ops)
+	require.NoError(t, err)
+}
+
+// TestCreateTxWithOpsValidatesIdempotentDuplicateCredits verifies that the
+// duplicate replay path validates requested credit addresses before it treats a
+// matching tx row as idempotent.
+func TestCreateTxWithOpsValidatesIdempotentDuplicateCredits(t *testing.T) {
+	t.Parallel()
+
+	params := &chaincfg.RegressionNetParams
+	paidKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	paidAddr, err := address.NewAddressPubKey(
+		paidKey.PubKey().SerializeCompressed(), params,
+	)
+	require.NoError(t, err)
+
+	wrongKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	wrongAddr, err := address.NewAddressPubKey(
+		wrongKey.PubKey().SerializeCompressed(), params,
+	)
+	require.NoError(t, err)
+
+	paidScript, err := txscript.PayToAddrScript(paidAddr)
+	require.NoError(t, err)
+
+	tx := wire.NewMsgTx(wire.TxVersion)
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{31}},
+	})
+	tx.AddTxOut(&wire.TxOut{Value: 1_000, PkScript: paidScript})
+
+	req, err := NewCreateTxRequest(CreateTxParams{
+		WalletID: 5,
+		Tx:       tx,
+		Received: time.Unix(456, 0),
+		Status:   TxStatusPending,
+		Credits:  map[uint32]address.Address{0: wrongAddr},
+	})
+	require.NoError(t, err)
+
+	existing := CreateTxExistingTarget{
+		ID:         4,
+		Status:     req.Params.Status,
+		IsCoinbase: req.IsCoinbase,
+		Label:      req.Params.Label,
+	}
+
+	ops := &mockCreateTxOps{}
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
+	ops.On("LoadExisting", mock.Anything, req).Return(&existing, nil).Once()
+
+	err = CreateTxWithOps(context.Background(), req, ops)
+	require.ErrorIs(t, err, ErrInvalidParam)
+}
+
+// TestCreateTxWithOpsValidatesDuplicateBlock verifies that an exact confirmed
+// duplicate still checks the caller's block metadata before replaying edge
+// writes.
+func TestCreateTxWithOpsValidatesDuplicateBlock(t *testing.T) {
+	t.Parallel()
+
+	req, err := NewCreateTxRequest(CreateTxParams{
+		WalletID: 5,
+		Tx:       testRegularMsgTx(),
+		Received: time.Unix(456, 0),
+		Block:    testBlock(77),
+		Status:   TxStatusPublished,
+		Label:    "mined",
+	})
+	require.NoError(t, err)
+
+	height := req.Params.Block.Height
+	hash := req.Params.Block.Hash
+	existing := CreateTxExistingTarget{
+		ID:          4,
+		Status:      req.Params.Status,
+		HasBlock:    true,
+		BlockHeight: &height,
+		BlockHash:   &hash,
+		IsCoinbase:  req.IsCoinbase,
+		Label:       req.Params.Label,
+	}
+
+	ops := &mockCreateTxOps{}
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
+
+	ops.On("LoadExisting", mock.Anything, req).Return(&existing, nil).Once()
+	ops.On("PrepareBlock", mock.Anything, req).Return(ErrBlockMismatch).Once()
+
+	err = CreateTxWithOps(context.Background(), req, ops)
+	require.ErrorIs(t, err, ErrBlockMismatch)
+}
+
+// TestCreateTxWithOpsIgnoresUnminedConfirmedDuplicate verifies that an unmined
+// re-observation of an already confirmed transaction is a no-op.
+func TestCreateTxWithOpsIgnoresUnminedConfirmedDuplicate(t *testing.T) {
+	t.Parallel()
+
+	req := testCreateTxRequest(t)
+	existing := CreateTxExistingTarget{
+		ID:       4,
+		Status:   TxStatusPublished,
+		HasBlock: true,
+	}
+
+	ops := &mockCreateTxOps{}
+	t.Cleanup(func() {
+		ops.AssertExpectations(t)
+	})
+
+	ops.On("LoadExisting", mock.Anything, req).Return(&existing, nil).Once()
+
+	err := CreateTxWithOps(context.Background(), req, ops)
+	require.NoError(t, err)
 }
 
 // TestCreateTxWithOpsConfirmExisting verifies that the shared CreateTx flow can
@@ -797,6 +946,11 @@ func TestCreateTxWithOpsConfirmExisting(t *testing.T) {
 	ops.On("LoadExisting", mock.Anything, req).Return(&existing, nil).Once()
 
 	ops.On("ConfirmExisting", mock.Anything, req, existing).Return(nil).Once()
+	ops.On("ListConflictTxns", mock.Anything, req).Return(
+		[]int64(nil), []chainhash.Hash(nil), nil,
+	).Once()
+	ops.On("InsertCredits", mock.Anything, req, int64(7)).Return(nil).Once()
+	ops.On("MarkInputsSpent", mock.Anything, req, int64(7)).Return(nil).Once()
 
 	err = CreateTxWithOps(context.Background(), req, ops)
 	require.NoError(t, err)
@@ -1792,6 +1946,104 @@ func TestCheckReuseCreateTx(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, test.want,
 				checkReuseCreateTx(test.req, test.existing))
+		})
+	}
+}
+
+// TestCheckIdempotentCreateTx verifies that duplicate observations are only
+// skipped when the persisted tx status, block assignment, coinbase flag, and
+// label already match the incoming request.
+func TestCheckIdempotentCreateTx(t *testing.T) {
+	t.Parallel()
+
+	confirmedReq, err := NewCreateTxRequest(CreateTxParams{
+		WalletID: 9,
+		Tx:       testRegularMsgTx(),
+		Received: time.Unix(556, 0),
+		Block:    testBlock(23),
+		Status:   TxStatusPublished,
+		Label:    "mined",
+		Credits:  map[uint32]address.Address{0: nil},
+	})
+	require.NoError(t, err)
+
+	height := uint32(23)
+	wrongHeight := uint32(24)
+	blockHash := confirmedReq.Params.Block.Hash
+	wrongHash := chainhash.Hash{99}
+	tests := []struct {
+		name     string
+		req      CreateTxRequest
+		existing CreateTxExistingTarget
+		want     bool
+	}{
+		{
+			name: "unmined duplicate",
+			req:  testCreateTxRequest(t),
+			existing: CreateTxExistingTarget{
+				Status: TxStatusPending,
+			},
+			want: true,
+		},
+		{
+			name: "confirmed duplicate",
+			req:  confirmedReq,
+			existing: CreateTxExistingTarget{
+				Status:      TxStatusPublished,
+				HasBlock:    true,
+				BlockHeight: &height,
+				BlockHash:   &blockHash,
+				Label:       "mined",
+			},
+			want: true,
+		},
+		{
+			name: "different status",
+			req:  testCreateTxRequest(t),
+			existing: CreateTxExistingTarget{
+				Status: TxStatusPublished,
+			},
+		},
+		{
+			name: "different block",
+			req:  confirmedReq,
+			existing: CreateTxExistingTarget{
+				Status:      TxStatusPublished,
+				HasBlock:    true,
+				BlockHeight: &wrongHeight,
+				BlockHash:   &blockHash,
+				Label:       "mined",
+			},
+		},
+		{
+			name: "different block hash",
+			req:  confirmedReq,
+			existing: CreateTxExistingTarget{
+				Status:      TxStatusPublished,
+				HasBlock:    true,
+				BlockHeight: &height,
+				BlockHash:   &wrongHash,
+				Label:       "mined",
+			},
+		},
+		{
+			name: "different label",
+			req:  confirmedReq,
+			existing: CreateTxExistingTarget{
+				Status:      TxStatusPublished,
+				HasBlock:    true,
+				BlockHeight: &height,
+				BlockHash:   &blockHash,
+				Label:       "other",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, test.want,
+				checkIdempotentCreateTx(test.req, test.existing))
 		})
 	}
 }

--- a/wallet/internal/db/txstore_common_test.go
+++ b/wallet/internal/db/txstore_common_test.go
@@ -2370,3 +2370,79 @@ func TestValidateCreditAddrMembership(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateBatchTransactionsWalletID verifies that the shared batch
+// wallet-ID validator accepts a batch whose transactions all match the batch
+// wallet and rejects any transaction owned by a different wallet with
+// ErrInvalidParam.
+func TestValidateBatchTransactionsWalletID(t *testing.T) {
+	t.Parallel()
+
+	const batchWalletID = 7
+
+	t.Run("all match", func(t *testing.T) {
+		t.Parallel()
+
+		err := ValidateBatchTransactionsWalletID(batchWalletID,
+			[]CreateTxParams{
+				{WalletID: batchWalletID},
+				{WalletID: batchWalletID},
+			})
+		require.NoError(t, err)
+	})
+
+	t.Run("empty batch", func(t *testing.T) {
+		t.Parallel()
+
+		err := ValidateBatchTransactionsWalletID(batchWalletID, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("mismatch rejected", func(t *testing.T) {
+		t.Parallel()
+
+		err := ValidateBatchTransactionsWalletID(batchWalletID,
+			[]CreateTxParams{
+				{WalletID: batchWalletID},
+				{WalletID: 99},
+			})
+		require.ErrorIs(t, err, ErrInvalidParam)
+	})
+}
+
+// TestValidateBatchTransactionsTx verifies that the shared batch nil-Tx
+// validator accepts a batch whose transactions all carry a Tx and rejects a
+// batch with any nil Tx with ErrInvalidParam, so the parents-first sort never
+// dereferences a nil transaction.
+func TestValidateBatchTransactionsTx(t *testing.T) {
+	t.Parallel()
+
+	tx := testRegularMsgTx()
+
+	t.Run("all present", func(t *testing.T) {
+		t.Parallel()
+
+		err := ValidateBatchTransactionsTx([]CreateTxParams{
+			{Tx: tx},
+			{Tx: tx},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("empty batch", func(t *testing.T) {
+		t.Parallel()
+
+		err := ValidateBatchTransactionsTx(nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("nil tx rejected", func(t *testing.T) {
+		t.Parallel()
+
+		err := ValidateBatchTransactionsTx([]CreateTxParams{
+			{Tx: tx},
+			{Tx: nil},
+		})
+		require.ErrorIs(t, err, ErrInvalidParam)
+	})
+}

--- a/wallet/internal/db/utxostore_common.go
+++ b/wallet/internal/db/utxostore_common.go
@@ -198,6 +198,52 @@ func BuildUtxoInfo(hash []byte, outputIndex uint32, amount int64,
 	}, nil
 }
 
+// WatchOutputFromRow converts a ListOutputsToWatch result row into the public
+// UtxoInfo shape. Only OutPoint and PkScript are populated, mirroring the
+// legacy wtxmgr OutputsToWatch contract where those are the only fields a
+// rescan reads; the remaining fields keep their zero values so SQL backends
+// stay byte-for-byte identical to the kvdb watch-output view.
+//
+// The watch script is read from the funding transaction's own output
+// (TxOut[outputIndex].PkScript) rather than from the credited address row.
+// A bare-multisig output the wallet partly owns is recorded against a member
+// address whose own script differs from the multisig output script, so the
+// address script would watch the wrong thing; the on-chain output script is
+// what a rescan must match, matching the kvdb credit walk.
+func WatchOutputFromRow(hash []byte, outputIndex int64,
+	rawTx []byte) (*UtxoInfo, error) {
+
+	index, err := Int64ToUint32(outputIndex)
+	if err != nil {
+		return nil, fmt.Errorf("watch output index: %w", err)
+	}
+
+	outPoint, err := buildOutPoint(hash, index)
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := deserializeMsgTx(rawTx)
+	if err != nil {
+		return nil, fmt.Errorf("watch output %v: %w", outPoint, err)
+	}
+
+	// Compare in uint64 so the bounds check stays correct for output
+	// indexes above math.MaxInt32: an int(index) conversion can overflow to
+	// a negative value on 32-bit platforms and wrongly pass the check. len
+	// is never negative, so widening it to uint64 is lossless.
+	if uint64(index) >= uint64(len(tx.TxOut)) {
+		return nil, fmt.Errorf("%w: watch output index %d out of range "+
+			"for tx %s with %d outputs", ErrInvalidParam, index,
+			outPoint.Hash, len(tx.TxOut))
+	}
+
+	return &UtxoInfo{
+		OutPoint: outPoint,
+		PkScript: tx.TxOut[index].PkScript,
+	}, nil
+}
+
 // BuildLeasedOutput converts SQL lease-row fields into the public LeasedOutput
 // type.
 func BuildLeasedOutput(hash []byte, outputIndex uint32, lockID []byte,

--- a/wallet/internal/db/utxostore_common_test.go
+++ b/wallet/internal/db/utxostore_common_test.go
@@ -1,7 +1,9 @@
 package db
 
 import (
+	"bytes"
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -532,4 +534,75 @@ func TestBuildLeasedOutputInvalidHash(t *testing.T) {
 	_, err := BuildLeasedOutput([]byte{1, 2, 3}, 7, lockID, time.Unix(777, 0))
 
 	require.Error(t, err)
+}
+
+// TestWatchOutputFromRow verifies that WatchOutputFromRow reads the watch
+// script from the funding transaction's own output for a valid index.
+//
+// Scenario:
+// - One outputs-to-watch row carries a serialized funding transaction.
+// Setup:
+// - Build a single-output transaction and serialize it.
+// Action:
+// - Convert the row into the public watch-output view.
+// Assertions:
+// - Only the outpoint and the on-chain output script are populated.
+func TestWatchOutputFromRow(t *testing.T) {
+	t.Parallel()
+
+	hash := chainhash.Hash{4, 5, 6}
+	pkScript := []byte{0x00, 0x14, 0x01, 0x02, 0x03}
+
+	tx := wire.NewMsgTx(2)
+	// A non-empty input set keeps the serialized form unambiguous: a tx with
+	// zero inputs serializes a leading zero that Deserialize would misread as
+	// the SegWit marker.
+	tx.AddTxIn(wire.NewTxIn(&wire.OutPoint{Index: 0}, nil, nil))
+	tx.AddTxOut(wire.NewTxOut(1000, pkScript))
+
+	var buf bytes.Buffer
+	require.NoError(t, tx.Serialize(&buf))
+
+	info, err := WatchOutputFromRow(hash[:], 0, buf.Bytes())
+	require.NoError(t, err)
+	require.Equal(t, hash, info.OutPoint.Hash)
+	require.Equal(t, uint32(0), info.OutPoint.Index)
+	require.Equal(t, pkScript, info.PkScript)
+}
+
+// TestWatchOutputFromRowIndexAboveMaxInt32 verifies that an output index above
+// math.MaxInt32 is rejected with db.ErrInvalidParam rather than overflowing the
+// bounds check on 32-bit platforms.
+//
+// Scenario:
+// - An outputs-to-watch row claims an output index above math.MaxInt32.
+// Setup:
+// - Build a single-output transaction so any large index is out of range.
+// Action:
+//   - Convert the row, supplying an index that still fits in uint32 (so the
+//     int64->uint32 narrowing succeeds) but exceeds math.MaxInt32.
+//
+// Assertions:
+//   - The bounds check rejects the index with ErrInvalidParam, without
+//     panicking or wrapping to a negative slice index.
+func TestWatchOutputFromRowIndexAboveMaxInt32(t *testing.T) {
+	t.Parallel()
+
+	hash := chainhash.Hash{7, 8, 9}
+
+	tx := wire.NewMsgTx(2)
+	// A non-empty input set keeps the serialized form unambiguous: a tx with
+	// zero inputs serializes a leading zero that Deserialize would misread as
+	// the SegWit marker.
+	tx.AddTxIn(wire.NewTxIn(&wire.OutPoint{Index: 0}, nil, nil))
+	tx.AddTxOut(wire.NewTxOut(1000, []byte{0x00, 0x14}))
+
+	var buf bytes.Buffer
+	require.NoError(t, tx.Serialize(&buf))
+
+	// math.MaxInt32+1 narrows cleanly to a uint32 but, converted to int on a
+	// 32-bit platform, would overflow to a negative value and wrongly pass an
+	// int(index) < len bounds check.
+	_, err := WatchOutputFromRow(hash[:], math.MaxInt32+1, buf.Bytes())
+	require.ErrorIs(t, err, ErrInvalidParam)
 }

--- a/wallet/internal/sql/pg/queries/transactions.sql
+++ b/wallet/internal/sql/pg/queries/transactions.sql
@@ -140,6 +140,28 @@ WHERE
     AND t.tx_status IN (0, 1)
 ORDER BY t.received_time DESC, t.id DESC;
 
+-- name: ListActiveTransactionRaws :many
+-- Lists active wallet transaction rows and their raw transaction bytes.
+--
+-- How:
+-- - Reads from transactions only and filters to rows that may currently spend
+--   wallet-owned outputs (`pending` and `published`).
+-- - Returns the primary key, transaction hash, block assignment, and raw
+--   transaction bytes so callers can rebuild input outpoints not normalized in
+--   the SQL schema.
+-- Performance:
+-- - Matches the wallet/status index used by active wallet history paths.
+SELECT
+    t.id,
+    t.tx_hash,
+    t.block_height,
+    t.raw_tx
+FROM transactions AS t
+WHERE
+    t.wallet_id = $1
+    AND t.tx_status IN (0, 1)
+ORDER BY t.id;
+
 -- name: ListTransactionsByHeightRange :many
 -- Lists all confirmed transactions for a wallet in the provided height range.
 --

--- a/wallet/internal/sql/pg/queries/utxos.sql
+++ b/wallet/internal/sql/pg/queries/utxos.sql
@@ -481,3 +481,43 @@ WHERE
         FROM transactions AS t
         WHERE t.id = u.tx_id AND t.wallet_id = $1
     );
+
+-- name: ListOutputsToWatch :many
+-- Lists every output a recovery rescan must keep watching for one wallet.
+--
+-- How:
+-- - Starts from the wallet's UTXO rows joined to their funding transaction;
+--   the rescan needs each outpoint plus the on-chain output script. The script
+--   is taken from the funding transaction's raw_tx (TxOut[output_index]) in the
+--   Store Go layer rather than from the credited address: a bare-multisig
+--   output the wallet partly owns is recorded against a member address whose
+--   own script differs from the multisig output script, so the address script
+--   would be the wrong thing to watch. Reading the actual output script matches
+--   the kvdb OutputsToWatch contract.
+-- - Includes outputs whose funding transaction is still active (pending or
+--   published); invalidated parents (replaced/failed/orphaned) are excluded so
+--   the watch set matches the legacy wtxmgr credit walk.
+-- - Keeps an output when it is either still unspent OR spent only by an
+--   unmined, still-active transaction. This mirrors the legacy behaviour of
+--   returning unmined credits and credits spent by other unmined txs, while
+--   dropping outputs already spent by a confirmed transaction.
+-- - Locked (leased) outputs are intentionally retained because leasing is
+--   modelled separately from existence and the rescan must still watch them.
+SELECT
+    t.tx_hash,
+    u.output_index,
+    t.raw_tx
+FROM utxos AS u
+INNER JOIN transactions AS t ON u.tx_id = t.id
+LEFT JOIN transactions AS spend ON u.spent_by_tx_id = spend.id
+WHERE
+    t.wallet_id = sqlc.arg('wallet_id')
+    AND t.tx_status IN (0, 1)
+    AND (
+        u.spent_by_tx_id IS NULL
+        OR (
+            spend.block_height IS NULL
+            AND spend.tx_status IN (0, 1)
+        )
+    )
+ORDER BY t.tx_hash, u.output_index;

--- a/wallet/internal/sql/pg/queries/utxos.sql
+++ b/wallet/internal/sql/pg/queries/utxos.sql
@@ -374,14 +374,19 @@ ORDER BY u.spent_by_tx_id;
 --   considers outputs whose parent status is `pending` or `published`.
 -- - Returns the nullable `spent_by_tx_id` column so callers can distinguish
 --   between an external/unknown parent and a wallet-owned conflict.
+-- - Returns the owner address script so duplicate credit replay can verify it
+--   matches the already-recorded UTXO rather than only checking outpoint
+--   existence.
 -- Performance:
 -- - Targets one wallet-scoped outpoint through the unique `(tx_id,
 --   output_index)` key after the parent hash lookup.
-SELECT u.spent_by_tx_id
+SELECT u.spent_by_tx_id, a.script_pub_key
 FROM transactions AS t
 INNER JOIN utxos AS u ON t.id = u.tx_id
+INNER JOIN addresses AS a ON u.address_id = a.id
 WHERE
     t.wallet_id = $1
+    AND a.wallet_id = $1
     AND t.tx_hash = $2
     AND u.output_index = $3
     AND t.tx_status IN (0, 1);

--- a/wallet/internal/sql/pg/sqlc/db.go
+++ b/wallet/internal/sql/pg/sqlc/db.go
@@ -216,6 +216,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.listKeyScopesByWalletStmt, err = db.PrepareContext(ctx, ListKeyScopesByWallet); err != nil {
 		return nil, fmt.Errorf("error preparing query ListKeyScopesByWallet: %w", err)
 	}
+	if q.listOutputsToWatchStmt, err = db.PrepareContext(ctx, ListOutputsToWatch); err != nil {
+		return nil, fmt.Errorf("error preparing query ListOutputsToWatch: %w", err)
+	}
 	if q.listOwnedInputPrevOutputsByTxHashesStmt, err = db.PrepareContext(ctx, ListOwnedInputPrevOutputsByTxHashes); err != nil {
 		return nil, fmt.Errorf("error preparing query ListOwnedInputPrevOutputsByTxHashes: %w", err)
 	}
@@ -613,6 +616,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing listKeyScopesByWalletStmt: %w", cerr)
 		}
 	}
+	if q.listOutputsToWatchStmt != nil {
+		if cerr := q.listOutputsToWatchStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listOutputsToWatchStmt: %w", cerr)
+		}
+	}
 	if q.listOwnedInputPrevOutputsByTxHashesStmt != nil {
 		if cerr := q.listOwnedInputPrevOutputsByTxHashesStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing listOwnedInputPrevOutputsByTxHashesStmt: %w", cerr)
@@ -836,6 +844,7 @@ type Queries struct {
 	listAddressesByAccountStmt                  *sql.Stmt
 	listAddressesByScriptPubKeysStmt            *sql.Stmt
 	listKeyScopesByWalletStmt                   *sql.Stmt
+	listOutputsToWatchStmt                      *sql.Stmt
 	listOwnedInputPrevOutputsByTxHashesStmt     *sql.Stmt
 	listOwnedOutputsByTxIDsStmt                 *sql.Stmt
 	listRawImportedAddressesStmt                *sql.Stmt
@@ -930,6 +939,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		listAddressesByAccountStmt:                  q.listAddressesByAccountStmt,
 		listAddressesByScriptPubKeysStmt:            q.listAddressesByScriptPubKeysStmt,
 		listKeyScopesByWalletStmt:                   q.listKeyScopesByWalletStmt,
+		listOutputsToWatchStmt:                      q.listOutputsToWatchStmt,
 		listOwnedInputPrevOutputsByTxHashesStmt:     q.listOwnedInputPrevOutputsByTxHashesStmt,
 		listOwnedOutputsByTxIDsStmt:                 q.listOwnedOutputsByTxIDsStmt,
 		listRawImportedAddressesStmt:                q.listRawImportedAddressesStmt,

--- a/wallet/internal/sql/pg/sqlc/db.go
+++ b/wallet/internal/sql/pg/sqlc/db.go
@@ -201,6 +201,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.listAccountsByWalletScopeStmt, err = db.PrepareContext(ctx, ListAccountsByWalletScope); err != nil {
 		return nil, fmt.Errorf("error preparing query ListAccountsByWalletScope: %w", err)
 	}
+	if q.listActiveTransactionRawsStmt, err = db.PrepareContext(ctx, ListActiveTransactionRaws); err != nil {
+		return nil, fmt.Errorf("error preparing query ListActiveTransactionRaws: %w", err)
+	}
 	if q.listActiveUtxoLeasesStmt, err = db.PrepareContext(ctx, ListActiveUtxoLeases); err != nil {
 		return nil, fmt.Errorf("error preparing query ListActiveUtxoLeases: %w", err)
 	}
@@ -591,6 +594,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing listAccountsByWalletScopeStmt: %w", cerr)
 		}
 	}
+	if q.listActiveTransactionRawsStmt != nil {
+		if cerr := q.listActiveTransactionRawsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listActiveTransactionRawsStmt: %w", cerr)
+		}
+	}
 	if q.listActiveUtxoLeasesStmt != nil {
 		if cerr := q.listActiveUtxoLeasesStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing listActiveUtxoLeasesStmt: %w", cerr)
@@ -839,6 +847,7 @@ type Queries struct {
 	listAccountsByWalletStmt                    *sql.Stmt
 	listAccountsByWalletAndNameStmt             *sql.Stmt
 	listAccountsByWalletScopeStmt               *sql.Stmt
+	listActiveTransactionRawsStmt               *sql.Stmt
 	listActiveUtxoLeasesStmt                    *sql.Stmt
 	listAddressTypesStmt                        *sql.Stmt
 	listAddressesByAccountStmt                  *sql.Stmt
@@ -934,6 +943,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		listAccountsByWalletStmt:                    q.listAccountsByWalletStmt,
 		listAccountsByWalletAndNameStmt:             q.listAccountsByWalletAndNameStmt,
 		listAccountsByWalletScopeStmt:               q.listAccountsByWalletScopeStmt,
+		listActiveTransactionRawsStmt:               q.listActiveTransactionRawsStmt,
 		listActiveUtxoLeasesStmt:                    q.listActiveUtxoLeasesStmt,
 		listAddressTypesStmt:                        q.listAddressTypesStmt,
 		listAddressesByAccountStmt:                  q.listAddressesByAccountStmt,

--- a/wallet/internal/sql/pg/sqlc/querier.go
+++ b/wallet/internal/sql/pg/sqlc/querier.go
@@ -341,6 +341,27 @@ type Querier interface {
 	ListAddressesByScriptPubKeys(ctx context.Context, arg ListAddressesByScriptPubKeysParams) ([]ListAddressesByScriptPubKeysRow, error)
 	// Lists all key scopes for a wallet, ordered by ID.
 	ListKeyScopesByWallet(ctx context.Context, walletID int64) ([]ListKeyScopesByWalletRow, error)
+	// Lists every output a recovery rescan must keep watching for one wallet.
+	//
+	// How:
+	// - Starts from the wallet's UTXO rows joined to their funding transaction;
+	//   the rescan needs each outpoint plus the on-chain output script. The script
+	//   is taken from the funding transaction's raw_tx (TxOut[output_index]) in the
+	//   Store Go layer rather than from the credited address: a bare-multisig
+	//   output the wallet partly owns is recorded against a member address whose
+	//   own script differs from the multisig output script, so the address script
+	//   would be the wrong thing to watch. Reading the actual output script matches
+	//   the kvdb OutputsToWatch contract.
+	// - Includes outputs whose funding transaction is still active (pending or
+	//   published); invalidated parents (replaced/failed/orphaned) are excluded so
+	//   the watch set matches the legacy wtxmgr credit walk.
+	// - Keeps an output when it is either still unspent OR spent only by an
+	//   unmined, still-active transaction. This mirrors the legacy behaviour of
+	//   returning unmined credits and credits spent by other unmined txs, while
+	//   dropping outputs already spent by a confirmed transaction.
+	// - Locked (leased) outputs are intentionally retained because leasing is
+	//   modelled separately from existence and the rescan must still watch them.
+	ListOutputsToWatch(ctx context.Context, walletID int64) ([]ListOutputsToWatchRow, error)
 	// ListOwnedInputPrevOutputsByTxHashes lists wallet-owned previous outputs that
 	// may be spent by selected transaction inputs.
 	//

--- a/wallet/internal/sql/pg/sqlc/querier.go
+++ b/wallet/internal/sql/pg/sqlc/querier.go
@@ -234,10 +234,13 @@ type Querier interface {
 	//   considers outputs whose parent status is `pending` or `published`.
 	// - Returns the nullable `spent_by_tx_id` column so callers can distinguish
 	//   between an external/unknown parent and a wallet-owned conflict.
+	// - Returns the owner address script so duplicate credit replay can verify it
+	//   matches the already-recorded UTXO rather than only checking outpoint
+	//   existence.
 	// Performance:
 	// - Targets one wallet-scoped outpoint through the unique `(tx_id,
 	//   output_index)` key after the parent hash lookup.
-	GetUtxoSpendByOutpoint(ctx context.Context, arg GetUtxoSpendByOutpointParams) (sql.NullInt64, error)
+	GetUtxoSpendByOutpoint(ctx context.Context, arg GetUtxoSpendByOutpointParams) (GetUtxoSpendByOutpointRow, error)
 	GetWalletByID(ctx context.Context, id int64) (GetWalletByIDRow, error)
 	GetWalletByName(ctx context.Context, walletName string) (GetWalletByNameRow, error)
 	GetWalletSecrets(ctx context.Context, walletID int64) (WalletSecret, error)
@@ -317,6 +320,17 @@ type Querier interface {
 	ListAccountsByWalletAndName(ctx context.Context, arg ListAccountsByWalletAndNameParams) ([]ListAccountsByWalletAndNameRow, error)
 	// Lists all accounts for a wallet and scope tuple.
 	ListAccountsByWalletScope(ctx context.Context, arg ListAccountsByWalletScopeParams) ([]ListAccountsByWalletScopeRow, error)
+	// Lists active wallet transaction rows and their raw transaction bytes.
+	//
+	// How:
+	// - Reads from transactions only and filters to rows that may currently spend
+	//   wallet-owned outputs (`pending` and `published`).
+	// - Returns the primary key, transaction hash, block assignment, and raw
+	//   transaction bytes so callers can rebuild input outpoints not normalized in
+	//   the SQL schema.
+	// Performance:
+	// - Matches the wallet/status index used by active wallet history paths.
+	ListActiveTransactionRaws(ctx context.Context, walletID int64) ([]ListActiveTransactionRawsRow, error)
 	// Lists all currently active leases for a wallet.
 	//
 	// How:

--- a/wallet/internal/sql/pg/sqlc/transactions.sql.go
+++ b/wallet/internal/sql/pg/sqlc/transactions.sql.go
@@ -243,6 +243,65 @@ func (q *Queries) InsertTransaction(ctx context.Context, arg InsertTransactionPa
 	return id, err
 }
 
+const ListActiveTransactionRaws = `-- name: ListActiveTransactionRaws :many
+SELECT
+    t.id,
+    t.tx_hash,
+    t.block_height,
+    t.raw_tx
+FROM transactions AS t
+WHERE
+    t.wallet_id = $1
+    AND t.tx_status IN (0, 1)
+ORDER BY t.id
+`
+
+type ListActiveTransactionRawsRow struct {
+	ID          int64
+	TxHash      []byte
+	BlockHeight sql.NullInt32
+	RawTx       []byte
+}
+
+// Lists active wallet transaction rows and their raw transaction bytes.
+//
+// How:
+//   - Reads from transactions only and filters to rows that may currently spend
+//     wallet-owned outputs (`pending` and `published`).
+//   - Returns the primary key, transaction hash, block assignment, and raw
+//     transaction bytes so callers can rebuild input outpoints not normalized in
+//     the SQL schema.
+//
+// Performance:
+// - Matches the wallet/status index used by active wallet history paths.
+func (q *Queries) ListActiveTransactionRaws(ctx context.Context, walletID int64) ([]ListActiveTransactionRawsRow, error) {
+	rows, err := q.query(ctx, q.listActiveTransactionRawsStmt, ListActiveTransactionRaws, walletID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListActiveTransactionRawsRow
+	for rows.Next() {
+		var i ListActiveTransactionRawsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.TxHash,
+			&i.BlockHeight,
+			&i.RawTx,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const ListOwnedInputPrevOutputsByTxHashes = `-- name: ListOwnedInputPrevOutputsByTxHashes :many
 SELECT
     t.tx_hash,

--- a/wallet/internal/sql/pg/sqlc/utxos.sql.go
+++ b/wallet/internal/sql/pg/sqlc/utxos.sql.go
@@ -526,6 +526,76 @@ func (q *Queries) InsertUtxo(ctx context.Context, arg InsertUtxoParams) (int64, 
 	return id, err
 }
 
+const ListOutputsToWatch = `-- name: ListOutputsToWatch :many
+SELECT
+    t.tx_hash,
+    u.output_index,
+    t.raw_tx
+FROM utxos AS u
+INNER JOIN transactions AS t ON u.tx_id = t.id
+LEFT JOIN transactions AS spend ON u.spent_by_tx_id = spend.id
+WHERE
+    t.wallet_id = $1
+    AND t.tx_status IN (0, 1)
+    AND (
+        u.spent_by_tx_id IS NULL
+        OR (
+            spend.block_height IS NULL
+            AND spend.tx_status IN (0, 1)
+        )
+    )
+ORDER BY t.tx_hash, u.output_index
+`
+
+type ListOutputsToWatchRow struct {
+	TxHash      []byte
+	OutputIndex int32
+	RawTx       []byte
+}
+
+// Lists every output a recovery rescan must keep watching for one wallet.
+//
+// How:
+//   - Starts from the wallet's UTXO rows joined to their funding transaction;
+//     the rescan needs each outpoint plus the on-chain output script. The script
+//     is taken from the funding transaction's raw_tx (TxOut[output_index]) in the
+//     Store Go layer rather than from the credited address: a bare-multisig
+//     output the wallet partly owns is recorded against a member address whose
+//     own script differs from the multisig output script, so the address script
+//     would be the wrong thing to watch. Reading the actual output script matches
+//     the kvdb OutputsToWatch contract.
+//   - Includes outputs whose funding transaction is still active (pending or
+//     published); invalidated parents (replaced/failed/orphaned) are excluded so
+//     the watch set matches the legacy wtxmgr credit walk.
+//   - Keeps an output when it is either still unspent OR spent only by an
+//     unmined, still-active transaction. This mirrors the legacy behaviour of
+//     returning unmined credits and credits spent by other unmined txs, while
+//     dropping outputs already spent by a confirmed transaction.
+//   - Locked (leased) outputs are intentionally retained because leasing is
+//     modelled separately from existence and the rescan must still watch them.
+func (q *Queries) ListOutputsToWatch(ctx context.Context, walletID int64) ([]ListOutputsToWatchRow, error) {
+	rows, err := q.query(ctx, q.listOutputsToWatchStmt, ListOutputsToWatch, walletID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListOutputsToWatchRow
+	for rows.Next() {
+		var i ListOutputsToWatchRow
+		if err := rows.Scan(&i.TxHash, &i.OutputIndex, &i.RawTx); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const ListSpendingTxIDsByParentTxID = `-- name: ListSpendingTxIDsByParentTxID :many
 SELECT DISTINCT u.spent_by_tx_id
 FROM utxos AS u

--- a/wallet/internal/sql/pg/sqlc/utxos.sql.go
+++ b/wallet/internal/sql/pg/sqlc/utxos.sql.go
@@ -398,11 +398,13 @@ func (q *Queries) GetUtxoIDByOutpoint(ctx context.Context, arg GetUtxoIDByOutpoi
 }
 
 const GetUtxoSpendByOutpoint = `-- name: GetUtxoSpendByOutpoint :one
-SELECT u.spent_by_tx_id
+SELECT u.spent_by_tx_id, a.script_pub_key
 FROM transactions AS t
 INNER JOIN utxos AS u ON t.id = u.tx_id
+INNER JOIN addresses AS a ON u.address_id = a.id
 WHERE
     t.wallet_id = $1
+    AND a.wallet_id = $1
     AND t.tx_hash = $2
     AND u.output_index = $3
     AND t.tx_status IN (0, 1)
@@ -414,6 +416,11 @@ type GetUtxoSpendByOutpointParams struct {
 	OutputIndex int32
 }
 
+type GetUtxoSpendByOutpointRow struct {
+	SpentByTxID  sql.NullInt64
+	ScriptPubKey []byte
+}
+
 // Returns the current spend edge for one wallet-owned outpoint.
 //
 // How:
@@ -421,15 +428,18 @@ type GetUtxoSpendByOutpointParams struct {
 //     considers outputs whose parent status is `pending` or `published`.
 //   - Returns the nullable `spent_by_tx_id` column so callers can distinguish
 //     between an external/unknown parent and a wallet-owned conflict.
+//   - Returns the owner address script so duplicate credit replay can verify it
+//     matches the already-recorded UTXO rather than only checking outpoint
+//     existence.
 //
 // Performance:
 //   - Targets one wallet-scoped outpoint through the unique `(tx_id,
 //     output_index)` key after the parent hash lookup.
-func (q *Queries) GetUtxoSpendByOutpoint(ctx context.Context, arg GetUtxoSpendByOutpointParams) (sql.NullInt64, error) {
+func (q *Queries) GetUtxoSpendByOutpoint(ctx context.Context, arg GetUtxoSpendByOutpointParams) (GetUtxoSpendByOutpointRow, error) {
 	row := q.queryRow(ctx, q.getUtxoSpendByOutpointStmt, GetUtxoSpendByOutpoint, arg.WalletID, arg.TxHash, arg.OutputIndex)
-	var spent_by_tx_id sql.NullInt64
-	err := row.Scan(&spent_by_tx_id)
-	return spent_by_tx_id, err
+	var i GetUtxoSpendByOutpointRow
+	err := row.Scan(&i.SpentByTxID, &i.ScriptPubKey)
+	return i, err
 }
 
 const HasInvalidWalletUtxoByOutpoint = `-- name: HasInvalidWalletUtxoByOutpoint :one

--- a/wallet/internal/sql/sqlite/queries/transactions.sql
+++ b/wallet/internal/sql/sqlite/queries/transactions.sql
@@ -145,6 +145,28 @@ WHERE
     AND t.tx_status IN (0, 1)
 ORDER BY t.received_time DESC, t.id DESC;
 
+-- name: ListActiveTransactionRaws :many
+-- Lists active wallet transaction rows and their raw transaction bytes.
+--
+-- How:
+-- - Reads from transactions only and filters to rows that may currently spend
+--   wallet-owned outputs (`pending` and `published`).
+-- - Returns the primary key, transaction hash, block assignment, and raw
+--   transaction bytes so callers can rebuild input outpoints not normalized in
+--   the SQL schema.
+-- Performance:
+-- - Matches the wallet/status index used by active wallet history paths.
+SELECT
+    t.id,
+    t.tx_hash,
+    t.block_height,
+    t.raw_tx
+FROM transactions AS t
+WHERE
+    t.wallet_id = ?
+    AND t.tx_status IN (0, 1)
+ORDER BY t.id;
+
 -- name: ListTransactionsByHeightRange :many
 -- Lists all confirmed transactions for a wallet in the provided height range.
 --

--- a/wallet/internal/sql/sqlite/queries/utxos.sql
+++ b/wallet/internal/sql/sqlite/queries/utxos.sql
@@ -492,3 +492,43 @@ WHERE
         FROM transactions AS t
         WHERE t.id = utxos.tx_id AND t.wallet_id = ?1
     );
+
+-- name: ListOutputsToWatch :many
+-- Lists every output a recovery rescan must keep watching for one wallet.
+--
+-- How:
+-- - Starts from the wallet's UTXO rows joined to their funding transaction;
+--   the rescan needs each outpoint plus the on-chain output script. The script
+--   is taken from the funding transaction's raw_tx (TxOut[output_index]) in the
+--   Store Go layer rather than from the credited address: a bare-multisig
+--   output the wallet partly owns is recorded against a member address whose
+--   own script differs from the multisig output script, so the address script
+--   would be the wrong thing to watch. Reading the actual output script matches
+--   the kvdb OutputsToWatch contract.
+-- - Includes outputs whose funding transaction is still active (pending or
+--   published); invalidated parents (replaced/failed/orphaned) are excluded so
+--   the watch set matches the legacy wtxmgr credit walk.
+-- - Keeps an output when it is either still unspent OR spent only by an
+--   unmined, still-active transaction. This mirrors the legacy behaviour of
+--   returning unmined credits and credits spent by other unmined txs, while
+--   dropping outputs already spent by a confirmed transaction.
+-- - Locked (leased) outputs are intentionally retained because leasing is
+--   modelled separately from existence and the rescan must still watch them.
+SELECT
+    t.tx_hash,
+    u.output_index,
+    t.raw_tx
+FROM utxos AS u
+INNER JOIN transactions AS t ON u.tx_id = t.id
+LEFT JOIN transactions AS spend ON u.spent_by_tx_id = spend.id
+WHERE
+    t.wallet_id = sqlc.arg('wallet_id')
+    AND t.tx_status IN (0, 1)
+    AND (
+        u.spent_by_tx_id IS NULL
+        OR (
+            spend.block_height IS NULL
+            AND spend.tx_status IN (0, 1)
+        )
+    )
+ORDER BY t.tx_hash, u.output_index;

--- a/wallet/internal/sql/sqlite/queries/utxos.sql
+++ b/wallet/internal/sql/sqlite/queries/utxos.sql
@@ -385,14 +385,19 @@ ORDER BY u.spent_by_tx_id;
 --   considers outputs whose parent status is `pending` or `published`.
 -- - Returns the nullable `spent_by_tx_id` column so callers can distinguish
 --   between an external/unknown parent and a wallet-owned conflict.
+-- - Returns the owner address script so duplicate credit replay can verify it
+--   matches the already-recorded UTXO rather than only checking outpoint
+--   existence.
 -- Performance:
 -- - Targets one wallet-scoped outpoint through the unique `(tx_id,
 --   output_index)` key after the parent hash lookup.
-SELECT utxos.spent_by_tx_id
+SELECT utxos.spent_by_tx_id, a.script_pub_key
 FROM transactions AS t
 INNER JOIN utxos ON t.id = utxos.tx_id
+INNER JOIN addresses AS a ON utxos.address_id = a.id
 WHERE
     t.wallet_id = ?1
+    AND a.wallet_id = ?1
     AND t.tx_hash = ?2
     AND utxos.output_index = ?3
     AND t.tx_status IN (0, 1);

--- a/wallet/internal/sql/sqlite/sqlc/db.go
+++ b/wallet/internal/sql/sqlite/sqlc/db.go
@@ -216,6 +216,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.listKeyScopesByWalletStmt, err = db.PrepareContext(ctx, ListKeyScopesByWallet); err != nil {
 		return nil, fmt.Errorf("error preparing query ListKeyScopesByWallet: %w", err)
 	}
+	if q.listOutputsToWatchStmt, err = db.PrepareContext(ctx, ListOutputsToWatch); err != nil {
+		return nil, fmt.Errorf("error preparing query ListOutputsToWatch: %w", err)
+	}
 	if q.listOwnedInputPrevOutputsByTxHashesStmt, err = db.PrepareContext(ctx, ListOwnedInputPrevOutputsByTxHashes); err != nil {
 		return nil, fmt.Errorf("error preparing query ListOwnedInputPrevOutputsByTxHashes: %w", err)
 	}
@@ -613,6 +616,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing listKeyScopesByWalletStmt: %w", cerr)
 		}
 	}
+	if q.listOutputsToWatchStmt != nil {
+		if cerr := q.listOutputsToWatchStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listOutputsToWatchStmt: %w", cerr)
+		}
+	}
 	if q.listOwnedInputPrevOutputsByTxHashesStmt != nil {
 		if cerr := q.listOwnedInputPrevOutputsByTxHashesStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing listOwnedInputPrevOutputsByTxHashesStmt: %w", cerr)
@@ -836,6 +844,7 @@ type Queries struct {
 	listAddressesByAccountStmt                  *sql.Stmt
 	listAddressesByScriptPubKeysStmt            *sql.Stmt
 	listKeyScopesByWalletStmt                   *sql.Stmt
+	listOutputsToWatchStmt                      *sql.Stmt
 	listOwnedInputPrevOutputsByTxHashesStmt     *sql.Stmt
 	listOwnedOutputsByTxIDsStmt                 *sql.Stmt
 	listRawImportedAddressesStmt                *sql.Stmt
@@ -930,6 +939,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		listAddressesByAccountStmt:                  q.listAddressesByAccountStmt,
 		listAddressesByScriptPubKeysStmt:            q.listAddressesByScriptPubKeysStmt,
 		listKeyScopesByWalletStmt:                   q.listKeyScopesByWalletStmt,
+		listOutputsToWatchStmt:                      q.listOutputsToWatchStmt,
 		listOwnedInputPrevOutputsByTxHashesStmt:     q.listOwnedInputPrevOutputsByTxHashesStmt,
 		listOwnedOutputsByTxIDsStmt:                 q.listOwnedOutputsByTxIDsStmt,
 		listRawImportedAddressesStmt:                q.listRawImportedAddressesStmt,

--- a/wallet/internal/sql/sqlite/sqlc/db.go
+++ b/wallet/internal/sql/sqlite/sqlc/db.go
@@ -201,6 +201,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.listAccountsByWalletScopeStmt, err = db.PrepareContext(ctx, ListAccountsByWalletScope); err != nil {
 		return nil, fmt.Errorf("error preparing query ListAccountsByWalletScope: %w", err)
 	}
+	if q.listActiveTransactionRawsStmt, err = db.PrepareContext(ctx, ListActiveTransactionRaws); err != nil {
+		return nil, fmt.Errorf("error preparing query ListActiveTransactionRaws: %w", err)
+	}
 	if q.listActiveUtxoLeasesStmt, err = db.PrepareContext(ctx, ListActiveUtxoLeases); err != nil {
 		return nil, fmt.Errorf("error preparing query ListActiveUtxoLeases: %w", err)
 	}
@@ -591,6 +594,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing listAccountsByWalletScopeStmt: %w", cerr)
 		}
 	}
+	if q.listActiveTransactionRawsStmt != nil {
+		if cerr := q.listActiveTransactionRawsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listActiveTransactionRawsStmt: %w", cerr)
+		}
+	}
 	if q.listActiveUtxoLeasesStmt != nil {
 		if cerr := q.listActiveUtxoLeasesStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing listActiveUtxoLeasesStmt: %w", cerr)
@@ -839,6 +847,7 @@ type Queries struct {
 	listAccountsByWalletStmt                    *sql.Stmt
 	listAccountsByWalletAndNameStmt             *sql.Stmt
 	listAccountsByWalletScopeStmt               *sql.Stmt
+	listActiveTransactionRawsStmt               *sql.Stmt
 	listActiveUtxoLeasesStmt                    *sql.Stmt
 	listAddressTypesStmt                        *sql.Stmt
 	listAddressesByAccountStmt                  *sql.Stmt
@@ -934,6 +943,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		listAccountsByWalletStmt:                    q.listAccountsByWalletStmt,
 		listAccountsByWalletAndNameStmt:             q.listAccountsByWalletAndNameStmt,
 		listAccountsByWalletScopeStmt:               q.listAccountsByWalletScopeStmt,
+		listActiveTransactionRawsStmt:               q.listActiveTransactionRawsStmt,
 		listActiveUtxoLeasesStmt:                    q.listActiveUtxoLeasesStmt,
 		listAddressTypesStmt:                        q.listAddressTypesStmt,
 		listAddressesByAccountStmt:                  q.listAddressesByAccountStmt,

--- a/wallet/internal/sql/sqlite/sqlc/querier.go
+++ b/wallet/internal/sql/sqlite/sqlc/querier.go
@@ -232,10 +232,13 @@ type Querier interface {
 	//   considers outputs whose parent status is `pending` or `published`.
 	// - Returns the nullable `spent_by_tx_id` column so callers can distinguish
 	//   between an external/unknown parent and a wallet-owned conflict.
+	// - Returns the owner address script so duplicate credit replay can verify it
+	//   matches the already-recorded UTXO rather than only checking outpoint
+	//   existence.
 	// Performance:
 	// - Targets one wallet-scoped outpoint through the unique `(tx_id,
 	//   output_index)` key after the parent hash lookup.
-	GetUtxoSpendByOutpoint(ctx context.Context, arg GetUtxoSpendByOutpointParams) (sql.NullInt64, error)
+	GetUtxoSpendByOutpoint(ctx context.Context, arg GetUtxoSpendByOutpointParams) (GetUtxoSpendByOutpointRow, error)
 	GetWalletByID(ctx context.Context, id int64) (GetWalletByIDRow, error)
 	GetWalletByName(ctx context.Context, walletName string) (GetWalletByNameRow, error)
 	GetWalletSecrets(ctx context.Context, walletID int64) (WalletSecret, error)
@@ -314,6 +317,17 @@ type Querier interface {
 	ListAccountsByWalletAndName(ctx context.Context, arg ListAccountsByWalletAndNameParams) ([]ListAccountsByWalletAndNameRow, error)
 	// Lists all accounts for a wallet and scope tuple.
 	ListAccountsByWalletScope(ctx context.Context, arg ListAccountsByWalletScopeParams) ([]ListAccountsByWalletScopeRow, error)
+	// Lists active wallet transaction rows and their raw transaction bytes.
+	//
+	// How:
+	// - Reads from transactions only and filters to rows that may currently spend
+	//   wallet-owned outputs (`pending` and `published`).
+	// - Returns the primary key, transaction hash, block assignment, and raw
+	//   transaction bytes so callers can rebuild input outpoints not normalized in
+	//   the SQL schema.
+	// Performance:
+	// - Matches the wallet/status index used by active wallet history paths.
+	ListActiveTransactionRaws(ctx context.Context, walletID int64) ([]ListActiveTransactionRawsRow, error)
 	// Lists all currently active leases for a wallet.
 	//
 	// How:

--- a/wallet/internal/sql/sqlite/sqlc/querier.go
+++ b/wallet/internal/sql/sqlite/sqlc/querier.go
@@ -338,6 +338,27 @@ type Querier interface {
 	ListAddressesByScriptPubKeys(ctx context.Context, arg ListAddressesByScriptPubKeysParams) ([]ListAddressesByScriptPubKeysRow, error)
 	// Lists all key scopes for a wallet, ordered by ID.
 	ListKeyScopesByWallet(ctx context.Context, walletID int64) ([]ListKeyScopesByWalletRow, error)
+	// Lists every output a recovery rescan must keep watching for one wallet.
+	//
+	// How:
+	// - Starts from the wallet's UTXO rows joined to their funding transaction;
+	//   the rescan needs each outpoint plus the on-chain output script. The script
+	//   is taken from the funding transaction's raw_tx (TxOut[output_index]) in the
+	//   Store Go layer rather than from the credited address: a bare-multisig
+	//   output the wallet partly owns is recorded against a member address whose
+	//   own script differs from the multisig output script, so the address script
+	//   would be the wrong thing to watch. Reading the actual output script matches
+	//   the kvdb OutputsToWatch contract.
+	// - Includes outputs whose funding transaction is still active (pending or
+	//   published); invalidated parents (replaced/failed/orphaned) are excluded so
+	//   the watch set matches the legacy wtxmgr credit walk.
+	// - Keeps an output when it is either still unspent OR spent only by an
+	//   unmined, still-active transaction. This mirrors the legacy behaviour of
+	//   returning unmined credits and credits spent by other unmined txs, while
+	//   dropping outputs already spent by a confirmed transaction.
+	// - Locked (leased) outputs are intentionally retained because leasing is
+	//   modelled separately from existence and the rescan must still watch them.
+	ListOutputsToWatch(ctx context.Context, walletID int64) ([]ListOutputsToWatchRow, error)
 	// ListOwnedInputPrevOutputsByTxHashes lists wallet-owned previous outputs that
 	// may be spent by selected transaction inputs.
 	//

--- a/wallet/internal/sql/sqlite/sqlc/transactions.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/transactions.sql.go
@@ -245,6 +245,65 @@ func (q *Queries) InsertTransaction(ctx context.Context, arg InsertTransactionPa
 	return id, err
 }
 
+const ListActiveTransactionRaws = `-- name: ListActiveTransactionRaws :many
+SELECT
+    t.id,
+    t.tx_hash,
+    t.block_height,
+    t.raw_tx
+FROM transactions AS t
+WHERE
+    t.wallet_id = ?
+    AND t.tx_status IN (0, 1)
+ORDER BY t.id
+`
+
+type ListActiveTransactionRawsRow struct {
+	ID          int64
+	TxHash      []byte
+	BlockHeight sql.NullInt64
+	RawTx       []byte
+}
+
+// Lists active wallet transaction rows and their raw transaction bytes.
+//
+// How:
+//   - Reads from transactions only and filters to rows that may currently spend
+//     wallet-owned outputs (`pending` and `published`).
+//   - Returns the primary key, transaction hash, block assignment, and raw
+//     transaction bytes so callers can rebuild input outpoints not normalized in
+//     the SQL schema.
+//
+// Performance:
+// - Matches the wallet/status index used by active wallet history paths.
+func (q *Queries) ListActiveTransactionRaws(ctx context.Context, walletID int64) ([]ListActiveTransactionRawsRow, error) {
+	rows, err := q.query(ctx, q.listActiveTransactionRawsStmt, ListActiveTransactionRaws, walletID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListActiveTransactionRawsRow
+	for rows.Next() {
+		var i ListActiveTransactionRawsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.TxHash,
+			&i.BlockHeight,
+			&i.RawTx,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const ListOwnedInputPrevOutputsByTxHashes = `-- name: ListOwnedInputPrevOutputsByTxHashes :many
 SELECT
     t.tx_hash,

--- a/wallet/internal/sql/sqlite/sqlc/utxos.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/utxos.sql.go
@@ -406,11 +406,13 @@ func (q *Queries) GetUtxoIDByOutpoint(ctx context.Context, arg GetUtxoIDByOutpoi
 }
 
 const GetUtxoSpendByOutpoint = `-- name: GetUtxoSpendByOutpoint :one
-SELECT utxos.spent_by_tx_id
+SELECT utxos.spent_by_tx_id, a.script_pub_key
 FROM transactions AS t
 INNER JOIN utxos ON t.id = utxos.tx_id
+INNER JOIN addresses AS a ON utxos.address_id = a.id
 WHERE
     t.wallet_id = ?1
+    AND a.wallet_id = ?1
     AND t.tx_hash = ?2
     AND utxos.output_index = ?3
     AND t.tx_status IN (0, 1)
@@ -422,6 +424,11 @@ type GetUtxoSpendByOutpointParams struct {
 	OutputIndex int64
 }
 
+type GetUtxoSpendByOutpointRow struct {
+	SpentByTxID  sql.NullInt64
+	ScriptPubKey []byte
+}
+
 // Returns the current spend edge for one wallet-owned outpoint.
 //
 // How:
@@ -429,15 +436,18 @@ type GetUtxoSpendByOutpointParams struct {
 //     considers outputs whose parent status is `pending` or `published`.
 //   - Returns the nullable `spent_by_tx_id` column so callers can distinguish
 //     between an external/unknown parent and a wallet-owned conflict.
+//   - Returns the owner address script so duplicate credit replay can verify it
+//     matches the already-recorded UTXO rather than only checking outpoint
+//     existence.
 //
 // Performance:
 //   - Targets one wallet-scoped outpoint through the unique `(tx_id,
 //     output_index)` key after the parent hash lookup.
-func (q *Queries) GetUtxoSpendByOutpoint(ctx context.Context, arg GetUtxoSpendByOutpointParams) (sql.NullInt64, error) {
+func (q *Queries) GetUtxoSpendByOutpoint(ctx context.Context, arg GetUtxoSpendByOutpointParams) (GetUtxoSpendByOutpointRow, error) {
 	row := q.queryRow(ctx, q.getUtxoSpendByOutpointStmt, GetUtxoSpendByOutpoint, arg.WalletID, arg.TxHash, arg.OutputIndex)
-	var spent_by_tx_id sql.NullInt64
-	err := row.Scan(&spent_by_tx_id)
-	return spent_by_tx_id, err
+	var i GetUtxoSpendByOutpointRow
+	err := row.Scan(&i.SpentByTxID, &i.ScriptPubKey)
+	return i, err
 }
 
 const HasInvalidWalletUtxoByOutpoint = `-- name: HasInvalidWalletUtxoByOutpoint :one

--- a/wallet/internal/sql/sqlite/sqlc/utxos.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/utxos.sql.go
@@ -534,6 +534,76 @@ func (q *Queries) InsertUtxo(ctx context.Context, arg InsertUtxoParams) (int64, 
 	return id, err
 }
 
+const ListOutputsToWatch = `-- name: ListOutputsToWatch :many
+SELECT
+    t.tx_hash,
+    u.output_index,
+    t.raw_tx
+FROM utxos AS u
+INNER JOIN transactions AS t ON u.tx_id = t.id
+LEFT JOIN transactions AS spend ON u.spent_by_tx_id = spend.id
+WHERE
+    t.wallet_id = ?1
+    AND t.tx_status IN (0, 1)
+    AND (
+        u.spent_by_tx_id IS NULL
+        OR (
+            spend.block_height IS NULL
+            AND spend.tx_status IN (0, 1)
+        )
+    )
+ORDER BY t.tx_hash, u.output_index
+`
+
+type ListOutputsToWatchRow struct {
+	TxHash      []byte
+	OutputIndex int64
+	RawTx       []byte
+}
+
+// Lists every output a recovery rescan must keep watching for one wallet.
+//
+// How:
+//   - Starts from the wallet's UTXO rows joined to their funding transaction;
+//     the rescan needs each outpoint plus the on-chain output script. The script
+//     is taken from the funding transaction's raw_tx (TxOut[output_index]) in the
+//     Store Go layer rather than from the credited address: a bare-multisig
+//     output the wallet partly owns is recorded against a member address whose
+//     own script differs from the multisig output script, so the address script
+//     would be the wrong thing to watch. Reading the actual output script matches
+//     the kvdb OutputsToWatch contract.
+//   - Includes outputs whose funding transaction is still active (pending or
+//     published); invalidated parents (replaced/failed/orphaned) are excluded so
+//     the watch set matches the legacy wtxmgr credit walk.
+//   - Keeps an output when it is either still unspent OR spent only by an
+//     unmined, still-active transaction. This mirrors the legacy behaviour of
+//     returning unmined credits and credits spent by other unmined txs, while
+//     dropping outputs already spent by a confirmed transaction.
+//   - Locked (leased) outputs are intentionally retained because leasing is
+//     modelled separately from existence and the rescan must still watch them.
+func (q *Queries) ListOutputsToWatch(ctx context.Context, walletID int64) ([]ListOutputsToWatchRow, error) {
+	rows, err := q.query(ctx, q.listOutputsToWatchStmt, ListOutputsToWatch, walletID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListOutputsToWatchRow
+	for rows.Next() {
+		var i ListOutputsToWatchRow
+		if err := rows.Scan(&i.TxHash, &i.OutputIndex, &i.RawTx); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const ListSpendingTxIDsByParentTxID = `-- name: ListSpendingTxIDsByParentTxID :many
 SELECT DISTINCT u.spent_by_tx_id
 FROM utxos AS u


### PR DESCRIPTION
Adds the scan-batch scaffolding — `db.ScanHorizon` / scan-batch query types,
account-name queries, scan-horizon extension helpers, and the
`AddressInfo.HasDerivationPath` population — together with the `waddrmgr`
rollback support it builds on (`RestoreSyncedTo`, `EvictDerivedAddresses`).

Split out of the runtime Store PR (#1256) for reviewability; content-preserving,
no commit changes. Stacked on `prep-runtime-1`.
