### PR TITLE
multi: bump stale Go version references

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ env:
 
   # If you change this please run `make lint` to see where else it needs to be
   # updated as well.
-  GO_VERSION: 1.24.6
+  GO_VERSION: 1.25.11
 
   BITCOIND_VERSION: '22.0'
   BITCOIND_IMAGE: 'lightninglabs/bitcoin-core'

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Wallet clients can use one of two RPC servers:
 
 ## Requirements
 
-[Go](http://golang.org) 1.12 or newer.
+[Go](http://golang.org) 1.25.11 or newer.
 
 ## Installation and updating
 

--- a/rpc/gen_protos_docker.sh
+++ b/rpc/gen_protos_docker.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # golang docker image version used in this script.
-GO_IMAGE=docker.io/library/golang:1.23.12-alpine
+GO_IMAGE=docker.io/library/golang:1.25.11-alpine
 
 # protobuf generator version with legacy plugins=grpc support. Using v1.4.3 to
 # maintain backward compatibility - generates single file instead of separate


### PR DESCRIPTION
Update stale Go version references to match the current repository go.mod version: `1.25.11`.