### PR TITLE
wallet/txauthor+wtxmgr: pin new leaf tags, drop replaces (submodule tag prep, round 2)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,9 +12,9 @@ require (
 	github.com/btcsuite/btcd/wire/v2 v2.0.0
 	github.com/btcsuite/btclog v1.0.0
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.3.5
-	github.com/btcsuite/btcwallet/wallet/txrules v1.2.2
-	github.com/btcsuite/btcwallet/wallet/txsizes v1.2.5
-	github.com/btcsuite/btcwallet/walletdb v1.5.1
+	github.com/btcsuite/btcwallet/wallet/txrules v1.3.0
+	github.com/btcsuite/btcwallet/wallet/txsizes v1.3.0
+	github.com/btcsuite/btcwallet/walletdb v1.6.0
 	github.com/btcsuite/btcwallet/wtxmgr v1.5.6
 	github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792
 	github.com/davecgh/go-spew v1.1.1

--- a/wallet/txauthor/go.mod
+++ b/wallet/txauthor/go.mod
@@ -6,13 +6,13 @@ require (
 	github.com/btcsuite/btcd/chaincfg/v2 v2.0.0
 	github.com/btcsuite/btcd/txscript/v2 v2.0.0
 	github.com/btcsuite/btcd/wire/v2 v2.0.0
-	github.com/btcsuite/btcwallet/wallet/txrules v1.2.0
-	github.com/btcsuite/btcwallet/wallet/txsizes v1.2.3
+	github.com/btcsuite/btcwallet/wallet/txrules v1.3.0
+	github.com/btcsuite/btcwallet/wallet/txsizes v1.3.0
 )
 
 require (
 	github.com/aead/siphash v1.0.1 // indirect
-	github.com/btcsuite/btcd v0.26.0-beta.rc1 // indirect
+	github.com/btcsuite/btcd v0.26.0 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.5.0 // indirect
 	github.com/btcsuite/btcd/chainhash/v2 v2.0.0 // indirect
 	github.com/btcsuite/btclog v1.0.0 // indirect
@@ -30,7 +30,3 @@ require (
 )
 
 go 1.25.11
-
-replace github.com/btcsuite/btcwallet/wallet/txrules => ../txrules
-
-replace github.com/btcsuite/btcwallet/wallet/txsizes => ../txsizes

--- a/wallet/txauthor/go.sum
+++ b/wallet/txauthor/go.sum
@@ -1,7 +1,7 @@
 github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
-github.com/btcsuite/btcd v0.26.0-beta.rc1 h1:1gCNMsV113Rlm9vNri+K+HOfSKv+eDdELu4JujFOa8M=
-github.com/btcsuite/btcd v0.26.0-beta.rc1/go.mod h1:7ft7+a/MoJHFouFopCb1zyiR9IWPlrcPVn6K/lJ1dcA=
+github.com/btcsuite/btcd v0.26.0 h1:yntnSshlG3+H7dTwIOR4LTFXDPojVBsFORBNN5y5c/c=
+github.com/btcsuite/btcd v0.26.0/go.mod h1:7ft7+a/MoJHFouFopCb1zyiR9IWPlrcPVn6K/lJ1dcA=
 github.com/btcsuite/btcd/address/v2 v2.0.0 h1:UVu8Hal6Siu4XastFe+JX5JkeBYONbDUIY5E+SVTs6I=
 github.com/btcsuite/btcd/address/v2 v2.0.0/go.mod h1:htJK1AtaeK3bKNfZY63ep2oN8LbrI6qvmPGe1vekb3I=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=
@@ -18,6 +18,10 @@ github.com/btcsuite/btcd/wire/v2 v2.0.0 h1:mYSKzZZ0a1sK+aMhXzfDSVsSzRkWkU3x2U04T
 github.com/btcsuite/btcd/wire/v2 v2.0.0/go.mod h1:bGxkPkk8IiDvUo1D96wE03llBIk7p2MdWYRyAQwLmqM=
 github.com/btcsuite/btclog v1.0.0 h1:sEkpKJMmfGiyZjADwEIgB1NSwMyfdD1FB8v6+w1T0Ns=
 github.com/btcsuite/btclog v1.0.0/go.mod h1:w7xnGOhwT3lmrS4H3b/D1XAXxvh+tbhUm8xeHN2y3TQ=
+github.com/btcsuite/btcwallet/wallet/txrules v1.3.0 h1:D5aGMwWIxdqek3xEJs4eOdMoh6iga2EI2xSlaXCdnNo=
+github.com/btcsuite/btcwallet/wallet/txrules v1.3.0/go.mod h1:ZzSdn2XrsUDPa193Q/su1sJY+716rlFK2H1mYwbY/18=
+github.com/btcsuite/btcwallet/wallet/txsizes v1.3.0 h1:2W9qt0edMoX8crx0Wm4Cv+eAj4B3jlbn0N/5fckLHSU=
+github.com/btcsuite/btcwallet/wallet/txsizes v1.3.0/go.mod h1:42aE6+LMZSSEisQAa15Xml25ncuJFfhCrkcpB5OmkZk=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decred/dcrd/crypto/blake256 v1.1.0 h1:zPMNGQCm0g4QTY27fOCorQW7EryeQ/U0x++OzVrdms8=

--- a/wtxmgr/go.mod
+++ b/wtxmgr/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/btcsuite/btcd/wire/v2 v2.0.0
 	github.com/btcsuite/btclog v1.0.0
 	github.com/btcsuite/btcwallet v0.16.18
-	github.com/btcsuite/btcwallet/walletdb v1.5.1
+	github.com/btcsuite/btcwallet/walletdb v1.6.0
 	github.com/lightningnetwork/lnd/clock v1.0.1
 	github.com/stretchr/testify v1.10.0
 )
@@ -29,7 +29,3 @@ require (
 )
 
 go 1.25.11
-
-replace github.com/btcsuite/btcwallet/walletdb => ../walletdb
-
-replace github.com/btcsuite/btcwallet => ..

--- a/wtxmgr/go.sum
+++ b/wtxmgr/go.sum
@@ -16,6 +16,10 @@ github.com/btcsuite/btcd/wire/v2 v2.0.0 h1:mYSKzZZ0a1sK+aMhXzfDSVsSzRkWkU3x2U04T
 github.com/btcsuite/btcd/wire/v2 v2.0.0/go.mod h1:bGxkPkk8IiDvUo1D96wE03llBIk7p2MdWYRyAQwLmqM=
 github.com/btcsuite/btclog v1.0.0 h1:sEkpKJMmfGiyZjADwEIgB1NSwMyfdD1FB8v6+w1T0Ns=
 github.com/btcsuite/btclog v1.0.0/go.mod h1:w7xnGOhwT3lmrS4H3b/D1XAXxvh+tbhUm8xeHN2y3TQ=
+github.com/btcsuite/btcwallet v0.16.18 h1:6h0kMxij4igPu35jOPAWZbn22ceOC4me4L3jj8Za6Zk=
+github.com/btcsuite/btcwallet v0.16.18/go.mod h1:4TTru0cgIPbCZpY4aRfAVwX87zrQw4GXM8MH6+A5xZw=
+github.com/btcsuite/btcwallet/walletdb v1.6.0 h1:Yund5XbdqFxNW7+R2Sxs02bMC5fMrmORj4GN8MV55no=
+github.com/btcsuite/btcwallet/walletdb v1.6.0/go.mod h1:q9xif0Csp52GVb3l252BbHCuyiCnuEbrPWu/HAsvaYc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decred/dcrd/crypto/blake256 v1.1.0 h1:zPMNGQCm0g4QTY27fOCorQW7EryeQ/U0x++OzVrdms8=


### PR DESCRIPTION
In this PR, we do the second round of submodule tag prep on top of #1274.
Now that the leaf modules are tagged (`walletdb/v1.6.0`,
`wallet/txrules/v1.3.0`, `wallet/txsizes/v1.3.0`), we can point the level-1
modules at those tags and drop the `../` replace rules they used to build
against the in-tree copies during the btcd v2-module migration.

For `txauthor`, we bump `txrules` and `txsizes` to `v1.3.0` and align the
indirect `btcd` require to `v0.26.0`. For `wtxmgr`, we bump `walletdb` to
`v1.6.0`. Both build and test green against the published tags, so once
this lands they're ready to be tagged `wallet/txauthor/v1.4.0` and
`wtxmgr/v1.6.0`.

## On the wtxmgr btcwallet require

One thing worth calling out: we keep `github.com/btcsuite/btcwallet v0.16.18`
in `wtxmgr/go.mod`. It looks like a stale self-reference, but it isn't, it's
there for the `github.com/btcsuite/btcwallet/build` logging subpackage that
wtxmgr imports. That package only pulls in `btclog`, so it compiles cleanly
against the old tag and no btcd v2 types leak in through it.

This is the one genuinely circular edge in the graph (`wtxmgr -> btcwallet/build
-> root`). Pinning it at `v0.16.18` is harmless: when the root module itself
consumes `wtxmgr`, the main module always wins in MVS, so `v0.16.18` is never
actually selected there. It only matters for standalone wtxmgr builds, where
the old `build` package is perfectly fine. Once the root is tagged we can
optionally bump this in a follow-up, but it's not needed for correctness.

## What's next

After this merges I'll tag `wallet/txauthor/v1.4.0` and `wtxmgr/v1.6.0`,
then pause so we can sort out the neutrino side
([lightninglabs/neutrino#364](https://github.com/lightninglabs/neutrino/pull/364)):
bump its btcwallet submodule requires to the new tags, drop the
`guggero/neutrino` replace, push a neutrino tag, and finally pin that back
in the btcwallet root `go.mod` (which also drops the last replace rules
there).