### PR TITLE
Start SQL Integration Tests

### DIFF
--- a/bwtest/database.go
+++ b/bwtest/database.go
@@ -18,6 +18,9 @@ const (
 	// dbNameKvdb is the identifier used for the kvdb wallet backend.
 	dbNameKvdb = "kvdb"
 
+	// dbNameSQLite is the identifier used for the SQLite wallet backend.
+	dbNameSQLite = "sqlite"
+
 	// kvdbDriver is the walletdb driver name used for kvdb.
 	kvdbDriver = "bdb"
 

--- a/bwtest/harness.go
+++ b/bwtest/harness.go
@@ -178,10 +178,23 @@ func (h *HarnessTest) Subtest(t *testing.T) *HarnessTest {
 func (h *HarnessTest) NewWalletManager() *wallet.Manager {
 	h.Helper()
 
-	// Fixed kvdb until #1292 introduces backend selection: this PR only
-	// moves database ownership to the Manager.
-	//nolint:staticcheck // This boundary intentionally exercises legacy kvdb.
-	backend := wallet.DBBackendKVDB
+	// Switch explicitly: mapping every unknown -db value onto kvdb would let
+	// `db=postgres` pass while exercising kvdb, and the PostgreSQL Manager is
+	// not part of this milestone.
+	var backend wallet.DBBackend
+
+	switch h.dbType {
+	case dbNameKvdb:
+		//nolint:staticcheck // This case intentionally exercises legacy kvdb.
+		backend = wallet.DBBackendKVDB
+
+	case dbNameSQLite:
+		backend = wallet.DBBackendSQLite
+
+	default:
+		h.Fatalf("unsupported -db value %q: the wallet Manager serves "+
+			"kvdb and sqlite", h.dbType)
+	}
 
 	manager, err := wallet.NewManager(h.Context(), wallet.ManagerConfig{
 		Backend:     backend,

--- a/bwtest/harness.go
+++ b/bwtest/harness.go
@@ -3,6 +3,7 @@ package bwtest
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -62,6 +63,10 @@ type HarnessTest struct {
 
 	// dbType is the configured wallet database backend.
 	dbType string
+
+	// managers holds the wallet managers created for this subtest. They are
+	// closed after every registered wallet has stopped.
+	managers []*wallet.Manager
 
 	// mu protects harness state that can be accessed across the main test and
 	// subtests. This includes the wallet registry and idempotent shutdown.
@@ -159,7 +164,7 @@ func (h *HarnessTest) Subtest(t *testing.T) *HarnessTest {
 		// If a test fails, we still try to stop wallets to avoid leaking
 		// goroutines into the next test, but we skip assertions.
 		if st.Failed() {
-			err := st.stopActiveWallets(context.Background())
+			err := st.teardownWallets(context.Background())
 			if err != nil {
 				st.Logf("failed to stop wallets during failed-test cleanup: %v",
 					err)
@@ -172,7 +177,7 @@ func (h *HarnessTest) Subtest(t *testing.T) *HarnessTest {
 			return
 		}
 
-		err := st.stopActiveWallets(context.Background())
+		err := st.teardownWallets(context.Background())
 		require.NoError(st, err, "failed to stop wallets")
 
 		mempool, err := st.getRawMempool()
@@ -220,15 +225,26 @@ func (h *HarnessTest) NewWalletManager() *wallet.Manager {
 	})
 	require.NoError(h, err, "failed to create wallet manager")
 
-	// Temporary: close this Manager directly. #1292 replaces this with the
-	// registry-ordered teardown that stops wallets first.
-	h.Cleanup(func() { _ = manager.Close() })
+	h.managers = append(h.managers, manager)
 
 	// Verify the Manager opened the backend requested by the -db flag without
 	// adding a production accessor solely for the test.
 	h.Cleanup(h.assertBackendArtifact)
 
 	return manager
+}
+
+// teardownWallets stops registered wallets and then closes their Managers.
+func (h *HarnessTest) teardownWallets(ctx context.Context) error {
+	err := h.stopActiveWallets(ctx)
+
+	for _, manager := range h.managers {
+		err = errors.Join(err, manager.Close())
+	}
+
+	h.managers = nil
+
+	return err
 }
 
 // assertBackendArtifact verifies the Manager created the requested database.
@@ -385,7 +401,9 @@ func (h *HarnessTest) Stop() {
 func (h *HarnessTest) stopActiveWallets(ctx context.Context) error {
 	h.Helper()
 
-	for _, w := range h.ActiveWallets() {
+	var stopErr error
+
+	for i, w := range h.ActiveWallets() {
 		if w == nil {
 			// Keep cleanup robust against partially initialized test state. A
 			// caller could register a wallet reference and fail before the
@@ -400,11 +418,13 @@ func (h *HarnessTest) stopActiveWallets(ctx context.Context) error {
 		// legacy fields initialized.
 		err := w.Stop(ctx)
 		if err != nil {
-			return fmt.Errorf("stop wallet: %w", err)
+			stopErr = errors.Join(stopErr, fmt.Errorf(
+				"stop wallet %d: %w", i, err,
+			))
 		}
 	}
 
-	return nil
+	return stopErr
 }
 
 // setUpChainClient creates and starts a chain client for the active harness

--- a/bwtest/harness.go
+++ b/bwtest/harness.go
@@ -2,7 +2,10 @@ package bwtest
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
 	"runtime/debug"
 	"sync"
@@ -15,6 +18,20 @@ import (
 )
 
 const (
+	// sqliteHeaderLen is the length of SQLite's fixed file header string.
+	sqliteHeaderLen = 16
+
+	// sqliteHeaderMagic is the header string every SQLite database starts
+	// with.
+	sqliteHeaderMagic = "SQLite format 3\x00"
+
+	// bboltMagicOffset is the offset of bbolt's magic within the first page
+	// header, bboltMagicLen is its width, and bboltMagic is the value
+	// stored there.
+	bboltMagicOffset = 16
+	bboltMagicLen    = 4
+	bboltMagic       = 0xED0CDAED
+
 	// defaultChainReconnectAttempts is the number of times the chain RPC client
 	// will attempt to reconnect before failing.
 	defaultChainReconnectAttempts = 5
@@ -207,7 +224,72 @@ func (h *HarnessTest) NewWalletManager() *wallet.Manager {
 	// registry-ordered teardown that stops wallets first.
 	h.Cleanup(func() { _ = manager.Close() })
 
+	// Verify the Manager opened the backend requested by the -db flag without
+	// adding a production accessor solely for the test.
+	h.Cleanup(h.assertBackendArtifact)
+
 	return manager
+}
+
+// assertBackendArtifact verifies the Manager created the requested database.
+func (h *HarnessTest) assertBackendArtifact() {
+	h.Helper()
+
+	err := validateBackendArtifact(h.dbType, h.WalletDBPath)
+	require.NoError(h, err)
+}
+
+// validateBackendArtifact verifies that a database file has the requested
+// backend's header.
+func validateBackendArtifact(dbType, dbPath string) error {
+	switch dbType {
+	case dbNameKvdb, dbNameSQLite:
+
+	default:
+		return fmt.Errorf("%w: %s", ErrUnknownDBBackend, dbType)
+	}
+
+	// The path is created and owned by the test harness.
+	f, err := os.Open(dbPath) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("open wallet database artifact: %w", err)
+	}
+
+	defer func() { _ = f.Close() }()
+
+	// Read enough for both signatures: SQLite's header string, and bbolt's
+	// magic at offset 16 of the first page.
+	header := make([]byte, bboltMagicOffset+bboltMagicLen)
+
+	_, err = io.ReadFull(f, header)
+	if err != nil {
+		return fmt.Errorf("read wallet database header: %w", err)
+	}
+
+	sqlite := string(header[:sqliteHeaderLen]) == sqliteHeaderMagic
+	bbolt := binary.LittleEndian.Uint32(
+		header[bboltMagicOffset:bboltMagicOffset+bboltMagicLen],
+	) == bboltMagic
+
+	var detected string
+	switch {
+	case sqlite:
+		detected = dbNameSQLite
+
+	case bbolt:
+		detected = dbNameKvdb
+
+	default:
+		return fmt.Errorf("unrecognized wallet database artifact: %s",
+			dbPath)
+	}
+
+	if detected != dbType {
+		return fmt.Errorf("db=%s requested but %s is a %s database",
+			dbType, dbPath, detected)
+	}
+
+	return nil
 }
 
 // RegisterWallet registers a wallet with the harness.

--- a/bwtest/harness_test.go
+++ b/bwtest/harness_test.go
@@ -1,0 +1,79 @@
+package bwtest
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestBackendArtifactValidatesExpectedBackend verifies that backend artifact
+// validation reports positive, mismatched, and malformed headers without
+// depending on testing.T failure state.
+func TestBackendArtifactValidatesExpectedBackend(t *testing.T) {
+	t.Parallel()
+
+	sqliteHeader := make([]byte, bboltMagicOffset+bboltMagicLen)
+	copy(sqliteHeader, sqliteHeaderMagic)
+
+	kvdbHeader := make([]byte, bboltMagicOffset+bboltMagicLen)
+	binary.LittleEndian.PutUint32(
+		kvdbHeader[bboltMagicOffset:], bboltMagic,
+	)
+
+	testCases := []struct {
+		name    string
+		dbType  string
+		header  []byte
+		wantErr string
+	}{
+		{name: "sqlite matches", dbType: dbNameSQLite,
+			header: sqliteHeader},
+		{name: "kvdb matches", dbType: dbNameKvdb,
+			header: kvdbHeader},
+		{
+			name:    "sqlite mismatches kvdb",
+			dbType:  dbNameKvdb,
+			header:  sqliteHeader,
+			wantErr: "is a sqlite database",
+		},
+		{
+			name:    "kvdb mismatches sqlite",
+			dbType:  dbNameSQLite,
+			header:  kvdbHeader,
+			wantErr: "is a kvdb database",
+		},
+		{
+			name:    "unknown header",
+			dbType:  dbNameSQLite,
+			header:  make([]byte, bboltMagicOffset+bboltMagicLen),
+			wantErr: "unrecognized wallet database artifact",
+		},
+		{
+			name:    "truncated header",
+			dbType:  dbNameKvdb,
+			header:  []byte("short"),
+			wantErr: "read wallet database header",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			dbPath := filepath.Join(t.TempDir(), "wallet.db")
+			err := os.WriteFile(dbPath, testCase.header, 0o600)
+			require.NoError(t, err)
+
+			err = validateBackendArtifact(testCase.dbType, dbPath)
+			if testCase.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.ErrorContains(t, err, testCase.wantErr)
+		})
+	}
+}

--- a/bwtest/harness_test.go
+++ b/bwtest/harness_test.go
@@ -5,9 +5,103 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/btcsuite/btcwallet/wallet"
 	"github.com/stretchr/testify/require"
 )
+
+// TestTeardownWalletsClosesManagerAfterFailedCreate verifies that centralized
+// teardown releases a Manager even when wallet creation fails.
+func TestTeardownWalletsClosesManagerAfterFailedCreate(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		dbType  string
+		backend wallet.DBBackend
+	}{
+		{
+			name:   "kvdb",
+			dbType: dbNameKvdb,
+			//nolint:staticcheck // This case covers legacy kvdb teardown.
+			backend: wallet.DBBackendKVDB,
+		},
+		{
+			name:    "sqlite",
+			dbType:  dbNameSQLite,
+			backend: wallet.DBBackendSQLite,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			testManagerTeardownAfterFailedCreate(
+				t, testCase.dbType, testCase.backend,
+			)
+		})
+	}
+}
+
+// testManagerTeardownAfterFailedCreate exercises centralized Manager cleanup
+// for one database backend.
+func testManagerTeardownAfterFailedCreate(t *testing.T, dbType string,
+	backend wallet.DBBackend) {
+
+	t.Helper()
+
+	h := &HarnessTest{
+		T:            t,
+		dbType:       dbType,
+		WalletDBPath: filepath.Join(t.TempDir(), "wallet.db"),
+	}
+
+	manager := h.NewWalletManager()
+	require.NotNil(t, manager)
+
+	// Force Create to fail after the Manager has opened its database.
+	pubPass := []byte("public")
+	cfg := wallet.Config{
+		Name:          "failed-create",
+		PubPassphrase: pubPass,
+	}
+	w, err := manager.Create(cfg, wallet.CreateWalletParams{
+		Mode:              wallet.ModeGenSeed,
+		PubPassphrase:     pubPass,
+		PrivatePassphrase: []byte("private"),
+	})
+	require.ErrorIs(t, err, wallet.ErrMissingParam)
+	require.Nil(t, w)
+
+	// Bound teardown so a missing Manager close fails instead of hanging.
+	done := make(chan error, 1)
+	go func() {
+		done <- h.teardownWallets(t.Context())
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+
+	case <-time.After(teardownWaitLimit):
+		t.Fatal("teardownWallets did not return: the Manager was " +
+			"probably never closed")
+	}
+
+	// A fresh Manager proves the database was released.
+	reopened, err := wallet.NewManager(t.Context(), wallet.ManagerConfig{
+		Backend:     backend,
+		DataSource:  h.WalletDBPath,
+		ChainParams: h.NetParams(),
+	})
+	require.NoError(t, err, "teardown must release the database")
+	require.NoError(t, reopened.Close())
+}
+
+// teardownWaitLimit bounds teardown so a leaked Manager fails the test.
+const teardownWaitLimit = 30 * time.Second
 
 // TestBackendArtifactValidatesExpectedBackend verifies that backend artifact
 // validation reports positive, mismatched, and malformed headers without

--- a/bwtest/harness_wallet.go
+++ b/bwtest/harness_wallet.go
@@ -1,7 +1,6 @@
 package bwtest
 
 import (
-	"context"
 	"strings"
 	"time"
 
@@ -68,19 +67,11 @@ func (h *HarnessTest) CreateEmptyWallet() *wallet.Wallet {
 	w, err := manager.Create(cfg, params)
 	require.NoError(h, err, "failed to create wallet")
 
-	// Register so harness-level assertions (MineBlocks and friends) can see
-	// this wallet.
+	// Register before Start, and only register: teardownWallets is the single
+	// cleanup owner. Registering after Start would leave a wallet whose Start
+	// failed unregistered, and a second direct Stop callback here would stop a
+	// successful one twice, out of order with the Manager close.
 	h.RegisterWallet(w)
-
-	// Temporary, until #1292 owns teardown through the registries: stop this
-	// wallet directly. The callback is registered after NewWalletManager's
-	// Close, and testing.Cleanup runs LIFO, so the wallet stops before the
-	// Manager closes the database underneath it.
-	h.Cleanup(func() {
-		// A background context: the test context may already be done by
-		// the time cleanup runs.
-		_ = w.Stop(context.Background())
-	})
 
 	err = w.Start(h.Context())
 	require.NoError(h, err, "failed to start wallet")

--- a/itest/manager_test.go
+++ b/itest/manager_test.go
@@ -3,7 +3,6 @@
 package itest
 
 import (
-	"context"
 	"time"
 
 	"github.com/btcsuite/btcwallet/bwtest"
@@ -37,15 +36,11 @@ func testCreateWallet(h *bwtest.HarnessTest) {
 	w, err := manager.Create(cfg, params)
 	require.NoError(h, err, "failed to create wallet")
 
-	// Register so harness-level assertions can see this wallet.
+	// Register before Start so teardown owns the wallet even if Start fails.
+	// The harness stops every registered wallet and then closes every
+	// Manager. Do not add another Stop cleanup here; it would only stop the
+	// wallet early and duplicate the harness-owned teardown.
 	h.RegisterWallet(w)
-
-	// Temporary, until #1292 owns teardown through the registries: stop this
-	// wallet directly. Registered after the Manager's Close and run first,
-	// since testing.Cleanup is LIFO.
-	h.Cleanup(func() {
-		_ = w.Stop(context.Background())
-	})
 
 	err = w.Start(h.Context())
 	require.NoError(h, err, "failed to start wallet")


### PR DESCRIPTION
Runs the existing Manager integration test on both backends, so the SQL store is
exercised end to end against a real chain backend rather than only by unit
tests.

Stacked on `impl-runtime-store-6`.

## What lands here

1 commits:

1. `bwtest+itest: select backend, own teardown`
 The harness maps its
`-db` flag to the Manager backend, so the existing `manager` case runs on either
backend without a second test case:

```text
make itest chain=btcd db=kvdb   icase=manager
make itest chain=btcd db=sqlite icase=manager
```

Both pass, each executing exactly one case, `manager_create_wallet`.

## The default stays kvdb

An earlier revision of this PR flipped the global default for newly created
wallets from kvdb to SQLite, which is what the branch name still refers to.
**It does not do that any more** — both commands select the backend explicitly,
and the global default is unchanged. A consistent flip touches the `Makefile`
default and the docs as well as the code, for no capability the itests need.

## Teardown ownership

One cleanup owner stops every registered wallet and *then* closes every Manager,
joining the errors. A Manager owns the database its wallets use, so closing it
first would pull the store out from under a running wallet; `testing.Cleanup`
runs LIFO, which is how the previous duplicate `Stop` inverted that order.

Teardown also checks the on-disk artifact against the requested backend. Without
that check a `db=sqlite` run could pass while the Manager quietly opened kvdb —
which is what made the previous revision's SQLite claim hollow.

`db=postgres` is rejected with a clear message: the harness provisions no DSN.
The PostgreSQL **Store** is retained and green, and the existing shared DB
contract keeps running on PostgreSQL in CI; only the Manager and daemon harness
defer to #321.

