### PR TITLE
multi: add keyvault lifecycle boundary

### DIFF
--- a/docs/developer/adr/0010-keyvault-encryption-layer.md
+++ b/docs/developer/adr/0010-keyvault-encryption-layer.md
@@ -2,106 +2,185 @@
 
 ## 1. Context
 
-The updated encryption model defined in ADR 0009 and the planned
-cryptographic primitive migration proposed in ADR 0007 require a clear
-boundary between domain logic and the SQL database layer. The
-legacy `waddrmgr` design tightly couples storage, locking, and key derivation,
-which complicates the SQL migration and makes encryption behavior hard to test
-in isolation.
+The encryption model defined in ADR 0009 and the cryptographic primitive
+migration proposed in ADR 0007 require a clear boundary between wallet domain
+logic and database persistence.
 
-To address this, we need a dedicated component that owns lock state, key
-derivation, and encryption, while keeping the database layer strictly
-encryption agnostic.
+The legacy `waddrmgr` design couples storage, locking, key derivation, and
+encryption. This makes the SQL migration harder, spreads encryption behavior
+across persistence code, and makes lock state difficult to test in isolation.
 
-The `db.Store` remains available to other callers for non-cryptographic
+We need a dedicated component that owns lock state, key derivation, secret
+material lifetime, and encryption. The database layer should remain encryption
+agnostic and store encrypted key material as opaque bytes.
+
+The `db.Store` remains available to other wallet code for non-cryptographic
 queries and updates.
 
 ## 2. Decision
 
-We will introduce a dedicated **`wallet/internal/keyvault`** package that
-defines the encryption boundary between domain code and the SQL store layer.
-Keyvault accesses the database through `db.Store`, not by talking directly
-to the SQL backend.
+We will introduce a dedicated `wallet/internal/keyvault` package. This package
+defines the encryption boundary between wallet domain code and the store layer.
+
+A wallet facing `keyvault.Vault` is scoped to exactly one wallet at construction
+time. It receives a `db.Store` and a wallet identifier during wiring, then keeps
+persistence routing internal. Callers that hold a vault do not pass a wallet ID
+to each lock, unlock, encrypt, decrypt, or derivation operation.
+
+Keyvault accesses persistence through `db.Store`. It does not talk directly to
+SQL backends.
 
 ```mermaid
 flowchart TD
-    A[Domain Code] -->|crypto ops| B[keyvault]
-    A -->|non-crypto ops| E[db.Store]
-    B -->|derive| C[btcutil/hdkeychain]
-    B -->|decrypt/encrypt| F[XChaCha20Poly1305</br>XSalsa20Poly1305]
-    B -->|read/write| E
-    B -->|read/write| H[(memory cache)]
-    E --> D[(SQL DB)]
-    E --> G[(kvdb)]
-    classDef store fill:#f8f9fb,stroke:#9aa0a6,stroke-width:1px
-    class G,D store
+    wallet[Wallet]
+
+    subgraph support[Supporting libraries]
+        hd[btcutil/hdkeychain<br/>BIP32 and BIP44 derivation]
+        crypto[AEAD crypto<br/>current and migrated primitives]
+    end
+
+    subgraph vault_boundary[keyvault boundary]
+        vault[keyvault.Vault<br/>wallet scoped lock state<br/>key lifecycle<br/>secret material API]
+        cache[(In memory secret cache<br/>unlocked keys<br/>derived keys)]
+    end
+
+    subgraph store_boundary[db.Store boundary]
+        store[db.Store<br/>multi wallet persistence API]
+
+        subgraph backends[Persistence backends]
+            sql[(SQL backend<br/>rows scoped by wallet_id)]
+            kvdb[(kvdb backend<br/>legacy storage)]
+        end
+    end
+
+    wallet -->|owns wallet scoped vault| vault
+    wallet -->|uses store for non cryptographic data| store
+    vault -->|persists encrypted key material| store
+    vault -->|loads encrypted key material| store
+    vault -->|keeps unlocked material| cache
+    vault -->|derives HD keys| hd
+    vault -->|encrypts and decrypts secrets| crypto
+    store -->|routes by wallet_id| sql
+    store -->|adapts legacy layout| kvdb
 ```
