### PR TITLE
wallet: support independent create scrypt parameters

### DIFF
--- a/waddrmgr/manager.go
+++ b/waddrmgr/manager.go
@@ -1808,6 +1808,20 @@ func Create(ns walletdb.ReadWriteBucket, rootKey *hdkeychain.ExtendedKey,
 	chainParams *chaincfg.Params, config *ScryptOptions,
 	birthday time.Time) error {
 
+	return CreateWithScryptOptions(
+		ns, rootKey, pubPassphrase, privPassphrase, chainParams, config,
+		config, birthday,
+	)
+}
+
+// CreateWithScryptOptions creates an address manager with independent scrypt
+// parameters for the public and private master keys. Separate parameters are
+// applied even when both passphrases contain the same bytes.
+func CreateWithScryptOptions(ns walletdb.ReadWriteBucket,
+	rootKey *hdkeychain.ExtendedKey, pubPassphrase, privPassphrase []byte,
+	chainParams *chaincfg.Params, publicConfig,
+	privateConfig *ScryptOptions, birthday time.Time) error {
+
 	// If the seed argument is nil we create in watchingOnly mode.
 	isWatchingOnly := rootKey == nil
 
@@ -1833,13 +1847,16 @@ func Create(ns walletdb.ReadWriteBucket, rootKey *hdkeychain.ExtendedKey,
 		return maybeConvertDbError(err)
 	}
 
-	if config == nil {
-		config = &DefaultScryptOptions
+	if publicConfig == nil {
+		publicConfig = &DefaultScryptOptions
+	}
+	if privateConfig == nil {
+		privateConfig = &DefaultScryptOptions
 	}
 
 	// Generate new master keys.  These master keys are used to protect the
 	// crypto keys that will be generated next.
-	masterKeyPub, err := newSecretKey(&pubPassphrase, config)
+	masterKeyPub, err := newSecretKey(&pubPassphrase, publicConfig)
 	if err != nil {
 		str := "failed to master public key"
 		return managerError(ErrCrypto, str, err)
@@ -1879,7 +1896,7 @@ func Create(ns walletdb.ReadWriteBucket, rootKey *hdkeychain.ExtendedKey,
 	var cryptoKeyPrivEnc []byte
 	var cryptoKeyScriptEnc []byte
 	if !isWatchingOnly {
-		masterKeyPriv, err = newSecretKey(&privPassphrase, config)
+		masterKeyPriv, err = newSecretKey(&privPassphrase, privateConfig)
 		if err != nil {
 			str := "failed to master private key"
 			return managerError(ErrCrypto, str, err)

--- a/waddrmgr/manager_test.go
+++ b/waddrmgr/manager_test.go
@@ -99,6 +99,48 @@ type expectedAddr struct {
 	scriptNotSecret bool
 }
 
+func TestCreateWithScryptOptions(t *testing.T) {
+	teardown, db := emptyDB(t)
+	defer teardown()
+
+	passphrase := []byte("same-passphrase")
+	publicConfig := &ScryptOptions{N: 16, R: 8, P: 1}
+	privateConfig := &ScryptOptions{N: 64, R: 8, P: 1}
+	var manager *Manager
+	err := walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		namespace, err := tx.CreateTopLevelBucket(waddrmgrNamespaceKey)
+		if err != nil {
+			return err
+		}
+
+		err = CreateWithScryptOptions(
+			namespace, rootKey, passphrase, passphrase,
+			&chaincfg.MainNetParams, publicConfig, privateConfig,
+			time.Time{},
+		)
+		if err != nil {
+			return err
+		}
+
+		manager, err = Open(
+			namespace, passphrase, &chaincfg.MainNetParams,
+		)
+
+		return err
+	})
+	require.NoError(t, err)
+	defer manager.Close()
+
+	require.Equal(t, publicConfig.N, manager.masterKeyPub.Parameters.N)
+	require.Equal(t, privateConfig.N, manager.masterKeyPriv.Parameters.N)
+	err = walletdb.View(db, func(tx walletdb.ReadTx) error {
+		namespace := tx.ReadBucket(waddrmgrNamespaceKey)
+
+		return manager.Unlock(namespace, passphrase)
+	})
+	require.NoError(t, err)
+}
+
 // testNamePrefix is a helper to return a prefix to show for test errors based
 // on the state of the test context.
 func testNamePrefix(tc *testContext) string {

--- a/wallet/loader.go
+++ b/wallet/loader.go
@@ -45,6 +45,8 @@ var (
 // loaderConfig contains the configuration options for the loader.
 type loaderConfig struct {
 	walletSyncRetryInterval time.Duration
+	createPublicScrypt      *waddrmgr.ScryptOptions
+	createPrivateScrypt     *waddrmgr.ScryptOptions
 }
 
 // defaultLoaderConfig returns the default configuration options for the loader.
@@ -62,6 +64,30 @@ type LoaderOption func(*loaderConfig)
 func WithWalletSyncRetryInterval(interval time.Duration) LoaderOption {
 	return func(c *loaderConfig) {
 		c.walletSyncRetryInterval = interval
+	}
+}
+
+// WithCreateScryptOptions configures independent public and private scrypt
+// parameters for wallets created by the loader. It does not affect existing
+// wallets, whose parameters are persisted in the wallet database.
+func WithCreateScryptOptions(public,
+	private *waddrmgr.ScryptOptions) LoaderOption {
+
+	return func(c *loaderConfig) {
+		setCreateScryptOptions(c, public, private)
+	}
+}
+
+func setCreateScryptOptions(c *loaderConfig, public,
+	private *waddrmgr.ScryptOptions) {
+
+	if public != nil {
+		publicCopy := *public
+		c.createPublicScrypt = &publicCopy
+	}
+	if private != nil {
+		privateCopy := *private
+		c.createPrivateScrypt = &privateCopy
 	}
 }
 
@@ -177,6 +203,24 @@ func (l *Loader) OnWalletCreated(fn func(walletdb.ReadWriteTx) error) {
 	l.walletCreated = fn
 }
 
+// SetCreateScryptOptions configures independent public and private scrypt
+// parameters for a subsequent wallet creation. It returns ErrLoaded after the
+// loader has already created or opened a wallet.
+func (l *Loader) SetCreateScryptOptions(public,
+	private *waddrmgr.ScryptOptions) error {
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.wallet != nil {
+		return ErrLoaded
+	}
+
+	setCreateScryptOptions(l.cfg, public, private)
+
+	return nil
+}
+
 // CreateNewWallet creates a new wallet using the provided public and private
 // passphrases.  The seed is optional.  If non-nil, addresses are derived from
 // this seed.  If nil, a secure random seed is generated.
@@ -278,9 +322,10 @@ func (l *Loader) createNewWallet(pubPassphrase, privPassphrase []byte,
 			return nil, err
 		}
 	} else {
-		err := CreateWithCallback(
+		err := CreateWithCallbackAndScryptOptions(
 			l.db, pubPassphrase, privPassphrase, rootKey,
-			l.chainParams, bday, l.walletCreated,
+			l.chainParams, l.cfg.createPublicScrypt,
+			l.cfg.createPrivateScrypt, bday, l.walletCreated,
 		)
 		if err != nil {
 			return nil, err

--- a/wallet/loader_test.go
+++ b/wallet/loader_test.go
@@ -1,0 +1,29 @@
+package wallet
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoaderSetCreateScryptOptions(t *testing.T) {
+	loader := NewLoader(
+		&chaincfg.MainNetParams, t.TempDir(), true, 0, 0,
+	)
+	publicConfig := &waddrmgr.ScryptOptions{N: 16, R: 8, P: 1}
+	privateConfig := &waddrmgr.ScryptOptions{N: 64, R: 8, P: 1}
+
+	err := loader.SetCreateScryptOptions(publicConfig, privateConfig)
+	require.NoError(t, err)
+
+	publicConfig.N = 32
+	privateConfig.N = 128
+	require.Equal(t, 16, loader.cfg.createPublicScrypt.N)
+	require.Equal(t, 64, loader.cfg.createPrivateScrypt.N)
+
+	loader.wallet = &Wallet{}
+	err = loader.SetCreateScryptOptions(publicConfig, privateConfig)
+	require.ErrorIs(t, err, ErrLoaded)
+}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -4321,7 +4321,22 @@ func CreateWithCallback(db walletdb.DB, pubPass, privPass []byte,
 	birthday time.Time, cb func(walletdb.ReadWriteTx) error) error {
 
 	return create(
-		db, pubPass, privPass, rootKey, params, birthday, false, cb,
+		db, pubPass, privPass, rootKey, params, nil, nil, birthday,
+		false, cb,
+	)
+}
+
+// CreateWithCallbackAndScryptOptions creates a wallet with independent scrypt
+// parameters for its public and private master keys.
+func CreateWithCallbackAndScryptOptions(db walletdb.DB, pubPass,
+	privPass []byte, rootKey *hdkeychain.ExtendedKey,
+	params *chaincfg.Params, publicConfig,
+	privateConfig *waddrmgr.ScryptOptions, birthday time.Time,
+	cb func(walletdb.ReadWriteTx) error) error {
+
+	return create(
+		db, pubPass, privPass, rootKey, params, publicConfig,
+		privateConfig, birthday, false, cb,
 	)
 }
 
@@ -4333,7 +4348,7 @@ func CreateWatchingOnlyWithCallback(db walletdb.DB, pubPass []byte,
 	cb func(walletdb.ReadWriteTx) error) error {
 
 	return create(
-		db, pubPass, nil, nil, params, birthday, true, cb,
+		db, pubPass, nil, nil, params, nil, nil, birthday, true, cb,
 	)
 }
 
@@ -4345,7 +4360,8 @@ func Create(db walletdb.DB, pubPass, privPass []byte,
 	birthday time.Time) error {
 
 	return create(
-		db, pubPass, privPass, rootKey, params, birthday, false, nil,
+		db, pubPass, privPass, rootKey, params, nil, nil, birthday,
+		false, nil,
 	)
 }
 
@@ -4357,12 +4373,13 @@ func CreateWatchingOnly(db walletdb.DB, pubPass []byte,
 	params *chaincfg.Params, birthday time.Time) error {
 
 	return create(
-		db, pubPass, nil, nil, params, birthday, true, nil,
+		db, pubPass, nil, nil, params, nil, nil, birthday, true, nil,
 	)
 }
 
 func create(db walletdb.DB, pubPass, privPass []byte,
 	rootKey *hdkeychain.ExtendedKey, params *chaincfg.Params,
+	publicConfig, privateConfig *waddrmgr.ScryptOptions,
 	birthday time.Time, isWatchingOnly bool,
 	cb func(walletdb.ReadWriteTx) error) error {
 
@@ -4401,9 +4418,9 @@ func create(db walletdb.DB, pubPass, privPass []byte,
 			return err
 		}
 
-		err = waddrmgr.Create(
-			addrmgrNs, rootKey, pubPass, privPass, params, nil,
-			birthday,
+		err = waddrmgr.CreateWithScryptOptions(
+			addrmgrNs, rootKey, pubPass, privPass, params,
+			publicConfig, privateConfig, birthday,
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Change Description

In this PR, we let wallet creators select independent scrypt parameters for
the public and private master keys. The motivating case is a wallet with a
known public passphrase and a user-supplied private passphrase: callers can
reduce the public-key setup cost without weakening private-key encryption.

Existing `Create` entry points keep their old behavior by applying the same
config, or the same default, to both keys. The loader copies supplied configs,
rejects changes after a wallet is loaded, and does not alter existing wallet
databases. A regression test also uses identical public and private
passphrase bytes and verifies that their persisted KDF profiles remain
independent.

This supports the Wavelength browser-wallet optimization tracked in
lightninglabs/wavelength-sdk#53. With public `N=16` and the private key left at
the default `N=2^18`, the downstream prototype reduced create p95 from 2,735
ms to 1,782 ms and unlock p95 from 1,220 ms to 662 ms.

## Steps to Test

```bash
go test ./waddrmgr ./wallet
```

The full `go test ./...` run passes the changed packages. Its
`chain/TestBitcoindEvents` integration test fails locally because the spawned
Bitcoin Core v30 process does not remain available. The same failure
reproduces on the untouched `origin/master` base.

## Pull Request Checklist

### Testing

- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation

- [x] The change is not [insubstantial](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#ideal-git-commit-structure).
- [x] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md) for further guidance.
