### PR TITLE
wallet+db: add GetAccountSecret Store surface and keyvault routing

### DIFF
--- a/.github/actions/rebase/action.yml
+++ b/.github/actions/rebase/action.yml
@@ -1,15 +1,36 @@
 name: "Rebase on to the PR target base branch"
 description: "A reusable workflow that's used to rebase the PR code on to the target base branch."
 
+outputs:
+  base-ref:
+    description: "The current pull request base branch."
+    value: ${{ steps.pr-base.outputs.ref }}
+
 runs:
   using: "composite"
 
   steps:
-    - name: fetch and rebase on ${{ github.base_ref }}
+    - name: resolve the current pull request base
+      id: pr-base
       shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        base_ref=$(gh api \
+          "repos/${GH_REPO}/pulls/${PR_NUMBER}" \
+          --jq '.base.ref')
+        echo "ref=${base_ref}" >> "${GITHUB_OUTPUT}"
+
+    - name: fetch and rebase on the pull request base
+      shell: bash
+      env:
+        BASE_REF: ${{ steps.pr-base.outputs.ref }}
       run: |
         git remote add upstream https://github.com/${{ github.repository }}
-        git fetch upstream ${{ github.base_ref }}:refs/remotes/upstream/${{ github.base_ref }}
+        git fetch upstream \
+          "${BASE_REF}:refs/remotes/upstream/${BASE_REF}"
         export GIT_COMMITTER_EMAIL="btcwallet-ci@example.com"
         export GIT_COMMITTER_NAME="btcwallet CI"
-        git rebase upstream/${{ github.base_ref }}
+        git rebase "upstream/${BASE_REF}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,11 +101,14 @@ jobs:
         with:
           go-version: '${{ env.GO_VERSION }}'
 
-      - name: fetch and rebase on ${{ github.base_ref }}
+      - name: fetch and rebase on the PR base
+        id: rebase
         uses: ./.github/actions/rebase
 
       - name: check commits
-        run: scripts/check-each-commit.sh upstream/${{ github.base_ref }}
+        env:
+          BASE_REF: ${{ steps.rebase.outputs.base-ref }}
+        run: scripts/check-each-commit.sh "upstream/${BASE_REF}"
 
   ########################
   # run unit tests

--- a/scripts/check-each-commit.sh
+++ b/scripts/check-each-commit.sh
@@ -8,8 +8,12 @@ fi
 set -e
 set -x
 
-if [[ "$(git log --pretty="%H %D" | grep "^[0-9a-f]*.* $1")" = "" ]]; then
+if ! git merge-base --is-ancestor "$1" HEAD; then
 	echo "It seems like the current checked-out commit is not based on $1"
 	exit 1
 fi
-git rebase --exec scripts/check-commit.sh $1
+
+commit_count=$(git rev-list --count "$1"..HEAD)
+echo "Checking $commit_count commit(s) above $1"
+
+git rebase --exec scripts/check-commit.sh "$1"

--- a/waddrmgr/address.go
+++ b/waddrmgr/address.go
@@ -728,6 +728,21 @@ type baseScriptAddress struct {
 	scriptMutex     sync.Mutex
 }
 
+// encryptedScript returns the stored, still-encrypted script material for the
+// address. It is nil for watch-only script addresses that persist no script.
+func (a *baseScriptAddress) encryptedScript() []byte {
+	return a.scriptEncrypted
+}
+
+// scriptIsSecret reports whether the stored script ciphertext is encrypted
+// under the script crypto key (CKTScript) rather than the public crypto key
+// (CKTPublic). The base type is used only by pay-to-script-hash addresses,
+// whose script is always secret; witnessScriptAddress overrides this with its
+// per-address flag.
+func (a *baseScriptAddress) scriptIsSecret() bool {
+	return true
+}
+
 var _ clearTextScriptSetter = (*baseScriptAddress)(nil)
 
 // unlock decrypts and stores the associated script.  It will fail if the key is
@@ -962,6 +977,15 @@ func (a *witnessScriptAddress) Script() ([]byte, error) {
 	// script stored in memory can be cleared at any time. Otherwise,
 	// the returned script could be invalidated from under the caller.
 	return a.unlock(cryptoKey)
+}
+
+// scriptIsSecret reports whether the stored script ciphertext is encrypted
+// under the script crypto key (CKTScript) rather than the public crypto key
+// (CKTPublic). It mirrors the key selection in Script above and applies to
+// pay-to-witness-script-hash and (via embedding) taproot script-path
+// addresses, whose secrecy is fixed at import time.
+func (a *witnessScriptAddress) scriptIsSecret() bool {
+	return a.isSecretScript
 }
 
 // Enforce witnessScriptAddress satisfies the ManagedScriptAddress interface.

--- a/waddrmgr/common_test.go
+++ b/waddrmgr/common_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcwallet/walletdb"
 	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -25,8 +26,6 @@ var (
 		0xbe, 0x8b, 0x56, 0xc8, 0x83, 0x77, 0x95, 0x59, 0x8b,
 		0xb6, 0xc4, 0x40, 0xc0, 0x64,
 	}
-
-	rootKey, _ = hdkeychain.NewMaster(seed, &chaincfg.MainNetParams)
 
 	pubPassphrase   = []byte("_DJr{fL4H0O}*-0\n:V1izc)(6BomK")
 	privPassphrase  = []byte("81lUHXnOMZ@?XXd7O9xyDIWIbXX-lj")
@@ -264,6 +263,21 @@ func emptyDB(t *testing.T) (tearDownFunc func(), db walletdb.DB) {
 	return
 }
 
+// testRootKey returns a master key derived from seed. Every caller gets its own
+// key even though the value is always the same: hdkeychain.ExtendedKey caches
+// derived state on first use, so tests sharing one key mutate it concurrently
+// and race under -race, despite each test only reading from its own view. The
+// value being identical is what makes this safe -- derived addresses and the
+// expected constants below are unchanged.
+func testRootKey(t *testing.T) *hdkeychain.ExtendedKey {
+	t.Helper()
+
+	rootKey, err := hdkeychain.NewMaster(seed, &chaincfg.MainNetParams)
+	require.NoError(t, err)
+
+	return rootKey
+}
+
 // setupManager creates a new address manager and returns a teardown function
 // that should be invoked to ensure it is closed and removed upon completion.
 func setupManager(t *testing.T) (tearDownFunc func(), db walletdb.DB, mgr *Manager) {
@@ -282,7 +296,7 @@ func setupManager(t *testing.T) (tearDownFunc func(), db walletdb.DB, mgr *Manag
 			return err
 		}
 		err = Create(
-			ns, rootKey, pubPassphrase, privPassphrase,
+			ns, testRootKey(t), pubPassphrase, privPassphrase,
 			&chaincfg.MainNetParams, fastScrypt, time.Time{},
 		)
 		if err != nil {

--- a/waddrmgr/manager_secret_test.go
+++ b/waddrmgr/manager_secret_test.go
@@ -1,0 +1,391 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package waddrmgr
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAccountSecretDerived verifies that AccountSecret returns the persisted
+// encrypted private key of a normal derived (default) account, as a
+// caller-owned copy, and nothing else.
+func TestAccountSecretDerived(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: a created, unlocked manager and its BIP0044 scoped manager.
+	teardown, db, mgr := setupManager(t)
+	t.Cleanup(teardown)
+
+	scopedMgr := fetchBIP44Scoped(t, mgr)
+
+	var (
+		gotEnc       []byte
+		expectedPriv *hdkeychain.ExtendedKey
+	)
+
+	err := walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+		// Unlock so we can decrypt the returned ciphertext for
+		// verification, then read the account secret.
+		err := mgr.Unlock(ns, privPassphrase)
+		if err != nil {
+			return err
+		}
+
+		gotEnc, err = assertCiphertextCopy(t, func() ([]byte, error) {
+			return scopedMgr.AccountSecret(ns, DefaultAccountNum)
+		})
+		if err != nil {
+			return err
+		}
+
+		// Derive the expected account private key straight from the
+		// seed for cross-checking the returned ciphertext.
+		expectedPriv = deriveTestAccountPrivKey(t)
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Assert: a non-nil ciphertext that is a caller-owned copy.
+	require.NotNil(t, gotEnc)
+	require.NotEmpty(t, gotEnc)
+
+	// Assert: decrypting the returned ciphertext with the crypto private
+	// key yields the expected account private key. This proves the stored
+	// ciphertext was returned verbatim (and never re-derived).
+	mgr.mtx.RLock()
+	serialized, err := mgr.cryptoKeyPriv.Decrypt(gotEnc)
+	mgr.mtx.RUnlock()
+	require.NoError(t, err)
+	require.Equal(t, expectedPriv.String(), string(serialized))
+}
+
+// TestAccountSecretWatchOnly verifies that AccountSecret returns a nil
+// encrypted private key for a watch-only imported account, which holds none.
+func TestAccountSecretWatchOnly(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: a created manager and its BIP0044 scoped manager.
+	teardown, db, mgr := setupManager(t)
+	t.Cleanup(teardown)
+
+	scopedMgr := fetchBIP44Scoped(t, mgr)
+
+	// Import a watch-only account with a known fingerprint.
+	acctKey := deriveTestAccountKey(t)
+	require.NotNil(t, acctKey)
+
+	acctKeyPub, err := acctKey.Neuter()
+	require.NoError(t, err)
+
+	const wantFingerprint = uint32(0xdeadbeef)
+
+	var account uint32
+
+	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+		account, err = scopedMgr.NewAccountWatchingOnly(
+			ns, "watch-only", acctKeyPub, wantFingerprint, nil,
+		)
+
+		return err
+	})
+	require.NoError(t, err)
+
+	// Act: read the account secret for the watch-only account.
+	var gotEnc []byte
+
+	err = walletdb.View(db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+
+		gotEnc, err = scopedMgr.AccountSecret(ns, account)
+
+		return err
+	})
+	require.NoError(t, err)
+
+	// Assert: a watch-only account exposes no private key.
+	require.Nil(t, gotEnc)
+}
+
+// TestAccountSecretNotFound verifies that AccountSecret returns
+// ErrAccountNotFound for an account that does not exist.
+func TestAccountSecretNotFound(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: a created manager and its BIP0044 scoped manager.
+	teardown, db, mgr := setupManager(t)
+	t.Cleanup(teardown)
+
+	scopedMgr := fetchBIP44Scoped(t, mgr)
+
+	// Act: read a non-existent account.
+	err := walletdb.View(db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+
+		_, err := scopedMgr.AccountSecret(ns, 9999)
+
+		return err
+	})
+
+	// Assert: the account-not-found error is returned.
+	require.True(
+		t, checkManagerError(t, "missing account", err,
+			ErrAccountNotFound),
+	)
+}
+
+// TestManagedAddressSecretPubKey verifies that ManagedAddressSecret returns the
+// stored encrypted private key (and no script) for an imported pubkey address.
+func TestManagedAddressSecretPubKey(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: a created, unlocked manager and its BIP0044 scoped manager.
+	teardown, db, mgr := setupManager(t)
+	t.Cleanup(teardown)
+
+	scopedMgr := fetchBIP44Scoped(t, mgr)
+
+	// A fixed private key we can import and later cross-check.
+	privKeyBytes := hexToBytes(
+		"c27d6581b92785834b381fa697c4b0ff" +
+			"c4574b495743722e0acb7601b1b68b99",
+	)
+	privKey, _ := btcec.PrivKeyFromBytes(privKeyBytes)
+	wif, err := btcutil.NewWIF(privKey, &chaincfg.MainNetParams, true)
+	require.NoError(t, err)
+
+	var (
+		importedAddr address.Address
+		gotPriv      []byte
+		gotScript    []byte
+		gotSecret    bool
+	)
+
+	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+		err := mgr.Unlock(ns, privPassphrase)
+		if err != nil {
+			return err
+		}
+
+		managed, err := scopedMgr.ImportPrivateKey(
+			ns, wif, &BlockStamp{},
+		)
+		if err != nil {
+			return err
+		}
+
+		importedAddr = managed.Address()
+
+		// Act: read the address secret twice through the copy
+		// assertion, so an aliased buffer would be caught here.
+		gotPriv, err = assertCiphertextCopy(t, func() ([]byte, error) {
+			priv, script, secret, err := scopedMgr.
+				ManagedAddressSecret(ns, importedAddr)
+			gotScript, gotSecret = script, secret
+
+			return priv, err
+		})
+
+		return err
+	})
+	require.NoError(t, err)
+
+	// Assert: a private-key ciphertext is returned and no script, so the
+	// script-secrecy flag is false.
+	require.NotEmpty(t, gotPriv)
+	require.Nil(t, gotScript)
+	require.False(t, gotSecret)
+
+	// Assert: the ciphertext decrypts to the imported private key.
+	mgr.mtx.RLock()
+	serialized, err := mgr.cryptoKeyPriv.Decrypt(gotPriv)
+	mgr.mtx.RUnlock()
+	require.NoError(t, err)
+	require.Equal(t, privKeyBytes, serialized)
+}
+
+// TestManagedAddressSecretScript verifies that ManagedAddressSecret returns the
+// stored encrypted script (and no private key) for an imported script address.
+func TestManagedAddressSecretScript(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: a created, unlocked manager and its BIP0044 scoped manager.
+	teardown, db, mgr := setupManager(t)
+	t.Cleanup(teardown)
+
+	scopedMgr := fetchBIP44Scoped(t, mgr)
+
+	script := hexToBytes(
+		"51210373c717acd6b1d4c9d92e5c5c6c62c1c1c1c1c1c1c1c1c1c1c1c1c" +
+			"1c1c1c1c1c151ae",
+	)
+
+	var (
+		importedAddr address.Address
+		gotPriv      []byte
+		gotScript    []byte
+		gotSecret    bool
+	)
+
+	err := walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+		err := mgr.Unlock(ns, privPassphrase)
+		if err != nil {
+			return err
+		}
+
+		managed, err := scopedMgr.ImportScript(
+			ns, script, &BlockStamp{},
+		)
+		if err != nil {
+			return err
+		}
+
+		importedAddr = managed.Address()
+
+		// Act: read the address secret twice through the copy
+		// assertion, so an aliased buffer would be caught here.
+		gotScript, err = assertCiphertextCopy(
+			t, func() ([]byte, error) {
+				priv, script, secret, err := scopedMgr.
+					ManagedAddressSecret(ns, importedAddr)
+				gotPriv, gotSecret = priv, secret
+
+				return script, err
+			},
+		)
+
+		return err
+	})
+	require.NoError(t, err)
+
+	// Assert: a script ciphertext is returned and no private key.
+	// ImportScript stores a P2SH redeem script, which is always secret, so
+	// the flag is set.
+	require.Nil(t, gotPriv)
+	require.NotEmpty(t, gotScript)
+	require.True(t, gotSecret)
+
+	// Assert: the ciphertext decrypts to the imported script under the
+	// script crypto key, matching the reported secrecy.
+	mgr.mtx.RLock()
+	serialized, err := mgr.cryptoKeyScript.Decrypt(gotScript)
+	mgr.mtx.RUnlock()
+	require.NoError(t, err)
+	require.Equal(t, script, serialized)
+}
+
+// TestManagedAddressSecretNotFound verifies that ManagedAddressSecret returns
+// the not-found error for an address that was never added to the manager,
+// keeping it distinguishable from a found-but-secretless address.
+func TestManagedAddressSecretNotFound(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: a created manager and its BIP0044 scoped manager.
+	teardown, db, mgr := setupManager(t)
+	t.Cleanup(teardown)
+
+	scopedMgr := fetchBIP44Scoped(t, mgr)
+
+	// A valid P2PKH address that was never imported.
+	unknown, err := address.NewAddressPubKeyHash(
+		hexToBytes("0000000000000000000000000000000000000000"),
+		&chaincfg.MainNetParams,
+	)
+	require.NoError(t, err)
+
+	// Act: look up the unknown address.
+	err = walletdb.View(db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+
+		_, _, _, err := scopedMgr.ManagedAddressSecret(ns, unknown)
+
+		return err
+	})
+
+	// Assert: the address-not-found error is returned.
+	require.True(
+		t, checkManagerError(t, "missing address", err,
+			ErrAddressNotFound),
+	)
+}
+
+// assertCiphertextCopy reads a ciphertext twice through read, mutating the
+// first result in place between reads. If read returns an independent copy the
+// mutation cannot reach the second read, so the two results differ and the
+// second is returned for any further assertions. A returned alias would make
+// the two results the same mutated buffer.
+func assertCiphertextCopy(t *testing.T, read func() ([]byte, error)) ([]byte,
+	error) {
+
+	t.Helper()
+
+	first, err := read()
+	if err != nil {
+		return nil, err
+	}
+
+	require.NotEmpty(t, first)
+
+	for i := range first {
+		first[i] ^= 0xff
+	}
+
+	second, err := read()
+	if err != nil {
+		return nil, err
+	}
+
+	require.NotEqual(t, first, second)
+
+	return second, nil
+}
+
+// fetchBIP44Scoped is a small helper that returns the concrete BIP0044 scoped
+// key manager for the given root manager.
+func fetchBIP44Scoped(t *testing.T, mgr *Manager) *ScopedKeyManager {
+	t.Helper()
+
+	acctStore, err := mgr.FetchScopedKeyManager(KeyScopeBIP0044)
+	require.NoError(t, err)
+
+	scopedMgr, ok := acctStore.(*ScopedKeyManager)
+	require.True(t, ok)
+
+	return scopedMgr
+}
+
+// deriveTestAccountPrivKey derives the default BIP0044 account extended private
+// key straight from the test seed so tests can cross-check the ciphertext
+// returned by AccountSecret.
+func deriveTestAccountPrivKey(t *testing.T) *hdkeychain.ExtendedKey {
+	t.Helper()
+
+	masterKey, err := hdkeychain.NewMaster(seed, &chaincfg.MainNetParams)
+	require.NoError(t, err)
+
+	scopeKey, err := deriveCoinTypeKey(masterKey, KeyScopeBIP0044)
+	require.NoError(t, err)
+
+	accountKey, err := deriveAccountKey(scopeKey, 0)
+	require.NoError(t, err)
+
+	return accountKey
+}

--- a/waddrmgr/manager_test.go
+++ b/waddrmgr/manager_test.go
@@ -1968,7 +1968,7 @@ func TestManager(t *testing.T) {
 		{
 			name:                "created with seed",
 			createdWatchingOnly: false,
-			rootKey:             rootKey,
+			rootKey:             testRootKey(t),
 			privPassphrase:      privPassphrase,
 		},
 		{
@@ -2348,7 +2348,7 @@ func TestScopedKeyManagerManagement(t *testing.T) {
 			return err
 		}
 		err = Create(
-			ns, rootKey, pubPassphrase, privPassphrase,
+			ns, testRootKey(t), pubPassphrase, privPassphrase,
 			&chaincfg.MainNetParams, fastScrypt, time.Time{},
 		)
 		if err != nil {
@@ -2682,7 +2682,7 @@ func TestRootHDKeyNeutering(t *testing.T) {
 			return err
 		}
 		err = Create(
-			ns, rootKey, pubPassphrase, privPassphrase,
+			ns, testRootKey(t), pubPassphrase, privPassphrase,
 			&chaincfg.MainNetParams, fastScrypt, time.Time{},
 		)
 		if err != nil {
@@ -2774,7 +2774,7 @@ func TestNewRawAccount(t *testing.T) {
 			return err
 		}
 		err = Create(
-			ns, rootKey, pubPassphrase, privPassphrase,
+			ns, testRootKey(t), pubPassphrase, privPassphrase,
 			&chaincfg.MainNetParams, fastScrypt, time.Time{},
 		)
 		if err != nil {
@@ -2906,7 +2906,7 @@ func TestNewRawAccountHybrid(t *testing.T) {
 			return err
 		}
 		err = Create(
-			ns, rootKey, pubPassphrase, privPassphrase,
+			ns, testRootKey(t), pubPassphrase, privPassphrase,
 			&chaincfg.MainNetParams, fastScrypt, time.Time{},
 		)
 		if err != nil {
@@ -3029,7 +3029,7 @@ func TestDeriveFromKeyPathCache(t *testing.T) {
 			return err
 		}
 		err = Create(
-			ns, rootKey, pubPassphrase, privPassphrase,
+			ns, testRootKey(t), pubPassphrase, privPassphrase,
 			&chaincfg.MainNetParams, fastScrypt, time.Time{},
 		)
 		if err != nil {
@@ -3275,7 +3275,7 @@ func TestManagedAddressValidation(t *testing.T) {
 			return err
 		}
 		err = Create(
-			ns, rootKey, pubPassphrase, privPassphrase,
+			ns, testRootKey(t), pubPassphrase, privPassphrase,
 			&chaincfg.MainNetParams, fastScrypt, time.Time{},
 		)
 		if err != nil {

--- a/waddrmgr/scoped_manager.go
+++ b/waddrmgr/scoped_manager.go
@@ -1,6 +1,7 @@
 package waddrmgr
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
@@ -716,6 +717,117 @@ func (s *ScopedKeyManager) AccountProperties(ns walletdb.ReadBucket,
 	}
 
 	return props, nil
+}
+
+// AccountSecret reads the persisted account row and returns the stored
+// encrypted account extended private key exactly as persisted, so an account's
+// secret can be relocated to another store without decrypting or re-deriving
+// it. The ciphertext is cloned, so the returned buffer never aliases
+// manager-held state.
+//
+// Watch-only, imported-xpub, or otherwise private-less accounts return a nil
+// blob (not an error). An absent account returns ErrAccountNotFound.
+func (s *ScopedKeyManager) AccountSecret(ns walletdb.ReadBucket,
+	account uint32) ([]byte, error) {
+
+	// Read the raw account row directly rather than going through
+	// loadAccountInfo, which would decrypt and cache the private key and
+	// require the manager to be unlocked. We only need the persisted
+	// material here.
+	rowInterface, err := fetchAccountInfo(ns, &s.scope, account)
+	if err != nil {
+		return nil, maybeConvertDbError(err)
+	}
+
+	switch row := rowInterface.(type) {
+	case *dbDefaultAccountRow:
+		// A default account row that carries no encrypted private key
+		// (e.g. an imported xpub persisted as a default row) reports a
+		// nil ciphertext rather than an empty slice. Clone a present
+		// ciphertext so the returned buffer is caller-owned.
+		if len(row.privKeyEncrypted) == 0 {
+			return nil, nil
+		}
+
+		return bytes.Clone(row.privKeyEncrypted), nil
+
+	case *dbWatchOnlyAccountRow:
+		// Watch-only accounts never hold a private key.
+		return nil, nil
+
+	default:
+		str := fmt.Sprintf("unsupported account type %T", row)
+
+		return nil, managerError(ErrDatabase, str, nil)
+	}
+}
+
+// ManagedAddressSecret resolves the given address and returns its persisted
+// secret material without decrypting it. For a public-key address it returns
+// the stored encrypted private key (nil when the address is watch-only or has
+// no private key); for a script address it returns the stored encrypted script
+// along with scriptSecret, which reports whether that ciphertext is encrypted
+// under the script crypto key (CKTScript) rather than the public crypto key
+// (CKTPublic) so the caller decrypts it with the matching key. An address that
+// exists but carries neither returns (nil, nil, false, nil), while an address
+// that cannot be resolved returns the ErrAddressNotFound error, keeping "found
+// but has no secret" distinguishable from "not found".
+func (s *ScopedKeyManager) ManagedAddressSecret(ns walletdb.ReadBucket,
+	addr address.Address) ([]byte, []byte, bool, error) {
+
+	// Reuse the standard address resolution path so caching and PK->PKH
+	// normalization behave identically to other reads.
+	managedAddr, err := s.Address(ns, addr)
+	if err != nil {
+		return nil, nil, false, err
+	}
+
+	// The ciphertext lives in the cached address's own buffers, which
+	// ConvertToWatchingOnly zeroes under s.mtx. Read and clone it while
+	// holding the same lock so the returned slice is an independent copy
+	// that neither races that zeroing nor lets a caller mutate cached
+	// state.
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	// Read the encrypted material straight from the concrete address types'
+	// unexported fields; we deliberately avoid the decrypting accessors.
+	switch a := managedAddr.(type) {
+	case *managedAddress:
+		if len(a.privKeyEncrypted) == 0 {
+			return nil, nil, false, nil
+		}
+
+		return bytes.Clone(a.privKeyEncrypted), nil, false, nil
+
+	case encryptedScriptGetter:
+		// All script address types embed baseScriptAddress and thus
+		// expose the stored ciphertext and the crypto key it is
+		// encrypted under through these accessors.
+		script := a.encryptedScript()
+		if len(script) == 0 {
+			return nil, nil, false, nil
+		}
+
+		return nil, bytes.Clone(script), a.scriptIsSecret(), nil
+
+	default:
+		// The address resolved but is of a type that holds no secret
+		// material we can export.
+		return nil, nil, false, nil
+	}
+}
+
+// encryptedScriptGetter is implemented by the script-based managed address
+// types so ManagedAddressSecret can read their stored ciphertext and the
+// crypto key it is encrypted under uniformly.
+type encryptedScriptGetter interface {
+	encryptedScript() []byte
+
+	// scriptIsSecret reports whether encryptedScript is encrypted under the
+	// script crypto key (CKTScript) rather than the public crypto key
+	// (CKTPublic), so a reader can decrypt it with the matching key.
+	scriptIsSecret() bool
 }
 
 // cachedKey is an entry within the LRU map that stores private keys that are

--- a/wallet/account_derive_test.go
+++ b/wallet/account_derive_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
-	walletmock "github.com/btcsuite/btcwallet/wallet/internal/bwtest/mock"
+	"github.com/btcsuite/btcwallet/wallet/internal/bwtest/keyvaultmock"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -22,8 +22,8 @@ import (
 // crypt — Encrypt and Decrypt both return a fresh copy of the input bytes
 // with no error. This lets tests roundtrip derived account material
 // without bringing in real cryptoKey wiring.
-func newIdentityVault() *walletmock.Vault {
-	vault := &walletmock.Vault{}
+func newIdentityVault() *keyvaultmock.Vault {
+	vault := &keyvaultmock.Vault{}
 	identity := func(_ waddrmgr.CryptoKeyType, b []byte) []byte {
 		out := make([]byte, len(b))
 		copy(out, b)
@@ -45,8 +45,8 @@ var errEncryptForTest = errors.New("encrypt boom")
 // newEncryptErrorVault returns a Vault whose Encrypt call always fails
 // with errEncryptForTest. Decrypt is left unconfigured because the tests
 // that consume this vault never reach a decrypt path.
-func newEncryptErrorVault() *walletmock.Vault {
-	vault := &walletmock.Vault{}
+func newEncryptErrorVault() *keyvaultmock.Vault {
+	vault := &keyvaultmock.Vault{}
 	vault.On("Encrypt", mock.Anything, mock.Anything).Return(
 		nil, errEncryptForTest,
 	)
@@ -111,7 +111,7 @@ func TestNewAccountDeriveFn_MaxAccountNumber(t *testing.T) {
 	masterKey := testMasterKey(t)
 	scope := db.KeyScope{Purpose: 84, Coin: 0}
 
-	derive := newAccountDeriveFn(masterKey, &walletmock.Vault{}, 0)
+	derive := newAccountDeriveFn(masterKey, &keyvaultmock.Vault{}, 0)
 	data, err := derive(t.Context(), scope, db.MaxAccountNumber+1, false)
 
 	require.Nil(t, data)

--- a/wallet/address_info_test.go
+++ b/wallet/address_info_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// watchOnlyAccount is the placeholder account name used across the address
+// metadata tests for records that carry no signable account identity.
+const watchOnlyAccount = "watch-only"
+
 // TestAddressInfoFromManagedAddressPubKey verifies conversion of a managed
 // pubkey address into wallet-owned metadata.
 func TestAddressInfoFromManagedAddressPubKey(t *testing.T) {
@@ -70,9 +74,8 @@ func TestAddressInfoFromManagedAddressPubKey(t *testing.T) {
 
 // TestAddressInfoFromStoreAddress verifies that the store-backed mapper keeps
 // address shape separate from imported key provenance. Imported-xpub children
-// are HD-shaped but do not expose public BIP32 metadata without a
-// wallet-derived
-// account number.
+// are HD-shaped but expose no wallet BIP44 derivation, because the store masks
+// an imported account's number onto the wallet's own default account.
 func TestAddressInfoFromStoreAddress(t *testing.T) {
 	t.Parallel()
 
@@ -109,6 +112,8 @@ func TestAddressInfoFromStoreAddress(t *testing.T) {
 		return info
 	}
 
+	accountID := uint32(42)
+
 	tests := []struct {
 		name         string
 		mutate       func(*db.AddressInfo)
@@ -117,16 +122,17 @@ func TestAddressInfoFromStoreAddress(t *testing.T) {
 		wantDeriv    bool
 		wantBranch   uint32
 		wantIndex    uint32
+		wantAccount  uint32
 	}{
 		{
-			// An imported-xpub external child carries a real branch/index but
-			// no wallet-derived account number, so public BIP32 derivation is
-			// intentionally absent instead of using fake account 0.
-			name: "imported-xpub HD external",
+			// An imported-xpub child with no account identity at
+			// all cannot key any derivation, so its derivation
+			// shape is absent.
+			name: "imported-xpub HD external no number",
 			mutate: func(info *db.AddressInfo) {
 				info.IsImported = true
 				info.HasDerivationPath = true
-				info.AccountName = "watch-only"
+				info.AccountName = watchOnlyAccount
 				info.Branch = waddrmgr.ExternalBranch
 				info.Index = 5
 			},
@@ -137,22 +143,39 @@ func TestAddressInfoFromStoreAddress(t *testing.T) {
 			wantIndex:    5,
 		},
 		{
-			// An imported-xpub internal child is still classified by branch
-			// even
-			// though its public BIP32 account metadata is unavailable.
+			// An imported-xpub external child has no wallet-derived
+			// account number, so it exposes no derivation at all:
+			// the store masks an imported account's number onto the
+			// wallet's own default account, and signing refuses the
+			// address before any secret lookup.
+			name: "imported-xpub HD external",
+			mutate: func(info *db.AddressInfo) {
+				info.IsImported = true
+				info.HasDerivationPath = true
+				info.AccountName = watchOnlyAccount
+				info.AccountID = &accountID
+				info.Branch = waddrmgr.ExternalBranch
+				info.Index = 5
+			},
+			wantImported: false,
+			wantInternal: false,
+			wantDeriv:    false,
+		},
+		{
+			// An imported-xpub internal child is classified by
+			// branch but still exposes no derivation.
 			name: "imported-xpub HD internal",
 			mutate: func(info *db.AddressInfo) {
 				info.IsImported = true
 				info.HasDerivationPath = true
-				info.AccountName = "watch-only"
+				info.AccountName = watchOnlyAccount
+				info.AccountID = &accountID
 				info.Branch = waddrmgr.InternalBranch
 				info.Index = 8
 			},
 			wantImported: false,
 			wantInternal: true,
 			wantDeriv:    false,
-			wantBranch:   waddrmgr.InternalBranch,
-			wantIndex:    8,
 		},
 		{
 			// A raw single import has no chain position, so it carries no
@@ -167,11 +190,12 @@ func TestAddressInfoFromStoreAddress(t *testing.T) {
 			wantDeriv:    false,
 		},
 		{
-			// A normal derived child has wallet-derived account metadata, so
-			// it exposes a public derivation path and branch classification.
+			// A normal derived child has wallet-derived account
+			// metadata, so it exposes a public derivation path with
+			// a real account number.
 			name: "derived internal",
 			mutate: func(info *db.AddressInfo) {
-				accountNumber := uint32(0)
+				accountNumber := uint32(3)
 
 				info.AccountName = defaultAccountName
 				info.AccountNumber = &accountNumber
@@ -184,6 +208,7 @@ func TestAddressInfoFromStoreAddress(t *testing.T) {
 			wantDeriv:    true,
 			wantBranch:   waddrmgr.InternalBranch,
 			wantIndex:    2,
+			wantAccount:  3,
 		},
 	}
 
@@ -201,8 +226,8 @@ func TestAddressInfoFromStoreAddress(t *testing.T) {
 			require.NoError(t, err)
 
 			// Assert: Classification matches HD vs raw-import
-			// expectations, and derivation info is populated only when a
-			// wallet-derived account number is available.
+			// expectations, and derivation info is populated only
+			// when a wallet-derived account number is available.
 			require.Equal(t, tc.wantImported, info.Imported)
 			require.Equal(t, tc.wantInternal, info.Internal)
 
@@ -215,6 +240,9 @@ func TestAddressInfoFromStoreAddress(t *testing.T) {
 			require.NotNil(t, info.Derivation)
 			require.Equal(t, tc.wantBranch, info.Derivation.Branch)
 			require.Equal(t, tc.wantIndex, info.Derivation.Index)
+			require.Equal(
+				t, tc.wantAccount, info.Derivation.Account,
+			)
 		})
 	}
 }

--- a/wallet/address_manager.go
+++ b/wallet/address_manager.go
@@ -150,6 +150,14 @@ type OutputScriptInfo struct {
 	// For nested P2WPKH-in-P2SH spends, this is a single push of RedeemScript.
 	// Native witness spends leave this nil.
 	SigScript []byte
+
+	// Script is the plaintext redeem or witness script for a script-based
+	// output (P2SH multisig, P2WSH, taproot script-path). It is decrypted
+	// from the address's stored encrypted script and, for taproot
+	// script-path imports, is the single revealed leaf script. It is nil
+	// for single-key (pubkey-spend) outputs, whose subscript is derived
+	// from the public key instead.
+	Script []byte
 }
 
 // AddressManager provides an interface for generating and inspecting wallet
@@ -236,6 +244,9 @@ func addressInfoFromManagedAddress(
 		return info, nil
 	}
 
+	// A managed address that exposes DerivationInfo is wallet-seed derived
+	// and always has a real BIP44 account number, so it is safe to expose
+	// as a public derivation path.
 	info.Derivation = &AddressDerivation{
 		KeyScope:             keyScope,
 		Account:              derivationPath.Account,
@@ -293,9 +304,14 @@ func addressInfoFromStoreAddress(storeAddr *db.AddressInfo,
 
 	info.PubKey = pubKey
 
-	// Imported-xpub children have a real branch/index but no wallet-derived
-	// account number. Do not fabricate account 0; without a BIP44 account
-	// number the public BIP32 derivation shape is intentionally absent.
+	// A derivation describes a wallet BIP44 path, so it needs a
+	// wallet-derived account number. Raw single imports have none, and
+	// neither do imported-xpub children: the store masks an imported
+	// account's number to 0, which is the wallet's own default derived
+	// account, so publishing a derivation for them would hand callers a
+	// path into the wrong account. Both cases expose no derivation at all,
+	// and signing refuses them with ErrNoAssocPrivateKey before any secret
+	// lookup.
 	if storeAddr.AccountNumber == nil {
 		return info, nil
 	}
@@ -861,16 +877,16 @@ func (w *Wallet) ImportTaprootScript(ctx context.Context,
 
 // encryptTaprootScript encodes and encrypts taproot script data before the
 // encrypted blob is handed to the store.
+//
+// The wallet's watch-only mode does not enter into it: every vault seals script
+// bodies with its script operation, and each backend resolves that to whatever
+// key its own format keeps for the purpose.
 func encryptTaprootScript(vault keyvault.Vault,
 	tapscript *waddrmgr.Tapscript) ([]byte, error) {
 
 	encodedScript, err := waddrmgr.EncodeTaprootScript(tapscript)
 	if err != nil {
 		return nil, fmt.Errorf("encode tapscript: %w", err)
-	}
-
-	if vault == nil {
-		return nil, fmt.Errorf("%w: keyVault", ErrMissingParam)
 	}
 
 	encryptedScript, err := vault.Encrypt(waddrmgr.CKTPublic, encodedScript)
@@ -932,6 +948,24 @@ func (w *Wallet) ScriptForOutput(ctx context.Context, output wire.TxOut) (
 	if err != nil {
 		return OutputScriptInfo{}, fmt.Errorf("unable to get address info "+
 			"for %s: %w", addr.String(), err)
+	}
+
+	// Script-based outputs (P2SH multisig, P2WSH, taproot script-path) have
+	// no single spending public key; their subscript is the stored,
+	// encrypted redeem or witness script. Resolve it through the store and
+	// key vault rather than the pubkey-derived script path below.
+	if isScriptSpendAddress(addressInfo) {
+		script, err := w.scriptForAddressInfo(
+			ctx, addressInfo, output.PkScript,
+		)
+		if err != nil {
+			return OutputScriptInfo{}, err
+		}
+
+		return OutputScriptInfo{
+			AddressInfo: addressInfo,
+			Script:      script,
+		}, nil
 	}
 
 	witnessProgram, redeemScript, sigScript, err := buildScriptsForAddressInfo(
@@ -1054,7 +1088,8 @@ func derivationForAddressInfo(addressInfo AddressInfo) (
 		Bip32Path: []uint32{
 			keyScope.Purpose + hdkeychain.HardenedKeyStart,
 			keyScope.Coin + hdkeychain.HardenedKeyStart,
-			addressInfo.Derivation.Account + hdkeychain.HardenedKeyStart,
+			addressInfo.Derivation.Account +
+				hdkeychain.HardenedKeyStart,
 			addressInfo.Derivation.Branch,
 			addressInfo.Derivation.Index,
 		},

--- a/wallet/address_manager_test.go
+++ b/wallet/address_manager_test.go
@@ -105,8 +105,6 @@ func expectStoreNewAddress(t *testing.T, w *Wallet, deps *mockWalletDeps,
 // AddressInfo for tests that exercise the wallet's address-info read
 // path. No call-count constraint — the same address may be looked up
 // multiple times (input decoration + change output info).
-//
-//nolint:unparam // Keep branch metadata in the helper signature.
 func expectSignerAddressInfo(t *testing.T, w *Wallet, deps *mockWalletDeps,
 	addr address.Address, addrType db.AddressType,
 	internal, imported bool, pubKey *btcec.PublicKey) {
@@ -666,6 +664,48 @@ func TestGetDerivationInfoNoDerivationInfo(t *testing.T) {
 	require.ErrorIs(t, err, ErrDerivationPathNotFound)
 }
 
+// TestGetDerivationInfoImportedXpubNoAccountNumber verifies that an
+// imported-xpub HD child (a store address that is HD-shaped and carries a
+// durable AccountID but no wallet-derived BIP44 account number) exposes no
+// public derivation path: GetDerivationInfo must refuse rather than fabricate a
+// public account 0. Such a child is not signable either — the signer refuses it
+// for lack of a wallet-derived account number, before any secret lookup.
+func TestGetDerivationInfoImportedXpubNoAccountNumber(t *testing.T) {
+	t.Parallel()
+
+	w, deps := createStartedWalletWithMocks(t)
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	pubKey := privKey.PubKey()
+	addr, err := address.NewAddressWitnessPubKeyHash(
+		address.Hash160(pubKey.SerializeCompressed()),
+		w.cfg.ChainParams,
+	)
+	require.NoError(t, err)
+
+	// Build a store record for an imported-xpub external child: HD path
+	// present, a durable AccountID, but no wallet-derived account number.
+	info := addressInfoFromAddr(t, addr)
+	accountID := uint32(7)
+	info.AddrType = db.WitnessPubKey
+	info.IsImported = true
+	info.HasDerivationPath = true
+	info.AccountName = watchOnlyAccount
+	info.AccountID = &accountID
+	info.KeyScope = db.KeyScope(waddrmgr.KeyScopeBIP0084)
+	info.Index = 3
+	info.PubKey = pubKey.SerializeCompressed()
+
+	expectStoreAddressInfo(t, w, deps, addr, info)
+
+	// Act & Assert: the public derivation path must be refused because no
+	// real account number exists.
+	_, err = w.GetDerivationInfo(t.Context(), addr)
+	require.ErrorIs(t, err, ErrDerivationPathNotFound)
+}
+
 // TestListAddresses tests the ListAddresses method to ensure it returns the
 // correct addresses and balances for a given account.
 func TestListAddresses(t *testing.T) {
@@ -896,6 +936,31 @@ func TestImportTaprootScript(t *testing.T) {
 	require.Equal(t, addr, info.Addr)
 	require.Equal(t, waddrmgr.TaprootScript, info.AddrType)
 	require.True(t, info.Imported)
+}
+
+// newTestTapscript builds a single-leaf taproot script for import tests.
+func newTestTapscript(t *testing.T) waddrmgr.Tapscript {
+	t.Helper()
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	pubKey := privKey.PubKey()
+	script, err := txscript.NewScriptBuilder().
+		AddData(pubKey.SerializeCompressed()).
+		AddOp(txscript.OP_CHECKSIG).
+		Script()
+	require.NoError(t, err)
+
+	leaf := txscript.NewTapLeaf(txscript.BaseLeafVersion, script)
+
+	return waddrmgr.Tapscript{
+		Type: waddrmgr.TapscriptTypeFullTree,
+		ControlBlock: &txscript.ControlBlock{
+			InternalKey: pubKey,
+		},
+		Leaves: []txscript.TapLeaf{leaf},
+	}
 }
 
 // TestScriptForOutput tests the ScriptForOutput method to ensure it returns the

--- a/wallet/cache.go
+++ b/wallet/cache.go
@@ -21,6 +21,12 @@ type runtimeCache interface {
 	GetAccount(ctx context.Context,
 		query db.GetAccountQuery) (*db.AccountInfo, error)
 
+	// GetAccountSecret returns encrypted account-level signing material.
+	// The result mirrors the underlying db.AccountStore.GetAccountSecret
+	// contract and never contains plaintext key material.
+	GetAccountSecret(ctx context.Context,
+		query db.GetAccountSecretQuery) (*db.AccountSecret, error)
+
 	// ListAccounts returns accounts matching the given query. The result
 	// mirrors the underlying db.AccountStore.ListAccounts contract.
 	ListAccounts(ctx context.Context,
@@ -72,6 +78,20 @@ func (c *storeRuntimeCache) GetAccount(ctx context.Context,
 	query db.GetAccountQuery) (*db.AccountInfo, error) {
 
 	return c.store.GetAccount(ctx, query)
+}
+
+// GetAccountSecret delegates to the underlying db.Store.
+//
+// NOTE: pass-through today. See storeRuntimeCache's TODO(yy).
+//
+// TODO(yy): drop the wrapcheck exemption once the cache layer wraps
+// store errors with its own typed errors.
+//
+//nolint:wrapcheck
+func (c *storeRuntimeCache) GetAccountSecret(ctx context.Context,
+	query db.GetAccountSecretQuery) (*db.AccountSecret, error) {
+
+	return c.store.GetAccountSecret(ctx, query)
 }
 
 // ListAccounts delegates to the underlying db.Store.

--- a/wallet/cache.go
+++ b/wallet/cache.go
@@ -37,6 +37,12 @@ type runtimeCache interface {
 	GetAddress(ctx context.Context,
 		query db.GetAddressQuery) (*db.AddressInfo, error)
 
+	// GetAddressSecret returns encrypted address-level secret material.
+	// The result mirrors the underlying db.AddressStore.GetAddressSecret
+	// contract and never contains plaintext key or script material.
+	GetAddressSecret(ctx context.Context,
+		query db.GetAddressSecretQuery) (*db.AddressSecret, error)
+
 	// ListAddresses returns one page of addresses for the given query.
 	// Mirrors the underlying db.AddressStore.ListAddresses contract.
 	ListAddresses(ctx context.Context, query db.ListAddressesQuery) (
@@ -120,6 +126,20 @@ func (c *storeRuntimeCache) GetAddress(ctx context.Context,
 	query db.GetAddressQuery) (*db.AddressInfo, error) {
 
 	return c.store.GetAddress(ctx, query)
+}
+
+// GetAddressSecret delegates to the underlying db.Store.
+//
+// NOTE: pass-through today. See storeRuntimeCache's TODO(yy).
+//
+// TODO(yy): drop the wrapcheck exemption once the cache layer wraps
+// store errors with its own typed errors.
+//
+//nolint:wrapcheck
+func (c *storeRuntimeCache) GetAddressSecret(ctx context.Context,
+	query db.GetAddressSecretQuery) (*db.AddressSecret, error) {
+
+	return c.store.GetAddressSecret(ctx, query)
 }
 
 // ListAddresses delegates to the underlying db.Store.

--- a/wallet/common_test.go
+++ b/wallet/common_test.go
@@ -24,7 +24,6 @@ var (
 	errMock           = errors.New("mock error")
 	errChainMock      = errors.New("chain error")
 	errPutMock        = errors.New("put error")
-	errLockMock       = errors.New("lock fail")
 	errDBFail         = errors.New("db fail")
 	errDeriveFail     = errors.New("derive fail")
 	errLoadStateFail  = errors.New("load state fail")
@@ -139,7 +138,9 @@ func createTestWalletWithMocks(t *testing.T) (*Wallet, *mockWalletDeps) {
 		state:       newWalletState(mockSyncer),
 		lifetimeCtx: ctx,
 		cancel:      cancel,
-		requestChan: make(chan any, 1),
+		// Unbuffered, matching production: a buffered channel here would
+		// let a send succeed without the main loop taking the request.
+		requestChan: make(chan any),
 		lockTimer:   time.NewTimer(time.Hour),
 		birthdayBlock: waddrmgr.BlockStamp{
 			Height: 100,
@@ -183,6 +184,16 @@ func createTestWalletWithMocks(t *testing.T) (*Wallet, *mockWalletDeps) {
 	})
 
 	return w, deps
+}
+
+// expectStopTeardown registers the one mock call Stop makes to clear in-memory
+// secret material: it locks the key vault. The expectation is optional so a
+// test that never stops the wallet is unaffected, and registered so a test that
+// does call Stop does not trip the strict mocks. It must be called after any
+// operation-specific Lock().Once() expectation so that expectation is matched
+// first and this pass-through absorbs only the extra stop-time Lock.
+func expectStopTeardown(deps *mockWalletDeps) {
+	deps.vault.On("Lock").Return().Maybe()
 }
 
 // createStartedWalletWithMocks creates a fully started and unlocked Wallet
@@ -232,6 +243,8 @@ func createStartedWalletWithID(t *testing.T, walletID uint32) (*Wallet,
 
 	// Mock the syncer run.
 	deps.syncer.On("run", mock.Anything).Return(nil).Once()
+
+	expectStopTeardown(deps)
 
 	// Start the wallet.
 	require.NoError(t, w.Start(t.Context()))

--- a/wallet/common_test.go
+++ b/wallet/common_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	bwmock "github.com/btcsuite/btcwallet/bwtest/mock"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/bwtest/keyvaultmock"
 	walletmock "github.com/btcsuite/btcwallet/wallet/internal/bwtest/mock"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
@@ -96,7 +97,7 @@ func setupTestDB(t *testing.T) (walletdb.DB, func()) {
 // mockWalletDeps holds the mocked dependencies for the Wallet.
 type mockWalletDeps struct {
 	addrStore      *bwmock.AddrStore
-	vault          *walletmock.Vault
+	vault          *keyvaultmock.Vault
 	store          *walletmock.Store
 	txStore        *bwmock.TxStore
 	syncer         *mockChainSyncer
@@ -117,7 +118,7 @@ func createTestWalletWithMocks(t *testing.T) (*Wallet, *mockWalletDeps) {
 	t.Cleanup(cleanup)
 
 	mockAddrStore := &bwmock.AddrStore{}
-	mockVault := &walletmock.Vault{}
+	mockVault := &keyvaultmock.Vault{}
 	mockStore := &walletmock.Store{}
 	mockTxStore := &bwmock.TxStore{}
 	mockSyncer := &mockChainSyncer{}

--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/keyvault"
 )
 
 const (
@@ -39,6 +40,18 @@ var (
 	// ErrStateChanged is returned when the wallet state changes
 	// unexpectedly during an operation, such as a rescan setup.
 	ErrStateChanged = errors.New("wallet state changed unexpectedly")
+)
+
+// The passphrase sentinels below are part of the wallet's public API: callers
+// match on them with errors.Is. They alias the values used inside the wallet's
+// key vault rather than copying them, so an error raised deep in the vault
+// matches here with no translation step -- which matters because the vault
+// lives under wallet/internal and external callers cannot import it.
+var (
+
+	// ErrInvalidPassphrase is returned when a supplied passphrase does not
+	// match the one guarding the wallet.
+	ErrInvalidPassphrase = keyvault.ErrInvalidPassphrase
 )
 
 // UnlockRequest contains the parameters for unlocking the wallet.
@@ -85,20 +98,39 @@ type Info struct {
 }
 
 // ChangePassphraseRequest contains the parameters for changing wallet
-// passphrases. It supports changing the public passphrase, the private
-// passphrase, or both simultaneously.
+// passphrases.
+//
+// The two halves are selected independently. A SQL wallet has only the private
+// passphrase; kvdb additionally protects its public metadata with a separate
+// public passphrase, so a caller on that backend may rotate either half or
+// both.
 type ChangePassphraseRequest struct {
 	// ChangePublic indicates whether the public passphrase should be
 	// changed.
+	//
+	// Deprecated: kvdb is a legacy backend and is the only one with a
+	// separate public passphrase. This field will be removed with kvdb
+	// support.
 	ChangePublic bool
-	PublicOld    []byte
-	PublicNew    []byte
+
+	// PublicOld and PublicNew are read only when ChangePublic is set.
+	//
+	// Deprecated: kvdb is a legacy backend and is the only one with a
+	// separate public passphrase. These fields will be removed with kvdb
+	// support.
+	PublicOld []byte
+	PublicNew []byte
 
 	// ChangePrivate indicates whether the private passphrase should be
 	// changed.
 	ChangePrivate bool
-	PrivateOld    []byte
-	PrivateNew    []byte
+
+	// PrivateOld and PrivateNew are read only when ChangePrivate is set.
+	// The old passphrase is required even when the wallet is unlocked,
+	// because the rotation re-derives the old master key to unwrap the
+	// existing key material.
+	PrivateOld []byte
+	PrivateNew []byte
 }
 
 // Controller provides an interface for managing the wallet's lifecycle and
@@ -347,6 +379,13 @@ func (w *Wallet) Stop(stopCtx context.Context) error {
 		return fmt.Errorf("stop request cancelled: %w", stopCtx.Err())
 	}
 
+	// Lock the key vault so no decrypted signing keys outlive the shutdown.
+	// The background goroutines have exited, so no signer is running.
+	// Unconditional rather than gated on the unlocked state bit: Lock is
+	// void and idempotent, so a never-unlocked vault is a no-op, and gating
+	// would only add a way to skip it.
+	w.keyVault.Lock()
+
 	// Mark the wallet as stopped.
 	err = w.state.toStopped()
 	if err != nil {
@@ -424,7 +463,6 @@ func (w *Wallet) ChangePassphrase(ctx context.Context,
 		return err
 	}
 
-	// Wait for the result.
 	return w.waitForResp(ctx, r.resp)
 }
 
@@ -700,8 +738,10 @@ func (w *Wallet) handleUnlockReq(req unlockReq) {
 		return
 	}
 
-	// Attempt to unlock the underlying address manager.
-	err = w.DBUnlock(w.lifetimeCtx, req.req.Passphrase)
+	// Attempt to unlock the key vault. The vault has no auto-lock of its
+	// own; the controller keeps owning the auto-lock schedule through its
+	// lockTimer below.
+	err = w.keyVault.Unlock(w.lifetimeCtx, req.req.Passphrase)
 	if err != nil {
 		req.resp <- err
 		return
@@ -752,22 +792,12 @@ func (w *Wallet) handleLockReq(req lockReq) {
 		}
 	}
 
-	// Signal the address manager to lock, clearing sensitive data.
-	err = w.addrStore.Lock()
-	if err != nil {
-		log.Errorf("Could not lock wallet: %v", err)
+	// Signal the key vault to lock, clearing sensitive data. Lock is void
+	// and idempotent: the vault swallows an already-locked condition and
+	// logs any other failure internally.
+	w.keyVault.Lock()
 
-		// If the wallet is already locked, we consider this a success
-		// (idempotency) and proceed to ensure our state is consistent.
-		if !waddrmgr.IsError(err, waddrmgr.ErrLocked) {
-			req.resp <- err
-
-			return
-		}
-	}
-
-	// Even if an error occurred (e.g. already locked), we ensure the
-	// wallet's high-level state is synchronized to 'locked'.
+	// Synchronize the wallet's high-level state to 'locked'.
 	w.state.toLocked()
 
 	// Report the result back to the caller.
@@ -775,8 +805,9 @@ func (w *Wallet) handleLockReq(req lockReq) {
 }
 
 // handleChangePassphraseReq processes a request to rotate the wallet's
-// passphrases. It can change either the public passphrase, the private
-// passphrase, or both in a single atomic database update.
+// passphrase, re-wrapping the persisted key material under the new one.
+//
+//nolint:staticcheck // Bridges the legacy kvdb public-passphrase fields.
 func (w *Wallet) handleChangePassphraseReq(req changePassphraseReq) {
 	// First, validate that the wallet is in a state that allows changing
 	// the passphrase.
@@ -786,8 +817,34 @@ func (w *Wallet) handleChangePassphraseReq(req changePassphraseReq) {
 		return
 	}
 
-	// Delegate the cryptographic rotation to the database layer.
-	err = w.DBPutPassphrase(w.lifetimeCtx, req.req)
+	// The vault owns the encryption boundary, so it performs the rotation.
+	// Both halves travel together: kvdb applies them in one transaction,
+	// and SQL refuses a request naming the public half before touching
+	// anything.
+	params := keyvault.ChangePassphraseParams{}
+	if req.req.ChangePublic {
+		params.PublicOld = req.req.PublicOld
+		if params.PublicOld == nil {
+			params.PublicOld = []byte{}
+		}
+
+		params.PublicNew = req.req.PublicNew
+	}
+
+	if req.req.ChangePrivate {
+		params.PrivateOld = req.req.PrivateOld
+		if params.PrivateOld == nil {
+			params.PrivateOld = []byte{}
+		}
+
+		params.PrivateNew = req.req.PrivateNew
+	}
+
+	err = w.keyVault.ChangePassphrase(w.lifetimeCtx, params)
+	if err != nil {
+		req.resp <- err
+		return
+	}
 
 	// Report the result back to the caller.
 	req.resp <- err

--- a/wallet/controller_test.go
+++ b/wallet/controller_test.go
@@ -2,6 +2,7 @@ package wallet
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"sync"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/keyvault"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -43,9 +45,8 @@ func TestPerformRuntimeSetupRoutesStoreStartup(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestHandleUnlockReq verifies that the handleUnlockReq method correctly
-// processes an unlock request by invoking the address manager's Unlock method
-// and updating the wallet state.
+// TestHandleUnlockReq verifies that handleUnlockReq unlocks the key vault and
+// updates the wallet state.
 func TestHandleUnlockReq(t *testing.T) {
 	t.Parallel()
 
@@ -60,8 +61,10 @@ func TestHandleUnlockReq(t *testing.T) {
 	pass := []byte("password")
 	req := newUnlockReq(UnlockRequest{Passphrase: pass})
 
-	// Setup the expected call to the address manager's Unlock method.
-	deps.addrStore.On("Unlock", mock.Anything, pass).Return(nil).Once()
+	// Setup the expected call to the key vault's Unlock method.
+	deps.vault.On(
+		"Unlock", mock.Anything, pass,
+	).Return(nil).Once()
 
 	// Act: Dispatch the unlock request to the handler.
 	w.handleUnlockReq(req)
@@ -73,9 +76,8 @@ func TestHandleUnlockReq(t *testing.T) {
 	require.True(t, w.state.isUnlocked())
 }
 
-// TestHandleUnlockReq_Errors verifies that handleUnlockReq correctly handles
-// error conditions, such as attempting to unlock a stopped wallet or a failure
-// from the underlying storage.
+// TestHandleUnlockReq_Errors verifies that handleUnlockReq rejects a stopped
+// wallet and propagates key-vault failures.
 func TestHandleUnlockReq_Errors(t *testing.T) {
 	t.Parallel()
 
@@ -97,7 +99,7 @@ func TestHandleUnlockReq_Errors(t *testing.T) {
 		require.ErrorIs(t, err, ErrStateForbidden)
 	})
 
-	t.Run("DBUnlock_Failure", func(t *testing.T) {
+	t.Run("key vault failure", func(t *testing.T) {
 		t.Parallel()
 
 		// Arrange: Create a test wallet and transition to 'Started'.
@@ -107,17 +109,128 @@ func TestHandleUnlockReq_Errors(t *testing.T) {
 
 		pass := []byte("password")
 		req := newUnlockReq(UnlockRequest{Passphrase: pass})
-		deps.addrStore.On("Unlock", mock.Anything, pass).Return(
+		deps.vault.On(
+			"Unlock", mock.Anything, pass,
+		).Return(
 			errDBMock,
 		).Once()
 
 		// Act: Attempt to unlock the wallet.
 		w.handleUnlockReq(req)
 
-		// Assert: Verify that the database error is propagated.
+		// Assert: Verify that the key-vault error is propagated.
 		err := <-req.resp
 		require.ErrorContains(t, err, "db error")
 	})
+}
+
+// TestControllerChangePassphrase_Interrupted_WaitCancelled verifies
+// ChangePassphrase when response wait is interrupted by context cancellation.
+func TestControllerChangePassphrase_Interrupted_WaitCancelled(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Block during response wait and cancel context.
+	w, _ := createTestWalletWithMocks(t)
+
+	require.NoError(t, w.state.toStarting())
+	require.NoError(t, w.state.toStarted())
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- w.ChangePassphrase(ctx,
+			ChangePassphraseRequest{})
+	}()
+
+	select {
+	case <-w.requestChan:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for request")
+	}
+
+	// Act: Cancel context.
+	cancel()
+
+	// Assert: Verify error.
+	select {
+	case err := <-errChan:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for response")
+	}
+}
+
+// TestControllerChangePassphrase_Interrupted_WaitShutdown verifies
+// ChangePassphrase when response wait is interrupted by wallet shutdown.
+func TestControllerChangePassphrase_Interrupted_WaitShutdown(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Block during response wait and trigger shutdown.
+	w, _ := createTestWalletWithMocks(t)
+
+	require.NoError(t, w.state.toStarting())
+	require.NoError(t, w.state.toStarted())
+
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- w.ChangePassphrase(t.Context(),
+			ChangePassphraseRequest{})
+	}()
+
+	select {
+	case <-w.requestChan:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for request")
+	}
+
+	// Act: Stop wallet.
+	w.cancel()
+
+	// Assert: Verify error.
+	select {
+	case err := <-errChan:
+		require.ErrorIs(t, err, ErrWalletShuttingDown)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for response")
+	}
+}
+
+// TestControllerChangePassphrase_Interrupted_WaitTimeout verifies
+// ChangePassphrase when response wait times out.
+func TestControllerChangePassphrase_Interrupted_WaitTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Block during response wait and allow timeout.
+	w, _ := createTestWalletWithMocks(t)
+
+	require.NoError(t, w.state.toStarting())
+	require.NoError(t, w.state.toStarted())
+
+	ctx, cancel := context.WithTimeout(t.Context(),
+		10*time.Millisecond)
+	defer cancel()
+
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- w.ChangePassphrase(ctx,
+			ChangePassphraseRequest{})
+	}()
+
+	select {
+	case <-w.requestChan:
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+
+	// Assert: Verify timeout.
+	select {
+	case err := <-errChan:
+		require.ErrorContains(t, err,
+			"context deadline exceeded")
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for response")
+	}
 }
 
 // TestHandleLockReq verifies that the handleLockReq method correctly processes
@@ -135,8 +248,8 @@ func TestHandleLockReq(t *testing.T) {
 
 	req := newLockReq()
 
-	// Setup the expected call to the address manager's Lock method.
-	deps.addrStore.On("Lock").Return(nil).Once()
+	// Setup the expected call to the key vault's Lock method.
+	deps.vault.On("Lock").Return().Once()
 
 	// Act: Dispatch the lock request to the handler.
 	w.handleLockReq(req)
@@ -215,11 +328,13 @@ func TestHandleChangePassphraseReq(t *testing.T) {
 	}
 	req := newChangePassphraseReq(reqStruct)
 
-	// Setup the expected call to the address manager's ChangePassphrase
-	// method.
-	deps.addrStore.On(
-		"ChangePassphrase", mock.Anything, []byte("old"),
-		[]byte("new"), true, mock.Anything,
+	// The handler rotates the passphrase through the key vault.
+	deps.vault.On(
+		"ChangePassphrase", mock.Anything,
+		keyvault.ChangePassphraseParams{
+			PrivateOld: []byte("old"),
+			PrivateNew: []byte("new"),
+		},
 	).Return(nil).Once()
 
 	// Act: Call the handler.
@@ -261,6 +376,9 @@ func TestControllerStart(t *testing.T) {
 	deps.syncer.On(
 		"run", mock.Anything,
 	).Return(nil).Once()
+
+	// Allow Stop to clear secret material.
+	expectStopTeardown(deps)
 
 	// Act: Start the wallet.
 	err := w.Start(t.Context())
@@ -542,11 +660,21 @@ func TestControllerStop(t *testing.T) {
 		if !ok {
 			return
 		}
+
 		<-ctx.Done()
 	}).Return(nil).Once()
 
 	require.NoError(t, w.Start(t.Context()))
 	require.True(t, w.state.isStarted())
+
+	// Put the wallet in the unlocked state, mirroring a wallet that holds
+	// decrypted vault keys at shutdown. Stop must lock the vault exactly
+	// once so no runtime key outlives a serial Stop and a later Unlock does
+	// not fail with ErrVaultUnlocked.
+	w.state.toUnlocked()
+	require.True(t, w.state.isUnlocked())
+
+	deps.vault.On("Lock").Return().Once()
 
 	// Act: Stop the wallet.
 	err := w.Stop(t.Context())
@@ -555,6 +683,7 @@ func TestControllerStop(t *testing.T) {
 	// no longer 'Started'.
 	require.NoError(t, err)
 	require.False(t, w.state.isStarted())
+	deps.vault.AssertExpectations(t)
 
 	// Act: Call Stop again to verify idempotency.
 	err = w.Stop(t.Context())
@@ -588,8 +717,8 @@ func TestControllerLock(t *testing.T) {
 	w.state.toUnlocked()
 	require.True(t, w.state.isUnlocked())
 
-	// Expect a call to the address manager's Lock method.
-	deps.addrStore.On("Lock").Return(nil).Once()
+	// Expect a call to the key vault's Lock method.
+	deps.vault.On("Lock").Return().Once()
 
 	// Act: Call the Lock method.
 	err := w.Lock(t.Context())
@@ -597,6 +726,11 @@ func TestControllerLock(t *testing.T) {
 	// Assert: Verify success and that the wallet state is locked.
 	require.NoError(t, err)
 	require.False(t, w.state.isUnlocked())
+
+	// Allow Stop's extra Lock. Registered
+	// after the operation's Lock().Once() above so that expectation is
+	// matched first and this pass-through absorbs only the teardown Lock.
+	expectStopTeardown(deps)
 
 	// Cleanup: Stop the wallet to release resources.
 	err = w.Stop(t.Context())
@@ -627,8 +761,13 @@ func TestControllerUnlock(t *testing.T) {
 
 	pass := []byte("password")
 
-	// Expect a call to the address manager's Unlock method.
-	deps.addrStore.On("Unlock", mock.Anything, pass).Return(nil).Once()
+	// Expect a call to the key vault's Unlock method. Unlock dispatches no
+	// Lock; the only Lock here comes from the cleanup Stop below, so it is
+	// permitted rather than expected -- TestControllerStop is the sole
+	// Stop-to-Vault dispatch falsifier.
+	deps.vault.On(
+		"Unlock", mock.Anything, pass,
+	).Return(nil).Once()
 
 	// Act: Call the Unlock method.
 	err := w.Unlock(t.Context(), UnlockRequest{Passphrase: pass})
@@ -637,7 +776,8 @@ func TestControllerUnlock(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, w.state.isUnlocked())
 
-	// Cleanup: Stop the wallet to release resources.
+	expectStopTeardown(deps)
+
 	err = w.Stop(t.Context())
 	require.NoError(t, err)
 	w.wg.Wait()
@@ -670,11 +810,17 @@ func TestControllerChangePassphrase(t *testing.T) {
 		PrivateNew:    []byte("new"),
 	}
 
-	// Expect a call to ChangePassphrase in the address store.
-	deps.addrStore.On(
-		"ChangePassphrase", mock.Anything, []byte("old"), []byte("new"),
-		true, mock.Anything,
+	// ChangePassphrase rotates the passphrase through the key vault.
+	deps.vault.On(
+		"ChangePassphrase", mock.Anything,
+		keyvault.ChangePassphraseParams{
+			PrivateOld: []byte("old"),
+			PrivateNew: []byte("new"),
+		},
 	).Return(nil).Once()
+
+	// Allow Stop to clear secret material.
+	expectStopTeardown(deps)
 
 	// Act: Call ChangePassphrase.
 	err := w.ChangePassphrase(t.Context(), req)
@@ -797,6 +943,9 @@ func TestControllerStart_WithAccounts(t *testing.T) {
 		mock.Anything).Return(nil).Once()
 	deps.syncer.On("run", mock.Anything).Return(nil).Once()
 
+	// Allow Stop to clear secret material.
+	expectStopTeardown(deps)
+
 	// Act: Start the wallet.
 	err := w.Start(t.Context())
 
@@ -827,9 +976,9 @@ func TestMainLoop_AutoLock(t *testing.T) {
 	w.lockTimer = time.NewTimer(time.Millisecond * 10)
 
 	lockCalled := make(chan struct{})
-	deps.addrStore.On("Lock").Run(func(args mock.Arguments) {
+	deps.vault.On("Lock").Run(func(args mock.Arguments) {
 		close(lockCalled)
-	}).Return(nil).Once()
+	}).Return().Once()
 
 	// Act: Start main loop.
 	w.wg.Add(1)
@@ -1023,115 +1172,6 @@ func TestControllerChangePassphrase_Interrupted_SendShutdown(t *testing.T) {
 	require.ErrorIs(t, err, ErrWalletShuttingDown)
 }
 
-// TestControllerChangePassphrase_Interrupted_WaitCancelled verifies
-// ChangePassphrase when response wait is interrupted by context cancellation.
-func TestControllerChangePassphrase_Interrupted_WaitCancelled(t *testing.T) {
-	t.Parallel()
-
-	// Arrange: Block during response wait and cancel context.
-	w, _ := createTestWalletWithMocks(t)
-
-	require.NoError(t, w.state.toStarting())
-	require.NoError(t, w.state.toStarted())
-
-	ctx, cancel := context.WithCancel(t.Context())
-
-	errChan := make(chan error, 1)
-	go func() {
-		errChan <- w.ChangePassphrase(ctx,
-			ChangePassphraseRequest{})
-	}()
-
-	select {
-	case <-w.requestChan:
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for request")
-	}
-
-	// Act: Cancel context.
-	cancel()
-
-	// Assert: Verify error.
-	select {
-	case err := <-errChan:
-		require.ErrorIs(t, err, context.Canceled)
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for response")
-	}
-}
-
-// TestControllerChangePassphrase_Interrupted_WaitShutdown verifies
-// ChangePassphrase when response wait is interrupted by wallet shutdown.
-func TestControllerChangePassphrase_Interrupted_WaitShutdown(t *testing.T) {
-	t.Parallel()
-
-	// Arrange: Block during response wait and trigger shutdown.
-	w, _ := createTestWalletWithMocks(t)
-
-	require.NoError(t, w.state.toStarting())
-	require.NoError(t, w.state.toStarted())
-
-	errChan := make(chan error, 1)
-	go func() {
-		errChan <- w.ChangePassphrase(t.Context(),
-			ChangePassphraseRequest{})
-	}()
-
-	select {
-	case <-w.requestChan:
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for request")
-	}
-
-	// Act: Stop wallet.
-	w.cancel()
-
-	// Assert: Verify error.
-	select {
-	case err := <-errChan:
-		require.ErrorIs(t, err, ErrWalletShuttingDown)
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for response")
-	}
-}
-
-// TestControllerChangePassphrase_Interrupted_WaitTimeout verifies
-// ChangePassphrase when response wait times out.
-func TestControllerChangePassphrase_Interrupted_WaitTimeout(t *testing.T) {
-	t.Parallel()
-
-	// Arrange: Block during response wait and allow timeout.
-	w, _ := createTestWalletWithMocks(t)
-
-	require.NoError(t, w.state.toStarting())
-	require.NoError(t, w.state.toStarted())
-
-	ctx, cancel := context.WithTimeout(t.Context(),
-		10*time.Millisecond)
-	defer cancel()
-
-	errChan := make(chan error, 1)
-	go func() {
-		errChan <- w.ChangePassphrase(ctx,
-			ChangePassphraseRequest{})
-	}()
-
-	select {
-	case <-w.requestChan:
-	case <-time.After(time.Second):
-		t.Fatal("timeout")
-	}
-
-	// Assert: Verify timeout.
-	select {
-	case err := <-errChan:
-		require.ErrorContains(t, err,
-			"context deadline exceeded")
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for response")
-	}
-}
-
 // TestHandleChangePassphraseReq_Errors verifies error handling for the
 // internal change passphrase request handler.
 func TestHandleChangePassphraseReq_Errors(t *testing.T) {
@@ -1182,6 +1222,9 @@ func TestControllerInfo(t *testing.T) {
 
 	// Mock syncState to indicate the wallet is fully synced.
 	deps.syncer.On("syncState").Return(syncStateSynced)
+
+	// Allow Stop to clear secret material.
+	expectStopTeardown(deps)
 
 	require.NoError(t, w.Start(t.Context()))
 
@@ -1372,6 +1415,9 @@ func TestControllerStart_BirthdayNotSet(t *testing.T) {
 		mock.Anything).Return(nil).Once()
 	deps.syncer.On("run", mock.Anything).Return(nil).Once()
 
+	// Allow Stop to clear secret material.
+	expectStopTeardown(deps)
+
 	// Act: Start the wallet.
 	err := w.Start(t.Context())
 
@@ -1403,10 +1449,12 @@ func TestControllerUnlock_DefaultTimeout(t *testing.T) {
 
 	pass := []byte("pass")
 	req := UnlockRequest{Passphrase: pass}
-	deps.addrStore.On("Unlock", mock.Anything, pass).Return(nil).Once()
+	deps.vault.On(
+		"Unlock", mock.Anything, pass,
+	).Return(nil).Once()
 	// Auto-lock might trigger if the test runs slowly, but it's not
 	// guaranteed.
-	deps.addrStore.On("Lock").Return(nil).Maybe()
+	deps.vault.On("Lock").Return().Maybe()
 
 	// Act: Perform Unlock with default timeout.
 	err := w.Unlock(t.Context(), req)
@@ -1463,7 +1511,9 @@ func TestControllerUnlock_NegativeTimeout(t *testing.T) {
 
 	pass := []byte("pass")
 	req := UnlockRequest{Passphrase: pass, Timeout: -1}
-	deps.addrStore.On("Unlock", mock.Anything, pass).Return(nil).Once()
+	deps.vault.On(
+		"Unlock", mock.Anything, pass,
+	).Return(nil).Once()
 
 	// Act: Perform Unlock with negative timeout (no auto-lock).
 	err := w.Unlock(t.Context(), req)
@@ -1476,9 +1526,8 @@ func TestControllerUnlock_NegativeTimeout(t *testing.T) {
 	w.wg.Wait()
 }
 
-// TestControllerUnlock_DBUnlockFail verifies Unlock failure when
-// DBUnlock fails.
-func TestControllerUnlock_DBUnlockFail(t *testing.T) {
+// TestControllerUnlockVaultFailure verifies Unlock reports a key-vault error.
+func TestControllerUnlockVaultFailure(t *testing.T) {
 	t.Parallel()
 
 	// Arrange: Setup a wallet and mock an unlock failure.
@@ -1492,7 +1541,7 @@ func TestControllerUnlock_DBUnlockFail(t *testing.T) {
 	go w.mainLoop()
 
 	pass := []byte("pass")
-	deps.addrStore.On("Unlock", mock.Anything, pass).Return(
+	deps.vault.On("Unlock", mock.Anything, pass).Return(
 		errDBMock).Once()
 
 	// Act: Attempt Unlock.
@@ -1504,28 +1553,6 @@ func TestControllerUnlock_DBUnlockFail(t *testing.T) {
 	// Clean up.
 	w.cancel()
 	w.wg.Wait()
-}
-
-// TestHandleLockReq_LockError verifies error handling when Lock fails.
-func TestHandleLockReq_LockError(t *testing.T) {
-	t.Parallel()
-
-	// Arrange: Setup mock expectations where internal lock fails.
-	w, deps := createTestWalletWithMocks(t)
-
-	require.NoError(t, w.state.toStarting())
-	require.NoError(t, w.state.toStarted())
-
-	req := lockReq{resp: make(chan error, 1)}
-
-	deps.addrStore.On("Lock").Return(errLockMock).Once()
-
-	// Act: Handle lock request.
-	w.handleLockReq(req)
-	err := <-req.resp
-
-	// Assert: Verify error.
-	require.ErrorContains(t, err, "lock fail")
 }
 
 // TestSubmitRescanRequest_HeightOverflow verifies large start height rejection.
@@ -1736,4 +1763,17 @@ func TestWaitForBackoff_Shutdown(t *testing.T) {
 	// Assert: Verify that the operation was aborted.
 	require.False(t, ok)
 	require.Equal(t, time.Duration(0), nextBackoff)
+}
+
+// TestPassphraseSentinelIsReachable pins that the wallet's exported
+// passphrase sentinel is the same value the key vault returns, wrapped as a
+// real return path wraps them. External callers cannot import
+// wallet/internal/keyvault, so if these ever became independent copies instead
+// of aliases, errors.Is would silently stop matching for every caller outside
+// this module.
+func TestPassphraseSentinelIsReachable(t *testing.T) {
+	t.Parallel()
+
+	require.ErrorIs(t, fmt.Errorf("vault: %w",
+		keyvault.ErrInvalidPassphrase), ErrInvalidPassphrase)
 }

--- a/wallet/controller_test.go
+++ b/wallet/controller_test.go
@@ -148,40 +148,6 @@ func TestHandleLockReq(t *testing.T) {
 	require.False(t, w.state.isUnlocked())
 }
 
-// TestHandleLockReq_Idempotency verifies that if the wallet is already locked
-// (indicated by waddrmgr.ErrLocked), the lock request treats it as a success
-// and ensures the state is consistent.
-func TestHandleLockReq_Idempotency(t *testing.T) {
-	t.Parallel()
-
-	// Arrange: Create a test wallet and transition it to 'Started'.
-	w, deps := createTestWalletWithMocks(t)
-	require.NoError(t, w.state.toStarting())
-	require.NoError(t, w.state.toStarted())
-
-	// Transition the wallet to the 'Unlocked' state for testing.
-	w.state.toUnlocked()
-
-	req := newLockReq()
-
-	// Setup the expected call to the address manager's Lock method
-	// returning ErrLocked.
-	errLocked := waddrmgr.ManagerError{
-		ErrorCode:   waddrmgr.ErrLocked,
-		Description: "address manager is locked",
-	}
-	deps.addrStore.On("Lock").Return(errLocked).Once()
-
-	// Act: Dispatch the lock request to the handler.
-	w.handleLockReq(req)
-
-	// Assert: Verify that the response indicates success and the wallet
-	// state is 'Locked'.
-	resp := <-req.resp
-	require.NoError(t, resp)
-	require.False(t, w.state.isUnlocked())
-}
-
 // TestHandleLockReq_Errors verifies that handleLockReq correctly handles error
 // conditions, such as attempting to lock a stopped wallet.
 func TestHandleLockReq_Errors(t *testing.T) {

--- a/wallet/db_ops.go
+++ b/wallet/db_ops.go
@@ -198,65 +198,6 @@ func (w *Wallet) DBDeleteExpiredLockedOutputs(_ context.Context) error {
 	return nil
 }
 
-// DBUnlock attempts to unlock the wallet's address manager with the provided
-// passphrase.
-//
-// TODO(yy): Refactor this in the `Store` implementation - the only db
-// operation needed is to load the account info and derive the private keys.
-func (w *Wallet) DBUnlock(_ context.Context, passphrase []byte) error {
-	err := walletdb.View(w.cfg.DB, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-		return w.addrStore.Unlock(addrmgrNs, passphrase)
-	})
-	if err != nil {
-		return fmt.Errorf("view: %w", err)
-	}
-
-	return nil
-}
-
-// DBPutPassphrase updates the wallet's public or private passphrases.
-//
-// TODO(yy): Refactor this in the `Store` implementation - we can call
-// `UpdateWallet` instead.
-func (w *Wallet) DBPutPassphrase(_ context.Context,
-	req ChangePassphraseRequest) error {
-
-	err := walletdb.Update(w.cfg.DB, func(tx walletdb.ReadWriteTx) error {
-		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-
-		if req.ChangePublic {
-			err := w.addrStore.ChangePassphrase(
-				addrmgrNs, req.PublicOld, req.PublicNew,
-				false, &waddrmgr.DefaultScryptOptions,
-			)
-			if err != nil {
-				return fmt.Errorf("change public passphrase: "+
-					"%w", err)
-			}
-		}
-
-		if req.ChangePrivate {
-			err := w.addrStore.ChangePassphrase(
-				addrmgrNs, req.PrivateOld,
-				req.PrivateNew, true,
-				&waddrmgr.DefaultScryptOptions,
-			)
-			if err != nil {
-				return fmt.Errorf("change private passphrase: "+
-					"%w", err)
-			}
-		}
-
-		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("update: %w", err)
-	}
-
-	return nil
-}
-
 // DBGetAllAccounts ensures all account properties are loaded into the address
 // manager's cache.
 //

--- a/wallet/db_ops_test.go
+++ b/wallet/db_ops_test.go
@@ -142,25 +142,6 @@ func TestDBBirthdayBlock(t *testing.T) {
 	require.Equal(t, block, retBlock)
 }
 
-// TestDBUnlock verifies that the wallet can successfully unlock its address
-// manager using the provided passphrase.
-func TestDBUnlock(t *testing.T) {
-	t.Parallel()
-
-	// Arrange: Create a test wallet and setup the expected mock call for
-	// unlocking the address manager.
-	w, mocks := createTestWalletWithMocks(t)
-	pass := []byte("password")
-
-	mocks.addrStore.On("Unlock", mock.Anything, pass).Return(nil).Once()
-
-	// Act: Attempt to unlock the wallet with the passphrase.
-	err := w.DBUnlock(t.Context(), pass)
-
-	// Assert: Verify that the unlock operation succeeded.
-	require.NoError(t, err)
-}
-
 // TestDBDeleteExpiredLockedOutputs verifies that the wallet successfully
 // invokes the transaction store to remove any expired output locks.
 func TestDBDeleteExpiredLockedOutputs(t *testing.T) {
@@ -179,70 +160,6 @@ func TestDBDeleteExpiredLockedOutputs(t *testing.T) {
 
 	// Assert: Verify that the cleanup operation finished without error.
 	require.NoError(t, err)
-}
-
-// TestDBPutPassphrase verifies that the wallet can successfully update both
-// its public and private passphrases in the address manager.
-func TestDBPutPassphrase(t *testing.T) {
-	t.Parallel()
-
-	// Arrange: Create a test wallet and a request to change both
-	// passphrases.
-	w, mocks := createTestWalletWithMocks(t)
-
-	req := ChangePassphraseRequest{
-		ChangePublic:  true,
-		PublicOld:     []byte("old"),
-		PublicNew:     []byte("new"),
-		ChangePrivate: true,
-		PrivateOld:    []byte("old_priv"),
-		PrivateNew:    []byte("new_priv"),
-	}
-
-	// Setup mock calls for both passphrase changes.
-	mocks.addrStore.On(
-		"ChangePassphrase", mock.Anything, []byte("old"), []byte("new"),
-		false, mock.Anything,
-	).Return(nil).Once()
-
-	mocks.addrStore.On(
-		"ChangePassphrase", mock.Anything, req.PrivateOld,
-		req.PrivateNew, true,
-		mock.MatchedBy(func(opts *waddrmgr.ScryptOptions) bool {
-			return opts.N == 16 && opts.R == 8 && opts.P == 1
-		}),
-	).Return(nil).Once()
-
-	// Act: Commit the passphrase changes to the database.
-	err := w.DBPutPassphrase(t.Context(), req)
-
-	// Assert: Verify that both passphrases were updated successfully.
-	require.NoError(t, err)
-}
-
-// TestDBPutPassphrase_Error verifies that DBPutPassphrase correctly handles
-// and returns errors encountered during the passphrase update process.
-func TestDBPutPassphrase_Error(t *testing.T) {
-	t.Parallel()
-
-	// Arrange: Create a test wallet and setup a mock call that simulates
-	// a database error during a private passphrase change.
-	w, mocks := createTestWalletWithMocks(t)
-
-	req := ChangePassphraseRequest{
-		ChangePrivate: true,
-	}
-
-	mocks.addrStore.On(
-		"ChangePassphrase", mock.Anything, mock.Anything,
-		mock.Anything, true, mock.Anything,
-	).Return(errDBMock).Once()
-
-	// Act: Attempt to change the passphrase, expecting a failure.
-	err := w.DBPutPassphrase(t.Context(), req)
-
-	// Assert: Verify that the expected database error is returned.
-	require.ErrorContains(t, err, "db error")
 }
 
 // TestDBPutBlocks_Error verifies that DBPutBlocks correctly handles errors

--- a/wallet/deprecated.go
+++ b/wallet/deprecated.go
@@ -29,7 +29,6 @@ import (
 	"github.com/btcsuite/btcwallet/internal/prompt"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	kvdb "github.com/btcsuite/btcwallet/wallet/internal/db/kvdb"
-	"github.com/btcsuite/btcwallet/wallet/internal/keyvault"
 	"github.com/btcsuite/btcwallet/wallet/txauthor"
 	"github.com/btcsuite/btcwallet/wallet/txrules"
 	"github.com/btcsuite/btcwallet/walletdb"
@@ -7215,10 +7214,15 @@ func OpenWithRetry(db walletdb.DB, pubPass []byte, cbs *waddrmgr.OpenCallbacks,
 		id:        walletID,
 		addrStore: addrMgr,
 		store:     store,
-		keyVault: keyvault.NewWalletVault(
-			store, walletID, addrMgr.WatchOnly(),
-		),
-		txStore:          txMgr,
+		cache:     newStoreRuntimeCache(store),
+		keyVault:  kvdb.NewLegacyWalletVault(db, addrMgr),
+		txStore:   txMgr,
+
+		// The shared Wallet reads its network from cfg, so the routed
+		// address and signing paths this constructor still serves
+		// panic without it. The deprecated sub-struct's own
+		// chainParams only covers the legacy paths.
+		cfg:              Config{ChainParams: params},
 		walletDeprecated: deprecated,
 	}
 

--- a/wallet/deprecated_test.go
+++ b/wallet/deprecated_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -17,6 +18,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg/v2"
@@ -2324,4 +2326,120 @@ func runTestCase(t *testing.T, w *Wallet, scope waddrmgr.KeyScope,
 	if err != nil {
 		t.Fatalf("error validating tx: %v", err)
 	}
+}
+
+// TestOpenWithRetryRoutedSigning verifies that a wallet opened through the
+// deprecated OpenWithRetry constructor can resolve signing material for an
+// imported WIF through the routed public API.
+//
+// It pins both pieces of constructor wiring routed signing needs:
+//
+//   - the legacy vault. kvdb has no GetWalletSecrets, so wiring the canonical
+//     WalletVault here compiles but leaves every routed signing call broken.
+//   - the runtime cache. GetPrivKeyForAddress resolves the address secret
+//     through w.cache, so dropping the constructor's cache initialization
+//     nil-panics this test rather than passing silently.
+//
+// The imported key is presented as P2PK, which is the shape that regressed:
+// ScopedKeyManager.Address normalizes P2PK to P2PKH before reading the row but
+// AddrAccount does not, so a secret lookup handed the caller's original
+// address missed every wallet-owned P2PK address.
+func TestOpenWithRetryRoutedSigning(t *testing.T) {
+	t.Parallel()
+
+	var (
+		pubPass  = []byte("public")
+		privPass = []byte("private")
+	)
+
+	dbPath := filepath.Join(t.TempDir(), "wallet.db")
+
+	dbConn, err := walletdb.Create(
+		"bdb", dbPath, true, time.Minute, false,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dbConn.Close() })
+
+	seed, err := hdkeychain.GenerateSeed(hdkeychain.RecommendedSeedLen)
+	require.NoError(t, err)
+	rootKey, err := hdkeychain.NewMaster(seed, &chainParams)
+	require.NoError(t, err)
+
+	err = CreateDeprecated(
+		dbConn, pubPass, privPass, rootKey, &chainParams, time.Now(),
+	)
+	require.NoError(t, err)
+
+	// Act: reopen through the deprecated constructor.
+	w, err := OpenWithRetry(
+		dbConn, pubPass, nil, &chainParams, 0,
+		defaultSyncRetryInterval,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, w.keyVault)
+	require.NotNil(t, w.cache)
+
+	// The vault unlocks with the private passphrase, which is what routed
+	// signing needs. A vault backed by GetWalletSecrets fails here instead.
+	require.NoError(t, w.keyVault.Unlock(t.Context(), privPass))
+	require.False(t, w.keyVault.IsLocked())
+
+	// This constructor cannot Start: it has no chain to verify a birthday
+	// against. Claim the signing-capable state directly so the routed public
+	// call below is reachable.
+	require.NoError(t, w.state.toStarting())
+	require.NoError(t, w.state.toStarted())
+	w.state.toUnlocked()
+
+	// A wallet that has synced has a birthday block; CreateDeprecated leaves
+	// it unset, and the import path reads it to decide whether to move the
+	// birthday back.
+	err = walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		return w.addrStore.SetBirthdayBlock(
+			tx.ReadWriteBucket(waddrmgrNamespaceKey),
+			waddrmgr.BlockStamp{
+				Hash:   *chainParams.GenesisHash,
+				Height: 0,
+			}, true,
+		)
+	})
+	require.NoError(t, err)
+
+	// The retained import path notifies the chain about the new address.
+	chainClient := &bwmock.Chain{}
+	chainClient.On("NotifyReceived", mock.Anything).Return(nil).Once()
+	w.chainClient = chainClient
+
+	// Import a WIF through the retained deprecated path.
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	wif, err := btcutil.NewWIF(privKey, &chainParams, true)
+	require.NoError(t, err)
+
+	_, err = w.ImportPrivateKey(
+		waddrmgr.KeyScopeBIP0044, wif, nil, false,
+	)
+	require.NoError(t, err)
+
+	// Assert: the imported key resolves through the routed public API when
+	// presented as P2PK, the shape whose account lookup regressed.
+	p2pk, err := address.NewAddressPubKey(
+		privKey.PubKey().SerializeCompressed(), &chainParams,
+	)
+	require.NoError(t, err)
+
+	got, err := w.GetPrivKeyForAddress(t.Context(), p2pk)
+	require.NoError(t, err)
+	require.Equal(t, privKey.Serialize(), got.Serialize())
+
+	// The same key resolves through its P2PKH form, proving the two spellings
+	// reach one row rather than the normalization masking a miss.
+	gotHash, err := w.GetPrivKeyForAddress(
+		t.Context(), p2pk.AddressPubKeyHash(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, privKey.Serialize(), gotHash.Serialize())
+
+	chainClient.AssertExpectations(t)
 }

--- a/wallet/internal/bwtest/keyvaultmock/vault.go
+++ b/wallet/internal/bwtest/keyvaultmock/vault.go
@@ -2,12 +2,17 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package mock
+// Package keyvaultmock contains a testify-based mock for the wallet key-vault
+// interface. It lives in its own package because it imports keyvault, and the
+// keyvault package's own tests depend on the shared mock package; keeping the
+// vault mock separate avoids an import cycle in the keyvault test build.
+package keyvaultmock
 
 import (
 	"context"
 
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/keyvault"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -37,6 +42,7 @@ func (m *Vault) Decrypt(keyType waddrmgr.CryptoKeyType,
 // Unlock forwards to the configured testify expectations.
 func (m *Vault) Unlock(ctx context.Context, passphrase []byte) error {
 	args := m.Called(ctx, passphrase)
+
 	return args.Error(0)
 }
 
@@ -48,22 +54,27 @@ func (m *Vault) Lock() {
 // IsLocked forwards to the configured testify expectations.
 func (m *Vault) IsLocked() bool {
 	args := m.Called()
+
 	return args.Bool(0)
 }
 
 // ChangePassphrase forwards to the configured testify expectations.
 func (m *Vault) ChangePassphrase(ctx context.Context,
-	passphrase []byte) error {
+	params keyvault.ChangePassphraseParams) error {
 
-	args := m.Called(ctx, passphrase)
+	args := m.Called(ctx, params)
+
 	return args.Error(0)
 }
 
-// returnBytes resolves the first programmed Return arg into a byte slice.
+// returnBytes resolves the first programmed Return arg into a byte slice. A
+// programmed func lets a test transform its input, which is how the identity
+// vault echoes plaintext back through the cipher methods.
 func returnBytes(args mock.Arguments, keyType waddrmgr.CryptoKeyType,
 	input []byte) []byte {
 
-	if fn, ok := args.Get(0).(func(waddrmgr.CryptoKeyType, []byte) []byte); ok {
+	fn, ok := args.Get(0).(func(waddrmgr.CryptoKeyType, []byte) []byte)
+	if ok {
 		return fn(keyType, input)
 	}
 
@@ -78,3 +89,6 @@ func returnBytes(args mock.Arguments, keyType waddrmgr.CryptoKeyType,
 
 	return b
 }
+
+// A compile-time check that the mock satisfies the interface it stands in for.
+var _ keyvault.Vault = (*Vault)(nil)

--- a/wallet/internal/bwtest/keyvaultmock/vault.go
+++ b/wallet/internal/bwtest/keyvaultmock/vault.go
@@ -73,9 +73,15 @@ func (m *Vault) ChangePassphrase(ctx context.Context,
 func returnBytes(args mock.Arguments, keyType waddrmgr.CryptoKeyType,
 	input []byte) []byte {
 
-	fn, ok := args.Get(0).(func(waddrmgr.CryptoKeyType, []byte) []byte)
+	// Both shapes are accepted: a stub that cares about the key class takes
+	// it, one that only transforms bytes does not.
+	cryptFn, ok := args.Get(0).(func(waddrmgr.CryptoKeyType, []byte) []byte)
 	if ok {
-		return fn(keyType, input)
+		return cryptFn(keyType, input)
+	}
+
+	if fn, ok := args.Get(0).(func([]byte) []byte); ok {
+		return fn(input)
 	}
 
 	if args.Get(0) == nil {

--- a/wallet/internal/bwtest/mock/store.go
+++ b/wallet/internal/bwtest/mock/store.go
@@ -178,6 +178,18 @@ func (m *Store) GetAccount(ctx context.Context,
 	return args.Get(0).(*db.AccountInfo), args.Error(1)
 }
 
+// GetAccountSecret implements the db.AccountStore interface.
+func (m *Store) GetAccountSecret(ctx context.Context,
+	query db.GetAccountSecretQuery) (*db.AccountSecret, error) {
+
+	args := m.Called(ctx, query)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*db.AccountSecret), args.Error(1)
+}
+
 // ListAccounts implements the db.AccountStore interface.
 func (m *Store) ListAccounts(ctx context.Context,
 	query db.ListAccountsQuery) ([]db.AccountInfo, error) {

--- a/wallet/internal/db/accountstore_common.go
+++ b/wallet/internal/db/accountstore_common.go
@@ -1,0 +1,25 @@
+package db
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// MapGetAccountSecretErr returns the typed ErrAccountNotFound when err is
+// sql.ErrNoRows, describing the selector the caller queried by, and falls back
+// to a wrapped form otherwise.
+//
+// It is shared rather than per backend because it names no generated query or
+// driver type: sql.ErrNoRows is the database/sql sentinel both SQL backends
+// return for a missing row. Backend-specific classification of driver error
+// codes stays in each backend's ClassifyError.
+func MapGetAccountSecretErr(err error, query GetAccountSecretQuery) error {
+	if !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("get account secret: %w", err)
+	}
+
+	return fmt.Errorf("account %d in scope %d/%d: %w",
+		query.AccountNumber, query.Scope.Purpose, query.Scope.Coin,
+		ErrAccountNotFound)
+}

--- a/wallet/internal/db/accountstore_common_test.go
+++ b/wallet/internal/db/accountstore_common_test.go
@@ -1,0 +1,62 @@
+package db
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// errBackend is a stand-in for a non-ErrNoRows backend failure.
+var errBackend = errors.New("backend failure")
+
+// TestMapGetAccountSecretErr verifies a missing row maps to the typed
+// not-found error naming the account, while any other failure is wrapped
+// unchanged.
+func TestMapGetAccountSecretErr(t *testing.T) {
+	t.Parallel()
+
+	query := GetAccountSecretQuery{
+		WalletID:      2,
+		Scope:         KeyScope{Purpose: 84, Coin: 0},
+		AccountNumber: 3,
+	}
+
+	tests := []struct {
+		name    string
+		err     error
+		wantIs  error
+		wantMsg string
+	}{
+		{
+			name:    "missing account",
+			err:     sql.ErrNoRows,
+			wantIs:  ErrAccountNotFound,
+			wantMsg: "account 3 in scope 84/0",
+		},
+		{
+			// A non-ErrNoRows failure is not a missing account and
+			// must stay distinguishable from one.
+			name:    "other failure passes through",
+			err:     fmt.Errorf("wrapped: %w", errBackend),
+			wantIs:  errBackend,
+			wantMsg: "get account secret",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := MapGetAccountSecretErr(test.err, query)
+			require.ErrorIs(t, err, test.wantIs)
+			require.ErrorContains(t, err, test.wantMsg)
+
+			if !errors.Is(test.wantIs, ErrAccountNotFound) {
+				require.NotErrorIs(t, err, ErrAccountNotFound)
+			}
+		})
+	}
+}

--- a/wallet/internal/db/accountstore_getaccountsecret.go
+++ b/wallet/internal/db/accountstore_getaccountsecret.go
@@ -1,0 +1,7 @@
+package db
+
+import "errors"
+
+// ErrAccountSecretUnavailable is returned when a backend does not expose
+// store-side account secret material through AccountStore.
+var ErrAccountSecretUnavailable = errors.New("account secret unavailable")

--- a/wallet/internal/db/addressstore_common.go
+++ b/wallet/internal/db/addressstore_common.go
@@ -171,6 +171,10 @@ type AddressSecretRow struct {
 
 	// EncryptedScript is the encrypted script for script-based addresses.
 	EncryptedScript []byte
+
+	// ScriptIsSecret reports which key encrypted EncryptedScript. See
+	// AddressSecret.ScriptIsSecret.
+	ScriptIsSecret bool
 }
 
 // AddressSecretRowToSecret converts raw secret row fields into an AddressSecret
@@ -193,6 +197,7 @@ func AddressSecretRowToSecret(row AddressSecretRow) (*AddressSecret, error) {
 		AddressID:        addrID,
 		EncryptedPrivKey: row.EncryptedPrivKey,
 		EncryptedScript:  row.EncryptedScript,
+		ScriptIsSecret:   row.ScriptIsSecret,
 	}, nil
 }
 

--- a/wallet/internal/db/addressstore_getsecret.go
+++ b/wallet/internal/db/addressstore_getsecret.go
@@ -1,0 +1,18 @@
+package db
+
+// Validate checks that the address-secret query provides exactly one address
+// selector.
+//
+// It uses the same sentinel as GetAddressQuery.Validate: the two queries share
+// the selector and the failure, so a caller that already distinguishes a
+// malformed address query needs no second error to switch on.
+func (query GetAddressSecretQuery) Validate() error {
+	hasAddressID := query.AddressID != nil
+
+	hasScriptPubKey := len(query.ScriptPubKey) > 0
+	if hasAddressID == hasScriptPubKey {
+		return ErrInvalidAddressQuery
+	}
+
+	return nil
+}

--- a/wallet/internal/db/addressstore_getsecret_test.go
+++ b/wallet/internal/db/addressstore_getsecret_test.go
@@ -1,0 +1,70 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetAddressSecretQueryValidate verifies that an address-secret query
+// accepts exactly one selector.
+func TestGetAddressSecretQueryValidate(t *testing.T) {
+	t.Parallel()
+
+	addressID := uint32(1)
+
+	tests := []struct {
+		name       string
+		query      GetAddressSecretQuery
+		wantErr    error
+		wantErrNil bool
+	}{{
+		name:    "nil script",
+		query:   GetAddressSecretQuery{WalletID: 1},
+		wantErr: ErrInvalidAddressQuery,
+	}, {
+		name: "empty script",
+		query: GetAddressSecretQuery{
+			WalletID:     1,
+			ScriptPubKey: []byte{},
+		},
+		wantErr: ErrInvalidAddressQuery,
+	}, {
+		name: "address ID",
+		query: GetAddressSecretQuery{
+			WalletID:  1,
+			AddressID: &addressID,
+		},
+		wantErrNil: true,
+	}, {
+		name: "populated script",
+		query: GetAddressSecretQuery{
+			WalletID:     1,
+			ScriptPubKey: []byte{0x00, 0x14},
+		},
+		wantErrNil: true,
+	}, {
+		name: "both selectors",
+		query: GetAddressSecretQuery{
+			WalletID:     1,
+			AddressID:    &addressID,
+			ScriptPubKey: []byte{0x00, 0x14},
+		},
+		wantErr: ErrInvalidAddressQuery,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := test.query.Validate()
+			if test.wantErrNil {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.ErrorIs(t, err, test.wantErr)
+		})
+	}
+}

--- a/wallet/internal/db/addressstore_newimported.go
+++ b/wallet/internal/db/addressstore_newimported.go
@@ -20,7 +20,7 @@ type CreateImportedAddressRow struct {
 //   - validate the request's static shape before any backend step runs
 //   - load the wallet watch-only mode
 //   - reject private-key material imported into a watch-only wallet
-//   - reject an import lacking private-key material into a spendable wallet
+//   - reject an import without its own private key into a spendable wallet
 //   - insert the imported address row
 //   - persist encrypted secret material when the import carries any
 //   - assemble the AddressInfo from the request and inserted row
@@ -119,12 +119,11 @@ func (p NewImportedAddressParams) ValidateBasic() error {
 
 // ValidateWatchOnly checks imported address creation parameters against the
 // parent wallet's watch-only state. A watch-only wallet must not receive
-// private-key-bearing imports. The symmetric direction (a spendable wallet
-// must not receive an imported address without private-key material) is
-// enforced at the SQL-backend entry through requireAddressPrivKeyOnSpendable;
-// kvdb's data model carries different invariants around legacy imported
-// address rows (a grandfathered legacy shape), so the symmetric check is not
-// applied there.
+// private-key-bearing imports. The symmetric direction (a spendable wallet's
+// imported address must carry its own encrypted private key) is enforced at the
+// SQL-backend entry through RequireAddressPrivKeyOnSpendable; kvdb's data
+// model carries different invariants around legacy imported address rows (a
+// grandfathered legacy shape), so the symmetric check is not applied there.
 func (p NewImportedAddressParams) ValidateWatchOnly(
 	walletIsWatchOnly bool) error {
 
@@ -137,12 +136,18 @@ func (p NewImportedAddressParams) ValidateWatchOnly(
 	return nil
 }
 
-// RequireAddressPrivKeyOnSpendable enforces the ADR 0012 symmetric
-// invariant for SQL backends: a spendable wallet must not receive an
-// imported address without encrypted private-key material. Public-only
-// and script-only imports are both rejected (HasPrivateKey covers both
-// — script-only imports have material in EncryptedScript but no priv
-// key).
+// RequireAddressPrivKeyOnSpendable enforces the ADR 0012 symmetric invariant:
+// on a spendable wallet, every imported address must carry its own encrypted
+// private key. ADR 0012 rejects a public-only *or script-only* import with
+// ErrSpendableWalletNeedsAddressPrivKey; a watch-only wallet accepts both.
+//
+// Holding a redeem, witness or tapscript is not spend capability. A script
+// describes a spending *condition*, not the signing material that satisfies it
+// -- a 2-of-3 multisig script is not spendable because the wallet holds its
+// bytes. So script presence cannot substitute for the private key here.
+//
+// Script-only imports remain accepted on a uniformly watch-only wallet, which
+// is where observing a script without being able to spend it is the point.
 func RequireAddressPrivKeyOnSpendable(walletID uint32,
 	walletIsWatchOnly bool, hasPrivKey bool) error {
 

--- a/wallet/internal/db/addressstore_newimported_test.go
+++ b/wallet/internal/db/addressstore_newimported_test.go
@@ -6,11 +6,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestNewImportedAddressParamsValidateWatchOnly verifies the symmetric
-// watch-only invariant rejects mismatched mode imports in both directions
-// for imported addresses. A script-only import (no priv key, has script) is
-// rejected in a spendable wallet because the spend-capability invariant
-// requires private-key material per ADR 0012.
+// TestNewImportedAddressParamsValidateWatchOnly verifies the watch-only
+// direction of the imported-address invariant: a watch-only wallet rejects a
+// private-key-bearing import, while a spendable wallet accepts any shape at
+// this stage. The symmetric spendable-side requirement (a spendable wallet
+// must carry spend material) is enforced separately by
+// RequireAddressPrivKeyOnSpendable.
 func TestNewImportedAddressParamsValidateWatchOnly(t *testing.T) {
 	t.Parallel()
 
@@ -65,18 +66,51 @@ func TestNewImportedAddressParamsValidateWatchOnly(t *testing.T) {
 }
 
 // TestRequireAddressPrivKeyOnSpendable verifies the SQL-only symmetric
-// rejection for imported addresses. Public-only AND script-only imports are
-// rejected in spendable wallets because both lack the encrypted private-key
-// material that ADR 0012 requires.
+// invariant for imported addresses: a spendable wallet requires an address
+// private key and rejects an import without one, while a watch-only wallet
+// accepts a public-only import. ADR 0012 grants script-only imports no waiver
+// on a spendable wallet.
 func TestRequireAddressPrivKeyOnSpendable(t *testing.T) {
 	t.Parallel()
 
-	err := RequireAddressPrivKeyOnSpendable(7, false, false)
-	require.ErrorIs(t, err, ErrSpendableWalletNeedsAddressPrivKey)
+	tests := []struct {
+		name          string
+		watchOnly     bool
+		hasPrivKey    bool
+		wantRejection bool
+	}{
+		{
+			name:          "spendable public-only rejected",
+			wantRejection: true,
+		},
+		{
+			name:       "spendable private-key accepted",
+			hasPrivKey: true,
+		},
+		{
+			name:      "watch-only public-only accepted",
+			watchOnly: true,
+		},
+	}
 
-	err = RequireAddressPrivKeyOnSpendable(7, false, true)
-	require.NoError(t, err)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	err = RequireAddressPrivKeyOnSpendable(7, true, false)
-	require.NoError(t, err)
+			err := RequireAddressPrivKeyOnSpendable(
+				7, tc.watchOnly, tc.hasPrivKey,
+			)
+
+			if tc.wantRejection {
+				require.ErrorIs(
+					t, err,
+					ErrSpendableWalletNeedsAddressPrivKey,
+				)
+
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
 }

--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -595,9 +595,8 @@ type GetAccountQuery struct {
 	SkipBalance bool
 }
 
-// GetAccountSecretQuery contains the parameters for querying account-level
-// signing material. The query must specify either the account name or the
-// account number within the provided wallet and scope.
+// GetAccountSecretQuery selects account-level signing material by BIP44 account
+// number within the provided wallet and scope.
 type GetAccountSecretQuery struct {
 	// WalletID is the ID of the wallet to query.
 	WalletID uint32
@@ -609,7 +608,7 @@ type GetAccountSecretQuery struct {
 	// are the only kind that hold account-level signing material: imported
 	// accounts are created from an extended public key and have none, and
 	// imported private keys are per-address material reached through
-	// GetAddressSecret instead. One selector therefore suffices.
+	// GetAddressSecret instead.
 	AccountNumber uint32
 }
 
@@ -779,6 +778,20 @@ type AddressSecret struct {
 	// EncryptedScript is the encrypted redeem or witness script for
 	// P2SH/P2WSH addresses. For Taproot, this is the TLV-encoded Tapscript.
 	EncryptedScript []byte
+
+	// ScriptIsSecret reports which key encrypted EncryptedScript. It exists
+	// for kvdb only: waddrmgr records the choice per address, so witness and
+	// taproot script rows carry a persisted flag selecting the script key or
+	// the public key, legacy P2SH rows have no flag and always use the
+	// script key, and one manager can hold both kinds at once. The fact
+	// therefore has to travel with the row rather than be inferred from
+	// wallet state.
+	//
+	// It carries no information on SQL, where script ciphertext is always
+	// written under the script key, so a SQL row is always true.
+	//
+	// TODO(yy): remove this field once kvdb support is dropped.
+	ScriptIsSecret bool
 }
 
 // NewDerivedAddressParams contains the parameters for creating a new derived
@@ -875,8 +888,20 @@ type GetAddressSecretQuery struct {
 	// databases (signed 64-bit integers).
 	WalletID uint32
 
-	// AddressID is the ID of the address whose secret should be fetched.
-	AddressID uint32
+	// AddressID is the durable SQL row ID of the address whose secret should
+	// be fetched. It is nil for the deprecated kvdb backend, which has no
+	// stable wallet-wide address ID.
+	AddressID *uint32
+
+	// ScriptPubKey is the output script identifying the address whose
+	// secret should be fetched. This compatibility selector exists because
+	// the deprecated kvdb backend has no durable wallet-wide address ID. SQL
+	// accepts it too so wallet code can remain backend-neutral during the
+	// transition.
+	//
+	// TODO(yy): remove this selector with kvdb support and use AddressID at
+	// every call site.
+	ScriptPubKey []byte
 }
 
 // ListAddressesQuery contains the parameters for listing addresses.

--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -457,6 +457,22 @@ type AccountInfo struct {
 	rowID int64
 }
 
+// AccountSecret holds the encrypted account-level key material used by signing
+// operations. The encrypted private key must be decrypted by the caller through
+// the wallet key vault. This type intentionally carries no plaintext key
+// material.
+type AccountSecret struct {
+	// EncryptedPrivateKey is the account-level extended private key
+	// encrypted by the wallet's key vault. A nil value means the account
+	// has no private account material and cannot sign derived child keys.
+	//
+	// This is the only field: the type carries encrypted secret material
+	// and nothing else. Wallet, scope, account identity and the account
+	// xpub are public metadata, already available through GetAccount, and
+	// the query itself carries the selector the caller asked by.
+	EncryptedPrivateKey []byte
+}
+
 // ScopeAddrSchema is the address schema of a particular KeyScope. It is
 // persisted on the key_scopes row and consulted when deriving any keys
 // for a particular scope to know how to encode the public keys as
@@ -577,6 +593,24 @@ type GetAccountQuery struct {
 	// coinbase maturity, locked-output exclusion) use Store.Balance with
 	// BalanceParams instead.
 	SkipBalance bool
+}
+
+// GetAccountSecretQuery contains the parameters for querying account-level
+// signing material. The query must specify either the account name or the
+// account number within the provided wallet and scope.
+type GetAccountSecretQuery struct {
+	// WalletID is the ID of the wallet to query.
+	WalletID uint32
+
+	// Scope is the key scope of the account.
+	Scope KeyScope
+
+	// AccountNumber is the BIP44 account number to query. Derived accounts
+	// are the only kind that hold account-level signing material: imported
+	// accounts are created from an extended public key and have none, and
+	// imported private keys are per-address material reached through
+	// GetAddressSecret instead. One selector therefore suffices.
+	AccountNumber uint32
 }
 
 // ListAccountsQuery holds the set of options for a ListAccounts query.

--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -264,6 +264,12 @@ type AccountStore interface {
 	GetAccount(ctx context.Context, query GetAccountQuery) (
 		*AccountInfo, error)
 
+	// GetAccountSecret retrieves encrypted account-level signing material
+	// for one account. The result contains encrypted material only; callers
+	// must use the wallet key vault to decrypt it.
+	GetAccountSecret(ctx context.Context, query GetAccountSecretQuery) (
+		*AccountSecret, error)
+
 	// ListAccounts returns a slice of AccountInfo for all accounts,
 	// optionally filtered by name or key scope. It returns an empty slice
 	// if no accounts are found.

--- a/wallet/internal/db/itest/accountstore_getaccountsecret_test.go
+++ b/wallet/internal/db/itest/accountstore_getaccountsecret_test.go
@@ -1,0 +1,112 @@
+//go:build itest
+
+package itest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/stretchr/testify/require"
+)
+
+// derivedAccountName is the derived-account name the account-secret tests use.
+const derivedAccountName = "derived"
+
+// TestGetAccountSecret verifies that GetAccountSecret returns account rows
+// with encrypted private key material, watch-only nil material, and not-found
+// errors as distinct outcomes.
+func TestGetAccountSecret(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWallet(t, store, "wallet-get-account-secret")
+	scope := db.KeyScopeBIP0084
+	pubKey := []byte("derived-account-pubkey")
+	privKey := []byte("encrypted-account-privkey")
+
+	const fingerprint = uint32(0xAABBCCDD)
+
+	derived, err := store.CreateDerivedAccount(
+		t.Context(), db.CreateDerivedAccountParams{
+			WalletID: walletID,
+			Scope:    scope,
+			Name:     derivedAccountName,
+		}, func(_ context.Context, _ db.KeyScope, _ uint32,
+			walletIsWatchOnly bool) (*db.DerivedAccountData,
+			error) {
+
+			require.False(t, walletIsWatchOnly)
+
+			return &db.DerivedAccountData{
+				PublicKey:            pubKey,
+				EncryptedPrivateKey:  privKey,
+				MasterKeyFingerprint: fingerprint,
+			}, nil
+		},
+	)
+	require.NoError(t, err)
+
+	require.NotNil(t, derived.AccountNumber,
+		"a derived account always carries a BIP44 account number")
+
+	secret, err := store.GetAccountSecret(
+		t.Context(), db.GetAccountSecretQuery{
+			WalletID:      walletID,
+			Scope:         scope,
+			AccountNumber: *derived.AccountNumber,
+		},
+	)
+	require.NoError(t, err)
+
+	// AccountSecret carries only the encrypted private key. Identity and the
+	// account xpub are public metadata, covered by the GetAccount tests.
+	require.Equal(t, privKey, secret.EncryptedPrivateKey)
+
+	// A derived account on a watch-only wallet resolves through the same
+	// account-number selector but carries no private material. Imported
+	// accounts are not covered here: they are created from an extended
+	// public key, so they never hold account-level signing material and are
+	// unreachable through this query by design.
+	watchOnlyWalletID := newWatchOnlyWallet(
+		t, store, "watch-only-get-account-secret",
+	)
+	watchOnly, err := store.CreateDerivedAccount(
+		t.Context(), db.CreateDerivedAccountParams{
+			WalletID: watchOnlyWalletID,
+			Scope:    scope,
+			Name:     "watch-only-derived",
+		}, func(_ context.Context, _ db.KeyScope, _ uint32,
+			walletIsWatchOnly bool) (*db.DerivedAccountData,
+			error) {
+
+			require.True(t, walletIsWatchOnly)
+
+			return &db.DerivedAccountData{
+				PublicKey: []byte("watch-only-pubkey"),
+			}, nil
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, watchOnly.AccountNumber)
+
+	secret, err = store.GetAccountSecret(
+		t.Context(), db.GetAccountSecretQuery{
+			WalletID:      watchOnlyWalletID,
+			Scope:         scope,
+			AccountNumber: *watchOnly.AccountNumber,
+		},
+	)
+	require.NoError(t, err)
+	require.Nil(t, secret.EncryptedPrivateKey,
+		"a watch-only account has no private material to expose")
+
+	_, err = store.GetAccountSecret(
+		t.Context(), db.GetAccountSecretQuery{
+			WalletID:      walletID,
+			Scope:         scope,
+			AccountNumber: 999,
+		},
+	)
+	require.ErrorIs(t, err, db.ErrAccountNotFound)
+}

--- a/wallet/internal/db/itest/addressstore_test.go
+++ b/wallet/internal/db/itest/addressstore_test.go
@@ -193,7 +193,6 @@ func TestNewImportedAddress(t *testing.T) {
 	t.Parallel()
 
 	store := NewTestStore(t)
-	queries := store.Queries()
 
 	privKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
@@ -303,14 +302,10 @@ func TestNewImportedAddress(t *testing.T) {
 			require.Equal(t, tc.expectedAddrType, info.AddrType)
 
 			// Verify address_secrets row for imported addresses.
-			addressID := getAddressID(
-				t, queries, params.ScriptPubKey, walletID,
-			)
-
 			secret, err := store.GetAddressSecret(
 				t.Context(), db.GetAddressSecretQuery{
-					WalletID:  walletID,
-					AddressID: uint32(addressID),
+					WalletID:     walletID,
+					ScriptPubKey: params.ScriptPubKey,
 				},
 			)
 
@@ -417,7 +412,6 @@ func TestNewImportedAddressWithEncryptedScript(t *testing.T) {
 	t.Parallel()
 
 	store := NewTestStore(t)
-	queries := store.Queries()
 
 	redeemScript := RandomBytes(32)
 	witnessScript := RandomBytes(48)
@@ -505,14 +499,10 @@ func TestNewImportedAddressWithEncryptedScript(t *testing.T) {
 			require.Equal(t, tc.expectedAddrType, info.AddrType)
 			require.Equal(t, walletIsWatchOnly, info.IsWatchOnly)
 
-			addressID := getAddressID(
-				t, queries, params.ScriptPubKey, walletID,
-			)
-
 			secret, err := store.GetAddressSecret(
 				t.Context(), db.GetAddressSecretQuery{
-					WalletID:  walletID,
-					AddressID: uint32(addressID),
+					WalletID:     walletID,
+					ScriptPubKey: params.ScriptPubKey,
 				},
 			)
 			require.NoError(t, err)
@@ -555,8 +545,8 @@ func TestNewImportedAddressNormalizesEmptyPrivateKey(t *testing.T) {
 
 	secret, err := store.GetAddressSecret(
 		t.Context(), db.GetAddressSecretQuery{
-			WalletID:  walletID,
-			AddressID: info.ID,
+			WalletID:     walletID,
+			ScriptPubKey: params.ScriptPubKey,
 		},
 	)
 	require.NoError(t, err)
@@ -841,15 +831,14 @@ func TestWatchOnlyAddressSecretTriggers(t *testing.T) {
 		)
 
 		initialPrivKey := RandomBytes(32)
-		info, err := store.NewImportedAddress(
-			t.Context(), db.NewImportedAddressParams{
-				WalletID:            walletID,
-				AddressType:         db.WitnessPubKey,
-				PubKey:              RandomBytes(33),
-				ScriptPubKey:        RandomBytes(32),
-				EncryptedPrivateKey: initialPrivKey,
-			},
-		)
+		params := db.NewImportedAddressParams{
+			WalletID:            walletID,
+			AddressType:         db.WitnessPubKey,
+			PubKey:              RandomBytes(33),
+			ScriptPubKey:        RandomBytes(32),
+			EncryptedPrivateKey: initialPrivKey,
+		}
+		info, err := store.NewImportedAddress(t.Context(), params)
 		require.NoError(t, err)
 		require.False(t, info.IsWatchOnly)
 
@@ -862,8 +851,8 @@ func TestWatchOnlyAddressSecretTriggers(t *testing.T) {
 
 		secret, err := store.GetAddressSecret(
 			t.Context(), db.GetAddressSecretQuery{
-				WalletID:  walletID,
-				AddressID: info.ID,
+				WalletID:     walletID,
+				ScriptPubKey: params.ScriptPubKey,
 			},
 		)
 		require.NoError(t, err)
@@ -1326,7 +1315,7 @@ func TestGetAddressSecret(t *testing.T) {
 				secret, err := store.GetAddressSecret(
 					t.Context(), db.GetAddressSecretQuery{
 						WalletID:  walletID,
-						AddressID: info.ID,
+						AddressID: &info.ID,
 					},
 				)
 				require.NoError(t, err)
@@ -1340,7 +1329,7 @@ func TestGetAddressSecret(t *testing.T) {
 				_, err := store.GetAddressSecret(
 					t.Context(), db.GetAddressSecretQuery{
 						WalletID:  walletID,
-						AddressID: info.ID,
+						AddressID: &info.ID,
 					},
 				)
 				require.ErrorIs(t, err, db.ErrSecretNotFound)
@@ -1361,26 +1350,26 @@ func TestGetAddressSecret(t *testing.T) {
 			EncryptedPrivateKey: RandomBytes(32),
 		}
 
-		info, err := store.NewImportedAddress(t.Context(), params)
+		_, err := store.NewImportedAddress(t.Context(), params)
 		require.NoError(t, err)
 
 		_, err = store.GetAddressSecret(
 			t.Context(), db.GetAddressSecretQuery{
-				WalletID:  otherWalletID,
-				AddressID: info.ID,
+				WalletID:     otherWalletID,
+				ScriptPubKey: params.ScriptPubKey,
 			},
 		)
 		require.ErrorIs(t, err, db.ErrAddressNotFound)
 	})
 
-	// Test non-existent address ID.
+	// Test a script pubkey that belongs to no address.
 	t.Run("non-existent address", func(t *testing.T) {
 		walletID := newWallet(t, store, "wallet-secrets-nonexistent")
 
 		_, err := store.GetAddressSecret(
 			t.Context(), db.GetAddressSecretQuery{
-				WalletID:  walletID,
-				AddressID: 999999,
+				WalletID:     walletID,
+				ScriptPubKey: RandomBytes(32),
 			},
 		)
 		require.ErrorIs(t, err, db.ErrAddressNotFound)
@@ -2387,8 +2376,8 @@ func TestGetAddressSecret_DerivedAddress(t *testing.T) {
 	// Derived addresses have no row in address_secrets table.
 	_, err = store.GetAddressSecret(
 		t.Context(), db.GetAddressSecretQuery{
-			WalletID:  walletID,
-			AddressID: addrInfo.ID,
+			WalletID:     walletID,
+			ScriptPubKey: addrInfo.ScriptPubKey,
 		},
 	)
 

--- a/wallet/internal/db/itest/addressstore_test.go
+++ b/wallet/internal/db/itest/addressstore_test.go
@@ -519,6 +519,100 @@ func TestNewImportedAddressWithEncryptedScript(t *testing.T) {
 	}
 }
 
+// TestNewImportedTaprootScriptRejectedOnSpendable verifies the ADR 0012
+// invariant at the store boundary: a spendable (non-watch-only) wallet cannot
+// import a taproot script that carries only encrypted script material and no
+// address private key.
+//
+// This test previously asserted the opposite. Holding a tapscript is not spend
+// capability -- the script states a spending condition, not the signing
+// material
+// that satisfies it -- so it cannot stand in for the address private key. The
+// same import on a watch-only wallet is accepted, which is covered below.
+func TestNewImportedTaprootScriptRejectedOnSpendable(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+
+	walletID := newWallet(t, store, "wallet-spendable-taproot-script")
+
+	params := db.NewImportedAddressParams{
+		WalletID:        walletID,
+		AddressType:     db.TaprootPubKey,
+		ScriptPubKey:    RandomBytes(32),
+		EncryptedScript: RandomBytes(48),
+	}
+
+	_, err := store.NewImportedAddress(t.Context(), params)
+	require.ErrorIs(t, err, db.ErrSpendableWalletNeedsAddressPrivKey)
+}
+
+// TestNewImportedTaprootScriptWatchOnly verifies the accepted half of the same
+// invariant: a watch-only wallet may import a script-only taproot address and
+// read its encrypted script back. Observing a script that cannot be spent is
+// what a watch-only wallet is for.
+func TestNewImportedTaprootScriptWatchOnly(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+
+	walletID := newWatchOnlyWallet(
+		t, store, "wallet-watchonly-taproot-script",
+	)
+
+	encryptedScript := RandomBytes(48)
+	params := db.NewImportedAddressParams{
+		WalletID:        walletID,
+		AddressType:     db.TaprootPubKey,
+		ScriptPubKey:    RandomBytes(32),
+		EncryptedScript: encryptedScript,
+	}
+
+	info, err := store.NewImportedAddress(t.Context(), params)
+	require.NoError(t, err)
+	require.True(t, info.IsImported)
+	require.True(t, info.HasScript)
+	require.True(t, info.IsWatchOnly)
+	require.Equal(t, db.TaprootPubKey, info.AddrType)
+
+	// Read the imported script back, mirroring how ScriptForOutput resolves
+	// the encrypted script for a taproot script-path spend.
+	secret, err := store.GetAddressSecret(
+		t.Context(), db.GetAddressSecretQuery{
+			WalletID:     walletID,
+			ScriptPubKey: params.ScriptPubKey,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, encryptedScript, secret.EncryptedScript)
+	require.Empty(t, secret.EncryptedPrivKey)
+
+	// SQL script ciphertext is always written under the script key.
+	require.True(t, secret.ScriptIsSecret)
+}
+
+// TestGetAddressSecretRejectsEmptySelector verifies that the SQL backends
+// reject an address-secret query with no script pubkey instead of issuing the
+// read. A malformed selector must not read as a missing secret, and must fail
+// the same way on every backend.
+func TestGetAddressSecretRejectsEmptySelector(t *testing.T) {
+	t.Parallel()
+
+	store := NewTestStore(t)
+	walletID := newWatchOnlyWallet(t, store, "empty-secret-selector")
+
+	for _, script := range [][]byte{nil, {}} {
+		secret, err := store.GetAddressSecret(
+			t.Context(), db.GetAddressSecretQuery{
+				WalletID:     walletID,
+				ScriptPubKey: script,
+			},
+		)
+		require.ErrorIs(t, err, db.ErrInvalidAddressQuery)
+		require.Nil(t, secret)
+	}
+}
+
 // TestNewImportedAddressNormalizesEmptyPrivateKey verifies that empty private
 // key payloads are treated as absent for validation and persisted as NULL.
 func TestNewImportedAddressNormalizesEmptyPrivateKey(t *testing.T) {

--- a/wallet/internal/db/itest/fixtures_pg_test.go
+++ b/wallet/internal/db/itest/fixtures_pg_test.go
@@ -736,23 +736,6 @@ func GetAccountID(t *testing.T, queries *sqlc.Queries,
 	return row.ID
 }
 
-// getAddressID retrieves an address ID by script and wallet.
-func getAddressID(t *testing.T, queries *sqlc.Queries, scriptPubKey []byte,
-	walletID uint32) int64 {
-
-	t.Helper()
-
-	addr, err := queries.GetAddressByScriptPubKey(
-		t.Context(), sqlc.GetAddressByScriptPubKeyParams{
-			ScriptPubKey: scriptPubKey,
-			WalletID:     int64(walletID),
-		},
-	)
-	require.NoError(t, err)
-
-	return addr.ID
-}
-
 // MustDeleteAddress deletes an address by ID for test scenarios.
 func MustDeleteAddress(t *testing.T, dbConn *sql.DB, addressID uint32) {
 	t.Helper()

--- a/wallet/internal/db/itest/fixtures_sqlite_test.go
+++ b/wallet/internal/db/itest/fixtures_sqlite_test.go
@@ -741,23 +741,6 @@ func GetAccountID(t *testing.T, queries *sqlc.Queries,
 	return row.ID
 }
 
-// getAddressID retrieves an address ID by script and wallet.
-func getAddressID(t *testing.T, queries *sqlc.Queries,
-	scriptPubKey []byte, walletID uint32) int64 {
-
-	t.Helper()
-
-	addr, err := queries.GetAddressByScriptPubKey(
-		t.Context(), sqlc.GetAddressByScriptPubKeyParams{
-			ScriptPubKey: scriptPubKey,
-			WalletID:     int64(walletID),
-		},
-	)
-	require.NoError(t, err)
-
-	return addr.ID
-}
-
 // MustDeleteAddress deletes an address by ID for test scenarios.
 func MustDeleteAddress(t *testing.T, dbConn *sql.DB, addressID uint32) {
 	t.Helper()

--- a/wallet/internal/db/kvdb/accountstore_fingerprints_test.go
+++ b/wallet/internal/db/kvdb/accountstore_fingerprints_test.go
@@ -78,6 +78,9 @@ func fingerprintDeriveFnFixture(t *testing.T,
 // fingerprintDeriveFnFixture stamps on every derived account.
 const testFingerprintValue uint32 = 0xC0DEC0DE
 
+// fpDerivedAccountName is the derived-account name the fingerprint tests share.
+const fpDerivedAccountName = "fp-derived"
+
 // TestCreateDerivedAccountPersistsMasterKeyFingerprint verifies a
 // derived account's master fingerprint round-trips through the
 // kvdb side bucket independently of waddrmgr's default-account row
@@ -97,7 +100,7 @@ func TestCreateDerivedAccountPersistsMasterKeyFingerprint(t *testing.T) {
 	info, err := store.CreateDerivedAccount(t.Context(),
 		db.CreateDerivedAccountParams{
 			Scope: scope,
-			Name:  "fp-derived",
+			Name:  fpDerivedAccountName,
 		},
 		deriveFn,
 	)
@@ -107,7 +110,7 @@ func TestCreateDerivedAccountPersistsMasterKeyFingerprint(t *testing.T) {
 
 	// Round-trip via Store.GetAccount — the value must come back
 	// from the side bucket, not from waddrmgr's row.
-	name := "fp-derived"
+	name := fpDerivedAccountName
 	got, err := store.GetAccount(t.Context(), db.GetAccountQuery{
 		Scope: scope,
 		Name:  &name,

--- a/wallet/internal/db/kvdb/accountstore_getaccountsecret.go
+++ b/wallet/internal/db/kvdb/accountstore_getaccountsecret.go
@@ -1,0 +1,115 @@
+package kvdb
+
+import (
+	"context"
+	"errors"
+
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/walletdb"
+)
+
+// accountSecretReader is the narrow slice of *waddrmgr.ScopedKeyManager that
+// GetAccountSecret needs. The scoped-manager methods exporting encrypted
+// account material live on the concrete type rather than on AccountStore, so
+// kvdb asserts to this local interface instead of widening AccountStore.
+type accountSecretReader interface {
+	// AccountSecret returns the stored encrypted account private key
+	// ciphertext, nil when the account is watch-only or imported.
+	AccountSecret(ns walletdb.ReadBucket, account uint32) ([]byte, error)
+}
+
+// checkContext reports the context's cancellation state. Secret reads consult
+// it on both sides of the walletdb view so a canceled request never receives
+// key material.
+func checkContext(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+
+	default:
+		return nil
+	}
+}
+
+// GetAccountSecret retrieves encrypted account-level signing material from the
+// legacy address manager, resolved by BIP44 account number within the scope.
+func (s *Store) GetAccountSecret(ctx context.Context,
+	query db.GetAccountSecretQuery) (*db.AccountSecret, error) {
+
+	// Honor cancellation before entering walletdb so a canceled signing
+	// request never reads secret material.
+	err := checkContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	scope := waddrmgr.KeyScope{
+		Purpose: query.Scope.Purpose,
+		Coin:    query.Scope.Coin,
+	}
+
+	var secret *db.AccountSecret
+
+	err = walletdb.View(s.db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgr.NamespaceKey)
+		if ns == nil {
+			return db.ErrAccountNotFound
+		}
+
+		var err error
+
+		secret, err = s.buildAccountSecret(ns, scope, query)
+
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Re-check after the read: the context may have been canceled while the
+	// lookup ran, and a canceled request must not receive secret material.
+	err = checkContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return secret, nil
+}
+
+// buildAccountSecret resolves the query's account within the given namespace
+// and scope and assembles its encrypted secret material. It is the read body
+// of GetAccountSecret, factored out so the exported method stays thin.
+func (s *Store) buildAccountSecret(ns walletdb.ReadBucket,
+	scope waddrmgr.KeyScope,
+	query db.GetAccountSecretQuery) (*db.AccountSecret, error) {
+
+	scopedMgr, err := s.addrStore.FetchScopedKeyManager(scope)
+	if err != nil {
+		return nil, translateAccountErr(err, db.ErrAccountNotFound)
+	}
+
+	reader, ok := scopedMgr.(accountSecretReader)
+	if !ok {
+		return nil, errScopedAccountSecretUnsupported
+	}
+
+	encPriv, err := reader.AccountSecret(ns, query.AccountNumber)
+	if err != nil {
+		return nil, translateAccountErr(err, db.ErrAccountNotFound)
+	}
+
+	return &db.AccountSecret{
+		EncryptedPrivateKey: encPriv,
+	}, nil
+}
+
+// errScopedAccountSecretUnsupported is returned when a mocked or alternate
+// scoped manager does not expose kvdb's encrypted-account-secret reader.
+var errScopedAccountSecretUnsupported = errors.New(
+	"kvdb: scoped account secret export unsupported",
+)
+
+// compile-time guard: the concrete waddrmgr scoped manager satisfies the
+// narrow reader interface GetAccountSecret asserts to.
+var _ accountSecretReader = (*waddrmgr.ScopedKeyManager)(nil)

--- a/wallet/internal/db/kvdb/accountstore_getaccountsecret_test.go
+++ b/wallet/internal/db/kvdb/accountstore_getaccountsecret_test.go
@@ -1,0 +1,100 @@
+package kvdb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/stretchr/testify/require"
+)
+
+// bip84Scope is the db.KeyScope used by the account-secret tests.
+var bip84Scope = db.KeyScope{
+	Purpose: waddrmgr.KeyScopeBIP0084.Purpose,
+	Coin:    waddrmgr.KeyScopeBIP0084.Coin,
+}
+
+// TestGetAccountSecretDerived verifies that a derived account returns its
+// encrypted private key when selected by BIP44 account number.
+func TestGetAccountSecretDerived(t *testing.T) {
+	t.Parallel()
+
+	store, mgr, cleanup := newAccountStoreFixture(t)
+	t.Cleanup(cleanup)
+
+	deriveFn := fingerprintDeriveFnFixture(t, mgr)
+	info, err := store.CreateDerivedAccount(t.Context(),
+		db.CreateDerivedAccountParams{
+			Scope: bip84Scope,
+			Name:  fpDerivedAccountName,
+		},
+		deriveFn,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, info.AccountNumber)
+
+	secret, err := store.GetAccountSecret(t.Context(),
+		db.GetAccountSecretQuery{
+			Scope:         bip84Scope,
+			AccountNumber: *info.AccountNumber,
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, secret)
+	require.NotNil(t, secret.EncryptedPrivateKey,
+		"derived account must expose encrypted private key")
+}
+
+// TestGetAccountSecretNotFound verifies that querying an absent account number
+// returns ErrAccountNotFound.
+func TestGetAccountSecretNotFound(t *testing.T) {
+	t.Parallel()
+
+	store, _, cleanup := newAccountStoreFixture(t)
+	t.Cleanup(cleanup)
+
+	_, err := store.GetAccountSecret(t.Context(),
+		db.GetAccountSecretQuery{
+			Scope:         bip84Scope,
+			AccountNumber: 99,
+		},
+	)
+	require.ErrorIs(t, err, db.ErrAccountNotFound)
+}
+
+// TestGetAccountSecretCanceledCtx verifies that a canceled context aborts the
+// read: a signing request that is canceled before it reaches walletdb must not
+// enter the store and return secret account material.
+func TestGetAccountSecretCanceledCtx(t *testing.T) {
+	t.Parallel()
+
+	store, mgr, cleanup := newAccountStoreFixture(t)
+	t.Cleanup(cleanup)
+
+	deriveFn := fingerprintDeriveFnFixture(t, mgr)
+	info, err := store.CreateDerivedAccount(t.Context(),
+		db.CreateDerivedAccountParams{
+			Scope: bip84Scope,
+			Name:  "cancel-derived",
+		},
+		deriveFn,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, info.AccountNumber)
+
+	// The account exists, so an uncanceled read would succeed. A canceled
+	// context must abort before the walletdb lookup and surface
+	// context.Canceled instead of the secret.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	secret, err := store.GetAccountSecret(ctx,
+		db.GetAccountSecretQuery{
+			Scope:         bip84Scope,
+			AccountNumber: *info.AccountNumber,
+		},
+	)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, secret)
+}

--- a/wallet/internal/db/kvdb/addressstore.go
+++ b/wallet/internal/db/kvdb/addressstore.go
@@ -386,7 +386,13 @@ func resolvedAddressInfo(ns walletdb.ReadBucket,
 		return nil, fmt.Errorf("lookup address: %w", err)
 	}
 
-	manager, account, err := resolver.AddrAccount(ns, addr)
+	// Look the account up by the address waddrmgr actually persisted, not by
+	// the one the caller passed. ScopedKeyManager.Address normalizes a P2PK
+	// address to its P2PKH form before reading the row, but AddrAccount does
+	// not, so handing it the original address would miss every wallet-owned
+	// P2PK address — its serialized-pubkey lookup cannot match a pubkey-hash
+	// row.
+	manager, account, err := resolver.AddrAccount(ns, managedAddr.Address())
 	if err != nil {
 		return nil, fmt.Errorf("lookup address account: %w", err)
 	}
@@ -453,12 +459,171 @@ func (s *Store) IterAddresses(ctx context.Context,
 	)
 }
 
-// GetAddressSecret is not yet implemented for kvdb.
-func (s *Store) GetAddressSecret(ctx context.Context,
-	_ db.GetAddressSecretQuery) (*db.AddressSecret, error) {
-
-	return nil, notImplemented(ctx, "GetAddressSecret")
+// addressSecretReader is the narrow slice of *waddrmgr.ScopedKeyManager that
+// GetAddressSecret needs. ManagedAddressSecret lives on the concrete type
+// rather than the AccountStore interface, so kvdb asserts to this local
+// interface (mirroring accountSecretReader) instead of widening AccountStore.
+type addressSecretReader interface {
+	// ManagedAddressSecret returns the encrypted private key and encrypted
+	// script for an address, both nil when the address exists but carries
+	// no secret material, plus whether the script ciphertext is encrypted
+	// under the script crypto key (CKTScript) rather than the public crypto
+	// key (CKTPublic).
+	ManagedAddressSecret(ns walletdb.ReadBucket,
+		addr address.Address) (encPriv, encScript []byte,
+		scriptSecret bool, err error)
 }
+
+// GetAddressSecret retrieves the encrypted secret material for an address.
+// kvdb is queried by script pubkey: it converts the script to a standard
+// address, resolves the owning scoped key manager across the active scopes,
+// and reads the persisted ciphertext without decrypting it. An address that
+// resolves but has no secret, and one that does not resolve at all, both map
+// to ErrSecretNotFound.
+func (s *Store) GetAddressSecret(ctx context.Context,
+	query db.GetAddressSecretQuery) (*db.AddressSecret, error) {
+
+	// A missing selector is a malformed query, not a missing secret, and
+	// must read the same on every backend.
+	err := query.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	// The deprecated kvdb address IDs are synthetic per-account ordinals,
+	// not stable wallet-wide identities. Only its script selector is safe.
+	if query.AddressID != nil {
+		return nil, db.ErrInvalidAddressQuery
+	}
+
+	// Honor cancellation before entering walletdb so a canceled signing
+	// request never reads secret material.
+	err = checkContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	addr := addressFromScript(query.ScriptPubKey, s.addrStore.ChainParams())
+	if addr == nil {
+		return nil, db.ErrSecretNotFound
+	}
+
+	var secret *db.AddressSecret
+
+	err = walletdb.View(s.db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgr.NamespaceKey)
+		if ns == nil {
+			return errMissingAddrmgrNamespace
+		}
+
+		var err error
+
+		secret, err = s.buildAddressSecret(ns, addr)
+
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Re-check after the read: the context may have been canceled while the
+	// lookup ran, and a canceled request must not receive secret material.
+	err = checkContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return secret, nil
+}
+
+// buildAddressSecret resolves the owning scoped key manager for addr within
+// the given namespace and returns its encrypted secret material. It is the
+// read body of GetAddressSecret, factored out so the exported method stays
+// thin. An address that resolves but carries no secret maps to
+// ErrSecretNotFound.
+func (s *Store) buildAddressSecret(ns walletdb.ReadBucket,
+	addr address.Address) (*db.AddressSecret, error) {
+
+	// Resolve the managed address first and look the account up by the
+	// address waddrmgr actually persisted. ScopedKeyManager.Address
+	// normalizes a P2PK address to its P2PKH form before reading the row,
+	// but AddrAccount does not, so handing it the caller's original address
+	// would miss every wallet-owned P2PK address — its serialized-pubkey
+	// lookup cannot match a pubkey-hash row. resolvedAddressInfo resolves
+	// the same way for the info path.
+	managedAddr, err := s.addrStore.Address(ns, addr)
+	if err != nil {
+		if waddrmgr.IsError(err, waddrmgr.ErrAddressNotFound) {
+			return nil, db.ErrSecretNotFound
+		}
+
+		return nil, fmt.Errorf("lookup address: %w", err)
+	}
+
+	resolvedAddr := managedAddr.Address()
+
+	// AddrAccount iterates the active scoped managers and returns the one
+	// that owns the address, so the caller need not know its scope in
+	// advance.
+	scopedMgr, _, err := s.addrStore.AddrAccount(ns, resolvedAddr)
+	if err != nil {
+		if waddrmgr.IsError(err, waddrmgr.ErrAddressNotFound) {
+			return nil, db.ErrSecretNotFound
+		}
+
+		return nil, fmt.Errorf("lookup address account: %w", err)
+	}
+
+	reader, ok := scopedMgr.(addressSecretReader)
+	if !ok {
+		return nil, errScopedAddressSecretUnsupported
+	}
+
+	// The third result is waddrmgr's per-address secrecy flag, which the
+	// store contract reports so the caller decrypts under the key the row
+	// was actually written with. waddrmgr already applies the right rule
+	// per address type: P2SH scripts are always secret, while witness and
+	// taproot rows carry a persisted flag.
+	encPriv, encScript, scriptIsSecret, err := reader.ManagedAddressSecret(
+		ns, resolvedAddr,
+	)
+	if err != nil {
+		if waddrmgr.IsError(err, waddrmgr.ErrAddressNotFound) {
+			return nil, db.ErrSecretNotFound
+		}
+
+		return nil, fmt.Errorf("read address secret: %w", err)
+	}
+
+	// A resolved address with neither ciphertext has no secret to return,
+	// which the contract represents as ErrSecretNotFound.
+	if encPriv == nil && encScript == nil {
+		return nil, db.ErrSecretNotFound
+	}
+
+	return &db.AddressSecret{
+		// kvdb has no synthetic address row identity.
+		AddressID:        0,
+		EncryptedPrivKey: encPriv,
+		EncryptedScript:  encScript,
+
+		// Report the crypto key waddrmgr encrypted the script under so
+		// the caller decrypts it with the matching key: script imports
+		// with isSecretScript=false persist under the public crypto key
+		// (CKTPublic), while secret imports use the script crypto key.
+		ScriptIsSecret: scriptIsSecret,
+	}, nil
+}
+
+// errScopedAddressSecretUnsupported is returned when a mocked or alternate
+// scoped manager does not expose kvdb's encrypted-address-secret reader.
+var errScopedAddressSecretUnsupported = errors.New(
+	"kvdb: scoped address secret export unsupported",
+)
+
+// compile-time guard: the concrete waddrmgr scoped manager satisfies the
+// narrow reader interface GetAddressSecret asserts to.
+var _ addressSecretReader = (*waddrmgr.ScopedKeyManager)(nil)
 
 // ListAddressTypes returns the static set of address types supported by the
 // store contract.
@@ -646,6 +811,13 @@ func (s *Store) importScriptAddress(ns walletdb.ReadWriteBucket,
 	manager waddrmgr.AccountStore,
 	params db.NewImportedAddressParams) (waddrmgr.ManagedAddress, error) {
 
+	// Decrypt the transport blob under the crypto key the wallet sealed it
+	// with. The wallet always asks its vault for the public crypto key
+	// (CKTPublic) — see encryptTaprootScript — because the scripts it
+	// imports are public spending data, not secret key material, and
+	// CKTPublic is the one class a locked or watch-only manager can still
+	// serve. Watch-only mode does not enter into it: it is a property of
+	// the wallet, not of the blob.
 	script, err := s.addrStore.Decrypt(
 		waddrmgr.CKTPublic, params.EncryptedScript,
 	)
@@ -653,8 +825,17 @@ func (s *Store) importScriptAddress(ns walletdb.ReadWriteBucket,
 		return nil, fmt.Errorf("decrypt imported script: %w", err)
 	}
 
+	// The manager re-encrypts the plaintext under the crypto key implied by
+	// isSecretScript, so it must record the same secrecy the transport class
+	// declared: public in, public out. Persisting these rows secret would
+	// both contradict the CKTPublic blob they were built from and make them
+	// unreadable while the wallet is locked, which is exactly when a
+	// retained script is needed to recognize an incoming spend.
 	blockStamp := s.addrStore.SyncedTo()
 	switch params.AddressType {
+	// A legacy P2SH import is always secret in waddrmgr, so a watch-only
+	// manager rejects it with ErrWatchingOnly. That is the legacy contract:
+	// the manager holds no key it may store a P2SH redeem script under.
 	case db.ScriptHash:
 		return importScriptHashAddress(
 			ns, manager, script, &blockStamp,
@@ -695,7 +876,8 @@ func importScriptHashAddress(ns walletdb.ReadWriteBucket,
 	return managedAddr, nil
 }
 
-// importWitnessScriptAddress imports legacy P2WSH script material.
+// importWitnessScriptAddress imports legacy P2WSH script material as a
+// non-secret script, matching the CKTPublic blob it was built from.
 func importWitnessScriptAddress(ns walletdb.ReadWriteBucket,
 	manager waddrmgr.AccountStore, script []byte,
 	blockStamp *waddrmgr.BlockStamp) (waddrmgr.ManagedAddress, error) {
@@ -710,7 +892,8 @@ func importWitnessScriptAddress(ns walletdb.ReadWriteBucket,
 	return managedAddr, nil
 }
 
-// importTaprootScriptAddress imports legacy taproot script material.
+// importTaprootScriptAddress imports legacy taproot script material as a
+// non-secret script, as in importWitnessScriptAddress.
 func importTaprootScriptAddress(ns walletdb.ReadWriteBucket,
 	manager waddrmgr.AccountStore, script []byte,
 	blockStamp *waddrmgr.BlockStamp) (waddrmgr.ManagedAddress, error) {

--- a/wallet/internal/db/kvdb/addressstore_getsecret_test.go
+++ b/wallet/internal/db/kvdb/addressstore_getsecret_test.go
@@ -1,0 +1,261 @@
+package kvdb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetAddressSecretImportedPrivateKey verifies that an imported private-key
+// address returns its encrypted private key and no script.
+func TestGetAddressSecretImportedPrivateKey(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	addrStore := newSpendableAddrMgr(t, dbConn)
+	store := NewStore(dbConn, nil, addrStore)
+
+	unlockAddrStore(t, dbConn, addrStore)
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	wif, err := btcutil.NewWIF(privKey, addrStore.ChainParams(), false)
+	require.NoError(t, err)
+
+	manager, err := addrStore.FetchScopedKeyManager(
+		waddrmgr.KeyScopeBIP0084,
+	)
+	require.NoError(t, err)
+
+	var pkScript []byte
+
+	err = walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+
+		managedAddr, err := manager.ImportPrivateKey(ns, wif, nil)
+		if err != nil {
+			return err
+		}
+
+		pkScript, err = txscript.PayToAddrScript(managedAddr.Address())
+
+		return err
+	})
+	require.NoError(t, err)
+
+	secret, err := store.GetAddressSecret(t.Context(),
+		db.GetAddressSecretQuery{
+			WalletID:     0,
+			ScriptPubKey: pkScript,
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, secret)
+	require.NotEmpty(t, secret.EncryptedPrivKey,
+		"imported private-key address must expose encrypted priv key")
+	require.Empty(t, secret.EncryptedScript)
+	require.Equal(t, uint32(0), secret.AddressID)
+}
+
+// TestGetAddressSecretCanceledCtx verifies that a canceled context aborts the
+// read: a signing request that is canceled before it reaches walletdb must not
+// enter the store and return secret key material.
+func TestGetAddressSecretCanceledCtx(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	addrStore := newSpendableAddrMgr(t, dbConn)
+	store := NewStore(dbConn, nil, addrStore)
+
+	unlockAddrStore(t, dbConn, addrStore)
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	wif, err := btcutil.NewWIF(privKey, addrStore.ChainParams(), false)
+	require.NoError(t, err)
+
+	manager, err := addrStore.FetchScopedKeyManager(
+		waddrmgr.KeyScopeBIP0084,
+	)
+	require.NoError(t, err)
+
+	var pkScript []byte
+
+	err = walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+
+		managedAddr, err := manager.ImportPrivateKey(ns, wif, nil)
+		if err != nil {
+			return err
+		}
+
+		pkScript, err = txscript.PayToAddrScript(managedAddr.Address())
+
+		return err
+	})
+	require.NoError(t, err)
+
+	// The address exists and carries a private key, so an uncanceled read
+	// would succeed. A canceled context must abort before the walletdb
+	// lookup and surface context.Canceled instead of the secret.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	secret, err := store.GetAddressSecret(ctx,
+		db.GetAddressSecretQuery{
+			WalletID:     0,
+			ScriptPubKey: pkScript,
+		},
+	)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, secret)
+}
+
+// TestGetAddressSecretRejectsEmptySelector verifies that kvdb rejects an
+// address-secret query with no script pubkey rather than mapping the malformed
+// selector onto ErrSecretNotFound. The failure must read the same on every
+// backend.
+func TestGetAddressSecretRejectsEmptySelector(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	store := NewStore(dbConn, nil, newSpendableAddrMgr(t, dbConn))
+
+	for _, script := range [][]byte{nil, {}} {
+		secret, err := store.GetAddressSecret(t.Context(),
+			db.GetAddressSecretQuery{
+				WalletID:     0,
+				ScriptPubKey: script,
+			},
+		)
+		require.ErrorIs(t, err, db.ErrInvalidAddressQuery)
+		require.Nil(t, secret)
+	}
+}
+
+// TestGetAddressSecretP2SHScriptIsSecret verifies that a legacy P2SH redeem
+// script is always reported secret. waddrmgr stores no per-row flag for P2SH:
+// it only ever encrypts those under the script crypto key, so the store must
+// report ScriptIsSecret=true and the ciphertext must decrypt under that key.
+func TestGetAddressSecretP2SHScriptIsSecret(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	addrStore := newSpendableAddrMgr(t, dbConn)
+	store := NewStore(dbConn, nil, addrStore)
+
+	// A P2SH import is always secret in waddrmgr, so the manager must be
+	// unlocked to hold the script key.
+	unlockAddrStore(t, dbConn, addrStore)
+
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	redeemScript, err := txscript.NewScriptBuilder().
+		AddData(privKey.PubKey().SerializeCompressed()).
+		AddOp(txscript.OP_CHECKSIG).
+		Script()
+	require.NoError(t, err)
+
+	addr, err := address.NewAddressScriptHash(
+		redeemScript, addrStore.ChainParams(),
+	)
+	require.NoError(t, err)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	scope, err := legacyImportScope(db.ScriptHash)
+	require.NoError(t, err)
+	manager, err := addrStore.FetchScopedKeyManager(scope)
+	require.NoError(t, err)
+
+	err = walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+		bs := addrStore.SyncedTo()
+
+		_, err := manager.ImportScript(ns, redeemScript, &bs)
+
+		return err
+	})
+	require.NoError(t, err)
+
+	secret, err := store.GetAddressSecret(t.Context(),
+		db.GetAddressSecretQuery{
+			WalletID:     0,
+			ScriptPubKey: pkScript,
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, secret)
+	require.True(t, secret.ScriptIsSecret)
+
+	got, err := addrStore.Decrypt(
+		waddrmgr.CKTScript, secret.EncryptedScript,
+	)
+	require.NoError(t, err)
+	require.Equal(t, redeemScript, got)
+}
+
+// TestGetAddressSecretUnknownScript verifies that a script the wallet does not
+// own maps to ErrSecretNotFound.
+func TestGetAddressSecretUnknownScript(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	addrStore := newSpendableAddrMgr(t, dbConn)
+	store := NewStore(dbConn, nil, addrStore)
+
+	// Build a standard P2WPKH script for a key the wallet has never seen.
+	privKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	pkScript := p2wpkhScript(t, privKey, addrStore.ChainParams())
+
+	_, err = store.GetAddressSecret(t.Context(),
+		db.GetAddressSecretQuery{
+			WalletID:     0,
+			ScriptPubKey: pkScript,
+		},
+	)
+	require.ErrorIs(t, err, db.ErrSecretNotFound)
+}
+
+// p2wpkhScript builds a P2WPKH output script for the given key on chainParams.
+func p2wpkhScript(t *testing.T, privKey *btcec.PrivateKey,
+	chainParams *chaincfg.Params) []byte {
+
+	t.Helper()
+
+	pubKeyHash := address.Hash160(privKey.PubKey().SerializeCompressed())
+	addr, err := address.NewAddressWitnessPubKeyHash(
+		pubKeyHash, chainParams,
+	)
+	require.NoError(t, err)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	return pkScript
+}

--- a/wallet/internal/db/kvdb/addressstore_test.go
+++ b/wallet/internal/db/kvdb/addressstore_test.go
@@ -585,6 +585,10 @@ func TestAddressStoreImportTaprootScript(t *testing.T) {
 	addrStore := newSpendableAddrMgr(t, dbConn)
 	store := NewStore(dbConn, nil, addrStore)
 
+	// Deriving the taproot key needs an unlocked manager; the transport blob
+	// travels under the public crypto key, as the wallet seals it.
+	unlockAddrStore(t, dbConn, addrStore)
+
 	tapscript, pkScript := testTaprootScript(t, addrStore)
 	encodedScript, err := waddrmgr.EncodeTaprootScript(&tapscript)
 	require.NoError(t, err)

--- a/wallet/internal/db/kvdb/vault.go
+++ b/wallet/internal/db/kvdb/vault.go
@@ -1,0 +1,200 @@
+package kvdb
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/keyvault"
+	"github.com/btcsuite/btcwallet/walletdb"
+)
+
+// LegacyWalletVault adapts the legacy address manager to keyvault.Vault.
+type LegacyWalletVault struct {
+	db  walletdb.DB
+	mgr *waddrmgr.Manager
+}
+
+// Compile-time assertion that LegacyWalletVault satisfies keyvault.Vault.
+var _ keyvault.Vault = (*LegacyWalletVault)(nil)
+
+// NewLegacyWalletVault creates a Vault backed by a legacy walletdb address
+// manager.
+func NewLegacyWalletVault(db walletdb.DB,
+	mgr *waddrmgr.Manager) *LegacyWalletVault {
+
+	return &LegacyWalletVault{
+		db:  db,
+		mgr: mgr,
+	}
+}
+
+// Unlock authenticates the private passphrase through the legacy address
+// manager.
+func (v *LegacyWalletVault) Unlock(ctx context.Context,
+	passphrase []byte) error {
+
+	err := checkContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Honor the Vault contract: unlocking an already-unlocked vault must
+	// return ErrVaultUnlocked without re-validating the passphrase.
+	if !v.mgr.IsLocked() {
+		return keyvault.ErrVaultUnlocked
+	}
+
+	err = walletdb.View(v.db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgr.NamespaceKey)
+		if ns == nil {
+			return errMissingAddrmgrNamespace
+		}
+
+		return v.mgr.Unlock(ns, passphrase)
+	})
+	if err != nil {
+		return fmt.Errorf("view: %w", translateVaultErr(err))
+	}
+
+	return nil
+}
+
+// Lock clears any cached secret key material from the legacy address manager.
+//
+// Lock is idempotent and has nothing to surface for the no-op cases: an
+// already-locked manager returns waddrmgr.ErrLocked and a watch-only manager
+// returns waddrmgr.ErrWatchingOnly (it holds no private material to clear).
+// Both are swallowed. Any other failure is only logged because the
+// keyvault.Vault contract gives Lock no way to surface an error.
+func (v *LegacyWalletVault) Lock() {
+	err := v.mgr.Lock()
+	switch {
+	case err == nil:
+
+	case waddrmgr.IsError(err, waddrmgr.ErrLocked):
+
+	case waddrmgr.IsError(err, waddrmgr.ErrWatchingOnly):
+
+	default:
+		log.Errorf("LegacyWalletVault lock manager: %v", err)
+	}
+}
+
+// IsLocked reports whether the legacy address manager is currently locked.
+func (v *LegacyWalletVault) IsLocked() bool {
+	return v.mgr.IsLocked()
+}
+
+// Encrypt encrypts key material under the requested legacy crypto-key class.
+func (v *LegacyWalletVault) Encrypt(keyType waddrmgr.CryptoKeyType,
+	plaintext []byte) ([]byte, error) {
+
+	return v.crypt(v.mgr.Encrypt, keyType, plaintext, "encrypt")
+}
+
+// Decrypt decrypts key material under the requested legacy crypto-key class.
+func (v *LegacyWalletVault) Decrypt(keyType waddrmgr.CryptoKeyType,
+	ciphertext []byte) ([]byte, error) {
+
+	return v.crypt(v.mgr.Decrypt, keyType, ciphertext, "decrypt")
+}
+
+// crypt forwards a cipher operation to the address manager and maps its
+// sentinels onto the keyvault ones. The crypto-key class stays a caller
+// argument here: the legacy format records per script row which key protects
+// it, so the adapter cannot pick one for the whole manager.
+func (v *LegacyWalletVault) crypt(op func(waddrmgr.CryptoKeyType,
+	[]byte) ([]byte, error), keyType waddrmgr.CryptoKeyType, in []byte,
+	what string) ([]byte, error) {
+
+	out, err := op(keyType, in)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", what, translateVaultErr(err))
+	}
+
+	return out, nil
+}
+
+// ChangePassphrase re-wraps the address manager's key material inside a single
+// walletdb transaction.
+//
+// The legacy dual layout keeps public metadata and private key material under
+// separate passphrases, so a request may rotate either half or both. Both are
+// applied in the same transaction to preserve the base API's atomicity.
+// Validation and the row writes belong to the address manager, so this works
+// whether or not the manager is unlocked. The manager applies the new material
+// to its own in-memory state; this adapter neither observes nor reorders that.
+//
+//nolint:staticcheck // Implements the legacy kvdb dual-passphrase format.
+func (v *LegacyWalletVault) ChangePassphrase(ctx context.Context,
+	params keyvault.ChangePassphraseParams) error {
+
+	// Bail before the walletdb access and the expensive scrypt derivation
+	// when the request is already canceled.
+	err := checkContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	changePublic := params.PublicOld != nil
+
+	changePrivate := params.PrivateOld != nil
+	if !changePublic && !changePrivate {
+		return nil
+	}
+
+	err = walletdb.Update(v.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+		if ns == nil {
+			return errMissingAddrmgrNamespace
+		}
+
+		if changePublic {
+			err := v.mgr.ChangePassphrase(
+				ns, params.PublicOld, params.PublicNew, false,
+				&waddrmgr.DefaultScryptOptions,
+			)
+			if err != nil {
+				return err
+			}
+		}
+
+		if changePrivate {
+			err := v.mgr.ChangePassphrase(
+				ns, params.PrivateOld, params.PrivateNew, true,
+				&waddrmgr.DefaultScryptOptions,
+			)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("update: %w", translateVaultErr(err))
+	}
+
+	return nil
+}
+
+// translateVaultErr maps the waddrmgr sentinels an adapter method can surface
+// onto their keyvault.Vault equivalents, so callers handle a keyvault.Vault
+// backed by the legacy manager the same way they handle WalletVault. A wrong
+// passphrase (waddrmgr.ErrWrongPassphrase) becomes
+// keyvault.ErrInvalidPassphrase and a locked/watch-only crypto-key access
+// (waddrmgr.ErrLocked) becomes keyvault.ErrVaultLocked, matching what
+// WalletVault returns for those cases. Any other error is returned unchanged.
+func translateVaultErr(err error) error {
+	switch {
+	case waddrmgr.IsError(err, waddrmgr.ErrWrongPassphrase):
+		return keyvault.ErrInvalidPassphrase
+
+	case waddrmgr.IsError(err, waddrmgr.ErrLocked):
+		return keyvault.ErrVaultLocked
+
+	default:
+		return err
+	}
+}

--- a/wallet/internal/db/kvdb/vault_test.go
+++ b/wallet/internal/db/kvdb/vault_test.go
@@ -1,0 +1,246 @@
+package kvdb
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/keyvault"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLegacyWalletVaultTranslatesManagerSentinels verifies that the adapter
+// surfaces keyvault sentinels rather than leaking the underlying waddrmgr
+// sentinels, so callers can handle keyvault.Vault errors backend-independently
+// (matching what WalletVault returns for the same cases).
+func TestLegacyWalletVaultTranslatesManagerSentinels(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unlock wrong passphrase", func(t *testing.T) {
+		t.Parallel()
+
+		dbConn, cleanup := newTestDB(t)
+		t.Cleanup(cleanup)
+
+		mgr := newSpendableAddrMgr(t, dbConn)
+		vault := NewLegacyWalletVault(dbConn, mgr)
+
+		// waddrmgr.Manager.Unlock reports a wrong passphrase as
+		// waddrmgr.ErrWrongPassphrase; the adapter must translate it to
+		// keyvault.ErrInvalidPassphrase, matching WalletVault.
+		err := vault.Unlock(t.Context(), []byte("wrong-passphrase"))
+		require.ErrorIs(t, err, keyvault.ErrInvalidPassphrase)
+		require.False(
+			t, waddrmgr.IsError(err, waddrmgr.ErrWrongPassphrase),
+		)
+	})
+
+	t.Run("encrypt while locked", func(t *testing.T) {
+		t.Parallel()
+
+		dbConn, cleanup := newTestDB(t)
+		t.Cleanup(cleanup)
+
+		// A freshly opened manager is locked, so encrypting under the
+		// script crypto key hits waddrmgr.ErrLocked; the adapter must
+		// translate it to keyvault.ErrVaultLocked, matching
+		// WalletVault.
+		mgr := newSpendableAddrMgr(t, dbConn)
+		vault := NewLegacyWalletVault(dbConn, mgr)
+		require.True(t, vault.IsLocked())
+
+		_, err := vault.Encrypt(waddrmgr.CKTScript, []byte("plaintext"))
+		require.ErrorIs(t, err, keyvault.ErrVaultLocked)
+		require.False(t, waddrmgr.IsError(err, waddrmgr.ErrLocked))
+	})
+
+	t.Run("decrypt while locked", func(t *testing.T) {
+		t.Parallel()
+
+		dbConn, cleanup := newTestDB(t)
+		t.Cleanup(cleanup)
+
+		mgr := newSpendableAddrMgr(t, dbConn)
+		vault := NewLegacyWalletVault(dbConn, mgr)
+		require.True(t, vault.IsLocked())
+
+		_, err := vault.Decrypt(waddrmgr.CKTScript, []byte("ciphertext"))
+		require.ErrorIs(t, err, keyvault.ErrVaultLocked)
+		require.False(t, waddrmgr.IsError(err, waddrmgr.ErrLocked))
+	})
+}
+
+// TestLegacyWalletVaultUnlockAlreadyUnlocked verifies that unlocking an
+// already-unlocked vault returns keyvault.ErrVaultUnlocked without validating
+// the passphrase and without locking the manager. A wrong passphrase must not
+// disturb the unlocked state.
+func TestLegacyWalletVaultUnlockAlreadyUnlocked(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	mgr := newSpendableAddrMgr(t, dbConn)
+	vault := NewLegacyWalletVault(dbConn, mgr)
+
+	// Unlock once with the correct passphrase.
+	require.NoError(t, vault.Unlock(t.Context(), testPrivPass))
+	require.False(t, vault.IsLocked())
+
+	// A second unlock with a wrong passphrase must short-circuit to
+	// ErrVaultUnlocked (contract: no passphrase validation while unlocked)
+	// and leave the manager unlocked rather than locking it.
+	err := vault.Unlock(t.Context(), []byte("wrong-passphrase"))
+	require.ErrorIs(t, err, keyvault.ErrVaultUnlocked)
+	require.False(t, vault.IsLocked(),
+		"a rejected re-unlock must not lock the manager")
+}
+
+// TestLegacyWalletVaultLockWatchOnly verifies that locking a watch-only vault
+// is a silent no-op: waddrmgr.Manager.Lock returns ErrWatchingOnly for a
+// watch-only manager, and the Vault contract makes Lock void, so nothing must
+// be logged as an error.
+//
+// Not parallel: it swaps the package logger, which is process-global state.
+//
+//nolint:paralleltest // mutates the package logger; must not run in parallel.
+func TestLegacyWalletVaultLockWatchOnly(t *testing.T) {
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	mgr := newSpendableAddrMgr(t, dbConn)
+	convertAddrStoreToWatchOnly(t, dbConn, mgr)
+
+	vault := NewLegacyWalletVault(dbConn, mgr)
+
+	// Capture package log output so we can assert Lock swallows the
+	// watch-only case instead of logging it as an error.
+	var buf bytes.Buffer
+
+	restore := log
+	backend := btclog.NewBackend(&buf)
+	logger := backend.Logger("KVDBTEST")
+	logger.SetLevel(btclog.LevelTrace)
+	log = logger
+	t.Cleanup(func() {
+		log = restore
+	})
+
+	// Lock is void; it must not panic and must not log an error for the
+	// watch-only no-op.
+	require.NotPanics(t, vault.Lock)
+
+	require.NotContains(t, buf.String(), "lock manager",
+		"watch-only Lock must not log an error")
+}
+
+// TestLegacyWalletVaultChangePassphrase covers the adapter's rotation
+// behaviour. A private-only rotation must retire the old private passphrase
+// before the new one is accepted.
+func TestLegacyWalletVaultChangePassphrase(t *testing.T) {
+	t.Parallel()
+
+	newPrivPass := []byte("brand-new-priv-pass")
+
+	tests := []struct {
+		name   string
+		params keyvault.ChangePassphraseParams
+
+		// wantErr is the error the rotation must return; nil means it
+		// must succeed.
+		wantErr error
+
+		// wantUnlock is the passphrase that must unlock the manager
+		// after the request settles.
+		wantUnlock []byte
+	}{{
+		name: "private only",
+		params: keyvault.ChangePassphraseParams{
+			PrivateOld: testPrivPass,
+			PrivateNew: newPrivPass,
+		},
+		wantUnlock: newPrivPass,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			dbConn, cleanup := newTestDB(t)
+			t.Cleanup(cleanup)
+
+			mgr := newSpendableAddrMgr(t, dbConn)
+			vault := NewLegacyWalletVault(dbConn, mgr)
+
+			err := vault.ChangePassphrase(t.Context(), test.params)
+			if test.wantErr != nil {
+				require.ErrorIs(t, err, test.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// A rotated private half must retire the old
+			// passphrase before the new one is accepted.
+			if test.params.PrivateOld != nil && test.wantErr == nil {
+				require.Error(
+					t, vault.Unlock(
+						t.Context(), testPrivPass,
+					),
+				)
+			}
+
+			// A failed unlock already leaves the manager locked,
+			// but be explicit before retrying.
+			vault.Lock()
+			require.NoError(
+				t, vault.Unlock(t.Context(), test.wantUnlock),
+			)
+		})
+	}
+}
+
+// TestLegacyWalletVaultForwardsExplicitKeyClass verifies that the adapter
+// forwards the caller's explicit CryptoKeyType to the legacy manager rather
+// than selecting a key itself: the Vault takes the key class as an argument, so
+// wallet mode is not its policy to make.
+func TestLegacyWalletVaultForwardsExplicitKeyClass(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		keyType waddrmgr.CryptoKeyType
+	}{
+		{name: "public", keyType: waddrmgr.CKTPublic},
+		{name: "script", keyType: waddrmgr.CKTScript},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			dbConn, cleanup := newTestDB(t)
+			t.Cleanup(cleanup)
+
+			mgr := newSpendableAddrMgr(t, dbConn)
+			vault := NewLegacyWalletVault(dbConn, mgr)
+
+			// The script key is only available while unlocked.
+			require.NoError(
+				t, vault.Unlock(t.Context(), testPrivPass),
+			)
+
+			plaintext := []byte("explicit key class")
+
+			ciphertext, err := vault.Encrypt(
+				test.keyType, plaintext,
+			)
+			require.NoError(t, err)
+			require.NotEqual(t, plaintext, ciphertext)
+
+			got, err := vault.Decrypt(test.keyType, ciphertext)
+			require.NoError(t, err)
+			require.Equal(t, plaintext, got)
+		})
+	}
+}

--- a/wallet/internal/db/pg/accountstore_getaccountsecret.go
+++ b/wallet/internal/db/pg/accountstore_getaccountsecret.go
@@ -1,0 +1,39 @@
+package pg
+
+import (
+	"context"
+
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+)
+
+// GetAccountSecret retrieves encrypted account-level signing material for one
+// account.
+func (s *Store) GetAccountSecret(ctx context.Context,
+	query db.GetAccountSecretQuery) (*db.AccountSecret, error) {
+
+	var secret *db.AccountSecret
+
+	err := s.execRead(ctx, func(q *sqlc.Queries) error {
+		row, err := q.GetAccountSecret(ctx, sqlc.GetAccountSecretParams{
+			WalletID: int64(query.WalletID),
+			Purpose:  int64(query.Scope.Purpose),
+			CoinType: int64(query.Scope.Coin),
+			AccountNumber: db.NullableUint32ToSQLInt64(
+				&query.AccountNumber,
+			),
+		})
+		if err != nil {
+			return db.MapGetAccountSecretErr(err, query)
+		}
+
+		secret = &db.AccountSecret{EncryptedPrivateKey: row}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return secret, nil
+}

--- a/wallet/internal/db/pg/addressstore_common.go
+++ b/wallet/internal/db/pg/addressstore_common.go
@@ -26,6 +26,10 @@ func addressSecretRowToSecret(
 		AddressID:        row.AddressID,
 		EncryptedPrivKey: row.EncryptedPrivKey,
 		EncryptedScript:  row.EncryptedScript,
+
+		// SQL script ciphertext is always encrypted under the script
+		// key; only kvdb records a per-row choice.
+		ScriptIsSecret: true,
 	})
 }
 

--- a/wallet/internal/db/pg/addressstore_common.go
+++ b/wallet/internal/db/pg/addressstore_common.go
@@ -29,6 +29,19 @@ func addressSecretRowToSecret(
 	})
 }
 
+// addressSecretByIDRowToSecret converts a PostgreSQL ID-selected secret row to
+// the shared database type.
+func addressSecretByIDRowToSecret(
+	row sqlc.GetAddressSecretByIDRow) (*db.AddressSecret, error) {
+
+	return db.AddressSecretRowToSecret(db.AddressSecretRow{
+		AddressID:        row.AddressID,
+		EncryptedPrivKey: row.EncryptedPrivKey,
+		EncryptedScript:  row.EncryptedScript,
+		ScriptIsSecret:   true,
+	})
+}
+
 // addressInfoRow is a type constraint that unifies all PostgreSQL address
 // row types that share the same field structure. This enables a single
 // generic conversion function to handle all address query result types.

--- a/wallet/internal/db/pg/addressstore_getsecret.go
+++ b/wallet/internal/db/pg/addressstore_getsecret.go
@@ -14,19 +14,46 @@ import (
 func (s *Store) GetAddressSecret(ctx context.Context,
 	query db.GetAddressSecretQuery) (*db.AddressSecret, error) {
 
+	err := query.Validate()
+	if err != nil {
+		return nil, err
+	}
+
 	var secret *db.AddressSecret
 
-	err := s.execRead(ctx, func(q *sqlc.Queries) error {
+	err = s.execRead(ctx, func(q *sqlc.Queries) error {
+		if query.AddressID != nil {
+			row, err := q.GetAddressSecretByID(
+				ctx, sqlc.GetAddressSecretByIDParams{
+					WalletID: int64(query.WalletID),
+					ID:       int64(*query.AddressID),
+				},
+			)
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("address secret for wallet %d "+
+					"address %d: %w", query.WalletID,
+					*query.AddressID, db.ErrAddressNotFound)
+			}
+
+			if err != nil {
+				return fmt.Errorf("get address secret by ID: %w", err)
+			}
+
+			secret, err = addressSecretByIDRowToSecret(row)
+
+			return err
+		}
+
 		row, err := q.GetAddressSecret(
 			ctx, sqlc.GetAddressSecretParams{
-				WalletID: int64(query.WalletID),
-				ID:       int64(query.AddressID),
+				WalletID:     int64(query.WalletID),
+				ScriptPubKey: query.ScriptPubKey,
 			},
 		)
 		if errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf(
-				"address secret for wallet %d address %d: %w",
-				query.WalletID, query.AddressID, db.ErrAddressNotFound)
+			return fmt.Errorf("address secret for wallet %d "+
+				"script %x: %w", query.WalletID,
+				query.ScriptPubKey, db.ErrAddressNotFound)
 		}
 
 		if err != nil {

--- a/wallet/internal/db/sqlite/accountstore_getaccountsecret.go
+++ b/wallet/internal/db/sqlite/accountstore_getaccountsecret.go
@@ -1,0 +1,39 @@
+package sqlite
+
+import (
+	"context"
+
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+)
+
+// GetAccountSecret retrieves encrypted account-level signing material for one
+// account.
+func (s *Store) GetAccountSecret(ctx context.Context,
+	query db.GetAccountSecretQuery) (*db.AccountSecret, error) {
+
+	var secret *db.AccountSecret
+
+	err := s.execRead(ctx, func(q *sqlc.Queries) error {
+		row, err := q.GetAccountSecret(ctx, sqlc.GetAccountSecretParams{
+			WalletID: int64(query.WalletID),
+			Purpose:  int64(query.Scope.Purpose),
+			CoinType: int64(query.Scope.Coin),
+			AccountNumber: db.NullableUint32ToSQLInt64(
+				&query.AccountNumber,
+			),
+		})
+		if err != nil {
+			return db.MapGetAccountSecretErr(err, query)
+		}
+
+		secret = &db.AccountSecret{EncryptedPrivateKey: row}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return secret, nil
+}

--- a/wallet/internal/db/sqlite/addressstore_common.go
+++ b/wallet/internal/db/sqlite/addressstore_common.go
@@ -26,6 +26,10 @@ func addressSecretRowToSecret(
 		AddressID:        row.AddressID,
 		EncryptedPrivKey: row.EncryptedPrivKey,
 		EncryptedScript:  row.EncryptedScript,
+
+		// SQL script ciphertext is always encrypted under the script
+		// key; only kvdb records a per-row choice.
+		ScriptIsSecret: true,
 	})
 }
 

--- a/wallet/internal/db/sqlite/addressstore_common.go
+++ b/wallet/internal/db/sqlite/addressstore_common.go
@@ -29,6 +29,19 @@ func addressSecretRowToSecret(
 	})
 }
 
+// addressSecretByIDRowToSecret converts a SQLite ID-selected secret row to the
+// shared database type.
+func addressSecretByIDRowToSecret(
+	row sqlc.GetAddressSecretByIDRow) (*db.AddressSecret, error) {
+
+	return db.AddressSecretRowToSecret(db.AddressSecretRow{
+		AddressID:        row.AddressID,
+		EncryptedPrivKey: row.EncryptedPrivKey,
+		EncryptedScript:  row.EncryptedScript,
+		ScriptIsSecret:   true,
+	})
+}
+
 // addressInfoRow is a type constraint union that represents all SQLite
 // address row types that share the same field structure. This enables a
 // single generic conversion function to handle all address query result types.

--- a/wallet/internal/db/sqlite/addressstore_getsecret.go
+++ b/wallet/internal/db/sqlite/addressstore_getsecret.go
@@ -14,19 +14,46 @@ import (
 func (s *Store) GetAddressSecret(ctx context.Context,
 	query db.GetAddressSecretQuery) (*db.AddressSecret, error) {
 
+	err := query.Validate()
+	if err != nil {
+		return nil, err
+	}
+
 	var secret *db.AddressSecret
 
-	err := s.execRead(ctx, func(q *sqlc.Queries) error {
+	err = s.execRead(ctx, func(q *sqlc.Queries) error {
+		if query.AddressID != nil {
+			row, err := q.GetAddressSecretByID(
+				ctx, sqlc.GetAddressSecretByIDParams{
+					WalletID: int64(query.WalletID),
+					ID:       int64(*query.AddressID),
+				},
+			)
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("address secret for wallet %d "+
+					"address %d: %w", query.WalletID,
+					*query.AddressID, db.ErrAddressNotFound)
+			}
+
+			if err != nil {
+				return fmt.Errorf("get address secret by ID: %w", err)
+			}
+
+			secret, err = addressSecretByIDRowToSecret(row)
+
+			return err
+		}
+
 		row, err := q.GetAddressSecret(
 			ctx, sqlc.GetAddressSecretParams{
-				WalletID: int64(query.WalletID),
-				ID:       int64(query.AddressID),
+				WalletID:     int64(query.WalletID),
+				ScriptPubKey: query.ScriptPubKey,
 			},
 		)
 		if errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf(
-				"address secret for wallet %d address %d: %w",
-				query.WalletID, query.AddressID, db.ErrAddressNotFound)
+			return fmt.Errorf("address secret for wallet %d "+
+				"script %x: %w", query.WalletID,
+				query.ScriptPubKey, db.ErrAddressNotFound)
 		}
 
 		if err != nil {

--- a/wallet/internal/keyvault/keyvault.go
+++ b/wallet/internal/keyvault/keyvault.go
@@ -45,8 +45,48 @@ type Vault interface {
 	// type.
 	Decrypt(keyType waddrmgr.CryptoKeyType, ciphertext []byte) ([]byte, error)
 
-	// ChangePassphrase rotates persisted wallet secrets to the provided new
-	// private passphrase. The vault must already be unlocked when this method
-	// is called.
-	ChangePassphrase(ctx context.Context, newPassphrase []byte) error
+	// ChangePassphrase re-wraps the persisted wallet secrets according to
+	// params.
+	//
+	// Implementations validate the whole request before reading or
+	// mutating any secret, so a request an implementation cannot serve in
+	// full changes nothing.
+	//
+	// The rotation preserves the vault's original locked/unlocked state: an
+	// unlocked vault stays unlocked with its runtime keys unchanged, and a
+	// locked vault leaves no decrypted state behind. The old passphrase is
+	// required even while locked, because a locked vault holds no decrypted
+	// keys and must re-derive the old master key from the persisted
+	// parameters before re-wrapping under the new one.
+	ChangePassphrase(ctx context.Context,
+		params ChangePassphraseParams) error
+}
+
+// ErrPublicPassphraseUnsupported reports that a backend was asked to rotate a
+// public passphrase it does not have. SQL wallets protect all key material
+// under one passphrase; only the legacy kvdb format keeps a separate public
+// half.
+var ErrPublicPassphraseUnsupported = errors.New(
+	"public passphrase rotation unsupported",
+)
+
+// ChangePassphraseParams contains the passphrase halves to rotate.
+//
+// The two halves are independent because the legacy kvdb format protects
+// public metadata and private key material under separate passphrases and can
+// rotate either or both in one transaction. A non-nil old passphrase selects
+// that half; this preserves a non-nil empty passphrase as a valid request.
+type ChangePassphraseParams struct {
+	// PublicOld and PublicNew contain the old and new public passphrases. A
+	// non-nil PublicOld requests their rotation.
+	//
+	// Deprecated: only the legacy kvdb format has a separate public
+	// passphrase. Remove these fields with kvdb support.
+	PublicOld []byte
+	PublicNew []byte
+
+	// PrivateOld and PrivateNew contain the old and new private passphrases.
+	// A non-nil PrivateOld requests their rotation.
+	PrivateOld []byte
+	PrivateNew []byte
 }

--- a/wallet/internal/keyvault/vault.go
+++ b/wallet/internal/keyvault/vault.go
@@ -14,6 +14,20 @@ var (
 	// which may indicate a programming error or data corruption. Normal
 	// operation should not return this error, and that's why it's unexported.
 	errUnexpectedState = errors.New("unexpected state")
+
+	// errRootKeyNotPrivate reports that a neutered (public/xpub) key was
+	// supplied as the master root key for a spendable wallet. A spendable
+	// wallet must be able to sign, so its root key has to be private.
+	errRootKeyNotPrivate = errors.New(
+		"spendable wallet requires a private root key",
+	)
+
+	// errEmptyPassphrase reports that an empty private passphrase was
+	// supplied for a spendable wallet, mirroring
+	// waddrmgr.ErrEmptyPassphrase.
+	errEmptyPassphrase = errors.New(
+		"spendable wallet requires a non-empty private passphrase",
+	)
 )
 
 // WalletVault adapts db.Store wallet secret storage to the wallet key-vault

--- a/wallet/internal/keyvault/vault_cipher.go
+++ b/wallet/internal/keyvault/vault_cipher.go
@@ -76,11 +76,15 @@ func (v *WalletVault) selectUnlockedCryptoKey(
 		}
 
 		return &v.unlockedState.cryptoKeyPrivate, nil
-	case waddrmgr.CKTScript:
+	case waddrmgr.CKTScript, waddrmgr.CKTPublic:
+		// A SQL wallet derives one key per class from a single
+		// passphrase and has no separate public crypto key. The legacy
+		// format kept one so that non-secret script rows stayed
+		// readable while locked, and the retained taproot script import
+		// still asks for that class; map it onto the script key so the
+		// import works and its ciphertext is recorded as script-key
+		// material.
 		return &v.unlockedState.cryptoKeyScript, nil
-	case waddrmgr.CKTPublic:
-		return nil, fmt.Errorf("public crypto key: %w",
-			errUnsupportedCryptoKeyType)
 	default:
 		return nil, fmt.Errorf("%d: %w", keyType, errUnsupportedCryptoKeyType)
 	}

--- a/wallet/internal/keyvault/vault_cipher_test.go
+++ b/wallet/internal/keyvault/vault_cipher_test.go
@@ -89,11 +89,6 @@ func TestWalletVaultEncryptUnsupportedKeyTypes(t *testing.T) {
 		message string
 	}{
 		{
-			name:    "public key",
-			keyType: waddrmgr.CKTPublic,
-			message: "public crypto key",
-		},
-		{
 			name:    "invalid key type",
 			keyType: waddrmgr.CryptoKeyType(0xff),
 			message: "255",
@@ -193,11 +188,6 @@ func TestWalletVaultDecryptUnsupportedKeyTypes(t *testing.T) {
 		message string
 	}{
 		{
-			name:    "public key",
-			keyType: waddrmgr.CKTPublic,
-			message: "public crypto key",
-		},
-		{
 			name:    "invalid key type",
 			keyType: waddrmgr.CryptoKeyType(0xff),
 			message: "255",
@@ -233,4 +223,33 @@ func TestWalletVaultDecryptMalformedCiphertext(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, snacl.ErrMalformed)
 	require.ErrorContains(t, err, "wallet 1 vault Decrypt: decrypt")
+}
+
+// TestWalletVaultPublicMapsToScriptKey verifies that a CKTPublic request is
+// served by the script key. A SQL wallet has no separate public crypto key,
+// but the retained taproot script import asks for that class, so the mapping
+// is what keeps the import working and round-tripping.
+func TestWalletVaultPublicMapsToScriptKey(t *testing.T) {
+	t.Parallel()
+
+	state := makeUnlockedState(t)
+	vault := NewWalletVault(nil, 1, false)
+	vault.unlockedState = state
+	t.Cleanup(vault.Lock)
+
+	plaintext := []byte("taproot script body")
+
+	ciphertext, err := vault.Encrypt(waddrmgr.CKTPublic, plaintext)
+	require.NoError(t, err)
+	require.NotEqual(t, plaintext, ciphertext)
+
+	// The same blob opens under either name, which is what makes the
+	// mapping safe: the store records ScriptIsSecret for these rows.
+	got, err := vault.Decrypt(waddrmgr.CKTPublic, ciphertext)
+	require.NoError(t, err)
+	require.Equal(t, plaintext, got)
+
+	got, err = vault.Decrypt(waddrmgr.CKTScript, ciphertext)
+	require.NoError(t, err)
+	require.Equal(t, plaintext, got)
 }

--- a/wallet/internal/keyvault/vault_genesis.go
+++ b/wallet/internal/keyvault/vault_genesis.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
 	"github.com/btcsuite/btcwallet/snacl"
+	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 )
 
@@ -18,24 +19,48 @@ import (
 // decryptWalletSecrets.
 //
 // A watch-only wallet holds no signing material, so only the script crypto key
-// is produced and hdRootKey is ignored (it may be nil). A spendable wallet
-// requires a non-nil hdRootKey.
+// is produced and hdRootKey is ignored (it may be nil or neutered) and the
+// passphrase may be empty. A spendable wallet requires a non-nil, private
+// hdRootKey and a non-empty privatePassphrase; violations are rejected before
+// any secret material is derived.
 //
 // The returned secrets contain only ciphertext. Every plaintext buffer this
 // function controls is zeroed before returning; the one copy it cannot wipe is
 // the immutable string hdRootKey.String() returns, which Go keeps read-only on
 // the heap until it is garbage collected.
+// CreateWalletSecrets derives a new SQL wallet's secrets at the production
+// scrypt cost. Tests that cannot afford it call createWalletSecretsWithScrypt
+// directly with cheaper parameters.
 func CreateWalletSecrets(privatePassphrase []byte,
 	hdRootKey *hdkeychain.ExtendedKey, watchOnly bool) (*db.WalletSecrets,
 	error) {
 
-	// Derive the master private key from the passphrase using the default
+	return createWalletSecretsWithScrypt(
+		privatePassphrase, hdRootKey, watchOnly,
+		&waddrmgr.DefaultScryptOptions,
+	)
+}
+
+// createWalletSecretsWithScrypt is CreateWalletSecrets with the key-derivation
+// cost as a parameter, so tests can use FastScryptOptions.
+func createWalletSecretsWithScrypt(privatePassphrase []byte,
+	hdRootKey *hdkeychain.ExtendedKey, watchOnly bool,
+	scrypt *waddrmgr.ScryptOptions) (*db.WalletSecrets, error) {
+
+	// Validate the spendable inputs up front, before any secret material is
+	// derived or persisted. Watch-only wallets hold no signing material, so
+	// they accept a nil (or neutered) root key and an empty passphrase.
+	err := validateGenesisInputs(privatePassphrase, hdRootKey, watchOnly)
+	if err != nil {
+		return nil, err
+	}
+
+	// Derive the master private key from the passphrase using the supplied
 	// scrypt parameters. NewSecretKey generates a fresh salt and derives
 	// the key; Marshal persists the parameters (salt + N/R/P), not the key
 	// itself, so Unlock can re-derive it from the same passphrase.
 	masterKey, err := snacl.NewSecretKey(
-		&privatePassphrase, snacl.DefaultN, snacl.DefaultR,
-		snacl.DefaultP,
+		&privatePassphrase, scrypt.N, scrypt.R, scrypt.P,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("new master private key: %w", err)
@@ -64,11 +89,6 @@ func CreateWalletSecrets(privatePassphrase []byte,
 	// key is all it needs.
 	if watchOnly {
 		return secrets, nil
-	}
-
-	if hdRootKey == nil {
-		return nil, fmt.Errorf("%w: spendable wallet requires an HD root key",
-			errUnexpectedState)
 	}
 
 	// A spendable wallet additionally holds a private crypto key protecting
@@ -101,4 +121,36 @@ func CreateWalletSecrets(privatePassphrase []byte,
 	secrets.EncryptedMasterHdPrivKey = encryptedMasterHDPrivKey
 
 	return secrets, nil
+}
+
+// validateGenesisInputs rejects invalid spendable-wallet genesis inputs before
+// any secret material is derived or persisted. Watch-only wallets hold no
+// signing material, so they accept a nil (or neutered) root key and an empty
+// passphrase and always pass.
+func validateGenesisInputs(privatePassphrase []byte,
+	hdRootKey *hdkeychain.ExtendedKey, watchOnly bool) error {
+
+	if watchOnly {
+		return nil
+	}
+
+	// A spendable wallet needs an HD root key to derive keys from.
+	if hdRootKey == nil {
+		return fmt.Errorf("%w: spendable wallet requires an HD root "+
+			"key", errUnexpectedState)
+	}
+
+	// The root key must be private; a neutered/xpub key cannot serve as a
+	// spendable wallet's master private key.
+	if !hdRootKey.IsPrivate() {
+		return errRootKeyNotPrivate
+	}
+
+	// The private passphrase protects the master key, so it may not be
+	// empty. This mirrors waddrmgr.Create's rejection.
+	if len(privatePassphrase) == 0 {
+		return errEmptyPassphrase
+	}
+
+	return nil
 }

--- a/wallet/internal/keyvault/vault_genesis.go
+++ b/wallet/internal/keyvault/vault_genesis.go
@@ -1,0 +1,104 @@
+package keyvault
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
+	"github.com/btcsuite/btcwallet/snacl"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+)
+
+// CreateWalletSecrets generates the initial encrypted secret material for a new
+// wallet, mirroring the genesis waddrmgr.Create performs for the legacy
+// backend. It derives a master private key from privatePassphrase, generates
+// fresh script (and, for spendable wallets, private) crypto keys, encrypts
+// them, and — for a spendable wallet — encrypts the master HD private key
+// under the private crypto key. The result is the db.WalletSecrets the store
+// persists and that WalletVault.Unlock later reproduces via
+// decryptWalletSecrets.
+//
+// A watch-only wallet holds no signing material, so only the script crypto key
+// is produced and hdRootKey is ignored (it may be nil). A spendable wallet
+// requires a non-nil hdRootKey.
+//
+// The returned secrets contain only ciphertext. Every plaintext buffer this
+// function controls is zeroed before returning; the one copy it cannot wipe is
+// the immutable string hdRootKey.String() returns, which Go keeps read-only on
+// the heap until it is garbage collected.
+func CreateWalletSecrets(privatePassphrase []byte,
+	hdRootKey *hdkeychain.ExtendedKey, watchOnly bool) (*db.WalletSecrets,
+	error) {
+
+	// Derive the master private key from the passphrase using the default
+	// scrypt parameters. NewSecretKey generates a fresh salt and derives
+	// the key; Marshal persists the parameters (salt + N/R/P), not the key
+	// itself, so Unlock can re-derive it from the same passphrase.
+	masterKey, err := snacl.NewSecretKey(
+		&privatePassphrase, snacl.DefaultN, snacl.DefaultR,
+		snacl.DefaultP,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("new master private key: %w", err)
+	}
+	defer masterKey.Zero()
+
+	// Every wallet, watch-only included, protects scripts with a script
+	// crypto key encrypted under the master key.
+	cryptoKeyScript, err := snacl.GenerateCryptoKey()
+	if err != nil {
+		return nil, fmt.Errorf("generate crypto key script: %w", err)
+	}
+	defer cryptoKeyScript.Zero()
+
+	encryptedCryptoKeyScript, err := masterKey.Encrypt(cryptoKeyScript[:])
+	if err != nil {
+		return nil, fmt.Errorf("encrypt crypto key script: %w", err)
+	}
+
+	secrets := &db.WalletSecrets{
+		MasterPrivParams:         masterKey.Marshal(),
+		EncryptedCryptoScriptKey: encryptedCryptoKeyScript,
+	}
+
+	// A watch-only wallet has no private signing material, so the script
+	// key is all it needs.
+	if watchOnly {
+		return secrets, nil
+	}
+
+	if hdRootKey == nil {
+		return nil, fmt.Errorf("%w: spendable wallet requires an HD root key",
+			errUnexpectedState)
+	}
+
+	// A spendable wallet additionally holds a private crypto key protecting
+	// private material, plus the master HD private key encrypted under it.
+	cryptoKeyPrivate, err := snacl.GenerateCryptoKey()
+	if err != nil {
+		return nil, fmt.Errorf("generate crypto key private: %w", err)
+	}
+	defer cryptoKeyPrivate.Zero()
+
+	encryptedCryptoKeyPrivate, err := masterKey.Encrypt(cryptoKeyPrivate[:])
+	if err != nil {
+		return nil, fmt.Errorf("encrypt crypto key private: %w", err)
+	}
+
+	// hdRootKey.String() returns an immutable plaintext xprv; that string
+	// copy cannot be wiped, but the byte buffer we hand to Encrypt can, so
+	// zero it once the ciphertext is produced.
+	hdRootKeyBytes := []byte(hdRootKey.String())
+	defer clear(hdRootKeyBytes)
+
+	encryptedMasterHDPrivKey, err := cryptoKeyPrivate.Encrypt(
+		hdRootKeyBytes,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt master HD private key: %w", err)
+	}
+
+	secrets.EncryptedCryptoPrivKey = encryptedCryptoKeyPrivate
+	secrets.EncryptedMasterHdPrivKey = encryptedMasterHDPrivKey
+
+	return secrets, nil
+}

--- a/wallet/internal/keyvault/vault_genesis_test.go
+++ b/wallet/internal/keyvault/vault_genesis_test.go
@@ -1,0 +1,203 @@
+package keyvault
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcwallet/snacl"
+	"github.com/stretchr/testify/require"
+)
+
+// testGenesisRootKey builds a deterministic spendable HD root key for genesis
+// tests.
+func testGenesisRootKey(t *testing.T) *hdkeychain.ExtendedKey {
+	t.Helper()
+
+	seed := []byte("0123456789abcdef0123456789abcdef")
+	hdRootKey, err := hdkeychain.NewMaster(
+		seed, &chaincfg.RegressionNetParams,
+	)
+	require.NoError(t, err)
+
+	return hdRootKey
+}
+
+// TestCreateWalletSecretsRoundtrip verifies what CreateWalletSecrets persists
+// for each wallet mode and that it decrypts back under the correct passphrase —
+// the parity guarantee that a SQL wallet derives the same keys as the legacy
+// backend for a given seed — while the wrong passphrase is rejected.
+func TestCreateWalletSecretsRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	const passphrase = "correct horse battery staple"
+
+	tests := []struct {
+		name      string
+		watchOnly bool
+
+		// decryptPass is the passphrase used to decrypt; when it
+		// differs from the creating one the decrypt must be rejected.
+		decryptPass string
+		wantErr     error
+	}{{
+		name:        "spendable",
+		decryptPass: passphrase,
+	}, {
+		name:        "watch-only",
+		watchOnly:   true,
+		decryptPass: passphrase,
+	}, {
+		name:        "wrong passphrase",
+		decryptPass: "wrong passphrase",
+		wantErr:     ErrInvalidPassphrase,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var hdRootKey *hdkeychain.ExtendedKey
+			if !test.watchOnly {
+				hdRootKey = testGenesisRootKey(t)
+			}
+
+			secrets, err := CreateWalletSecrets(
+				[]byte(passphrase), hdRootKey, test.watchOnly,
+			)
+			require.NoError(t, err)
+
+			// The master private params are always persisted; the
+			// private halves only for a spendable wallet.
+			require.NotEmpty(t, secrets.MasterPrivParams)
+			require.NotEmpty(t, secrets.EncryptedCryptoScriptKey)
+
+			if test.watchOnly {
+				require.Empty(t, secrets.EncryptedCryptoPrivKey)
+				require.Empty(
+					t, secrets.EncryptedMasterHdPrivKey,
+				)
+			} else {
+				require.NotEmpty(
+					t, secrets.EncryptedCryptoPrivKey,
+				)
+				require.NotEmpty(
+					t, secrets.EncryptedMasterHdPrivKey,
+				)
+			}
+
+			state, err := decryptWalletSecrets(
+				secrets, []byte(test.decryptPass),
+				test.watchOnly,
+			)
+			if test.wantErr != nil {
+				require.ErrorIs(t, err, test.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			defer state.zero()
+
+			require.NotEqual(
+				t, snacl.CryptoKey{}, state.cryptoKeyScript,
+			)
+
+			if test.watchOnly {
+				// Watch-only wallets hold no private material.
+				require.Nil(t, state.hdRootKey)
+				require.Equal(
+					t, snacl.CryptoKey{},
+					state.cryptoKeyPrivate,
+				)
+
+				return
+			}
+
+			// The decrypted HD root key must round-trip exactly.
+			require.NotNil(t, state.hdRootKey)
+			require.Equal(
+				t, hdRootKey.String(), state.hdRootKey.String(),
+			)
+			require.NotEqual(
+				t, snacl.CryptoKey{}, state.cryptoKeyPrivate,
+			)
+		})
+	}
+}
+
+// TestCreateWalletSecretsInputGuards verifies that CreateWalletSecrets rejects
+// invalid spendable inputs before deriving secret material.
+func TestCreateWalletSecretsInputGuards(t *testing.T) {
+	t.Parallel()
+
+	passphrase := []byte("correct horse battery staple")
+
+	tests := []struct {
+		name       string
+		passphrase []byte
+		rootKey    func(t *testing.T) *hdkeychain.ExtendedKey
+		watchOnly  bool
+		wantErr    error
+	}{
+		{
+			name:       "spendable nil root key",
+			passphrase: passphrase,
+			rootKey: func(*testing.T) *hdkeychain.ExtendedKey {
+				return nil
+			},
+			watchOnly: false,
+			wantErr:   errUnexpectedState,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			secrets, err := CreateWalletSecrets(
+				tc.passphrase, tc.rootKey(t), tc.watchOnly,
+			)
+
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				require.Nil(t, secrets)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, secrets)
+		})
+	}
+}
+
+// TestCreateWalletSecretsCiphertextOnly verifies that no persisted secret
+// field carries the plaintext master HD private key. This is the observable
+// half of the function's zeroing guarantee: the xprv is only ever handed to
+// the caller as ciphertext, never in the clear.
+func TestCreateWalletSecretsCiphertextOnly(t *testing.T) {
+	t.Parallel()
+
+	passphrase := []byte("correct horse battery staple")
+	hdRootKey := testGenesisRootKey(t)
+	plaintextXPriv := []byte(hdRootKey.String())
+
+	secrets, err := CreateWalletSecrets(passphrase, hdRootKey, false)
+	require.NoError(t, err)
+
+	// None of the returned fields may embed the plaintext xprv bytes.
+	require.NotContains(t, string(secrets.MasterPrivParams),
+		string(plaintextXPriv))
+	require.False(t, bytes.Contains(
+		secrets.EncryptedCryptoPrivKey, plaintextXPriv,
+	))
+	require.False(t, bytes.Contains(
+		secrets.EncryptedCryptoScriptKey, plaintextXPriv,
+	))
+	require.False(t, bytes.Contains(
+		secrets.EncryptedMasterHdPrivKey, plaintextXPriv,
+	))
+}

--- a/wallet/internal/keyvault/vault_genesis_test.go
+++ b/wallet/internal/keyvault/vault_genesis_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcwallet/snacl"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,7 +65,7 @@ func TestCreateWalletSecretsRoundtrip(t *testing.T) {
 				hdRootKey = testGenesisRootKey(t)
 			}
 
-			secrets, err := CreateWalletSecrets(
+			secrets, err := createWalletSecretsFast(
 				[]byte(passphrase), hdRootKey, test.watchOnly,
 			)
 			require.NoError(t, err)
@@ -129,7 +131,8 @@ func TestCreateWalletSecretsRoundtrip(t *testing.T) {
 }
 
 // TestCreateWalletSecretsInputGuards verifies that CreateWalletSecrets rejects
-// invalid spendable inputs before deriving secret material.
+// invalid spendable inputs before deriving secret material, while watch-only
+// wallets keep accepting a neutered xpub and an empty passphrase.
 func TestCreateWalletSecretsInputGuards(t *testing.T) {
 	t.Parallel()
 
@@ -143,6 +146,13 @@ func TestCreateWalletSecretsInputGuards(t *testing.T) {
 		wantErr    error
 	}{
 		{
+			name:       "spendable private key and passphrase",
+			passphrase: passphrase,
+			rootKey:    testGenesisRootKey,
+			watchOnly:  false,
+			wantErr:    nil,
+		},
+		{
 			name:       "spendable nil root key",
 			passphrase: passphrase,
 			rootKey: func(*testing.T) *hdkeychain.ExtendedKey {
@@ -151,13 +161,48 @@ func TestCreateWalletSecretsInputGuards(t *testing.T) {
 			watchOnly: false,
 			wantErr:   errUnexpectedState,
 		},
+		{
+			name:       "spendable neutered root key",
+			passphrase: passphrase,
+			rootKey: func(t *testing.T) *hdkeychain.ExtendedKey {
+				t.Helper()
+
+				neutered, err := testGenesisRootKey(t).Neuter()
+				require.NoError(t, err)
+
+				return neutered
+			},
+			watchOnly: false,
+			wantErr:   errRootKeyNotPrivate,
+		},
+		{
+			name:       "spendable empty passphrase",
+			passphrase: nil,
+			rootKey:    testGenesisRootKey,
+			watchOnly:  false,
+			wantErr:    errEmptyPassphrase,
+		},
+		{
+			name:       "watch-only neutered key empty passphrase",
+			passphrase: nil,
+			rootKey: func(t *testing.T) *hdkeychain.ExtendedKey {
+				t.Helper()
+
+				neutered, err := testGenesisRootKey(t).Neuter()
+				require.NoError(t, err)
+
+				return neutered
+			},
+			watchOnly: true,
+			wantErr:   nil,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			secrets, err := CreateWalletSecrets(
+			secrets, err := createWalletSecretsFast(
 				tc.passphrase, tc.rootKey(t), tc.watchOnly,
 			)
 
@@ -185,7 +230,7 @@ func TestCreateWalletSecretsCiphertextOnly(t *testing.T) {
 	hdRootKey := testGenesisRootKey(t)
 	plaintextXPriv := []byte(hdRootKey.String())
 
-	secrets, err := CreateWalletSecrets(passphrase, hdRootKey, false)
+	secrets, err := createWalletSecretsFast(passphrase, hdRootKey, false)
 	require.NoError(t, err)
 
 	// None of the returned fields may embed the plaintext xprv bytes.
@@ -200,4 +245,39 @@ func TestCreateWalletSecretsCiphertextOnly(t *testing.T) {
 	require.False(t, bytes.Contains(
 		secrets.EncryptedMasterHdPrivKey, plaintextXPriv,
 	))
+}
+
+// createWalletSecretsFast is CreateWalletSecrets at a key-derivation cost cheap
+// enough for tests. The exported path's production cost is asserted separately
+// by TestCreateWalletSecretsUsesProductionScrypt.
+func createWalletSecretsFast(privatePassphrase []byte,
+	hdRootKey *hdkeychain.ExtendedKey, watchOnly bool) (*db.WalletSecrets,
+	error) {
+
+	return createWalletSecretsWithScrypt(
+		privatePassphrase, hdRootKey, watchOnly,
+		&waddrmgr.FastScryptOptions,
+	)
+}
+
+// TestCreateWalletSecretsUsesProductionScrypt pins the key-derivation cost of
+// new SQL wallets to waddrmgr's production options.
+//
+// snacl's own defaults are 2^14, sixteen times cheaper than the 2^18 every
+// existing wallet uses, and the parameters are persisted with the wallet — so a
+// weaker cost here would permanently lower the offline passphrase-cracking cost
+// for every wallet created, with no way to raise it later.
+func TestCreateWalletSecretsUsesProductionScrypt(t *testing.T) {
+	t.Parallel()
+
+	secrets, err := CreateWalletSecrets([]byte("passphrase"), nil, true)
+	require.NoError(t, err)
+
+	var masterKey snacl.SecretKey
+	require.NoError(t, masterKey.Unmarshal(secrets.MasterPrivParams))
+
+	require.Equal(t, waddrmgr.DefaultScryptOptions.N, masterKey.Parameters.N,
+		"new SQL wallets must use the production scrypt cost")
+	require.Equal(t, waddrmgr.DefaultScryptOptions.R, masterKey.Parameters.R)
+	require.Equal(t, waddrmgr.DefaultScryptOptions.P, masterKey.Parameters.P)
 }

--- a/wallet/internal/keyvault/vault_lifecycle.go
+++ b/wallet/internal/keyvault/vault_lifecycle.go
@@ -1,7 +1,6 @@
 package keyvault
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -216,18 +215,35 @@ func decryptCryptoKey(masterPrivateKey *snacl.SecretKey,
 	return cryptoKey, nil
 }
 
-// ChangePassphrase rotates persisted wallet secrets to the new private
-// passphrase and keeps the existing unlocked runtime state unchanged.
+// ChangePassphrase re-wraps the persisted wallet secrets from oldPassphrase to
+// newPassphrase. It preserves the vault's original locked/unlocked state: the
+// runtime keys held while unlocked are never touched, and a locked vault leaves
+// no decrypted state behind because the rotation reads and re-encrypts only the
+// persisted ciphertext.
 func (v *WalletVault) ChangePassphrase(ctx context.Context,
-	newPassphrase []byte) error {
+	params ChangePassphraseParams) error {
 
+	// Validate before touching any secret. A SQL wallet has no public
+	// passphrase, so a request naming one cannot be served in full and must
+	// leave the persisted state untouched rather than rotating the private
+	// half and then reporting failure.
+	if params.PublicOld != nil {
+		return fmt.Errorf("wallet %d vault ChangePassphrase: %w",
+			v.walletID, ErrPublicPassphraseUnsupported)
+	}
+
+	if params.PrivateOld == nil {
+		return nil
+	}
+
+	oldPassphrase, newPassphrase := params.PrivateOld, params.PrivateNew
+
+	// Hold the lock for the whole rotation so it serializes against
+	// Lock/Unlock/Encrypt/Decrypt. The rotation itself never reads or
+	// writes v.unlockedState, so the vault's locked/unlocked state is
+	// preserved regardless of the outcome.
 	v.mtx.Lock()
 	defer v.mtx.Unlock()
-
-	if v.unlockedState == nil {
-		return fmt.Errorf("wallet %d vault ChangePassphrase: %w",
-			v.walletID, ErrVaultLocked)
-	}
 
 	secrets, err := v.store.GetWalletSecrets(ctx, v.walletID)
 	if err != nil {
@@ -235,22 +251,12 @@ func (v *WalletVault) ChangePassphrase(ctx context.Context,
 			"get secrets: %w", v.walletID, err)
 	}
 
-	updateParams, err := v.makeRotatedWalletSecrets(secrets, newPassphrase)
+	updateParams, err := v.makeRotatedWalletSecrets(
+		secrets, oldPassphrase, newPassphrase,
+	)
 	if err != nil {
 		return fmt.Errorf("wallet %d vault ChangePassphrase: "+
 			"rotate secrets: %w", v.walletID, err)
-	}
-
-	// Validate that the rotated secrets derive the same runtime keys before
-	// persisting them. This prevents storing secrets that would leave the vault
-	// unable to reproduce its current key material.
-	//
-	// This should only fail if there is a bug in this rotation path or in the
-	// underlying cryptographic implementation.
-	err = v.validateRotatedWalletSecrets(updateParams, newPassphrase)
-	if err != nil {
-		return fmt.Errorf("wallet %d vault ChangePassphrase: "+
-			"validate rotated secrets: %w", v.walletID, err)
 	}
 
 	err = v.store.UpdateWalletSecrets(ctx, updateParams)
@@ -262,84 +268,53 @@ func (v *WalletVault) ChangePassphrase(ctx context.Context,
 	return nil
 }
 
-// validateRotatedWalletSecrets confirms rotated persisted secrets decrypt with
-// the new passphrase to the same runtime keys already held in memory.
-func (v *WalletVault) validateRotatedWalletSecrets(
-	params db.UpdateWalletSecretsParams, passphrase []byte) error {
-
-	updatedSecrets := db.WalletSecrets{
-		MasterPrivParams:         params.MasterPrivParams,
-		EncryptedCryptoPrivKey:   params.EncryptedCryptoPrivKey,
-		EncryptedCryptoScriptKey: params.EncryptedCryptoScriptKey,
-		EncryptedMasterHdPrivKey: params.EncryptedMasterHdPrivKey,
-	}
-
-	validatedState, err := decryptWalletSecrets(
-		&updatedSecrets, passphrase, v.watchOnly,
-	)
-	if err != nil {
-		return fmt.Errorf("decrypt rotated secrets: %w", err)
-	}
-	defer validatedState.zero()
-
-	if !unlockedStateEqual(v.unlockedState, validatedState) {
-		return fmt.Errorf("rotated secrets changed runtime keys: %w",
-			errUnexpectedState)
-	}
-
-	return nil
-}
-
-// unlockedStateEqual reports whether two unlocked states hold equal runtime
-// keys.
-func unlockedStateEqual(a, b *unlockedState) bool {
-	if a == nil || b == nil {
-		return a == b
-	}
-
-	if !bytes.Equal(a.cryptoKeyPrivate[:], b.cryptoKeyPrivate[:]) {
-		return false
-	}
-
-	if !bytes.Equal(a.cryptoKeyScript[:], b.cryptoKeyScript[:]) {
-		return false
-	}
-
-	if a.hdRootKey == nil || b.hdRootKey == nil {
-		return a.hdRootKey == b.hdRootKey
-	}
-
-	return a.hdRootKey.String() == b.hdRootKey.String()
-}
-
-// makeRotatedWalletSecrets creates a persisted wallet secret update encrypted
-// with a new private passphrase from the currently unlocked runtime state.
+// makeRotatedWalletSecrets validates the old private passphrase and re-encrypts
+// the persisted crypto keys under a master key derived from the new
+// passphrase. It mirrors CreateWalletSecrets: it derives the old master key
+// from the stored parameters (which validates oldPassphrase against the stored
+// digest), decrypts the persisted crypto key blobs with it, and re-encrypts
+// them under a freshly salted master key derived from newPassphrase. The master
+// HD private key ciphertext is carried forward unchanged because it is
+// encrypted under the crypto private key, not the passphrase.
 //
-// TODO(gus): wrap this with secret.Do from Go 1.26+ to avoid
-// leaking HD private key string material while waiting for GC.
+// A wrong oldPassphrase is reported as ErrInvalidPassphrase and no persisted
+// state is mutated. This does not read v.unlockedState, so it works whether the
+// vault is locked or unlocked.
+//
+// TODO(gus): wrap this with secret.Do from Go 1.26+ to avoid leaking decrypted
+// key material while waiting for GC.
 func (v *WalletVault) makeRotatedWalletSecrets(secrets *db.WalletSecrets,
-	newPassphrase []byte) (db.UpdateWalletSecretsParams, error) {
+	oldPassphrase, newPassphrase []byte) (db.UpdateWalletSecretsParams,
+	error) {
 
 	if secrets == nil {
 		return db.UpdateWalletSecretsParams{},
 			fmt.Errorf("missing wallet secrets: %w", errUnexpectedState)
 	}
 
-	// First, we need to load the old key parameters to be able to derive the
-	// new key.
-	var currentMasterPrivateKey snacl.SecretKey
+	// Derive the old master private key from the stored parameters.
+	// DeriveKey validates oldPassphrase against the stored digest, so a
+	// wrong passphrase is rejected here before any secret material is
+	// touched.
+	var oldMasterPrivateKey snacl.SecretKey
 
-	err := currentMasterPrivateKey.Unmarshal(secrets.MasterPrivParams)
+	err := oldMasterPrivateKey.Unmarshal(secrets.MasterPrivParams)
 	if err != nil {
 		return db.UpdateWalletSecretsParams{}, fmt.Errorf(
 			"unmarshal master private parameters: %w", err,
 		)
 	}
-	defer currentMasterPrivateKey.Zero()
+	defer oldMasterPrivateKey.Zero()
 
-	keyParams := currentMasterPrivateKey.Parameters
+	err = deriveMasterPrivateKey(&oldMasterPrivateKey, oldPassphrase)
+	if err != nil {
+		return db.UpdateWalletSecretsParams{}, err
+	}
 
-	// Second, generate the new key.
+	keyParams := oldMasterPrivateKey.Parameters
+
+	// Derive a new master private key from the new passphrase. NewSecretKey
+	// generates a fresh salt; the scrypt cost parameters are preserved.
 	newMasterPrivateKey, err := snacl.NewSecretKey(
 		&newPassphrase, keyParams.N, keyParams.R, keyParams.P,
 	)
@@ -349,15 +324,20 @@ func (v *WalletVault) makeRotatedWalletSecrets(secrets *db.WalletSecrets,
 	}
 	defer newMasterPrivateKey.Zero()
 
-	if v.watchOnly {
-		encryptedCryptoKeyScript, scriptErr := newMasterPrivateKey.Encrypt(
-			v.unlockedState.cryptoKeyScript[:],
-		)
-		if scriptErr != nil {
-			return db.UpdateWalletSecretsParams{},
-				fmt.Errorf("encrypt crypto key script: %w", scriptErr)
-		}
+	// Re-encrypt the script crypto key under the new master key. Every
+	// wallet, watch-only included, holds a script crypto key.
+	encryptedCryptoKeyScript, err := reEncryptCryptoKey(
+		&oldMasterPrivateKey, newMasterPrivateKey,
+		secrets.EncryptedCryptoScriptKey,
+	)
+	if err != nil {
+		return db.UpdateWalletSecretsParams{},
+			fmt.Errorf("re-encrypt crypto key script: %w", err)
+	}
 
+	// A watch-only wallet has no private crypto key or HD root material, so
+	// the script key is all it needs.
+	if v.watchOnly {
 		return db.UpdateWalletSecretsParams{
 			WalletID:                 v.walletID,
 			MasterPrivParams:         newMasterPrivateKey.Marshal(),
@@ -365,20 +345,32 @@ func (v *WalletVault) makeRotatedWalletSecrets(secrets *db.WalletSecrets,
 		}, nil
 	}
 
-	encryptedCryptoKeyPrivate, err := newMasterPrivateKey.Encrypt(
-		v.unlockedState.cryptoKeyPrivate[:],
+	// Re-encrypt the private crypto key under the new master key.
+	// Decrypting it with the old master key also confirms oldPassphrase can
+	// reproduce the spendable key material, beyond the digest check
+	// performed above.
+	encryptedCryptoKeyPrivate, err := reEncryptCryptoKey(
+		&oldMasterPrivateKey, newMasterPrivateKey,
+		secrets.EncryptedCryptoPrivKey,
 	)
 	if err != nil {
 		return db.UpdateWalletSecretsParams{},
-			fmt.Errorf("encrypt crypto key private: %w", err)
+			fmt.Errorf("re-encrypt crypto key private: %w", err)
 	}
 
-	encryptedCryptoKeyScript, err := newMasterPrivateKey.Encrypt(
-		v.unlockedState.cryptoKeyScript[:],
+	// The HD-root ciphertext is encrypted under the crypto private key, not
+	// the passphrase, so it is carried forward unchanged. Validate that it
+	// still decrypts and parses under that key before persisting it, so a
+	// corrupt or mismatched root cannot let rotation report success while
+	// stranding the wallet: after rotation, unlock recovers the HD root the
+	// same way and must not be the first place the corruption surfaces.
+	err = validateCarriedHDRoot(
+		&oldMasterPrivateKey, secrets.EncryptedCryptoPrivKey,
+		secrets.EncryptedMasterHdPrivKey,
 	)
 	if err != nil {
 		return db.UpdateWalletSecretsParams{},
-			fmt.Errorf("encrypt crypto key script: %w", err)
+			fmt.Errorf("validate carried HD root: %w", err)
 	}
 
 	return db.UpdateWalletSecretsParams{
@@ -386,6 +378,82 @@ func (v *WalletVault) makeRotatedWalletSecrets(secrets *db.WalletSecrets,
 		MasterPrivParams:         newMasterPrivateKey.Marshal(),
 		EncryptedCryptoPrivKey:   encryptedCryptoKeyPrivate,
 		EncryptedCryptoScriptKey: encryptedCryptoKeyScript,
+
+		// The master HD private key is encrypted under the crypto
+		// private key, not the passphrase, so its ciphertext is carried
+		// forward unchanged.
 		EncryptedMasterHdPrivKey: secrets.EncryptedMasterHdPrivKey,
 	}, nil
+}
+
+// validateCarriedHDRoot confirms the carried HD-root ciphertext is recoverable
+// before a passphrase rotation persists it. It decrypts the crypto private key
+// with the (already validated) old master key, uses it to decrypt the HD-root
+// ciphertext, and parses the result as an extended key. Rotation preserves the
+// crypto private key plaintext, so a root that recovers here also recovers
+// under the newly re-encrypted crypto private key. Any failure is reported as
+// errUnexpectedState.
+func validateCarriedHDRoot(oldMasterKey *snacl.SecretKey,
+	encryptedCryptoKeyPrivate, encryptedHDRoot []byte) error {
+
+	cryptoKeyPrivate, err := decryptCryptoKey(
+		oldMasterKey, encryptedCryptoKeyPrivate,
+	)
+	if err != nil {
+		return fmt.Errorf("crypto key private: %w", err)
+	}
+	defer cryptoKeyPrivate.Zero()
+
+	if len(encryptedHDRoot) == 0 {
+		return fmt.Errorf("missing master HD private key: %w",
+			errUnexpectedState)
+	}
+
+	decryptedHDRoot, err := cryptoKeyPrivate.Decrypt(encryptedHDRoot)
+	if err != nil {
+		return fmt.Errorf("decrypt master HD private key: %w: %w",
+			errUnexpectedState, err)
+	}
+	defer clear(decryptedHDRoot)
+
+	hdRootKey, err := hdkeychain.NewKeyFromString(string(decryptedHDRoot))
+	if err != nil {
+		return fmt.Errorf("parse master HD private key: %w: %w",
+			errUnexpectedState, err)
+	}
+
+	// The parsed key is only used to confirm the ciphertext is recoverable;
+	// zero it immediately since validation keeps no runtime state.
+	hdRootKey.Zero()
+
+	return nil
+}
+
+// reEncryptCryptoKey decrypts a persisted crypto key blob with the old master
+// key and re-encrypts it under the new master key, zeroing the decrypted
+// plaintext before returning. It validates that the decrypted key has the
+// expected size.
+func reEncryptCryptoKey(oldMasterKey, newMasterKey *snacl.SecretKey,
+	ciphertext []byte) ([]byte, error) {
+
+	decrypted, err := oldMasterKey.Decrypt(ciphertext)
+	defer clear(decrypted)
+
+	if err != nil {
+		return nil, fmt.Errorf("decrypt crypto key: %w: %w",
+			errUnexpectedState, err)
+	}
+
+	if len(decrypted) != snacl.KeySize {
+		return nil, fmt.Errorf("decrypt crypto key expected %d bytes, "+
+			"got %d: %w", snacl.KeySize, len(decrypted),
+			errUnexpectedState)
+	}
+
+	reEncrypted, err := newMasterKey.Encrypt(decrypted)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt crypto key: %w", err)
+	}
+
+	return reEncrypted, nil
 }

--- a/wallet/internal/keyvault/vault_lifecycle_test.go
+++ b/wallet/internal/keyvault/vault_lifecycle_test.go
@@ -236,17 +236,124 @@ func TestWalletVaultUnlockMalformedScriptKeyLocksVault(t *testing.T) {
 	require.Nil(t, vault.unlockedState)
 }
 
-// TestWalletVaultChangePassphraseLockedRequiresUnlockedState verifies that
-// changing private passphrase state requires an already unlocked vault.
-func TestWalletVaultChangePassphraseLockedRequiresUnlockedState(t *testing.T) {
+// TestWalletVaultChangePassphraseLockedRotates verifies that a locked vault can
+// rotate its passphrase from persisted ciphertext and stays locked with no
+// decrypted state left behind.
+func TestWalletVaultChangePassphraseLockedRotates(t *testing.T) {
 	t.Parallel()
 
-	vault := NewWalletVault(nil, 1, false)
-	err := vault.ChangePassphrase(t.Context(), correctPassphrase)
-	require.Error(t, err)
-	require.ErrorIs(t, err, ErrVaultLocked)
+	oldSecrets, oldExpected := makeWalletSecrets(t, correctPassphrase)
+	newPassphrase := []byte("new-passphrase")
+
+	const walletID = uint32(19)
+
+	var capturedUpdate db.UpdateWalletSecretsParams
+
+	store := new(bwmock.Store)
+	store.On("GetWalletSecrets", mock.Anything, walletID).Return(
+		oldSecrets, nil,
+	).Once()
+	store.On("UpdateWalletSecrets", mock.Anything, mock.MatchedBy(
+		func(params db.UpdateWalletSecretsParams) bool {
+			capturedUpdate = params
+			return true
+		},
+	)).Return(nil).Once()
+	t.Cleanup(func() {
+		store.AssertExpectations(t)
+	})
+
+	// Never unlock the vault: it must rotate from persisted ciphertext.
+	vault := NewWalletVault(store, walletID, false)
+	require.True(t, vault.IsLocked())
+
+	err := vault.ChangePassphrase(
+		t.Context(), ChangePassphraseParams{
+			PrivateOld: correctPassphrase,
+			PrivateNew: newPassphrase,
+		},
+	)
+	require.NoError(t, err)
+
+	// The vault must remain locked with no runtime state.
 	require.True(t, vault.IsLocked())
 	require.Nil(t, vault.unlockedState)
+
+	// The rotated secrets must decrypt with the new passphrase to the same
+	// runtime keys and reject the old passphrase.
+	cryptoScriptKey := capturedUpdate.EncryptedCryptoScriptKey
+	masterHDPrivKey := capturedUpdate.EncryptedMasterHdPrivKey
+
+	updatedSecrets := &db.WalletSecrets{
+		MasterPrivParams:         capturedUpdate.MasterPrivParams,
+		EncryptedCryptoPrivKey:   capturedUpdate.EncryptedCryptoPrivKey,
+		EncryptedCryptoScriptKey: cryptoScriptKey,
+		EncryptedMasterHdPrivKey: masterHDPrivKey,
+	}
+
+	newState, err := decryptWalletSecrets(
+		updatedSecrets, newPassphrase, false,
+	)
+	require.NoError(t, err)
+	t.Cleanup(newState.zero)
+	require.Equal(
+		t, oldExpected.cryptoKeyPrivate[:],
+		newState.cryptoKeyPrivate[:],
+	)
+	require.Equal(
+		t, oldExpected.cryptoKeyScript[:], newState.cryptoKeyScript[:],
+	)
+	require.Equal(
+		t, oldExpected.hdRootKey.String(), newState.hdRootKey.String(),
+	)
+
+	_, err = decryptWalletSecrets(updatedSecrets, correctPassphrase, false)
+	require.ErrorIs(t, err, ErrInvalidPassphrase)
+}
+
+// TestWalletVaultChangePassphraseWrongOldPassphrase verifies that a wrong old
+// private passphrase is rejected without mutating persisted or runtime state.
+func TestWalletVaultChangePassphraseWrongOldPassphrase(t *testing.T) {
+	t.Parallel()
+
+	oldSecrets, oldExpected := makeWalletSecrets(t, correctPassphrase)
+
+	const walletID = uint32(20)
+
+	store := new(bwmock.Store)
+
+	// Unlock fetches the secrets once; ChangePassphrase fetches them again
+	// before validating the (wrong) old passphrase.
+	store.On("GetWalletSecrets", mock.Anything, walletID).Return(
+		oldSecrets, nil,
+	).Twice()
+	t.Cleanup(func() {
+		// UpdateWalletSecrets must never be called on a wrong
+		// passphrase.
+		store.AssertExpectations(t)
+		store.AssertNotCalled(t, "UpdateWalletSecrets")
+	})
+
+	vault := NewWalletVault(store, walletID, false)
+	require.NoError(t, vault.Unlock(t.Context(), correctPassphrase))
+	t.Cleanup(vault.Lock)
+
+	oldState := vault.unlockedState
+	err := vault.ChangePassphrase(
+		t.Context(), ChangePassphraseParams{
+			PrivateOld: wrongPassphrase,
+			PrivateNew: []byte("new-passphrase"),
+		},
+	)
+	require.ErrorIs(t, err, ErrInvalidPassphrase)
+
+	// Runtime state must be untouched.
+	require.Same(t, oldState, vault.unlockedState)
+	require.Equal(
+		t, oldExpected.cryptoKeyPrivate[:],
+		oldState.cryptoKeyPrivate[:],
+	)
+	require.False(t, vault.IsLocked())
 }
 
 // TestWalletVaultChangePassphraseUpdateErrorPreservesState verifies that
@@ -262,12 +369,11 @@ func TestWalletVaultChangePassphraseUpdateErrorPreservesState(t *testing.T) {
 	var capturedUpdate db.UpdateWalletSecretsParams
 
 	store := new(bwmock.Store)
+
+	// Unlock and ChangePassphrase each fetch the persisted secrets once.
 	store.On("GetWalletSecrets", mock.Anything, walletID).Return(
 		oldSecrets, nil,
-	).Once()
-	store.On("GetWalletSecrets", mock.Anything, walletID).Return(
-		oldSecrets, nil,
-	).Once()
+	).Twice()
 	store.On("UpdateWalletSecrets", mock.Anything, mock.MatchedBy(
 		func(params db.UpdateWalletSecretsParams) bool {
 			capturedUpdate = params
@@ -283,7 +389,12 @@ func TestWalletVaultChangePassphraseUpdateErrorPreservesState(t *testing.T) {
 	t.Cleanup(vault.Lock)
 
 	oldState := vault.unlockedState
-	err := vault.ChangePassphrase(t.Context(), newPassphrase)
+	err := vault.ChangePassphrase(
+		t.Context(), ChangePassphraseParams{
+			PrivateOld: correctPassphrase,
+			PrivateNew: newPassphrase,
+		},
+	)
 	require.Error(t, err)
 	require.ErrorIs(t, err, errStoreUnavailable)
 
@@ -315,12 +426,11 @@ func TestWalletVaultChangePassphraseSuccessPersistsRotation(t *testing.T) {
 	var capturedUpdate db.UpdateWalletSecretsParams
 
 	store := new(bwmock.Store)
+
+	// Unlock and ChangePassphrase each fetch the persisted secrets once.
 	store.On("GetWalletSecrets", mock.Anything, walletID).Return(
 		oldSecrets, nil,
-	).Once()
-	store.On("GetWalletSecrets", mock.Anything, walletID).Return(
-		oldSecrets, nil,
-	).Once()
+	).Twice()
 	store.On("UpdateWalletSecrets", mock.Anything, mock.MatchedBy(
 		func(params db.UpdateWalletSecretsParams) bool {
 			capturedUpdate = params
@@ -337,9 +447,12 @@ func TestWalletVaultChangePassphraseSuccessPersistsRotation(t *testing.T) {
 
 	oldState := vault.unlockedState
 
-	require.NoError(
-		t, vault.ChangePassphrase(t.Context(), newPassphrase),
-	)
+	require.NoError(t, vault.ChangePassphrase(
+		t.Context(), ChangePassphraseParams{
+			PrivateOld: correctPassphrase,
+			PrivateNew: newPassphrase,
+		},
+	))
 	require.Same(t, oldState, vault.unlockedState)
 	require.Equal(
 		t, oldExpected.cryptoKeyPrivate[:],
@@ -394,12 +507,11 @@ func TestWalletVaultChangePassphrasePreservesHDRootCiphertext(t *testing.T) {
 	var capturedUpdate db.UpdateWalletSecretsParams
 
 	store := new(bwmock.Store)
+
+	// Unlock and ChangePassphrase each fetch the persisted secrets once.
 	store.On("GetWalletSecrets", mock.Anything, walletID).Return(
 		oldSecrets, nil,
-	).Once()
-	store.On("GetWalletSecrets", mock.Anything, walletID).Return(
-		oldSecrets, nil,
-	).Once()
+	).Twice()
 	store.On("UpdateWalletSecrets", mock.Anything, mock.MatchedBy(
 		func(params db.UpdateWalletSecretsParams) bool {
 			capturedUpdate = params
@@ -414,12 +526,60 @@ func TestWalletVaultChangePassphrasePreservesHDRootCiphertext(t *testing.T) {
 	require.NoError(t, vault.Unlock(t.Context(), correctPassphrase))
 	t.Cleanup(vault.Lock)
 
-	err := vault.ChangePassphrase(t.Context(), newPassphrase)
+	err := vault.ChangePassphrase(
+		t.Context(), ChangePassphraseParams{
+			PrivateOld: correctPassphrase,
+			PrivateNew: newPassphrase,
+		},
+	)
 	require.NoError(t, err)
 	require.Equal(
 		t, oldSecrets.EncryptedMasterHdPrivKey,
 		capturedUpdate.EncryptedMasterHdPrivKey,
 	)
+}
+
+// TestWalletVaultChangePassphraseCorruptHDRootFails verifies that private
+// passphrase rotation validates the carried HD-root ciphertext before
+// persisting it. A corrupt/mismatched root ciphertext must fail the rotation
+// instead of reporting success while stranding the wallet (the rotated
+// secrets would be unusable because unlock can no longer recover the HD root).
+func TestWalletVaultChangePassphraseCorruptHDRootFails(t *testing.T) {
+	t.Parallel()
+
+	oldSecrets, _ := makeWalletSecrets(t, correctPassphrase)
+	newPassphrase := []byte("new-passphrase")
+
+	// Corrupt the persisted HD-root ciphertext. The old master key still
+	// derives (correctPassphrase is valid) and both crypto keys still
+	// re-encrypt, so without an HD-root validation step the rotation would
+	// wrongly report success.
+	oldSecrets.EncryptedMasterHdPrivKey = []byte("not-a-valid-ciphertext")
+
+	const walletID = uint32(19)
+
+	store := new(bwmock.Store)
+
+	// ChangePassphrase fetches the persisted secrets once. It must never
+	// reach UpdateWalletSecrets because validation fails first, so no
+	// UpdateWalletSecrets expectation is registered.
+	store.On("GetWalletSecrets", mock.Anything, walletID).Return(
+		oldSecrets, nil,
+	).Once()
+	t.Cleanup(func() {
+		store.AssertExpectations(t)
+	})
+
+	vault := NewWalletVault(store, walletID, false)
+
+	err := vault.ChangePassphrase(
+		t.Context(), ChangePassphraseParams{
+			PrivateOld: correctPassphrase,
+			PrivateNew: newPassphrase,
+		},
+	)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errUnexpectedState)
 }
 
 // TestWalletVaultUnlockWatchOnlySkipsPrivateMaterial verifies that watch-only
@@ -472,12 +632,11 @@ func TestWalletVaultChangePassphraseWatchOnlyRotatesScriptMaterial(
 	var capturedUpdate db.UpdateWalletSecretsParams
 
 	store := new(bwmock.Store)
+
+	// Unlock and ChangePassphrase each fetch the persisted secrets once.
 	store.On("GetWalletSecrets", mock.Anything, walletID).Return(
 		oldSecrets, nil,
-	).Once()
-	store.On("GetWalletSecrets", mock.Anything, walletID).Return(
-		oldSecrets, nil,
-	).Once()
+	).Twice()
 	store.On("UpdateWalletSecrets", mock.Anything, mock.MatchedBy(
 		func(params db.UpdateWalletSecretsParams) bool {
 			capturedUpdate = params
@@ -493,7 +652,12 @@ func TestWalletVaultChangePassphraseWatchOnlyRotatesScriptMaterial(
 	t.Cleanup(vault.Lock)
 
 	oldState := vault.unlockedState
-	require.NoError(t, vault.ChangePassphrase(t.Context(), newPassphrase))
+	require.NoError(t, vault.ChangePassphrase(
+		t.Context(), ChangePassphraseParams{
+			PrivateOld: correctPassphrase,
+			PrivateNew: newPassphrase,
+		},
+	))
 	require.Same(t, oldState, vault.unlockedState)
 	require.Equal(
 		t, expected.cryptoKeyScript[:], vault.unlockedState.cryptoKeyScript[:],
@@ -570,7 +734,9 @@ func makeWalletSecrets(t *testing.T, passphrase []byte) (*db.WalletSecrets,
 	require.NoError(t, err)
 
 	seed := []byte("0123456789abcdef0123456789abcdef")
-	hdRootKey, err := hdkeychain.NewMaster(seed, &chaincfg.RegressionNetParams)
+	hdRootKey, err := hdkeychain.NewMaster(
+		seed, &chaincfg.RegressionNetParams,
+	)
 	require.NoError(t, err)
 
 	encryptedPrivateKey, err := masterPrivateKey.Encrypt(privateKey[:])

--- a/wallet/internal/sql/pg/queries/accounts.sql
+++ b/wallet/internal/sql/pg/queries/accounts.sql
@@ -52,6 +52,20 @@ INSERT INTO account_secrets (
     $1, $2
 );
 
+-- name: GetAccountSecret :one
+-- Returns account-level key material for signing. The account row is returned
+-- even when no account_secrets row exists so callers can distinguish a
+-- watch-only account from an absent account.
+SELECT acs.encrypted_private_key
+FROM accounts AS a
+INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
+WHERE
+    a.wallet_id = sqlc.arg('wallet_id')
+    AND ks.purpose = sqlc.arg('purpose')
+    AND ks.coin_type = sqlc.arg('coin_type')
+    AND a.account_number = sqlc.arg('account_number');
+
 -- name: GetAccountByScopeAndName :one
 -- Returns a single account by scope id and account name.
 SELECT

--- a/wallet/internal/sql/pg/queries/addresses.sql
+++ b/wallet/internal/sql/pg/queries/addresses.sql
@@ -94,6 +94,16 @@ SELECT
     s.encrypted_script
 FROM addresses AS a
 LEFT JOIN address_secrets AS s ON a.id = s.address_id
+WHERE a.wallet_id = $1 AND a.script_pub_key = $2;
+
+-- name: GetAddressSecretByID :one
+-- Retrieves secret information for an address using its durable SQL row ID.
+SELECT
+    a.id AS address_id,
+    s.encrypted_priv_key,
+    s.encrypted_script
+FROM addresses AS a
+LEFT JOIN address_secrets AS s ON a.id = s.address_id
 WHERE a.wallet_id = $1 AND a.id = $2;
 
 -- name: CreateDerivedAddress :one

--- a/wallet/internal/sql/pg/sqlc/accounts.sql.go
+++ b/wallet/internal/sql/pg/sqlc/accounts.sql.go
@@ -741,6 +741,40 @@ func (q *Queries) GetAccountPropsByWalletAndId(ctx context.Context, arg GetAccou
 	return i, err
 }
 
+const GetAccountSecret = `-- name: GetAccountSecret :one
+SELECT acs.encrypted_private_key
+FROM accounts AS a
+INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
+WHERE
+    a.wallet_id = $1
+    AND ks.purpose = $2
+    AND ks.coin_type = $3
+    AND a.account_number = $4
+`
+
+type GetAccountSecretParams struct {
+	WalletID      int64
+	Purpose       int64
+	CoinType      int64
+	AccountNumber sql.NullInt64
+}
+
+// Returns account-level key material for signing. The account row is returned
+// even when no account_secrets row exists so callers can distinguish a
+// watch-only account from an absent account.
+func (q *Queries) GetAccountSecret(ctx context.Context, arg GetAccountSecretParams) ([]byte, error) {
+	row := q.queryRow(ctx, q.getAccountSecretStmt, GetAccountSecret,
+		arg.WalletID,
+		arg.Purpose,
+		arg.CoinType,
+		arg.AccountNumber,
+	)
+	var encrypted_private_key []byte
+	err := row.Scan(&encrypted_private_key)
+	return encrypted_private_key, err
+}
+
 const GetAndIncrementNextExternalIndex = `-- name: GetAndIncrementNextExternalIndex :one
 UPDATE accounts
 SET next_external_index = next_external_index + 1

--- a/wallet/internal/sql/pg/sqlc/addresses.sql.go
+++ b/wallet/internal/sql/pg/sqlc/addresses.sql.go
@@ -237,12 +237,12 @@ SELECT
     s.encrypted_script
 FROM addresses AS a
 LEFT JOIN address_secrets AS s ON a.id = s.address_id
-WHERE a.wallet_id = $1 AND a.id = $2
+WHERE a.wallet_id = $1 AND a.script_pub_key = $2
 `
 
 type GetAddressSecretParams struct {
-	WalletID int64
-	ID       int64
+	WalletID     int64
+	ScriptPubKey []byte
 }
 
 type GetAddressSecretRow struct {
@@ -256,8 +256,37 @@ type GetAddressSecretRow struct {
 // - Address exists without secret row: returns row with NULL secret fields
 // - Address does not exist: returns no rows (sql.ErrNoRows)
 func (q *Queries) GetAddressSecret(ctx context.Context, arg GetAddressSecretParams) (GetAddressSecretRow, error) {
-	row := q.queryRow(ctx, q.getAddressSecretStmt, GetAddressSecret, arg.WalletID, arg.ID)
+	row := q.queryRow(ctx, q.getAddressSecretStmt, GetAddressSecret, arg.WalletID, arg.ScriptPubKey)
 	var i GetAddressSecretRow
+	err := row.Scan(&i.AddressID, &i.EncryptedPrivKey, &i.EncryptedScript)
+	return i, err
+}
+
+const GetAddressSecretByID = `-- name: GetAddressSecretByID :one
+SELECT
+    a.id AS address_id,
+    s.encrypted_priv_key,
+    s.encrypted_script
+FROM addresses AS a
+LEFT JOIN address_secrets AS s ON a.id = s.address_id
+WHERE a.wallet_id = $1 AND a.id = $2
+`
+
+type GetAddressSecretByIDParams struct {
+	WalletID int64
+	ID       int64
+}
+
+type GetAddressSecretByIDRow struct {
+	AddressID        int64
+	EncryptedPrivKey []byte
+	EncryptedScript  []byte
+}
+
+// Retrieves secret information for an address using its durable SQL row ID.
+func (q *Queries) GetAddressSecretByID(ctx context.Context, arg GetAddressSecretByIDParams) (GetAddressSecretByIDRow, error) {
+	row := q.queryRow(ctx, q.getAddressSecretByIDStmt, GetAddressSecretByID, arg.WalletID, arg.ID)
+	var i GetAddressSecretByIDRow
 	err := row.Scan(&i.AddressID, &i.EncryptedPrivKey, &i.EncryptedScript)
 	return i, err
 }

--- a/wallet/internal/sql/pg/sqlc/db.go
+++ b/wallet/internal/sql/pg/sqlc/db.go
@@ -108,6 +108,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getAccountPropsByWalletAndIdStmt, err = db.PrepareContext(ctx, GetAccountPropsByWalletAndId); err != nil {
 		return nil, fmt.Errorf("error preparing query GetAccountPropsByWalletAndId: %w", err)
 	}
+	if q.getAccountSecretStmt, err = db.PrepareContext(ctx, GetAccountSecret); err != nil {
+		return nil, fmt.Errorf("error preparing query GetAccountSecret: %w", err)
+	}
 	if q.getActiveUtxoLeaseLockIDStmt, err = db.PrepareContext(ctx, GetActiveUtxoLeaseLockID); err != nil {
 		return nil, fmt.Errorf("error preparing query GetActiveUtxoLeaseLockID: %w", err)
 	}
@@ -446,6 +449,11 @@ func (q *Queries) Close() error {
 	if q.getAccountPropsByWalletAndIdStmt != nil {
 		if cerr := q.getAccountPropsByWalletAndIdStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getAccountPropsByWalletAndIdStmt: %w", cerr)
+		}
+	}
+	if q.getAccountSecretStmt != nil {
+		if cerr := q.getAccountSecretStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getAccountSecretStmt: %w", cerr)
 		}
 	}
 	if q.getActiveUtxoLeaseLockIDStmt != nil {
@@ -840,6 +848,7 @@ type Queries struct {
 	getAccountByWalletScopeAndNumberStmt        *sql.Stmt
 	getAccountPropsByIdStmt                     *sql.Stmt
 	getAccountPropsByWalletAndIdStmt            *sql.Stmt
+	getAccountSecretStmt                        *sql.Stmt
 	getActiveUtxoLeaseLockIDStmt                *sql.Stmt
 	getAddressByScriptPubKeyStmt                *sql.Stmt
 	getAddressSecretStmt                        *sql.Stmt
@@ -939,6 +948,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getAccountByWalletScopeAndNumberStmt:        q.getAccountByWalletScopeAndNumberStmt,
 		getAccountPropsByIdStmt:                     q.getAccountPropsByIdStmt,
 		getAccountPropsByWalletAndIdStmt:            q.getAccountPropsByWalletAndIdStmt,
+		getAccountSecretStmt:                        q.getAccountSecretStmt,
 		getActiveUtxoLeaseLockIDStmt:                q.getActiveUtxoLeaseLockIDStmt,
 		getAddressByScriptPubKeyStmt:                q.getAddressByScriptPubKeyStmt,
 		getAddressSecretStmt:                        q.getAddressSecretStmt,

--- a/wallet/internal/sql/pg/sqlc/db.go
+++ b/wallet/internal/sql/pg/sqlc/db.go
@@ -120,6 +120,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getAddressSecretStmt, err = db.PrepareContext(ctx, GetAddressSecret); err != nil {
 		return nil, fmt.Errorf("error preparing query GetAddressSecret: %w", err)
 	}
+	if q.getAddressSecretByIDStmt, err = db.PrepareContext(ctx, GetAddressSecretByID); err != nil {
+		return nil, fmt.Errorf("error preparing query GetAddressSecretByID: %w", err)
+	}
 	if q.getAddressTypeByIDStmt, err = db.PrepareContext(ctx, GetAddressTypeByID); err != nil {
 		return nil, fmt.Errorf("error preparing query GetAddressTypeByID: %w", err)
 	}
@@ -469,6 +472,11 @@ func (q *Queries) Close() error {
 	if q.getAddressSecretStmt != nil {
 		if cerr := q.getAddressSecretStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getAddressSecretStmt: %w", cerr)
+		}
+	}
+	if q.getAddressSecretByIDStmt != nil {
+		if cerr := q.getAddressSecretByIDStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getAddressSecretByIDStmt: %w", cerr)
 		}
 	}
 	if q.getAddressTypeByIDStmt != nil {
@@ -852,6 +860,7 @@ type Queries struct {
 	getActiveUtxoLeaseLockIDStmt                *sql.Stmt
 	getAddressByScriptPubKeyStmt                *sql.Stmt
 	getAddressSecretStmt                        *sql.Stmt
+	getAddressSecretByIDStmt                    *sql.Stmt
 	getAddressTypeByIDStmt                      *sql.Stmt
 	getAndIncrementNextAccountNumberStmt        *sql.Stmt
 	getAndIncrementNextExternalIndexStmt        *sql.Stmt
@@ -952,6 +961,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getActiveUtxoLeaseLockIDStmt:                q.getActiveUtxoLeaseLockIDStmt,
 		getAddressByScriptPubKeyStmt:                q.getAddressByScriptPubKeyStmt,
 		getAddressSecretStmt:                        q.getAddressSecretStmt,
+		getAddressSecretByIDStmt:                    q.getAddressSecretByIDStmt,
 		getAddressTypeByIDStmt:                      q.getAddressTypeByIDStmt,
 		getAndIncrementNextAccountNumberStmt:        q.getAndIncrementNextAccountNumberStmt,
 		getAndIncrementNextExternalIndexStmt:        q.getAndIncrementNextExternalIndexStmt,

--- a/wallet/internal/sql/pg/sqlc/querier.go
+++ b/wallet/internal/sql/pg/sqlc/querier.go
@@ -174,6 +174,8 @@ type Querier interface {
 	// - Address exists without secret row: returns row with NULL secret fields
 	// - Address does not exist: returns no rows (sql.ErrNoRows)
 	GetAddressSecret(ctx context.Context, arg GetAddressSecretParams) (GetAddressSecretRow, error)
+	// Retrieves secret information for an address using its durable SQL row ID.
+	GetAddressSecretByID(ctx context.Context, arg GetAddressSecretByIDParams) (GetAddressSecretByIDRow, error)
 	// Returns a single address type by its ID.
 	GetAddressTypeByID(ctx context.Context, id int16) (AddressType, error)
 	// Atomically gets the next derived account number for a key scope and

--- a/wallet/internal/sql/pg/sqlc/querier.go
+++ b/wallet/internal/sql/pg/sqlc/querier.go
@@ -155,6 +155,10 @@ type Querier interface {
 	GetAccountPropsById(ctx context.Context, id int64) (GetAccountPropsByIdRow, error)
 	// Returns full account properties by wallet id and account id.
 	GetAccountPropsByWalletAndId(ctx context.Context, arg GetAccountPropsByWalletAndIdParams) (GetAccountPropsByWalletAndIdRow, error)
+	// Returns account-level key material for signing. The account row is returned
+	// even when no account_secrets row exists so callers can distinguish a
+	// watch-only account from an absent account.
+	GetAccountSecret(ctx context.Context, arg GetAccountSecretParams) ([]byte, error)
 	// Returns the lock ID for the current active lease on a UTXO ID.
 	//
 	// How:

--- a/wallet/internal/sql/sqlite/queries/accounts.sql
+++ b/wallet/internal/sql/sqlite/queries/accounts.sql
@@ -52,6 +52,20 @@ INSERT INTO account_secrets (
     ?, ?
 );
 
+-- name: GetAccountSecret :one
+-- Returns account-level key material for signing. The account row is returned
+-- even when no account_secrets row exists so callers can distinguish a
+-- watch-only account from an absent account.
+SELECT acs.encrypted_private_key
+FROM accounts AS a
+INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
+WHERE
+    a.wallet_id = sqlc.arg('wallet_id')
+    AND ks.purpose = sqlc.arg('purpose')
+    AND ks.coin_type = sqlc.arg('coin_type')
+    AND a.account_number = sqlc.arg('account_number');
+
 -- name: GetAccountByScopeAndName :one
 -- Returns a single account by scope id and account name.
 SELECT

--- a/wallet/internal/sql/sqlite/queries/addresses.sql
+++ b/wallet/internal/sql/sqlite/queries/addresses.sql
@@ -98,6 +98,16 @@ SELECT
     s.encrypted_script
 FROM addresses AS a
 LEFT JOIN address_secrets AS s ON a.id = s.address_id
+WHERE a.wallet_id = ? AND a.script_pub_key = ?;
+
+-- name: GetAddressSecretByID :one
+-- Retrieves secret information for an address using its durable SQL row ID.
+SELECT
+    a.id AS address_id,
+    s.encrypted_priv_key,
+    s.encrypted_script
+FROM addresses AS a
+LEFT JOIN address_secrets AS s ON a.id = s.address_id
 WHERE a.wallet_id = ? AND a.id = ?;
 
 -- name: CreateDerivedAddress :one

--- a/wallet/internal/sql/sqlite/sqlc/accounts.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/accounts.sql.go
@@ -748,6 +748,40 @@ func (q *Queries) GetAccountPropsByWalletAndId(ctx context.Context, arg GetAccou
 	return i, err
 }
 
+const GetAccountSecret = `-- name: GetAccountSecret :one
+SELECT acs.encrypted_private_key
+FROM accounts AS a
+INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
+LEFT JOIN account_secrets AS acs ON a.id = acs.account_id
+WHERE
+    a.wallet_id = ?1
+    AND ks.purpose = ?2
+    AND ks.coin_type = ?3
+    AND a.account_number = ?4
+`
+
+type GetAccountSecretParams struct {
+	WalletID      int64
+	Purpose       int64
+	CoinType      int64
+	AccountNumber sql.NullInt64
+}
+
+// Returns account-level key material for signing. The account row is returned
+// even when no account_secrets row exists so callers can distinguish a
+// watch-only account from an absent account.
+func (q *Queries) GetAccountSecret(ctx context.Context, arg GetAccountSecretParams) ([]byte, error) {
+	row := q.queryRow(ctx, q.getAccountSecretStmt, GetAccountSecret,
+		arg.WalletID,
+		arg.Purpose,
+		arg.CoinType,
+		arg.AccountNumber,
+	)
+	var encrypted_private_key []byte
+	err := row.Scan(&encrypted_private_key)
+	return encrypted_private_key, err
+}
+
 const GetAndIncrementNextExternalIndex = `-- name: GetAndIncrementNextExternalIndex :one
 UPDATE accounts
 SET next_external_index = next_external_index + 1

--- a/wallet/internal/sql/sqlite/sqlc/addresses.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/addresses.sql.go
@@ -238,12 +238,12 @@ SELECT
     s.encrypted_script
 FROM addresses AS a
 LEFT JOIN address_secrets AS s ON a.id = s.address_id
-WHERE a.wallet_id = ? AND a.id = ?
+WHERE a.wallet_id = ? AND a.script_pub_key = ?
 `
 
 type GetAddressSecretParams struct {
-	WalletID int64
-	ID       int64
+	WalletID     int64
+	ScriptPubKey []byte
 }
 
 type GetAddressSecretRow struct {
@@ -257,8 +257,37 @@ type GetAddressSecretRow struct {
 // - Address exists without secret row: returns row with NULL secret fields
 // - Address does not exist: returns no rows (sql.ErrNoRows)
 func (q *Queries) GetAddressSecret(ctx context.Context, arg GetAddressSecretParams) (GetAddressSecretRow, error) {
-	row := q.queryRow(ctx, q.getAddressSecretStmt, GetAddressSecret, arg.WalletID, arg.ID)
+	row := q.queryRow(ctx, q.getAddressSecretStmt, GetAddressSecret, arg.WalletID, arg.ScriptPubKey)
 	var i GetAddressSecretRow
+	err := row.Scan(&i.AddressID, &i.EncryptedPrivKey, &i.EncryptedScript)
+	return i, err
+}
+
+const GetAddressSecretByID = `-- name: GetAddressSecretByID :one
+SELECT
+    a.id AS address_id,
+    s.encrypted_priv_key,
+    s.encrypted_script
+FROM addresses AS a
+LEFT JOIN address_secrets AS s ON a.id = s.address_id
+WHERE a.wallet_id = ? AND a.id = ?
+`
+
+type GetAddressSecretByIDParams struct {
+	WalletID int64
+	ID       int64
+}
+
+type GetAddressSecretByIDRow struct {
+	AddressID        int64
+	EncryptedPrivKey []byte
+	EncryptedScript  []byte
+}
+
+// Retrieves secret information for an address using its durable SQL row ID.
+func (q *Queries) GetAddressSecretByID(ctx context.Context, arg GetAddressSecretByIDParams) (GetAddressSecretByIDRow, error) {
+	row := q.queryRow(ctx, q.getAddressSecretByIDStmt, GetAddressSecretByID, arg.WalletID, arg.ID)
+	var i GetAddressSecretByIDRow
 	err := row.Scan(&i.AddressID, &i.EncryptedPrivKey, &i.EncryptedScript)
 	return i, err
 }

--- a/wallet/internal/sql/sqlite/sqlc/db.go
+++ b/wallet/internal/sql/sqlite/sqlc/db.go
@@ -108,6 +108,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getAccountPropsByWalletAndIdStmt, err = db.PrepareContext(ctx, GetAccountPropsByWalletAndId); err != nil {
 		return nil, fmt.Errorf("error preparing query GetAccountPropsByWalletAndId: %w", err)
 	}
+	if q.getAccountSecretStmt, err = db.PrepareContext(ctx, GetAccountSecret); err != nil {
+		return nil, fmt.Errorf("error preparing query GetAccountSecret: %w", err)
+	}
 	if q.getActiveUtxoLeaseLockIDStmt, err = db.PrepareContext(ctx, GetActiveUtxoLeaseLockID); err != nil {
 		return nil, fmt.Errorf("error preparing query GetActiveUtxoLeaseLockID: %w", err)
 	}
@@ -446,6 +449,11 @@ func (q *Queries) Close() error {
 	if q.getAccountPropsByWalletAndIdStmt != nil {
 		if cerr := q.getAccountPropsByWalletAndIdStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getAccountPropsByWalletAndIdStmt: %w", cerr)
+		}
+	}
+	if q.getAccountSecretStmt != nil {
+		if cerr := q.getAccountSecretStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getAccountSecretStmt: %w", cerr)
 		}
 	}
 	if q.getActiveUtxoLeaseLockIDStmt != nil {
@@ -840,6 +848,7 @@ type Queries struct {
 	getAccountByWalletScopeAndNumberStmt        *sql.Stmt
 	getAccountPropsByIdStmt                     *sql.Stmt
 	getAccountPropsByWalletAndIdStmt            *sql.Stmt
+	getAccountSecretStmt                        *sql.Stmt
 	getActiveUtxoLeaseLockIDStmt                *sql.Stmt
 	getAddressByScriptPubKeyStmt                *sql.Stmt
 	getAddressSecretStmt                        *sql.Stmt
@@ -939,6 +948,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getAccountByWalletScopeAndNumberStmt:        q.getAccountByWalletScopeAndNumberStmt,
 		getAccountPropsByIdStmt:                     q.getAccountPropsByIdStmt,
 		getAccountPropsByWalletAndIdStmt:            q.getAccountPropsByWalletAndIdStmt,
+		getAccountSecretStmt:                        q.getAccountSecretStmt,
 		getActiveUtxoLeaseLockIDStmt:                q.getActiveUtxoLeaseLockIDStmt,
 		getAddressByScriptPubKeyStmt:                q.getAddressByScriptPubKeyStmt,
 		getAddressSecretStmt:                        q.getAddressSecretStmt,

--- a/wallet/internal/sql/sqlite/sqlc/db.go
+++ b/wallet/internal/sql/sqlite/sqlc/db.go
@@ -120,6 +120,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getAddressSecretStmt, err = db.PrepareContext(ctx, GetAddressSecret); err != nil {
 		return nil, fmt.Errorf("error preparing query GetAddressSecret: %w", err)
 	}
+	if q.getAddressSecretByIDStmt, err = db.PrepareContext(ctx, GetAddressSecretByID); err != nil {
+		return nil, fmt.Errorf("error preparing query GetAddressSecretByID: %w", err)
+	}
 	if q.getAddressTypeByIDStmt, err = db.PrepareContext(ctx, GetAddressTypeByID); err != nil {
 		return nil, fmt.Errorf("error preparing query GetAddressTypeByID: %w", err)
 	}
@@ -469,6 +472,11 @@ func (q *Queries) Close() error {
 	if q.getAddressSecretStmt != nil {
 		if cerr := q.getAddressSecretStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getAddressSecretStmt: %w", cerr)
+		}
+	}
+	if q.getAddressSecretByIDStmt != nil {
+		if cerr := q.getAddressSecretByIDStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getAddressSecretByIDStmt: %w", cerr)
 		}
 	}
 	if q.getAddressTypeByIDStmt != nil {
@@ -852,6 +860,7 @@ type Queries struct {
 	getActiveUtxoLeaseLockIDStmt                *sql.Stmt
 	getAddressByScriptPubKeyStmt                *sql.Stmt
 	getAddressSecretStmt                        *sql.Stmt
+	getAddressSecretByIDStmt                    *sql.Stmt
 	getAddressTypeByIDStmt                      *sql.Stmt
 	getAndIncrementNextAccountNumberStmt        *sql.Stmt
 	getAndIncrementNextExternalIndexStmt        *sql.Stmt
@@ -952,6 +961,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getActiveUtxoLeaseLockIDStmt:                q.getActiveUtxoLeaseLockIDStmt,
 		getAddressByScriptPubKeyStmt:                q.getAddressByScriptPubKeyStmt,
 		getAddressSecretStmt:                        q.getAddressSecretStmt,
+		getAddressSecretByIDStmt:                    q.getAddressSecretByIDStmt,
 		getAddressTypeByIDStmt:                      q.getAddressTypeByIDStmt,
 		getAndIncrementNextAccountNumberStmt:        q.getAndIncrementNextAccountNumberStmt,
 		getAndIncrementNextExternalIndexStmt:        q.getAndIncrementNextExternalIndexStmt,

--- a/wallet/internal/sql/sqlite/sqlc/querier.go
+++ b/wallet/internal/sql/sqlite/sqlc/querier.go
@@ -171,6 +171,8 @@ type Querier interface {
 	// - Address exists without secret row: returns row with NULL secret fields
 	// - Address does not exist: returns no rows (sql.ErrNoRows)
 	GetAddressSecret(ctx context.Context, arg GetAddressSecretParams) (GetAddressSecretRow, error)
+	// Retrieves secret information for an address using its durable SQL row ID.
+	GetAddressSecretByID(ctx context.Context, arg GetAddressSecretByIDParams) (GetAddressSecretByIDRow, error)
 	// Returns a single address type by its ID.
 	GetAddressTypeByID(ctx context.Context, id int64) (AddressType, error)
 	// Atomically gets the next derived account number for a key scope and

--- a/wallet/internal/sql/sqlite/sqlc/querier.go
+++ b/wallet/internal/sql/sqlite/sqlc/querier.go
@@ -152,6 +152,10 @@ type Querier interface {
 	GetAccountPropsById(ctx context.Context, id int64) (GetAccountPropsByIdRow, error)
 	// Returns full account properties by wallet id and account id.
 	GetAccountPropsByWalletAndId(ctx context.Context, arg GetAccountPropsByWalletAndIdParams) (GetAccountPropsByWalletAndIdRow, error)
+	// Returns account-level key material for signing. The account row is returned
+	// even when no account_secrets row exists so callers can distinguish a
+	// watch-only account from an absent account.
+	GetAccountSecret(ctx context.Context, arg GetAccountSecretParams) ([]byte, error)
 	// Returns the lock ID for the current active lease on a UTXO ID.
 	//
 	// How:

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -12,7 +12,6 @@ import (
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	kvdb "github.com/btcsuite/btcwallet/wallet/internal/db/kvdb"
-	"github.com/btcsuite/btcwallet/wallet/internal/keyvault"
 )
 
 var (
@@ -345,9 +344,11 @@ func (m *Manager) Load(cfg Config) (*Wallet, error) {
 		addrStore: addrMgr,
 		store:     store,
 		cache:     newStoreRuntimeCache(store),
-		keyVault: keyvault.NewWalletVault(
-			store, walletID, addrMgr.WatchOnly(),
-		),
+
+		// TODO(yy): This constructor is the deprecated kvdb path. SQL
+		// Manager backends supply their vault during backend assembly;
+		// remove this assignment with kvdb support.
+		keyVault:          kvdb.NewLegacyWalletVault(cfg.DB, addrMgr),
 		txStore:           txMgr,
 		requestChan:       make(chan any),
 		lifetimeCtx:       lifetimeCtx,

--- a/wallet/psbt_manager.go
+++ b/wallet/psbt_manager.go
@@ -1052,9 +1052,16 @@ func (w *Wallet) parseBip32Path(path []uint32) (BIP32Path, error) {
 	bip32Path := BIP32Path{
 		KeyScope: scope,
 		DerivationPath: waddrmgr.DerivationPath{
-			Account: account,
-			Branch:  branch,
-			Index:   index,
+			// InternalAccount is the wallet's database account
+			// number that both the legacy DeriveFromKeyPath and
+			// the SQL account-secret lookup key on. Leaving it
+			// unset always resolves account 0, so a PSBT for a
+			// non-zero account would otherwise sign with the wrong
+			// key or fail to find one.
+			InternalAccount: account,
+			Account:         account,
+			Branch:          branch,
+			Index:           index,
 		},
 	}
 
@@ -1124,16 +1131,12 @@ func shouldSkipSigningError(err error, idx int) bool {
 	}
 
 	// In a collaborative PSBT workflow, the transaction may contain inputs
-	// that belong to other parties. Even if a derivation path is present
-	// and valid (e.g. BIP-84), it might correspond to a different signer's
-	// key (same path, different seed).
-	//
-	// If we encounter `errComputeRawSig`, it means we failed to produce a
-	// signature. This usually happens because we don't have the private
-	// key for the derived address (it's someone else's input). In this
-	// case, we skip the input and log a debug message, allowing us to
-	// proceed and sign the inputs that we DO own.
-	if errors.Is(err, errComputeRawSig) {
+	// that belong to other parties. Skip only explicit ownership failures;
+	// operational Store, vault, tweaking and signing errors must reach the
+	// caller.
+	missingSigningKey := errors.Is(err, ErrAccountNotInStore) ||
+		errors.Is(err, ErrWatchOnlyAccount)
+	if errors.Is(err, errComputeRawSig) && missingSigningKey {
 		log.Debugf("Skipping input %d: %v", idx, err)
 		return true
 	}
@@ -2287,9 +2290,10 @@ func addInputInfoSegWitV1(in *psbt.PInput, utxo *wire.TxOut,
 func createOutputInfoFromAddressInfo(txOut *wire.TxOut,
 	addr AddressInfo) (*psbt.POutput, error) {
 
-	// We don't know the derivation path for imported keys. Those shouldn't
-	// be selected as change outputs in the first place, but just to make
-	// sure we don't run into an issue, we return early for imported keys.
+	// We don't know the public derivation path for imported keys. Those
+	// shouldn't be selected as change outputs in the first place, but just
+	// to make sure we don't run into an issue, we return early for imported
+	// keys.
 	if addr.Derivation == nil || addr.PubKey == nil {
 		return nil, fmt.Errorf("error adding output info to PSBT: %w",
 			ErrImportedAddrNoDerivation)
@@ -2302,7 +2306,8 @@ func createOutputInfoFromAddressInfo(txOut *wire.TxOut,
 		Bip32Path: []uint32{
 			addr.Derivation.KeyScope.Purpose + hdkeychain.HardenedKeyStart,
 			addr.Derivation.KeyScope.Coin + hdkeychain.HardenedKeyStart,
-			addr.Derivation.Account + hdkeychain.HardenedKeyStart,
+			addr.Derivation.Account +
+				hdkeychain.HardenedKeyStart,
 			addr.Derivation.Branch,
 			addr.Derivation.Index,
 		},

--- a/wallet/psbt_manager_test.go
+++ b/wallet/psbt_manager_test.go
@@ -6,6 +6,7 @@ package wallet
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"slices"
@@ -31,7 +32,6 @@ import (
 
 var (
 	errDb           = errors.New("db error")
-	errKeyNotFound  = errors.New("key not found")
 	errAddrNotFound = errors.New("addr not found")
 )
 
@@ -1562,9 +1562,10 @@ func TestParseBip32Path(t *testing.T) {
 			wantPath: BIP32Path{
 				KeyScope: waddrmgr.KeyScopeBIP0044,
 				DerivationPath: waddrmgr.DerivationPath{
-					Account: 0,
-					Branch:  0,
-					Index:   0,
+					InternalAccount: 0,
+					Account:         0,
+					Branch:          0,
+					Index:           0,
 				},
 			},
 		},
@@ -1576,9 +1577,10 @@ func TestParseBip32Path(t *testing.T) {
 			wantPath: BIP32Path{
 				KeyScope: waddrmgr.KeyScopeBIP0084,
 				DerivationPath: waddrmgr.DerivationPath{
-					Account: 1,
-					Branch:  0,
-					Index:   5,
+					InternalAccount: 1,
+					Account:         1,
+					Branch:          0,
+					Index:           5,
 				},
 			},
 		},
@@ -1625,9 +1627,10 @@ func TestParseBip32Path(t *testing.T) {
 					Purpose: 999, Coin: 0,
 				},
 				DerivationPath: waddrmgr.DerivationPath{
-					Account: 0,
-					Branch:  0,
-					Index:   0,
+					InternalAccount: 0,
+					Account:         0,
+					Branch:          0,
+					Index:           0,
 				},
 			},
 			expectedErr: nil,
@@ -1790,9 +1793,35 @@ func TestShouldSkipSigningError(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "compute raw sig error should be skipped",
-			err:      fmt.Errorf("wrapped: %w", errComputeRawSig),
+			name: "missing account should be skipped",
+			err: fmt.Errorf(
+				"%w: %w", errComputeRawSig,
+				ErrAccountNotInStore,
+			),
 			expected: true,
+		},
+		{
+			name: "watch only account should be skipped",
+			err: fmt.Errorf(
+				"%w: %w", errComputeRawSig,
+				ErrWatchOnlyAccount,
+			),
+			expected: true,
+		},
+		{
+			name: "store error should not be skipped",
+			err: fmt.Errorf(
+				"%w: %w", errComputeRawSig, errDb,
+			),
+			expected: false,
+		},
+		{
+			name: "cancellation should not be skipped",
+			err: fmt.Errorf(
+				"%w: %w", errComputeRawSig,
+				context.Canceled,
+			),
+			expected: false,
 		},
 		{
 			name: "unknown BIP32 purpose error should be " +
@@ -2620,18 +2649,16 @@ func TestSignTaprootPsbtInput(t *testing.T) {
 
 	w, mocks := createUnlockedWalletWithMocks(t)
 
-	// Arrange: Mock address lookup flow.
-	// 1. FetchScopedKeyManager
-	mocks.addrStore.On("FetchScopedKeyManager", mock.Anything).
-		Return(mocks.accountManager, nil)
-
-	// 2. DeriveFromKeyPath (called inside walletdb.View)
-	mocks.accountManager.On(
-		"DeriveFromKeyPath", mock.Anything, mock.Anything,
-	).Return(mocks.pubKeyAddr, nil)
-
-	// 3. Address/PrivKey from ManagedAddress
-	mocks.pubKeyAddr.On("PrivKey").Return(privKey, nil)
+	// Arrange: Program the store-routed signer key lookup for the BIP-86
+	// path (purpose 86, coin type 1 for RegressionNet, account 0, branch 0,
+	// index 0). The key-path signature is not validated against a specific
+	// key here, so the derived leaf keys are discarded.
+	_, _ = expectStoreSignerPrivKey(
+		t, mocks, w.id, waddrmgr.KeyScope{Purpose: 86, Coin: 1},
+		waddrmgr.DerivationPath{
+			InternalAccount: 0, Branch: 0, Index: 0,
+		},
+	)
 
 	// Act: Call signTaprootPsbtInput to sign the input using the mocked
 	// wallet and keys.
@@ -2702,13 +2729,16 @@ func TestSignBip32PsbtInput(t *testing.T) {
 
 	w, mocks := createUnlockedWalletWithMocks(t)
 
-	// Arrange: Mock address lookup flow.
-	mocks.addrStore.On("FetchScopedKeyManager", mock.Anything).
-		Return(mocks.accountManager, nil)
-	mocks.accountManager.On(
-		"DeriveFromKeyPath", mock.Anything, mock.Anything,
-	).Return(mocks.pubKeyAddr, nil)
-	mocks.pubKeyAddr.On("PrivKey").Return(privKey, nil)
+	// Arrange: Program the store-routed signer key lookup for the BIP-84
+	// path (purpose 84, coin type 1 for RegressionNet, account 0, branch 0,
+	// index 0). The resulting PartialSig echoes the derivation entry's
+	// public key, so the derived leaf keys are discarded.
+	_, _ = expectStoreSignerPrivKey(
+		t, mocks, w.id, waddrmgr.KeyScope{Purpose: 84, Coin: 1},
+		waddrmgr.DerivationPath{
+			InternalAccount: 0, Branch: 0, Index: 0,
+		},
+	)
 
 	// Act: Call signBip32PsbtInput to sign the input using the mocked
 	// wallet and keys.
@@ -2748,77 +2778,97 @@ func TestSignPsbtFailNilParams(t *testing.T) {
 func TestSignPsbt(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Setup keys.
-	privKey, err := btcec.NewPrivateKey()
-	require.NoError(t, err)
-
-	pubKey := privKey.PubKey()
-	pubKeyBytes := pubKey.SerializeCompressed()
-
-	// Arrange: Define the BIP32 derivation path for the input key
-	// (RegressionNet, P2WKH).
-	derivationPath := []uint32{
-		hdkeychain.HardenedKeyStart + 84,
-		// CoinType 1 (RegressionNet)
-		hdkeychain.HardenedKeyStart + 1,
-		hdkeychain.HardenedKeyStart + 0,
-		0, 0,
-	}
-	derivation := &psbt.Bip32Derivation{
-		PubKey:    pubKeyBytes,
-		Bip32Path: derivationPath,
+	// The store account-secret lookup keys on InternalAccount, so a path
+	// that leaves it unset would silently resolve account 0 and sign with
+	// the wrong key. Both the default and a non-zero account are exercised.
+	tests := []struct {
+		name    string
+		account uint32
+	}{
+		{name: "default account", account: 0},
+		{name: "non-zero account", account: 2},
 	}
 
-	// Arrange: Create a P2WKH UTXO that corresponds to the derivation path,
-	// representing the input to be signed.
-	p2wkhAddr, err := address.NewAddressWitnessPubKeyHash(
-		address.Hash160(pubKeyBytes), &chainParams,
-	)
-	require.NoError(t, err)
-	p2wkhScript, err := txscript.PayToAddrScript(p2wkhAddr)
-	require.NoError(t, err)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 
-	utxo := &wire.TxOut{
-		Value:    1000,
-		PkScript: p2wkhScript,
+			// Arrange: Setup keys.
+			privKey, err := btcec.NewPrivateKey()
+			require.NoError(t, err)
+
+			pubKey := privKey.PubKey()
+			pubKeyBytes := pubKey.SerializeCompressed()
+
+			// Arrange: Define the BIP32 derivation path for the
+			// input key (RegressionNet, P2WKH, coin type 1).
+			derivationPath := []uint32{
+				hdkeychain.HardenedKeyStart + 84,
+				hdkeychain.HardenedKeyStart + 1,
+				hdkeychain.HardenedKeyStart + test.account,
+				0, 0,
+			}
+			derivation := &psbt.Bip32Derivation{
+				PubKey:    pubKeyBytes,
+				Bip32Path: derivationPath,
+			}
+
+			// Arrange: Create a P2WKH UTXO matching that path.
+			p2wkhAddr, err := address.NewAddressWitnessPubKeyHash(
+				address.Hash160(pubKeyBytes), &chainParams,
+			)
+			require.NoError(t, err)
+			p2wkhScript, err := txscript.PayToAddrScript(p2wkhAddr)
+			require.NoError(t, err)
+
+			utxo := &wire.TxOut{
+				Value:    1000,
+				PkScript: p2wkhScript,
+			}
+
+			// Arrange: Create the PSBT packet to be signed.
+			tx := wire.NewMsgTx(2)
+			tx.AddTxIn(&wire.TxIn{})
+			tx.AddTxOut(&wire.TxOut{
+				Value: 1000, PkScript: []byte{},
+			})
+			packet, err := psbt.NewFromUnsignedTx(tx)
+			require.NoError(t, err)
+
+			packet.Inputs[0].WitnessUtxo = utxo
+			packet.Inputs[0].Bip32Derivation =
+				[]*psbt.Bip32Derivation{derivation}
+			packet.Inputs[0].SighashType = txscript.SigHashAll
+
+			signParams := &SignPsbtParams{Packet: packet}
+			w, mocks := createUnlockedWalletWithMocks(t)
+
+			// Arrange: Program the store-routed signer key lookup
+			// for the resolved account. The derived leaf keys are
+			// discarded because the PartialSig echoes the
+			// derivation entry's public key.
+			_, _ = expectStoreSignerPrivKey(
+				t, mocks, w.id,
+				waddrmgr.KeyScope{Purpose: 84, Coin: 1},
+				waddrmgr.DerivationPath{
+					InternalAccount: test.account,
+					Branch:          0,
+					Index:           0,
+				},
+			)
+
+			// Act: Call SignPsbt on the packet.
+			result, err := w.SignPsbt(t.Context(), signParams)
+
+			// Assert: the input is reported signed and the packet
+			// carries the generated signature.
+			require.NoError(t, err)
+			require.Len(t, result.SignedInputs, 1)
+			require.Equal(t, uint32(0), result.SignedInputs[0])
+			require.Len(t, packet.Inputs[0].PartialSigs, 1)
+			mocks.store.AssertExpectations(t)
+		})
 	}
-
-	// Arrange: Create a PSBT packet containing the transaction to be
-	// signed.
-	tx := wire.NewMsgTx(2)
-	tx.AddTxIn(&wire.TxIn{})
-	tx.AddTxOut(&wire.TxOut{Value: 1000, PkScript: []byte{}})
-	packet, err := psbt.NewFromUnsignedTx(tx)
-	require.NoError(t, err)
-
-	packet.Inputs[0].WitnessUtxo = utxo
-	packet.Inputs[0].Bip32Derivation = []*psbt.Bip32Derivation{derivation}
-	packet.Inputs[0].SighashType = txscript.SigHashAll
-
-	signParams := &SignPsbtParams{Packet: packet}
-	// Arrange: Wrap the packet in SignPsbtParams.
-	w, mocks := createUnlockedWalletWithMocks(t)
-
-	// Arrange: Configure mock expectations for key derivation and private
-	// key retrieval.
-	mocks.addrStore.On("FetchScopedKeyManager", mock.Anything).
-		Return(mocks.accountManager, nil)
-	mocks.accountManager.On(
-		"DeriveFromKeyPath", mock.Anything, mock.Anything,
-	).Return(mocks.pubKeyAddr, nil)
-	mocks.pubKeyAddr.On("PrivKey").Return(privKey, nil)
-
-	// Act: Call SignPsbt to perform the full signing workflow on the
-	// packet.
-	result, err := w.SignPsbt(t.Context(), signParams)
-
-	// Assert: Verify that the operation succeeded, the input is reported as
-	// signed, and the underlying PSBT packet contains the generated
-	// signature.
-	require.NoError(t, err)
-	require.Len(t, result.SignedInputs, 1)
-	require.Equal(t, uint32(0), result.SignedInputs[0])
-	require.Len(t, packet.Inputs[0].PartialSigs, 1)
 }
 
 // TestSignPsbtInputsNotReady tests that SignPsbt fails if inputs are not ready
@@ -2874,56 +2924,106 @@ func TestSignPsbtInvalidDerivationPath(t *testing.T) {
 	require.ErrorIs(t, err, ErrInvalidBip32Path)
 }
 
-// TestSignPsbtSignErrorSkippable tests that SignPsbt skips an input if
-// signing fails with a skippable error (e.g. key not found).
-func TestSignPsbtSignErrorSkippable(t *testing.T) {
+// TestSignPsbtClassifiesSignError tests that SignPsbt skips explicit ownership
+// failures while returning cancellation and operational Store errors.
+func TestSignPsbtClassifiesSignError(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Packet with valid input.
-	tx := wire.NewMsgTx(2)
-	tx.AddTxIn(&wire.TxIn{})
-	tx.AddTxOut(&wire.TxOut{Value: 1000, PkScript: []byte{}})
-	packet, err := psbt.NewFromUnsignedTx(tx)
-	require.NoError(t, err)
-
-	p2wkhScript, _ := txscript.PayToAddrScript(
-		&address.AddressWitnessPubKeyHash{},
-	) // Dummy script
-	packet.Inputs[0].WitnessUtxo = &wire.TxOut{
-		Value:    1000,
-		PkScript: p2wkhScript,
-	}
-	// Valid path.
-	packet.Inputs[0].Bip32Derivation = []*psbt.Bip32Derivation{{
-		Bip32Path: []uint32{
-			hdkeychain.HardenedKeyStart + 84,
-			hdkeychain.HardenedKeyStart + 1,
-			hdkeychain.HardenedKeyStart + 0,
-			0, 0,
+	tests := []struct {
+		name      string
+		storeErr  error
+		wantError error
+		cancel    bool
+	}{
+		{
+			name:     "missing account skips input",
+			storeErr: db.ErrAccountNotFound,
 		},
-		PubKey: make([]byte, 33),
-	}}
-	packet.Inputs[0].SighashType = txscript.SigHashAll
+		{
+			name:      "canceled context returns error",
+			storeErr:  context.Canceled,
+			wantError: context.Canceled,
+			cancel:    true,
+		},
+		{
+			name:      "store failure returns error",
+			storeErr:  errDb,
+			wantError: errDb,
+		},
+	}
 
-	signParams := &SignPsbtParams{Packet: packet}
-	w, mocks := createUnlockedWalletWithMocks(t)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	// Arrange: Mocks to simulate signing failure.
-	mocks.addrStore.On("FetchScopedKeyManager", mock.Anything).
-		Return(mocks.accountManager, nil)
-	mocks.accountManager.On(
-		"DeriveFromKeyPath", mock.Anything, mock.Anything,
-	).Return(mocks.pubKeyAddr, nil)
+			// Arrange: Build a packet with one input and a valid BIP-84
+			// derivation path.
+			tx := wire.NewMsgTx(2)
+			tx.AddTxIn(&wire.TxIn{})
+			tx.AddTxOut(&wire.TxOut{
+				Value: 1000, PkScript: []byte{},
+			})
+			packet, err := psbt.NewFromUnsignedTx(tx)
+			require.NoError(t, err)
 
-	// PrivKey returns error!
-	mocks.pubKeyAddr.On("PrivKey").Return(nil, errKeyNotFound)
+			p2wkhScript, err := txscript.PayToAddrScript(
+				&address.AddressWitnessPubKeyHash{},
+			)
+			require.NoError(t, err)
 
-	// Act.
-	result, err := w.SignPsbt(t.Context(), signParams)
+			packet.Inputs[0].WitnessUtxo = &wire.TxOut{
+				Value:    1000,
+				PkScript: p2wkhScript,
+			}
+			packet.Inputs[0].Bip32Derivation =
+				[]*psbt.Bip32Derivation{{
+					Bip32Path: []uint32{
+						hdkeychain.HardenedKeyStart + 84,
+						hdkeychain.HardenedKeyStart + 1,
+						hdkeychain.HardenedKeyStart + 0,
+						0, 0,
+					},
+					PubKey: make([]byte, 33),
+				}}
+			packet.Inputs[0].SighashType = txscript.SigHashAll
 
-	// Assert: No error, but nothing signed.
-	require.NoError(t, err)
-	require.Empty(t, result.SignedInputs)
+			w, mocks := createUnlockedWalletWithMocks(t)
+			mocks.store.On(
+				"GetAccountSecret", mock.Anything,
+				db.GetAccountSecretQuery{
+					WalletID: w.id,
+					Scope: db.KeyScope{
+						Purpose: 84, Coin: 1,
+					},
+					AccountNumber: 0,
+				},
+			).Return(
+				(*db.AccountSecret)(nil), tc.storeErr,
+			).Once()
+
+			ctx := t.Context()
+			if tc.cancel {
+				var cancel context.CancelFunc
+
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
+
+			// Act.
+			result, err := w.SignPsbt(
+				ctx, &SignPsbtParams{Packet: packet},
+			)
+
+			// Assert: Only explicit ownership failures are skipped.
+			if tc.wantError != nil {
+				require.ErrorIs(t, err, tc.wantError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Empty(t, result.SignedInputs)
+		})
+	}
 }
 
 // TestSignTaprootPsbtInputErrors tests various error conditions in
@@ -3074,21 +3174,27 @@ func TestAddScriptToPInput(t *testing.T) {
 func TestFinalizeInput(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Setup keys.
-	privKey, err := btcec.NewPrivateKey()
-	require.NoError(t, err)
-
-	pubKey := privKey.PubKey()
-
-	p2wkhAddr, err := address.NewAddressWitnessPubKeyHash(
-		address.Hash160(pubKey.SerializeCompressed()), &chainParams,
-	)
-	require.NoError(t, err)
-	p2wkhScript, err := txscript.PayToAddrScript(p2wkhAddr)
-	require.NoError(t, err)
-
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
+
+		w, mocks := createUnlockedWalletWithMocks(t)
+
+		// The signing key is resolved through the store account secret;
+		// take the leaf public key to build the input address.
+		scope := waddrmgr.KeyScopeBIP0084
+		path := waddrmgr.DerivationPath{}
+		_, pubKey := expectStoreSignerPrivKey(
+			t, mocks, w.id, scope, path,
+		)
+
+		p2wkhAddr, err := address.NewAddressWitnessPubKeyHash(
+			address.Hash160(pubKey.SerializeCompressed()),
+			&chainParams,
+		)
+		require.NoError(t, err)
+		p2wkhScript, err := txscript.PayToAddrScript(p2wkhAddr)
+		require.NoError(t, err)
+
 		// Arrange: Valid PSBT input.
 		tx := wire.NewMsgTx(2)
 		tx.AddTxIn(&wire.TxIn{})
@@ -3101,17 +3207,11 @@ func TestFinalizeInput(t *testing.T) {
 		}
 		packet.Inputs[0].SighashType = txscript.SigHashAll
 
-		w, mocks := createUnlockedWalletWithMocks(t)
-
-		// Arrange: Mock dependencies.
-		expectSignerAddressInfo(
-			t, w, mocks, p2wkhAddr, db.WitnessPubKey, false, false, pubKey,
-		)
-		mocks.addrStore.On("Address", mock.Anything, mock.Anything).
-			Return(mocks.pubKeyAddr, nil).Once()
-		expectDerivedSignerPrivKey(
-			t, mocks, waddrmgr.KeyScopeBIP0084,
-			waddrmgr.DerivationPath{}, privKey,
+		// Arrange: Mock dependencies with a usable derivation scope so
+		// signing routes through the store account secret.
+		expectSignerAddressInfoWithKeyScope(
+			t, w, mocks, p2wkhAddr, db.WitnessPubKey, false, false,
+			pubKey, scope,
 		)
 
 		sigHashes := txscript.NewTxSigHashes(
@@ -3194,44 +3294,23 @@ func TestFinalizeInput(t *testing.T) {
 func TestFinalizePsbtSuccess(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Setup keys.
-	privKey, err := btcec.NewPrivateKey()
-	require.NoError(t, err)
-
-	pubKey := privKey.PubKey()
-
-	// Arrange: Create addresses/scripts.
-	p2wkhAddr, err := address.NewAddressWitnessPubKeyHash(
-		address.Hash160(pubKey.SerializeCompressed()), &chainParams,
-	)
-	require.NoError(t, err)
-	p2wkhScript, err := txscript.PayToAddrScript(p2wkhAddr)
-	require.NoError(t, err)
-
-	trAddr, err := address.NewAddressTaproot(
-		schnorr.SerializePubKey(pubKey), &chainParams,
-	)
-	require.NoError(t, err)
-	trScript, err := txscript.PayToAddrScript(trAddr)
-	require.NoError(t, err)
-
 	tests := []struct {
 		name     string
-		pkScript []byte
 		addrType waddrmgr.AddressType
-		addr     address.Address
+		dbType   db.AddressType
+		keyScope waddrmgr.KeyScope
 	}{
 		{
 			name:     "p2wkh",
-			pkScript: p2wkhScript,
 			addrType: waddrmgr.WitnessPubKey,
-			addr:     p2wkhAddr,
+			dbType:   db.WitnessPubKey,
+			keyScope: waddrmgr.KeyScopeBIP0084,
 		},
 		{
 			name:     "taproot",
-			pkScript: trScript,
 			addrType: waddrmgr.TaprootPubKey,
-			addr:     trAddr,
+			dbType:   db.TaprootPubKey,
+			keyScope: waddrmgr.KeyScopeBIP0086,
 		},
 	}
 
@@ -3239,10 +3318,37 @@ func TestFinalizePsbtSuccess(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			keyScope := waddrmgr.KeyScopeBIP0084
+			w, mocks := createUnlockedWalletWithMocks(t)
+
+			// The signing key is resolved through the store account
+			// secret; take the leaf public key to build the input
+			// address.
+			path := waddrmgr.DerivationPath{}
+			_, pubKey := expectStoreSignerPrivKey(
+				t, mocks, w.id, tc.keyScope, path,
+			)
+
+			var (
+				addr address.Address
+				err  error
+			)
 			if tc.addrType == waddrmgr.TaprootPubKey {
-				keyScope = waddrmgr.KeyScopeBIP0086
+				addr, err = address.NewAddressTaproot(
+					schnorr.SerializePubKey(pubKey),
+					&chainParams,
+				)
+			} else {
+				addr, err = address.NewAddressWitnessPubKeyHash(
+					address.Hash160(
+						pubKey.SerializeCompressed(),
+					), &chainParams,
+				)
 			}
+
+			require.NoError(t, err)
+
+			pkScript, err := txscript.PayToAddrScript(addr)
+			require.NoError(t, err)
 
 			// Arrange: Create PSBT.
 			tx := wire.NewMsgTx(2)
@@ -3253,32 +3359,16 @@ func TestFinalizePsbtSuccess(t *testing.T) {
 
 			packet.Inputs[0].WitnessUtxo = &wire.TxOut{
 				Value:    1000,
-				PkScript: tc.pkScript,
+				PkScript: pkScript,
 			}
 			packet.Inputs[0].SighashType = txscript.SigHashDefault
 
-			w, mocks := createUnlockedWalletWithMocks(t)
-
-			// Arrange: Mock Store.GetAddress for ScriptForOutput.
-			dbAddrType := db.WitnessPubKey
-			if tc.addrType == waddrmgr.TaprootPubKey {
-				dbAddrType = db.TaprootPubKey
-			}
-
-			expectSignerAddressInfo(
-				t, w, mocks, tc.addr, dbAddrType, false, false, pubKey,
-			)
-			mocks.addrStore.On("Address", mock.Anything,
-				mock.MatchedBy(func(a address.Address) bool {
-					return a.String() == tc.addr.String()
-				}),
-			).Return(mocks.pubKeyAddr, nil).Once()
-			// Create a copy of the private key to avoid data races
-			// when parallel tests call Zero() on it.
-			privKeyCopy := *privKey
-			expectDerivedSignerPrivKey(
-				t, mocks, keyScope, waddrmgr.DerivationPath{},
-				&privKeyCopy,
+			// Arrange: Mock Store.GetAddress for ScriptForOutput
+			// with a usable derivation scope so signing routes
+			// through the store account secret.
+			expectSignerAddressInfoWithKeyScope(
+				t, w, mocks, addr, tc.dbType, false, false,
+				pubKey, tc.keyScope,
 			)
 
 			// Act: Call FinalizePsbt.

--- a/wallet/signer.go
+++ b/wallet/signer.go
@@ -858,7 +858,6 @@ func (w *Wallet) resolveImportedAddrPrivKey(ctx context.Context,
 
 	return privKey, nil
 }
-
 // loadManagedPubKeyAddr loads a managed pubkey address for signer-private key
 // access.
 func (w *Wallet) loadManagedPubKeyAddr(addr address.Address) (
@@ -986,7 +985,100 @@ func (w *Wallet) resolveDerivedPrivKey(accountManager waddrmgr.AccountStore,
 
 	return privKey, nil
 }
+// isScriptSpendAddress reports whether an address is spent through a redeem or
+// witness script rather than a single public key. These are the P2SH, P2WSH
+// and taproot script-path families, whose spending script is stored encrypted
+// per address rather than derived from a public key.
+func isScriptSpendAddress(addressInfo AddressInfo) bool {
+	spendType := addressInfo.AddrType.SpendType()
 
+	return spendType == waddrmgr.SpendTypeScriptHash ||
+		spendType == waddrmgr.SpendTypeWitnessScript ||
+		spendType == waddrmgr.SpendTypeTaprootScriptPath
+}
+// scriptForAddressInfo resolves the plaintext redeem or witness script for a
+// script-based output from its encrypted material in the store. The stored
+// script is decrypted through the key vault under the script crypto key. For
+// taproot script-path addresses the stored blob is a TLV-encoded Tapscript, so
+// it is decoded and the revealed leaf script returned; for P2SH and P2WSH the
+// decrypted bytes are the redeem or witness script directly.
+//
+// An address that exists but carries no encrypted script (a watch-only import)
+// yields ErrNoAssocPrivateKey, matching the private-key surface: the wallet
+// cannot spend it.
+func (w *Wallet) scriptForAddressInfo(ctx context.Context,
+	addressInfo AddressInfo, scriptPubKey []byte) ([]byte, error) {
+
+	secret, err := w.cache.GetAddressSecret(ctx, db.GetAddressSecretQuery{
+		WalletID:     w.id,
+		ScriptPubKey: scriptPubKey,
+	})
+	switch {
+	case errors.Is(err, db.ErrSecretNotFound),
+		errors.Is(err, db.ErrAddressNotFound):
+
+		return nil, ErrNoAssocPrivateKey
+
+	case err != nil:
+		return nil, fmt.Errorf("fetch address secret: %w", err)
+	}
+
+	if len(secret.EncryptedScript) == 0 {
+		return nil, ErrNoAssocPrivateKey
+	}
+
+	// Decrypt the script under the key the store reports it was written
+	// with. waddrmgr records that per address: a non-secret witness or
+	// taproot row is sealed under the public key and stays readable while
+	// locked, everything else under the script key.
+	scriptKey := waddrmgr.CKTPublic
+	if secret.ScriptIsSecret {
+		scriptKey = waddrmgr.CKTScript
+	}
+
+	plaintext, err := w.keyVault.Decrypt(scriptKey, secret.EncryptedScript)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt script: %w", err)
+	}
+
+	// Non-taproot script families store the redeem or witness script
+	// directly, so the decrypted bytes are the script itself.
+	if addressInfo.AddrType.SpendType() !=
+		waddrmgr.SpendTypeTaprootScriptPath {
+
+		return plaintext, nil
+	}
+
+	// Taproot script-path imports store a TLV-encoded Tapscript; decode it
+	// and return the single revealed leaf script.
+	tapscript, err := waddrmgr.DecodeTaprootScript(plaintext)
+	if err != nil {
+		return nil, fmt.Errorf("decode tapscript: %w", err)
+	}
+
+	script, err := revealedTapscriptLeaf(tapscript)
+	if err != nil {
+		return nil, fmt.Errorf("%w: addr %v", err, addressInfo.Addr)
+	}
+
+	return script, nil
+}
+// revealedTapscriptLeaf returns the single leaf script a taproot script-path
+// spend commits to. It supports the partial-reveal form (one revealed script)
+// and the full-tree form when the tree holds exactly one leaf; other shapes do
+// not carry a unique spending script and are rejected.
+func revealedTapscriptLeaf(tapscript *waddrmgr.Tapscript) ([]byte, error) {
+	switch {
+	case len(tapscript.RevealedScript) > 0:
+		return tapscript.RevealedScript, nil
+
+	case len(tapscript.Leaves) == 1:
+		return tapscript.Leaves[0].Script, nil
+
+	default:
+		return nil, ErrDerivationPathNotFound
+	}
+}
 // resolveDerivedPrivKeyFromStore resolves one derived private key from the
 // account-level encrypted secret stored behind the wallet store, addressed by
 // the derivation path's BIP44 account number.

--- a/wallet/signer.go
+++ b/wallet/signer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/btcsuite/btcd/address/v2"
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -13,8 +14,10 @@ import (
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btcwallet/internal/zero"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/keyvault"
 	"github.com/btcsuite/btcwallet/walletdb"
 )
 
@@ -34,6 +37,14 @@ var (
 	// ErrInvalidSignParam is returned when the parameters for the signing
 	// operation are invalid.
 	ErrInvalidSignParam = errors.New("invalid signing parameters")
+
+	// ErrWatchOnlyAccount is returned when account metadata exists but has
+	// no private key material available for signing.
+	ErrWatchOnlyAccount = errors.New("account is watch-only")
+
+	// ErrAccountNotInStore is returned when neither legacy waddrmgr nor the
+	// durable store can resolve the signing account.
+	ErrAccountNotInStore = errors.New("account not in store")
 )
 
 // Signer provides an interface for common, safe cryptographic operations,
@@ -234,7 +245,6 @@ type UnlockingScript struct {
 	// inputs, this will be nil.
 	SigScript []byte
 }
-
 // PrivKeyTweaker is a function type that can be used to pass in a callback for
 // tweaking a private key before it's used to sign an input.
 type PrivKeyTweaker func(*btcec.PrivateKey) (*btcec.PrivateKey, error)
@@ -350,7 +360,6 @@ func (l LegacySpendDetails) Sign(params *RawSigParams,
 
 	return rawSig, nil
 }
-
 // isSpendDetails implements the sealed interface.
 func (l LegacySpendDetails) isSpendDetails() {}
 
@@ -360,7 +369,6 @@ type SegwitV0SpendDetails struct {
 	// this should be the P2PKH script of the key.
 	WitnessScript []byte
 }
-
 // Sign performs the version-specific signing operation for a SegWit v0 input.
 func (s SegwitV0SpendDetails) Sign(params *RawSigParams,
 	privKey *btcec.PrivateKey) (RawSignature, error) {
@@ -383,7 +391,6 @@ func (s SegwitV0SpendDetails) Sign(params *RawSigParams,
 
 	return sig[:len(sig)-1], nil
 }
-
 // isSpendDetails implements the sealed interface.
 func (s SegwitV0SpendDetails) isSpendDetails() {}
 
@@ -400,7 +407,6 @@ type TaprootSpendDetails struct {
 	// only used for ScriptPathSpend.
 	WitnessScript []byte
 }
-
 // Sign performs the version-specific signing operation for a Taproot input.
 func (t TaprootSpendDetails) Sign(params *RawSigParams,
 	privKey *btcec.PrivateKey) (RawSignature, error) {
@@ -449,7 +455,6 @@ func (t TaprootSpendDetails) Sign(params *RawSigParams,
 
 	return rawSig, nil
 }
-
 // isSpendDetails implements the sealed interface.
 func (t TaprootSpendDetails) isSpendDetails() {}
 
@@ -460,7 +465,7 @@ var _ SpendDetails = (*SegwitV0SpendDetails)(nil)
 var _ SpendDetails = (*TaprootSpendDetails)(nil)
 
 // DerivePubKey derives a public key from a full BIP-32 derivation path.
-func (w *Wallet) DerivePubKey(_ context.Context, path BIP32Path) (
+func (w *Wallet) DerivePubKey(ctx context.Context, path BIP32Path) (
 	*btcec.PublicKey, error) {
 
 	err := w.state.validateStarted()
@@ -469,13 +474,33 @@ func (w *Wallet) DerivePubKey(_ context.Context, path BIP32Path) (
 	}
 
 	managedPubKeyAddr, err := w.fetchManagedPubKeyAddress(path)
-	if err != nil {
+	switch {
+	case err == nil:
+		return managedPubKeyAddr.PubKey(), nil
+
+	// SQL-only accounts have no mirrored legacy waddrmgr scope/account, so
+	// the lookup above misses. Mirror derivePathPrivKey's fallback and
+	// resolve the public key from the account-level extended public key in
+	// the store. Unlike the private-key fallback this works for watch-only
+	// accounts too, since it never needs the encrypted private material.
+	case isWaddrmgrAccountClassError(
+		err, waddrmgr.ErrScopeNotFound, waddrmgr.ErrAccountNotFound,
+	):
+
+		pubKey, storeErr := w.resolveDerivedPubKeyFromStore(
+			ctx, path.KeyScope, path.DerivationPath,
+		)
+		if storeErr != nil {
+			return nil, fmt.Errorf("store account fallback after "+
+				"legacy address miss: %w: %w", err, storeErr)
+		}
+
+		return pubKey, nil
+
+	default:
 		return nil, err
 	}
-
-	return managedPubKeyAddr.PubKey(), nil
 }
-
 // fetchManagedPubKeyAddress is a helper function that encapsulates the common
 // logic of fetching a scoped key manager, deriving a managed address from a
 // BIP32 path, and ensuring it is a public key address.
@@ -541,11 +566,34 @@ func (w *Wallet) fetchManagedPubKeyAddress(path BIP32Path) (
 
 	return managedPubKeyAddr, nil
 }
+// derivePathPrivKey resolves the signing private key for a full BIP-32 path.
+//
+// The private key is resolved entirely through the durable store: the
+// account-level extended private key is fetched by the path's BIP44 account
+// number, decrypted through keyVault, and the branch and index derived
+// locally. This single path covers both SQL-backed and kvdb-backed wallets
+// because the kvdb store adapter exports the legacy address manager's
+// encrypted account material through the same account-secret contract.
+//
+// This resolver is used by the path-driven signer entry points (SignDigest,
+// ECDH, DerivePrivKey and ComputeRawSig/PSBT), which have only a derivation
+// path. Address-driven paths reach the same resolver through
+// privKeyForAddressInfo once the store has resolved the address to its
+// derivation info, so both address the account by number.
+//
+// The returned private key is owned by the caller, who is responsible for
+// zeroing it once signing completes.
+func (w *Wallet) derivePathPrivKey(ctx context.Context, path BIP32Path) (
+	*btcec.PrivateKey, error) {
 
+	return w.resolveDerivedPrivKeyFromStore(
+		ctx, path.KeyScope, path.DerivationPath,
+	)
+}
 // ECDH performs a scalar multiplication (ECDH-like operation) between a key
 // from the wallet and a remote public key. The output returned will be the
 // sha256 of the resulting shared point serialized in compressed format.
-func (w *Wallet) ECDH(_ context.Context, path BIP32Path,
+func (w *Wallet) ECDH(ctx context.Context, path BIP32Path,
 	pub *btcec.PublicKey) ([32]byte, error) {
 
 	err := w.state.canSign()
@@ -553,16 +601,9 @@ func (w *Wallet) ECDH(_ context.Context, path BIP32Path,
 		return [32]byte{}, err
 	}
 
-	managedPubKeyAddr, err := w.fetchManagedPubKeyAddress(path)
+	privKey, err := w.derivePathPrivKey(ctx, path)
 	if err != nil {
 		return [32]byte{}, err
-	}
-
-	// Get the private key for the derived address.
-	privKey, err := managedPubKeyAddr.PrivKey()
-	if err != nil {
-		return [32]byte{}, fmt.Errorf("cannot get private key: %w",
-			err)
 	}
 	defer privKey.Zero()
 
@@ -574,7 +615,6 @@ func (w *Wallet) ECDH(_ context.Context, path BIP32Path,
 
 	return sharedSecret, nil
 }
-
 // validateSignDigestIntent validates the parameters of a SignDigestIntent.
 func validateSignDigestIntent(intent *SignDigestIntent) error {
 	// The digest must be exactly 32 bytes.
@@ -599,9 +639,8 @@ func validateSignDigestIntent(intent *SignDigestIntent) error {
 
 	return nil
 }
-
 // SignDigest signs a message digest based on the provided intent.
-func (w *Wallet) SignDigest(_ context.Context, path BIP32Path,
+func (w *Wallet) SignDigest(ctx context.Context, path BIP32Path,
 	intent *SignDigestIntent) (Signature, error) {
 
 	err := w.state.canSign()
@@ -614,15 +653,9 @@ func (w *Wallet) SignDigest(_ context.Context, path BIP32Path,
 		return nil, err
 	}
 
-	managedPubKeyAddr, err := w.fetchManagedPubKeyAddress(path)
+	privKey, err := w.derivePathPrivKey(ctx, path)
 	if err != nil {
 		return nil, err
-	}
-
-	// Get the private key for the derived address.
-	privKey, err := managedPubKeyAddr.PrivKey()
-	if err != nil {
-		return nil, fmt.Errorf("cannot get private key: %w", err)
 	}
 	defer privKey.Zero()
 
@@ -630,7 +663,6 @@ func (w *Wallet) SignDigest(_ context.Context, path BIP32Path,
 	// pure computation, so it can be done outside the DB transaction.
 	return signDigestWithPrivKey(privKey, intent)
 }
-
 // signDigestWithPrivKey performs the actual signing of a digest with a given
 // private key, based on the options specified in the SignDigestIntent. It
 // acts as a dispatcher to the appropriate signing algorithm.
@@ -645,7 +677,6 @@ func signDigestWithPrivKey(privKey *btcec.PrivateKey,
 	// Otherwise, we'll generate an ECDSA signature.
 	return signDigestECDSA(privKey, intent)
 }
-
 // signDigestSchnorr performs the actual signing of a digest with a given
 // private key, using the Schnorr signature algorithm.
 func signDigestSchnorr(privKey *btcec.PrivateKey,
@@ -664,7 +695,6 @@ func signDigestSchnorr(privKey *btcec.PrivateKey,
 
 	return SchnorrSignature{sig}, nil
 }
-
 // signDigestECDSA performs the actual signing of a digest with a given
 // private key, using the ECDSA signature algorithm.
 func signDigestECDSA(privKey *btcec.PrivateKey,
@@ -679,7 +709,6 @@ func signDigestECDSA(privKey *btcec.PrivateKey,
 
 	return ECDSASignature{sig}, nil
 }
-
 // ComputeUnlockingScript generates the full sigScript and witness required to
 // spend a UTXO.
 func (w *Wallet) ComputeUnlockingScript(ctx context.Context,
@@ -717,7 +746,6 @@ func (w *Wallet) ComputeUnlockingScript(ctx context.Context,
 	// unlocking script.
 	return signAndAssembleScript(params, privKey, &scriptInfo)
 }
-
 // privKeyForOutput returns the private key needed to sign for the given
 // wallet-controlled output.
 func (w *Wallet) privKeyForOutput(scriptInfo OutputScriptInfo) (
@@ -734,7 +762,6 @@ func (w *Wallet) privKeyForOutput(scriptInfo OutputScriptInfo) (
 
 	return w.resolvePrivKey(pubKeyAddr)
 }
-
 // canUseAddressInfoDerivation reports whether address metadata contains enough
 // derivation information to derive a private key without a legacy address row.
 func canUseAddressInfoDerivation(addressInfo AddressInfo) bool {
@@ -744,7 +771,6 @@ func canUseAddressInfoDerivation(addressInfo AddressInfo) bool {
 
 	return addressInfo.Derivation.KeyScope != (waddrmgr.KeyScope{})
 }
-
 // privKeyForAddressInfo derives the private key described by store-backed
 // address metadata.
 func (w *Wallet) privKeyForAddressInfo(addressInfo AddressInfo) (
@@ -895,6 +921,175 @@ func (w *Wallet) resolveDerivedPrivKey(accountManager waddrmgr.AccountStore,
 	return privKey, nil
 }
 
+// resolveDerivedPrivKeyFromStore resolves one derived private key from the
+// account-level encrypted secret stored behind the wallet store, addressed by
+// the derivation path's BIP44 account number.
+//
+// One selector suffices because derived accounts are the only kind holding
+// account-level signing material: an imported account is created from an
+// extended public key, so callers reaching an imported-xpub child must refuse
+// before arriving here rather than falling back to account 0.
+//
+// A watch-only account (no encrypted private material) yields
+// ErrWatchOnlyAccount, and an account that is not in the store yields
+// ErrAccountNotInStore. The returned private key is owned by the caller, who
+// is responsible for zeroing it once signing completes.
+func (w *Wallet) resolveDerivedPrivKeyFromStore(ctx context.Context,
+	keyScope waddrmgr.KeyScope,
+	path waddrmgr.DerivationPath) (*btcec.PrivateKey, error) {
+
+	query := db.GetAccountSecretQuery{
+		WalletID:      w.id,
+		Scope:         db.KeyScope(keyScope),
+		AccountNumber: path.InternalAccount,
+	}
+
+	secret, err := w.cache.GetAccountSecret(ctx, query)
+	switch {
+	case errors.Is(err, db.ErrAccountSecretUnavailable),
+		errors.Is(err, db.ErrAccountNotFound):
+
+		return nil, ErrAccountNotInStore
+
+	case err != nil:
+		return nil, fmt.Errorf("fetch account secret: %w", err)
+	}
+
+	if len(secret.EncryptedPrivateKey) == 0 {
+		return nil, ErrWatchOnlyAccount
+	}
+
+	return deriveStoredAccountChildKey(
+		w.keyVault, secret.EncryptedPrivateKey, path,
+	)
+}
+// TODO(yy): Move account-child secret derivation behind keyvault so account
+// secrets no longer cross the vault boundary.
+
+// deriveStoredAccountChildKey decrypts an account's encrypted private key with
+// the wallet's keyVault and walks the branch and index derivation to produce
+// the leaf private key. The decrypted byte slice and intermediate HD keys are
+// zeroed before the call returns. Note that hdkeychain/base58 parsing allocates
+// a transient immutable string copy of the decrypted bytes that cannot be
+// wiped and is left to the garbage collector.
+func deriveStoredAccountChildKey(vault keyvault.Vault,
+	encryptedAccountPriv []byte,
+	path waddrmgr.DerivationPath) (*btcec.PrivateKey, error) {
+
+	plaintext, err := vault.Decrypt(
+		waddrmgr.CKTPrivate, encryptedAccountPriv,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt account priv: %w", err)
+	}
+
+	acctPriv, err := hdkeychain.NewKeyFromString(string(plaintext))
+	if err != nil {
+		zero.Bytes(plaintext)
+		return nil, fmt.Errorf("parse account priv: %w", err)
+	}
+
+	zero.Bytes(plaintext)
+
+	defer acctPriv.Zero()
+
+	branchKey, err := deriveChildKey(acctPriv, path.Branch)
+	if err != nil {
+		return nil, fmt.Errorf("derive branch: %w", err)
+	}
+	defer branchKey.Zero()
+
+	addrKey, err := deriveChildKey(branchKey, path.Index)
+	if err != nil {
+		return nil, fmt.Errorf("derive index: %w", err)
+	}
+	defer addrKey.Zero()
+
+	privKey, err := addrKey.ECPrivKey()
+	if err != nil {
+		return nil, fmt.Errorf("derive private key: %w", err)
+	}
+
+	return privKey, nil
+}
+// resolveDerivedPubKeyFromStore resolves one derived public key from the
+// account-level extended public key stored behind the wallet store. It is the
+// public-key counterpart of resolveDerivedPrivKeyFromStore and, since the
+// account xpub is stored in plaintext, it also serves watch-only accounts that
+// hold no encrypted private material.
+func (w *Wallet) resolveDerivedPubKeyFromStore(ctx context.Context,
+	keyScope waddrmgr.KeyScope,
+	path waddrmgr.DerivationPath) (*btcec.PublicKey, error) {
+
+	// The account xpub is public metadata, so it comes from the account read
+	// rather than the secret read: AccountSecret carries encrypted private
+	// material only. SkipBalance keeps this to one backend query, and the
+	// public path works while the wallet is locked.
+	account, err := w.cache.GetAccount(ctx, db.GetAccountQuery{
+		WalletID:      w.id,
+		Scope:         db.KeyScope(keyScope),
+		AccountNumber: &path.InternalAccount,
+		SkipBalance:   true,
+	})
+	switch {
+	case errors.Is(err, db.ErrAccountNotFound):
+		return nil, ErrAccountNotInStore
+
+	case err != nil:
+		return nil, fmt.Errorf("fetch account: %w", err)
+	}
+
+	if len(account.PublicKey) == 0 {
+		return nil, fmt.Errorf(
+			"%w: account public key", ErrMissingParam,
+		)
+	}
+
+	return deriveStoredAccountChildPubKey(account.PublicKey, path)
+}
+// deriveStoredAccountChildPubKey parses an account-level extended public key
+// and walks the branch and index derivation to produce the leaf public key.
+// The intermediate HD keys are zeroed before the call returns.
+func deriveStoredAccountChildPubKey(accountPubKey []byte,
+	path waddrmgr.DerivationPath) (*btcec.PublicKey, error) {
+
+	acctPub, err := hdkeychain.NewKeyFromString(string(accountPubKey))
+	if err != nil {
+		return nil, fmt.Errorf("parse account pub: %w", err)
+	}
+	defer acctPub.Zero()
+
+	branchKey, err := deriveChildKey(acctPub, path.Branch)
+	if err != nil {
+		return nil, fmt.Errorf("derive branch: %w", err)
+	}
+	defer branchKey.Zero()
+
+	addrKey, err := deriveChildKey(branchKey, path.Index)
+	if err != nil {
+		return nil, fmt.Errorf("derive index: %w", err)
+	}
+	defer addrKey.Zero()
+
+	pubKey, err := addrKey.ECPubKey()
+	if err != nil {
+		return nil, fmt.Errorf("derive public key: %w", err)
+	}
+
+	return pubKey, nil
+}
+// isWaddrmgrAccountClassError reports whether err wraps a waddrmgr
+// ManagerError whose code belongs to the supplied set.
+func isWaddrmgrAccountClassError(err error,
+	codes ...waddrmgr.ErrorCode) bool {
+
+	var mErr waddrmgr.ManagerError
+	if !errors.As(err, &mErr) {
+		return false
+	}
+
+	return slices.Contains(codes, mErr.ErrorCode)
+}
 // signAndAssembleScript is a helper function that performs the final signing
 // and script assembly for a given set of parameters and a private key.
 func signAndAssembleScript(params *UnlockingScriptParams,
@@ -957,7 +1152,6 @@ func signAndAssembleScript(params *UnlockingScriptParams,
 			scriptInfo.AddrType)
 	}
 }
-
 // redeemSigScript wraps a redeem script into the final scriptSig push required
 // for nested witness spends.
 func redeemSigScript(redeemScript []byte) ([]byte, error) {
@@ -975,10 +1169,9 @@ func redeemSigScript(redeemScript []byte) ([]byte, error) {
 
 	return sigScript, nil
 }
-
 // ComputeRawSig generates a raw signature for a single transaction input. The
 // caller is responsible for assembling the final witness.
-func (w *Wallet) ComputeRawSig(_ context.Context, params *RawSigParams) (
+func (w *Wallet) ComputeRawSig(ctx context.Context, params *RawSigParams) (
 	RawSignature, error) {
 
 	err := w.state.canSign()
@@ -986,17 +1179,9 @@ func (w *Wallet) ComputeRawSig(_ context.Context, params *RawSigParams) (
 		return nil, err
 	}
 
-	// Get the managed address for the specified derivation path. This will
-	// be used to retrieve the private key.
-	managedAddr, err := w.fetchManagedPubKeyAddress(params.Path)
+	privKey, err := w.derivePathPrivKey(ctx, params.Path)
 	if err != nil {
 		return nil, err
-	}
-
-	// Get the private key for the address.
-	privKey, err := managedAddr.PrivKey()
-	if err != nil {
-		return nil, fmt.Errorf("cannot get private key: %w", err)
 	}
 	defer privKey.Zero()
 
@@ -1018,12 +1203,11 @@ func (w *Wallet) ComputeRawSig(_ context.Context, params *RawSigParams) (
 
 	return rawSig, nil
 }
-
 // DerivePrivKey derives a private key from a full BIP-32 derivation
 // path.
 //
 // DANGER: This method exports sensitive key material.
-func (w *Wallet) DerivePrivKey(_ context.Context, path BIP32Path) (
+func (w *Wallet) DerivePrivKey(ctx context.Context, path BIP32Path) (
 	*btcec.PrivateKey, error) {
 
 	err := w.state.canSign()
@@ -1031,19 +1215,8 @@ func (w *Wallet) DerivePrivKey(_ context.Context, path BIP32Path) (
 		return nil, err
 	}
 
-	managedPubKeyAddr, err := w.fetchManagedPubKeyAddress(path)
-	if err != nil {
-		return nil, err
-	}
-
-	privKey, err := managedPubKeyAddr.PrivKey()
-	if err != nil {
-		return nil, fmt.Errorf("cannot get private key: %w", err)
-	}
-
-	return privKey, nil
+	return w.derivePathPrivKey(ctx, path)
 }
-
 // GetPrivKeyForAddress returns the private key for a given address.
 //
 // DANGER: This method exports sensitive key material.
@@ -1081,7 +1254,6 @@ func (w *Wallet) GetPrivKeyForAddress(ctx context.Context, a address.Address) (
 		return nil, fmt.Errorf("GetPrivKeyForAddress: %w", err)
 	}
 }
-
 // PrivKeyForAddress looks up the associated private key for a P2PKH or P2PK
 // address.
 func (w *Wallet) PrivKeyForAddress(a address.Address) (

--- a/wallet/signer.go
+++ b/wallet/signer.go
@@ -245,6 +245,7 @@ type UnlockingScript struct {
 	// inputs, this will be nil.
 	SigScript []byte
 }
+
 // PrivKeyTweaker is a function type that can be used to pass in a callback for
 // tweaking a private key before it's used to sign an input.
 type PrivKeyTweaker func(*btcec.PrivateKey) (*btcec.PrivateKey, error)
@@ -360,6 +361,7 @@ func (l LegacySpendDetails) Sign(params *RawSigParams,
 
 	return rawSig, nil
 }
+
 // isSpendDetails implements the sealed interface.
 func (l LegacySpendDetails) isSpendDetails() {}
 
@@ -369,6 +371,7 @@ type SegwitV0SpendDetails struct {
 	// this should be the P2PKH script of the key.
 	WitnessScript []byte
 }
+
 // Sign performs the version-specific signing operation for a SegWit v0 input.
 func (s SegwitV0SpendDetails) Sign(params *RawSigParams,
 	privKey *btcec.PrivateKey) (RawSignature, error) {
@@ -391,6 +394,7 @@ func (s SegwitV0SpendDetails) Sign(params *RawSigParams,
 
 	return sig[:len(sig)-1], nil
 }
+
 // isSpendDetails implements the sealed interface.
 func (s SegwitV0SpendDetails) isSpendDetails() {}
 
@@ -407,6 +411,7 @@ type TaprootSpendDetails struct {
 	// only used for ScriptPathSpend.
 	WitnessScript []byte
 }
+
 // Sign performs the version-specific signing operation for a Taproot input.
 func (t TaprootSpendDetails) Sign(params *RawSigParams,
 	privKey *btcec.PrivateKey) (RawSignature, error) {
@@ -455,6 +460,7 @@ func (t TaprootSpendDetails) Sign(params *RawSigParams,
 
 	return rawSig, nil
 }
+
 // isSpendDetails implements the sealed interface.
 func (t TaprootSpendDetails) isSpendDetails() {}
 
@@ -501,6 +507,7 @@ func (w *Wallet) DerivePubKey(ctx context.Context, path BIP32Path) (
 		return nil, err
 	}
 }
+
 // fetchManagedPubKeyAddress is a helper function that encapsulates the common
 // logic of fetching a scoped key manager, deriving a managed address from a
 // BIP32 path, and ensuring it is a public key address.
@@ -566,6 +573,7 @@ func (w *Wallet) fetchManagedPubKeyAddress(path BIP32Path) (
 
 	return managedPubKeyAddr, nil
 }
+
 // derivePathPrivKey resolves the signing private key for a full BIP-32 path.
 //
 // The private key is resolved entirely through the durable store: the
@@ -590,6 +598,7 @@ func (w *Wallet) derivePathPrivKey(ctx context.Context, path BIP32Path) (
 		ctx, path.KeyScope, path.DerivationPath,
 	)
 }
+
 // ECDH performs a scalar multiplication (ECDH-like operation) between a key
 // from the wallet and a remote public key. The output returned will be the
 // sha256 of the resulting shared point serialized in compressed format.
@@ -615,6 +624,7 @@ func (w *Wallet) ECDH(ctx context.Context, path BIP32Path,
 
 	return sharedSecret, nil
 }
+
 // validateSignDigestIntent validates the parameters of a SignDigestIntent.
 func validateSignDigestIntent(intent *SignDigestIntent) error {
 	// The digest must be exactly 32 bytes.
@@ -639,6 +649,7 @@ func validateSignDigestIntent(intent *SignDigestIntent) error {
 
 	return nil
 }
+
 // SignDigest signs a message digest based on the provided intent.
 func (w *Wallet) SignDigest(ctx context.Context, path BIP32Path,
 	intent *SignDigestIntent) (Signature, error) {
@@ -663,6 +674,7 @@ func (w *Wallet) SignDigest(ctx context.Context, path BIP32Path,
 	// pure computation, so it can be done outside the DB transaction.
 	return signDigestWithPrivKey(privKey, intent)
 }
+
 // signDigestWithPrivKey performs the actual signing of a digest with a given
 // private key, based on the options specified in the SignDigestIntent. It
 // acts as a dispatcher to the appropriate signing algorithm.
@@ -677,6 +689,7 @@ func signDigestWithPrivKey(privKey *btcec.PrivateKey,
 	// Otherwise, we'll generate an ECDSA signature.
 	return signDigestECDSA(privKey, intent)
 }
+
 // signDigestSchnorr performs the actual signing of a digest with a given
 // private key, using the Schnorr signature algorithm.
 func signDigestSchnorr(privKey *btcec.PrivateKey,
@@ -695,6 +708,7 @@ func signDigestSchnorr(privKey *btcec.PrivateKey,
 
 	return SchnorrSignature{sig}, nil
 }
+
 // signDigestECDSA performs the actual signing of a digest with a given
 // private key, using the ECDSA signature algorithm.
 func signDigestECDSA(privKey *btcec.PrivateKey,
@@ -709,6 +723,7 @@ func signDigestECDSA(privKey *btcec.PrivateKey,
 
 	return ECDSASignature{sig}, nil
 }
+
 // ComputeUnlockingScript generates the full sigScript and witness required to
 // spend a UTXO.
 func (w *Wallet) ComputeUnlockingScript(ctx context.Context,
@@ -746,6 +761,7 @@ func (w *Wallet) ComputeUnlockingScript(ctx context.Context,
 	// unlocking script.
 	return signAndAssembleScript(params, privKey, &scriptInfo)
 }
+
 // privKeyForOutput returns the private key needed to sign for the given
 // wallet-controlled output.
 //
@@ -762,6 +778,7 @@ func (w *Wallet) privKeyForOutput(ctx context.Context,
 
 	return w.resolveImportedAddrPrivKey(ctx, scriptInfo.scriptPubKey())
 }
+
 // scriptPubKey returns the output pkScript associated with the address
 // metadata. It re-derives the script from the address so callers that only
 // hold OutputScriptInfo need not thread the raw pkScript separately.
@@ -775,6 +792,7 @@ func (info OutputScriptInfo) scriptPubKey() []byte {
 
 	return script
 }
+
 // canUseAddressInfoDerivation reports whether address metadata contains enough
 // derivation information to derive a private key without a legacy address row.
 func canUseAddressInfoDerivation(addressInfo AddressInfo) bool {
@@ -784,6 +802,7 @@ func canUseAddressInfoDerivation(addressInfo AddressInfo) bool {
 
 	return addressInfo.Derivation.KeyScope != (waddrmgr.KeyScope{})
 }
+
 // privKeyForAddressInfo derives the private key described by store-backed
 // address metadata. It resolves the owning account's encrypted extended
 // private key through the store, decrypts it through keyVault, and derives the
@@ -817,6 +836,7 @@ func (w *Wallet) privKeyForAddressInfo(ctx context.Context,
 		ctx, derivation.KeyScope, derivationPath,
 	)
 }
+
 // resolveImportedAddrPrivKey resolves the private key for an imported address
 // from its encrypted private-key material in the store. Imported addresses
 // have no derivation path, so the key is stored per-address rather than
@@ -858,133 +878,7 @@ func (w *Wallet) resolveImportedAddrPrivKey(ctx context.Context,
 
 	return privKey, nil
 }
-// loadManagedPubKeyAddr loads a managed pubkey address for signer-private key
-// access.
-func (w *Wallet) loadManagedPubKeyAddr(addr address.Address) (
-	waddrmgr.ManagedPubKeyAddress, error) {
 
-	var pubKeyAddr waddrmgr.ManagedPubKeyAddress
-
-	err := walletdb.View(w.cfg.DB, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-
-		managedAddr, err := w.addrStore.Address(addrmgrNs, addr)
-		if err != nil {
-			return fmt.Errorf("fetch address: %w", err)
-		}
-
-		var ok bool
-
-		pubKeyAddr, ok = managedAddr.(waddrmgr.ManagedPubKeyAddress)
-		if !ok {
-			return fmt.Errorf("%w: addr %s", ErrNotPubKeyAddress,
-				managedAddr.Address())
-		}
-
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("view signer address: %w", err)
-	}
-
-	return pubKeyAddr, nil
-}
-
-// resolvePrivKey resolves the private key for a managed pubkey address without
-// using output-script inspection as the private-key lookup seam.
-func (w *Wallet) resolvePrivKey(pubKeyAddr waddrmgr.ManagedPubKeyAddress) (
-	*btcec.PrivateKey, error) {
-
-	// Imported spendable keys have no derivation path, so we fall back to the
-	// dedicated private-key lookup exposed by the managed pubkey address.
-	if pubKeyAddr.Imported() {
-		privKey, err := pubKeyAddr.PrivKey()
-		if err != nil {
-			return nil, fmt.Errorf("fetch imported private key: %w", err)
-		}
-
-		return privKey, nil
-	}
-
-	keyScope, derivationPath, ok := pubKeyAddr.DerivationInfo()
-	if !ok {
-		return nil, fmt.Errorf("%w: addr=%v", ErrDerivationPathNotFound,
-			pubKeyAddr.Address())
-	}
-
-	return w.resolveDerivedPathPrivKey(keyScope, derivationPath)
-}
-
-// resolveDerivedPathPrivKey resolves one derived private key through the scoped
-// manager cache or the database-backed fallback.
-func (w *Wallet) resolveDerivedPathPrivKey(keyScope waddrmgr.KeyScope,
-	derivationPath waddrmgr.DerivationPath) (*btcec.PrivateKey, error) {
-
-	// TODO(yy): SQL-only accounts (created via Store.CreateDerivedAccount
-	// without a mirrored legacy waddrmgr account) miss both
-	// DeriveFromKeyPathCache and the DB-backed DeriveFromKeyPath fallback
-	// below because the legacy waddrmgr has no row for them. The
-	// signer-store PR (impl-tx-creator-store) will replace this path for
-	// SQL-only accounts with a keyVault-backed derivation: fetch
-	// account_secrets.encrypted_priv_key, decrypt via w.keyVault, and
-	// derive at branch/index locally — symmetric to deriveAddressData's
-	// AccountPubKey plumbing on the public-key side.
-	accountManager, err := w.addrStore.FetchScopedKeyManager(keyScope)
-	if err != nil {
-		return nil, fmt.Errorf("fetch scoped key manager: %w", err)
-	}
-
-	privKey, err := accountManager.DeriveFromKeyPathCache(derivationPath)
-	if err == nil {
-		return privKey, nil
-	}
-
-	// Only a cold account cache warrants the slower DB-backed fallback. Other
-	// derivation errors are real failures that re-running through the database
-	// will not repair.
-	if !waddrmgr.IsError(err, waddrmgr.ErrAccountNotCached) {
-		return nil, fmt.Errorf("derive private key from cache: %w", err)
-	}
-
-	return w.resolveDerivedPrivKey(accountManager, derivationPath)
-}
-
-// resolveDerivedPrivKey resolves one derived private key through the normal
-// database-backed derivation path after a cache miss.
-func (w *Wallet) resolveDerivedPrivKey(accountManager waddrmgr.AccountStore,
-	derivationPath waddrmgr.DerivationPath) (*btcec.PrivateKey, error) {
-
-	var privKey *btcec.PrivateKey
-
-	err := walletdb.View(w.cfg.DB, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-
-		managedAddr, err := accountManager.DeriveFromKeyPath(
-			addrmgrNs, derivationPath,
-		)
-		if err != nil {
-			return fmt.Errorf("derive private key from db: %w", err)
-		}
-
-		pubKeyAddr, ok := managedAddr.(waddrmgr.ManagedPubKeyAddress)
-		if !ok {
-			return fmt.Errorf("%w: addr %s", ErrNotPubKeyAddress,
-				managedAddr.Address())
-		}
-
-		privKey, err = pubKeyAddr.PrivKey()
-		if err != nil {
-			return fmt.Errorf("fetch derived private key: %w", err)
-		}
-
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("view signer derivation: %w", err)
-	}
-
-	return privKey, nil
-}
 // isScriptSpendAddress reports whether an address is spent through a redeem or
 // witness script rather than a single public key. These are the P2SH, P2WSH
 // and taproot script-path families, whose spending script is stored encrypted
@@ -996,6 +890,7 @@ func isScriptSpendAddress(addressInfo AddressInfo) bool {
 		spendType == waddrmgr.SpendTypeWitnessScript ||
 		spendType == waddrmgr.SpendTypeTaprootScriptPath
 }
+
 // scriptForAddressInfo resolves the plaintext redeem or witness script for a
 // script-based output from its encrypted material in the store. The stored
 // script is decrypted through the key vault under the script crypto key. For
@@ -1063,6 +958,7 @@ func (w *Wallet) scriptForAddressInfo(ctx context.Context,
 
 	return script, nil
 }
+
 // revealedTapscriptLeaf returns the single leaf script a taproot script-path
 // spend commits to. It supports the partial-reveal form (one revealed script)
 // and the full-tree form when the tree holds exactly one leaf; other shapes do
@@ -1079,6 +975,7 @@ func revealedTapscriptLeaf(tapscript *waddrmgr.Tapscript) ([]byte, error) {
 		return nil, ErrDerivationPathNotFound
 	}
 }
+
 // resolveDerivedPrivKeyFromStore resolves one derived private key from the
 // account-level encrypted secret stored behind the wallet store, addressed by
 // the derivation path's BIP44 account number.
@@ -1121,6 +1018,7 @@ func (w *Wallet) resolveDerivedPrivKeyFromStore(ctx context.Context,
 		w.keyVault, secret.EncryptedPrivateKey, path,
 	)
 }
+
 // TODO(yy): Move account-child secret derivation behind keyvault so account
 // secrets no longer cross the vault boundary.
 
@@ -1170,6 +1068,7 @@ func deriveStoredAccountChildKey(vault keyvault.Vault,
 
 	return privKey, nil
 }
+
 // resolveDerivedPubKeyFromStore resolves one derived public key from the
 // account-level extended public key stored behind the wallet store. It is the
 // public-key counterpart of resolveDerivedPrivKeyFromStore and, since the
@@ -1205,6 +1104,7 @@ func (w *Wallet) resolveDerivedPubKeyFromStore(ctx context.Context,
 
 	return deriveStoredAccountChildPubKey(account.PublicKey, path)
 }
+
 // deriveStoredAccountChildPubKey parses an account-level extended public key
 // and walks the branch and index derivation to produce the leaf public key.
 // The intermediate HD keys are zeroed before the call returns.
@@ -1236,6 +1136,7 @@ func deriveStoredAccountChildPubKey(accountPubKey []byte,
 
 	return pubKey, nil
 }
+
 // isWaddrmgrAccountClassError reports whether err wraps a waddrmgr
 // ManagerError whose code belongs to the supplied set.
 func isWaddrmgrAccountClassError(err error,
@@ -1248,6 +1149,7 @@ func isWaddrmgrAccountClassError(err error,
 
 	return slices.Contains(codes, mErr.ErrorCode)
 }
+
 // signAndAssembleScript is a helper function that performs the final signing
 // and script assembly for a given set of parameters and a private key.
 func signAndAssembleScript(params *UnlockingScriptParams,
@@ -1310,6 +1212,7 @@ func signAndAssembleScript(params *UnlockingScriptParams,
 			scriptInfo.AddrType)
 	}
 }
+
 // redeemSigScript wraps a redeem script into the final scriptSig push required
 // for nested witness spends.
 func redeemSigScript(redeemScript []byte) ([]byte, error) {
@@ -1327,6 +1230,7 @@ func redeemSigScript(redeemScript []byte) ([]byte, error) {
 
 	return sigScript, nil
 }
+
 // ComputeRawSig generates a raw signature for a single transaction input. The
 // caller is responsible for assembling the final witness.
 func (w *Wallet) ComputeRawSig(ctx context.Context, params *RawSigParams) (
@@ -1361,6 +1265,7 @@ func (w *Wallet) ComputeRawSig(ctx context.Context, params *RawSigParams) (
 
 	return rawSig, nil
 }
+
 // DerivePrivKey derives a private key from a full BIP-32 derivation
 // path.
 //
@@ -1375,6 +1280,7 @@ func (w *Wallet) DerivePrivKey(ctx context.Context, path BIP32Path) (
 
 	return w.derivePathPrivKey(ctx, path)
 }
+
 // GetPrivKeyForAddress returns the private key for a given address.
 //
 // DANGER: This method exports sensitive key material.
@@ -1388,6 +1294,7 @@ func (w *Wallet) GetPrivKeyForAddress(ctx context.Context, a address.Address) (
 
 	return w.privKeyForAddress(ctx, a)
 }
+
 // PrivKeyForAddress looks up the associated private key for a wallet address.
 //
 // It is the context-free compatibility wrapper over privKeyForAddress used by
@@ -1406,6 +1313,7 @@ func (w *Wallet) PrivKeyForAddress(a address.Address) (
 
 	return w.privKeyForAddress(context.Background(), a)
 }
+
 // privKeyForAddress resolves the private key for a wallet address through the
 // store. Derived addresses resolve through the owning account's encrypted
 // extended private key; imported addresses resolve through their own encrypted

--- a/wallet/signer.go
+++ b/wallet/signer.go
@@ -727,7 +727,7 @@ func (w *Wallet) ComputeUnlockingScript(ctx context.Context,
 		return nil, err
 	}
 
-	privKey, err := w.privKeyForOutput(scriptInfo)
+	privKey, err := w.privKeyForOutput(ctx, scriptInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -748,19 +748,32 @@ func (w *Wallet) ComputeUnlockingScript(ctx context.Context,
 }
 // privKeyForOutput returns the private key needed to sign for the given
 // wallet-controlled output.
-func (w *Wallet) privKeyForOutput(scriptInfo OutputScriptInfo) (
+//
+// Derived addresses resolve through the account-level secret; imported
+// addresses have no derivation path and resolve through their own encrypted
+// private key material in the store.
+func (w *Wallet) privKeyForOutput(ctx context.Context,
+	scriptInfo OutputScriptInfo) (
 	*btcec.PrivateKey, error) {
 
 	if canUseAddressInfoDerivation(scriptInfo.AddressInfo) {
-		return w.privKeyForAddressInfo(scriptInfo.AddressInfo)
+		return w.privKeyForAddressInfo(ctx, scriptInfo.AddressInfo)
 	}
 
-	pubKeyAddr, err := w.loadManagedPubKeyAddr(scriptInfo.Addr)
+	return w.resolveImportedAddrPrivKey(ctx, scriptInfo.scriptPubKey())
+}
+// scriptPubKey returns the output pkScript associated with the address
+// metadata. It re-derives the script from the address so callers that only
+// hold OutputScriptInfo need not thread the raw pkScript separately.
+func (info OutputScriptInfo) scriptPubKey() []byte {
+	// The script is only used to key the store lookup. A derivation error
+	// returns nil, so the subsequent query fails address-query validation.
+	script, err := txscript.PayToAddrScript(info.Addr)
 	if err != nil {
-		return nil, err
+		return nil
 	}
 
-	return w.resolvePrivKey(pubKeyAddr)
+	return script
 }
 // canUseAddressInfoDerivation reports whether address metadata contains enough
 // derivation information to derive a private key without a legacy address row.
@@ -772,25 +785,78 @@ func canUseAddressInfoDerivation(addressInfo AddressInfo) bool {
 	return addressInfo.Derivation.KeyScope != (waddrmgr.KeyScope{})
 }
 // privKeyForAddressInfo derives the private key described by store-backed
-// address metadata.
-func (w *Wallet) privKeyForAddressInfo(addressInfo AddressInfo) (
+// address metadata. It resolves the owning account's encrypted extended
+// private key through the store, decrypts it through keyVault, and derives the
+// leaf key at the address's branch and index.
+func (w *Wallet) privKeyForAddressInfo(ctx context.Context,
+	addressInfo AddressInfo) (
 	*btcec.PrivateKey, error) {
 
+	// An address with no derivation is either a raw single import or an
+	// imported-xpub child. Neither has wallet-derived account-level private
+	// material to resolve, so refuse before any secret lookup rather than
+	// reading a missing account number as account 0, which is the wallet's
+	// own default derived account.
 	derivation := addressInfo.Derivation
 	if derivation == nil {
-		return nil, fmt.Errorf("%w: derivation info not found for %v",
-			ErrDerivationPathNotFound, addressInfo.Addr)
+		return nil, ErrNoAssocPrivateKey
 	}
 
+	internalAccount := derivation.Account
+	hardenedAccount := internalAccount + hdkeychain.HardenedKeyStart
+
 	derivationPath := waddrmgr.DerivationPath{
-		InternalAccount:      derivation.Account,
-		Account:              derivation.Account + hdkeychain.HardenedKeyStart,
+		InternalAccount:      internalAccount,
+		Account:              hardenedAccount,
 		Branch:               derivation.Branch,
 		Index:                derivation.Index,
 		MasterKeyFingerprint: derivation.MasterKeyFingerprint,
 	}
 
-	return w.resolveDerivedPathPrivKey(derivation.KeyScope, derivationPath)
+	return w.resolveDerivedPrivKeyFromStore(
+		ctx, derivation.KeyScope, derivationPath,
+	)
+}
+// resolveImportedAddrPrivKey resolves the private key for an imported address
+// from its encrypted private-key material in the store. Imported addresses
+// have no derivation path, so the key is stored per-address rather than
+// derived from an account. An address that exists but holds no private-key
+// material (watch-only import) yields ErrNoAssocPrivateKey.
+func (w *Wallet) resolveImportedAddrPrivKey(ctx context.Context,
+	scriptPubKey []byte) (*btcec.PrivateKey, error) {
+
+	secret, err := w.cache.GetAddressSecret(ctx, db.GetAddressSecretQuery{
+		WalletID:     w.id,
+		ScriptPubKey: scriptPubKey,
+	})
+	switch {
+	// A resolved address that carries no secret, and (for kvdb) an address
+	// that does not resolve at all, both surface as ErrSecretNotFound.
+	// Either way the wallet holds no spendable key for this address.
+	case errors.Is(err, db.ErrSecretNotFound),
+		errors.Is(err, db.ErrAddressNotFound):
+
+		return nil, ErrNoAssocPrivateKey
+
+	case err != nil:
+		return nil, fmt.Errorf("fetch address secret: %w", err)
+	}
+
+	if len(secret.EncryptedPrivKey) == 0 {
+		return nil, ErrNoAssocPrivateKey
+	}
+
+	plaintext, err := w.keyVault.Decrypt(
+		waddrmgr.CKTPrivate, secret.EncryptedPrivKey,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt imported priv: %w", err)
+	}
+
+	privKey, _ := btcec.PrivKeyFromBytes(plaintext)
+	zero.Bytes(plaintext)
+
+	return privKey, nil
 }
 
 // loadManagedPubKeyAddr loads a managed pubkey address for signer-private key
@@ -1228,34 +1294,16 @@ func (w *Wallet) GetPrivKeyForAddress(ctx context.Context, a address.Address) (
 		return nil, err
 	}
 
-	// Try the store-routed lookup so SQL-derived addresses (persisted
-	// only in the store) can be signed for. Fall back to the legacy
-	// waddrmgr lookup ONLY when the address is genuinely not in the
-	// store, or when the store record lacks usable derivation metadata
-	// (imported / kvdb cases). Unexpected store errors must surface — do
-	// not mask them.
-	info, err := w.GetAddressInfo(ctx, a)
-	switch {
-	case err == nil && canUseAddressInfoDerivation(info):
-		return w.privKeyForAddressInfo(info)
-
-	case err == nil:
-		// Store record exists but no usable derivation info
-		// (imported case).
-		return w.PrivKeyForAddress(a)
-
-	case errors.Is(err, db.ErrAddressNotFound):
-		// Address not in the store — fall through to the legacy
-		// lookup (kvdb path or pre-store legacy address).
-		return w.PrivKeyForAddress(a)
-
-	default:
-		// Unexpected store error: surface, don't mask.
-		return nil, fmt.Errorf("GetPrivKeyForAddress: %w", err)
-	}
+	return w.privKeyForAddress(ctx, a)
 }
-// PrivKeyForAddress looks up the associated private key for a P2PKH or P2PK
-// address.
+// PrivKeyForAddress looks up the associated private key for a wallet address.
+//
+// It is the context-free compatibility wrapper over privKeyForAddress used by
+// callers on the legacy Signer interface. It performs no walletdb transaction
+// of its own; the private key is resolved entirely through the store and
+// keyVault.
+//
+// DANGER: This method exports sensitive key material.
 func (w *Wallet) PrivKeyForAddress(a address.Address) (
 	*btcec.PrivateKey, error) {
 
@@ -1264,31 +1312,39 @@ func (w *Wallet) PrivKeyForAddress(a address.Address) (
 		return nil, err
 	}
 
-	var privKey *btcec.PrivateKey
+	return w.privKeyForAddress(context.Background(), a)
+}
+// privKeyForAddress resolves the private key for a wallet address through the
+// store. Derived addresses resolve through the owning account's encrypted
+// extended private key; imported addresses resolve through their own encrypted
+// private key material. An address that is not owned by the wallet, or that
+// holds no spendable key, yields ErrNoAssocPrivateKey.
+func (w *Wallet) privKeyForAddress(ctx context.Context,
+	a address.Address) (*btcec.PrivateKey, error) {
 
-	err = walletdb.View(w.cfg.DB, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+	info, err := w.GetAddressInfo(ctx, a)
+	switch {
+	case err == nil && canUseAddressInfoDerivation(info):
+		return w.privKeyForAddressInfo(ctx, info)
 
-		addr, err := w.addrStore.Address(addrmgrNs, a)
+	case err == nil:
+		// The address is owned but has no usable derivation metadata,
+		// so it is an imported address whose private key (if any) lives
+		// in its own encrypted secret.
+		scriptPubKey, err := txscript.PayToAddrScript(a)
 		if err != nil {
-			return fmt.Errorf("failed to get address: %w", err)
+			return nil, fmt.Errorf("pay to addr script: %w", err)
 		}
 
-		managedPubKeyAddr, ok := addr.(waddrmgr.ManagedPubKeyAddress)
-		if !ok {
-			return ErrNoAssocPrivateKey
-		}
+		return w.resolveImportedAddrPrivKey(ctx, scriptPubKey)
 
-		privKey, err = managedPubKeyAddr.PrivKey()
-		if err != nil {
-			return fmt.Errorf("failed to get private key: %w", err)
-		}
+	case errors.Is(err, db.ErrAddressNotFound):
+		// The address is not owned by the wallet, so the wallet holds
+		// no private key for it.
+		return nil, ErrNoAssocPrivateKey
 
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to view database: %w", err)
+	default:
+		// Unexpected store error: surface, don't mask.
+		return nil, fmt.Errorf("priv key for address: %w", err)
 	}
-
-	return privKey, nil
 }

--- a/wallet/signer_test.go
+++ b/wallet/signer_test.go
@@ -7,6 +7,7 @@ package wallet
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -27,6 +28,7 @@ import (
 	"github.com/btcsuite/btcwallet/wallet/internal/bwtest/keyvaultmock"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	sqlitedb "github.com/btcsuite/btcwallet/wallet/internal/db/sqlite"
+	"github.com/btcsuite/btcwallet/wallet/internal/keyvault"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -173,11 +175,8 @@ func TestDerivePubKeyNotPubKeyAddr(t *testing.T) {
 func TestECDHSuccess(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Set up the wallet, mocks, and test keys.
+	// Arrange: Set up the wallet and mocks.
 	w, mocks := createUnlockedWalletWithMocks(t)
-
-	// Use a hardcoded private key for deterministic test results.
-	privKey, _ := deterministicPrivKey(t)
 
 	remoteKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
@@ -193,34 +192,27 @@ func TestECDHSuccess(t *testing.T) {
 		},
 	}
 
-	// Configure the full mock chain to return the test private key.
-	//
-	// NOTE: We must use a copy since the ECDH method will zero out the key.
-	privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
+	// The ECDH key is resolved through the store account secret; take the
+	// leaf private key the signer will derive so we can compute the
+	// expected shared secret independently.
+	privKey, _ := expectStoreSignerPrivKey(
+		t, mocks, w.id, path.KeyScope, path.DerivationPath,
+	)
 
-	mocks.addrStore.On("FetchScopedKeyManager", path.KeyScope).
-		Return(mocks.accountManager, nil).Once()
-	mocks.accountManager.On(
-		"DeriveFromKeyPath", mock.Anything, path.DerivationPath,
-	).Return(mocks.pubKeyAddr, nil).Once()
-	mocks.pubKeyAddr.On("PrivKey").Return(privKeyCopy, nil).Once()
+	// Compute the expected shared secret before ECDH runs, since ECDH
+	// zeroes the private key it derived internally (a separate copy from
+	// this one).
+	expectedSecret := btcec.GenerateSharedSecret(privKey, remotePubKey)
+
+	var expectedSecretArray [32]byte
+	copy(expectedSecretArray[:], expectedSecret)
 
 	// Act: Perform the ECDH operation.
 	sharedSecret, err := w.ECDH(t.Context(), path, remotePubKey)
 
 	// Assert: Check that the correct shared secret is returned.
 	require.NoError(t, err)
-
-	// Calculate the expected secret independently to verify.
-	expectedSecret := btcec.GenerateSharedSecret(privKey, remotePubKey)
-
-	var expectedSecretArray [32]byte
-	copy(expectedSecretArray[:], expectedSecret)
-
 	require.Equal(t, expectedSecretArray, sharedSecret)
-
-	// Finally, assert that the private key is zeroed out.
-	require.Equal(t, byte(0), privKeyCopy.Serialize()[0])
 }
 
 // TestECDHFails tests the failure case where the key derivation fails during
@@ -228,8 +220,8 @@ func TestECDHSuccess(t *testing.T) {
 func TestECDHFails(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Set up the wallet and configure the mock addrStore to return
-	// an error.
+	// Arrange: Set up the wallet and configure the store account-secret
+	// lookup to fail with an unexpected error.
 	w, mocks := createUnlockedWalletWithMocks(t)
 	path := BIP32Path{KeyScope: waddrmgr.KeyScopeBIP0084}
 
@@ -238,8 +230,13 @@ func TestECDHFails(t *testing.T) {
 
 	remotePubKey := remoteKey.PubKey()
 
-	mocks.addrStore.On("FetchScopedKeyManager", path.KeyScope).
-		Return((*bwmock.AccountStore)(nil), errDerivationFailed).Once()
+	accountNumber := path.DerivationPath.InternalAccount
+	mocks.store.On("GetAccountSecret", mock.Anything,
+		db.GetAccountSecretQuery{
+			WalletID:      w.id,
+			Scope:         db.KeyScope(path.KeyScope),
+			AccountNumber: accountNumber,
+		}).Return((*db.AccountSecret)(nil), errDerivationFailed).Once()
 
 	// Act: Attempt to perform the ECDH operation.
 	_, err = w.ECDH(t.Context(), path, remotePubKey)
@@ -262,20 +259,93 @@ func deterministicPrivKey(t *testing.T) (*btcec.PrivateKey, *btcec.PublicKey) {
 	return privKey, pubKey
 }
 
-// expectDerivedSignerPrivKey wires the signer-private key lookup path for a
-// derived managed pubkey address.
-func expectDerivedSignerPrivKey(t *testing.T, mocks *mockWalletDeps,
-	scope waddrmgr.KeyScope, path waddrmgr.DerivationPath,
-	privKey *btcec.PrivateKey) {
+// testAccountXPrv is a deterministic account-level extended private key used to
+// back the store-routed signer path in mock-based tests. Its child keys are
+// derived locally, and the store + vault mocks are programmed to return this
+// xprv, so the signer resolves the same leaf key the test derives.
+func testAccountXPrv(t *testing.T) *hdkeychain.ExtendedKey {
+	t.Helper()
+
+	seed := bytes.Repeat([]byte{0x2E}, hdkeychain.RecommendedSeedLen)
+	master, err := hdkeychain.NewMaster(seed, &chainParams)
+	require.NoError(t, err)
+
+	// A non-hardened child stands in for the account key; the exact path is
+	// irrelevant because the signer never re-derives above the account.
+	acct, err := master.Derive(7)
+	require.NoError(t, err)
+
+	return acct
+}
+
+// deriveLeafKeys derives the leaf private and public keys at the given branch
+// and index from an account extended private key, mirroring the local
+// derivation the store-routed signer performs after decrypting the account
+// xprv.
+func deriveLeafKeys(t *testing.T, acct *hdkeychain.ExtendedKey,
+	branch, index uint32) (*btcec.PrivateKey, *btcec.PublicKey) {
 
 	t.Helper()
 
-	mocks.pubKeyAddr.On("Imported").Return(false).Once()
-	mocks.pubKeyAddr.On("DerivationInfo").Return(scope, path, true).Once()
-	mocks.addrStore.On("FetchScopedKeyManager", scope).
-		Return(mocks.accountManager, nil).Once()
-	mocks.accountManager.On("DeriveFromKeyPathCache", path).
-		Return(privKey, nil).Once()
+	branchKey, err := acct.Derive(branch)
+	require.NoError(t, err)
+
+	leafKey, err := branchKey.Derive(index)
+	require.NoError(t, err)
+
+	privKey, err := leafKey.ECPrivKey()
+	require.NoError(t, err)
+
+	pubKey, err := leafKey.ECPubKey()
+	require.NoError(t, err)
+
+	return privKey, pubKey
+}
+
+// expectStoreSignerPrivKey wires the store-routed signer private-key lookup for
+// a derived address: the account secret is fetched by account number and its
+// encrypted extended private key is decrypted through the vault. The vault mock
+// runs as an identity cipher, so the plaintext handed to the signer is the
+// account xprv string itself.
+//
+// It returns the leaf private and public keys the signer will derive at the
+// path's branch and index, so callers can build the matching address and assert
+// against the recovered key.
+func expectStoreSignerPrivKey(t *testing.T, mocks *mockWalletDeps,
+	walletID uint32, scope waddrmgr.KeyScope,
+	path waddrmgr.DerivationPath) (*btcec.PrivateKey, *btcec.PublicKey) {
+
+	t.Helper()
+
+	acct := testAccountXPrv(t)
+	encAcctPriv := []byte(acct.String())
+
+	accountNumber := path.InternalAccount
+	mocks.store.On("GetAccountSecret", mock.Anything,
+		db.GetAccountSecretQuery{
+			WalletID:      walletID,
+			Scope:         db.KeyScope(scope),
+			AccountNumber: accountNumber,
+		}).Return(&db.AccountSecret{
+		EncryptedPrivateKey: encAcctPriv,
+	}, nil).Once()
+
+	mocks.vault.On("Decrypt", waddrmgr.CKTPrivate, encAcctPriv).Return(
+		identityDecrypt, nil,
+	).Once()
+
+	privKey, pubKey := deriveLeafKeys(t, acct, path.Branch, path.Index)
+
+	return privKey, pubKey
+}
+
+// identityDecrypt is a vault decrypt stub that returns the ciphertext
+// unchanged, standing in for a real decrypt of never-encrypted test material.
+func identityDecrypt(b []byte) []byte {
+	out := make([]byte, len(b))
+	copy(out, b)
+
+	return out
 }
 
 // TestSignDigest tests the signing of a message digest with different signature
@@ -284,8 +354,9 @@ func TestSignDigest(t *testing.T) {
 	t.Parallel()
 
 	// We'll use a common set of parameters for all signing test cases to
-	// ensure the only variable is the signing intent itself.
-	privKey, pubKey := deterministicPrivKey(t)
+	// ensure the only variable is the signing intent itself. The signing
+	// key is resolved through the store account secret, so the concrete
+	// key pair is produced per case by expectStoreSignerPrivKey.
 	path := BIP32Path{
 		KeyScope: waddrmgr.KeyScopeBIP0084,
 		DerivationPath: waddrmgr.DerivationPath{
@@ -308,9 +379,9 @@ func TestSignDigest(t *testing.T) {
 		intent *SignDigestIntent
 
 		// verify is a function that verifies the signature produced by
-		// the signing intent.
+		// the signing intent against the resolved leaf key pair.
 		verify func(t *testing.T, sig Signature,
-			pubKey *btcec.PublicKey)
+			privKey *btcec.PrivateKey, pubKey *btcec.PublicKey)
 	}{
 		{
 			name: "ECDSA success",
@@ -320,7 +391,7 @@ func TestSignDigest(t *testing.T) {
 				CompactSig: false,
 			},
 			verify: func(t *testing.T, sig Signature,
-				pubKey *btcec.PublicKey) {
+				_ *btcec.PrivateKey, pubKey *btcec.PublicKey) {
 
 				t.Helper()
 
@@ -340,7 +411,7 @@ func TestSignDigest(t *testing.T) {
 				CompactSig: true,
 			},
 			verify: func(t *testing.T, sig Signature,
-				pubKey *btcec.PublicKey) {
+				_ *btcec.PrivateKey, pubKey *btcec.PublicKey) {
 
 				t.Helper()
 
@@ -363,7 +434,7 @@ func TestSignDigest(t *testing.T) {
 				SigType: SigTypeSchnorr,
 			},
 			verify: func(t *testing.T, sig Signature,
-				pubKey *btcec.PublicKey) {
+				_ *btcec.PrivateKey, pubKey *btcec.PublicKey) {
 
 				t.Helper()
 
@@ -386,7 +457,7 @@ func TestSignDigest(t *testing.T) {
 				TaprootTweak: []byte("test tweak"),
 			},
 			verify: func(t *testing.T, sig Signature,
-				pubKey *btcec.PublicKey) {
+				privKey *btcec.PrivateKey, _ *btcec.PublicKey) {
 
 				t.Helper()
 
@@ -412,76 +483,62 @@ func TestSignDigest(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Arrange: Set up a mock wallet that will return our
-			// deterministic private key for the specified
-			// derivation path. This allows us to test the signing
-			// logic in isolation.
+			// Arrange: Set up a mock wallet whose store account
+			// secret resolves to a deterministic account xprv, so
+			// the signer derives a known leaf key for the path.
 			w, mocks := createUnlockedWalletWithMocks(t)
 
-			// Configure the full mock chain to return the test
-			// private key.
-			//
-			// NOTE: We must use a copy since the ECDH method will
-			// zero out the key.
-			privKeyCopy, _ := btcec.PrivKeyFromBytes(
-				privKey.Serialize(),
-			)
-
-			mocks.addrStore.On(
-				"FetchScopedKeyManager", path.KeyScope,
-			).Return(mocks.accountManager, nil).Once()
-			mocks.accountManager.On(
-				"DeriveFromKeyPath", mock.Anything,
+			privKey, pubKey := expectStoreSignerPrivKey(
+				t, mocks, w.id, path.KeyScope,
 				path.DerivationPath,
-			).Return(mocks.pubKeyAddr, nil).Once()
-			mocks.pubKeyAddr.On("PrivKey").Return(
-				privKeyCopy, nil,
-			).Once()
+			)
 
 			// Act: Attempt to sign the message with the wallet.
 			sig, err := w.SignDigest(t.Context(), path, tc.intent)
 
 			// Assert: Verify that the signature was created
-			// successfully and is valid for the given public key.
-			// We also assert that the private key was cleared from
-			// memory after the operation.
+			// successfully and is valid for the resolved leaf key.
 			require.NoError(t, err)
-			tc.verify(t, sig, pubKey)
-			require.Equal(t, byte(0), privKeyCopy.Serialize()[0])
+			tc.verify(t, sig, privKey, pubKey)
 		})
 	}
 }
 
-// TestSignDigestFail tests failure modes of SignDigest.
+// TestSignDigestFail tests failure modes of SignDigest through the store-routed
+// key path.
 func TestSignDigestFail(t *testing.T) {
 	t.Parallel()
 
 	w, mocks := createUnlockedWalletWithMocks(t)
 	path := BIP32Path{KeyScope: waddrmgr.KeyScopeBIP0084}
 
+	accountNumber := path.DerivationPath.InternalAccount
+	query := db.GetAccountSecretQuery{
+		WalletID:      w.id,
+		Scope:         db.KeyScope(path.KeyScope),
+		AccountNumber: accountNumber,
+	}
+
 	digest := make([]byte, 32)
 	intent := &SignDigestIntent{Digest: digest}
 
-	// Test Case 1: Fetching the key manager fails.
-	// We expect an `errManagerNotFound` error to be returned.
-	mocks.addrStore.On("FetchScopedKeyManager", path.KeyScope).
-		Return((*bwmock.AccountStore)(nil), errManagerNotFound).Once()
+	// Test Case 1: The signing account is not in the store. We expect
+	// ErrAccountNotInStore to be returned.
+	mocks.store.On("GetAccountSecret", mock.Anything, query).Return(
+		(*db.AccountSecret)(nil), db.ErrAccountNotFound,
+	).Once()
 
 	_, err := w.SignDigest(t.Context(), path, intent)
-	require.ErrorIs(t, err, errManagerNotFound)
+	require.ErrorIs(t, err, ErrAccountNotInStore)
 
-	// Test Case 2: Obtaining the private key for signing fails.
-	// We expect a `privkey error` to be returned.
-	mocks.addrStore.On("FetchScopedKeyManager", path.KeyScope).
-		Return(mocks.accountManager, nil).Once()
-	mocks.accountManager.On("DeriveFromKeyPath",
-		mock.Anything, mock.Anything).
-		Return(mocks.pubKeyAddr, nil).Once()
-	mocks.pubKeyAddr.On("PrivKey").Return((*btcec.PrivateKey)(nil),
-		errPrivKeyMock).Once()
+	// Test Case 2: The account exists but is watch-only (no encrypted
+	// private material). We expect ErrWatchOnlyAccount to be returned.
+	mocks.store.On("GetAccountSecret", mock.Anything, query).Return(
+		&db.AccountSecret{}, nil,
+	).Once()
 
 	_, err = w.SignDigest(t.Context(), path, intent)
-	require.ErrorContains(t, err, "privkey error")
+	require.ErrorIs(t, err, ErrWatchOnlyAccount)
 }
 
 // TestValidateSignDigestIntent tests the validation logic for SignDigestIntent.
@@ -567,13 +624,23 @@ func TestValidateSignDigestIntent(t *testing.T) {
 func TestComputeUnlockingScriptP2PKH(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Set up the wallet, keys, and a dummy transaction that will
-	// be used to spend the P2PKH output.
+	// Arrange: Set up the wallet and a dummy transaction that will be used
+	// to spend the P2PKH output.
 	w, mocks := createUnlockedWalletWithMocks(t)
-	privKey, pubKey := deterministicPrivKey(t)
 
-	// Create a P2PKH address and the corresponding previous output script.
-	// This is the output we want to create an unlocking script for.
+	// The signer resolves the private key through the store account secret,
+	// so program that path and take the leaf keys it will derive.
+	scope := waddrmgr.KeyScopeBIP0044
+	path := waddrmgr.DerivationPath{
+		InternalAccount: 0,
+		Account:         0,
+		Branch:          0,
+		Index:           0,
+	}
+	_, pubKey := expectStoreSignerPrivKey(t, mocks, w.id, scope, path)
+
+	// Create a P2PKH address for the derived leaf public key and the
+	// corresponding previous output script.
 	addr, err := address.NewAddressPubKeyHash(
 		address.Hash160(pubKey.SerializeCompressed()),
 		w.cfg.ChainParams,
@@ -584,29 +651,10 @@ func TestComputeUnlockingScriptP2PKH(t *testing.T) {
 
 	prevOut, tx := createDummyTestTx(pkScript)
 
-	// The wallet needs to be able to find the private key for the given
-	// address. We mock the address store to return a mock address that,
-	// when queried, will provide the private key for signing. This
-	// simulates a real scenario where the wallet's address manager would
-	// fetch the key from the database.
-	expectSignerAddressInfo(
-		t, w, mocks, addr, db.PubKeyHash, false, false, pubKey,
-	)
-	mocks.addrStore.On("Address",
-		mock.Anything, addr,
-	).Return(mocks.pubKeyAddr, nil).Once()
-
-	// Configure the full mock chain to return the test private key.
-	//
-	// NOTE: We must use a copy since the ECDH method will zero out the key.
-	privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
-	expectDerivedSignerPrivKey(
-		t, mocks, waddrmgr.KeyScopeBIP0044, waddrmgr.DerivationPath{
-			InternalAccount: 0,
-			Account:         0,
-			Branch:          0,
-			Index:           0,
-		}, privKeyCopy,
+	// The wallet resolves the address metadata through the store; the
+	// derivation scope makes the metadata directly usable for signing.
+	expectSignerAddressInfoWithKeyScope(
+		t, w, mocks, addr, db.PubKeyHash, false, false, pubKey, scope,
 	)
 
 	// Act: With the setup complete, we can now ask the wallet to compute
@@ -639,10 +687,6 @@ func TestComputeUnlockingScriptP2PKH(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NoError(t, vm.Execute(), "script execution failed")
-
-	// Finally, we ensure that the private key was not mutated during the
-	// signing process.
-	require.Equal(t, byte(0), privKeyCopy.Serialize()[0])
 }
 
 // TestComputeUnlockingScriptP2WKH tests that the wallet can generate a valid
@@ -650,12 +694,21 @@ func TestComputeUnlockingScriptP2PKH(t *testing.T) {
 func TestComputeUnlockingScriptP2WKH(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Set up the wallet, keys, and a dummy transaction that will
-	// be used to spend the P2WKH output.
+	// Arrange: Set up the wallet and a dummy transaction that will be used
+	// to spend the P2WKH output.
 	w, mocks := createUnlockedWalletWithMocks(t)
-	privKey, pubKey := deterministicPrivKey(t)
 
-	// Create a P2WKH address and the corresponding previous output script.
+	scope := waddrmgr.KeyScopeBIP0084
+	path := waddrmgr.DerivationPath{
+		InternalAccount: 0,
+		Account:         0,
+		Branch:          0,
+		Index:           0,
+	}
+	_, pubKey := expectStoreSignerPrivKey(t, mocks, w.id, scope, path)
+
+	// Create a P2WKH address for the derived leaf public key and the
+	// corresponding previous output script.
 	addr, err := address.NewAddressWitnessPubKeyHash(
 		address.Hash160(pubKey.SerializeCompressed()),
 		w.cfg.ChainParams,
@@ -666,27 +719,11 @@ func TestComputeUnlockingScriptP2WKH(t *testing.T) {
 
 	prevOut, tx := createDummyTestTx(pkScript)
 
-	// The wallet needs to be able to find the private key for the given
-	// address. We mock the address store to return a mock address that,
-	// when queried, will provide the private key for signing.
-	expectSignerAddressInfo(
+	// The wallet resolves the address metadata through the store; the
+	// derivation scope makes the metadata directly usable for signing.
+	expectSignerAddressInfoWithKeyScope(
 		t, w, mocks, addr, db.WitnessPubKey, false, false, pubKey,
-	)
-	mocks.addrStore.On("Address",
-		mock.Anything, addr,
-	).Return(mocks.pubKeyAddr, nil).Once()
-
-	// Configure the full mock chain to return the test private key.
-	//
-	// NOTE: We must use a copy since the ECDH method will zero out the key.
-	privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
-	expectDerivedSignerPrivKey(
-		t, mocks, waddrmgr.KeyScopeBIP0084, waddrmgr.DerivationPath{
-			InternalAccount: 0,
-			Account:         0,
-			Branch:          0,
-			Index:           0,
-		}, privKeyCopy,
+		scope,
 	)
 
 	// Act: With the setup complete, we can now ask the wallet to compute
@@ -718,10 +755,6 @@ func TestComputeUnlockingScriptP2WKH(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NoError(t, vm.Execute(), "script execution failed")
-
-	// Finally, we ensure that the private key was not mutated during the
-	// signing process.
-	require.Equal(t, byte(0), privKeyCopy.Serialize()[0])
 }
 
 // TestComputeUnlockingScriptNP2WKH tests that the wallet can generate a valid
@@ -729,13 +762,21 @@ func TestComputeUnlockingScriptP2WKH(t *testing.T) {
 func TestComputeUnlockingScriptNP2WKH(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Set up the wallet, keys, and a dummy transaction.
+	// Arrange: Set up the wallet and a dummy transaction.
 	w, mocks := createUnlockedWalletWithMocks(t)
-	privKey, pubKey := deterministicPrivKey(t)
 
-	// Create a NP2WKH address. This is a P2WKH output nested within a
-	// P2SH output. This is done by creating the witness program first,
-	// and then using its hash in a P2SH script.
+	scope := waddrmgr.KeyScopeBIP0049Plus
+	path := waddrmgr.DerivationPath{
+		InternalAccount: 0,
+		Account:         0,
+		Branch:          0,
+		Index:           0,
+	}
+	_, pubKey := expectStoreSignerPrivKey(t, mocks, w.id, scope, path)
+
+	// Create a NP2WKH address for the derived leaf public key. This is a
+	// P2WKH output nested within a P2SH output. This is done by creating
+	// the witness program first, and then using its hash in a P2SH script.
 	p2sh, err := txscript.NewScriptBuilder().
 		AddOp(txscript.OP_0).
 		AddData(address.Hash160(pubKey.SerializeCompressed())).
@@ -748,29 +789,12 @@ func TestComputeUnlockingScriptNP2WKH(t *testing.T) {
 
 	prevOut, tx := createDummyTestTx(pkScript)
 
-	// The wallet needs to be able to find the private key for the given
-	// address. We mock the address store to return a mock address that,
-	// when queried, will provide the private key for signing. For NP2WKH,
-	// the wallet also needs the public key to reconstruct the witness
-	// program, so we mock that as well.
-	expectSignerAddressInfo(
+	// The wallet resolves the address metadata through the store; the
+	// derivation scope makes the metadata directly usable for signing. The
+	// nested witness program is rebuilt from the address public key.
+	expectSignerAddressInfoWithKeyScope(
 		t, w, mocks, addr, db.NestedWitnessPubKey, false, false, pubKey,
-	)
-	mocks.addrStore.On("Address",
-		mock.Anything, addr,
-	).Return(mocks.pubKeyAddr, nil).Once()
-
-	// Configure the full mock chain to return the test private key.
-	//
-	// NOTE: We must use a copy since the ECDH method will zero out the key.
-	privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
-	expectDerivedSignerPrivKey(
-		t, mocks, waddrmgr.KeyScopeBIP0049Plus, waddrmgr.DerivationPath{
-			InternalAccount: 0,
-			Account:         0,
-			Branch:          0,
-			Index:           0,
-		}, privKeyCopy,
+		scope,
 	)
 
 	// Act: With the setup complete, we can now ask the wallet to compute
@@ -804,10 +828,6 @@ func TestComputeUnlockingScriptNP2WKH(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NoError(t, vm.Execute(), "script execution failed")
-
-	// Finally, we ensure that the private key was not mutated during the
-	// signing process.
-	require.Equal(t, byte(0), privKeyCopy.Serialize()[0])
 }
 
 // TestComputeUnlockingScriptP2TR tests that the wallet can generate a valid
@@ -817,10 +837,19 @@ func TestComputeUnlockingScriptP2TR(t *testing.T) {
 
 	// Arrange: Set up the wallet, keys, and a dummy transaction.
 	w, mocks := createUnlockedWalletWithMocks(t)
-	privKey, pubKey := deterministicPrivKey(t)
 
-	// Create a P2TR address for a key-path spend. This involves computing
-	// the taproot output key from the internal public key.
+	scope := waddrmgr.KeyScopeBIP0086
+	path := waddrmgr.DerivationPath{
+		InternalAccount: 0,
+		Account:         0,
+		Branch:          0,
+		Index:           0,
+	}
+	_, pubKey := expectStoreSignerPrivKey(t, mocks, w.id, scope, path)
+
+	// Create a P2TR address for a key-path spend of the derived leaf public
+	// key. This involves computing the taproot output key from the internal
+	// public key.
 	addr, err := address.NewAddressTaproot(
 		schnorr.SerializePubKey(
 			txscript.ComputeTaprootOutputKey(pubKey, nil),
@@ -832,27 +861,11 @@ func TestComputeUnlockingScriptP2TR(t *testing.T) {
 
 	prevOut, tx := createDummyTestTx(pkScript)
 
-	// The wallet needs to be able to find the private key for the given
-	// address. We mock the address store to return a mock address that,
-	// when queried, will provide the private key for signing.
-	expectSignerAddressInfo(
+	// The wallet resolves the address metadata through the store; the
+	// derivation scope makes the metadata directly usable for signing.
+	expectSignerAddressInfoWithKeyScope(
 		t, w, mocks, addr, db.TaprootPubKey, false, false, pubKey,
-	)
-	mocks.addrStore.On("Address",
-		mock.Anything, addr,
-	).Return(mocks.pubKeyAddr, nil).Once()
-
-	// Configure the full mock chain to return the test private key.
-	//
-	// NOTE: We must use a copy since the ECDH method will zero out the key.
-	privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
-	expectDerivedSignerPrivKey(
-		t, mocks, waddrmgr.KeyScopeBIP0086, waddrmgr.DerivationPath{
-			InternalAccount: 0,
-			Account:         0,
-			Branch:          0,
-			Index:           0,
-		}, privKeyCopy,
+		scope,
 	)
 
 	// Act: With the setup complete, we can now ask the wallet to compute
@@ -888,10 +901,6 @@ func TestComputeUnlockingScriptP2TR(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NoError(t, vm.Execute(), "script execution failed")
-
-	// Finally, we ensure that the private key was not mutated during the
-	// signing process.
-	require.Equal(t, byte(0), privKeyCopy.Serialize()[0])
 }
 
 // TestComputeUnlockingScriptSQLDerivedAddress verifies that an address created
@@ -914,9 +923,6 @@ func TestComputeUnlockingScriptSQLDerivedAddress(t *testing.T) {
 		t.Context(), "default", waddrmgr.WitnessPubKey, false,
 	)
 	require.NoError(t, err)
-
-	_, err = w.loadManagedPubKeyAddr(addr)
-	require.Error(t, err)
 
 	pkScript, err := txscript.PayToAddrScript(addr)
 	require.NoError(t, err)
@@ -948,13 +954,112 @@ func TestComputeUnlockingScriptSQLDerivedAddress(t *testing.T) {
 	require.NoError(t, vm.Execute(), "script execution failed")
 }
 
+// TestResolveDerivedPrivKeyFromStoreDerivedSuccess exercises the store-backed
+// success path end to end: the account's encrypted extended private key is
+// fetched from the store, decrypted through the key vault under CKTPrivate, the
+// account xprv is parsed, and the leaf key at a specific branch and index is
+// derived. It asserts the recovered leaf key equals one derived independently
+// from the same account xprv, so a wrong crypto-key selection on decrypt or a
+// bad child derivation cannot slip through unnoticed.
+//
+// Unlike the identity-cipher helpers used elsewhere, the stored ciphertext here
+// is deliberately distinct from the plaintext xprv, so the assertion only holds
+// if the vault Decrypt call is actually made and its output is what gets
+// parsed.
+func TestResolveDerivedPrivKeyFromStoreDerivedSuccess(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: a real account xprv whose leaf key the signer must recover,
+	// and a marked ciphertext that differs from the plaintext so the
+	// decrypt step is load-bearing.
+	w, mocks := createUnlockedWalletWithMocks(t)
+
+	acct := testAccountXPrv(t)
+	plaintextXPrv := []byte(acct.String())
+	encAcctPriv := append([]byte("vault-ciphertext:"), plaintextXPrv...)
+	require.NotEqual(t, plaintextXPrv, encAcctPriv)
+
+	scope := waddrmgr.KeyScopeBIP0084
+	path := waddrmgr.DerivationPath{
+		InternalAccount: 4,
+		Branch:          1,
+		Index:           5,
+	}
+
+	// The store returns the encrypted account material keyed by account
+	// number (path-only caller, so accountID is nil below).
+	accountNumber := path.InternalAccount
+	mocks.store.On("GetAccountSecret", mock.Anything,
+		db.GetAccountSecretQuery{
+			WalletID:      w.id,
+			Scope:         db.KeyScope(scope),
+			AccountNumber: accountNumber,
+		}).Return(&db.AccountSecret{
+		EncryptedPrivateKey: encAcctPriv,
+	}, nil).Once()
+
+	// The vault decrypts the ciphertext under the private crypto key back
+	// to the plaintext account xprv. Returning a closure lets the mock
+	// ignore the (distinct) ciphertext input and hand back the known
+	// plaintext.
+	mocks.vault.On("Decrypt", waddrmgr.CKTPrivate, encAcctPriv).Return(
+		func([]byte) []byte {
+			out := make([]byte, len(plaintextXPrv))
+			copy(out, plaintextXPrv)
+
+			return out
+		}, nil,
+	).Once()
+
+	// The expected leaf key, derived independently from the same account
+	// xprv at the same branch and index.
+	wantPriv, _ := deriveLeafKeys(t, acct, path.Branch, path.Index)
+
+	// Act: resolve the derived private key through the store.
+	gotPriv, err := w.resolveDerivedPrivKeyFromStore(
+		t.Context(), scope, path,
+	)
+
+	// Assert: the decrypt -> parse -> derive chain produced the exact leaf
+	// key, proving the crypto-key type and child derivation are correct.
+	require.NoError(t, err)
+	require.Equal(t, wantPriv.Serialize(), gotPriv.Serialize())
+	gotPriv.Zero()
+}
+
 // TestGetPrivKeyForAddressSQLDerivedAddress verifies that GetPrivKeyForAddress
-// recovers the private key for an address whose only persistent record lives
-// in the SQL store.
+// recovers the private key for an address owned by a SQL-only account, driving
+// the store-secret + vault-decrypt fallback rather than any waddrmgr-mirrored
+// material.
+//
+// The "default" account (number 0) is mirrored between the SQL store and the
+// legacy waddrmgr manager (both seeded identically), so signing it does not
+// distinguish the store path from a legacy lookup. This test instead signs from
+// a secondary account that exists ONLY in the SQL store (a non-zero account
+// number), so the recovered key can only come from the store's encrypted
+// account secret decrypted through the vault.
 func TestGetPrivKeyForAddressSQLDerivedAddress(t *testing.T) {
 	t.Parallel()
 
-	w, chain, _ := newSQLAddressSigningWallet(t)
+	w, chain, vault := newSQLAddressSigningWallet(t)
+
+	// Create a second derived account that lives only in the SQL store; it
+	// has no counterpart in the legacy waddrmgr manager.
+	secondary, err := w.store.CreateDerivedAccount(
+		t.Context(), db.CreateDerivedAccountParams{
+			WalletID: w.id,
+			Scope:    db.KeyScope(waddrmgr.KeyScopeBIP0084),
+			Name:     "secondary",
+		}, testAccountDerivationFunc(),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, secondary.AccountNumber)
+	require.NotNil(t, secondary.AccountID)
+
+	// The secondary account must not be the wallet's default account 0,
+	// which is the one mirrored through waddrmgr.
+	require.NotZero(t, *secondary.AccountNumber)
+
 	chain.On(
 		"NotifyReceived",
 		mock.MatchedBy(func(addrs []address.Address) bool {
@@ -963,31 +1068,55 @@ func TestGetPrivKeyForAddressSQLDerivedAddress(t *testing.T) {
 	).Return(nil).Once()
 
 	addr, err := w.NewAddress(
-		t.Context(), "default", waddrmgr.WitnessPubKey, false,
+		t.Context(), "secondary", waddrmgr.WitnessPubKey, false,
 	)
 	require.NoError(t, err)
 
-	// The legacy managed-address lookup should fail for a SQL-only
-	// derived address — this confirms the test exercises the derivation
-	// path rather than the kvdb fallback.
-	_, err = w.loadManagedPubKeyAddr(addr)
-	require.Error(t, err)
+	// Read back the store's view of the address so the expected leaf key is
+	// derived at exactly the branch and index the store assigned.
+	info, err := w.GetAddressInfo(t.Context(), addr)
+	require.NoError(t, err)
+	require.NotNil(t, info.Derivation, "SQL-derived address must carry "+
+		"derivation metadata")
+	require.Equal(
+		t, *secondary.AccountNumber, info.Derivation.Account,
+	)
 
+	// Independently derive the expected leaf key from the same seed the
+	// SQL account derivation used, at the secondary account number and the
+	// store-assigned branch and index.
+	seed := bytes.Repeat([]byte{0x5A}, hdkeychain.RecommendedSeedLen)
+	master, err := hdkeychain.NewMaster(seed, &chainParams)
+	require.NoError(t, err)
+	acctKey, err := deriveBIP44AccountKey(
+		master, db.KeyScope(waddrmgr.KeyScopeBIP0084),
+		*secondary.AccountNumber,
+	)
+	require.NoError(t, err)
+	wantPriv, _ := deriveLeafKeys(
+		t, acctKey, info.Derivation.Branch, info.Derivation.Index,
+	)
+
+	// Act: resolve the private key. This drives GetAccountSecret keyed by
+	// the durable account id and decrypts the account xprv through the
+	// vault.
 	priv, err := w.GetPrivKeyForAddress(t.Context(), addr)
 	require.NoError(t, err, "GetPrivKeyForAddress must succeed for "+
-		"SQL-derived addresses")
+		"SQL-only derived addresses")
 	require.NotNil(t, priv)
+
+	// Assert: the recovered key matches the independently derived leaf key,
+	// and the vault's private decrypt path actually ran.
+	require.Equal(t, wantPriv.Serialize(), priv.Serialize())
+	vault.AssertCalled(t, "Decrypt", waddrmgr.CKTPrivate, mock.Anything)
 	priv.Zero()
 }
 
 // TestNewAddressOnSQLOnlyAccount verifies that SQL-owned accounts can derive
 // receive addresses without a mirrored legacy waddrmgr account.
 //
-// The test exercises the public-key path only. Signing with addresses owned
-// by a SQL-only account currently routes through the legacy waddrmgr
-// derivation cache, which does not see SQL-only accounts; that gap is
-// tracked separately and will be closed by the signer-store work on
-// impl-tx-creator-store using keyVault-backed account-secret derivation.
+// The test exercises the public-key path; signer coverage for SQL-only
+// accounts is provided by TestGetPrivKeyForAddressSQLDerivedAddress.
 func TestNewAddressOnSQLOnlyAccount(t *testing.T) {
 	t.Parallel()
 
@@ -1062,8 +1191,8 @@ func TestComputeUnlockingScriptFail_ScriptForOutput(t *testing.T) {
 	require.ErrorContains(t, err, "unable to get address info")
 }
 
-// TestComputeUnlockingScriptFail_PrivKey tests failure when private key
-// retrieval fails.
+// TestComputeUnlockingScriptFail_PrivKey tests failure when the store-routed
+// private key resolution fails.
 func TestComputeUnlockingScriptFail_PrivKey(t *testing.T) {
 	t.Parallel()
 
@@ -1083,35 +1212,23 @@ func TestComputeUnlockingScriptFail_PrivKey(t *testing.T) {
 	)
 	sigHashes := txscript.NewTxSigHashes(tx, fetcher)
 
-	// Arrange: Set up the wallet and mocks.
+	// Arrange: Set up the wallet and mocks. A usable derivation scope
+	// routes signing through the store account secret, whose lookup we
+	// fail.
 	w, mocks := createUnlockedWalletWithMocks(t)
+	scope := waddrmgr.KeyScopeBIP0044
 
-	// Mock address store and managed address.
-	expectSignerAddressInfo(
-		t, w, mocks, addr, db.PubKeyHash, false, false, pubKey,
+	expectSignerAddressInfoWithKeyScope(
+		t, w, mocks, addr, db.PubKeyHash, false, false, pubKey, scope,
 	)
-	mocks.addrStore.On("Address", mock.Anything, addr).
-		Return(mocks.pubKeyAddr, nil).Once()
-	mocks.pubKeyAddr.On("Imported").Return(false).Once()
-	mocks.pubKeyAddr.On("DerivationInfo").Return(
-		waddrmgr.KeyScopeBIP0044, waddrmgr.DerivationPath{
-			InternalAccount: 0,
-			Account:         0,
-			Branch:          0,
-			Index:           0,
-		}, true,
-	).Once()
 
-	mocks.addrStore.On("FetchScopedKeyManager", waddrmgr.KeyScopeBIP0044).
-		Return(mocks.accountManager, nil).Once()
-	mocks.accountManager.On("DeriveFromKeyPathCache",
-		waddrmgr.DerivationPath{
-			InternalAccount: 0,
-			Account:         0,
-			Branch:          0,
-			Index:           0,
-		},
-	).Return((*btcec.PrivateKey)(nil), errPrivKeyMock).Once()
+	accountNumber := uint32(0)
+	mocks.store.On("GetAccountSecret", mock.Anything,
+		db.GetAccountSecretQuery{
+			WalletID:      w.id,
+			Scope:         db.KeyScope(scope),
+			AccountNumber: accountNumber,
+		}).Return((*db.AccountSecret)(nil), errPrivKeyMock).Once()
 
 	params := &UnlockingScriptParams{
 		Tx:        tx,
@@ -1127,54 +1244,396 @@ func TestComputeUnlockingScriptFail_PrivKey(t *testing.T) {
 	require.ErrorContains(t, err, "privkey error")
 }
 
-// TestResolvePrivKeyFallsBackAfterCacheMiss tests that derived private key
-// resolution falls back to DB-backed derivation when the account cache is cold.
-func TestResolvePrivKeyFallsBackAfterCacheMiss(t *testing.T) {
+// TestComputeUnlockingScriptImportedAddress verifies that
+// ComputeUnlockingScript signs for an imported address by resolving the private
+// key from its own encrypted secret in the store rather than an account
+// derivation.
+func TestComputeUnlockingScriptImportedAddress(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Create a started wallet and configure the signer key lookup path
-	// to miss the account cache before falling back to DB-backed derivation.
-	w, mocks := createStartedWalletWithMocks(t)
-	privKey, _ := deterministicPrivKey(t)
-	path := waddrmgr.DerivationPath{
-		InternalAccount: 0,
-		Account:         0,
-		Branch:          0,
-		Index:           1,
-	}
+	w, mocks := createUnlockedWalletWithMocks(t)
 
-	mocks.pubKeyAddr.On("Imported").Return(false).Once()
-	mocks.pubKeyAddr.On("DerivationInfo").Return(
-		waddrmgr.KeyScopeBIP0084, path, true,
-	).Once()
-	mocks.addrStore.On("FetchScopedKeyManager", waddrmgr.KeyScopeBIP0084).
-		Return(mocks.accountManager, nil).Once()
-	mocks.accountManager.On("DeriveFromKeyPathCache", path).
-		Return(
-			(*btcec.PrivateKey)(nil),
-			waddrmgr.ManagerError{
-				ErrorCode:   waddrmgr.ErrAccountNotCached,
-				Description: "account not cached",
-			},
-		).Once()
-	mocks.accountManager.On("DeriveFromKeyPath", mock.Anything, path).
-		Return(mocks.pubKeyAddr, nil).Once()
-	mocks.pubKeyAddr.On("PrivKey").Return(privKey, nil).Once()
+	// The imported private key is stored per-address; the vault decrypts
+	// the stored ciphertext (identity here) to the raw 32-byte key.
+	privKey, pubKey := deterministicPrivKey(t)
+	encPriv := privKey.Serialize()
 
-	// Act: Resolve the private key for the managed pubkey address.
-	resolvedPrivKey, err := w.resolvePrivKey(mocks.pubKeyAddr)
+	addr, err := address.NewAddressWitnessPubKeyHash(
+		address.Hash160(pubKey.SerializeCompressed()),
+		w.cfg.ChainParams,
+	)
+	require.NoError(t, err)
+	pkScript, err := txscript.PayToAddrScript(addr)
 	require.NoError(t, err)
 
-	// Assert: The fallback path returns the same private key bytes.
-	require.Equal(t, privKey.Serialize(), resolvedPrivKey.Serialize())
+	prevOut, tx := createDummyTestTx(pkScript)
+
+	// The store reports the address as imported (no derivation path), so
+	// the signer resolves the key through the per-address secret.
+	expectStoreAddressInfo(t, w, mocks, addr, &db.AddressInfo{
+		ScriptPubKey: pkScript,
+		AddrType:     db.WitnessPubKey,
+		IsImported:   true,
+		PubKey:       pubKey.SerializeCompressed(),
+	})
+	mocks.store.On("GetAddressSecret", mock.Anything,
+		db.GetAddressSecretQuery{
+			WalletID:     w.id,
+			ScriptPubKey: pkScript,
+		}).Return(
+		&db.AddressSecret{EncryptedPrivKey: encPriv}, nil,
+	).Once()
+	mocks.vault.On("Decrypt", waddrmgr.CKTPrivate, encPriv).Return(
+		identityDecrypt, nil,
+	).Once()
+
+	fetcher := txscript.NewCannedPrevOutputFetcher(
+		prevOut.PkScript, prevOut.Value,
+	)
+	sigHashes := txscript.NewTxSigHashes(tx, fetcher)
+	params := &UnlockingScriptParams{
+		Tx:         tx,
+		InputIndex: 0,
+		Output:     prevOut,
+		SigHashes:  sigHashes,
+		HashType:   txscript.SigHashAll,
+	}
+
+	// Act.
+	script, err := w.ComputeUnlockingScript(t.Context(), params)
+	require.NoError(t, err)
+
+	// Assert: The witness spends the imported P2WKH output.
+	require.Nil(t, script.SigScript)
+	require.NotNil(t, script.Witness)
+	tx.TxIn[0].Witness = script.Witness
+
+	vm, err := txscript.NewEngine(
+		prevOut.PkScript, tx, 0, txscript.StandardVerifyFlags, nil,
+		sigHashes, prevOut.Value, fetcher,
+	)
+	require.NoError(t, err)
+	require.NoError(t, vm.Execute(), "script execution failed")
+}
+
+// TestScriptForOutputScriptClasses verifies that ScriptForOutput resolves each
+// stored script class through the same lookup and returns the caller-visible
+// script: the redeem script verbatim for P2SH, the witness script verbatim for
+// P2WSH, and the decoded leaf script for an imported taproot Tapscript.
+func TestScriptForOutputScriptClasses(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		addrType db.AddressType
+
+		// build returns the address to resolve, the blob the store
+		// persists as the encrypted script, and the script the wallet
+		// must hand back.
+		build func(*testing.T, *Wallet) (address.Address, []byte,
+			[]byte)
+	}{{
+		name:     "p2sh redeem script",
+		addrType: db.ScriptHash,
+		build: func(t *testing.T, w *Wallet) (address.Address, []byte,
+			[]byte) {
+
+			t.Helper()
+
+			_, pubKey := deterministicPrivKey(t)
+
+			// A representative multisig redeem script; its exact
+			// contents are opaque to the wallet, which stores and
+			// returns it verbatim.
+			redeemScript, err := txscript.NewScriptBuilder().
+				AddOp(txscript.OP_1).
+				AddData(pubKey.SerializeCompressed()).
+				AddOp(txscript.OP_1).
+				AddOp(txscript.OP_CHECKMULTISIG).
+				Script()
+			require.NoError(t, err)
+
+			addr, err := address.NewAddressScriptHash(
+				redeemScript, w.cfg.ChainParams,
+			)
+			require.NoError(t, err)
+
+			return addr, redeemScript, redeemScript
+		},
+	}, {
+		name:     "p2wsh witness script",
+		addrType: db.WitnessScript,
+		build: func(t *testing.T, w *Wallet) (address.Address, []byte,
+			[]byte) {
+
+			t.Helper()
+
+			_, pubKey := deterministicPrivKey(t)
+
+			witnessScript, err := txscript.NewScriptBuilder().
+				AddData(pubKey.SerializeCompressed()).
+				AddOp(txscript.OP_CHECKSIG).
+				Script()
+			require.NoError(t, err)
+
+			scriptHash := sha256.Sum256(witnessScript)
+			addr, err := address.NewAddressWitnessScriptHash(
+				scriptHash[:], w.cfg.ChainParams,
+			)
+			require.NoError(t, err)
+
+			return addr, witnessScript, witnessScript
+		},
+	}, {
+		name:     "taproot leaf script",
+		addrType: db.TaprootPubKey,
+		build: func(t *testing.T, w *Wallet) (address.Address, []byte,
+			[]byte) {
+
+			t.Helper()
+
+			_, internalKey := deterministicPrivKey(t)
+
+			// A single-leaf taproot script tree and the imported
+			// Tapscript committing to it, mirroring
+			// ImportTaprootScript's persisted shape.
+			leafScript, err := txscript.NewScriptBuilder().
+				AddData(schnorr.SerializePubKey(internalKey)).
+				AddOp(txscript.OP_CHECKSIG).
+				Script()
+			require.NoError(t, err)
+
+			leaf := txscript.NewBaseTapLeaf(leafScript)
+			tapscript := &waddrmgr.Tapscript{
+				Type:   waddrmgr.TapscriptTypeFullTree,
+				Leaves: []txscript.TapLeaf{leaf},
+				ControlBlock: &txscript.ControlBlock{
+					InternalKey: internalKey,
+				},
+			}
+
+			taprootKey, err := tapscript.TaprootKey()
+			require.NoError(t, err)
+
+			addr, err := address.NewAddressTaproot(
+				schnorr.SerializePubKey(taprootKey),
+				w.cfg.ChainParams,
+			)
+			require.NoError(t, err)
+
+			// The store persists the TLV-encoded Tapscript as the
+			// encrypted script; the identity vault returns it
+			// unchanged on decrypt, and ScriptForOutput decodes it
+			// back to the leaf script.
+			encoded, err := waddrmgr.EncodeTaprootScript(tapscript)
+			require.NoError(t, err)
+
+			return addr, encoded, leafScript
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			w, mocks := createUnlockedWalletWithMocks(t)
+			addr, stored, want := test.build(t, w)
+
+			script := assertScriptForOutput(
+				t, w, mocks, addr, test.addrType, stored,
+			)
+			require.Equal(t, want, script)
+		})
+	}
+}
+
+// TestScriptForOutputWatchOnlyTaprootSQL exercises the full watch-only taproot
+// round trip against a live SQLite store and the production store-backed key
+// vault: ImportTaprootScript seals the Tapscript, the SQLite store persists
+// that ciphertext, and ScriptForOutput reads it back. This is a read path
+// reachable without signing, and it runs through keyvault.NewWalletVault --
+// the vault every SQL wallet actually uses -- rather than the legacy manager
+// shim, which is what made an earlier version of this test pass against a
+// vault configuration production never runs.
+//
+// The round trip alone cannot pin the wallet-to-store pairing, because a
+// store-backed vault resolves both script key types onto its single
+// passphrase-derived script key: the seal and the open agree no matter which
+// secrecy the store reports. So the persisted secrecy is asserted directly,
+// which is what fails if the store's derivation is inverted.
+func TestScriptForOutputWatchOnlyTaprootSQL(t *testing.T) {
+	t.Parallel()
+
+	// Imported addresses never derive, so a stub derivation is enough.
+	deriveAddress := func(context.Context,
+		db.AddressDerivationParams) (*db.DerivedAddressData, error) {
+
+		return nil, errDerivationFailed
+	}
+	store, err := sqlitedb.NewStore(t.Context(), sqlitedb.Config{
+		DBPath:        filepath.Join(t.TempDir(), "wallet.sqlite"),
+		DeriveAddress: deriveAddress,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+
+	// Real watch-only wallet secrets, so the vault derives its script key
+	// from the passphrase exactly as production does.
+	passphrase := []byte("watch-only-passphrase")
+	secrets, err := keyvault.CreateWalletSecrets(passphrase, nil, true)
+	require.NoError(t, err)
+
+	walletInfo, err := store.CreateWallet(
+		t.Context(), db.CreateWalletParams{
+			Name:                "sql-watch-only-taproot",
+			ManagerVersion:      1,
+			MasterKeyPrivParams: secrets.MasterPrivParams,
+			EncryptedCryptoScriptKey: secrets.
+				EncryptedCryptoScriptKey,
+			IsWatchOnly: true,
+		},
+	)
+	require.NoError(t, err)
+
+	vault := keyvault.NewWalletVault(store, walletInfo.ID, true)
+	require.NoError(t, vault.Unlock(t.Context(), passphrase))
+	t.Cleanup(vault.Lock)
+
+	chain := &bwmock.Chain{}
+	w := &Wallet{
+		store:       store,
+		keyVault:    vault,
+		cache:       newStoreRuntimeCache(store),
+		state:       newWalletState(nil),
+		isWatchOnly: true,
+		cfg: Config{
+			Chain:       chain,
+			ChainParams: &chainParams,
+		},
+		id: walletInfo.ID,
+	}
+	require.NoError(t, w.state.toStarting())
+	require.NoError(t, w.state.toStarted())
+
+	tapscript := newTestTapscript(t)
+	leafScript := tapscript.Leaves[0].Script
+
+	// Import notifies the chain of the new watch-only address.
+	taprootKey, err := tapscript.TaprootKey()
+	require.NoError(t, err)
+	addr, err := address.NewAddressTaproot(
+		schnorr.SerializePubKey(taprootKey), w.cfg.ChainParams,
+	)
+	require.NoError(t, err)
+	chain.On("NotifyReceived", []address.Address{addr}).Return(nil).Once()
+
+	info, err := w.ImportTaprootScript(t.Context(), tapscript)
+	require.NoError(t, err)
+	require.Equal(t, waddrmgr.TaprootScript, info.AddrType)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	// A watch-only wallet still seals script bodies: its passphrase derives
+	// a script key even with no private key material. This is the assertion
+	// that pins that behaviour, because the round trip below would succeed
+	// just as well if the script were stored in the clear.
+	encodedScript, err := waddrmgr.EncodeTaprootScript(&tapscript)
+	require.NoError(t, err)
+
+	secret, err := store.GetAddressSecret(
+		t.Context(), db.GetAddressSecretQuery{
+			WalletID:     walletInfo.ID,
+			ScriptPubKey: pkScript,
+		},
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, secret.EncryptedScript)
+	require.NotEqual(t, encodedScript, secret.EncryptedScript,
+		"a watch-only wallet's script must not persist in plaintext")
+
+	// ScriptForOutput reads the imported script back through the same vault
+	// that sealed it, returning the revealed leaf script.
+	got, err := w.ScriptForOutput(
+		t.Context(), wire.TxOut{PkScript: pkScript},
+	)
+	require.NoError(t, err)
+	require.Equal(t, leafScript, got.Script)
+
+	// A locked vault has no key to open the script with: the script key is
+	// zeroed on lock even on a watch-only wallet.
+	w.keyVault.Lock()
+
+	_, err = w.ScriptForOutput(
+		t.Context(), wire.TxOut{PkScript: pkScript},
+	)
+	require.ErrorIs(t, err, keyvault.ErrVaultLocked)
+
+	chain.AssertExpectations(t)
+}
+
+// assertScriptForOutput drives ScriptForOutput for a script-based output whose
+// encrypted script decrypts (via the identity vault) to encScript, and returns
+// the resolved OutputScriptInfo.Script. It programs the store address lookup as
+// a script address and the address-secret lookup as script-only.
+//
+// Every stored script body reads back through the vault's single script
+// operation, so there is no per-address crypto class for the test to select.
+func assertScriptForOutput(t *testing.T, w *Wallet, mocks *mockWalletDeps,
+	addr address.Address, addrType db.AddressType, encScript []byte) []byte {
+
+	t.Helper()
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	// The store owns the address as an imported script address.
+	expectStoreAddressInfo(t, w, mocks, addr, &db.AddressInfo{
+		ScriptPubKey: pkScript,
+		AddrType:     addrType,
+		IsImported:   true,
+		HasScript:    true,
+	})
+
+	// The address secret carries only the encrypted script.
+	mocks.store.On("GetAddressSecret", mock.Anything,
+		db.GetAddressSecretQuery{
+			WalletID:     w.id,
+			ScriptPubKey: pkScript,
+		}).Return(&db.AddressSecret{
+		EncryptedScript: encScript,
+	}, nil).Once()
+
+	mocks.vault.On("Decrypt", mock.Anything, encScript).Return(
+		identityDecrypt, nil,
+	).Once()
+
+	info, err := w.ScriptForOutput(
+		t.Context(), wire.TxOut{PkScript: pkScript},
+	)
+	require.NoError(t, err)
+
+	return info.Script
 }
 
 // TestComputeUnlockingScriptFail_Tweak tests failure when the tweaker fails.
 func TestComputeUnlockingScriptFail_Tweak(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Set up keys, address, and transaction.
-	privKey, pubKey := deterministicPrivKey(t)
+	// Arrange: Set up the wallet and mocks. The key is resolved through the
+	// store account secret.
+	w, mocks := createUnlockedWalletWithMocks(t)
+	scope := waddrmgr.KeyScopeBIP0044
+	path := waddrmgr.DerivationPath{
+		InternalAccount: 0,
+		Account:         0,
+		Branch:          0,
+		Index:           0,
+	}
+	_, pubKey := expectStoreSignerPrivKey(t, mocks, w.id, scope, path)
+
 	addr, err := address.NewAddressPubKeyHash(
 		address.Hash160(pubKey.SerializeCompressed()), &chainParams,
 	)
@@ -1189,24 +1648,8 @@ func TestComputeUnlockingScriptFail_Tweak(t *testing.T) {
 	)
 	sigHashes := txscript.NewTxSigHashes(tx, fetcher)
 
-	// Arrange: Set up the wallet and mocks.
-	w, mocks := createUnlockedWalletWithMocks(t)
-
-	// Mock address store and managed address.
-	expectSignerAddressInfo(
-		t, w, mocks, addr, db.PubKeyHash, false, false, pubKey,
-	)
-	mocks.addrStore.On("Address", mock.Anything, addr).
-		Return(mocks.pubKeyAddr, nil).Once()
-
-	privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
-	expectDerivedSignerPrivKey(
-		t, mocks, waddrmgr.KeyScopeBIP0044, waddrmgr.DerivationPath{
-			InternalAccount: 0,
-			Account:         0,
-			Branch:          0,
-			Index:           0,
-		}, privKeyCopy,
+	expectSignerAddressInfoWithKeyScope(
+		t, w, mocks, addr, db.PubKeyHash, false, false, pubKey, scope,
 	)
 
 	// Define failing tweaker.
@@ -1386,10 +1829,20 @@ func newSQLAddressSigningWallet(t *testing.T) (*Wallet, *bwmock.Chain,
 	chain := &bwmock.Chain{}
 	vault := &keyvaultmock.Vault{}
 
+	// The signer decrypts account and address secrets through the vault.
+	// The SQL store persists the account xprv (and any imported priv key)
+	// as the stored ciphertext, so an identity decrypt returns exactly that
+	// material. Kept optional so pure address-derivation tests that never
+	// sign do not trip the expectation assertions.
+	vault.On("Decrypt", waddrmgr.CKTPrivate, mock.Anything).Return(
+		identityDecrypt, nil,
+	).Maybe()
+
 	w = &Wallet{
 		addrStore: addrStore,
 		store:     store,
 		keyVault:  vault,
+		cache:     newStoreRuntimeCache(store),
 		state:     newWalletState(nil),
 		cfg: Config{
 			DB:          legacyDB,
@@ -1493,7 +1946,12 @@ func testAccountDerivationFunc() db.AccountDerivationFunc {
 			MasterKeyFingerprint: 1,
 		}
 		if !walletIsWatchOnly {
-			data.EncryptedPrivateKey = []byte{3}
+			// Store the account xprv string as the "encrypted"
+			// private material. The signing wallet's vault mock
+			// decrypts as an identity cipher, so the signer
+			// recovers this exact xprv and derives child keys that
+			// match the account public key above.
+			data.EncryptedPrivateKey = []byte(accountKey.String())
 		}
 
 		return data, nil
@@ -1505,11 +1963,16 @@ func testAccountDerivationFunc() db.AccountDerivationFunc {
 func TestComputeRawSigLegacyP2PKH(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Set up the wallet, mocks, and a deterministic private key.
+	// Arrange: Set up the wallet and mocks. The signing key is resolved
+	// through the store account secret.
 	w, mocks := createUnlockedWalletWithMocks(t)
-	privKey, pubKey := deterministicPrivKey(t)
 
-	// Create a P2PKH address from the public key.
+	path := BIP32Path{KeyScope: waddrmgr.KeyScopeBIP0084}
+	_, pubKey := expectStoreSignerPrivKey(
+		t, mocks, w.id, path.KeyScope, path.DerivationPath,
+	)
+
+	// Create a P2PKH address from the derived leaf public key.
 	pubKeyHash := address.Hash160(pubKey.SerializeCompressed())
 	addr, err := address.NewAddressPubKeyHash(
 		pubKeyHash, w.cfg.ChainParams,
@@ -1521,19 +1984,6 @@ func TestComputeRawSigLegacyP2PKH(t *testing.T) {
 	require.NoError(t, err)
 
 	prevOut, tx := createDummyTestTx(pkScript)
-
-	// Configure the full mock chain to return the test private key.
-	//
-	// NOTE: We must use a copy since the ECDH method will zero out the key.
-	privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
-
-	path := BIP32Path{KeyScope: waddrmgr.KeyScopeBIP0084}
-	mocks.addrStore.On("FetchScopedKeyManager", path.KeyScope).
-		Return(mocks.accountManager, nil).Once()
-	mocks.accountManager.On(
-		"DeriveFromKeyPath", mock.Anything, mock.Anything,
-	).Return(mocks.pubKeyAddr, nil).Once()
-	mocks.pubKeyAddr.On("PrivKey").Return(privKeyCopy, nil).Once()
 
 	// Create the raw signature parameters.
 	fetcher := txscript.NewCannedPrevOutputFetcher(
@@ -1573,20 +2023,19 @@ func TestComputeRawSigLegacyP2PKH(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NoError(t, vm.Execute(), "signature verification failed")
-
-	// Finally, assert that the private key is zeroed out.
-	require.Equal(t, byte(0), privKeyCopy.Serialize()[0])
 }
 
 // TestComputeRawSigLegacyP2SH tests the signing of a legacy P2SH input.
 func TestComputeRawSigLegacyP2SH(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Set up the wallet with mocks and a deterministic private
-	// key for testing.
+	// Arrange: Set up the wallet with mocks. The signing key is resolved
+	// through the store account secret. P2SH addresses use BIP0049 scope.
 	w, mocks := createUnlockedWalletWithMocks(t)
-	privKey, pubKey := deterministicPrivKey(t)
-	privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
+	path := BIP32Path{KeyScope: waddrmgr.KeyScopeBIP0049Plus}
+	_, pubKey := expectStoreSignerPrivKey(
+		t, mocks, w.id, path.KeyScope, path.DerivationPath,
+	)
 
 	// Create a P2SH redeem script. This involves pushing the public key
 	// and the CHECKSIG opcode.
@@ -1610,16 +2059,6 @@ func TestComputeRawSigLegacyP2SH(t *testing.T) {
 
 	// Create a dummy transaction and a previous output to spend.
 	prevOut, tx := createDummyTestTx(pkScript)
-
-	// Configure the address manager mock to return the correct key manager
-	// and address information. P2SH addresses use BIP0049 derivation scope.
-	path := BIP32Path{KeyScope: waddrmgr.KeyScopeBIP0049Plus}
-	mocks.addrStore.On("FetchScopedKeyManager", path.KeyScope).
-		Return(mocks.accountManager, nil).Once()
-	mocks.accountManager.On("DeriveFromKeyPath",
-		mock.Anything, mock.Anything).
-		Return(mocks.pubKeyAddr, nil).Once()
-	mocks.pubKeyAddr.On("PrivKey").Return(privKeyCopy, nil).Once()
 
 	// Prepare the inputs for the signing operation.
 	fetcher := txscript.NewCannedPrevOutputFetcher(
@@ -1652,11 +2091,16 @@ func TestComputeRawSigLegacyP2SH(t *testing.T) {
 func TestComputeRawSigSegwitV0(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Set up the wallet, mocks, and a deterministic private key.
+	// Arrange: Set up the wallet and mocks. The signing key is resolved
+	// through the store account secret.
 	w, mocks := createUnlockedWalletWithMocks(t)
-	privKey, pubKey := deterministicPrivKey(t)
 
-	// Create a P2WKH address from the public key.
+	path := BIP32Path{KeyScope: waddrmgr.KeyScopeBIP0084}
+	_, pubKey := expectStoreSignerPrivKey(
+		t, mocks, w.id, path.KeyScope, path.DerivationPath,
+	)
+
+	// Create a P2WKH address from the derived leaf public key.
 	pubKeyHash := address.Hash160(pubKey.SerializeCompressed())
 	addr, err := address.NewAddressWitnessPubKeyHash(
 		pubKeyHash, w.cfg.ChainParams,
@@ -1668,19 +2112,6 @@ func TestComputeRawSigSegwitV0(t *testing.T) {
 	require.NoError(t, err)
 
 	prevOut, tx := createDummyTestTx(pkScript)
-
-	// Configure the full mock chain to return the test private key.
-	//
-	// NOTE: We must use a copy since the ECDH method will zero out the key.
-	privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
-
-	path := BIP32Path{KeyScope: waddrmgr.KeyScopeBIP0084}
-	mocks.addrStore.On("FetchScopedKeyManager", path.KeyScope).
-		Return(mocks.accountManager, nil).Once()
-	mocks.accountManager.On(
-		"DeriveFromKeyPath", mock.Anything, mock.Anything,
-	).Return(mocks.pubKeyAddr, nil).Once()
-	mocks.pubKeyAddr.On("PrivKey").Return(privKeyCopy, nil).Once()
 
 	// Create the raw signature parameters.
 	fetcher := txscript.NewCannedPrevOutputFetcher(
@@ -1722,9 +2153,6 @@ func TestComputeRawSigSegwitV0(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NoError(t, vm.Execute(), "signature verification failed")
-
-	// Finally, assert that the private key is zeroed out.
-	require.Equal(t, byte(0), privKeyCopy.Serialize()[0])
 }
 
 // TestComputeRawSigTaprootKeySpendPath tests the successful signing of a
@@ -1732,11 +2160,16 @@ func TestComputeRawSigSegwitV0(t *testing.T) {
 func TestComputeRawSigTaprootKeySpendPath(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Set up the wallet, mocks, and a deterministic private key.
+	// Arrange: Set up the wallet and mocks. The signing key is resolved
+	// through the store account secret.
 	w, mocks := createUnlockedWalletWithMocks(t)
-	privKey, internalKey := deterministicPrivKey(t)
 
-	// Create a P2TR address from the public key.
+	path := BIP32Path{KeyScope: waddrmgr.KeyScopeBIP0086}
+	_, internalKey := expectStoreSignerPrivKey(
+		t, mocks, w.id, path.KeyScope, path.DerivationPath,
+	)
+
+	// Create a P2TR address from the derived leaf public key.
 	addr, err := address.NewAddressTaproot(
 		schnorr.SerializePubKey(
 			txscript.ComputeTaprootOutputKey(internalKey, nil),
@@ -1749,19 +2182,6 @@ func TestComputeRawSigTaprootKeySpendPath(t *testing.T) {
 	require.NoError(t, err)
 
 	prevOut, tx := createDummyTestTx(pkScript)
-
-	// Configure the full mock chain to return the test private key.
-	//
-	// NOTE: We must use a copy since the ECDH method will zero out the key.
-	privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
-
-	path := BIP32Path{KeyScope: waddrmgr.KeyScopeBIP0086}
-	mocks.addrStore.On("FetchScopedKeyManager", path.KeyScope).
-		Return(mocks.accountManager, nil).Once()
-	mocks.accountManager.On(
-		"DeriveFromKeyPath", mock.Anything, mock.Anything,
-	).Return(mocks.pubKeyAddr, nil).Once()
-	mocks.pubKeyAddr.On("PrivKey").Return(privKeyCopy, nil).Once()
 
 	// Create the raw signature parameters.
 	fetcher := txscript.NewMultiPrevOutFetcher(
@@ -1797,9 +2217,6 @@ func TestComputeRawSigTaprootKeySpendPath(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NoError(t, vm.Execute(), "signature verification failed")
-
-	// Finally, assert that the private key is zeroed out.
-	require.Equal(t, byte(0), privKeyCopy.Serialize()[0])
 }
 
 // TestComputeRawSigTaprootScriptPath tests the successful signing of a Taproot
@@ -1807,11 +2224,16 @@ func TestComputeRawSigTaprootKeySpendPath(t *testing.T) {
 func TestComputeRawSigTaprootScriptPath(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Set up the wallet, mocks, and a deterministic private key.
+	// Arrange: Set up the wallet and mocks. The signing key is resolved
+	// through the store account secret.
 	w, mocks := createUnlockedWalletWithMocks(t)
-	privKey, internalKey := deterministicPrivKey(t)
 
-	// Create a script to spend.
+	path := BIP32Path{KeyScope: waddrmgr.KeyScopeBIP0086}
+	_, internalKey := expectStoreSignerPrivKey(
+		t, mocks, w.id, path.KeyScope, path.DerivationPath,
+	)
+
+	// Create a script to spend, committing to the derived leaf key.
 	script, err := txscript.NewScriptBuilder().
 		AddData(schnorr.SerializePubKey(internalKey)).
 		AddOp(txscript.OP_CHECKSIG).
@@ -1834,17 +2256,6 @@ func TestComputeRawSigTaprootScriptPath(t *testing.T) {
 	require.NoError(t, err)
 
 	prevOut, tx := createDummyTestTx(pkScript)
-
-	// Configure the full mock chain to return the test private key.
-	privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
-
-	path := BIP32Path{KeyScope: waddrmgr.KeyScopeBIP0086}
-	mocks.addrStore.On("FetchScopedKeyManager", path.KeyScope).
-		Return(mocks.accountManager, nil).Once()
-	mocks.accountManager.On(
-		"DeriveFromKeyPath", mock.Anything, mock.Anything,
-	).Return(mocks.pubKeyAddr, nil).Once()
-	mocks.pubKeyAddr.On("PrivKey").Return(privKeyCopy, nil).Once()
 
 	// Create the raw signature parameters.
 	fetcher := txscript.NewMultiPrevOutFetcher(
@@ -1890,16 +2301,11 @@ func TestComputeRawSigTaprootScriptPath(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NoError(t, vm.Execute(), "signature verification failed")
-
-	// Finally, assert that the private key is zeroed out.
-	require.Equal(t, byte(0), privKeyCopy.Serialize()[0])
 }
 
 // TestComputeRawSigFail tests various failure modes of ComputeRawSig.
 func TestComputeRawSigFail(t *testing.T) {
 	t.Parallel()
-
-	privKey, _ := deterministicPrivKey(t)
 
 	path := BIP32Path{KeyScope: waddrmgr.KeyScopeBIP0084}
 	prevOut := &wire.TxOut{PkScript: []byte{0x00}}
@@ -1910,14 +2316,30 @@ func TestComputeRawSigFail(t *testing.T) {
 	)
 	sigHashes := txscript.NewTxSigHashes(tx, fetcher)
 
-	// This subtest ensures that if fetching the key manager fails during
-	// the raw signature computation, the error is correctly propagated.
+	// storeSecretQuery builds the account-secret query the signer issues
+	// for the default account under the given scope.
+	storeSecretQuery := func(w *Wallet,
+		scope waddrmgr.KeyScope) db.GetAccountSecretQuery {
+
+		accountNumber := uint32(0)
+
+		return db.GetAccountSecretQuery{
+			WalletID:      w.id,
+			Scope:         db.KeyScope(scope),
+			AccountNumber: accountNumber,
+		}
+	}
+
+	// This subtest ensures that if the store account-secret lookup fails
+	// during the raw signature computation, the error is correctly
+	// propagated.
 	t.Run("Fetch Address Fail", func(t *testing.T) {
 		t.Parallel()
 		w, mocks := createUnlockedWalletWithMocks(t)
-		mocks.addrStore.On("FetchScopedKeyManager", path.KeyScope).
-			Return((*bwmock.AccountStore)(nil),
-				errManagerNotFound).Once()
+		mocks.store.On("GetAccountSecret", mock.Anything,
+			storeSecretQuery(w, path.KeyScope)).Return(
+			(*db.AccountSecret)(nil), errManagerNotFound,
+		).Once()
 
 		params := &RawSigParams{
 			Tx:        tx,
@@ -1932,21 +2354,15 @@ func TestComputeRawSigFail(t *testing.T) {
 		require.ErrorIs(t, err, errManagerNotFound)
 	})
 
-	// This subtest ensures that if obtaining the private key from the
-	// managed address fails during raw signature computation, the error is
-	// correctly propagated.
+	// This subtest ensures that a watch-only signing account yields the
+	// watch-only error during raw signature computation.
 	t.Run("PrivKey Fail", func(t *testing.T) {
 		t.Parallel()
 		w, mocks := createUnlockedWalletWithMocks(t)
-		mocks.addrStore.On("FetchScopedKeyManager", path.KeyScope).
-			Return(mocks.accountManager, nil).Once()
-
-		mocks.accountManager.On("DeriveFromKeyPath",
-			mock.Anything, mock.Anything).
-			Return(mocks.pubKeyAddr, nil).Once()
-
-		mocks.pubKeyAddr.On("PrivKey").Return((*btcec.PrivateKey)(nil),
-			errPrivKeyMock).Once()
+		mocks.store.On("GetAccountSecret", mock.Anything,
+			storeSecretQuery(w, path.KeyScope)).Return(
+			&db.AccountSecret{}, nil,
+		).Once()
 
 		params := &RawSigParams{
 			Tx:        tx,
@@ -1958,7 +2374,7 @@ func TestComputeRawSigFail(t *testing.T) {
 		}
 
 		_, err := w.ComputeRawSig(t.Context(), params)
-		require.ErrorContains(t, err, "privkey error")
+		require.ErrorIs(t, err, ErrWatchOnlyAccount)
 	})
 
 	// This subtest verifies that if the private key tweaking function
@@ -1967,15 +2383,9 @@ func TestComputeRawSigFail(t *testing.T) {
 	t.Run("Tweak Fail", func(t *testing.T) {
 		t.Parallel()
 		w, mocks := createUnlockedWalletWithMocks(t)
-		mocks.addrStore.On("FetchScopedKeyManager", path.KeyScope).
-			Return(mocks.accountManager, nil).Once()
-
-		mocks.accountManager.On("DeriveFromKeyPath",
-			mock.Anything, mock.Anything).
-			Return(mocks.pubKeyAddr, nil).Once()
-
-		privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
-		mocks.pubKeyAddr.On("PrivKey").Return(privKeyCopy, nil).Once()
+		expectStoreSignerPrivKey(
+			t, mocks, w.id, path.KeyScope, path.DerivationPath,
+		)
 
 		params := &RawSigParams{
 			Tx:        tx,
@@ -2001,15 +2411,9 @@ func TestComputeRawSigFail(t *testing.T) {
 	t.Run("Sign Fail", func(t *testing.T) {
 		t.Parallel()
 		w, mocks := createUnlockedWalletWithMocks(t)
-		mocks.addrStore.On("FetchScopedKeyManager", path.KeyScope).
-			Return(mocks.accountManager, nil).Once()
-
-		mocks.accountManager.On("DeriveFromKeyPath",
-			mock.Anything, mock.Anything).
-			Return(mocks.pubKeyAddr, nil).Once()
-
-		privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
-		mocks.pubKeyAddr.On("PrivKey").Return(privKeyCopy, nil).Once()
+		leafPriv, _ := expectStoreSignerPrivKey(
+			t, mocks, w.id, path.KeyScope, path.DerivationPath,
+		)
 
 		params := &RawSigParams{
 			Tx:        tx,
@@ -2022,9 +2426,12 @@ func TestComputeRawSigFail(t *testing.T) {
 		mockDetails := &mockSpendDetails{}
 		params.Details = mockDetails
 
-		mockDetails.On("Sign", params, privKeyCopy).
-			Return((RawSignature)(nil),
-				errSignMock)
+		// The signer derives its own leaf key; match on the value it
+		// resolves rather than object identity.
+		mockDetails.On("Sign", params, mock.MatchedBy(
+			func(pk *btcec.PrivateKey) bool {
+				return pk.Key.Equals(&leafPriv.Key)
+			})).Return((RawSignature)(nil), errSignMock)
 		_, err := w.ComputeRawSig(t.Context(), params)
 		require.ErrorContains(t, err, "sign error")
 		mockDetails.AssertExpectations(t)
@@ -2037,20 +2444,14 @@ func TestComputeRawSigFail(t *testing.T) {
 		t.Parallel()
 		w, mocks := createUnlockedWalletWithMocks(t)
 
-		path := BIP32Path{KeyScope: waddrmgr.KeyScopeBIP0086}
-		mocks.addrStore.On("FetchScopedKeyManager", path.KeyScope).
-			Return(mocks.accountManager, nil).Once()
-
-		mocks.accountManager.On("DeriveFromKeyPath",
-			mock.Anything, mock.Anything).
-			Return(mocks.pubKeyAddr, nil).Once()
-
-		privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
-		mocks.pubKeyAddr.On("PrivKey").Return(privKeyCopy, nil).Once()
+		scope := waddrmgr.KeyScopeBIP0086
+		expectStoreSignerPrivKey(
+			t, mocks, w.id, scope, waddrmgr.DerivationPath{},
+		)
 
 		params := &RawSigParams{
 			Tx:   wire.NewMsgTx(2),
-			Path: path,
+			Path: BIP32Path{KeyScope: scope},
 			Details: TaprootSpendDetails{
 				SpendPath: TaprootSpendPath(99), // Invalid path
 			},
@@ -2066,14 +2467,9 @@ func TestComputeRawSigFail(t *testing.T) {
 	t.Run("Segwit Sign Fail", func(t *testing.T) {
 		t.Parallel()
 		w, mocks := createUnlockedWalletWithMocks(t)
-		mocks.addrStore.On("FetchScopedKeyManager", path.KeyScope).
-			Return(mocks.accountManager, nil).Once()
-		mocks.accountManager.On("DeriveFromKeyPath",
-			mock.Anything, mock.Anything).
-			Return(mocks.pubKeyAddr, nil).Once()
-
-		privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
-		mocks.pubKeyAddr.On("PrivKey").Return(privKeyCopy, nil).Once()
+		expectStoreSignerPrivKey(
+			t, mocks, w.id, path.KeyScope, path.DerivationPath,
+		)
 
 		params := &RawSigParams{
 			Tx:        tx,
@@ -2096,14 +2492,9 @@ func TestComputeRawSigFail(t *testing.T) {
 	t.Run("Taproot KeyPath Sign Fail", func(t *testing.T) {
 		t.Parallel()
 		w, mocks := createUnlockedWalletWithMocks(t)
-		mocks.addrStore.On("FetchScopedKeyManager", path.KeyScope).
-			Return(mocks.accountManager, nil).Once()
-		mocks.accountManager.On("DeriveFromKeyPath",
-			mock.Anything, mock.Anything).
-			Return(mocks.pubKeyAddr, nil).Once()
-
-		privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
-		mocks.pubKeyAddr.On("PrivKey").Return(privKeyCopy, nil).Once()
+		expectStoreSignerPrivKey(
+			t, mocks, w.id, path.KeyScope, path.DerivationPath,
+		)
 
 		params := &RawSigParams{
 			Tx:        tx,
@@ -2124,14 +2515,9 @@ func TestComputeRawSigFail(t *testing.T) {
 	t.Run("Taproot ScriptPath Sign Fail", func(t *testing.T) {
 		t.Parallel()
 		w, mocks := createUnlockedWalletWithMocks(t)
-		mocks.addrStore.On("FetchScopedKeyManager", path.KeyScope).
-			Return(mocks.accountManager, nil).Once()
-		mocks.accountManager.On("DeriveFromKeyPath",
-			mock.Anything, mock.Anything).
-			Return(mocks.pubKeyAddr, nil).Once()
-
-		privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
-		mocks.pubKeyAddr.On("PrivKey").Return(privKeyCopy, nil).Once()
+		expectStoreSignerPrivKey(
+			t, mocks, w.id, path.KeyScope, path.DerivationPath,
+		)
 
 		params := &RawSigParams{
 			Tx:        tx,
@@ -2154,11 +2540,9 @@ func TestComputeRawSigFail(t *testing.T) {
 func TestDerivePrivKeySuccess(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Set up the wallet with mocks, a test key, and a
-	// derivation path.
+	// Arrange: Set up the wallet with mocks and a derivation path. The key
+	// is resolved through the store account secret.
 	w, mocks := createUnlockedWalletWithMocks(t)
-	privKey, err := btcec.NewPrivateKey()
-	require.NoError(t, err)
 
 	path := BIP32Path{
 		KeyScope: waddrmgr.KeyScopeBIP0084,
@@ -2168,37 +2552,35 @@ func TestDerivePrivKeySuccess(t *testing.T) {
 			Index:           0,
 		},
 	}
-
-	// Set up the mock account manager and the mock address that will be
-	// returned by the derivation call.
-	privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
-
-	mocks.addrStore.On("FetchScopedKeyManager", path.KeyScope).
-		Return(mocks.accountManager, nil).Once()
-	mocks.accountManager.On(
-		"DeriveFromKeyPath", mock.Anything, path.DerivationPath,
-	).Return(mocks.pubKeyAddr, nil).Once()
-	mocks.pubKeyAddr.On("PrivKey").Return(privKeyCopy, nil).Once()
+	leafPriv, _ := expectStoreSignerPrivKey(
+		t, mocks, w.id, path.KeyScope, path.DerivationPath,
+	)
 
 	// Act: Derive the private key.
 	derivedKey, err := w.DerivePrivKey(t.Context(), path)
 
 	// Assert: Check that the correct key is returned without error.
 	require.NoError(t, err)
-	require.Equal(t, privKey.Serialize(), derivedKey.Serialize())
+	require.Equal(t, leafPriv.Serialize(), derivedKey.Serialize())
 }
 
-// TestDerivePrivKeyFails tests the failure case where the key derivation fails.
+// TestDerivePrivKeyFails tests the failure case where the store account-secret
+// lookup fails.
 func TestDerivePrivKeyFails(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Set up the wallet and a test path. Configure the mock
-	// addrStore to return an error when fetching the key manager.
+	// Arrange: Set up the wallet and a test path. Configure the store to
+	// fail the account-secret lookup.
 	w, mocks := createUnlockedWalletWithMocks(t)
 	path := BIP32Path{KeyScope: waddrmgr.KeyScopeBIP0084}
 
-	mocks.addrStore.On("FetchScopedKeyManager", path.KeyScope).
-		Return((*bwmock.AccountStore)(nil), errManagerNotFound).Once()
+	accountNumber := path.DerivationPath.InternalAccount
+	mocks.store.On("GetAccountSecret", mock.Anything,
+		db.GetAccountSecretQuery{
+			WalletID:      w.id,
+			Scope:         db.KeyScope(path.KeyScope),
+			AccountNumber: accountNumber,
+		}).Return((*db.AccountSecret)(nil), errManagerNotFound).Once()
 
 	// Act: Attempt to derive the private key.
 	_, err := w.DerivePrivKey(t.Context(), path)
@@ -2208,53 +2590,43 @@ func TestDerivePrivKeyFails(t *testing.T) {
 }
 
 // TestGetPrivKeyForAddressSuccess tests the successful retrieval of a private
-// key by address via the legacy fallback when the address is not in the
-// store (kvdb-backed wallet path).
+// key for a derived address through the store account secret.
 func TestGetPrivKeyForAddressSuccess(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Set up the wallet, mocks, and a deterministic private key.
+	// Arrange: Set up the wallet and mocks. The key is resolved through the
+	// store account secret.
 	w, mocks := createUnlockedWalletWithMocks(t)
-	privKey, pubKey := deterministicPrivKey(t)
+	scope := waddrmgr.KeyScopeBIP0084
+	path := waddrmgr.DerivationPath{}
+	leafPriv, pubKey := expectStoreSignerPrivKey(
+		t, mocks, w.id, scope, path,
+	)
 
-	// Create a P2PKH address from the public key.
-	pubKeyHash := address.Hash160(pubKey.SerializeCompressed())
-	addr, err := address.NewAddressPubKeyHash(
-		pubKeyHash, w.cfg.ChainParams,
+	// Create a P2WKH address from the derived leaf public key.
+	addr, err := address.NewAddressWitnessPubKeyHash(
+		address.Hash160(pubKey.SerializeCompressed()),
+		w.cfg.ChainParams,
 	)
 	require.NoError(t, err)
 
-	pkScript, err := txscript.PayToAddrScript(addr)
-	require.NoError(t, err)
-
-	// The store returns ErrAddressNotFound so GetPrivKeyForAddress falls
-	// through to the legacy PrivKeyForAddress path. This matches the
-	// kvdb-backed wallet shape.
-	mocks.store.On("GetAddress", mock.Anything, db.GetAddressQuery{
-		WalletID:     w.id,
-		ScriptPubKey: pkScript,
-	}).Return((*db.AddressInfo)(nil), db.ErrAddressNotFound).Once()
-
-	// Configure the mock chain to return the test private key.
-	//
-	// NOTE: We must use a copy since the method will zero out the key.
-	privKeyCopy, _ := btcec.PrivKeyFromBytes(privKey.Serialize())
-
-	mocks.addrStore.On("Address", mock.Anything, addr).
-		Return(mocks.pubKeyAddr, nil).Once()
-	mocks.pubKeyAddr.On("PrivKey").Return(privKeyCopy, nil).Once()
+	// The store owns the address with a usable derivation scope, so the
+	// signer resolves the key through the account secret.
+	expectSignerAddressInfoWithKeyScope(
+		t, w, mocks, addr, db.WitnessPubKey, false, false, pubKey,
+		scope,
+	)
 
 	// Act: Get the private key for the address.
 	retrievedKey, err := w.GetPrivKeyForAddress(t.Context(), addr)
 
 	// Assert: Check that the correct key is returned.
 	require.NoError(t, err)
-	require.Equal(t, privKey.Serialize(), retrievedKey.Serialize())
+	require.Equal(t, leafPriv.Serialize(), retrievedKey.Serialize())
 }
 
 // TestGetPrivKeyForAddressFail tests the failure cases for retrieval of a
-// private key by address. Each case exercises the legacy fallback after the
-// store reports ErrAddressNotFound.
+// private key by address through the store.
 func TestGetPrivKeyForAddressFail(t *testing.T) {
 	t.Parallel()
 
@@ -2268,101 +2640,130 @@ func TestGetPrivKeyForAddressFail(t *testing.T) {
 	pkScript, err := txscript.PayToAddrScript(addr)
 	require.NoError(t, err)
 
-	// The store does not know the address in either case, so
-	// GetPrivKeyForAddress falls through to PrivKeyForAddress.
-	mocks.store.On("GetAddress", mock.Anything, db.GetAddressQuery{
+	query := db.GetAddressQuery{
 		WalletID:     w.id,
 		ScriptPubKey: pkScript,
-	}).Return((*db.AddressInfo)(nil), db.ErrAddressNotFound).Twice()
+	}
 
-	// Case 1: Address lookup fails.
-	mocks.addrStore.On("Address", mock.Anything, addr).
-		Return((*bwmock.ManagedAddress)(nil), errManagerNotFound).Once()
+	// Case 1: An unexpected store error surfaces, not masked.
+	mocks.store.On("GetAddress", mock.Anything, query).Return(
+		(*db.AddressInfo)(nil), errManagerNotFound,
+	).Once()
 
 	_, err = w.GetPrivKeyForAddress(t.Context(), addr)
 	require.ErrorIs(t, err, errManagerNotFound)
 
-	// Case 2: Address is not a pubkey address.
-	// We need a separate mock for this to ensure clean separation.
-	//
-	// NOTE: We can reuse the existing mocks but need to reset expectations
-	// or ensure ordering. Since we are in a single test function, we can
-	// just sequence them.
-	mockScriptAddr := &bwmock.ManagedAddress{}
-	mocks.addrStore.On("Address", mock.Anything, addr).
-		Return(mockScriptAddr, nil).Once()
+	// Case 2: The address is not owned by the wallet, so it has no
+	// associated private key.
+	mocks.store.On("GetAddress", mock.Anything, query).Return(
+		(*db.AddressInfo)(nil), db.ErrAddressNotFound,
+	).Once()
 
 	_, err = w.GetPrivKeyForAddress(t.Context(), addr)
 	require.ErrorIs(t, err, ErrNoAssocPrivateKey)
 }
 
-// TestDerivePrivKeyFail tests failure modes of DerivePrivKey.
+// TestGetPrivKeyForAddressImportedNoPrivKey verifies that requesting the
+// private key for a watch-only imported address (no stored private material)
+// returns ErrNoAssocPrivateKey.
+func TestGetPrivKeyForAddressImportedNoPrivKey(t *testing.T) {
+	t.Parallel()
+
+	w, mocks := createUnlockedWalletWithMocks(t)
+	_, pubKey := deterministicPrivKey(t)
+
+	addr, err := address.NewAddressWitnessPubKeyHash(
+		address.Hash160(pubKey.SerializeCompressed()),
+		w.cfg.ChainParams,
+	)
+	require.NoError(t, err)
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	// The address is owned but imported (no derivation path).
+	expectStoreAddressInfo(t, w, mocks, addr, &db.AddressInfo{
+		ScriptPubKey: pkScript,
+		AddrType:     db.WitnessPubKey,
+		IsImported:   true,
+		PubKey:       pubKey.SerializeCompressed(),
+	})
+
+	// The imported address carries no private-key material.
+	mocks.store.On("GetAddressSecret", mock.Anything,
+		db.GetAddressSecretQuery{
+			WalletID:     w.id,
+			ScriptPubKey: pkScript,
+		}).Return((*db.AddressSecret)(nil), db.ErrSecretNotFound).Once()
+
+	// Act + Assert.
+	_, err = w.GetPrivKeyForAddress(t.Context(), addr)
+	require.ErrorIs(t, err, ErrNoAssocPrivateKey)
+}
+
+// TestDerivePrivKeyFail tests failure modes of DerivePrivKey through the
+// store-routed key path.
 func TestDerivePrivKeyFail(t *testing.T) {
 	t.Parallel()
 
 	w, mocks := createUnlockedWalletWithMocks(t)
 	path := BIP32Path{KeyScope: waddrmgr.KeyScopeBIP0084}
 
-	// Test Case 1: Fetching key manager fails.
-	//
-	// We mock the address store to return an error when fetching the key
-	// manager. We expect this error to be propagated.
-	mocks.addrStore.On("FetchScopedKeyManager", path.KeyScope).
-		Return((*bwmock.AccountStore)(nil), errManagerNotFound).Once()
+	accountNumber := path.DerivationPath.InternalAccount
+	query := db.GetAccountSecretQuery{
+		WalletID:      w.id,
+		Scope:         db.KeyScope(path.KeyScope),
+		AccountNumber: accountNumber,
+	}
+
+	// Test Case 1: The account-secret lookup fails with an unexpected
+	// error, which is propagated.
+	mocks.store.On("GetAccountSecret", mock.Anything, query).Return(
+		(*db.AccountSecret)(nil), errPrivKeyMock,
+	).Once()
 
 	_, err := w.DerivePrivKey(t.Context(), path)
-	require.ErrorIs(t, err, errManagerNotFound)
+	require.ErrorIs(t, err, errPrivKeyMock)
 
-	// Test Case 2: PrivKey retrieval fails.
-	//
-	// We mock the key manager to return a valid address, but mock the
-	// address to return an error when fetching the private key. We expect
-	// a wrapped error indicating the failure.
-	mocks.addrStore.On("FetchScopedKeyManager", path.KeyScope).
-		Return(mocks.accountManager, nil).Once()
-	mocks.accountManager.On(
-		"DeriveFromKeyPath", mock.Anything, mock.Anything,
-	).Return(mocks.pubKeyAddr, nil).Once()
-	mocks.pubKeyAddr.On("PrivKey").
-		Return((*btcec.PrivateKey)(nil), errPrivKeyMock).Once()
+	// Test Case 2: The signing account is watch-only.
+	mocks.store.On("GetAccountSecret", mock.Anything, query).Return(
+		&db.AccountSecret{}, nil,
+	).Once()
 
 	_, err = w.DerivePrivKey(t.Context(), path)
-	require.ErrorContains(t, err, "cannot get private key")
+	require.ErrorIs(t, err, ErrWatchOnlyAccount)
 }
 
-// TestECDHFail tests failure modes of ECDH.
+// TestECDHFail tests failure modes of ECDH through the store-routed key path.
 func TestECDHFail(t *testing.T) {
 	t.Parallel()
 
 	w, mocks := createUnlockedWalletWithMocks(t)
 	path := BIP32Path{KeyScope: waddrmgr.KeyScopeBIP0084}
-	privKey, _ := btcec.NewPrivateKey()
+	remoteKey, _ := btcec.NewPrivateKey()
 
-	// Test Case 1: Fetching key manager fails.
-	//
-	// We mock the address store to return an error when fetching the key
-	// manager. We expect this error to be propagated.
-	mocks.addrStore.On("FetchScopedKeyManager", path.KeyScope).
-		Return((*bwmock.AccountStore)(nil), errManagerNotFound).Once()
+	accountNumber := path.DerivationPath.InternalAccount
+	query := db.GetAccountSecretQuery{
+		WalletID:      w.id,
+		Scope:         db.KeyScope(path.KeyScope),
+		AccountNumber: accountNumber,
+	}
 
-	_, err := w.ECDH(t.Context(), path, privKey.PubKey())
-	require.ErrorIs(t, err, errManagerNotFound)
+	// Test Case 1: The account-secret lookup fails with an unexpected
+	// error, which is propagated.
+	mocks.store.On("GetAccountSecret", mock.Anything, query).Return(
+		(*db.AccountSecret)(nil), errPrivKeyMock,
+	).Once()
 
-	// Test Case 2: PrivKey retrieval fails.
-	//
-	// We mock the key manager to return a valid address, but mock the
-	// address to return an error when fetching the private key. We expect
-	// a wrapped error indicating the failure.
-	mocks.addrStore.On("FetchScopedKeyManager", path.KeyScope).
-		Return(mocks.accountManager, nil).Once()
-	mocks.accountManager.On(
-		"DeriveFromKeyPath", mock.Anything, mock.Anything,
-	).Return(mocks.pubKeyAddr, nil).Once()
-	mocks.pubKeyAddr.On("PrivKey").
-		Return((*btcec.PrivateKey)(nil), errPrivKeyMock).Once()
+	_, err := w.ECDH(t.Context(), path, remoteKey.PubKey())
+	require.ErrorIs(t, err, errPrivKeyMock)
 
-	_, err = w.ECDH(t.Context(), path, privKey.PubKey())
-	require.ErrorContains(t, err, "cannot get private key")
+	// Test Case 2: The signing account is watch-only.
+	mocks.store.On("GetAccountSecret", mock.Anything, query).Return(
+		&db.AccountSecret{}, nil,
+	).Once()
+
+	_, err = w.ECDH(t.Context(), path, remoteKey.PubKey())
+	require.ErrorIs(t, err, ErrWatchOnlyAccount)
 }
 
 // TestSignDigestLocked tests that SignDigest fails when the wallet is locked.

--- a/wallet/signer_test.go
+++ b/wallet/signer_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/btcsuite/btcd/wire/v2"
 	bwmock "github.com/btcsuite/btcwallet/bwtest/mock"
 	"github.com/btcsuite/btcwallet/waddrmgr"
-	walletmock "github.com/btcsuite/btcwallet/wallet/internal/bwtest/mock"
+	"github.com/btcsuite/btcwallet/wallet/internal/bwtest/keyvaultmock"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	sqlitedb "github.com/btcsuite/btcwallet/wallet/internal/db/sqlite"
 	"github.com/btcsuite/btcwallet/walletdb"
@@ -1332,7 +1332,7 @@ func createDummyTestTx(pkScript []byte) (*wire.TxOut, *wire.MsgTx) {
 // newSQLAddressSigningWallet returns a started, unlocked wallet whose address
 // records are stored in SQLite while signing keys come from legacy waddrmgr.
 func newSQLAddressSigningWallet(t *testing.T) (*Wallet, *bwmock.Chain,
-	*walletmock.Vault) {
+	*keyvaultmock.Vault) {
 
 	t.Helper()
 
@@ -1384,7 +1384,7 @@ func newSQLAddressSigningWallet(t *testing.T) (*Wallet, *bwmock.Chain,
 	require.NoError(t, err)
 
 	chain := &bwmock.Chain{}
-	vault := &walletmock.Vault{}
+	vault := &keyvaultmock.Vault{}
 
 	w = &Wallet{
 		addrStore: addrStore,


### PR DESCRIPTION
Routes wallet secrets through `db.Store` and `keyvault.Vault` so the public
wallet package stops opening `walletdb` transactions for signing and for the
unlock/lock/rotate lifecycle. One code path serves both backends.

Stacked on `sql-wallet`.

## What lands here

19 commits:

1. `db+sql: add the account-secret query`
2. `waddrmgr: expose account and address secrets`
3. `wallet+db: add the account-secret store surface`
4. `db: cover the account-secret contract`
5. `keyvault: add wallet-secret genesis`
6. `db+sql: add address-secret selectors`
7. `db: map address-secret key metadata`
8. `keyvault: derive master key from stored params`
9. `keyvault: complete the passphrase lifecycle`
10. `kvdb: look up address secrets by script`
11. `kvdb: add the legacy wallet vault`
12. `db: record import provenance on new addresses`
13. `keyvault: map public-key requests to script key`
14. `wallet: derive signer keys through the Store`
15. `wallet: load imported keys through the Store`
16. `wallet: load spend scripts through the Store`
17. `wallet: route PSBT signing through the Store`
18. `wallet: route the lifecycle through the vault`
19. `ci: audit commits from the PR base`

The Store surface is implemented by SQLite, PostgreSQL and kvdb adapters.

## kvdb keeps its dual-encryption format — permanently

An earlier revision of this PR introduced a single-encryption waddrmgr format,
ADR 0014, format refusal and `ErrMigrationRequired`. **That is all gone, and
there is no follow-up task.** The reasoning, in order of weight:

- Its motive was one key model for both backends so the vault contract could be
  uniform. It is not needed: `LegacyWalletVault` satisfies `keyvault.Vault` over
  the existing dual format at the cost of one internal bit.
- A new format means writing **two** migrations for a backend being retired —
  dual→single, then single→SQL. Keeping one format means writing only the
  kvdb→SQL converter we owe anyway.
- The format needs a persisted discriminator and `mgrver` cannot serve as one:
  `migration.Upgrade` runs credential-free *before* `waddrmgr.Open`, and the
  engine stamps the version itself. The previous attempt worked around that by
  skipping *all* waddrmgr migrations for single-encryption wallets — a permanent
  migration hole.

So base's two passphrase fields stay. `Config.PubPassphrase` is the kvdb
**Load** credential and `CreateWalletParams.PubPassphrase` the **Create**
credential; SQL ignores both, and the public half is marked deprecated because
only the retiring backend has one.

## Design notes worth reviewing

- **The base `CryptoKeyType` cipher API is retained**, which avoids a ~540-line
  typed redesign that is prerequisite to neither deliverable. Retaining it alone
  leaves SQL script import broken, though: `ImportTaprootScript` encrypts under
  `CKTPublic`, which the SQL vault rejected outright, so the case failed at
  *encryption* before any store write. `WalletVault` therefore maps a
  `CKTPublic` request onto its script key — a SQL wallet has no separate public
  crypto key, and this import is the only caller asking for one.
- **`db.AddressSecret.ScriptIsSecret` is one bit, and it is unavoidable.**
  waddrmgr picks the decrypting key *per address*: witness and taproot rows
  carry a persisted flag, legacy P2SH is always secret, and one spendable
  manager can hold both — so no manager-level predicate can name the key for a
  given ciphertext. The bit travels with the row. It is cipher-key provenance,
  not watch-only state or identity, so it touches neither ADR 0012 nor 0013.
- **Account secrets select on the BIP44 account number alone.** `ImportAccount`
  takes an extended *public* key, so an imported account holds no account-level
  private material; derived accounts always have a number. An imported-xpub
  child is refused *before* the lookup rather than falling back to account 0,
  which is the wallet's own default account.
- **Address secrets select on the output script**, the only address identity
  both backends share. A kvdb address ID cannot serve: `setAddressID` assigns
  one-based ordinals by sorting an account's current addresses, so IDs collide
  across accounts and move when the view changes — selecting by ID would return
  the wrong secret.
- **`Stop` locks the vault.** This is a regression fix, not hardening. Base
  `wallet/controller.go` has zero `keyVault` references, so there is no parity
  to preserve; but once `Unlock` routes through the vault, decrypted material
  survives a `Stop` and the next `Unlock` fails against an already-unlocked
  vault, leaving the wallet permanently unable to sign.

### Note on the legacy script key

waddrmgr never populated `cryptoKeyScript` on unlock — upstream included — so
every legacy script ciphertext on disk was written under an all-zero
placeholder. Deriving the real key would make those records undecryptable, so
the legacy layout keeps the behaviour it shipped with.

`wallet/deprecated*` and `wallet/interface.go` are byte-identical to
`sql-wallet` on this branch.