+
+This is a structural boundary diagram, not a runtime call sequence.
+
+The `Wallet` struct holds two related dependencies:
+
+1. A wallet scoped `keyvault.Vault`
+2. A multi wallet `db.Store`
+
+Encrypted key material flows through the vault. Non-cryptographic wallet data
+may still flow directly through the store.
+
+The store remains the persistence boundary for wallet data and keeps wallet ID
+routing inside the store or adapter layer. The vault hides that routing from
+wallet facing lock, unlock, encryption, decryption, and derivation APIs.
 
 ### Responsibilities
 
 1. **Own lock state and key lifecycle**
-   Centralized management of unlock state, key derivation, key material
-   lifetime, and secure memory zeroing.
+   Keyvault manages unlock state, key material lifetime, auto lock behavior, and
+   secure memory zeroing.
 
 2. **Expose typed domain interfaces**
-   Methods return `*btcec.PrivateKey`, `*btcec.PublicKey`, and
-   `btcutil.Address` instead of encrypted `[]byte` values.
+   Keyvault returns domain types such as `*btcec.PrivateKey`,
+   `*btcec.PublicKey`, and `btcutil.Address` instead of exposing encrypted byte
+   slices to wallet code.
 
 3. **Handle HD derivation**
-   Use `btcutil/hdkeychain` for BIP32 and BIP44 derivation and return or
-   persist derived keys as needed.
+   Keyvault uses `btcutil/hdkeychain` for BIP32 and BIP44 derivation and returns
+   or persists derived key material as needed.
 
-4. **Maintain an in-memory cache**
-   Cache account level and derived keys to avoid repeated derivation and
-   database reads.
+4. **Maintain an in memory secret cache**
+   Keyvault may cache account level keys and derived keys while unlocked to
+   avoid repeated derivation and database reads.
 
-5. **Support multi-wallet operation**
-   A single keyvault instance manages multiple wallets via `wallet_id`
-   parameters.
+5. **Keep wallet facing APIs scoped to one wallet**
+   A wallet facing `keyvault.Vault` is configured for one wallet during
+   construction. Callers do not pass a wallet ID to every vault method.
 
 6. **Track current and planned cryptographic primitives**
-   Encryption follows the accepted single-passphrase model in ADR 0009 and
-   adopts ADR 0007 once the XChaCha20-Poly1305 migration is implemented.
+   Keyvault follows the single passphrase model accepted in ADR 0009 and adopts
+   the ADR 0007 primitive migration once implemented.
 
 7. **Coexist with `waddrmgr` during migration**
-   New code uses keyvault while legacy code continues to rely on
-   `waddrmgr` until the migration is complete.
+   New code uses keyvault while legacy code continues to rely on `waddrmgr`
+   until the migration is complete.
 
 ## 3. Consequences
 
+The wallet facing `keyvault.Vault` API intentionally does not expose wallet ID
+parameters on methods such as `Unlock`, `Lock`, `IsLocked`, `Encrypt`,
+`Decrypt`, or key derivation methods.
+
+Code that holds a vault already holds the vault selected for that wallet.
+Requiring every method call to pass a wallet ID would push database routing into
+controllers, accounts, addresses, and tests. It would also make cross wallet
+mistakes possible at every call site.
+
+The SQL and store layers remain multi wallet aware through `wallet_id` fields
+and parameters, consistent with ADR 0001. That routing is handled inside store
+implementations or keyvault adapters, not repeated throughout wallet domain
+code.
+
 ### Pros
 
-* **Separation of concerns**
-   Database code stores opaque bytes without knowledge of cryptography or lock
-   state.
+1. **Separation of concerns**
+   Database code stores opaque encrypted bytes without knowing about
+   cryptography, lock state, or key derivation.
 
-* **Type safety**
-  Callers work with strongly typed keys rather than raw blobs.
+2. **Type safety**
+   Wallet code works with typed keys and addresses instead of raw encrypted
+   blobs.
 
-* **Centralized lock management**
-  Prevents lock state divergence across components.
+3. **Centralized lock management**
+   Lock state, unlock timers, cache lifetime, and secret zeroing are owned by
+   one component.
 
-* **Performance**
-  Caching reduces repeated derivation and database access.
+4. **Extensible responsibility boundary**
+   Keyvault centralizes secret and key responsibilities, making it easier to
+   add future responsibilities behind the same boundary without spreading
+   changes across wallet callers.
 
-* **Testability**
-   Keyvault can be tested against mock databases, and domain logic can be
-   tested using mock keyvault implementations.
+5. **Lower call site complexity**
+   Wallet, account, address, and controller code can use a vault without
+   threading wallet IDs through every encryption or key access operation.
 
