### PR TITLE
chain: add SubmitPackage to the chain.Interface

### DIFF
--- a/chain/bitcoind_client.go
+++ b/chain/bitcoind_client.go
@@ -257,6 +257,30 @@ func (c *BitcoindClient) TestMempoolAccept(txns []*wire.MsgTx,
 	return c.chainConn.client.TestMempoolAccept(txns, maxFeeRate)
 }
 
+// SubmitPackage submits a package of related transactions (topologically
+// sorted, parents first and child last) to bitcoind's mempool for atomic
+// validation and acceptance via the submitpackage RPC. This is what allows a
+// zero-fee v3/TRUC parent to be accepted when paired with a fee-paying CPFP
+// child, which sendrawtransaction (single-tx) rejects.
+//
+// maxFeeRate is the optional per-tx fee-rate ceiling in BTC/kvB (pass a
+// pointer to 0 to disable the limit for high-feerate CPFP children).
+//
+// NOTE: This is part of the chain.Interface interface.
+func (c *BitcoindClient) SubmitPackage(txns []*wire.MsgTx,
+	maxFeeRate *float64) (*btcjson.SubmitPackageResult, error) {
+
+	// The rpcclient SubmitPackage exposes a maxBurnAmount limit too, which
+	// we don't surface on chain.Interface; pass nil to use the node
+	// default.
+	result, err := c.chainConn.client.SubmitPackage(txns, maxFeeRate, nil)
+	if err != nil {
+		return nil, c.MapRPCErr(err)
+	}
+
+	return result, nil
+}
+
 // Notifications returns a channel to retrieve notifications from.
 //
 // NOTE: This is part of the chain.Interface interface.

--- a/chain/btcd.go
+++ b/chain/btcd.go
@@ -204,6 +204,19 @@ func (c *RPCClient) BackEnd() string {
 	return "btcd"
 }
 
+// SubmitPackage is unimplemented for the btcd backend. btcd defines the
+// submitpackage JSON-RPC command type but its RPC server registers no handler
+// for it, so a RawRequest would fail with a method-not-found error. Returning
+// ErrUnimplemented avoids advertising support that does not exist; a btcd
+// server-side submitpackage handler must land before this can do anything.
+//
+// NOTE: This is part of the chain.Interface interface.
+func (c *RPCClient) SubmitPackage(_ []*wire.MsgTx,
+	_ *float64) (*btcjson.SubmitPackageResult, error) {
+
+	return nil, ErrUnimplemented
+}
+
 // Start attempts to establish a client connection with the remote server.
 // If successful, handler goroutines are started to process notifications
 // sent by the server.  After a limited number of connection attempts, this

--- a/chain/interface.go
+++ b/chain/interface.go
@@ -54,6 +54,8 @@ type Interface interface {
 	Notifications() <-chan interface{}
 	BackEnd() string
 	TestMempoolAccept([]*wire.MsgTx, float64) ([]*btcjson.TestMempoolAcceptResult, error)
+	SubmitPackage(txns []*wire.MsgTx,
+		maxFeeRate *float64) (*btcjson.SubmitPackageResult, error)
 	MapRPCErr(err error) error
 }
 

--- a/chain/neutrino.go
+++ b/chain/neutrino.go
@@ -239,6 +239,25 @@ func (s *NeutrinoClient) TestMempoolAccept(txns []*wire.MsgTx,
 	return nil, ErrUnimplemented
 }
 
+// SubmitPackage is unimplemented for the neutrino backend, mirroring
+// TestMempoolAccept: a light client has no mempool and cannot run the
+// submitpackage RPC, so it can neither validate nor atomically accept a
+// package, nor report whether one was accepted.
+//
+// A zero-fee parent paired with a fee-paying CPFP child can still reach the
+// network over neutrino by broadcasting each transaction individually (parents
+// first) via SendRawTransaction and relying on a peer's P2P 1p1c package
+// relay. That is a best-effort propagation step with no acceptance signal,
+// distinct from submitpackage's submit-for-acceptance contract, so it is left
+// to the caller rather than conflated with this method.
+//
+// NOTE: This is part of the chain.Interface interface.
+func (s *NeutrinoClient) SubmitPackage(_ []*wire.MsgTx,
+	_ *float64) (*btcjson.SubmitPackageResult, error) {
+
+	return nil, ErrUnimplemented
+}
+
 // FilterBlocks scans the blocks contained in the FilterBlocksRequest for any
 // addresses of interest. For each requested block, the corresponding compact
 // filter will first be checked for matches, skipping those that do not report

--- a/wallet/mock.go
+++ b/wallet/mock.go
@@ -103,6 +103,13 @@ func (m *mockChainClient) TestMempoolAccept(txns []*wire.MsgTx,
 	return nil, nil
 }
 
+// SubmitPackage is part of the chain.Interface interface.
+func (m *mockChainClient) SubmitPackage(txns []*wire.MsgTx,
+	maxFeeRate *float64) (*btcjson.SubmitPackageResult, error) {
+
+	return &btcjson.SubmitPackageResult{}, nil
+}
+
 func (m *mockChainClient) MapRPCErr(err error) error {
 	return nil
 }


### PR DESCRIPTION
### Summary

Adds `SubmitPackage` to `chain.Interface`, exposing Bitcoin Core's
`submitpackage` RPC so callers can submit a topologically-sorted package of
transactions (unconfirmed parents first, child last) for atomic validation and
acceptance.

This is what lets a **v3/TRUC** transaction package relay: a zero-fee parent
carrying an ephemeral (P2A) anchor is below the minimum relay fee and is
rejected by `sendrawtransaction` on its own, but is accepted when submitted
together with a fee-paying CPFP child whose combined feerate clears policy.
`TestMempoolAccept` already mirrors this kind of pass-through to a Core RPC;
`SubmitPackage` is the broadcasting counterpart.

### Details

- **`BitcoindClient`** forwards to `rpcclient`'s typed `SubmitPackage` method,
  keeping the multi-backend RPC layering intact — the `chain` package calls
  `rpcclient` rather than issuing its own `RawRequest`. Errors are mapped
  through `MapRPCErr` for parity with `SendRawTransaction`.
- The **btcd `RPCClient`** and **`NeutrinoClient`** return `ErrUnimplemented`,
  the same way `TestMempoolAccept` does on neutrino: btcd has no `submitpackage`
  server handler yet, and a neutrino light client has no mempool and so cannot
  validate or atomically accept a package. The method's contract therefore
  stays uniform across backends — it either accepts a package or reports that
  it is unimplemented, and never fabricates a success.
- `maxFeeRate` is the optional per-transaction fee-rate ceiling in BTC/kvB
  (`nil` leaves the node default unchanged; pass a pointer to `0` to disable the
  limit, which a high-feerate CPFP child requires).

### Dependency

The typed `rpcclient.SubmitPackage` method this builds on landed in
btcsuite/btcd#2551 and ships in the tagged **btcd v0.26.0**, which `master`
already depends on — so this PR carries no `replace` directives or dependency
bumps of its own; it just uses the tagged release.

### Testing

`go build ./...` and `go vet ./...` pass. The path was exercised end-to-end
against a regtest `bitcoind` v29: a zero-fee TRUC parent plus a fee-paying CPFP
child submitted as a package is accepted and confirms, where the parent alone
is rejected for `min relay fee not met`.