### PR TITLE
wallet/txrules+txsizes: align btcd to v0.26.0 (submodule tag prep, round 1)

### DIFF
--- a/wallet/txrules/go.mod
+++ b/wallet/txrules/go.mod
@@ -1,7 +1,7 @@
 module github.com/btcsuite/btcwallet/wallet/txrules
 
 require (
-	github.com/btcsuite/btcd v0.26.0-beta.rc1
+	github.com/btcsuite/btcd v0.26.0
 	github.com/btcsuite/btcd/btcutil/v2 v2.0.0
 	github.com/btcsuite/btcd/txscript/v2 v2.0.0
 	github.com/btcsuite/btcd/wire/v2 v2.0.0

--- a/wallet/txrules/go.sum
+++ b/wallet/txrules/go.sum
@@ -1,7 +1,7 @@
 github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
-github.com/btcsuite/btcd v0.26.0-beta.rc1 h1:1gCNMsV113Rlm9vNri+K+HOfSKv+eDdELu4JujFOa8M=
-github.com/btcsuite/btcd v0.26.0-beta.rc1/go.mod h1:7ft7+a/MoJHFouFopCb1zyiR9IWPlrcPVn6K/lJ1dcA=
+github.com/btcsuite/btcd v0.26.0 h1:yntnSshlG3+H7dTwIOR4LTFXDPojVBsFORBNN5y5c/c=
+github.com/btcsuite/btcd v0.26.0/go.mod h1:7ft7+a/MoJHFouFopCb1zyiR9IWPlrcPVn6K/lJ1dcA=
 github.com/btcsuite/btcd/address/v2 v2.0.0 h1:UVu8Hal6Siu4XastFe+JX5JkeBYONbDUIY5E+SVTs6I=
 github.com/btcsuite/btcd/address/v2 v2.0.0/go.mod h1:htJK1AtaeK3bKNfZY63ep2oN8LbrI6qvmPGe1vekb3I=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=

--- a/wallet/txsizes/go.mod
+++ b/wallet/txsizes/go.mod
@@ -1,7 +1,7 @@
 module github.com/btcsuite/btcwallet/wallet/txsizes
 
 require (
-	github.com/btcsuite/btcd v0.26.0-beta.rc1
+	github.com/btcsuite/btcd v0.26.0
 	github.com/btcsuite/btcd/txscript/v2 v2.0.0
 	github.com/btcsuite/btcd/wire/v2 v2.0.0
 )

--- a/wallet/txsizes/go.sum
+++ b/wallet/txsizes/go.sum
@@ -1,5 +1,5 @@
-github.com/btcsuite/btcd v0.26.0-beta.rc1 h1:1gCNMsV113Rlm9vNri+K+HOfSKv+eDdELu4JujFOa8M=
-github.com/btcsuite/btcd v0.26.0-beta.rc1/go.mod h1:7ft7+a/MoJHFouFopCb1zyiR9IWPlrcPVn6K/lJ1dcA=
+github.com/btcsuite/btcd v0.26.0 h1:yntnSshlG3+H7dTwIOR4LTFXDPojVBsFORBNN5y5c/c=
+github.com/btcsuite/btcd v0.26.0/go.mod h1:7ft7+a/MoJHFouFopCb1zyiR9IWPlrcPVn6K/lJ1dcA=
 github.com/btcsuite/btcd/address/v2 v2.0.0 h1:UVu8Hal6Siu4XastFe+JX5JkeBYONbDUIY5E+SVTs6I=
 github.com/btcsuite/btcd/address/v2 v2.0.0/go.mod h1:htJK1AtaeK3bKNfZY63ep2oN8LbrI6qvmPGe1vekb3I=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=


### PR DESCRIPTION
In this PR, we align the `btcd` requirement in the `txrules` and `txsizes`
submodules from `v0.26.0-beta.rc1` to the final `v0.26.0` release, matching
the version the root module and `wtxmgr` already track. This is the first
round of prep work for tagging the new btcd v2-module releases of all the
btcwallet submodules, following the merge of #1266.

The tagging has to happen bottom-up across the dependency levels, since a
dependent module can't bump its `require` to a fresh in-repo tag (and drop
its local `replace`) until that tag is actually published to the proxy. So
the plan is:

- **Round 1 (this PR):** line up the leaf modules on a consistent btcd
  base, then tag `walletdb/v1.6.0`, `wallet/txrules/v1.3.0`, and
  `wallet/txsizes/v1.3.0`. `walletdb` has no btcd dependency and no local
  replaces, so it needs no code change here, it just gets tagged off the
  same base.
- **Round 2 (follow-up PR):** bump `txauthor` and `wtxmgr` to point at the
  new leaf tags and drop their `../` replace rules, then tag
  `wallet/txauthor/v1.4.0` and `wtxmgr/v1.6.0`.
- Then over in neutrino ([lightninglabs/neutrino#364](https://github.com/lightninglabs/neutrino/pull/364))
  we bump the btcwallet submodule requires to the new tags, drop the
  `guggero/neutrino` replace, and push a neutrino tag, which finally gets
  pinned back in the btcwallet root `go.mod`.

The versions stay in the `v1.x` range since the module paths didn't change
to `/v2` (only the btcd dependency did), so each breaking bump lands as a
minor version per the usual btcwallet convention.