### PR TITLE
wallet: add manager transaction boundary

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -6,6 +6,7 @@ package wallet
 
 import (
 	"bytes"
+	"context"
 	"time"
 
 	"github.com/btcsuite/btcd/chainhash/v2"
@@ -13,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	walletstore "github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 )
@@ -164,9 +166,14 @@ func (w *Wallet) handleChainNotifications() {
 				})
 				notificationName = "block connected"
 			case chain.BlockDisconnected:
-				err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-					return w.disconnectBlock(tx, wtxmgr.BlockMeta(n))
-				})
+				err = w.store.Update(
+					context.Background(),
+					func(tx walletstore.ReadWriteTx) error {
+						return w.disconnectBlock(
+							tx, wtxmgr.BlockMeta(n),
+						)
+					}, func() {},
+				)
 				notificationName = "block disconnected"
 			case chain.RelevantTx:
 				err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
@@ -263,9 +270,11 @@ func (w *Wallet) connectBlock(dbtx walletdb.ReadWriteTx, b wtxmgr.BlockMeta) err
 // disconnectBlock handles a chain server reorganize by rolling back all
 // block history from the reorged block for a wallet in-sync with the chain
 // server.
-func (w *Wallet) disconnectBlock(dbtx walletdb.ReadWriteTx, b wtxmgr.BlockMeta) error {
-	addrmgrNs := dbtx.ReadWriteBucket(waddrmgrNamespaceKey)
-	txmgrNs := dbtx.ReadWriteBucket(wtxmgrNamespaceKey)
+func (w *Wallet) disconnectBlock(dbtx walletstore.ReadWriteTx,
+	b wtxmgr.BlockMeta) error {
+
+	addrStore := dbtx.Addr()
+	txStore := dbtx.Tx()
 
 	if !w.ChainSynced() {
 		return nil
@@ -274,7 +283,7 @@ func (w *Wallet) disconnectBlock(dbtx walletdb.ReadWriteTx, b wtxmgr.BlockMeta) 
 	// Disconnect the removed block and all blocks after it if we know about
 	// the disconnected block. Otherwise, the block is in the future.
 	if b.Height <= w.Manager.SyncedTo().Height {
-		hash, err := w.Manager.BlockHash(addrmgrNs, b.Height)
+		hash, err := addrStore.BlockHash(b.Height)
 		if err != nil {
 			return err
 		}
@@ -282,7 +291,7 @@ func (w *Wallet) disconnectBlock(dbtx walletdb.ReadWriteTx, b wtxmgr.BlockMeta) 
 			bs := waddrmgr.BlockStamp{
 				Height: b.Height - 1,
 			}
-			hash, err = w.Manager.BlockHash(addrmgrNs, bs.Height)
+			hash, err = addrStore.BlockHash(bs.Height)
 			if err != nil {
 				return err
 			}
@@ -295,12 +304,12 @@ func (w *Wallet) disconnectBlock(dbtx walletdb.ReadWriteTx, b wtxmgr.BlockMeta) 
 			}
 
 			bs.Timestamp = header.Timestamp
-			err = w.Manager.SetSyncedTo(addrmgrNs, &bs)
+			err = addrStore.SetSyncedTo(&bs)
 			if err != nil {
 				return err
 			}
 
-			err = w.TxStore.Rollback(txmgrNs, b.Height)
+			err = txStore.Rollback(b.Height)
 			if err != nil {
 				return err
 			}

--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+// Package db defines the backend-neutral transaction boundary used by the
+// wallet's address and transaction managers.
+package db
+
+import (
+	"context"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+)
+
+// AddrReadStore exposes address-manager reads within an existing wallet
+// transaction. Backend transaction handles remain private to the adapter.
+type AddrReadStore interface {
+	// BlockHash returns the block hash at a particular block height.
+	BlockHash(height int32) (*chainhash.Hash, error)
+}
+
+// AddrReadWriteStore exposes address-manager reads and writes within an
+// existing wallet transaction.
+type AddrReadWriteStore interface {
+	AddrReadStore
+
+	// SetSyncedTo marks the address manager as synced through the block.
+	SetSyncedTo(block *waddrmgr.BlockStamp) error
+}
+
+// TxReadWriteStore exposes transaction-manager writes within an existing
+// wallet transaction. The interface starts with the reorg operation and will
+// grow as the remaining wallet paths move behind the same boundary.
+type TxReadWriteStore interface {
+	// Rollback removes all blocks at height onwards, moving any transactions
+	// within each block to the unconfirmed pool.
+	Rollback(height int32) error
+}
+
+// ReadTx exposes the read-only manager views bound to one backend transaction.
+type ReadTx interface {
+	// Addr returns the address-manager read view.
+	Addr() AddrReadStore
+}
+
+// ReadWriteTx exposes the manager views bound to one writable backend
+// transaction.
+type ReadWriteTx interface {
+	// Addr returns the address-manager read/write view.
+	Addr() AddrReadWriteStore
+
+	// Tx returns the transaction-manager read/write view.
+	Tx() TxReadWriteStore
+}
+
+// Store owns backend transactions while preserving the wallet's existing
+// callback-oriented control flow. The reset callback runs before each attempt
+// because SQL backends may retry a transaction.
+type Store interface {
+	// View executes body in a read transaction.
+	View(ctx context.Context, body func(ReadTx) error, reset func()) error
+
+	// Update executes body in a read/write transaction.
+	Update(ctx context.Context, body func(ReadWriteTx) error,
+		reset func()) error
+}

--- a/wallet/internal/db/kvdb/store.go
+++ b/wallet/internal/db/kvdb/store.go
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+// Package kvdb adapts the existing walletdb-backed managers to the wallet's
+// backend-neutral transaction boundary.
+package kvdb
+
+import (
+	"context"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	walletstore "github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+)
+
+var (
+	addrmgrNamespaceKey = []byte("waddrmgr")
+	txmgrNamespaceKey   = []byte("wtxmgr")
+)
+
+// legacyAddrStore is the existing walletdb-backed address-manager surface used
+// by the adapter.
+type legacyAddrStore interface {
+	BlockHash(ns walletdb.ReadBucket, height int32) (*chainhash.Hash, error)
+	SetSyncedTo(ns walletdb.ReadWriteBucket,
+		block *waddrmgr.BlockStamp) error
+}
+
+// legacyTxStore is the existing walletdb-backed transaction-manager surface
+// used by the adapter.
+type legacyTxStore interface {
+	Rollback(ns walletdb.ReadWriteBucket, height int32) error
+}
+
+// Store binds the existing address and transaction managers to walletdb
+// transactions. It contains no storage logic of its own.
+type Store struct {
+	db        walletdb.DB
+	addrStore legacyAddrStore
+	txStore   legacyTxStore
+}
+
+// NewStore creates a walletdb adapter for the existing managers.
+func NewStore(db walletdb.DB, addrStore *waddrmgr.Manager,
+	txStore *wtxmgr.Store) *Store {
+
+	return newStore(db, addrStore, txStore)
+}
+
+func newStore(db walletdb.DB, addrStore legacyAddrStore,
+	txStore legacyTxStore) *Store {
+
+	return &Store{
+		db:        db,
+		addrStore: addrStore,
+		txStore:   txStore,
+	}
+}
+
+// View executes body in one walletdb read transaction.
+func (s *Store) View(ctx context.Context, body func(walletstore.ReadTx) error,
+	reset func()) error {
+
+	err := ctx.Err()
+	if err != nil {
+		return err
+	}
+
+	return walletdb.View(s.db, func(tx walletdb.ReadTx) error {
+		err := ctx.Err()
+		if err != nil {
+			return err
+		}
+
+		reset()
+
+		return body(&readTx{
+			addrStore: &addrReadStore{
+				ns:    tx.ReadBucket(addrmgrNamespaceKey),
+				store: s.addrStore,
+			},
+		})
+	})
+}
+
+// Update executes body in one walletdb read/write transaction.
+func (s *Store) Update(ctx context.Context,
+	body func(walletstore.ReadWriteTx) error, reset func()) error {
+
+	err := ctx.Err()
+	if err != nil {
+		return err
+	}
+
+	return walletdb.Update(s.db, func(tx walletdb.ReadWriteTx) error {
+		err := ctx.Err()
+		if err != nil {
+			return err
+		}
+
+		reset()
+
+		return body(&readWriteTx{
+			addrStore: &addrReadWriteStore{
+				ns:    tx.ReadWriteBucket(addrmgrNamespaceKey),
+				store: s.addrStore,
+			},
+			txStore: &txReadWriteStore{
+				ns:    tx.ReadWriteBucket(txmgrNamespaceKey),
+				store: s.txStore,
+			},
+		})
+	})
+}
+
+type readTx struct {
+	addrStore walletstore.AddrReadStore
+}
+
+// Addr returns the address-manager read view.
+//
+//nolint:ireturn // The transaction contract returns a domain interface.
+func (t *readTx) Addr() walletstore.AddrReadStore {
+	return t.addrStore
+}
+
+type readWriteTx struct {
+	addrStore walletstore.AddrReadWriteStore
+	txStore   walletstore.TxReadWriteStore
+}
+
+// Addr returns the address-manager read/write view.
+//
+//nolint:ireturn // The transaction contract returns a domain interface.
+func (t *readWriteTx) Addr() walletstore.AddrReadWriteStore {
+	return t.addrStore
+}
+
+// Tx returns the transaction-manager read/write view.
+//
+//nolint:ireturn // The transaction contract returns a domain interface.
+func (t *readWriteTx) Tx() walletstore.TxReadWriteStore {
+	return t.txStore
+}
+
+type addrReadStore struct {
+	ns    walletdb.ReadBucket
+	store legacyAddrStore
+}
+
+// BlockHash returns the block hash at a particular block height.
+func (s *addrReadStore) BlockHash(height int32) (*chainhash.Hash, error) {
+	return s.store.BlockHash(s.ns, height)
+}
+
+type addrReadWriteStore struct {
+	ns    walletdb.ReadWriteBucket
+	store legacyAddrStore
+}
+
+// BlockHash returns the block hash at a particular block height.
+func (s *addrReadWriteStore) BlockHash(height int32) (*chainhash.Hash, error) {
+	return s.store.BlockHash(s.ns, height)
+}
+
+// SetSyncedTo marks the address manager as synced through the block.
+func (s *addrReadWriteStore) SetSyncedTo(block *waddrmgr.BlockStamp) error {
+	return s.store.SetSyncedTo(s.ns, block)
+}
+
+type txReadWriteStore struct {
+	ns    walletdb.ReadWriteBucket
+	store legacyTxStore
+}
+
+// Rollback removes all blocks at height onwards.
+func (s *txReadWriteStore) Rollback(height int32) error {
+	return s.store.Rollback(s.ns, height)
+}
+
+var (
+	_ walletstore.Store              = (*Store)(nil)
+	_ walletstore.ReadTx             = (*readTx)(nil)
+	_ walletstore.ReadWriteTx        = (*readWriteTx)(nil)
+	_ walletstore.AddrReadStore      = (*addrReadStore)(nil)
+	_ walletstore.AddrReadWriteStore = (*addrReadWriteStore)(nil)
+	_ walletstore.TxReadWriteStore   = (*txReadWriteStore)(nil)
+)

--- a/wallet/internal/db/kvdb/store_test.go
+++ b/wallet/internal/db/kvdb/store_test.go
@@ -1,0 +1,238 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package kvdb
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	walletstore "github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/walletdb"
+	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	blockHashKey      = []byte("block-hash")
+	syncedToHeightKey = []byte("synced-to-height")
+	rollbackHeightKey = []byte("rollback-height")
+)
+
+type testAddrStore struct{}
+
+func (testAddrStore) BlockHash(ns walletdb.ReadBucket,
+	_ int32) (*chainhash.Hash, error) {
+
+	value := ns.Get(blockHashKey)
+	if value == nil {
+		return nil, errors.New("block hash not found")
+	}
+
+	var hash chainhash.Hash
+	copy(hash[:], value)
+
+	return &hash, nil
+}
+
+func (testAddrStore) SetSyncedTo(ns walletdb.ReadWriteBucket,
+	block *waddrmgr.BlockStamp) error {
+
+	return ns.Put(syncedToHeightKey, encodeHeight(block.Height))
+}
+
+type testTxStore struct{}
+
+func (testTxStore) Rollback(ns walletdb.ReadWriteBucket, height int32) error {
+	return ns.Put(rollbackHeightKey, encodeHeight(height))
+}
+
+func TestStoreUpdateSharesTransaction(t *testing.T) {
+	t.Parallel()
+
+	testErr := errors.New("rollback transaction")
+	tests := []struct {
+		name    string
+		bodyErr error
+	}{
+		{
+			name: "commit",
+		},
+		{
+			name:    "rollback",
+			bodyErr: testErr,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			db := testDB(t)
+			store := newStore(db, testAddrStore{}, testTxStore{})
+			shouldCommit := test.bodyErr == nil
+
+			var resetCount int
+
+			err := store.Update(
+				context.Background(), func(tx walletstore.ReadWriteTx) error {
+					err := tx.Addr().SetSyncedTo(&waddrmgr.BlockStamp{
+						Height: 101,
+					})
+					if err != nil {
+						return err
+					}
+
+					err = tx.Tx().Rollback(102)
+					if err != nil {
+						return err
+					}
+
+					return test.bodyErr
+				}, func() {
+					resetCount++
+				},
+			)
+			if shouldCommit {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, test.bodyErr)
+			}
+
+			require.Equal(t, 1, resetCount)
+
+			assertHeight := func(bucketKey, valueKey []byte,
+				expected int32) {
+
+				t.Helper()
+
+				err := walletdb.View(db, func(tx walletdb.ReadTx) error {
+					value := tx.ReadBucket(bucketKey).Get(valueKey)
+					if !shouldCommit {
+						require.Nil(t, value)
+
+						return nil
+					}
+
+					require.Equal(
+						t, expected, decodeHeight(value),
+					)
+
+					return nil
+				})
+				require.NoError(t, err)
+			}
+
+			assertHeight(addrmgrNamespaceKey, syncedToHeightKey, 101)
+			assertHeight(txmgrNamespaceKey, rollbackHeightKey, 102)
+		})
+	}
+}
+
+func TestStoreView(t *testing.T) {
+	t.Parallel()
+
+	db := testDB(t)
+	wantHash := chainhash.Hash{1, 2, 3}
+	err := walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		return tx.ReadWriteBucket(addrmgrNamespaceKey).Put(
+			blockHashKey, wantHash[:],
+		)
+	})
+	require.NoError(t, err)
+
+	store := newStore(db, testAddrStore{}, testTxStore{})
+
+	var resetCount int
+
+	err = store.View(
+		context.Background(), func(tx walletstore.ReadTx) error {
+			gotHash, err := tx.Addr().BlockHash(100)
+			require.NoError(t, err)
+			require.Equal(t, wantHash, *gotHash)
+
+			return nil
+		}, func() {
+			resetCount++
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, resetCount)
+}
+
+func TestStoreRejectsCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	db := testDB(t)
+	store := newStore(db, testAddrStore{}, testTxStore{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var (
+		bodyCalled  bool
+		resetCalled bool
+	)
+
+	err := store.Update(
+		ctx, func(walletstore.ReadWriteTx) error {
+			bodyCalled = true
+
+			return nil
+		}, func() {
+			resetCalled = true
+		},
+	)
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, bodyCalled)
+	require.False(t, resetCalled)
+}
+
+//nolint:ireturn // The test helper returns the walletdb driver interface.
+func testDB(t *testing.T) walletdb.DB {
+	t.Helper()
+
+	db, err := walletdb.Create(
+		"bdb", filepath.Join(t.TempDir(), "wallet.db"), true,
+		10*time.Second, false,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		_, err := tx.CreateTopLevelBucket(addrmgrNamespaceKey)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.CreateTopLevelBucket(txmgrNamespaceKey)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	return db
+}
+
+func encodeHeight(height int32) []byte {
+	var value [4]byte
+	binary.BigEndian.PutUint32(value[:], uint32(height))
+
+	return value[:]
+}
+
+func decodeHeight(value []byte) int32 {
+	return int32(binary.BigEndian.Uint32(value))
+}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -27,6 +27,8 @@ import (
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/chain"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	walletstore "github.com/btcsuite/btcwallet/wallet/internal/db"
+	walletkvdb "github.com/btcsuite/btcwallet/wallet/internal/db/kvdb"
 	"github.com/btcsuite/btcwallet/wallet/txauthor"
 	"github.com/btcsuite/btcwallet/wallet/txrules"
 	"github.com/btcsuite/btcwallet/walletdb"
@@ -126,6 +128,7 @@ type Wallet struct {
 
 	// Data stores
 	db      walletdb.DB
+	store   walletstore.Store
 	Manager *waddrmgr.Manager
 	TxStore *wtxmgr.Store
 
@@ -4484,6 +4487,7 @@ func OpenWithRetry(db walletdb.DB, pubPass []byte, cbs *waddrmgr.OpenCallbacks,
 	w := &Wallet{
 		publicPassphrase:    pubPass,
 		db:                  db,
+		store:               walletkvdb.NewStore(db, addrMgr, txMgr),
 		Manager:             addrMgr,
 		TxStore:             txMgr,
 		lockedOutpoints:     map[wire.OutPoint]struct{}{},


### PR DESCRIPTION
In this PR, we add the first backend-neutral transaction boundary in front of `waddrmgr` and `wtxmgr`. The cut is deliberately narrow: it covers the block-disconnect path first, where the wallet needs to read + update address-manager chain state and roll back the transaction store in one atomic transaction.

The wallet still owns the outer `View`/`Update` callback. For the legacy backend, the new adapter captures the existing `walletdb` buckets and forwards each call directly to `*waddrmgr.Manager` or `*wtxmgr.Store`. It doesn't reproduce either manager's logic, and it doesn't open a transaction per method.

This is the boundary PR that needs to precede #1293. The SQL store in that draft can then be reshaped to implement the same transaction-scoped interfaces, instead of introducing a second generic store contract and a second KVDB implementation.

## Transaction shape

`db.Store` exposes read-only and read/write callbacks. The transaction passed to a write callback provides `Addr()` and `Tx()` domain views, so both managers share the same underlying Bolt or SQL transaction. Neither the wallet callback nor the public manager-facing contract sees `walletdb.ReadBucket`, `walletdb.ReadWriteBucket`, `database/sql`, or generated sqlc types.

We start with `BlockHash`, `SetSyncedTo`, and `Rollback`. The interfaces can grow with each ported behavior, which keeps the next SQL PR reviewable and avoids requiring a giant address + transaction interface before any path can run end-to-end.

## Verification

The adapter tests exercise commit, rollback, reset, read-only access, and canceled contexts. In particular, the rollback vector writes through both manager adapters, returns an error from the outer callback, and verifies that neither namespace commits.

The following focused checks pass:

```
go test ./wallet ./wallet/internal/db/...
golangci-lint run ./wallet/internal/db/...
```

The full `go test ./...` run reached the affected packages successfully. Its only failures were the two `chain/TestBitcoindEvents` variants after their ephemeral local bitcoind RPC endpoints refused connections.

## Stack

This PR is based on #1290. PR #1293 stays draft while we restack its SQL metadata implementation on top of this boundary.

- [x] Add the transaction-scoped manager contracts.
- [x] Add the thin KVDB/Bolt forwarding adapter.
- [x] Route one cross-manager wallet path.
- [x] Preserve source authorship in the extracted commits.
- [ ] Restack and reshape #1293 as the SQL implementation.

See each commit message for a detailed description w.r.t the incremental changes.
