### PR TITLE
wallet+db: fix SQL-wallet review issues

### DIFF
--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -507,6 +507,13 @@ func dbScopeAddrSchema(
 func validateExtendedPubKey(pubKey *hdkeychain.ExtendedKey,
 	isAccountKey bool, chainParams *chaincfg.Params) error {
 
+	// A nil key cannot be validated and would otherwise panic on the
+	// IsPrivate call below.
+	if pubKey == nil {
+		return fmt.Errorf("%w: account key cannot be nil",
+			ErrInvalidAccountKey)
+	}
+
 	// Private keys are not allowed.
 	if pubKey.IsPrivate() {
 		return fmt.Errorf("%w: private keys cannot be imported",

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -153,6 +153,15 @@ func TestPropertiesToAccountInfoLockedDerivedNotMisclassified(t *testing.T) {
 	require.Equal(t, masterFingerprint, info.MasterKeyFingerprint)
 }
 
+// TestValidateExtendedPubKeyNil verifies that a nil account key is rejected
+// with an error instead of panicking.
+func TestValidateExtendedPubKeyNil(t *testing.T) {
+	t.Parallel()
+
+	err := validateExtendedPubKey(nil, true, &chaincfg.MainNetParams)
+	require.ErrorIs(t, err, ErrInvalidAccountKey)
+}
+
 // TestPropertiesToAccountInfoImportedClassifiedAndMasked verifies that an
 // imported account keeps imported-only account-info semantics.
 func TestPropertiesToAccountInfoImportedClassifiedAndMasked(t *testing.T) {

--- a/wallet/internal/db/itest/tx_store_corruption_test.go
+++ b/wallet/internal/db/itest/tx_store_corruption_test.go
@@ -501,17 +501,9 @@ func TestRollbackToBlockReturnsQueryErrorWhenBlocksTableMissing(t *testing.T) {
 	err := store.RollbackToBlock(t.Context(), 1)
 	require.Error(t, err)
 
-	// SQLite still fails while rewinding wallet sync-state heights because
-	// wallet_sync_states keeps direct block references with ON DELETE RESTRICT.
-	// PostgreSQL drops those dependent rows with CASCADE when the blocks table
-	// is removed, so rollback gets far enough to fail on the block delete
-	// instead.
-	_, ok := any(store).(*pg.Store)
-	if ok {
-		require.ErrorContains(t, err, "delete blocks at or above height")
-		return
-	}
-
+	// Rollback rewinds sync-state references by querying the greatest stored
+	// block below the rollback boundary, so both SQL backends now touch the
+	// blocks table before the delete step.
 	require.ErrorContains(t, err, "rewind wallet sync state heights")
 }
 

--- a/wallet/internal/db/itest/tx_utxo_store_test.go
+++ b/wallet/internal/db/itest/tx_utxo_store_test.go
@@ -1700,6 +1700,42 @@ func TestRollbackToBlockFailsCoinbaseDescendants(t *testing.T) {
 	require.Empty(t, childSpendingTxIDs(t, store, walletID, childTx.TxHash()))
 }
 
+// TestRollbackToBlockRewindsSyncToStoredLowerBlock verifies rollback rewinds
+// wallet sync references to the greatest stored block below the rollback
+// boundary instead of assuming height-1 exists in sparse block tables.
+func TestRollbackToBlockRewindsSyncToStoredLowerBlock(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	queries := store.Queries()
+	walletName := "wallet-rollback-sparse-sync"
+	walletID := newWallet(t, store, walletName)
+
+	forkBlock := CreateBlockFixture(t, queries, 5)
+	rollbackBlock := CreateBlockFixture(t, queries, 10)
+
+	err := store.UpdateWallet(t.Context(), db.UpdateWalletParams{
+		WalletID: walletID,
+		SyncedTo: &forkBlock,
+	})
+	require.NoError(t, err)
+
+	err = store.UpdateWallet(t.Context(), db.UpdateWalletParams{
+		WalletID: walletID,
+		SyncedTo: &rollbackBlock,
+	})
+	require.NoError(t, err)
+
+	err = store.RollbackToBlock(t.Context(), rollbackBlock.Height)
+	require.NoError(t, err)
+
+	walletInfo, err := store.GetWallet(t.Context(), walletName)
+	require.NoError(t, err)
+	require.NotNil(t, walletInfo.SyncedTo)
+	require.Equal(t, forkBlock.Height, walletInfo.SyncedTo.Height)
+	require.Equal(t, forkBlock.Hash, walletInfo.SyncedTo.Hash)
+}
+
 // TestCreateTxReconfirmsOrphanedCoinbase verifies that CreateTx can restore an
 // orphaned coinbase row to confirmed history when the same coinbase hash later
 // re-enters the best chain.

--- a/wallet/internal/db/kvdb/accountstore_listaccounts.go
+++ b/wallet/internal/db/kvdb/accountstore_listaccounts.go
@@ -198,6 +198,13 @@ func selectScopedManagers(mgr waddrmgr.AddrStore, filter *db.KeyScope) (
 	}
 
 	scopedMgr, err := mgr.FetchScopedKeyManager(scope)
+	if waddrmgr.IsError(err, waddrmgr.ErrScopeNotFound) {
+		// List queries return an empty result for an unknown scope,
+		// matching the Store contract and the SQL backend, rather than
+		// surfacing ErrAccountNotFound.
+		return nil, nil
+	}
+
 	if err != nil {
 		return nil, translateAccountErr(err, db.ErrAccountNotFound)
 	}

--- a/wallet/internal/db/kvdb/accountstore_test.go
+++ b/wallet/internal/db/kvdb/accountstore_test.go
@@ -1210,6 +1210,25 @@ func TestListAccountsSkipBalanceZeros(t *testing.T) {
 	}
 }
 
+// TestListAccountsMissingScopeReturnsEmpty verifies that a ListAccounts query
+// for a scope with no registered scoped key manager returns an empty result
+// with a nil error, preserving parity with the SQL backend rather than
+// surfacing ErrScopeNotFound/ErrAccountNotFound.
+func TestListAccountsMissingScopeReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	store, _, cleanup := newAccountStoreFixture(t)
+	t.Cleanup(cleanup)
+
+	scope := db.KeyScope{Purpose: 1234, Coin: 0}
+	accounts, err := store.ListAccounts(t.Context(), db.ListAccountsQuery{
+		Scope:       &scope,
+		SkipBalance: true,
+	})
+	require.NoError(t, err)
+	require.Empty(t, accounts)
+}
+
 // TestCreateImportedAccountAllowsMultipleInScope verifies kvdb retains the
 // legacy watch-only account behavior: imported accounts share the normal
 // per-scope account counter, so multiple imported accounts can exist in the

--- a/wallet/internal/db/kvdb/walletstore.go
+++ b/wallet/internal/db/kvdb/walletstore.go
@@ -83,6 +83,7 @@ func (s *Store) GetWallet(_ context.Context,
 		Birthday:      addrStore.Birthday().UTC(),
 		BirthdayBlock: birthdayBlock,
 		SyncedTo:      syncedTo,
+		IsWatchOnly:   addrStore.WatchOnly(),
 	}, nil
 }
 

--- a/wallet/internal/db/kvdb/walletstore_test.go
+++ b/wallet/internal/db/kvdb/walletstore_test.go
@@ -166,6 +166,24 @@ func TestGetWalletReadsLegacyMetadata(t *testing.T) {
 	require.Equal(t, "default", info.Name)
 	require.Equal(t, addrStore.Birthday().UTC(), info.Birthday)
 	require.Nil(t, info.BirthdayBlock)
+	require.False(t, info.IsWatchOnly)
+}
+
+// TestGetWalletReportsWatchOnly verifies kvdb.Store reports legacy wallet-level
+// watch-only state.
+func TestGetWalletReportsWatchOnly(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	addrStore := newAddrStore(t, dbConn)
+	convertAddrStoreToWatchOnly(t, dbConn, addrStore)
+	store := NewStore(dbConn, nil, addrStore)
+
+	info, err := store.GetWallet(t.Context(), "default")
+	require.NoError(t, err)
+	require.True(t, info.IsWatchOnly)
 }
 
 // TestGetWalletKvdbIgnoresName documents that kvdb echoes the requested

--- a/wallet/internal/db/pg/block.go
+++ b/wallet/internal/db/pg/block.go
@@ -44,6 +44,11 @@ func ensureBlockExists(ctx context.Context, qtx *sqlc.Queries,
 		return fmt.Errorf("insert block: %w", err)
 	}
 
+	_, err = requireBlockMatches(ctx, qtx, block)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/wallet/internal/db/pg/txstore_rollback.go
+++ b/wallet/internal/db/pg/txstore_rollback.go
@@ -66,19 +66,8 @@ func (o rollbackToBlockOps) RewindWalletSyncStateHeights(
 		return fmt.Errorf("convert rollback height: %w", err)
 	}
 
-	newHeight := sql.NullInt32{}
-	if height > 0 {
-		newHeight, err = db.Uint32ToNullInt32(height - 1)
-		if err != nil {
-			return fmt.Errorf("convert new height: %w", err)
-		}
-	}
-
 	_, err = o.qtx.RewindWalletSyncStateHeightsForRollback(
-		ctx, sqlc.RewindWalletSyncStateHeightsForRollbackParams{
-			RollbackHeight: rollbackHeight,
-			NewHeight:      newHeight,
-		},
+		ctx, rollbackHeight,
 	)
 	if err != nil {
 		return fmt.Errorf("rewind wallet sync state heights query: %w", err)

--- a/wallet/internal/db/sqlite/block.go
+++ b/wallet/internal/db/sqlite/block.go
@@ -46,6 +46,11 @@ func ensureBlockExists(ctx context.Context, qtx *sqlc.Queries,
 		return fmt.Errorf("insert block: %w", err)
 	}
 
+	_, err = requireBlockMatches(ctx, qtx, block)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/wallet/internal/db/sqlite/txstore_rollback.go
+++ b/wallet/internal/db/sqlite/txstore_rollback.go
@@ -48,16 +48,8 @@ func (o rollbackToBlockOps) ListRollbackRootHashes(ctx context.Context,
 func (o rollbackToBlockOps) RewindWalletSyncStateHeights(
 	ctx context.Context, height uint32) error {
 
-	newHeight := sql.NullInt64{}
-	if height > 0 {
-		newHeight = sql.NullInt64{Int64: int64(height - 1), Valid: true}
-	}
-
 	_, err := o.qtx.RewindWalletSyncStateHeightsForRollback(
-		ctx, sqlc.RewindWalletSyncStateHeightsForRollbackParams{
-			RollbackHeight: int64(height),
-			NewHeight:      newHeight,
-		},
+		ctx, int64(height),
 	)
 	if err != nil {
 		return fmt.Errorf("rewind wallet sync state heights query: %w", err)

--- a/wallet/internal/sql/pg/queries/transactions.sql
+++ b/wallet/internal/sql/pg/queries/transactions.sql
@@ -330,13 +330,13 @@ ORDER BY wallet_id, id;
 -- about to be deleted during RollbackToBlock.
 --
 -- How:
--- - Updates wallet_sync_states directly without joining other tables.
+-- - Computes the greatest stored block below the rollback boundary.
 -- - Rewrites both synced_height and birthday_height in one statement so the
 --   subsequent block delete does not violate `ON DELETE RESTRICT`.
--- - Example: if `rollback_height = 195`, then any `synced_height` or
---   `birthday_height` at 195 or above rewinds to `new_height = 194`.
--- - If rollback starts from height 0, callers pass `new_height = NULL` so the
---   sync state no longer points at any surviving block row.
+-- - Example: if `rollback_height = 195`, affected sync heights rewind to the
+--   greatest stored block below 195, not necessarily 194 on sparse block tables.
+-- - If there is no stored block below the boundary, the sync state no longer
+--   points at any surviving block row.
 -- Performance:
 -- - Touches only wallet_sync_states rows whose heights are at or above the
 --   rollback boundary.
@@ -346,14 +346,22 @@ SET
         WHEN
             synced_height IS NOT NULL
             AND synced_height >= sqlc.arg('rollback_height')::INTEGER
-            THEN sqlc.narg('new_height')
+            THEN (
+                SELECT max(block_height)::INTEGER
+                FROM blocks
+                WHERE block_height < sqlc.arg('rollback_height')::INTEGER
+            )
         ELSE synced_height
     END,
     birthday_height = CASE
         WHEN
             birthday_height IS NOT NULL
             AND birthday_height >= sqlc.arg('rollback_height')::INTEGER
-            THEN sqlc.narg('new_height')
+            THEN (
+                SELECT max(block_height)::INTEGER
+                FROM blocks
+                WHERE block_height < sqlc.arg('rollback_height')::INTEGER
+            )
         ELSE birthday_height
     END,
     updated_at = current_timestamp AT TIME ZONE 'UTC'

--- a/wallet/internal/sql/pg/sqlc/querier.go
+++ b/wallet/internal/sql/pg/sqlc/querier.go
@@ -539,17 +539,17 @@ type Querier interface {
 	// about to be deleted during RollbackToBlock.
 	//
 	// How:
-	// - Updates wallet_sync_states directly without joining other tables.
+	// - Computes the greatest stored block below the rollback boundary.
 	// - Rewrites both synced_height and birthday_height in one statement so the
 	//   subsequent block delete does not violate `ON DELETE RESTRICT`.
-	// - Example: if `rollback_height = 195`, then any `synced_height` or
-	//   `birthday_height` at 195 or above rewinds to `new_height = 194`.
-	// - If rollback starts from height 0, callers pass `new_height = NULL` so the
-	//   sync state no longer points at any surviving block row.
+	// - Example: if `rollback_height = 195`, affected sync heights rewind to the
+	//   greatest stored block below 195, not necessarily 194 on sparse block tables.
+	// - If there is no stored block below the boundary, the sync state no longer
+	//   points at any surviving block row.
 	// Performance:
 	// - Touches only wallet_sync_states rows whose heights are at or above the
 	//   rollback boundary.
-	RewindWalletSyncStateHeightsForRollback(ctx context.Context, arg RewindWalletSyncStateHeightsForRollbackParams) (int64, error)
+	RewindWalletSyncStateHeightsForRollback(ctx context.Context, rollbackHeight int32) (int64, error)
 	// Renames an account identified by wallet id, scope tuple, and current account name.
 	UpdateAccountNameByWalletScopeAndName(ctx context.Context, arg UpdateAccountNameByWalletScopeAndNameParams) (int64, error)
 	// Renames an account identified by wallet id, scope tuple, and account number.

--- a/wallet/internal/sql/pg/sqlc/transactions.sql.go
+++ b/wallet/internal/sql/pg/sqlc/transactions.sql.go
@@ -674,14 +674,22 @@ SET
         WHEN
             synced_height IS NOT NULL
             AND synced_height >= $1::INTEGER
-            THEN $2
+            THEN (
+                SELECT max(block_height)::INTEGER
+                FROM blocks
+                WHERE block_height < $1::INTEGER
+            )
         ELSE synced_height
     END,
     birthday_height = CASE
         WHEN
             birthday_height IS NOT NULL
             AND birthday_height >= $1::INTEGER
-            THEN $2
+            THEN (
+                SELECT max(block_height)::INTEGER
+                FROM blocks
+                WHERE block_height < $1::INTEGER
+            )
         ELSE birthday_height
     END,
     updated_at = current_timestamp AT TIME ZONE 'UTC'
@@ -696,28 +704,23 @@ WHERE
     )
 `
 
-type RewindWalletSyncStateHeightsForRollbackParams struct {
-	RollbackHeight int32
-	NewHeight      sql.NullInt32
-}
-
 // Rewrites wallet sync-state heights so they stop referencing blocks that are
 // about to be deleted during RollbackToBlock.
 //
 // How:
-//   - Updates wallet_sync_states directly without joining other tables.
+//   - Computes the greatest stored block below the rollback boundary.
 //   - Rewrites both synced_height and birthday_height in one statement so the
 //     subsequent block delete does not violate `ON DELETE RESTRICT`.
-//   - Example: if `rollback_height = 195`, then any `synced_height` or
-//     `birthday_height` at 195 or above rewinds to `new_height = 194`.
-//   - If rollback starts from height 0, callers pass `new_height = NULL` so the
-//     sync state no longer points at any surviving block row.
+//   - Example: if `rollback_height = 195`, affected sync heights rewind to the
+//     greatest stored block below 195, not necessarily 194 on sparse block tables.
+//   - If there is no stored block below the boundary, the sync state no longer
+//     points at any surviving block row.
 //
 // Performance:
 //   - Touches only wallet_sync_states rows whose heights are at or above the
 //     rollback boundary.
-func (q *Queries) RewindWalletSyncStateHeightsForRollback(ctx context.Context, arg RewindWalletSyncStateHeightsForRollbackParams) (int64, error) {
-	result, err := q.exec(ctx, q.rewindWalletSyncStateHeightsForRollbackStmt, RewindWalletSyncStateHeightsForRollback, arg.RollbackHeight, arg.NewHeight)
+func (q *Queries) RewindWalletSyncStateHeightsForRollback(ctx context.Context, rollbackHeight int32) (int64, error) {
+	result, err := q.exec(ctx, q.rewindWalletSyncStateHeightsForRollbackStmt, RewindWalletSyncStateHeightsForRollback, rollbackHeight)
 	if err != nil {
 		return 0, err
 	}

--- a/wallet/internal/sql/sqlite/queries/transactions.sql
+++ b/wallet/internal/sql/sqlite/queries/transactions.sql
@@ -337,13 +337,13 @@ ORDER BY wallet_id, id;
 -- about to be deleted during RollbackToBlock.
 --
 -- How:
--- - Updates wallet_sync_states directly without joining other tables.
+-- - Computes the greatest stored block below the rollback boundary.
 -- - Rewrites both synced_height and birthday_height in one statement so the
 --   subsequent block delete does not violate `ON DELETE RESTRICT`.
--- - Example: if `rollback_height = 195`, then any `synced_height` or
---   `birthday_height` at 195 or above rewinds to `new_height = 194`.
--- - If rollback starts from height 0, callers pass `new_height = NULL` so the
---   sync state no longer points at any surviving block row.
+-- - Example: if `rollback_height = 195`, affected sync heights rewind to the
+--   greatest stored block below 195, not necessarily 194 on sparse block tables.
+-- - If there is no stored block below the boundary, the sync state no longer
+--   points at any surviving block row.
 -- Performance:
 -- - Touches only wallet_sync_states rows whose heights are at or above the
 --   rollback boundary.
@@ -353,14 +353,22 @@ SET
         WHEN
             synced_height IS NOT NULL
             AND synced_height >= cast(sqlc.arg('rollback_height') AS INTEGER)
-            THEN sqlc.narg('new_height')
+            THEN (
+                SELECT max(block_height)
+                FROM blocks
+                WHERE block_height < cast(sqlc.arg('rollback_height') AS INTEGER)
+            )
         ELSE synced_height
     END,
     birthday_height = CASE
         WHEN
             birthday_height IS NOT NULL
             AND birthday_height >= cast(sqlc.arg('rollback_height') AS INTEGER)
-            THEN sqlc.narg('new_height')
+            THEN (
+                SELECT max(block_height)
+                FROM blocks
+                WHERE block_height < cast(sqlc.arg('rollback_height') AS INTEGER)
+            )
         ELSE birthday_height
     END,
     updated_at = current_timestamp

--- a/wallet/internal/sql/sqlite/sqlc/querier.go
+++ b/wallet/internal/sql/sqlite/sqlc/querier.go
@@ -536,17 +536,17 @@ type Querier interface {
 	// about to be deleted during RollbackToBlock.
 	//
 	// How:
-	// - Updates wallet_sync_states directly without joining other tables.
+	// - Computes the greatest stored block below the rollback boundary.
 	// - Rewrites both synced_height and birthday_height in one statement so the
 	//   subsequent block delete does not violate `ON DELETE RESTRICT`.
-	// - Example: if `rollback_height = 195`, then any `synced_height` or
-	//   `birthday_height` at 195 or above rewinds to `new_height = 194`.
-	// - If rollback starts from height 0, callers pass `new_height = NULL` so the
-	//   sync state no longer points at any surviving block row.
+	// - Example: if `rollback_height = 195`, affected sync heights rewind to the
+	//   greatest stored block below 195, not necessarily 194 on sparse block tables.
+	// - If there is no stored block below the boundary, the sync state no longer
+	//   points at any surviving block row.
 	// Performance:
 	// - Touches only wallet_sync_states rows whose heights are at or above the
 	//   rollback boundary.
-	RewindWalletSyncStateHeightsForRollback(ctx context.Context, arg RewindWalletSyncStateHeightsForRollbackParams) (int64, error)
+	RewindWalletSyncStateHeightsForRollback(ctx context.Context, rollbackHeight int64) (int64, error)
 	// Renames an account identified by wallet id, scope tuple, and current account name.
 	UpdateAccountNameByWalletScopeAndName(ctx context.Context, arg UpdateAccountNameByWalletScopeAndNameParams) (int64, error)
 	// Renames an account identified by wallet id, scope tuple, and account number.

--- a/wallet/internal/sql/sqlite/sqlc/transactions.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/transactions.sql.go
@@ -699,14 +699,22 @@ SET
         WHEN
             synced_height IS NOT NULL
             AND synced_height >= cast(?1 AS INTEGER)
-            THEN ?2
+            THEN (
+                SELECT max(block_height)
+                FROM blocks
+                WHERE block_height < cast(?1 AS INTEGER)
+            )
         ELSE synced_height
     END,
     birthday_height = CASE
         WHEN
             birthday_height IS NOT NULL
             AND birthday_height >= cast(?1 AS INTEGER)
-            THEN ?2
+            THEN (
+                SELECT max(block_height)
+                FROM blocks
+                WHERE block_height < cast(?1 AS INTEGER)
+            )
         ELSE birthday_height
     END,
     updated_at = current_timestamp
@@ -721,28 +729,23 @@ WHERE
     )
 `
 
-type RewindWalletSyncStateHeightsForRollbackParams struct {
-	RollbackHeight int64
-	NewHeight      sql.NullInt64
-}
-
 // Rewrites wallet sync-state heights so they stop referencing blocks that are
 // about to be deleted during RollbackToBlock.
 //
 // How:
-//   - Updates wallet_sync_states directly without joining other tables.
+//   - Computes the greatest stored block below the rollback boundary.
 //   - Rewrites both synced_height and birthday_height in one statement so the
 //     subsequent block delete does not violate `ON DELETE RESTRICT`.
-//   - Example: if `rollback_height = 195`, then any `synced_height` or
-//     `birthday_height` at 195 or above rewinds to `new_height = 194`.
-//   - If rollback starts from height 0, callers pass `new_height = NULL` so the
-//     sync state no longer points at any surviving block row.
+//   - Example: if `rollback_height = 195`, affected sync heights rewind to the
+//     greatest stored block below 195, not necessarily 194 on sparse block tables.
+//   - If there is no stored block below the boundary, the sync state no longer
+//     points at any surviving block row.
 //
 // Performance:
 //   - Touches only wallet_sync_states rows whose heights are at or above the
 //     rollback boundary.
-func (q *Queries) RewindWalletSyncStateHeightsForRollback(ctx context.Context, arg RewindWalletSyncStateHeightsForRollbackParams) (int64, error) {
-	result, err := q.exec(ctx, q.rewindWalletSyncStateHeightsForRollbackStmt, RewindWalletSyncStateHeightsForRollback, arg.RollbackHeight, arg.NewHeight)
+func (q *Queries) RewindWalletSyncStateHeightsForRollback(ctx context.Context, rollbackHeight int64) (int64, error) {
+	result, err := q.exec(ctx, q.rewindWalletSyncStateHeightsForRollbackStmt, RewindWalletSyncStateHeightsForRollback, rollbackHeight)
 	if err != nil {
 		return 0, err
 	}

--- a/wallet/psbt_manager.go
+++ b/wallet/psbt_manager.go
@@ -2272,13 +2272,9 @@ func addInputInfoSegWitV1(in *psbt.PInput, utxo *wire.TxOut,
 	}
 	in.SighashType = txscript.SigHashDefault
 
-	// Include the derivation path for each input in addition to the
-	// taproot specific info we have below.
-	in.Bip32Derivation = []*psbt.Bip32Derivation{
-		derivationInfo,
-	}
-
-	// Include the derivation path for each input.
+	// Taproot inputs carry only the taproot-specific derivation. Emitting a
+	// parallel Bip32Derivation would make the input ambiguous for the
+	// wallet's own signer (see validateDerivation), so it is omitted here.
 	in.TaprootBip32Derivation = []*psbt.TaprootBip32Derivation{{
 		XOnlyPubKey:          derivationInfo.PubKey[1:],
 		MasterKeyFingerprint: derivationInfo.MasterKeyFingerprint,

--- a/wallet/psbt_manager_test.go
+++ b/wallet/psbt_manager_test.go
@@ -408,6 +408,9 @@ func TestDecorateInputTaproot(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, utxo, pInput.WitnessUtxo)
 	require.Equal(t, txscript.SigHashDefault, pInput.SighashType)
+	// Taproot inputs carry only the taproot derivation (no Bip32Derivation),
+	// otherwise the wallet's own signer rejects them as ambiguous.
+	require.Empty(t, pInput.Bip32Derivation)
 	require.Len(t, pInput.TaprootBip32Derivation, 1)
 	require.Equal(
 		t, schnorr.SerializePubKey(pubKey),
@@ -3687,7 +3690,7 @@ func TestAddInputInfoSegWitV1(t *testing.T) {
 	// Assert: Verify fields are populated correctly.
 	require.Equal(t, utxo.Value, in.WitnessUtxo.Value)
 	require.Equal(t, txscript.SigHashDefault, in.SighashType)
-	require.Equal(t, derivation, in.Bip32Derivation[0])
+	require.Empty(t, in.Bip32Derivation)
 	require.Equal(t, pubKey[1:], in.TaprootBip32Derivation[0].XOnlyPubKey)
 }
 

--- a/wallet/recovery.go
+++ b/wallet/recovery.go
@@ -328,7 +328,18 @@ func (rs *RecoveryState) ProcessBlock(block *wire.MsgBlock) (
 		foundHorizons   map[waddrmgr.BranchScope]uint32
 	)
 
+	// A same-block lookahead rerun happens when this block pays to an
+	// already-watched lookahead address and expandHorizons derives more
+	// addresses before the block is filtered again. filterTx mutates
+	// rs.outpoints in place during each pass, so restore the pre-block set
+	// before every pass. Otherwise a spent watched outpoint deleted during
+	// the first pass would be missing from the second pass, and a spend-only
+	// transaction could be dropped from the final overwritten result.
+	outpointsSnapshot := copyOutpointMap(rs.outpoints)
+
 	for {
+		rs.outpoints = copyOutpointMap(outpointsSnapshot)
+
 		relevantTxs, foundScopes, relevantOutputs = rs.filterBlock(
 			block,
 		)
@@ -356,6 +367,16 @@ func (rs *RecoveryState) ProcessBlock(block *wire.MsgBlock) (
 		RelevantOutputs: relevantOutputs,
 		Expanded:        expanded,
 	}, nil
+}
+
+// copyOutpointMap returns a shallow copy of the watched outpoint set.
+func copyOutpointMap(src map[wire.OutPoint][]byte) map[wire.OutPoint][]byte {
+	dst := make(map[wire.OutPoint][]byte, len(src))
+	for op, script := range src {
+		dst[op] = script
+	}
+
+	return dst
 }
 
 // initAccountState initializes the recovery state for a specific account by

--- a/wallet/recovery_test.go
+++ b/wallet/recovery_test.go
@@ -567,6 +567,143 @@ func TestProcessBlock(t *testing.T) {
 	require.Equal(t, uint32(12), res.FoundHorizons[bs])
 }
 
+// TestProcessBlockKeepsSameBlockSpendOnExpansion verifies that a spend-only
+// transaction is retained in the final result when a credit in the same block
+// triggers a horizon expansion, forcing the filter loop to re-run. filterTx
+// deletes a watched outpoint as soon as it sees a spend of it, so a naive
+// re-run of filterBlock over the same block would no longer recognize that
+// spend on the second pass and silently drop the spend-only transaction from
+// the overwritten result. The block here pairs a spend of a pre-watched
+// outpoint (with no other relevance) with a credit to a lookahead address that
+// triggers expansion; the spend transaction must still appear in the final
+// RelevantTxs.
+func TestProcessBlockKeepsSameBlockSpendOnExpansion(t *testing.T) {
+	t.Parallel()
+
+	addrMgr := &bwmock.AddrStore{}
+	defer addrMgr.AssertExpectations(t)
+
+	accountStore := &bwmock.AccountStore{}
+	defer accountStore.AssertExpectations(t)
+
+	scope := waddrmgr.KeyScope{Purpose: 84, Coin: 0}
+	props := &waddrmgr.AccountProperties{
+		KeyScope:      scope,
+		AccountNumber: 0,
+
+		// Start fresh so the lookahead window is derived from scratch.
+		ExternalKeyCount: 0,
+		InternalKeyCount: 0,
+	}
+
+	addrMgr.On("FetchScopedKeyManager", scope).Return(
+		accountStore, nil,
+	).Maybe()
+
+	// Store generated addresses to construct block data.
+	addrs := make(map[int]btcutil.Address)
+
+	// Helper to mock DeriveAddr and store the generated address.
+	setupDerive := func(branch, idx uint32) {
+		id := int(branch)*1000 + int(idx)
+
+		hash := make([]byte, 20)
+		hash[0] = byte(id >> 8)
+		hash[1] = byte(id)
+		addr, _ := btcutil.NewAddressPubKeyHash(hash, &chainParams)
+		addrs[id] = addr
+
+		script, _ := txscript.PayToAddrScript(addr)
+		accountStore.On(
+			"DeriveAddr", uint32(0), branch, idx,
+		).Return(addr, script, nil).Maybe()
+	}
+
+	// Initial lookahead (0-9 for both branches) plus the external addresses
+	// (10-15) derived once finding index 5 expands the horizon to 6+10=16.
+	for i := range uint32(10) {
+		setupDerive(0, i)
+		setupDerive(1, i)
+	}
+
+	for i := uint32(10); i < 16; i++ {
+		setupDerive(0, i)
+	}
+
+	// Pre-watch an outpoint, mirroring a UTXO the wallet already owns and
+	// monitors for spends. This is the outpoint whose spend must survive
+	// the same-block expansion re-run.
+	watchedOp := wire.OutPoint{Hash: chainhash.Hash{0xaa}, Index: 0}
+	unspent := []wtxmgr.Credit{{
+		OutPoint: watchedOp,
+		PkScript: []byte{0x00},
+	}}
+
+	rs := NewRecoveryState(10, &chainParams, addrMgr)
+	err := rs.Initialize(
+		[]*waddrmgr.AccountProperties{props}, nil, unspent,
+	)
+	require.NoError(t, err)
+
+	// Construct the block.
+	block := wire.NewMsgBlock(wire.NewBlockHeader(
+		0, &chainhash.Hash{}, &chainhash.Hash{}, 0, 0,
+	))
+
+	// txSpend spends the watched outpoint and pays to an unrelated address,
+	// so its only relevance is the spend. It is placed first so the spend
+	// (and the outpoint deletion in filterTx) happens before the credit
+	// that triggers the expansion.
+	unrelatedHash := make([]byte, 20)
+	for i := range unrelatedHash {
+		unrelatedHash[i] = 0xff
+	}
+
+	unrelatedAddr, _ := btcutil.NewAddressPubKeyHash(
+		unrelatedHash, &chainParams,
+	)
+	unrelatedScript, _ := txscript.PayToAddrScript(unrelatedAddr)
+	txSpend := wire.NewMsgTx(2)
+	txSpend.AddTxIn(wire.NewTxIn(&watchedOp, nil, nil))
+	txSpend.AddTxOut(wire.NewTxOut(900, unrelatedScript))
+	_ = block.AddTransaction(txSpend)
+	spendHash := txSpend.TxHash()
+
+	// txCredit pays to addr 5 (within the initial lookahead), which marks
+	// the address found and triggers a horizon expansion, forcing the
+	// filter loop to run a second pass over the block.
+	addr5 := addrs[5]
+	script5, _ := txscript.PayToAddrScript(addr5)
+	txCredit := wire.NewMsgTx(2)
+	txCredit.AddTxOut(wire.NewTxOut(1000, script5))
+	_ = block.AddTransaction(txCredit)
+	creditHash := txCredit.TxHash()
+
+	// Process the block.
+	res, err := rs.ProcessBlock(block)
+	require.NoError(t, err)
+
+	// The credit must have triggered a lookahead expansion, which is what
+	// forces the second filter pass that exposes the bug.
+	require.True(t, res.Expanded,
+		"credit to lookahead address should expand the horizon")
+
+	// Both the spend and the credit must be reported as relevant. Before
+	// the fix, the spend-only transaction was dropped on the second pass
+	// because its outpoint had already been deleted.
+	relevant := make(map[chainhash.Hash]struct{}, len(res.RelevantTxs))
+	for _, tx := range res.RelevantTxs {
+		relevant[*tx.Hash()] = struct{}{}
+	}
+
+	require.Contains(t, relevant, spendHash,
+		"spend of a pre-watched outpoint must survive the same-block "+
+			"expansion re-run")
+	require.Contains(t, relevant, creditHash,
+		"credit to a watched address must be reported as relevant")
+	require.Len(t, res.RelevantTxs, 2)
+}
+
 // TestBuildCFilterData verifies the BuildCFilterData method of RecoveryState.
 // It ensures that the method correctly aggregates all relevant scripts from
 // both the transient address filters and the watched outpoints into a single

--- a/wallet/syncer_test.go
+++ b/wallet/syncer_test.go
@@ -2767,12 +2767,14 @@ func TestDispatchScanStrategy_OtherMethods(t *testing.T) {
 	t.Parallel()
 
 	hashes := []chainhash.Hash{{0x01}}
-	scanState := NewRecoveryState(10, nil, nil)
 
 	t.Run("FullBlocks", func(t *testing.T) {
 		t.Parallel()
 
-		// Arrange: Setup a syncer for FullBlocks strategy.
+		// Arrange: Setup a syncer for FullBlocks strategy. Each subtest
+		// owns its RecoveryState so the parallel dispatches do not race
+		// on its shared mutable state.
+		scanState := NewRecoveryState(10, nil, nil)
 		mockChain := &bwmock.Chain{}
 		s := newSyncer(
 			Config{
@@ -2796,7 +2798,10 @@ func TestDispatchScanStrategy_OtherMethods(t *testing.T) {
 	t.Run("CFilters", func(t *testing.T) {
 		t.Parallel()
 
-		// Arrange: Setup a syncer for CFilters strategy.
+		// Arrange: Setup a syncer for CFilters strategy. Each subtest
+		// owns its RecoveryState so the parallel dispatches do not race
+		// on its shared mutable state.
+		scanState := NewRecoveryState(10, nil, nil)
 		mockChain := &bwmock.Chain{}
 		s := newSyncer(
 			Config{
@@ -2825,7 +2830,10 @@ func TestDispatchScanStrategy_OtherMethods(t *testing.T) {
 	t.Run("Default_Unknown", func(t *testing.T) {
 		t.Parallel()
 
-		// Arrange: Setup a syncer with an unknown method.
+		// Arrange: Setup a syncer with an unknown method. Each subtest
+		// owns its RecoveryState so the parallel dispatches do not race
+		// on its shared mutable state.
+		scanState := NewRecoveryState(10, nil, nil)
 		mockChain := &bwmock.Chain{}
 		s := newSyncer(
 			Config{

--- a/wallet/tx_creator.go
+++ b/wallet/tx_creator.go
@@ -309,6 +309,11 @@ func (i *InputsPolicy) validate() error {
 	switch source := i.Source.(type) {
 	// If the source is a scoped account, it must have a non-empty account
 	// name.
+	case ScopedAccount:
+		if source.AccountName == "" {
+			return ErrMissingAccountName
+		}
+
 	case *ScopedAccount:
 		if source.AccountName == "" {
 			return ErrMissingAccountName
@@ -316,6 +321,9 @@ func (i *InputsPolicy) validate() error {
 
 	// If the source is a list of UTXOs, it must not be empty and must not
 	// contain duplicates.
+	case CoinSourceUTXOs:
+		return validateOutPoints(source.UTXOs)
+
 	case *CoinSourceUTXOs:
 		return validateOutPoints(source.UTXOs)
 
@@ -657,7 +665,11 @@ func (w *Wallet) determineChangeSource(intent *TxIntent) *ScopedAccount {
 
 	// If the inputs are from a specific account, use that for change.
 	if policy, ok := intent.Inputs.(*InputsPolicy); ok {
-		if account, ok := policy.Source.(*ScopedAccount); ok {
+		switch account := policy.Source.(type) {
+		case ScopedAccount:
+			return &account
+
+		case *ScopedAccount:
 			return account
 		}
 	}
@@ -840,11 +852,17 @@ func (w *Wallet) getEligibleUTXOs(ctx context.Context,
 
 	// If the source is a scoped account, we find all eligible outputs for
 	// that specific account and key scope.
+	case ScopedAccount:
+		return w.getEligibleUTXOsFromAccount(ctx, &source, minconf, bs)
+
 	case *ScopedAccount:
 		return w.getEligibleUTXOsFromAccount(ctx, source, minconf, bs)
 
 	// If the source is a list of UTXOs, we validate and fetch each UTXO
 	// from the provided list.
+	case CoinSourceUTXOs:
+		return w.getEligibleUTXOsFromList(ctx, &source, minconf, bs)
+
 	case *CoinSourceUTXOs:
 		return w.getEligibleUTXOsFromList(ctx, source, minconf, bs)
 

--- a/wallet/tx_creator_test.go
+++ b/wallet/tx_creator_test.go
@@ -311,6 +311,61 @@ func TestValidateTxIntent(t *testing.T) {
 	}
 }
 
+// TestInputsPolicyValidateValueSources verifies value-form coin sources follow
+// the same validation rules as their pointer forms.
+func TestInputsPolicyValidateValueSources(t *testing.T) {
+	t.Parallel()
+
+	validUTXO := wire.OutPoint{Hash: [32]byte{1}, Index: 0}
+	testCases := []struct {
+		name        string
+		source      CoinSource
+		expectedErr error
+	}{
+		{
+			name: "valid scoped account value",
+			source: ScopedAccount{
+				AccountName: defaultAccountName,
+				KeyScope:    waddrmgr.KeyScopeBIP0086,
+			},
+		},
+		{
+			name:        "empty scoped account value",
+			source:      ScopedAccount{},
+			expectedErr: ErrMissingAccountName,
+		},
+		{
+			name: "valid utxo source value",
+			source: CoinSourceUTXOs{
+				UTXOs: []wire.OutPoint{validUTXO},
+			},
+		},
+		{
+			name:        "empty utxo source value",
+			source:      CoinSourceUTXOs{},
+			expectedErr: ErrManualInputsEmpty,
+		},
+		{
+			name: "duplicate utxo source value",
+			source: CoinSourceUTXOs{
+				UTXOs: []wire.OutPoint{
+					validUTXO, validUTXO,
+				},
+			},
+			expectedErr: ErrDuplicatedUtxo,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := (&InputsPolicy{Source: tc.source}).validate()
+			require.ErrorIs(t, err, tc.expectedErr)
+		})
+	}
+}
+
 // unsupportedInputs is a mock implementation of the Inputs interface used for
 // testing purposes.
 type unsupportedInputs struct{}
@@ -327,6 +382,26 @@ type unsupportedCoinSource struct{}
 
 // isCoinSource marks unsupportedCoinSource as a CoinSource implementation.
 func (u *unsupportedCoinSource) isCoinSource() {}
+
+// TestDetermineChangeSourceValueScopedAccount verifies a value-form scoped
+// account is used as the change source for policy-selected inputs.
+func TestDetermineChangeSourceValueScopedAccount(t *testing.T) {
+	t.Parallel()
+
+	w, _ := createStartedWalletWithMocks(t)
+	policyAccountSource := ScopedAccount{
+		AccountName: "policy",
+		KeyScope:    waddrmgr.KeyScopeBIP0049Plus,
+	}
+	intent := &TxIntent{
+		Inputs: &InputsPolicy{
+			Source: policyAccountSource,
+		},
+	}
+
+	source := w.determineChangeSource(intent)
+	require.Equal(t, &policyAccountSource, source)
+}
 
 // TestDetermineChangeSource tests the behavior of the determineChangeSource
 // method, ensuring that it correctly selects a change source based on the
@@ -877,6 +952,81 @@ func TestGetEligibleUTXOsNilSourceResolvesDefaultAccount(t *testing.T) {
 	eligible, err := w.getEligibleUTXOs(t.Context(), nil, 1)
 
 	// Assert: the renamed default account still yields its spendable UTXO.
+	require.NoError(t, err)
+	require.Len(t, eligible, 1)
+	require.Equal(t, outPoint, eligible[0].OutPoint)
+}
+
+// TestGetEligibleUTXOsScopedAccountValue verifies value-form scoped account
+// sources dispatch to the account selection path.
+func TestGetEligibleUTXOsScopedAccountValue(t *testing.T) {
+	t.Parallel()
+
+	w, mocks := createTestWalletWithMocks(t)
+
+	accountName := "value-account"
+	scope := db.KeyScope(waddrmgr.KeyScopeBIP0084)
+	outPoint := wire.OutPoint{Hash: [32]byte{5}, Index: 0}
+	unspent := []db.UtxoInfo{{
+		OutPoint: outPoint,
+		Amount:   btcutil.Amount(10000),
+		PkScript: singleAddrPkScript(t),
+		Height:   100,
+	}}
+
+	mocks.chain.On("BlockStamp").Return(
+		&waddrmgr.BlockStamp{Height: 100}, nil,
+	).Once()
+	mocks.store.On("GetAccount", mock.Anything, db.GetAccountQuery{
+		WalletID: w.id,
+		Scope:    scope,
+		Name:     &accountName,
+	}).Return(&db.AccountInfo{AccountName: accountName}, nil).Once()
+	mocks.store.On("ListUTXOs", mock.Anything, db.ListUtxosQuery{
+		WalletID:    w.id,
+		Scope:       &scope,
+		AccountName: &accountName,
+	}).Return(unspent, nil).Once()
+
+	eligible, err := w.getEligibleUTXOs(
+		t.Context(), ScopedAccount{
+			AccountName: accountName,
+			KeyScope:    waddrmgr.KeyScopeBIP0084,
+		}, 1,
+	)
+	require.NoError(t, err)
+	require.Len(t, eligible, 1)
+	require.Equal(t, outPoint, eligible[0].OutPoint)
+}
+
+// TestGetEligibleUTXOsSourceUTXOsValue verifies value-form explicit UTXO
+// sources dispatch to the list selection path.
+func TestGetEligibleUTXOsSourceUTXOsValue(t *testing.T) {
+	t.Parallel()
+
+	w, mocks := createTestWalletWithMocks(t)
+
+	outPoint := wire.OutPoint{Hash: [32]byte{6}, Index: 0}
+	credit := &db.UtxoInfo{
+		OutPoint: outPoint,
+		Amount:   btcutil.Amount(10000),
+		PkScript: singleAddrPkScript(t),
+		Height:   100,
+	}
+
+	mocks.chain.On("BlockStamp").Return(
+		&waddrmgr.BlockStamp{Height: 100}, nil,
+	).Once()
+	mocks.store.On("GetUtxo", mock.Anything, db.GetUtxoQuery{
+		WalletID: w.id,
+		OutPoint: outPoint,
+	}).Return(credit, nil).Once()
+
+	eligible, err := w.getEligibleUTXOs(
+		t.Context(), CoinSourceUTXOs{
+			UTXOs: []wire.OutPoint{outPoint},
+		}, 1,
+	)
 	require.NoError(t, err)
 	require.Len(t, eligible, 1)
 	require.Equal(t, outPoint, eligible[0].OutPoint)


### PR DESCRIPTION
Addresses review findings and regressions surfaced while preparing the
SQL-wallet/runtime-store stack. This is the base branch for #1268.

Highlights:
- Fix taproot PSBT decoration so wallet-decorated taproot inputs do not carry
  both legacy and taproot derivations.
- Keep missing kvdb scopes consistent with `Store.ListAccounts` empty-list
  semantics.
- Snapshot recovery outpoints before same-block lookahead expansion.
- Harden SQL block consistency checks and sparse rollback sync-height rewinds.
- Surface kvdb watch-only wallet state and guard wallet account validation
  against nil extended pubkeys.
- Accept value-typed scoped account and coin-source inputs.
- Update the rollback corruption assertion to check backend-independent error
  context.

Validation:
- `make fmt`
- `make lint`
- `scripts/check-each-commit.sh sql-wallet`
- Focused wallet, kvdb, and DB integration regression tests