-* **Memory safety**
-  Secure memory handling and zeroing are centralized in one place.
+6. **Better testability**
+   Keyvault can be tested against mock stores, and wallet domain code can be
+   tested against mock vault implementations.
+
+7. **Per wallet isolation**
+   Each wallet has its own vault instance, lock state, cache, timers, and secret
+   material lifetime.
+
+8. **Migration support**
+   Keyvault can coexist with `waddrmgr`, allowing new SQL backed paths to move
+   behind the new boundary before legacy paths are removed.
 
 ### Cons
 
-* **Additional abstraction**
-  Introduces a new package boundary that must be maintained.
+1. **Additional abstraction**
+   The design introduces a new package boundary that must be maintained.
 
-* **Migration cost**
-  Existing code paths must be refactored to use the new keyvault API.
+2. **Migration cost**
+   Existing code paths must be refactored to use the new keyvault API.
 
-* **Temporary dual systems**
-   `waddrmgr` and keyvault will coexist during the transition period,
-   increasing short-term complexity.
+3. **Temporary dual systems**
+   `waddrmgr` and keyvault will coexist during the migration, increasing
+   temporary complexity.
+
+4. **Boundary discipline**
+   Implementations must keep wallet ID routing inside constructors, adapters, or
+   store methods. Exposing wallet ID on every vault method is rejected.
+
+5. **Constructor and adapter indirection**
+   Wiring a vault from `db.Store` plus wallet ID adds an adapter boundary
+   between wallet domain code and persistence. That boundary is intentional, but
+   future changes must keep it aligned with store methods that remain multi
+   wallet aware.
 
 ## 4. Status
 

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -67,7 +67,7 @@ func expectAccountDeriveSetup(t *testing.T, deps *mockWalletDeps,
 
 	deps.store.On("GetEncryptedHDSeed", mock.Anything, uint32(0)).
 		Return(append([]byte(nil), stub.encryptedSeed...), nil).Once()
-	deps.addrStore.On("Decrypt", waddrmgr.CKTPrivate,
+	deps.vault.On("Decrypt", waddrmgr.CKTPrivate,
 		mock.Anything).Return(
 		append([]byte(nil), stub.plaintextMasterKey...), nil,
 	).Once()

--- a/wallet/address_manager_test.go
+++ b/wallet/address_manager_test.go
@@ -770,7 +770,7 @@ func TestImportTaprootScript(t *testing.T) {
 	require.NoError(t, err)
 
 	encryptedScript := []byte("encrypted tapscript")
-	deps.addrStore.On(
+	deps.vault.On(
 		"Encrypt", waddrmgr.CKTPublic, encodedScript,
 	).Return(encryptedScript, nil).Once()
 	deps.store.On("NewImportedAddress", mock.Anything,

--- a/wallet/common_test.go
+++ b/wallet/common_test.go
@@ -97,6 +97,7 @@ func setupTestDB(t *testing.T) (walletdb.DB, func()) {
 // mockWalletDeps holds the mocked dependencies for the Wallet.
 type mockWalletDeps struct {
 	addrStore      *bwmock.AddrStore
+	vault          *walletmock.Vault
 	store          *walletmock.Store
 	txStore        *bwmock.TxStore
 	syncer         *mockChainSyncer
@@ -117,6 +118,7 @@ func createTestWalletWithMocks(t *testing.T) (*Wallet, *mockWalletDeps) {
 	t.Cleanup(cleanup)
 
 	mockAddrStore := &bwmock.AddrStore{}
+	mockVault := &walletmock.Vault{}
 	mockStore := &walletmock.Store{}
 	mockTxStore := &bwmock.TxStore{}
 	mockSyncer := &mockChainSyncer{}
@@ -132,7 +134,7 @@ func createTestWalletWithMocks(t *testing.T) (*Wallet, *mockWalletDeps) {
 		addrStore:   mockAddrStore,
 		store:       mockStore,
 		txStore:     mockTxStore,
-		keyVault:    mockAddrStore,
+		keyVault:    mockVault,
 		sync:        mockSyncer,
 		state:       newWalletState(mockSyncer),
 		lifetimeCtx: ctx,
@@ -155,6 +157,7 @@ func createTestWalletWithMocks(t *testing.T) (*Wallet, *mockWalletDeps) {
 
 	deps := &mockWalletDeps{
 		addrStore:      mockAddrStore,
+		vault:          mockVault,
 		store:          mockStore,
 		txStore:        mockTxStore,
 		syncer:         mockSyncer,
@@ -167,11 +170,13 @@ func createTestWalletWithMocks(t *testing.T) (*Wallet, *mockWalletDeps) {
 
 	t.Cleanup(func() {
 		mockAddrStore.AssertExpectations(t)
+		mockVault.AssertExpectations(t)
 		mockStore.AssertExpectations(t)
 		mockTxStore.AssertExpectations(t)
 		mockSyncer.AssertExpectations(t)
 		mockChain.AssertExpectations(t)
 		mockAddr.AssertExpectations(t)
+		mockVault.AssertExpectations(t)
 		mockAccountManager.AssertExpectations(t)
 		mockPubKeyAddr.AssertExpectations(t)
 		mockTaprootAddr.AssertExpectations(t)

--- a/wallet/deprecated.go
+++ b/wallet/deprecated.go
@@ -28,6 +28,7 @@ import (
 	"github.com/btcsuite/btcwallet/internal/prompt"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	kvdb "github.com/btcsuite/btcwallet/wallet/internal/db/kvdb"
+	"github.com/btcsuite/btcwallet/wallet/internal/keyvault"
 	"github.com/btcsuite/btcwallet/wallet/txauthor"
 	"github.com/btcsuite/btcwallet/wallet/txrules"
 	"github.com/btcsuite/btcwallet/walletdb"
@@ -7206,10 +7207,14 @@ func OpenWithRetry(db walletdb.DB, pubPass []byte, cbs *waddrmgr.OpenCallbacks,
 		syncRetryInterval:   syncRetryInterval,
 	}
 
+	walletID := uint32(0)
+	store := kvdb.NewStore(db, txMgr, addrMgr)
+
 	w := &Wallet{
+		id:               walletID,
 		addrStore:        addrMgr,
-		store:            kvdb.NewStore(db, txMgr, addrMgr),
-		keyVault:         addrMgr,
+		store:            store,
+		keyVault:         keyvault.NewDBVault(store, walletID),
 		txStore:          txMgr,
 		walletDeprecated: deprecated,
 	}

--- a/wallet/internal/bwtest/mock/vault.go
+++ b/wallet/internal/bwtest/mock/vault.go
@@ -5,6 +5,9 @@
 package mock
 
 import (
+	"context"
+	"time"
+
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/stretchr/testify/mock"
 )
@@ -30,6 +33,31 @@ func (m *Vault) Decrypt(keyType waddrmgr.CryptoKeyType,
 	args := m.Called(keyType, ciphertext)
 
 	return returnBytes(args, keyType, ciphertext), args.Error(1)
+}
+
+// Unlock forwards to the configured testify expectations.
+func (m *Vault) Unlock(ctx context.Context, passphrase []byte,
+	timeout time.Duration) error {
+
+	args := m.Called(ctx, passphrase, timeout)
+	return args.Error(0)
+}
+
+// Lock forwards to the configured testify expectations.
+func (m *Vault) Lock() {
+	m.Called()
+}
+
+// IsLocked forwards to the configured testify expectations.
+func (m *Vault) IsLocked() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
+// RefreshPrivatePassphrase forwards to the configured testify expectations.
+func (m *Vault) RefreshPrivatePassphrase(passphrase []byte) error {
+	args := m.Called(passphrase)
+	return args.Error(0)
 }
 
 // returnBytes resolves the first programmed Return arg into a byte slice.

--- a/wallet/internal/keyvault/db_vault.go
+++ b/wallet/internal/keyvault/db_vault.go
@@ -1,0 +1,77 @@
+package keyvault
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+)
+
+// errDBVaultNotImplemented marks db vault methods whose runtime state is not
+// available through db.Store yet.
+var errDBVaultNotImplemented = errors.New("db vault method not implemented")
+
+// DBVault adapts db.Store wallet secret storage to the wallet key-vault
+// boundary.
+type DBVault struct {
+	// store is the underlying durable persistence layer for the wallets.
+	store db.Store
+
+	// walletID is the wallet row id that this vault is scoped to.
+	walletID uint32
+}
+
+// Ensure DBVault implements keyvault.Vault.
+var _ Vault = (*DBVault)(nil)
+
+// NewDBVault creates a key-vault bridge scoped to one wallet row.
+func NewDBVault(store db.Store, walletID uint32) *DBVault {
+	return &DBVault{
+		store:    store,
+		walletID: walletID,
+	}
+}
+
+// Unlock is not implemented yet.
+// TODO(gus): implement it.
+func (v *DBVault) Unlock(_ context.Context, _ []byte, _ time.Duration) error {
+	return v.notImplemented("Unlock")
+}
+
+// Lock is not implemented yet.
+// TODO(gus): implement it.
+func (v *DBVault) Lock() {}
+
+// IsLocked is not implemented yet.
+// TODO(gus): implement it.
+func (v *DBVault) IsLocked() bool {
+	return true
+}
+
+// Encrypt is not implemented yet.
+// TODO(gus): implement it.
+func (v *DBVault) Encrypt(_ waddrmgr.CryptoKeyType, _ []byte) ([]byte, error) {
+	return nil, v.notImplemented("Encrypt")
+}
+
+// Decrypt  is not implemented yet.
+// TODO(gus): implement it.
+func (v *DBVault) Decrypt(_ waddrmgr.CryptoKeyType, _ []byte) ([]byte, error) {
+	return nil, v.notImplemented("Decrypt")
+}
+
+// RefreshPrivatePassphrase is not implemented yet.
+// TODO(gus): implement it.
+func (v *DBVault) RefreshPrivatePassphrase(_ []byte) error {
+	return v.notImplemented("RefreshPrivatePassphrase")
+}
+
+// notImplemented returns a scoped error for db vault methods that are still
+// awaiting DB-backed runtime crypto support.
+func (v *DBVault) notImplemented(method string) error {
+	return fmt.Errorf("wallet %d db vault %s: %w", v.walletID, method,
+		errDBVaultNotImplemented)
+}

--- a/wallet/internal/keyvault/keyvault.go
+++ b/wallet/internal/keyvault/keyvault.go
@@ -1,17 +1,46 @@
-// Package keyvault defines the wallet key-material encryption boundary.
+// Package keyvault defines the encryption boundary for wallet key material.
 package keyvault
 
-import "github.com/btcsuite/btcwallet/waddrmgr"
+import (
+	"context"
+	"time"
 
-// Vault provides encryption and decryption for wallet key material.
+	"github.com/btcsuite/btcwallet/waddrmgr"
+)
+
+// Vault manages the lock lifecycle and cryptographic operations for wallet key
+// material.
 type Vault interface {
-	// Encrypt encrypts plaintext key material with the selected key type.
+	// Unlock unlocks the vault with the provided passphrase and applies the
+	// requested automatic lock timeout.
+	//
+	// A zero timeout uses the implementation's default timeout.
+	// A negative timeout disables automatic locking until Lock is called.
+	// A positive timeout schedules Lock to run after that duration.
+	//
+	// A successful Unlock replaces any previously scheduled lock. An invalid
+	// passphrase must leave the vault locked.
+	Unlock(ctx context.Context, passphrase []byte, timeout time.Duration) error
+
+	// Lock locks the vault, clears any pending automatic lock, and erases
+	// secret material from memory. Lock is idempotent.
+	Lock()
+
+	// IsLocked reports whether the vault is currently locked.
+	IsLocked() bool
+
+	// Encrypt encrypts plaintext key material with the selected crypto key
+	// type.
 	Encrypt(keyType waddrmgr.CryptoKeyType, plaintext []byte) ([]byte, error)
 
-	// Decrypt decrypts ciphertext key material with the selected key type.
+	// Decrypt decrypts ciphertext key material with the selected crypto key
+	// type.
 	Decrypt(keyType waddrmgr.CryptoKeyType, ciphertext []byte) ([]byte, error)
-}
 
-// A compile-time assertion to ensure the legacy address manager satisfies the
-// keyvault boundary.
-var _ Vault = (*waddrmgr.Manager)(nil)
+	// RefreshPrivatePassphrase refreshes vault owned runtime passphrase and
+	// crypto state after a successful private passphrase rotation.
+	//
+	// The vault must still be unlocked with the new passphrase when this method
+	// is called.
+	RefreshPrivatePassphrase(passphrase []byte) error
+}

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -11,6 +11,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	kvdb "github.com/btcsuite/btcwallet/wallet/internal/db/kvdb"
+	"github.com/btcsuite/btcwallet/wallet/internal/keyvault"
 	"github.com/btcsuite/btcwallet/walletdb"
 )
 
@@ -340,7 +341,7 @@ func (m *Manager) Load(cfg Config) (*Wallet, error) {
 		addrStore:         addrMgr,
 		store:             store,
 		cache:             newStoreRuntimeCache(store),
-		keyVault:          addrMgr,
+		keyVault:          keyvault.NewDBVault(store, walletID),
 		txStore:           txMgr,
 		requestChan:       make(chan any),
 		lifetimeCtx:       lifetimeCtx,

--- a/wallet/signer_test.go
+++ b/wallet/signer_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	bwmock "github.com/btcsuite/btcwallet/bwtest/mock"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	walletmock "github.com/btcsuite/btcwallet/wallet/internal/bwtest/mock"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	sqlitedb "github.com/btcsuite/btcwallet/wallet/internal/db/sqlite"
 	"github.com/btcsuite/btcwallet/walletdb"
@@ -899,7 +900,9 @@ func TestComputeUnlockingScriptP2TR(t *testing.T) {
 func TestComputeUnlockingScriptSQLDerivedAddress(t *testing.T) {
 	t.Parallel()
 
-	w, chain := newSQLAddressSigningWallet(t)
+	w, chain, vault := newSQLAddressSigningWallet(t)
+	require.NotNil(t, vault)
+
 	chain.On(
 		"NotifyReceived",
 		mock.MatchedBy(func(addrs []btcutil.Address) bool {
@@ -951,7 +954,7 @@ func TestComputeUnlockingScriptSQLDerivedAddress(t *testing.T) {
 func TestGetPrivKeyForAddressSQLDerivedAddress(t *testing.T) {
 	t.Parallel()
 
-	w, chain := newSQLAddressSigningWallet(t)
+	w, chain, _ := newSQLAddressSigningWallet(t)
 	chain.On(
 		"NotifyReceived",
 		mock.MatchedBy(func(addrs []btcutil.Address) bool {
@@ -988,7 +991,7 @@ func TestGetPrivKeyForAddressSQLDerivedAddress(t *testing.T) {
 func TestNewAddressOnSQLOnlyAccount(t *testing.T) {
 	t.Parallel()
 
-	w, chain := newSQLAddressSigningWallet(t)
+	w, chain, _ := newSQLAddressSigningWallet(t)
 
 	_, err := w.store.CreateDerivedAccount(
 		t.Context(), db.CreateDerivedAccountParams{
@@ -1329,7 +1332,9 @@ func createDummyTestTx(pkScript []byte) (*wire.TxOut, *wire.MsgTx) {
 
 // newSQLAddressSigningWallet returns a started, unlocked wallet whose address
 // records are stored in SQLite while signing keys come from legacy waddrmgr.
-func newSQLAddressSigningWallet(t *testing.T) (*Wallet, *bwmock.Chain) {
+func newSQLAddressSigningWallet(t *testing.T) (*Wallet, *bwmock.Chain,
+	*walletmock.Vault) {
+
 	t.Helper()
 
 	legacyDB, cleanup := setupTestDB(t)
@@ -1380,10 +1385,12 @@ func newSQLAddressSigningWallet(t *testing.T) (*Wallet, *bwmock.Chain) {
 	require.NoError(t, err)
 
 	chain := &bwmock.Chain{}
+	vault := &walletmock.Vault{}
+
 	w = &Wallet{
 		addrStore: addrStore,
 		store:     store,
-		keyVault:  addrStore,
+		keyVault:  vault,
 		state:     newWalletState(nil),
 		cfg: Config{
 			DB:          legacyDB,
@@ -1399,9 +1406,10 @@ func newSQLAddressSigningWallet(t *testing.T) (*Wallet, *bwmock.Chain) {
 
 	t.Cleanup(func() {
 		chain.AssertExpectations(t)
+		vault.AssertExpectations(t)
 	})
 
-	return w, chain
+	return w, chain, vault
 }
 
 // newSpendableAddressManager creates and unlocks a deterministic legacy


### PR DESCRIPTION
This prepares the wallet/key encryption migration by making the keyvault the
future owner of wallet lock state, unlock timing, and passphrase refresh logic.

Today, legacy `waddrmgr` still owns the working lock/unlock/passphrase behavior.
This PR keeps those paths intact by moving them behind explicitly deprecated
methods, while adding the lifecycle shape that later PRs will implement in the
vault.

- add lock/unlock/passphrase-refresh methods to `keyvault.Vault`
- rename legacy `waddrmgr` lifecycle methods to deprecated entrypoints
- update existing wallet callers, mocks, and tests to keep using the legacy path
- document that keyvault is wallet-scoped in ADR 0010

Follow-up PRs will continue the vault implementation and gradually move callers
off the deprecated `waddrmgr` lifecycle.
