### PR TITLE
wallet: prototype Store-backed SQL runtime

### DIFF
--- a/waddrmgr/manager.go
+++ b/waddrmgr/manager.go
@@ -99,7 +99,14 @@ func isReservedAccountNum(acct uint32) bool {
 // ScryptOptions is used to hold the scrypt parameters needed when deriving new
 // passphrase keys.
 type ScryptOptions struct {
-	N, R, P int
+	// N is the scrypt CPU and memory cost parameter.
+	N int
+
+	// R is the scrypt block size parameter.
+	R int
+
+	// P is the scrypt parallelization parameter.
+	P int
 }
 
 // OpenCallbacks houses caller-provided callbacks that may be called when
@@ -176,6 +183,10 @@ type accountInfo struct {
 	// derivation path m/). This may be required by some hardware wallets
 	// for proper identification and signing.
 	masterKeyFingerprint uint32
+
+	// storeStale records that an ambiguous commit may have advanced the
+	// durable indexes beyond the values cached here.
+	storeStale bool
 }
 
 // AccountProperties contains properties associated with each account, such as
@@ -277,15 +288,25 @@ func newSecretKey(passphrase *[]byte,
 // EncryptorDecryptor provides an abstraction on top of snacl.CryptoKey so that
 // our tests can use dependency injection to force the behaviour they need.
 type EncryptorDecryptor interface {
+	// Encrypt encrypts the input with the underlying key.
 	Encrypt(in []byte) ([]byte, error)
+
+	// Decrypt decrypts the input with the underlying key.
 	Decrypt(in []byte) ([]byte, error)
+
+	// Bytes returns the underlying key bytes.
 	Bytes() []byte
+
+	// CopyBytes replaces the underlying key bytes.
 	CopyBytes([]byte)
+
+	// Zero clears the underlying key material.
 	Zero()
 }
 
 // cryptoKey extends snacl.CryptoKey to implement EncryptorDecryptor.
 type cryptoKey struct {
+	// CryptoKey provides the underlying encryption implementation.
 	snacl.CryptoKey
 }
 
@@ -442,7 +463,14 @@ func (m *Manager) lock() {
 			switch addr := ma.(type) {
 			case *managedAddress:
 				addr.lock()
+
 			case *scriptAddress:
+				addr.lock()
+
+			case *witnessScriptAddress:
+				addr.lock()
+
+			case *taprootScriptAddress:
 				addr.lock()
 			}
 		}
@@ -607,6 +635,8 @@ func (m *Manager) NewScopedKeyManager(ns walletdb.ReadWriteBucket,
 		addrSchema:  addrSchema,
 		rootManager: m,
 		addrs:       make(map[addrKey]ManagedAddress),
+		used:        make(map[addrKey]bool),
+		storeAddrs:  make(map[string]ManagedAddress),
 		acctInfo:    make(map[uint32]*accountInfo),
 		privKeyCache: lru.NewCache[DerivationPath, *cachedKey](
 			defaultPrivKeyCacheSize,
@@ -1101,9 +1131,22 @@ func (m *Manager) ConvertToWatchingOnly(ns walletdb.ReadWriteBucket) error {
 			case *managedAddress:
 				zero.Bytes(addr.privKeyEncrypted)
 				addr.privKeyEncrypted = nil
+
 			case *scriptAddress:
 				zero.Bytes(addr.scriptEncrypted)
 				addr.scriptEncrypted = nil
+
+			case *witnessScriptAddress:
+				if addr.isSecretScript {
+					zero.Bytes(addr.scriptEncrypted)
+					addr.scriptEncrypted = nil
+				}
+
+			case *taprootScriptAddress:
+				if addr.isSecretScript {
+					zero.Bytes(addr.scriptEncrypted)
+					addr.scriptEncrypted = nil
+				}
 			}
 		}
 	}
@@ -1166,6 +1209,17 @@ func (m *Manager) Lock() error {
 // This function will return an error if invoked on a watching-only address
 // manager.
 func (m *Manager) Unlock(ns walletdb.ReadBucket, passphrase []byte) error {
+	return m.unlock(ns, passphrase)
+}
+
+// UnlockFromStore unlocks a manager whose account state was loaded through a
+// ManagerReadStore. It never accesses a walletdb bucket.
+func (m *Manager) UnlockFromStore(passphrase []byte) error {
+	return m.unlock(nil, passphrase)
+}
+
+// unlock derives and caches all private manager and account keys.
+func (m *Manager) unlock(ns walletdb.ReadBucket, passphrase []byte) error {
 	// A watching-only address manager can't be unlocked.
 	if m.WatchOnly() {
 		return managerError(ErrWatchingOnly, errWatchingOnly, nil)
@@ -1215,6 +1269,10 @@ func (m *Manager) Unlock(ns walletdb.ReadBucket, passphrase []byte) error {
 	// extended keys.
 	for _, manager := range m.scopedManagers {
 		for account, acctInfo := range manager.acctInfo {
+			if len(acctInfo.acctKeyEncrypted) == 0 {
+				continue
+			}
+
 			decrypted, err := m.cryptoKeyPriv.Decrypt(acctInfo.acctKeyEncrypted)
 			if err != nil {
 				m.lock()
@@ -1236,11 +1294,28 @@ func (m *Manager) Unlock(ns walletdb.ReadBucket, passphrase []byte) error {
 
 		// We'll also derive any private keys that are pending due to
 		// them being created while the address manager was locked.
-		for _, info := range manager.deriveOnUnlock {
-			addressKey, _, _, err := manager.deriveKeyFromPath(
-				ns, info.managedAddr.InternalAccount(),
-				info.branch, info.index, true,
-			)
+		for len(manager.deriveOnUnlock) != 0 {
+			info := manager.deriveOnUnlock[0]
+			account := info.managedAddr.InternalAccount()
+			var addressKey *hdkeychain.ExtendedKey
+			if ns != nil {
+				addressKey, _, _, err = manager.deriveKeyFromPath(
+					ns, account, info.branch, info.index, true,
+				)
+			} else {
+				acctInfo := manager.acctInfo[account]
+				if acctInfo == nil || acctInfo.acctKeyPriv == nil {
+					m.lock()
+					str := fmt.Sprintf(
+						"private account %d not found", account,
+					)
+					return managerError(ErrAccountNotFound, str, nil)
+				}
+
+				addressKey, err = manager.deriveKey(
+					acctInfo, info.branch, info.index, true,
+				)
+			}
 			if err != nil {
 				m.lock()
 				return err
@@ -1282,7 +1357,8 @@ func (m *Manager) Unlock(ns walletdb.ReadBucket, passphrase []byte) error {
 	return nil
 }
 
-// ValidateAccountName validates the given account name and returns an error, if any.
+// ValidateAccountName validates the given account name and returns an error,
+// if any.
 func ValidateAccountName(name string) error {
 	if name == "" {
 		str := "accounts may not be named the empty string"
@@ -1504,7 +1580,8 @@ func deriveAccountKey(coinTypeKey *hdkeychain.ExtendedKey,
 // The branch is 0 for external addresses and 1 for internal addresses.
 func checkBranchKeys(acctKey *hdkeychain.ExtendedKey) error {
 	// Derive the external branch as the first child of the account key.
-	if _, err := acctKey.DeriveNonStandard(ExternalBranch); err != nil { // nolint:staticcheck
+	//nolint:staticcheck
+	if _, err := acctKey.DeriveNonStandard(ExternalBranch); err != nil {
 		return err
 	}
 
@@ -1623,6 +1700,8 @@ func loadManager(ns walletdb.ReadBucket, pubPassphrase []byte,
 			scope:      scope,
 			addrSchema: *scopeSchema,
 			addrs:      make(map[addrKey]ManagedAddress),
+			used:       make(map[addrKey]bool),
+			storeAddrs: make(map[string]ManagedAddress),
 			acctInfo:   make(map[uint32]*accountInfo),
 			privKeyCache: lru.NewCache[DerivationPath, *cachedKey](
 				defaultPrivKeyCacheSize,
@@ -1650,6 +1729,161 @@ func loadManager(ns walletdb.ReadBucket, pubPassphrase []byte,
 	}
 
 	return mgr, nil
+}
+
+// OpenFromSnapshot reconstructs an address manager from detached durable state.
+// Passphrase KDF, decryption, HD derivation, validation, and cache population
+// are all performed by this call.
+func OpenFromSnapshot(snapshot *ManagerSnapshot, pubPassphrase []byte,
+	chainParams *chaincfg.Params) (*Manager, error) {
+
+	if snapshot == nil {
+		return nil, managerError(
+			ErrDatabase, "address manager snapshot is nil", nil,
+		)
+	}
+	var (
+		masterKeyPriv snacl.SecretKey
+		masterKeyPub  snacl.SecretKey
+		cryptoKeyPub  = &cryptoKey{snacl.CryptoKey{}}
+		mgr           *Manager
+		opened        bool
+		err           error
+	)
+	defer func() {
+		if opened {
+			return
+		}
+
+		if mgr != nil {
+			mgr.Close()
+			return
+		}
+
+		cryptoKeyPub.Zero()
+		masterKeyPub.Zero()
+		masterKeyPriv.Zero()
+	}()
+
+	state := snapshot.state
+
+	if state.Version < latestMgrVersion {
+		return nil, managerError(
+			ErrUpgrade, "database upgrade required", nil,
+		)
+	}
+	if state.Version > latestMgrVersion {
+		str := "database version is greater than latest understood version"
+		return nil, managerError(ErrUpgrade, str, nil)
+	}
+
+	if !state.WatchOnly {
+		err := masterKeyPriv.Unmarshal(state.MasterPrivParams)
+		if err != nil {
+			str := "failed to unmarshal master private key"
+			return nil, managerError(ErrCrypto, str, err)
+		}
+	}
+
+	err = masterKeyPub.Unmarshal(state.MasterPubParams)
+	if err != nil {
+		str := "failed to unmarshal master public key"
+		return nil, managerError(ErrCrypto, str, err)
+	}
+
+	err = masterKeyPub.DeriveKey(&pubPassphrase)
+	if err != nil {
+		str := "invalid passphrase for master public key"
+		return nil, managerError(ErrWrongPassphrase, str, nil)
+	}
+
+	cryptoKeyPubCT, err := masterKeyPub.Decrypt(
+		state.EncryptedCryptoPubKey,
+	)
+	if err != nil {
+		str := "failed to decrypt crypto public key"
+		return nil, managerError(ErrCrypto, str, err)
+	}
+	cryptoKeyPub.CopyBytes(cryptoKeyPubCT)
+	zero.Bytes(cryptoKeyPubCT)
+
+	syncState := snapshot.sync
+	syncInfo := newSyncState(&syncState.StartBlock, &syncState.SyncedTo)
+
+	var privPassphraseSalt [saltSize]byte
+	_, err = rand.Read(privPassphraseSalt[:])
+	if err != nil {
+		str := "failed to read random source for passphrase salt"
+		return nil, managerError(ErrCrypto, str, err)
+	}
+
+	scopedManagers := make(
+		map[KeyScope]*ScopedKeyManager, len(snapshot.scopes),
+	)
+	for _, scopeSnapshot := range snapshot.scopes {
+		scopeState := scopeSnapshot.state
+		scopedManagers[scopeState.Scope] = &ScopedKeyManager{
+			scope:      scopeState.Scope,
+			addrSchema: scopeState.AddrSchema,
+			addrs:      make(map[addrKey]ManagedAddress),
+			used:       make(map[addrKey]bool),
+			storeAddrs: make(map[string]ManagedAddress),
+			acctInfo:   make(map[uint32]*accountInfo),
+			privKeyCache: lru.NewCache[DerivationPath, *cachedKey](
+				defaultPrivKeyCacheSize,
+			),
+		}
+	}
+
+	mgr = newManager(
+		chainParams, &masterKeyPub, &masterKeyPriv, cryptoKeyPub,
+		state.EncryptedCryptoPrivKey, state.EncryptedCryptoScriptKey,
+		syncInfo, syncState.Birthday, privPassphraseSalt, scopedManagers,
+		state.WatchOnly,
+	)
+
+	for _, scopeSnapshot := range snapshot.scopes {
+		scopedManager := scopedManagers[scopeSnapshot.state.Scope]
+		scopedManager.rootManager = mgr
+
+		err := scopedManager.loadStoreSnapshot(
+			scopeSnapshot.accounts, scopeSnapshot.addresses,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	opened = true
+	return mgr, nil
+}
+
+// OpenFromStore loads the real address manager from a backend-neutral durable
+// store. It remains a compatibility wrapper for transaction-bound callers;
+// callers that own the transaction should prefer ReadManagerSnapshot followed
+// by OpenFromSnapshot after the transaction closes.
+func OpenFromStore(store ManagerReadStore, pubPassphrase []byte,
+	chainParams *chaincfg.Params) (*Manager, error) {
+
+	snapshot, err := ReadManagerSnapshot(store)
+	if err != nil {
+		return nil, err
+	}
+
+	return OpenFromSnapshot(snapshot, pubPassphrase, chainParams)
+}
+
+// MarkAccountCacheStale marks one store-backed account for a durable index
+// refresh without discarding its cached public or private extended keys.
+func (m *Manager) MarkAccountCacheStale(scope KeyScope, account uint32) {
+	m.mtx.RLock()
+	scopedManager := m.scopedManagers[scope]
+	m.mtx.RUnlock()
+	if scopedManager == nil {
+		return
+	}
+
+	scopedManager.markAccountCacheStale(account)
 }
 
 // Open loads an existing address manager from the given namespace.  The public

--- a/waddrmgr/scoped_manager.go
+++ b/waddrmgr/scoped_manager.go
@@ -283,6 +283,11 @@ type ScopedKeyManager struct {
 	// addrs is a cached map of all the addresses that we currently
 	// manage.
 	addrs map[addrKey]ManagedAddress
+	used  map[addrKey]bool
+
+	// storeAddrs indexes the same cached addresses by their durable SHA256
+	// identifier for store-backed account iteration.
+	storeAddrs map[string]ManagedAddress
 
 	// acctInfo houses information about accounts including what is needed
 	// to generate deterministic chained keys for each created account.
@@ -563,6 +568,342 @@ func (s *ScopedKeyManager) loadAccountInfo(ns walletdb.ReadBucket,
 	// Add it to the cache and return it when everything is successful.
 	s.acctInfo[account] = acctInfo
 	return acctInfo, nil
+}
+
+// accountInfoFromState decrypts the account material represented by durable
+// store state. Private material is restored when the manager is unlocked.
+func (s *ScopedKeyManager) accountInfoFromState(
+	state AccountState) (*accountInfo, error) {
+
+	if len(state.EncryptedPubKey) == 0 {
+		return nil, managerError(
+			ErrDatabase, fmt.Sprintf("account %d has no public key",
+				state.Account), nil,
+		)
+	}
+
+	serializedKey, err := s.rootManager.cryptoKeyPub.Decrypt(
+		state.EncryptedPubKey,
+	)
+	if err != nil {
+		str := fmt.Sprintf("failed to decrypt public key for account %d",
+			state.Account)
+		return nil, managerError(ErrCrypto, str, err)
+	}
+	defer zero.Bytes(serializedKey)
+
+	accountKey, err := hdkeychain.NewKeyFromString(string(serializedKey))
+	if err != nil {
+		str := fmt.Sprintf("failed to decode public key for account %d",
+			state.Account)
+		return nil, managerError(ErrKeyChain, str, err)
+	}
+
+	var accountType accountType
+	switch state.Type {
+	case AccountDefault:
+		accountType = accountDefault
+
+	case AccountWatchOnly:
+		accountType = accountWatchOnly
+
+	default:
+		return nil, managerError(
+			ErrDatabase, fmt.Sprintf("unsupported account type %d",
+				state.Type), nil,
+		)
+	}
+
+	var schema *ScopeAddrSchema
+	if state.AddrSchema != nil {
+		copySchema := *state.AddrSchema
+		schema = &copySchema
+	}
+
+	info := &accountInfo{
+		acctName:             state.Name,
+		acctType:             accountType,
+		acctKeyEncrypted:     copyBytes(state.EncryptedPrivKey),
+		acctKeyPub:           accountKey,
+		nextExternalIndex:    state.NextExternalIndex,
+		nextInternalIndex:    state.NextInternalIndex,
+		addrSchema:           schema,
+		masterKeyFingerprint: state.MasterKeyFingerprint,
+	}
+
+	watchOnly := s.rootManager.WatchOnly() ||
+		len(state.EncryptedPrivKey) == 0
+	if s.rootManager.IsLocked() || watchOnly {
+		return info, nil
+	}
+
+	serializedKey, err = s.rootManager.cryptoKeyPriv.Decrypt(
+		state.EncryptedPrivKey,
+	)
+	if err != nil {
+		str := fmt.Sprintf("failed to decrypt private key for account %d",
+			state.Account)
+		return nil, managerError(ErrCrypto, str, err)
+	}
+	defer zero.Bytes(serializedKey)
+
+	info.acctKeyPriv, err = hdkeychain.NewKeyFromString(
+		string(serializedKey),
+	)
+	if err != nil {
+		str := fmt.Sprintf("failed to decode private key for account %d",
+			state.Account)
+		return nil, managerError(ErrKeyChain, str, err)
+	}
+
+	return info, nil
+}
+
+// loadStoreState reads and reconstructs account material, indexes, and every
+// supported managed address needed by a store-backed manager.
+func (s *ScopedKeyManager) loadStoreState(store ManagerReadStore) error {
+	accounts, err := store.Accounts(s.scope)
+	if err != nil {
+		return err
+	}
+	addresses, err := store.ActiveAddresses(s.scope)
+	if err != nil {
+		return err
+	}
+
+	return s.loadStoreSnapshot(accounts, addresses)
+}
+
+// loadStoreSnapshot reconstructs complete scoped cache state from detached
+// durable account and address rows.
+func (s *ScopedKeyManager) loadStoreSnapshot(accounts []AccountState,
+	addresses []AddressState) error {
+
+	for _, state := range accounts {
+		// The imported account has no HD public key and is outside this
+		// external-address PoC.
+		if state.Account == ImportedAddrAccount {
+			continue
+		}
+
+		info, err := s.accountInfoFromState(state)
+		if err != nil {
+			return err
+		}
+		s.acctInfo[state.Account] = info
+	}
+
+	for _, state := range addresses {
+		managed, err := s.managedAddressFromStoreState(state)
+		if err != nil {
+			return err
+		}
+
+		s.addrs[addrKey(managed.Address().ScriptAddress())] = managed
+		s.storeAddrs[string(state.Hash)] = managed
+		s.used[addrKey(managed.Address().ScriptAddress())] = state.Used
+
+		if state.Type == AddressChain {
+			info := s.acctInfo[state.Account]
+			switch *state.Branch {
+			case ExternalBranch:
+				if *state.Index+1 == info.nextExternalIndex {
+					info.lastExternalAddr = managed
+				}
+
+			case InternalBranch:
+				if *state.Index+1 == info.nextInternalIndex {
+					info.lastInternalAddr = managed
+				}
+			}
+		}
+	}
+
+	for account, info := range s.acctInfo {
+		if info.nextExternalIndex > 0 && info.lastExternalAddr == nil {
+			str := fmt.Sprintf("account %d last external address is missing",
+				account)
+			return managerError(ErrDatabase, str, nil)
+		}
+		if info.nextInternalIndex > 0 && info.lastInternalAddr == nil {
+			str := fmt.Sprintf("account %d last internal address is missing",
+				account)
+			return managerError(ErrDatabase, str, nil)
+		}
+	}
+
+	return nil
+}
+
+// accountPropertiesFromInfo returns the existing caller-facing account shape
+// from store-backed account cache state.
+func (s *ScopedKeyManager) accountPropertiesFromInfo(account uint32,
+	info *accountInfo) (*AccountProperties, error) {
+
+	props := &AccountProperties{
+		AccountNumber:        account,
+		AccountName:          info.acctName,
+		ExternalKeyCount:     info.nextExternalIndex,
+		InternalKeyCount:     info.nextInternalIndex,
+		AccountPubKey:        info.acctKeyPub,
+		MasterKeyFingerprint: info.masterKeyFingerprint,
+		KeyScope:             s.scope,
+		IsWatchOnly: s.rootManager.WatchOnly() ||
+			len(info.acctKeyEncrypted) == 0,
+		AddrSchema: info.addrSchema,
+	}
+
+	if info.acctType == accountDefault && IsDefaultScope(s.scope) {
+		var err error
+		props.AccountPubKey, err = s.cloneKeyWithVersion(info.acctKeyPub)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve account public key: %w",
+				err)
+		}
+	}
+
+	return props, nil
+}
+
+// refreshStoreLastAddress reconstructs the last address for one durable branch
+// while retaining private derivation whenever the manager is unlocked.
+func (s *ScopedKeyManager) refreshStoreLastAddress(info *accountInfo,
+	account, branch, nextIndex uint32) (ManagedAddress, error) {
+
+	if nextIndex == 0 {
+		return nil, nil
+	}
+
+	watchOnly := s.rootManager.WatchOnly() ||
+		len(info.acctKeyEncrypted) == 0
+	private := !s.rootManager.IsLocked() && !watchOnly
+	key, err := s.deriveKey(info, branch, nextIndex-1, private)
+	if err != nil {
+		return nil, err
+	}
+
+	managed, err := s.keyToManaged(key, DerivationPath{
+		InternalAccount:      account,
+		Account:              info.acctKeyPub.ChildIndex(),
+		Branch:               branch,
+		Index:                nextIndex - 1,
+		MasterKeyFingerprint: info.masterKeyFingerprint,
+	}, info)
+	if err != nil {
+		return nil, err
+	}
+
+	s.addrs[addrKey(managed.Address().ScriptAddress())] = managed
+	hash := sha256.Sum256(managed.Address().ScriptAddress())
+	s.storeAddrs[string(hash[:])] = managed
+	return managed, nil
+}
+
+// applyStoreAccountState refreshes mutable durable account metadata while
+// retaining the cached extended key objects and any decrypted private key.
+func (s *ScopedKeyManager) applyStoreAccountState(info *accountInfo,
+	state AccountState) error {
+
+	if info.nextExternalIndex != state.NextExternalIndex {
+		lastExternal, err := s.refreshStoreLastAddress(
+			info, state.Account, ExternalBranch,
+			state.NextExternalIndex,
+		)
+		if err != nil {
+			return err
+		}
+		info.lastExternalAddr = lastExternal
+	}
+
+	if info.nextInternalIndex != state.NextInternalIndex {
+		lastInternal, err := s.refreshStoreLastAddress(
+			info, state.Account, InternalBranch,
+			state.NextInternalIndex,
+		)
+		if err != nil {
+			return err
+		}
+		info.lastInternalAddr = lastInternal
+	}
+
+	info.nextExternalIndex = state.NextExternalIndex
+	info.nextInternalIndex = state.NextInternalIndex
+	info.acctName = state.Name
+	info.storeStale = false
+
+	return nil
+}
+
+// AccountPropertiesFromStore returns properties from the store-backed account
+// cache, loading durable state first if the cache was evicted.
+func (s *ScopedKeyManager) AccountPropertiesFromStore(
+	store ManagerReadStore, account uint32) (*AccountProperties, error) {
+	if account == ImportedAddrAccount {
+		_, err := store.Account(s.scope, account)
+		if err != nil {
+			return nil, err
+		}
+
+		addresses, err := store.AccountAddresses(s.scope, account)
+		if err != nil {
+			return nil, err
+		}
+
+		return &AccountProperties{
+			AccountNumber:    account,
+			AccountName:      ImportedAddrAccountName,
+			ImportedKeyCount: uint32(len(addresses)),
+			KeyScope:         s.scope,
+			IsWatchOnly:      s.rootManager.WatchOnly(),
+		}, nil
+	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	info := s.acctInfo[account]
+	if info == nil || info.storeStale {
+		state, err := store.Account(s.scope, account)
+		if err != nil {
+			return nil, err
+		}
+
+		if info == nil {
+			info, err = s.accountInfoFromState(state)
+			if err != nil {
+				return nil, err
+			}
+			s.acctInfo[account] = info
+		} else {
+			err = s.applyStoreAccountState(info, state)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return s.accountPropertiesFromInfo(account, info)
+}
+
+// markAccountCacheStale requires the account's mutable metadata to be refreshed
+// from durable state before it is next reported.
+func (s *ScopedKeyManager) markAccountCacheStale(account uint32) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	if info := s.acctInfo[account]; info != nil {
+		info.storeStale = true
+	}
+}
+
+// NextExternalAddressFromStore derives and persists one external address for
+// an existing account. Only commit-time index and address deltas are published
+// to the account cache.
+func (s *ScopedKeyManager) NextExternalAddressFromStore(
+	tx ManagerReadWriteTx, account uint32) (ManagedAddress,
+	*AccountProperties, error) {
+
+	return s.nextAddressFromStore(tx, account, false)
 }
 
 // AccountProperties returns properties associated with the account, such as
@@ -1066,7 +1407,8 @@ func (s *ScopedKeyManager) nextAddresses(ns walletdb.ReadWriteBucket,
 		var nextKey *hdkeychain.ExtendedKey
 		for {
 			// Derive the next child in the external chain branch.
-			key, err := branchKey.DeriveNonStandard(nextIndex) // nolint:staticcheck
+			//nolint:staticcheck
+			key, err := branchKey.DeriveNonStandard(nextIndex)
 			if err != nil {
 				// When this particular child is invalid, skip to the
 				// next index.
@@ -1296,7 +1638,8 @@ func (s *ScopedKeyManager) extendAddresses(ns walletdb.ReadWriteBucket,
 		var nextKey *hdkeychain.ExtendedKey
 		for {
 			// Derive the next child in the external chain branch.
-			key, err := branchKey.DeriveNonStandard(nextIndex) // nolint:staticcheck
+			//nolint:staticcheck
+			key, err := branchKey.DeriveNonStandard(nextIndex)
 			if err != nil {
 				// When this particular child is invalid, skip to the
 				// next index.
@@ -1757,7 +2100,8 @@ func (s *ScopedKeyManager) NewAccountWatchingOnly(ns walletdb.ReadWriteBucket,
 	return account, nil
 }
 
-// newAccountWatchingOnly is similar to newAccount, but for watching-only wallets.
+// newAccountWatchingOnly is similar to newAccount, but for watching-only
+// wallets.
 //
 // The master key fingerprint denotes the fingerprint of the root key
 // corresponding to the account public key (also known as the key with
@@ -2099,8 +2443,8 @@ func (s *ScopedKeyManager) toImportedPrivateManagedAddress(
 	return managedAddr, nil
 }
 
-// toPublicManagedAddress converts an imported public key to an imported managed
-// address.
+// toImportedPublicManagedAddress converts an imported public key to an imported
+// managed address.
 func (s *ScopedKeyManager) toImportedPublicManagedAddress(
 	pubKey *btcec.PublicKey, compressed bool) (*managedAddress, error) {
 
@@ -2169,6 +2513,13 @@ func (s *ScopedKeyManager) ImportWitnessScript(ns walletdb.ReadWriteBucket,
 func (s *ScopedKeyManager) ImportTaprootScript(ns walletdb.ReadWriteBucket,
 	tapscript *Tapscript, bs *BlockStamp, witnessVersion byte,
 	isSecretScript bool) (ManagedTaprootScriptAddress, error) {
+
+	if witnessVersion != witnessVersionV1 {
+		return nil, fmt.Errorf(
+			"invalid witness version %d for taproot script",
+			witnessVersion,
+		)
+	}
 
 	// Make sure we have everything we need to calculate the script root and
 	// tweak the taproot key.
@@ -2360,6 +2711,12 @@ func (s *ScopedKeyManager) LookupAccount(ns walletdb.ReadBucket, name string) (u
 // fetchUsed returns true if the provided address id was flagged used.
 func (s *ScopedKeyManager) fetchUsed(ns walletdb.ReadBucket,
 	addressID []byte) bool {
+	if ns == nil {
+		s.mtx.RLock()
+		defer s.mtx.RUnlock()
+
+		return s.used[addrKey(addressID)]
+	}
 
 	return fetchAddressUsed(ns, &s.scope, addressID)
 }

--- a/waddrmgr/store.go
+++ b/waddrmgr/store.go
@@ -1,42 +1,94 @@
 package waddrmgr
 
 import (
+	"errors"
 	"time"
 
 	"github.com/btcsuite/btcd/chainhash/v2"
 )
 
+var (
+	// ErrStoreAddressTypeUnsupported reports an address encoding that the
+	// store-backed manager cannot reconstruct safely.
+	ErrStoreAddressTypeUnsupported = errors.New(
+		"store-backed address type is unsupported",
+	)
+)
+
 // ManagerState contains the durable root address-manager state.
 type ManagerState struct {
-	Version                  uint32
-	CreatedAt                time.Time
-	WatchOnly                bool
-	MasterPubParams          []byte
-	MasterPrivParams         []byte
-	EncryptedCryptoPubKey    []byte
-	EncryptedCryptoPrivKey   []byte
+	// Version is the address-manager schema version.
+	Version uint32
+
+	// CreatedAt is the manager creation time.
+	CreatedAt time.Time
+
+	// WatchOnly records whether the manager has private material.
+	WatchOnly bool
+
+	// MasterPubParams contains the serialized public passphrase parameters.
+	MasterPubParams []byte
+
+	// MasterPrivParams contains the serialized private passphrase parameters.
+	MasterPrivParams []byte
+
+	// EncryptedCryptoPubKey contains the encrypted public crypto key.
+	EncryptedCryptoPubKey []byte
+
+	// EncryptedCryptoPrivKey contains the encrypted private crypto key.
+	EncryptedCryptoPrivKey []byte
+
+	// EncryptedCryptoScriptKey contains the encrypted script crypto key.
 	EncryptedCryptoScriptKey []byte
-	EncryptedMasterHDPubKey  []byte
+
+	// EncryptedMasterHDPubKey contains the encrypted master HD public key.
+	EncryptedMasterHDPubKey []byte
+
+	// EncryptedMasterHDPrivKey contains the encrypted master HD private key.
 	EncryptedMasterHDPrivKey []byte
 }
 
 // SyncState contains the durable address-manager chain position.
 type SyncState struct {
-	StartBlock            BlockStamp
-	SyncedTo              BlockStamp
-	Birthday              time.Time
-	BirthdayBlock         *BlockStamp
+	// StartBlock is the earliest block relevant to the manager.
+	StartBlock BlockStamp
+
+	// SyncedTo is the latest block processed by the manager.
+	SyncedTo BlockStamp
+
+	// Birthday is the earliest possible key creation time.
+	Birthday time.Time
+
+	// BirthdayBlock is the block associated with the manager birthday.
+	BirthdayBlock *BlockStamp
+
+	// BirthdayBlockVerified records whether BirthdayBlock was verified.
 	BirthdayBlockVerified bool
 }
 
 // KeyScopeState contains the durable state for one key scope.
 type KeyScopeState struct {
-	Scope                KeyScope
-	AddrSchema           ScopeAddrSchema
-	EncryptedCoinPubKey  []byte
+	// Scope identifies the key derivation scope.
+	Scope KeyScope
+
+	// AddrSchema defines the scope's external and internal address types.
+	AddrSchema ScopeAddrSchema
+
+	// EncryptedCoinPubKey contains the encrypted coin-type public key.
+	EncryptedCoinPubKey []byte
+
+	// EncryptedCoinPrivKey contains the encrypted coin-type private key.
 	EncryptedCoinPrivKey []byte
-	LastAccount          uint32
+
+	// LastAccount is the last account allocated in the scope.
+	LastAccount uint32
 }
+
+const (
+	// NoAccount is the last-account sentinel for a scope that has not yet
+	// allocated account zero.
+	NoAccount = ^uint32(0)
+)
 
 // AccountType identifies a durable address-manager account encoding.
 type AccountType uint8
@@ -51,16 +103,35 @@ const (
 
 // AccountState contains the durable state for one scoped account.
 type AccountState struct {
-	Scope                KeyScope
-	Account              uint32
-	Type                 AccountType
-	Name                 string
-	EncryptedPubKey      []byte
-	EncryptedPrivKey     []byte
+	// Scope identifies the account's key derivation scope.
+	Scope KeyScope
+
+	// Account is the account number within Scope.
+	Account uint32
+
+	// Type identifies how the account was created.
+	Type AccountType
+
+	// Name is the user-facing account name.
+	Name string
+
+	// EncryptedPubKey contains the encrypted account public key.
+	EncryptedPubKey []byte
+
+	// EncryptedPrivKey contains the encrypted account private key.
+	EncryptedPrivKey []byte
+
+	// MasterKeyFingerprint identifies the account's root key.
 	MasterKeyFingerprint uint32
-	NextExternalIndex    uint32
-	NextInternalIndex    uint32
-	AddrSchema           *ScopeAddrSchema
+
+	// NextExternalIndex is the next external child index to allocate.
+	NextExternalIndex uint32
+
+	// NextInternalIndex is the next internal child index to allocate.
+	NextInternalIndex uint32
+
+	// AddrSchema optionally overrides the scope's address schema.
+	AddrSchema *ScopeAddrSchema
 }
 
 // StoreAddressType identifies a durable address-manager address encoding.
@@ -99,21 +170,50 @@ const (
 
 // AddressState contains the durable state for one managed address.
 type AddressState struct {
-	Scope            KeyScope
-	Hash             []byte
-	Account          uint32
-	Type             StoreAddressType
-	AddedAt          time.Time
-	SyncStatus       AddressSyncStatus
-	Branch           *uint32
-	Index            *uint32
-	EncryptedPubKey  []byte
+	// Scope identifies the address's key derivation scope.
+	Scope KeyScope
+
+	// Hash is the durable digest of the address identifier.
+	Hash []byte
+
+	// Account is the address's account number.
+	Account uint32
+
+	// Type identifies how the address was created.
+	Type StoreAddressType
+
+	// AddedAt is the time the address was added to the manager.
+	AddedAt time.Time
+
+	// SyncStatus is the address's synchronization state.
+	SyncStatus AddressSyncStatus
+
+	// Branch is the optional HD derivation branch.
+	Branch *uint32
+
+	// Index is the optional HD derivation child index.
+	Index *uint32
+
+	// EncryptedPubKey contains encrypted imported public-key material.
+	EncryptedPubKey []byte
+
+	// EncryptedPrivKey contains encrypted imported private-key material.
 	EncryptedPrivKey []byte
-	EncryptedHash    []byte
-	EncryptedScript  []byte
-	WitnessVersion   *uint8
-	IsSecretScript   *bool
-	Used             bool
+
+	// EncryptedHash contains an encrypted imported script identity.
+	EncryptedHash []byte
+
+	// EncryptedScript contains an encrypted imported script.
+	EncryptedScript []byte
+
+	// WitnessVersion identifies an imported witness script version.
+	WitnessVersion *uint8
+
+	// IsSecretScript records whether a script requires private encryption.
+	IsSecretScript *bool
+
+	// Used records whether the address has appeared on chain.
+	Used bool
 }
 
 // ManagerReadStore exposes the complete durable waddrmgr read surface without
@@ -160,6 +260,7 @@ type ManagerReadStore interface {
 //
 //nolint:interfacebloat // The interface mirrors one existing manager domain.
 type ManagerReadWriteStore interface {
+	// ManagerReadStore provides the complete manager read surface.
 	ManagerReadStore
 
 	// PutManagerState replaces the durable root address-manager state.
@@ -208,4 +309,14 @@ type ManagerReadWriteStore interface {
 
 	// DeletePrivateKeys removes all persisted private key material.
 	DeletePrivateKeys() error
+}
+
+// ManagerReadWriteTx extends a writable manager store with a callback that is
+// invoked only after its enclosing transaction commits successfully.
+type ManagerReadWriteTx interface {
+	// ManagerReadWriteStore provides the manager read/write surface.
+	ManagerReadWriteStore
+
+	// OnCommit registers a callback for successful transaction commit.
+	OnCommit(func())
 }

--- a/waddrmgr/store_kv.go
+++ b/waddrmgr/store_kv.go
@@ -594,6 +594,16 @@ func (s *kvManagerReadWriteStore) PutKeyScope(state KeyScopeState) error {
 	if err != nil {
 		return err
 	}
+	if state.LastAccount == NoAccount {
+		bucket, err := fetchWriteScopeBucket(s.ns, &state.Scope)
+		if err != nil {
+			return err
+		}
+
+		return bucket.NestedReadWriteBucket(metaBucketName).Delete(
+			lastAccountName,
+		)
+	}
 
 	return s.SetLastAccount(state.Scope, state.LastAccount)
 }

--- a/waddrmgr/store_lifecycle.go
+++ b/waddrmgr/store_lifecycle.go
@@ -1,0 +1,824 @@
+package waddrmgr
+
+import (
+	"crypto/rand"
+	"crypto/sha512"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcwallet/internal/zero"
+	"github.com/btcsuite/btcwallet/snacl"
+	"github.com/lightninglabs/neutrino/cache/lru"
+)
+
+// createStoreKeyScope derives and persists one default manager key scope.
+func createStoreKeyScope(store ManagerReadWriteStore, scope KeyScope,
+	schema ScopeAddrSchema, root *hdkeychain.ExtendedKey,
+	cryptoKeyPub, cryptoKeyPriv EncryptorDecryptor) error {
+
+	coinTypeKeyPriv, err := deriveCoinTypeKey(root, scope)
+	if err != nil {
+		return managerError(
+			ErrKeyChain, "failed to derive cointype extended key", err,
+		)
+	}
+	defer coinTypeKeyPriv.Zero()
+
+	acctKeyPriv, err := deriveAccountKey(coinTypeKeyPriv, DefaultAccountNum)
+	if errors.Is(err, hdkeychain.ErrInvalidChild) {
+		return managerError(
+			ErrKeyChain, "the provided seed is unusable",
+			hdkeychain.ErrUnusableSeed,
+		)
+	}
+	if err != nil {
+		return err
+	}
+	defer acctKeyPriv.Zero()
+
+	if err := checkBranchKeys(acctKeyPriv); err != nil {
+		if errors.Is(err, hdkeychain.ErrInvalidChild) {
+			return managerError(
+				ErrKeyChain, "the provided seed is unusable",
+				hdkeychain.ErrUnusableSeed,
+			)
+		}
+
+		return err
+	}
+
+	coinTypeKeyPub, err := coinTypeKeyPriv.Neuter()
+	if err != nil {
+		return managerError(
+			ErrKeyChain, "failed to convert cointype private key", err,
+		)
+	}
+	defer coinTypeKeyPub.Zero()
+
+	acctKeyPub, err := acctKeyPriv.Neuter()
+	if err != nil {
+		return managerError(
+			ErrKeyChain, "failed to convert public key for account", err,
+		)
+	}
+	defer acctKeyPub.Zero()
+
+	coinPubEnc, err := cryptoKeyPub.Encrypt(
+		[]byte(coinTypeKeyPub.String()),
+	)
+	if err != nil {
+		return managerError(
+			ErrCrypto, "failed to encrypt cointype public key", err,
+		)
+	}
+
+	coinPrivEnc, err := cryptoKeyPriv.Encrypt(
+		[]byte(coinTypeKeyPriv.String()),
+	)
+	if err != nil {
+		return managerError(
+			ErrCrypto, "failed to encrypt cointype private key", err,
+		)
+	}
+
+	acctPubEnc, err := cryptoKeyPub.Encrypt([]byte(acctKeyPub.String()))
+	if err != nil {
+		return managerError(
+			ErrCrypto, "failed to encrypt public key for account", err,
+		)
+	}
+
+	acctPrivEnc, err := cryptoKeyPriv.Encrypt([]byte(acctKeyPriv.String()))
+	if err != nil {
+		return managerError(
+			ErrCrypto, "failed to encrypt private key for account", err,
+		)
+	}
+
+	err = store.PutKeyScope(KeyScopeState{
+		Scope:                scope,
+		AddrSchema:           schema,
+		EncryptedCoinPubKey:  coinPubEnc,
+		EncryptedCoinPrivKey: coinPrivEnc,
+		LastAccount:          DefaultAccountNum,
+	})
+	if err != nil {
+		return err
+	}
+
+	err = store.PutAccount(AccountState{
+		Scope:            scope,
+		Account:          DefaultAccountNum,
+		Type:             AccountDefault,
+		Name:             defaultAccountName,
+		EncryptedPubKey:  acctPubEnc,
+		EncryptedPrivKey: acctPrivEnc,
+	})
+	if err != nil {
+		return err
+	}
+
+	return store.PutAccount(AccountState{
+		Scope:           scope,
+		Account:         ImportedAddrAccount,
+		Type:            AccountDefault,
+		Name:            ImportedAddrAccountName,
+		EncryptedPubKey: []byte{},
+	})
+}
+
+// CreateFromStore initializes a manager through a backend-neutral writable
+// store. The caller must provide a single-attempt creation transaction.
+func CreateFromStore(store ManagerReadWriteStore,
+	rootKey *hdkeychain.ExtendedKey, pubPassphrase, privPassphrase []byte,
+	chainParams *chaincfg.Params, config *ScryptOptions,
+	birthday time.Time) error {
+
+	isWatchingOnly := rootKey == nil
+	if !isWatchingOnly && len(privPassphrase) == 0 {
+		return managerError(
+			ErrEmptyPassphrase, "private passphrase may not be empty", nil,
+		)
+	}
+	if config == nil {
+		config = &DefaultScryptOptions
+	}
+
+	masterKeyPub, err := newSecretKey(&pubPassphrase, config)
+	if err != nil {
+		return managerError(
+			ErrCrypto, "failed to create master public key", err,
+		)
+	}
+	defer masterKeyPub.Zero()
+
+	cryptoKeyPub, err := newCryptoKey()
+	if err != nil {
+		return managerError(
+			ErrCrypto, "failed to generate crypto public key", err,
+		)
+	}
+	defer cryptoKeyPub.Zero()
+
+	cryptoKeyPubEnc, err := masterKeyPub.Encrypt(cryptoKeyPub.Bytes())
+	if err != nil {
+		return managerError(
+			ErrCrypto, "failed to encrypt crypto public key", err,
+		)
+	}
+
+	state := ManagerState{
+		Version:               latestMgrVersion,
+		CreatedAt:             time.Now(),
+		WatchOnly:             isWatchingOnly,
+		MasterPubParams:       masterKeyPub.Marshal(),
+		EncryptedCryptoPubKey: cryptoKeyPubEnc,
+	}
+
+	var cryptoKeyPriv EncryptorDecryptor
+	if !isWatchingOnly {
+		masterKeyPriv, err := newSecretKey(&privPassphrase, config)
+		if err != nil {
+			return managerError(
+				ErrCrypto, "failed to create master private key", err,
+			)
+		}
+		defer masterKeyPriv.Zero()
+
+		privateKey, err := newCryptoKey()
+		if err != nil {
+			return managerError(
+				ErrCrypto, "failed to generate crypto private key", err,
+			)
+		}
+		defer privateKey.Zero()
+		cryptoKeyPriv = privateKey
+
+		cryptoKeyScript, err := newCryptoKey()
+		if err != nil {
+			return managerError(
+				ErrCrypto, "failed to generate crypto script key", err,
+			)
+		}
+		defer cryptoKeyScript.Zero()
+
+		state.MasterPrivParams = masterKeyPriv.Marshal()
+		state.EncryptedCryptoPrivKey, err = masterKeyPriv.Encrypt(
+			privateKey.Bytes(),
+		)
+		if err != nil {
+			return managerError(
+				ErrCrypto, "failed to encrypt crypto private key", err,
+			)
+		}
+
+		state.EncryptedCryptoScriptKey, err = masterKeyPriv.Encrypt(
+			cryptoKeyScript.Bytes(),
+		)
+		if err != nil {
+			return managerError(
+				ErrCrypto, "failed to encrypt crypto script key", err,
+			)
+		}
+
+		rootPubKey, err := rootKey.Neuter()
+		if err != nil {
+			return managerError(
+				ErrKeyChain, "failed to neuter master extended key", err,
+			)
+		}
+		defer rootPubKey.Zero()
+
+		state.EncryptedMasterHDPrivKey, err = privateKey.Encrypt(
+			[]byte(rootKey.String()),
+		)
+		if err != nil {
+			return managerError(
+				ErrCrypto, "failed to encrypt master private key", err,
+			)
+		}
+
+		state.EncryptedMasterHDPubKey, err = cryptoKeyPub.Encrypt(
+			[]byte(rootPubKey.String()),
+		)
+		if err != nil {
+			return managerError(
+				ErrCrypto, "failed to encrypt master public key", err,
+			)
+		}
+	}
+
+	err = store.PutManagerState(state)
+	if err != nil {
+		return err
+	}
+
+	genesis := BlockStamp{
+		Hash:      *chainParams.GenesisHash,
+		Height:    0,
+		Timestamp: chainParams.GenesisBlock.Header.Timestamp,
+	}
+	err = store.PutSyncState(SyncState{
+		StartBlock: genesis,
+		SyncedTo:   genesis,
+		Birthday:   birthday.Add(-48 * time.Hour),
+	})
+	if err != nil {
+		return err
+	}
+
+	if isWatchingOnly {
+		return nil
+	}
+
+	for _, scope := range DefaultKeyScopes {
+		err := createStoreKeyScope(
+			store, scope, ScopeAddrMap[scope], rootKey,
+			cryptoKeyPub, cryptoKeyPriv,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// PassphraseChange contains a prepared manager passphrase cache update. The
+// caller must Apply it after a successful commit or Close it on every failure.
+type PassphraseChange struct {
+	manager          *Manager
+	private          bool
+	masterKey        *snacl.SecretKey
+	encryptedPriv    []byte
+	encryptedScript  []byte
+	passphraseSalt   [saltSize]byte
+	hashedPassphrase [sha512.Size]byte
+	applied          bool
+}
+
+// Apply publishes a prepared passphrase change after durable commit.
+func (c *PassphraseChange) Apply() {
+	if c == nil || c.applied {
+		return
+	}
+
+	c.manager.mtx.Lock()
+	defer c.manager.mtx.Unlock()
+
+	if c.private {
+		c.manager.masterKeyPriv.Zero()
+		c.manager.masterKeyPriv = c.masterKey
+		c.manager.cryptoKeyPrivEncrypted = c.encryptedPriv
+		c.manager.cryptoKeyScriptEncrypted = c.encryptedScript
+		c.manager.privPassphraseSalt = c.passphraseSalt
+		c.manager.hashedPrivPassphrase = c.hashedPassphrase
+	} else {
+		c.manager.masterKeyPub.Zero()
+		c.manager.masterKeyPub = c.masterKey
+	}
+
+	c.masterKey = nil
+	c.applied = true
+}
+
+// Close zeros an unapplied prepared passphrase key.
+func (c *PassphraseChange) Close() {
+	if c == nil || c.masterKey == nil {
+		return
+	}
+
+	c.masterKey.Zero()
+	c.masterKey = nil
+}
+
+// ChangePassphraseFromStore prepares and persists one manager passphrase
+// change without publishing new encryption state before commit.
+func (m *Manager) ChangePassphraseFromStore(store ManagerReadWriteStore,
+	oldPassphrase, newPassphrase []byte, private bool,
+	config *ScryptOptions) (*PassphraseChange, error) {
+
+	if private && m.WatchOnly() {
+		return nil, managerError(ErrWatchingOnly, errWatchingOnly, nil)
+	}
+	if config == nil {
+		config = &DefaultScryptOptions
+	}
+
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	var keyName string
+	secretKey := snacl.SecretKey{Key: &snacl.CryptoKey{}}
+	if private {
+		keyName = "private"
+		secretKey.Parameters = m.masterKeyPriv.Parameters
+	} else {
+		keyName = "public"
+		secretKey.Parameters = m.masterKeyPub.Parameters
+	}
+	if err := secretKey.DeriveKey(&oldPassphrase); err != nil {
+		if errors.Is(err, snacl.ErrInvalidPassword) {
+			str := fmt.Sprintf(
+				"invalid passphrase for %s master key", keyName,
+			)
+			return nil, managerError(ErrWrongPassphrase, str, nil)
+		}
+
+		str := fmt.Sprintf("failed to derive %s master key", keyName)
+		return nil, managerError(ErrCrypto, str, err)
+	}
+	defer secretKey.Zero()
+
+	newMasterKey, err := newSecretKey(&newPassphrase, config)
+	if err != nil {
+		return nil, managerError(
+			ErrCrypto, "failed to create new master key", err,
+		)
+	}
+
+	state, err := store.ManagerState()
+	if err != nil {
+		newMasterKey.Zero()
+		return nil, err
+	}
+
+	change := &PassphraseChange{
+		manager:   m,
+		private:   private,
+		masterKey: newMasterKey,
+	}
+
+	if private {
+		_, err := rand.Read(change.passphraseSalt[:])
+		if err != nil {
+			change.Close()
+			return nil, managerError(
+				ErrCrypto, "failed to read passphrase salt", err,
+			)
+		}
+
+		decPriv, err := secretKey.Decrypt(m.cryptoKeyPrivEncrypted)
+		if err != nil {
+			change.Close()
+			return nil, managerError(
+				ErrCrypto, "failed to decrypt crypto private key", err,
+			)
+		}
+		change.encryptedPriv, err = newMasterKey.Encrypt(decPriv)
+		zero.Bytes(decPriv)
+		if err != nil {
+			change.Close()
+			return nil, managerError(
+				ErrCrypto, "failed to encrypt crypto private key", err,
+			)
+		}
+
+		decScript, err := secretKey.Decrypt(m.cryptoKeyScriptEncrypted)
+		if err != nil {
+			change.Close()
+			return nil, managerError(
+				ErrCrypto, "failed to decrypt crypto script key", err,
+			)
+		}
+		change.encryptedScript, err = newMasterKey.Encrypt(decScript)
+		zero.Bytes(decScript)
+		if err != nil {
+			change.Close()
+			return nil, managerError(
+				ErrCrypto, "failed to encrypt crypto script key", err,
+			)
+		}
+
+		if m.IsLocked() {
+			newMasterKey.Zero()
+		} else {
+			salted := append(change.passphraseSalt[:], newPassphrase...)
+			change.hashedPassphrase = sha512.Sum512(salted)
+			zero.Bytes(salted)
+		}
+
+		state.MasterPrivParams = newMasterKey.Marshal()
+		state.EncryptedCryptoPrivKey = change.encryptedPriv
+		state.EncryptedCryptoScriptKey = change.encryptedScript
+	} else {
+		encryptedPub, err := newMasterKey.Encrypt(m.cryptoKeyPub.Bytes())
+		if err != nil {
+			change.Close()
+			return nil, managerError(
+				ErrCrypto, "failed to encrypt crypto public key", err,
+			)
+		}
+
+		state.MasterPubParams = newMasterKey.Marshal()
+		state.EncryptedCryptoPubKey = encryptedPub
+	}
+
+	if err := store.PutManagerState(state); err != nil {
+		change.Close()
+		return nil, err
+	}
+
+	return change, nil
+}
+
+// newStoreScopedKeyManager constructs an empty store-backed scoped manager.
+func (m *Manager) newStoreScopedKeyManager(scope KeyScope,
+	addrSchema ScopeAddrSchema) *ScopedKeyManager {
+
+	return &ScopedKeyManager{
+		scope:       scope,
+		addrSchema:  addrSchema,
+		rootManager: m,
+		addrs:       make(map[addrKey]ManagedAddress),
+		used:        make(map[addrKey]bool),
+		storeAddrs:  make(map[string]ManagedAddress),
+		acctInfo:    make(map[uint32]*accountInfo),
+		privKeyCache: lru.NewCache[DerivationPath, *cachedKey](
+			defaultPrivKeyCacheSize,
+		),
+	}
+}
+
+// registerStoreScope adds one durable scoped manager to the root caches. The
+// root manager mutex must be held for writes.
+func (m *Manager) registerStoreScope(manager *ScopedKeyManager) {
+	scope := manager.scope
+	addrSchema := manager.addrSchema
+	m.scopedManagers[scope] = manager
+	m.externalAddrSchemas[addrSchema.ExternalAddrType] = append(
+		m.externalAddrSchemas[addrSchema.ExternalAddrType], scope,
+	)
+	m.internalAddrSchemas[addrSchema.InternalAddrType] = append(
+		m.internalAddrSchemas[addrSchema.InternalAddrType], scope,
+	)
+}
+
+// AttachScopedKeyManagerFromStore reconstructs and registers a scope that is
+// already durable, such as after an ambiguous creation commit.
+func (m *Manager) AttachScopedKeyManagerFromStore(
+	store ManagerReadStore, scope KeyScope) (*ScopedKeyManager, error) {
+
+	m.mtx.RLock()
+	if manager := m.scopedManagers[scope]; manager != nil {
+		m.mtx.RUnlock()
+		return manager, nil
+	}
+
+	state, err := store.KeyScope(scope)
+	if err != nil {
+		m.mtx.RUnlock()
+		return nil, err
+	}
+	manager := m.newStoreScopedKeyManager(scope, state.AddrSchema)
+	err = manager.loadStoreState(store)
+	m.mtx.RUnlock()
+	if err != nil {
+		return nil, err
+	}
+
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	if existing := m.scopedManagers[scope]; existing != nil {
+		return existing, nil
+	}
+	m.registerStoreScope(manager)
+
+	return manager, nil
+}
+
+// NewScopedKeyManagerFromStore creates and persists a registered key scope.
+// The returned manager may be used by later operations in the same transaction,
+// but it is registered with the root manager only after commit.
+func (m *Manager) NewScopedKeyManagerFromStore(tx ManagerReadWriteTx,
+	scope KeyScope, addrSchema ScopeAddrSchema) (*ScopedKeyManager, error) {
+
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	if _, ok := m.scopedManagers[scope]; ok {
+		return nil, managerError(
+			ErrAlreadyExists, "key scope already exists", nil,
+		)
+	}
+	_, err := tx.KeyScope(scope)
+	if err == nil {
+		return nil, managerError(
+			ErrAlreadyExists, "key scope already exists", nil,
+		)
+	}
+	if !IsError(err, ErrScopeNotFound) {
+		return nil, err
+	}
+
+	manager := m.newStoreScopedKeyManager(scope, addrSchema)
+
+	if m.WatchOnly() {
+		err := tx.PutKeyScope(KeyScopeState{
+			Scope:       scope,
+			AddrSchema:  addrSchema,
+			LastAccount: NoAccount,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		err = tx.PutAccount(AccountState{
+			Scope:           scope,
+			Account:         ImportedAddrAccount,
+			Type:            AccountDefault,
+			Name:            ImportedAddrAccountName,
+			EncryptedPubKey: []byte{},
+		})
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		if m.IsLocked() {
+			return nil, managerError(ErrLocked, errLocked, nil)
+		}
+
+		state, err := tx.ManagerState()
+		if err != nil {
+			return nil, err
+		}
+		if len(state.EncryptedMasterHDPrivKey) == 0 {
+			return nil, managerError(ErrWatchingOnly, errWatchingOnly, nil)
+		}
+
+		serializedRoot, err := m.cryptoKeyPriv.Decrypt(
+			state.EncryptedMasterHDPrivKey,
+		)
+		if err != nil {
+			return nil, managerError(
+				ErrLocked, "failed to decrypt master root key", err,
+			)
+		}
+		defer zero.Bytes(serializedRoot)
+
+		rootKey, err := hdkeychain.NewKeyFromString(string(serializedRoot))
+		if err != nil {
+			return nil, managerError(
+				ErrKeyChain, "failed to decode master root key", err,
+			)
+		}
+		defer rootKey.Zero()
+
+		err = createStoreKeyScope(
+			tx, scope, addrSchema, rootKey, m.cryptoKeyPub,
+			m.cryptoKeyPriv,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	tx.OnCommit(func() {
+		m.mtx.Lock()
+		defer m.mtx.Unlock()
+
+		m.registerStoreScope(manager)
+	})
+
+	return manager, nil
+}
+
+// convertToWatchingOnlyCache removes all private manager material after the
+// corresponding durable transaction commits. The root manager mutex must be
+// held for writes.
+func (m *Manager) convertToWatchingOnlyCache() {
+	managers := make([]*ScopedKeyManager, 0, len(m.scopedManagers))
+	for _, manager := range m.scopedManagers {
+		manager.mtx.Lock()
+		managers = append(managers, manager)
+	}
+	defer func() {
+		for i := len(managers) - 1; i >= 0; i-- {
+			managers[i].mtx.Unlock()
+		}
+	}()
+
+	if !m.IsLocked() {
+		m.lock()
+	}
+
+	for _, manager := range m.scopedManagers {
+		for _, info := range manager.acctInfo {
+			zero.Bytes(info.acctKeyEncrypted)
+			info.acctKeyEncrypted = nil
+		}
+		for _, managed := range manager.addrs {
+			switch addr := managed.(type) {
+			case *managedAddress:
+				zero.Bytes(addr.privKeyEncrypted)
+				addr.privKeyEncrypted = nil
+
+			case *scriptAddress:
+				zero.Bytes(addr.scriptEncrypted)
+				addr.scriptEncrypted = nil
+
+			case *witnessScriptAddress:
+				if addr.isSecretScript {
+					zero.Bytes(addr.scriptEncrypted)
+					addr.scriptEncrypted = nil
+				}
+
+			case *taprootScriptAddress:
+				if addr.isSecretScript {
+					zero.Bytes(addr.scriptEncrypted)
+					addr.scriptEncrypted = nil
+				}
+			}
+		}
+	}
+
+	zero.Bytes(m.cryptoKeyScriptEncrypted)
+	m.cryptoKeyScriptEncrypted = nil
+	m.cryptoKeyScript = nil
+	zero.Bytes(m.cryptoKeyPrivEncrypted)
+	m.cryptoKeyPrivEncrypted = nil
+	m.cryptoKeyPriv = nil
+	m.masterKeyPriv = nil
+	m.watchingOnly.Store(true)
+}
+
+// ConvertToWatchingOnlyFromStore permanently removes private durable material
+// and publishes the watch-only state only after commit.
+func (m *Manager) ConvertToWatchingOnlyFromStore(
+	tx ManagerReadWriteTx) error {
+
+	if m.WatchOnly() {
+		return nil
+	}
+
+	state, err := tx.ManagerState()
+	if err != nil {
+		return err
+	}
+	state.WatchOnly = true
+	state.MasterPrivParams = nil
+	state.EncryptedCryptoPrivKey = nil
+	state.EncryptedCryptoScriptKey = nil
+	state.EncryptedMasterHDPrivKey = nil
+
+	if err := tx.DeletePrivateKeys(); err != nil {
+		return err
+	}
+	if err := tx.PutManagerState(state); err != nil {
+		return err
+	}
+
+	tx.OnCommit(func() {
+		m.mtx.Lock()
+		defer m.mtx.Unlock()
+		m.convertToWatchingOnlyCache()
+	})
+
+	return nil
+}
+
+// SetBirthdayFromStore persists a birthday and publishes it after commit.
+func (m *Manager) SetBirthdayFromStore(tx ManagerReadWriteTx,
+	birthday time.Time) error {
+
+	if err := tx.SetBirthday(birthday); err != nil {
+		return err
+	}
+	tx.OnCommit(func() {
+		m.mtx.Lock()
+		m.birthday = birthday
+		m.mtx.Unlock()
+	})
+
+	return nil
+}
+
+// BirthdayBlockFromStore returns the durable birthday block and verification
+// state.
+func (m *Manager) BirthdayBlockFromStore(
+	store ManagerReadStore) (BlockStamp, bool, error) {
+
+	state, err := store.SyncState()
+	if err != nil {
+		return BlockStamp{}, false, err
+	}
+	if state.BirthdayBlock == nil {
+		return BlockStamp{}, false, managerError(
+			ErrBirthdayBlockNotSet, "birthday block is not set", nil,
+		)
+	}
+
+	return *state.BirthdayBlock, state.BirthdayBlockVerified, nil
+}
+
+// SetBirthdayBlockFromStore persists birthday-block state atomically.
+func (m *Manager) SetBirthdayBlockFromStore(tx ManagerReadWriteTx,
+	block BlockStamp, verified bool) error {
+
+	if err := tx.SetBirthdayBlock(&block); err != nil {
+		return err
+	}
+
+	return tx.SetBirthdayBlockVerified(verified)
+}
+
+// SetSyncedToFromStore persists a sync position and publishes it after commit.
+func (m *Manager) SetSyncedToFromStore(tx ManagerReadWriteTx,
+	block *BlockStamp) error {
+
+	if err := tx.SetSyncedTo(block); err != nil {
+		return err
+	}
+	if block == nil {
+		state, err := tx.SyncState()
+		if err != nil {
+			return err
+		}
+		block = &state.StartBlock
+	}
+	committedBlock := *block
+	tx.OnCommit(func() {
+		m.mtx.Lock()
+		m.syncState.syncedTo = committedBlock
+		m.mtx.Unlock()
+	})
+
+	return nil
+}
+
+// RefreshStartBlockFromStore replaces the cached import start block with its
+// durable value after a transaction with an ambiguous commit outcome.
+func (m *Manager) RefreshStartBlockFromStore(store ManagerReadStore) error {
+	state, err := store.SyncState()
+	if err != nil {
+		return err
+	}
+
+	m.mtx.Lock()
+	m.syncState.startBlock = state.StartBlock
+	m.mtx.Unlock()
+
+	return nil
+}
+
+// ApplySyncStateFromStore replaces the in-memory chain position with a
+// detached durable snapshot after an ambiguous Store commit is reconciled.
+func (m *Manager) ApplySyncStateFromStore(state SyncState) {
+	m.mtx.Lock()
+	m.syncState.startBlock = state.StartBlock
+	m.syncState.syncedTo = state.SyncedTo
+	m.birthday = state.Birthday
+	m.mtx.Unlock()
+}
+
+// InvalidateSyncStateCache resets the cached chain position to the durable
+// lower bound after a commit outcome cannot be reconciled.
+func (m *Manager) InvalidateSyncStateCache() {
+	m.mtx.Lock()
+	m.syncState.syncedTo = m.syncState.startBlock
+	m.mtx.Unlock()
+}

--- a/waddrmgr/store_manager.go
+++ b/waddrmgr/store_manager.go
@@ -1,0 +1,179 @@
+package waddrmgr
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/address/v2"
+)
+
+// AddressFromStore returns a managed address from any registered key scope.
+func (m *Manager) AddressFromStore(store ManagerReadStore,
+	addr address.Address) (ManagedAddress, error) {
+
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	for _, scopedManager := range m.scopedManagers {
+		managed, err := scopedManager.AddressFromStore(store, addr)
+		if err == nil {
+			return managed, nil
+		}
+	}
+
+	str := fmt.Sprintf("unable to find key for addr %v", addr)
+	return nil, managerError(ErrAddressNotFound, str, nil)
+}
+
+// AddrAccountFromStore returns the manager and account owning an address.
+func (m *Manager) AddrAccountFromStore(store ManagerReadStore,
+	addr address.Address) (*ScopedKeyManager, uint32, error) {
+
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	for _, scopedManager := range m.scopedManagers {
+		account, err := scopedManager.AddrAccountFromStore(store, addr)
+		if err == nil {
+			return scopedManager, account, nil
+		}
+	}
+
+	str := fmt.Sprintf("unable to find key for addr %v", addr)
+	return nil, 0, managerError(ErrAddressNotFound, str, nil)
+}
+
+// LookupAccountFromStore returns the first scoped account matching a name.
+func (m *Manager) LookupAccountFromStore(store ManagerReadStore,
+	name string) (KeyScope, uint32, error) {
+
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	for scope, scopedManager := range m.scopedManagers {
+		account, err := scopedManager.LookupAccountFromStore(store, name)
+		if err == nil {
+			return scope, account, nil
+		}
+	}
+
+	str := fmt.Sprintf("account name '%s' not found", name)
+	return KeyScope{}, 0, managerError(ErrAccountNotFound, str, nil)
+}
+
+// ForEachAccountAddressFromStore visits every matching account address across
+// registered key scopes.
+func (m *Manager) ForEachAccountAddressFromStore(store ManagerReadStore,
+	account uint32, fn func(ManagedAddress) error) error {
+
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	for _, scopedManager := range m.scopedManagers {
+		err := scopedManager.ForEachAccountAddressFromStore(
+			store, account, fn,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ForEachActiveAddressFromStore visits every active address across registered
+// key scopes.
+func (m *Manager) ForEachActiveAddressFromStore(store ManagerReadStore,
+	fn func(address.Address) error) error {
+
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	for _, scopedManager := range m.scopedManagers {
+		if err := scopedManager.ForEachActiveAddressFromStore(
+			store, fn,
+		); err != nil {
+
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ForEachRelevantActiveAddressFromStore visits default-scope addresses and
+// change addresses retained in non-default scopes.
+func (m *Manager) ForEachRelevantActiveAddressFromStore(
+	store ManagerReadStore, fn func(address.Address) error) error {
+
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	for scope, scopedManager := range m.scopedManagers {
+		var err error
+		if IsDefaultScope(scope) {
+			err = scopedManager.ForEachActiveAddressFromStore(store, fn)
+		} else {
+			err = scopedManager.ForEachInternalActiveAddressFromStore(
+				store, fn,
+			)
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// MarkUsedFromStore marks an address used in its registered key scope.
+func (m *Manager) MarkUsedFromStore(tx ManagerReadWriteTx,
+	addr address.Address) error {
+
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	for _, scopedManager := range m.scopedManagers {
+		_, err := scopedManager.AddressFromStore(tx, addr)
+		if err != nil {
+			continue
+		}
+
+		return scopedManager.MarkUsedFromStore(tx, addr)
+	}
+
+	str := fmt.Sprintf("unable to find key for addr %v", addr)
+	return managerError(ErrAddressNotFound, str, nil)
+}
+
+// IsWatchOnlyAccountFromStore reports whether one account lacks private HD
+// material.
+func (m *Manager) IsWatchOnlyAccountFromStore(store ManagerReadStore,
+	scope KeyScope, account uint32) (bool, error) {
+
+	if m.WatchOnly() || account == ImportedAddrAccount {
+		return true, nil
+	}
+
+	state, err := store.Account(scope, account)
+	if err != nil {
+		return false, err
+	}
+
+	return len(state.EncryptedPrivKey) == 0, nil
+}
+
+// AddressFromStoreStates reconstructs a managed address from detached durable
+// account and address state without reading a Store.
+func (m *Manager) AddressFromStoreStates(account AccountState,
+	state AddressState) (ManagedAddress, error) {
+
+	m.mtx.RLock()
+	manager := m.scopedManagers[state.Scope]
+	m.mtx.RUnlock()
+	if manager == nil {
+		str := fmt.Sprintf("scope %v not found", state.Scope)
+		return nil, managerError(ErrScopeNotFound, str, nil)
+	}
+
+	return manager.ManagedAddressFromStoreStates(account, state)
+}

--- a/waddrmgr/store_scoped.go
+++ b/waddrmgr/store_scoped.go
@@ -1,0 +1,1729 @@
+package waddrmgr
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcwallet/internal/zero"
+)
+
+// AddressPlanConflictError reports that an account changed after its next
+// address was prepared from a detached durable snapshot.
+type AddressPlanConflictError struct {
+	// Scope identifies the account's key scope.
+	Scope KeyScope
+
+	// Account identifies the account whose indexes changed.
+	Account uint32
+
+	// Reason describes the durable state mismatch.
+	Reason string
+}
+
+// Error describes the stale next-address plan.
+func (e *AddressPlanConflictError) Error() string {
+	return fmt.Sprintf("next address plan for %s account %d is stale: %s",
+		e.Scope, e.Account, e.Reason)
+}
+
+// nextAddressPlan contains a fully derived address and the exact durable state
+// transition needed to publish it. Its cryptographic preparation is private to
+// waddrmgr; Store users can only compare, write, and apply the prepared result.
+type nextAddressPlan struct {
+	manager   *ScopedKeyManager
+	account   AccountState
+	address   AddressState
+	managed   ManagedAddress
+	addressID []byte
+	hash      [sha256.Size]byte
+
+	nextExternal   uint32
+	nextInternal   uint32
+	deriveOnUnlock bool
+	applyOnce      sync.Once
+}
+
+// Address returns the prepared managed address.
+func (p *nextAddressPlan) Address() ManagedAddress {
+	return p.managed
+}
+
+// Commit revalidates the expected account indexes, writes the exact prepared
+// address state, and arranges cache publication after commit.
+func (p *nextAddressPlan) Commit(tx ManagerReadWriteTx) error {
+	state, err := tx.Account(p.account.Scope, p.account.Account)
+	if err != nil {
+		return err
+	}
+	if state.NextExternalIndex != p.account.NextExternalIndex ||
+		state.NextInternalIndex != p.account.NextInternalIndex {
+
+		return &AddressPlanConflictError{
+			Scope:   p.account.Scope,
+			Account: p.account.Account,
+			Reason:  "derivation indexes changed",
+		}
+	}
+
+	if err := tx.PutAddress(p.addressID, p.address); err != nil {
+		return err
+	}
+	if err := tx.SetAccountIndexes(
+		p.account.Scope, p.account.Account, p.nextExternal,
+		p.nextInternal,
+	); err != nil {
+
+		return err
+	}
+
+	tx.OnCommit(p.Apply)
+
+	return nil
+}
+
+// Reconcile compares durable state with the exact initial and committed plan
+// states. A durable result remains proven when a later allocation has advanced
+// the same account beyond this plan.
+func (p *nextAddressPlan) Reconcile(store ManagerReadStore) (bool, bool,
+	bool, error) {
+
+	state, err := store.Account(p.account.Scope, p.account.Account)
+	if err != nil {
+		return false, false, false, err
+	}
+
+	storedAddress, addressErr := store.Address(
+		p.account.Scope, p.addressID,
+	)
+	addressDurable := addressErr == nil &&
+		samePreparedAddress(storedAddress, p.address)
+	if addressErr != nil && !IsError(addressErr, ErrAddressNotFound) {
+		return false, false, false, addressErr
+	}
+
+	exactIndexes := state.NextExternalIndex == p.nextExternal &&
+		state.NextInternalIndex == p.nextInternal
+	if addressDurable && state.NextExternalIndex >= p.nextExternal &&
+		state.NextInternalIndex >= p.nextInternal {
+
+		return true, false, exactIndexes, nil
+	}
+
+	absent := IsError(addressErr, ErrAddressNotFound) &&
+		state.NextExternalIndex == p.account.NextExternalIndex &&
+		state.NextInternalIndex == p.account.NextInternalIndex
+
+	return false, absent, false, nil
+}
+
+// Apply publishes a proven durable next-address plan to manager caches once.
+func (p *nextAddressPlan) Apply() {
+	p.applyOnce.Do(func() {
+		s := p.manager
+		s.mtx.Lock()
+		defer s.mtx.Unlock()
+
+		info := s.acctInfo[p.account.Account]
+		if info != nil {
+			info.nextExternalIndex = p.nextExternal
+			info.nextInternalIndex = p.nextInternal
+			info.storeStale = false
+			if *p.address.Branch == InternalBranch {
+				info.lastInternalAddr = p.managed
+			} else {
+				info.lastExternalAddr = p.managed
+			}
+		}
+
+		key := addrKey(p.addressID)
+		s.addrs[key] = p.managed
+		s.used[key] = false
+		s.storeAddrs[string(p.hash[:])] = p.managed
+		if p.deriveOnUnlock {
+			s.deriveOnUnlock = append(
+				s.deriveOnUnlock, &unlockDeriveInfo{
+					managedAddr: p.managed,
+					branch:      *p.address.Branch,
+					index:       *p.address.Index,
+				},
+			)
+		}
+	})
+}
+
+// samePreparedAddress reports whether a durable address row is exactly the
+// non-hash state prepared before its transaction began.
+func samePreparedAddress(a, b AddressState) bool {
+	return a.Scope == b.Scope && a.Account == b.Account &&
+		a.Type == b.Type && a.AddedAt.Equal(b.AddedAt) &&
+		a.SyncStatus == b.SyncStatus && equalUint32(a.Branch, b.Branch) &&
+		equalUint32(a.Index, b.Index) &&
+		bytes.Equal(a.EncryptedPubKey, b.EncryptedPubKey) &&
+		bytes.Equal(a.EncryptedPrivKey, b.EncryptedPrivKey) &&
+		bytes.Equal(a.EncryptedHash, b.EncryptedHash) &&
+		bytes.Equal(a.EncryptedScript, b.EncryptedScript) &&
+		equalUint8(a.WitnessVersion, b.WitnessVersion) &&
+		equalBool(a.IsSecretScript, b.IsSecretScript) && a.Used == b.Used
+}
+
+// equalUint32 compares optional uint32 values.
+func equalUint32(a, b *uint32) bool {
+	return a == nil && b == nil || a != nil && b != nil && *a == *b
+}
+
+// equalUint8 compares optional uint8 values.
+func equalUint8(a, b *uint8) bool {
+	return a == nil && b == nil || a != nil && b != nil && *a == *b
+}
+
+// equalBool compares optional bool values.
+func equalBool(a, b *bool) bool {
+	return a == nil && b == nil || a != nil && b != nil && *a == *b
+}
+
+// managedAddressFromStoreState reconstructs one managed address from durable
+// state. The scoped manager mutex must be held for writes.
+func (s *ScopedKeyManager) managedAddressFromStoreState(
+	state AddressState) (ManagedAddress, error) {
+
+	switch state.Type {
+	case AddressChain:
+		if state.Branch == nil || state.Index == nil {
+			return nil, errors.New("stored chain address path is missing")
+		}
+
+		info := s.acctInfo[state.Account]
+		if info == nil {
+			str := fmt.Sprintf("account %d not found", state.Account)
+			return nil, managerError(ErrAccountNotFound, str, nil)
+		}
+
+		watchOnly := s.rootManager.WatchOnly() ||
+			len(info.acctKeyEncrypted) == 0
+		private := !s.rootManager.IsLocked() && !watchOnly
+		key, err := s.deriveKey(
+			info, *state.Branch, *state.Index, private,
+		)
+		if err != nil {
+			return nil, err
+		}
+		defer key.Zero()
+
+		path := DerivationPath{
+			InternalAccount:      state.Account,
+			Account:              info.acctKeyPub.ChildIndex(),
+			Branch:               *state.Branch,
+			Index:                *state.Index,
+			MasterKeyFingerprint: info.masterKeyFingerprint,
+		}
+		managed, err := newManagedAddressFromExtKey(
+			s, path, key, s.accountAddrType(
+				info, *state.Branch == InternalBranch,
+			), info,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if *state.Branch == InternalBranch {
+			managed.internal = true
+		}
+
+		if !private && !watchOnly {
+			s.deriveOnUnlock = append(
+				s.deriveOnUnlock, &unlockDeriveInfo{
+					managedAddr: managed,
+					branch:      *state.Branch,
+					index:       *state.Index,
+				},
+			)
+		}
+
+		return managed, nil
+
+	case AddressImported:
+		pubBytes, err := s.rootManager.cryptoKeyPub.Decrypt(
+			state.EncryptedPubKey,
+		)
+		if err != nil {
+			return nil, managerError(
+				ErrCrypto, "failed to decrypt imported public key", err,
+			)
+		}
+		defer zero.Bytes(pubBytes)
+
+		pubKey, err := btcec.ParsePubKey(pubBytes)
+		if err != nil {
+			return nil, managerError(
+				ErrCrypto, "invalid imported public key", err,
+			)
+		}
+
+		managed, err := newManagedAddressWithoutPrivKey(
+			s, ImportedDerivationPath, pubKey,
+			len(pubBytes) == btcec.PubKeyBytesLenCompressed,
+			s.addrSchema.ExternalAddrType,
+		)
+		if err != nil {
+			return nil, err
+		}
+		managed.privKeyEncrypted = copyBytes(state.EncryptedPrivKey)
+		managed.imported = true
+
+		return managed, nil
+
+	case AddressScript:
+		scriptHash, err := s.rootManager.cryptoKeyPub.Decrypt(
+			state.EncryptedHash,
+		)
+		if err != nil {
+			return nil, managerError(
+				ErrCrypto, "failed to decrypt imported script hash", err,
+			)
+		}
+		defer zero.Bytes(scriptHash)
+
+		return newScriptAddress(
+			s, state.Account, scriptHash, state.EncryptedScript,
+		)
+
+	case AddressWitnessScript, AddressTaprootScript:
+		if state.WitnessVersion == nil || state.IsSecretScript == nil {
+			return nil, errors.New("stored witness script metadata is missing")
+		}
+
+		scriptIdent, err := s.rootManager.cryptoKeyPub.Decrypt(
+			state.EncryptedHash,
+		)
+		if err != nil {
+			return nil, managerError(
+				ErrCrypto, "failed to decrypt imported script identity", err,
+			)
+		}
+		defer zero.Bytes(scriptIdent)
+
+		return newWitnessScriptAddress(
+			s, state.Account, scriptIdent, state.EncryptedScript,
+			*state.WitnessVersion, *state.IsSecretScript,
+		)
+
+	default:
+		return nil, fmt.Errorf("%w: type %d in scope %s",
+			ErrStoreAddressTypeUnsupported, state.Type, s.scope)
+	}
+}
+
+// AddressFromStore returns and caches one managed address from durable state.
+func (s *ScopedKeyManager) AddressFromStore(store ManagerReadStore,
+	addr address.Address) (ManagedAddress, error) {
+
+	if pubKeyAddr, ok := addr.(*address.AddressPubKey); ok {
+		addr = pubKeyAddr.AddressPubKeyHash()
+	}
+
+	key := addrKey(addr.ScriptAddress())
+	s.mtx.RLock()
+	managed := s.addrs[key]
+	s.mtx.RUnlock()
+	if managed != nil {
+		return managed, nil
+	}
+
+	state, err := store.Address(s.scope, addr.ScriptAddress())
+	if err != nil {
+		return nil, err
+	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	if managed = s.addrs[key]; managed != nil {
+		return managed, nil
+	}
+
+	managed, err = s.managedAddressFromStoreState(state)
+	if err != nil {
+		return nil, err
+	}
+	s.addrs[key] = managed
+	s.storeAddrs[string(state.Hash)] = managed
+	s.used[key] = state.Used
+
+	return managed, nil
+}
+
+// AddrAccountFromStore returns the account associated with a durable address.
+func (s *ScopedKeyManager) AddrAccountFromStore(store ManagerReadStore,
+	addr address.Address) (uint32, error) {
+
+	state, err := store.Address(s.scope, addr.ScriptAddress())
+	if err != nil {
+		return 0, err
+	}
+
+	return state.Account, nil
+}
+
+// LookupAccountFromStore returns the account number associated with a name.
+func (s *ScopedKeyManager) LookupAccountFromStore(store ManagerReadStore,
+	name string) (uint32, error) {
+
+	state, err := store.AccountByName(s.scope, name)
+	if err != nil {
+		return 0, err
+	}
+
+	return state.Account, nil
+}
+
+// AccountNameFromStore returns one durable account name.
+func (s *ScopedKeyManager) AccountNameFromStore(store ManagerReadStore,
+	account uint32) (string, error) {
+
+	state, err := store.Account(s.scope, account)
+	if err != nil {
+		return "", err
+	}
+
+	return state.Name, nil
+}
+
+// ForEachAccountFromStore visits every durable account in storage order.
+func (s *ScopedKeyManager) ForEachAccountFromStore(store ManagerReadStore,
+	fn func(uint32) error) error {
+
+	accounts, err := store.Accounts(s.scope)
+	if err != nil {
+		return err
+	}
+
+	for _, account := range accounts {
+		if err := fn(account.Account); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ForEachAccountAddressFromStore visits each durable address in one account.
+func (s *ScopedKeyManager) ForEachAccountAddressFromStore(
+	store ManagerReadStore, account uint32,
+	fn func(ManagedAddress) error) error {
+
+	states, err := store.AccountAddresses(s.scope, account)
+	if err != nil {
+		return err
+	}
+
+	for _, state := range states {
+		s.mtx.Lock()
+		managed := s.storeAddrs[string(state.Hash)]
+		var stateErr error
+		if managed == nil {
+			managed, stateErr = s.managedAddressFromStoreState(state)
+		}
+		if stateErr == nil && managed != nil {
+			key := addrKey(managed.Address().ScriptAddress())
+			s.addrs[key] = managed
+			s.storeAddrs[string(state.Hash)] = managed
+			s.used[key] = state.Used
+		}
+		s.mtx.Unlock()
+		if stateErr != nil {
+			return stateErr
+		}
+
+		if err := fn(managed); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// forEachActiveAddressFromStore visits active durable addresses, optionally
+// restricting the result to internal addresses.
+func (s *ScopedKeyManager) forEachActiveAddressFromStore(
+	store ManagerReadStore, internalOnly bool,
+	fn func(address.Address) error) error {
+
+	states, err := store.ActiveAddresses(s.scope)
+	if err != nil {
+		return err
+	}
+
+	for _, state := range states {
+		s.mtx.Lock()
+		managed := s.storeAddrs[string(state.Hash)]
+		var stateErr error
+		if managed == nil {
+			managed, stateErr = s.managedAddressFromStoreState(state)
+		}
+		if stateErr == nil && managed != nil {
+			key := addrKey(managed.Address().ScriptAddress())
+			s.addrs[key] = managed
+			s.storeAddrs[string(state.Hash)] = managed
+			s.used[key] = state.Used
+		}
+		s.mtx.Unlock()
+		if stateErr != nil {
+			return stateErr
+		}
+		if internalOnly && !managed.Internal() {
+			continue
+		}
+
+		if err := fn(managed.Address()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ForEachActiveAddressFromStore visits every active durable address.
+func (s *ScopedKeyManager) ForEachActiveAddressFromStore(
+	store ManagerReadStore, fn func(address.Address) error) error {
+
+	return s.forEachActiveAddressFromStore(store, false, fn)
+}
+
+// ForEachInternalActiveAddressFromStore visits active durable change
+// addresses.
+func (s *ScopedKeyManager) ForEachInternalActiveAddressFromStore(
+	store ManagerReadStore, fn func(address.Address) error) error {
+
+	return s.forEachActiveAddressFromStore(store, true, fn)
+}
+
+// ManagedAddressFromStoreStates reconstructs one address from detached account
+// and address rows without reading a Store or changing manager caches.
+func (s *ScopedKeyManager) ManagedAddressFromStoreStates(
+	account AccountState, state AddressState) (ManagedAddress, error) {
+
+	if state.Scope != s.scope {
+		return nil, fmt.Errorf("address scope %s does not match manager %s",
+			state.Scope, s.scope)
+	}
+	if state.Type != AddressChain {
+		s.mtx.Lock()
+		defer s.mtx.Unlock()
+
+		return s.managedAddressFromStoreState(state)
+	}
+	if account.Scope != state.Scope || account.Account != state.Account {
+		return nil, fmt.Errorf("account state does not own stored address")
+	}
+	if state.Branch == nil || state.Index == nil {
+		return nil, errors.New("stored chain address path is missing")
+	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	info, err := s.accountInfoFromState(account)
+	if err != nil {
+		return nil, err
+	}
+	defer zeroAccountInfo(info)
+
+	watchOnly := s.rootManager.WatchOnly() ||
+		len(info.acctKeyEncrypted) == 0
+	private := !s.rootManager.IsLocked() && !watchOnly
+	key, err := s.deriveKey(info, *state.Branch, *state.Index, private)
+	if err != nil {
+		return nil, err
+	}
+	defer key.Zero()
+
+	path := DerivationPath{
+		InternalAccount:      state.Account,
+		Account:              info.acctKeyPub.ChildIndex(),
+		Branch:               *state.Branch,
+		Index:                *state.Index,
+		MasterKeyFingerprint: info.masterKeyFingerprint,
+	}
+	managed, err := newManagedAddressFromExtKey(
+		s, path, key, s.accountAddrType(
+			info, *state.Branch == InternalBranch,
+		), info,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if *state.Branch == InternalBranch {
+		managed.internal = true
+	}
+
+	return managed, nil
+}
+
+// PrepareNextInternalAddress derives a complete internal-address plan from an
+// owned account snapshot. No Store transaction may be active while it runs.
+//
+//nolint:revive // Callers only need the opaque plan's exported methods.
+func (s *ScopedKeyManager) PrepareNextInternalAddress(
+	state AccountState) (*nextAddressPlan, error) {
+
+	if state.Scope != s.scope {
+		return nil, fmt.Errorf("account scope %s does not match manager %s",
+			state.Scope, s.scope)
+	}
+	if state.Account > MaxAccountNum {
+		return nil, managerError(
+			ErrAccountNumTooHigh, errAcctTooHigh, nil,
+		)
+	}
+	if state.NextInternalIndex >= MaxAddressesPerAccount {
+		return nil, managerError(
+			ErrTooManyAddresses, "maximum address count reached", nil,
+		)
+	}
+
+	state = copyAccountState(state)
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	info, err := s.accountInfoFromState(state)
+	if err != nil {
+		return nil, err
+	}
+	defer zeroAccountInfo(info)
+
+	watchOnly := s.rootManager.WatchOnly() ||
+		len(info.acctKeyEncrypted) == 0
+	accountKey := info.acctKeyPub
+	if !s.rootManager.IsLocked() && !watchOnly {
+		if info.acctKeyPriv == nil {
+			return nil, managerError(
+				ErrLocked, "private account key is unavailable", nil,
+			)
+		}
+		accountKey = info.acctKeyPriv
+	}
+
+	branch := uint32(InternalBranch)
+	branchKey, err := accountKey.DeriveNonStandard( // nolint:staticcheck
+		branch,
+	)
+	if err != nil {
+		return nil, managerError(
+			ErrKeyChain, "failed to derive internal branch", err,
+		)
+	}
+	defer branchKey.Zero()
+
+	index := state.NextInternalIndex
+	var child *hdkeychain.ExtendedKey
+	for {
+		child, err = branchKey.DeriveNonStandard(index) // nolint:staticcheck
+		if errors.Is(err, hdkeychain.ErrInvalidChild) {
+			index++
+			if index >= MaxAddressesPerAccount {
+				return nil, managerError(
+					ErrTooManyAddresses,
+					"maximum address count reached", nil,
+				)
+			}
+
+			continue
+		}
+		if err != nil {
+			return nil, managerError(
+				ErrKeyChain, fmt.Sprintf(
+					"failed to generate child %d", index,
+				), err,
+			)
+		}
+
+		break
+	}
+	child.SetNet(s.rootManager.chainParams)
+	defer child.Zero()
+
+	path := DerivationPath{
+		InternalAccount:      state.Account,
+		Account:              info.acctKeyPub.ChildIndex(),
+		Branch:               branch,
+		Index:                index,
+		MasterKeyFingerprint: info.masterKeyFingerprint,
+	}
+	managed, err := newManagedAddressFromExtKey(
+		s, path, child, s.accountAddrType(info, true), info,
+	)
+	if err != nil {
+		return nil, err
+	}
+	managed.internal = true
+
+	addressID := append([]byte(nil), managed.Address().ScriptAddress()...)
+	addressIndex := index
+	addressState := AddressState{
+		Scope:      s.scope,
+		Account:    state.Account,
+		Type:       AddressChain,
+		AddedAt:    time.Unix(time.Now().Unix(), 0),
+		SyncStatus: AddressSyncFull,
+		Branch:     &branch,
+		Index:      &addressIndex,
+	}
+
+	return &nextAddressPlan{
+		manager:        s,
+		account:        state,
+		address:        addressState,
+		managed:        managed,
+		addressID:      addressID,
+		hash:           sha256.Sum256(addressID),
+		nextExternal:   state.NextExternalIndex,
+		nextInternal:   index + 1,
+		deriveOnUnlock: !child.IsPrivate() && !watchOnly,
+	}, nil
+}
+
+// zeroAccountInfo clears detached extended-key material after preparation.
+func zeroAccountInfo(info *accountInfo) {
+	if info == nil {
+		return
+	}
+	if info.acctKeyPriv != nil {
+		info.acctKeyPriv.Zero()
+	}
+	if info.acctKeyPub != nil {
+		info.acctKeyPub.Zero()
+	}
+	zero.Bytes(info.acctKeyEncrypted)
+}
+
+// nextAddressFromStore derives and persists one address on the selected branch
+// while publishing cache changes only after commit.
+func (s *ScopedKeyManager) nextAddressFromStore(tx ManagerReadWriteTx,
+	account uint32, internal bool) (ManagedAddress, *AccountProperties,
+	error) {
+
+	if account > MaxAccountNum {
+		return nil, nil, managerError(
+			ErrAccountNumTooHigh, errAcctTooHigh, nil,
+		)
+	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	state, err := tx.Account(s.scope, account)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	branch := uint32(ExternalBranch)
+	nextIndex := state.NextExternalIndex
+	if internal {
+		branch = InternalBranch
+		nextIndex = state.NextInternalIndex
+	}
+	if nextIndex >= MaxAddressesPerAccount {
+		return nil, nil, managerError(
+			ErrTooManyAddresses, "maximum address count reached", nil,
+		)
+	}
+
+	cacheInfo := s.acctInfo[account]
+	info := cacheInfo
+	if info == nil {
+		info, err = s.accountInfoFromState(state)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	watchOnly := s.rootManager.WatchOnly() ||
+		len(info.acctKeyEncrypted) == 0
+	accountKey := info.acctKeyPub
+	if !s.rootManager.IsLocked() && !watchOnly {
+		if info.acctKeyPriv == nil {
+			return nil, nil, managerError(
+				ErrLocked, "private account key is unavailable", nil,
+			)
+		}
+		accountKey = info.acctKeyPriv
+	}
+
+	branchKey, err := accountKey.DeriveNonStandard(branch) // nolint:staticcheck
+	if err != nil {
+		return nil, nil, managerError(
+			ErrKeyChain, fmt.Sprintf("failed to derive branch %d", branch),
+			err,
+		)
+	}
+	defer branchKey.Zero()
+
+	index := nextIndex
+	var child *hdkeychain.ExtendedKey
+	for {
+		child, err = branchKey.DeriveNonStandard(index) // nolint:staticcheck
+		if errors.Is(err, hdkeychain.ErrInvalidChild) {
+			index++
+			if index >= MaxAddressesPerAccount {
+				return nil, nil, managerError(
+					ErrTooManyAddresses,
+					"maximum address count reached", nil,
+				)
+			}
+			continue
+		}
+		if err != nil {
+			return nil, nil, managerError(
+				ErrKeyChain, fmt.Sprintf(
+					"failed to generate child %d", index,
+				), err,
+			)
+		}
+		break
+	}
+	child.SetNet(s.rootManager.chainParams)
+	deriveOnUnlock := !child.IsPrivate() && !watchOnly
+
+	path := DerivationPath{
+		InternalAccount:      account,
+		Account:              info.acctKeyPub.ChildIndex(),
+		Branch:               branch,
+		Index:                index,
+		MasterKeyFingerprint: info.masterKeyFingerprint,
+	}
+	managed, err := newManagedAddressFromExtKey(
+		s, path, child, s.accountAddrType(info, internal), info,
+	)
+	child.Zero()
+	if err != nil {
+		return nil, nil, err
+	}
+	if internal {
+		managed.internal = true
+	}
+
+	addressIndex := index
+	err = tx.PutAddress(
+		managed.Address().ScriptAddress(), AddressState{
+			Scope:      s.scope,
+			Account:    account,
+			Type:       AddressChain,
+			AddedAt:    time.Now(),
+			SyncStatus: AddressSyncFull,
+			Branch:     &branch,
+			Index:      &addressIndex,
+		},
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	newNextIndex := index + 1
+	nextExternal := state.NextExternalIndex
+	nextInternal := state.NextInternalIndex
+	if internal {
+		nextInternal = newNextIndex
+	} else {
+		nextExternal = newNextIndex
+	}
+	err = tx.SetAccountIndexes(
+		s.scope, account, nextExternal, nextInternal,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	props, err := s.accountPropertiesFromInfo(account, info)
+	if err != nil {
+		return nil, nil, err
+	}
+	props.ExternalKeyCount = nextExternal
+	props.InternalKeyCount = nextInternal
+	props.AccountName = state.Name
+
+	tx.OnCommit(func() {
+		s.mtx.Lock()
+		defer s.mtx.Unlock()
+
+		if current := s.acctInfo[account]; current != nil {
+			cacheInfo = current
+		} else {
+			cacheInfo = info
+			s.acctInfo[account] = info
+		}
+		cacheInfo.acctName = state.Name
+		cacheInfo.nextExternalIndex = nextExternal
+		cacheInfo.nextInternalIndex = nextInternal
+		cacheInfo.storeStale = false
+		if internal {
+			cacheInfo.lastInternalAddr = managed
+		} else {
+			cacheInfo.lastExternalAddr = managed
+		}
+
+		key := addrKey(managed.Address().ScriptAddress())
+		s.addrs[key] = managed
+		s.used[key] = false
+		hash := sha256.Sum256(managed.Address().ScriptAddress())
+		s.storeAddrs[string(hash[:])] = managed
+		if deriveOnUnlock {
+			s.deriveOnUnlock = append(s.deriveOnUnlock, &unlockDeriveInfo{
+				managedAddr: managed,
+				branch:      branch,
+				index:       index,
+			})
+		}
+	})
+
+	return managed, props, nil
+}
+
+// NextInternalAddressFromStore derives and persists one internal address.
+func (s *ScopedKeyManager) NextInternalAddressFromStore(
+	tx ManagerReadWriteTx, account uint32) (ManagedAddress,
+	*AccountProperties, error) {
+
+	return s.nextAddressFromStore(tx, account, true)
+}
+
+// LastExternalAddressFromStore returns the latest durable external address.
+func (s *ScopedKeyManager) LastExternalAddressFromStore(
+	store ManagerReadStore, account uint32) (ManagedAddress, error) {
+
+	_, err := s.AccountPropertiesFromStore(store, account)
+	if err != nil {
+		return nil, err
+	}
+
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	info := s.acctInfo[account]
+	if info != nil && info.nextExternalIndex > 0 {
+		return info.lastExternalAddr, nil
+	}
+
+	return nil, managerError(
+		ErrAddressNotFound, "no previous external address", nil,
+	)
+}
+
+// LastInternalAddressFromStore returns the latest durable internal address.
+func (s *ScopedKeyManager) LastInternalAddressFromStore(
+	store ManagerReadStore, account uint32) (ManagedAddress, error) {
+
+	_, err := s.AccountPropertiesFromStore(store, account)
+	if err != nil {
+		return nil, err
+	}
+
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	info := s.acctInfo[account]
+	if info != nil && info.nextInternalIndex > 0 {
+		return info.lastInternalAddr, nil
+	}
+
+	return nil, managerError(
+		ErrAddressNotFound, "no previous internal address", nil,
+	)
+}
+
+// DeriveFromKeyPathFromStore derives a managed address using durable account
+// state without requiring that account to have been published to the cache.
+func (s *ScopedKeyManager) DeriveFromKeyPathFromStore(store ManagerReadStore,
+	path DerivationPath) (ManagedAddress, error) {
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	state, err := store.Account(s.scope, path.InternalAccount)
+	if err != nil {
+		return nil, err
+	}
+
+	info := s.acctInfo[path.InternalAccount]
+	if info == nil {
+		info, err = s.accountInfoFromState(state)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	private := !s.rootManager.IsLocked() &&
+		!s.rootManager.WatchOnly() && info.acctKeyPriv != nil
+	key, err := s.deriveKey(info, path.Branch, path.Index, private)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.keyToManaged(key, path, info)
+}
+
+// DeriveFromKeyPathFromAccountState derives an address from detached durable
+// account state without reading a Store or changing manager caches. It is used
+// to prepare recovery lookahead while no database transaction is active.
+func (s *ScopedKeyManager) DeriveFromKeyPathFromAccountState(
+	state AccountState, path DerivationPath) (ManagedAddress, error) {
+
+	if state.Scope != s.scope {
+		return nil, fmt.Errorf("account scope %s does not match manager %s",
+			state.Scope, s.scope)
+	}
+	if state.Account != path.InternalAccount {
+		return nil, fmt.Errorf("account %d does not match derivation account %d",
+			state.Account, path.InternalAccount)
+	}
+
+	// Recovery only needs public addresses. Avoid decrypting or retaining
+	// private account material in the detached derivation state.
+	state.EncryptedPrivKey = nil
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	info, err := s.accountInfoFromState(state)
+	if err != nil {
+		return nil, err
+	}
+	defer info.acctKeyPub.Zero()
+
+	key, err := s.deriveKey(info, path.Branch, path.Index, false)
+	if err != nil {
+		return nil, err
+	}
+
+	managed, err := newManagedAddressFromExtKey(
+		s, path, key, s.accountAddrType(
+			info, path.Branch == InternalBranch,
+		), info,
+	)
+	key.Zero()
+	if err != nil {
+		return nil, err
+	}
+	if path.Branch == InternalBranch {
+		managed.internal = true
+	}
+
+	return managed, nil
+}
+
+// newAccountFromStore derives and persists one private HD account. The scoped
+// manager mutex must be held for writes.
+func (s *ScopedKeyManager) newAccountFromStore(tx ManagerReadWriteTx,
+	account uint32, name string) (*AccountProperties, error) {
+
+	if err := ValidateAccountName(name); err != nil {
+		return nil, err
+	}
+
+	_, err := tx.AccountByName(s.scope, name)
+	if err == nil {
+		return nil, managerError(
+			ErrDuplicateAccount,
+			"account with the same name already exists", nil,
+		)
+	}
+	if !IsError(err, ErrAccountNotFound) {
+		return nil, err
+	}
+
+	scopeState, err := tx.KeyScope(s.scope)
+	if err != nil {
+		return nil, err
+	}
+	serializedKey, err := s.rootManager.cryptoKeyPriv.Decrypt(
+		scopeState.EncryptedCoinPrivKey,
+	)
+	if err != nil {
+		return nil, managerError(
+			ErrLocked, "failed to decrypt cointype private key", err,
+		)
+	}
+	defer zero.Bytes(serializedKey)
+
+	coinTypeKey, err := hdkeychain.NewKeyFromString(string(serializedKey))
+	if err != nil {
+		return nil, managerError(
+			ErrKeyChain, "failed to decode cointype private key", err,
+		)
+	}
+	defer coinTypeKey.Zero()
+
+	acctKeyPriv, err := deriveAccountKey(coinTypeKey, account)
+	if err != nil {
+		return nil, managerError(
+			ErrKeyChain, "failed to derive account private key", err,
+		)
+	}
+	defer acctKeyPriv.Zero()
+
+	acctKeyPub, err := acctKeyPriv.Neuter()
+	if err != nil {
+		return nil, managerError(
+			ErrKeyChain, "failed to derive account public key", err,
+		)
+	}
+	defer acctKeyPub.Zero()
+
+	pubEncrypted, err := s.rootManager.cryptoKeyPub.Encrypt(
+		[]byte(acctKeyPub.String()),
+	)
+	if err != nil {
+		return nil, managerError(
+			ErrCrypto, "failed to encrypt account public key", err,
+		)
+	}
+	privEncrypted, err := s.rootManager.cryptoKeyPriv.Encrypt(
+		[]byte(acctKeyPriv.String()),
+	)
+	if err != nil {
+		return nil, managerError(
+			ErrCrypto, "failed to encrypt account private key", err,
+		)
+	}
+
+	state := AccountState{
+		Scope:            s.scope,
+		Account:          account,
+		Type:             AccountDefault,
+		Name:             name,
+		EncryptedPubKey:  pubEncrypted,
+		EncryptedPrivKey: privEncrypted,
+	}
+	if err := tx.PutAccount(state); err != nil {
+		return nil, err
+	}
+	if err := tx.SetLastAccount(s.scope, account); err != nil {
+		return nil, err
+	}
+
+	info, err := s.accountInfoFromState(state)
+	if err != nil {
+		return nil, err
+	}
+	props, err := s.accountPropertiesFromInfo(account, info)
+	if err != nil {
+		return nil, err
+	}
+
+	tx.OnCommit(func() {
+		s.mtx.Lock()
+		defer s.mtx.Unlock()
+
+		s.acctInfo[account] = info
+	})
+
+	return props, nil
+}
+
+// NewAccountFromStore creates the next private HD account.
+func (s *ScopedKeyManager) NewAccountFromStore(tx ManagerReadWriteTx,
+	name string) (uint32, *AccountProperties, error) {
+
+	if s.rootManager.WatchOnly() {
+		return 0, nil, managerError(ErrWatchingOnly, errWatchingOnly, nil)
+	}
+	if s.rootManager.IsLocked() {
+		return 0, nil, managerError(ErrLocked, errLocked, nil)
+	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	scopeState, err := tx.KeyScope(s.scope)
+	if err != nil {
+		return 0, nil, err
+	}
+	account := scopeState.LastAccount + 1
+	props, err := s.newAccountFromStore(tx, account, name)
+
+	return account, props, err
+}
+
+// NewRawAccountFromStore creates a private HD account with an explicit number.
+func (s *ScopedKeyManager) NewRawAccountFromStore(
+	tx ManagerReadWriteTx, account uint32) error {
+
+	if s.rootManager.WatchOnly() {
+		return managerError(ErrWatchingOnly, errWatchingOnly, nil)
+	}
+	if s.rootManager.IsLocked() {
+		return managerError(ErrLocked, errLocked, nil)
+	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	_, err := s.newAccountFromStore(
+		tx, account, fmt.Sprintf("act:%v", account),
+	)
+	return err
+}
+
+// NewAccountWatchingOnlyFromStore creates the next imported extended-public-key
+// account.
+func (s *ScopedKeyManager) NewAccountWatchingOnlyFromStore(
+	tx ManagerReadWriteTx, name string, pubKey *hdkeychain.ExtendedKey,
+	masterKeyFingerprint uint32,
+	addrSchema *ScopeAddrSchema) (uint32, *AccountProperties, error) {
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	if err := ValidateAccountName(name); err != nil {
+		return 0, nil, err
+	}
+	_, err := tx.AccountByName(s.scope, name)
+	if err == nil {
+		return 0, nil, managerError(
+			ErrDuplicateAccount,
+			"account with the same name already exists", nil,
+		)
+	}
+	if !IsError(err, ErrAccountNotFound) {
+		return 0, nil, err
+	}
+
+	scopeState, err := tx.KeyScope(s.scope)
+	if err != nil {
+		return 0, nil, err
+	}
+	account := scopeState.LastAccount + 1
+	pubEncrypted, err := s.rootManager.cryptoKeyPub.Encrypt(
+		[]byte(pubKey.String()),
+	)
+	if err != nil {
+		return 0, nil, managerError(
+			ErrCrypto, "failed to encrypt account public key", err,
+		)
+	}
+
+	state := AccountState{
+		Scope:                s.scope,
+		Account:              account,
+		Type:                 AccountWatchOnly,
+		Name:                 name,
+		EncryptedPubKey:      pubEncrypted,
+		MasterKeyFingerprint: masterKeyFingerprint,
+		AddrSchema:           addrSchema,
+	}
+	if err := tx.PutAccount(state); err != nil {
+		return 0, nil, err
+	}
+	if err := tx.SetLastAccount(s.scope, account); err != nil {
+		return 0, nil, err
+	}
+
+	info, err := s.accountInfoFromState(state)
+	if err != nil {
+		return 0, nil, err
+	}
+	props, err := s.accountPropertiesFromInfo(account, info)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	tx.OnCommit(func() {
+		s.mtx.Lock()
+		defer s.mtx.Unlock()
+
+		s.acctInfo[account] = info
+	})
+
+	return account, props, nil
+}
+
+// RenameAccountFromStore persists a new account name and publishes it after
+// commit.
+func (s *ScopedKeyManager) RenameAccountFromStore(tx ManagerReadWriteTx,
+	account uint32, name string) (*AccountProperties, error) {
+
+	if isReservedAccountNum(account) {
+		return nil, managerError(
+			ErrInvalidAccount, "reserved account cannot be renamed", nil,
+		)
+	}
+	if err := ValidateAccountName(name); err != nil {
+		return nil, err
+	}
+	_, err := tx.AccountByName(s.scope, name)
+	if err == nil {
+		return nil, managerError(
+			ErrDuplicateAccount,
+			"account with the same name already exists", nil,
+		)
+	}
+	if !IsError(err, ErrAccountNotFound) {
+		return nil, err
+	}
+
+	state, err := tx.Account(s.scope, account)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.RenameAccount(s.scope, account, name); err != nil {
+		return nil, err
+	}
+	state.Name = name
+
+	s.mtx.Lock()
+	info := s.acctInfo[account]
+	if info == nil {
+		info, err = s.accountInfoFromState(state)
+	}
+	if err != nil {
+		s.mtx.Unlock()
+		return nil, err
+	}
+	props, err := s.accountPropertiesFromInfo(account, info)
+	s.mtx.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	props.AccountName = name
+
+	tx.OnCommit(func() {
+		s.mtx.Lock()
+		defer s.mtx.Unlock()
+
+		info.acctName = name
+		s.acctInfo[account] = info
+	})
+
+	return props, nil
+}
+
+// importedKeyID returns the durable identifier for an imported public key.
+func (s *ScopedKeyManager) importedKeyID(serializedPubKey []byte,
+	addrType AddressType) ([]byte, error) {
+
+	switch addrType {
+	case PubKeyHash, WitnessPubKey:
+		return address.Hash160(serializedPubKey), nil
+
+	case NestedWitnessPubKey:
+		pubKeyHash := address.Hash160(serializedPubKey)
+		witnessAddr, err := address.NewAddressWitnessPubKeyHash(
+			pubKeyHash, s.rootManager.chainParams,
+		)
+		if err != nil {
+			return nil, err
+		}
+		witnessScript, err := txscript.PayToAddrScript(witnessAddr)
+		if err != nil {
+			return nil, err
+		}
+
+		return address.Hash160(witnessScript), nil
+
+	case TaprootPubKey:
+		pubKey, err := btcec.ParsePubKey(serializedPubKey)
+		if err != nil {
+			return nil, err
+		}
+		taprootKey := txscript.ComputeTaprootKeyNoScript(pubKey)
+
+		return schnorr.SerializePubKey(taprootKey), nil
+
+	default:
+		return nil, fmt.Errorf("unsupported address type %v", addrType)
+	}
+}
+
+// lowerStartBlockFromStore atomically lowers the durable import start block.
+func lowerStartBlockFromStore(tx ManagerReadWriteStore,
+	block *BlockStamp) (bool, error) {
+
+	if block == nil {
+		return false, nil
+	}
+
+	syncState, err := tx.SyncState()
+	if err != nil {
+		return false, err
+	}
+	if block.Height >= syncState.StartBlock.Height {
+		return false, nil
+	}
+
+	syncState.StartBlock = *block
+	if err := tx.PutSyncState(syncState); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// putImportedKeyFromStore persists an imported key and any earlier start block.
+func (s *ScopedKeyManager) putImportedKeyFromStore(tx ManagerReadWriteTx,
+	serializedPubKey, encryptedPrivKey []byte, addrType AddressType,
+	block *BlockStamp) ([]byte, bool, error) {
+
+	addressID, err := s.importedKeyID(serializedPubKey, addrType)
+	if err != nil {
+		return nil, false, err
+	}
+
+	_, err = tx.Address(s.scope, addressID)
+	if err == nil {
+		str := fmt.Sprintf(
+			"address for public key %x already exists", serializedPubKey,
+		)
+		return nil, false, managerError(ErrDuplicateAddress, str, nil)
+	}
+	if !IsError(err, ErrAddressNotFound) {
+		return nil, false, err
+	}
+
+	encryptedPubKey, err := s.rootManager.cryptoKeyPub.Encrypt(
+		serializedPubKey,
+	)
+	if err != nil {
+		return nil, false, managerError(
+			ErrCrypto, "failed to encrypt imported public key", err,
+		)
+	}
+
+	err = tx.PutAddress(addressID, AddressState{
+		Scope:            s.scope,
+		Account:          ImportedAddrAccount,
+		Type:             AddressImported,
+		AddedAt:          time.Now(),
+		SyncStatus:       AddressSyncNone,
+		EncryptedPubKey:  encryptedPubKey,
+		EncryptedPrivKey: encryptedPrivKey,
+	})
+	if err != nil {
+		return nil, false, err
+	}
+
+	updateStart, err := lowerStartBlockFromStore(tx, block)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return addressID, updateStart, nil
+}
+
+// cacheImportedAddress publishes an imported managed address after commit. The
+// scoped manager mutex must be held for writes.
+func (s *ScopedKeyManager) cacheImportedAddress(addressID []byte,
+	managed ManagedAddress) {
+
+	key := addrKey(addressID)
+	s.addrs[key] = managed
+	s.used[key] = false
+	hash := sha256.Sum256(addressID)
+	s.storeAddrs[string(hash[:])] = managed
+}
+
+// ImportPublicKeyFromStore imports one public key through a writable store.
+func (s *ScopedKeyManager) ImportPublicKeyFromStore(tx ManagerReadWriteTx,
+	pubKey *btcec.PublicKey, block *BlockStamp) (ManagedAddress, error) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	serialized := pubKey.SerializeCompressed()
+	addressID, updateStart, err := s.putImportedKeyFromStore(
+		tx, serialized, nil, s.addrSchema.ExternalAddrType, block,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	managed, err := newManagedAddressWithoutPrivKey(
+		s, ImportedDerivationPath, pubKey, true,
+		s.addrSchema.ExternalAddrType,
+	)
+	if err != nil {
+		return nil, err
+	}
+	managed.imported = true
+
+	tx.OnCommit(func() {
+		s.mtx.Lock()
+		s.cacheImportedAddress(addressID, managed)
+		s.mtx.Unlock()
+		if updateStart {
+			s.rootManager.mtx.Lock()
+			if block.Height <
+				s.rootManager.syncState.startBlock.Height {
+
+				s.rootManager.syncState.startBlock = *block
+			}
+			s.rootManager.mtx.Unlock()
+		}
+	})
+
+	return managed, nil
+}
+
+// ImportPrivateKeyFromStore imports one private key through a writable store.
+func (s *ScopedKeyManager) ImportPrivateKeyFromStore(tx ManagerReadWriteTx,
+	wif *btcutil.WIF, block *BlockStamp) (ManagedPubKeyAddress, error) {
+
+	if !wif.IsForNet(s.rootManager.chainParams) {
+		str := fmt.Sprintf("private key is not for network %s",
+			s.rootManager.chainParams.Name)
+		return nil, managerError(ErrWrongNet, str, nil)
+	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	if s.rootManager.IsLocked() && !s.rootManager.WatchOnly() {
+		return nil, managerError(ErrLocked, errLocked, nil)
+	}
+
+	var encryptedPrivKey []byte
+	if !s.rootManager.WatchOnly() {
+		privKeyBytes := wif.PrivKey.Serialize()
+		var err error
+		encryptedPrivKey, err = s.rootManager.cryptoKeyPriv.Encrypt(
+			privKeyBytes,
+		)
+		zero.Bytes(privKeyBytes)
+		if err != nil {
+			return nil, managerError(
+				ErrCrypto, "failed to encrypt imported private key", err,
+			)
+		}
+	}
+
+	serialized := wif.SerializePubKey()
+	addressID, updateStart, err := s.putImportedKeyFromStore(
+		tx, serialized, encryptedPrivKey,
+		s.addrSchema.ExternalAddrType, block,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var managed *managedAddress
+	if s.rootManager.WatchOnly() {
+		managed, err = newManagedAddressWithoutPrivKey(
+			s, ImportedDerivationPath, wif.PrivKey.PubKey(),
+			wif.CompressPubKey, s.addrSchema.ExternalAddrType,
+		)
+	} else {
+		managed, err = newManagedAddress(
+			s, ImportedDerivationPath, wif.PrivKey,
+			wif.CompressPubKey, s.addrSchema.ExternalAddrType, nil,
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+	managed.imported = true
+
+	tx.OnCommit(func() {
+		s.mtx.Lock()
+		s.cacheImportedAddress(addressID, managed)
+		s.mtx.Unlock()
+		if updateStart {
+			s.rootManager.mtx.Lock()
+			if block.Height <
+				s.rootManager.syncState.startBlock.Height {
+
+				s.rootManager.syncState.startBlock = *block
+			}
+			s.rootManager.mtx.Unlock()
+		}
+	})
+
+	return managed, nil
+}
+
+// importScriptFromStore persists one legacy, witness, or taproot script.
+func (s *ScopedKeyManager) importScriptFromStore(tx ManagerReadWriteTx,
+	identity Identity, script []byte, block *BlockStamp, addrType AddressType,
+	witnessVersion byte, isSecretScript bool) (ManagedScriptAddress, error) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	if isSecretScript && s.rootManager.IsLocked() {
+		return nil, managerError(ErrLocked, errLocked, nil)
+	}
+	if isSecretScript && s.rootManager.WatchOnly() {
+		return nil, managerError(ErrWatchingOnly, errWatchingOnly, nil)
+	}
+
+	scriptID := identity()
+	_, err := tx.Address(s.scope, scriptID)
+	if err == nil {
+		str := fmt.Sprintf(
+			"address for script hash/key %x already exists", scriptID,
+		)
+		return nil, managerError(ErrDuplicateAddress, str, nil)
+	}
+	if !IsError(err, ErrAddressNotFound) {
+		return nil, err
+	}
+
+	encryptedHash, err := s.rootManager.cryptoKeyPub.Encrypt(scriptID)
+	if err != nil {
+		return nil, managerError(
+			ErrCrypto, "failed to encrypt script identity", err,
+		)
+	}
+	cryptoKey := s.rootManager.cryptoKeyScript
+	if !isSecretScript {
+		cryptoKey = s.rootManager.cryptoKeyPub
+	}
+	encryptedScript, err := cryptoKey.Encrypt(script)
+	if err != nil {
+		return nil, managerError(
+			ErrCrypto, "failed to encrypt imported script", err,
+		)
+	}
+
+	storeType := AddressScript
+	var version *uint8
+	var secret *bool
+	if addrType == WitnessScript || addrType == TaprootScript {
+		storeType = AddressWitnessScript
+		if addrType == TaprootScript {
+			storeType = AddressTaprootScript
+		}
+		version = &witnessVersion
+		secret = &isSecretScript
+	}
+	err = tx.PutAddress(scriptID, AddressState{
+		Scope:           s.scope,
+		Account:         ImportedAddrAccount,
+		Type:            storeType,
+		AddedAt:         time.Now(),
+		SyncStatus:      AddressSyncNone,
+		EncryptedHash:   encryptedHash,
+		EncryptedScript: encryptedScript,
+		WitnessVersion:  version,
+		IsSecretScript:  secret,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	updateStart, err := lowerStartBlockFromStore(tx, block)
+	if err != nil {
+		return nil, err
+	}
+
+	var managed ManagedScriptAddress
+	if addrType == WitnessScript || addrType == TaprootScript {
+		managed, err = newWitnessScriptAddress(
+			s, ImportedAddrAccount, scriptID, encryptedScript,
+			witnessVersion, isSecretScript,
+		)
+	} else {
+		managed, err = newScriptAddress(
+			s, ImportedAddrAccount, scriptID, encryptedScript,
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if setter, ok := managed.(clearTextScriptSetter); ok {
+		setter.setClearTextScript(script)
+	}
+
+	tx.OnCommit(func() {
+		s.mtx.Lock()
+		s.cacheImportedAddress(scriptID, managed)
+		s.mtx.Unlock()
+		if updateStart {
+			s.rootManager.mtx.Lock()
+			if block.Height <
+				s.rootManager.syncState.startBlock.Height {
+
+				s.rootManager.syncState.startBlock = *block
+			}
+			s.rootManager.mtx.Unlock()
+		}
+	})
+
+	return managed, nil
+}
+
+// ImportScriptFromStore imports one legacy pay-to-script-hash script.
+func (s *ScopedKeyManager) ImportScriptFromStore(tx ManagerReadWriteTx,
+	script []byte, block *BlockStamp) (ManagedScriptAddress, error) {
+
+	return s.importScriptFromStore(
+		tx, ScriptHashIdentity(script), script, block, Script, 0, true,
+	)
+}
+
+// ImportWitnessScriptFromStore imports one witness script.
+func (s *ScopedKeyManager) ImportWitnessScriptFromStore(
+	tx ManagerReadWriteTx, script []byte, block *BlockStamp,
+	witnessVersion byte, isSecretScript bool) (ManagedScriptAddress, error) {
+
+	return s.importScriptFromStore(
+		tx, WitnessScriptHashIdentity(script), script, block,
+		WitnessScript, witnessVersion, isSecretScript,
+	)
+}
+
+// ImportTaprootScriptFromStore imports one tapscript tree or full-key spend.
+func (s *ScopedKeyManager) ImportTaprootScriptFromStore(
+	tx ManagerReadWriteTx, tapscript *Tapscript, block *BlockStamp,
+	witnessVersion byte,
+	isSecretScript bool) (ManagedTaprootScriptAddress, error) {
+
+	if witnessVersion != witnessVersionV1 {
+		return nil, fmt.Errorf(
+			"invalid witness version %d for taproot script",
+			witnessVersion,
+		)
+	}
+
+	taprootKey, err := tapscript.TaprootKey()
+	if err != nil {
+		return nil, fmt.Errorf("error calculating script root: %w", err)
+	}
+	script, err := tlvEncodeTaprootScript(tapscript)
+	if err != nil {
+		return nil, fmt.Errorf("error encoding taproot script: %w", err)
+	}
+
+	managed, err := s.importScriptFromStore(
+		tx, TaprootIdentity(taprootKey), script, block, TaprootScript,
+		witnessVersion, isSecretScript,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return managed.(ManagedTaprootScriptAddress), nil
+}
+
+// MarkUsedFromStore marks an address used and updates the cache after commit.
+func (s *ScopedKeyManager) MarkUsedFromStore(tx ManagerReadWriteTx,
+	addr address.Address) error {
+
+	addressID := addr.ScriptAddress()
+	if err := tx.MarkAddressUsed(s.scope, addressID); err != nil {
+		return err
+	}
+
+	tx.OnCommit(func() {
+		s.mtx.Lock()
+		defer s.mtx.Unlock()
+		s.used[addrKey(addressID)] = true
+	})
+
+	return nil
+}

--- a/waddrmgr/store_snapshot.go
+++ b/waddrmgr/store_snapshot.go
@@ -1,0 +1,144 @@
+package waddrmgr
+
+// managerScopeSnapshot contains the complete durable state for one key scope.
+type managerScopeSnapshot struct {
+	state     KeyScopeState
+	accounts  []AccountState
+	addresses []AddressState
+}
+
+// ManagerSnapshot is an opaque, transaction-independent copy of the durable
+// address-manager state needed to reconstruct a Manager.
+type ManagerSnapshot struct {
+	state  ManagerState
+	sync   SyncState
+	scopes []managerScopeSnapshot
+}
+
+// copyManagerState detaches root manager byte slices from backend-owned rows.
+func copyManagerState(state ManagerState) ManagerState {
+	state.MasterPubParams = copyBytes(state.MasterPubParams)
+	state.MasterPrivParams = copyBytes(state.MasterPrivParams)
+	state.EncryptedCryptoPubKey = copyBytes(state.EncryptedCryptoPubKey)
+	state.EncryptedCryptoPrivKey = copyBytes(state.EncryptedCryptoPrivKey)
+	state.EncryptedCryptoScriptKey = copyBytes(
+		state.EncryptedCryptoScriptKey,
+	)
+	state.EncryptedMasterHDPubKey = copyBytes(state.EncryptedMasterHDPubKey)
+	state.EncryptedMasterHDPrivKey = copyBytes(state.EncryptedMasterHDPrivKey)
+
+	return state
+}
+
+// copySyncState detaches optional sync metadata from backend-owned rows.
+func copySyncState(state SyncState) SyncState {
+	if state.BirthdayBlock != nil {
+		birthdayBlock := *state.BirthdayBlock
+		state.BirthdayBlock = &birthdayBlock
+	}
+
+	return state
+}
+
+// copyKeyScopeState detaches key-scope byte slices from backend-owned rows.
+func copyKeyScopeState(state KeyScopeState) KeyScopeState {
+	state.EncryptedCoinPubKey = copyBytes(state.EncryptedCoinPubKey)
+	state.EncryptedCoinPrivKey = copyBytes(state.EncryptedCoinPrivKey)
+
+	return state
+}
+
+// copyAccountState detaches account keys and optional schema metadata from
+// backend-owned rows.
+func copyAccountState(state AccountState) AccountState {
+	state.EncryptedPubKey = copyBytes(state.EncryptedPubKey)
+	state.EncryptedPrivKey = copyBytes(state.EncryptedPrivKey)
+	if state.AddrSchema != nil {
+		addrSchema := *state.AddrSchema
+		state.AddrSchema = &addrSchema
+	}
+
+	return state
+}
+
+// copyAddressState detaches address material and optional path metadata from
+// backend-owned rows.
+func copyAddressState(state AddressState) AddressState {
+	state.Hash = copyBytes(state.Hash)
+	state.EncryptedPubKey = copyBytes(state.EncryptedPubKey)
+	state.EncryptedPrivKey = copyBytes(state.EncryptedPrivKey)
+	state.EncryptedHash = copyBytes(state.EncryptedHash)
+	state.EncryptedScript = copyBytes(state.EncryptedScript)
+
+	if state.Branch != nil {
+		branch := *state.Branch
+		state.Branch = &branch
+	}
+	if state.Index != nil {
+		index := *state.Index
+		state.Index = &index
+	}
+	if state.WitnessVersion != nil {
+		witnessVersion := *state.WitnessVersion
+		state.WitnessVersion = &witnessVersion
+	}
+	if state.IsSecretScript != nil {
+		isSecretScript := *state.IsSecretScript
+		state.IsSecretScript = &isSecretScript
+	}
+
+	return state
+}
+
+// ReadManagerSnapshot copies all durable state needed to reconstruct a Manager.
+// It performs no passphrase work, decryption, key derivation, or address
+// validation, so callers may invoke it inside a short read transaction.
+func ReadManagerSnapshot(store ManagerReadStore) (*ManagerSnapshot, error) {
+	managerState, err := store.ManagerState()
+	if err != nil {
+		return nil, err
+	}
+
+	syncState, err := store.SyncState()
+	if err != nil {
+		return nil, err
+	}
+
+	scopeStates, err := store.KeyScopes()
+	if err != nil {
+		return nil, err
+	}
+
+	snapshot := &ManagerSnapshot{
+		state:  copyManagerState(managerState),
+		sync:   copySyncState(syncState),
+		scopes: make([]managerScopeSnapshot, 0, len(scopeStates)),
+	}
+	for _, scopeState := range scopeStates {
+		accounts, err := store.Accounts(scopeState.Scope)
+		if err != nil {
+			return nil, err
+		}
+
+		addresses, err := store.ActiveAddresses(scopeState.Scope)
+		if err != nil {
+			return nil, err
+		}
+
+		scopeSnapshot := managerScopeSnapshot{
+			state:     copyKeyScopeState(scopeState),
+			accounts:  make([]AccountState, len(accounts)),
+			addresses: make([]AddressState, len(addresses)),
+		}
+		for i := range accounts {
+			scopeSnapshot.accounts[i] = copyAccountState(accounts[i])
+		}
+		for i := range addresses {
+			scopeSnapshot.addresses[i] = copyAddressState(addresses[i])
+		}
+
+		snapshot.scopes = append(snapshot.scopes, scopeSnapshot)
+	}
+
+	return snapshot, nil
+}

--- a/waddrmgr/store_test.go
+++ b/waddrmgr/store_test.go
@@ -120,3 +120,42 @@ func TestManagerStoreKVAdapter(t *testing.T) {
 	})
 	require.NoError(t, err)
 }
+
+// TestManagerStoreKVNoAccount verifies an unallocated scope keeps the legacy
+// account-zero sentinel instead of recording account zero as already used.
+func TestManagerStoreKVNoAccount(t *testing.T) {
+	teardown, database, _ := setupManager(t)
+	t.Cleanup(teardown)
+
+	scope := KeyScope{Purpose: 1_017, Coin: 1}
+	want := KeyScopeState{
+		Scope:       scope,
+		AddrSchema:  ScopeAddrMap[KeyScopeBIP0084],
+		LastAccount: NoAccount,
+	}
+	err := walletdb.Update(database, func(tx walletdb.ReadWriteTx) error {
+		store := BindManagerReadWriteStore(
+			tx.ReadWriteBucket(waddrmgrNamespaceKey),
+		)
+
+		if err := store.PutKeyScope(want); err != nil {
+			return err
+		}
+		if err := store.SetLastAccount(scope, 2); err != nil {
+			return err
+		}
+
+		return store.PutKeyScope(want)
+	})
+	require.NoError(t, err)
+
+	err = walletdb.View(database, func(tx walletdb.ReadTx) error {
+		store := BindManagerReadStore(tx.ReadBucket(waddrmgrNamespaceKey))
+		got, err := store.KeyScope(scope)
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+
+		return nil
+	})
+	require.NoError(t, err)
+}

--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -7,6 +7,8 @@ package wallet
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/btcsuite/btcd/chainhash/v2"
@@ -26,32 +28,258 @@ const (
 	birthdayBlockDelta = 2 * time.Hour
 )
 
-func (w *Wallet) handleChainNotifications() {
-	defer w.wg.Done()
+// StorePlanStaleError reports that durable wallet state changed after an RPC
+// plan was prepared but before its database-only apply began.
+type StorePlanStaleError struct {
+	// Operation identifies the synchronization operation that became stale.
+	Operation string
 
-	chainClient, err := w.requireChainClient()
+	// Reason describes the durable state mismatch.
+	Reason string
+}
+
+// Error describes the stale Store plan.
+func (e *StorePlanStaleError) Error() string {
+	return fmt.Sprintf("%s plan is stale: %s", e.Operation, e.Reason)
+}
+
+// UnresolvedStoreCommitError reports a Store commit whose durable outcome
+// could not be distinguished without risking replay of chain RPCs.
+type UnresolvedStoreCommitError struct {
+	// Operation identifies the synchronization operation being reconciled.
+	Operation string
+
+	// Err is the ambiguous commit or reconciliation failure.
+	Err error
+}
+
+// Error describes the unresolved Store commit.
+func (e *UnresolvedStoreCommitError) Error() string {
+	return fmt.Sprintf("%s commit outcome is unresolved: %v", e.Operation,
+		e.Err)
+}
+
+// Unwrap returns the ambiguous commit or reconciliation failure.
+func (e *UnresolvedStoreCommitError) Unwrap() error {
+	return e.Err
+}
+
+type storePlanStatus uint8
+
+const (
+	storePlanAbsent storePlanStatus = iota
+	storePlanCommitted
+	storePlanConflict
+)
+
+// sameBlockPosition reports whether two stamps identify the same chain block.
+func sameBlockPosition(a, b waddrmgr.BlockStamp) bool {
+	return a.Height == b.Height && a.Hash == b.Hash
+}
+
+// refreshStorePlanCaches reloads sync state and invalidates account-index
+// caches after an ambiguous commit has been reconciled as durable.
+func (w *Wallet) refreshStorePlanCaches(ctx context.Context,
+	accounts []waddrmgr.KeyScope) error {
+
+	var syncState waddrmgr.SyncState
+	err := w.store.View(ctx, func(tx walletstore.ReadTx) error {
+		var err error
+		syncState, err = tx.Addr().SyncState()
+		return err
+	}, func() {
+		syncState = waddrmgr.SyncState{}
+	})
 	if err != nil {
-		log.Errorf("handleChainNotifications called without RPC client")
-		return
+		return err
 	}
 
-	catchUpHashes := func(w *Wallet, client chain.Interface,
-		height int32) error {
-		// TODO(aakselrod): There's a race condition here, which
-		// happens when a reorg occurs between the
-		// rescanProgress notification and the last GetBlockHash
-		// call. The solution when using btcd is to make btcd
-		// send blockconnected notifications with each block
-		// the way Neutrino does, and get rid of the loop. The
-		// other alternative is to check the final hash and,
-		// if it doesn't match the original hash returned by
-		// the notification, to roll back and restart the
-		// rescan.
-		log.Infof("Catching up block hashes to height %d, this"+
-			" might take a while", height)
-		err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-			ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+	w.Manager.ApplySyncStateFromStore(syncState)
+	for _, scope := range accounts {
+		w.Manager.MarkAccountCacheStale(
+			scope, waddrmgr.DefaultAccountNum,
+		)
+	}
 
+	return nil
+}
+
+// invalidateStorePlanCaches prevents an unresolved commit from leaving
+// optimistic account or sync positions in memory.
+func (w *Wallet) invalidateStorePlanCaches(accounts []waddrmgr.KeyScope) {
+	w.Manager.InvalidateSyncStateCache()
+	for _, scope := range accounts {
+		w.Manager.MarkAccountCacheStale(
+			scope, waddrmgr.DefaultAccountNum,
+		)
+	}
+}
+
+// applyStorePlan applies a database-only plan once and reconciles an ambiguous
+// commit without rebuilding or replaying its RPC portion.
+func (w *Wallet) applyStorePlan(ctx context.Context, operation string,
+	body func(walletstore.ReadWriteTx) error,
+	status func(walletstore.ReadTx) (storePlanStatus, error),
+	accounts []waddrmgr.KeyScope) error {
+
+	for {
+		err := w.store.UpdateOnce(ctx, body, nil)
+		if err == nil {
+			return nil
+		}
+
+		var retryable *walletstore.RetryableTransactionError
+		if errors.As(err, &retryable) {
+			continue
+		}
+
+		var ambiguous *walletstore.AmbiguousCommitError
+		if !errors.As(err, &ambiguous) {
+			return err
+		}
+
+		outcome := storePlanConflict
+		viewErr := w.store.View(ctx, func(tx walletstore.ReadTx) error {
+			var err error
+			outcome, err = status(tx)
+			return err
+		}, func() {
+			outcome = storePlanConflict
+		})
+		if viewErr != nil {
+			w.invalidateStorePlanCaches(accounts)
+			return &UnresolvedStoreCommitError{
+				Operation: operation,
+				Err: errors.Join(
+					err, fmt.Errorf("reconcile commit: %w", viewErr),
+				),
+			}
+		}
+
+		switch outcome {
+		case storePlanAbsent:
+			continue
+
+		case storePlanCommitted:
+			ambiguous.ApplyCommitHooks()
+			if err := w.refreshStorePlanCaches(ctx, accounts); err != nil {
+				w.invalidateStorePlanCaches(accounts)
+				return &UnresolvedStoreCommitError{
+					Operation: operation,
+					Err:       errors.Join(ambiguous, err),
+				}
+			}
+
+			return nil
+
+		default:
+			w.invalidateStorePlanCaches(accounts)
+			return &UnresolvedStoreCommitError{
+				Operation: operation,
+				Err:       ambiguous,
+			}
+		}
+	}
+}
+
+// storePlanCommitStatus classifies a plan by comparing the durable tip with
+// its exact starting and terminal positions.
+func storePlanCommitStatus(tx walletstore.ReadTx, start,
+	target waddrmgr.BlockStamp) (storePlanStatus, error) {
+
+	state, err := tx.Addr().SyncState()
+	if err != nil {
+		return storePlanConflict, err
+	}
+
+	switch {
+	case sameBlockPosition(state.SyncedTo, target):
+		return storePlanCommitted, nil
+
+	case sameBlockPosition(state.SyncedTo, start):
+		return storePlanAbsent, nil
+
+	default:
+		return storePlanConflict, nil
+	}
+}
+
+// fetchStoreCatchUpPlan retrieves and validates a contiguous chain segment
+// without holding a Store transaction.
+func fetchStoreCatchUpPlan(client chain.Interface, start waddrmgr.BlockStamp,
+	height int32, finalHash *chainhash.Hash) ([]waddrmgr.BlockStamp, error) {
+
+	if height <= start.Height {
+		if finalHash == nil {
+			return nil, nil
+		}
+
+		var hash *chainhash.Hash
+		if height == start.Height {
+			hash = &start.Hash
+		} else {
+			var err error
+			hash, err = client.GetBlockHash(int64(height))
+			if err != nil {
+				return nil, err
+			}
+		}
+		if *hash != *finalHash {
+			return nil, fmt.Errorf("rescan final hash %v does not match %v",
+				*finalHash, *hash)
+		}
+
+		return nil, nil
+	}
+
+	plan := make([]waddrmgr.BlockStamp, 0, height-start.Height)
+	previousHash := start.Hash
+	for blockHeight := start.Height + 1; blockHeight <= height; blockHeight++ {
+
+		hash, err := client.GetBlockHash(int64(blockHeight))
+		if err != nil {
+			return nil, err
+		}
+		header, err := client.GetBlockHeader(hash)
+		if err != nil {
+			return nil, err
+		}
+		if header.BlockHash() != *hash {
+			return nil, fmt.Errorf("header hash does not match block %v", hash)
+		}
+		if header.PrevBlock != previousHash {
+			return nil, fmt.Errorf("block %d does not link to %v",
+				blockHeight, previousHash)
+		}
+
+		plan = append(plan, waddrmgr.BlockStamp{
+			Height:    blockHeight,
+			Hash:      *hash,
+			Timestamp: header.Timestamp,
+		})
+		previousHash = *hash
+	}
+
+	if finalHash != nil && plan[len(plan)-1].Hash != *finalHash {
+		return nil, fmt.Errorf("rescan final hash %v does not match %v",
+			*finalHash, plan[len(plan)-1].Hash)
+	}
+
+	return plan, nil
+}
+
+// catchUpHashes persists all block stamps through a rescan notification. Store
+// wallets fetch and validate the complete plan before opening the write.
+func (w *Wallet) catchUpHashes(client chain.Interface, height int32,
+	finalHash *chainhash.Hash) error {
+
+	log.Infof("Catching up block hashes to height %d, this might take a while",
+		height)
+
+	var err error
+	if w.db != nil {
+		err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+			ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
 			startBlock := w.Manager.SyncedTo()
 
 			for i := startBlock.Height + 1; i <= height; i++ {
@@ -59,30 +287,175 @@ func (w *Wallet) handleChainNotifications() {
 				if err != nil {
 					return err
 				}
-				header, err := chainClient.GetBlockHeader(hash)
+				header, err := client.GetBlockHeader(hash)
 				if err != nil {
 					return err
 				}
 
-				bs := waddrmgr.BlockStamp{
+				err = w.Manager.SetSyncedTo(ns, &waddrmgr.BlockStamp{
 					Height:    i,
 					Hash:      *hash,
 					Timestamp: header.Timestamp,
-				}
-				err = w.Manager.SetSyncedTo(ns, &bs)
+				})
 				if err != nil {
 					return err
 				}
 			}
+
 			return nil
 		})
+	} else {
+		err = w.catchUpHashesFromStore(client, height, finalHash)
+	}
+	if err != nil {
+		log.Errorf("Failed to update address manager sync state for height "+
+			"%d: %v", height, err)
+		return err
+	}
+
+	log.Info("Done catching up block hashes")
+	return nil
+}
+
+// catchUpHashesFromStore prepares an exact contiguous block plan and applies
+// it only if the durable starting tip remains unchanged.
+func (w *Wallet) catchUpHashesFromStore(client chain.Interface, height int32,
+	finalHash *chainhash.Hash) error {
+
+	var start waddrmgr.BlockStamp
+	err := w.store.View(context.Background(), func(tx walletstore.ReadTx) error {
+		state, err := tx.Addr().SyncState()
 		if err != nil {
-			log.Errorf("Failed to update address manager "+
-				"sync state for height %d: %v", height, err)
+			return err
+		}
+		start = state.SyncedTo
+		return nil
+	}, func() {
+		start = waddrmgr.BlockStamp{}
+	})
+	if err != nil {
+		return err
+	}
+
+	plan, err := fetchStoreCatchUpPlan(client, start, height, finalHash)
+	if err != nil || len(plan) == 0 {
+		return err
+	}
+	target := plan[len(plan)-1]
+
+	return w.applyStorePlan(
+		context.Background(), "catch-up", func(tx walletstore.ReadWriteTx) error {
+			state, err := tx.Addr().SyncState()
+			if err != nil {
+				return err
+			}
+			if !sameBlockPosition(state.SyncedTo, start) {
+				return &StorePlanStaleError{
+					Operation: "catch-up",
+					Reason: fmt.Sprintf("starting tip is %d:%v, want %d:%v",
+						state.SyncedTo.Height, state.SyncedTo.Hash,
+						start.Height, start.Hash),
+				}
+			}
+
+			for i := range plan {
+				if err := w.Manager.SetSyncedToFromStore(
+					tx.Addr(), &plan[i],
+				); err != nil {
+
+					return err
+				}
+			}
+
+			return nil
+		}, func(tx walletstore.ReadTx) (storePlanStatus, error) {
+			return storePlanCommitStatus(tx, start, target)
+		}, nil,
+	)
+}
+
+// updateChainStore reconciles an ambiguous chain update before deferred cache
+// and notification hooks are published. An absent atomic update is safe to
+// retry, while a durable update applies its captured hooks exactly once.
+func (w *Wallet) updateChainStore(ctx context.Context,
+	body func(walletstore.ReadWriteTx) error,
+	committed func(walletstore.ReadTx) (bool, error)) error {
+
+	for {
+		err := w.store.Update(ctx, body, nil)
+		if err == nil {
+			return nil
 		}
 
-		log.Info("Done catching up block hashes")
-		return err
+		var ambiguous *walletstore.AmbiguousCommitError
+		if !errors.As(err, &ambiguous) {
+			return err
+		}
+
+		var durable bool
+
+		viewErr := w.store.View(ctx, func(tx walletstore.ReadTx) error {
+			var err error
+
+			durable, err = committed(tx)
+
+			return err
+		}, func() {
+			durable = false
+		})
+		if viewErr != nil {
+			return errors.Join(
+				err, fmt.Errorf("reconcile chain commit: %w", viewErr),
+			)
+		}
+
+		if durable {
+			ambiguous.ApplyCommitHooks()
+			return nil
+		}
+	}
+}
+
+// syncBlockCommitted reports whether the durable wallet tip is the expected
+// block.
+func syncBlockCommitted(tx walletstore.ReadTx,
+	block wtxmgr.BlockMeta) (bool, error) {
+
+	state, err := tx.Addr().SyncState()
+	if err != nil {
+		return false, err
+	}
+
+	return state.SyncedTo.Height == block.Height &&
+		state.SyncedTo.Hash == block.Hash, nil
+}
+
+// relevantTxCommitted reports whether one transaction incidence is durable.
+func relevantTxCommitted(tx walletstore.ReadTx, record *wtxmgr.TxRecord,
+	block *wtxmgr.BlockMeta) (bool, error) {
+
+	var incidence *wtxmgr.Block
+	if block != nil {
+		incidence = &block.Block
+	}
+
+	details, err := tx.Tx().UniqueTxDetails(&record.Hash, incidence)
+	if err != nil {
+		return false, err
+	}
+
+	return details != nil, nil
+}
+
+// handleChainNotifications processes notifications from the active chain
+// backend until the wallet shuts down.
+func (w *Wallet) handleChainNotifications() {
+	defer w.wg.Done()
+
+	chainClient, err := w.requireChainClient()
+	if err != nil {
+		log.Errorf("handleChainNotifications called without RPC client")
+		return
 	}
 
 	waitForSync := func(birthdayBlock *waddrmgr.BlockStamp) error {
@@ -138,6 +511,7 @@ func (w *Wallet) handleChainNotifications() {
 				// missing relevant events.
 				birthdayStore := &walletBirthdayStore{
 					db:      w.db,
+					store:   w.store,
 					manager: w.Manager,
 				}
 				birthdayBlock, err := birthdaySanityCheck(
@@ -161,63 +535,136 @@ func (w *Wallet) handleChainNotifications() {
 				}
 
 			case chain.BlockConnected:
-				err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-					return w.connectBlock(tx, wtxmgr.BlockMeta(n))
-				})
+				if w.db != nil {
+					err = walletdb.Update(
+						w.db, func(tx walletdb.ReadWriteTx) error {
+							return w.connectBlock(
+								tx, wtxmgr.BlockMeta(n),
+							)
+						},
+					)
+				} else {
+					err = w.updateChainStore(
+						context.Background(),
+						func(tx walletstore.ReadWriteTx) error {
+							return w.connectBlockFromStore(
+								tx, wtxmgr.BlockMeta(n),
+							)
+						}, func(tx walletstore.ReadTx) (bool, error) {
+							return syncBlockCommitted(
+								tx, wtxmgr.BlockMeta(n),
+							)
+						},
+					)
+				}
+
 				notificationName = "block connected"
+
 			case chain.BlockDisconnected:
-				err = w.store.Update(
-					context.Background(),
-					func(tx walletstore.ReadWriteTx) error {
-						return w.disconnectBlock(
-							tx, wtxmgr.BlockMeta(n),
-						)
-					}, func() {},
+				err = w.processBlockDisconnected(
+					chainClient, wtxmgr.BlockMeta(n),
 				)
+
 				notificationName = "block disconnected"
+
 			case chain.RelevantTx:
-				err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-					return w.addRelevantTx(tx, n.TxRecord, n.Block)
-				})
+				if w.db != nil {
+					err = walletdb.Update(
+						w.db, func(tx walletdb.ReadWriteTx) error {
+							return w.addRelevantTx(
+								tx, n.TxRecord, n.Block,
+							)
+						},
+					)
+				} else {
+					err = w.updateChainStore(
+						context.Background(),
+						func(tx walletstore.ReadWriteTx) error {
+							return w.addRelevantTxFromStore(
+								tx, n.TxRecord, n.Block,
+							)
+						}, func(tx walletstore.ReadTx) (bool, error) {
+							return relevantTxCommitted(
+								tx, n.TxRecord, n.Block,
+							)
+						},
+					)
+				}
+
 				notificationName = "relevant transaction"
+
 			case chain.FilteredBlockConnected:
 				// Atomically update for the whole block.
 				if len(n.RelevantTxs) > 0 {
-					err = walletdb.Update(w.db, func(
-						tx walletdb.ReadWriteTx) error {
-						var err error
-						for _, rec := range n.RelevantTxs {
-							err = w.addRelevantTx(tx, rec,
-								n.Block)
-							if err != nil {
-								return err
+					if w.db != nil {
+						err = walletdb.Update(w.db, func(
+							tx walletdb.ReadWriteTx) error {
+							for _, rec := range n.RelevantTxs {
+								err := w.addRelevantTx(
+									tx, rec, n.Block,
+								)
+								if err != nil {
+									return err
+								}
 							}
-						}
-						return nil
-					})
+							return nil
+						})
+					} else {
+						err = w.updateChainStore(
+							context.Background(),
+							func(tx walletstore.ReadWriteTx) error {
+								for _, rec := range n.RelevantTxs {
+									err := w.addRelevantTxFromStore(
+										tx, rec, n.Block,
+									)
+									if err != nil {
+										return err
+									}
+								}
+								return nil
+							}, func(tx walletstore.ReadTx) (bool, error) {
+								for _, record := range n.RelevantTxs {
+									committed, err := relevantTxCommitted(
+										tx, record, n.Block,
+									)
+									if err != nil || !committed {
+										return committed, err
+									}
+								}
+
+								return true, nil
+							},
+						)
+					}
 				}
+
 				notificationName = "filtered block connected"
 
 			// The following require some database maintenance, but also
 			// need to be reported to the wallet's rescan goroutine.
 			case *chain.RescanProgress:
-				err = catchUpHashes(w, chainClient, n.Height)
+				err = w.catchUpHashes(chainClient, n.Height, &n.Hash)
 				notificationName = "rescan progress"
-				select {
-				case w.rescanNotifications <- n:
-				case <-w.quitChan():
-					return
+				if err == nil {
+					select {
+					case w.rescanNotifications <- n:
+					case <-w.quitChan():
+						return
+					}
 				}
 			case *chain.RescanFinished:
-				err = catchUpHashes(w, chainClient, n.Height)
+				err = w.catchUpHashes(chainClient, n.Height, n.Hash)
 				notificationName = "rescan finished"
-				w.SetChainSynced(true)
-				select {
-				case w.rescanNotifications <- n:
-				case <-w.quitChan():
-					return
+				if err == nil {
+					w.SetChainSynced(true)
+					select {
+					case w.rescanNotifications <- n:
+					case <-w.quitChan():
+						return
+					}
 				}
 			}
+
 			if err != nil {
 				// If we received a block connected notification
 				// while rescanning, then we can ignore logging
@@ -244,10 +691,33 @@ func (w *Wallet) handleChainNotifications() {
 	}
 }
 
+// processBlockDisconnected routes a disconnect through the active persistence
+// backend and publishes a detached notification only after an actual rewind.
+func (w *Wallet) processBlockDisconnected(client chain.Interface,
+	block wtxmgr.BlockMeta) error {
+
+	if w.db != nil {
+		return walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+			return w.disconnectBlockLegacy(tx, block)
+		})
+	}
+
+	rewound, err := w.disconnectBlockFromStore(client, block)
+	if err != nil || !rewound {
+		return err
+	}
+
+	hash := block.Hash
+	w.NtfnServer.notifyDetachedBlock(&hash)
+	return nil
+}
+
 // connectBlock handles a chain server notification by marking a wallet
 // that's currently in-sync with the chain server as being synced up to
 // the passed block.
-func (w *Wallet) connectBlock(dbtx walletdb.ReadWriteTx, b wtxmgr.BlockMeta) error {
+func (w *Wallet) connectBlock(dbtx walletdb.ReadWriteTx,
+	b wtxmgr.BlockMeta) error {
+
 	addrmgrNs := dbtx.ReadWriteBucket(waddrmgrNamespaceKey)
 
 	bs := waddrmgr.BlockStamp{
@@ -267,61 +737,204 @@ func (w *Wallet) connectBlock(dbtx walletdb.ReadWriteTx, b wtxmgr.BlockMeta) err
 	return nil
 }
 
-// disconnectBlock handles a chain server reorganize by rolling back all
-// block history from the reorged block for a wallet in-sync with the chain
-// server.
-func (w *Wallet) disconnectBlock(dbtx walletstore.ReadWriteTx,
+// connectBlockFromStore persists a connected block through the backend-neutral
+// manager transaction.
+func (w *Wallet) connectBlockFromStore(dbtx walletstore.ReadWriteTx,
 	b wtxmgr.BlockMeta) error {
 
-	addrStore := dbtx.Addr()
-	txStore := dbtx.Tx()
+	err := w.Manager.SetSyncedToFromStore(
+		dbtx.Addr(), &waddrmgr.BlockStamp{
+			Height:    b.Height,
+			Hash:      b.Hash,
+			Timestamp: b.Time,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	dbtx.Addr().OnCommit(func() {
+		w.NtfnServer.notifyAttachedBlockFromStore(&b)
+	})
+
+	return nil
+}
+
+// disconnectBlockLegacy preserves the walletdb disconnect behavior, including
+// its chain-header lookup inside the legacy database transaction.
+func (w *Wallet) disconnectBlockLegacy(dbtx walletdb.ReadWriteTx,
+	b wtxmgr.BlockMeta) error {
 
 	if !w.ChainSynced() {
 		return nil
 	}
 
-	// Disconnect the removed block and all blocks after it if we know about
-	// the disconnected block. Otherwise, the block is in the future.
-	if b.Height <= w.Manager.SyncedTo().Height {
-		hash, err := addrStore.BlockHash(b.Height)
-		if err != nil {
-			return err
-		}
-		if bytes.Equal(hash[:], b.Hash[:]) {
-			bs := waddrmgr.BlockStamp{
-				Height: b.Height - 1,
-			}
-			hash, err = addrStore.BlockHash(bs.Height)
-			if err != nil {
-				return err
-			}
-			b.Hash = *hash
-
-			client := w.ChainClient()
-			header, err := client.GetBlockHeader(hash)
-			if err != nil {
-				return err
-			}
-
-			bs.Timestamp = header.Timestamp
-			err = addrStore.SetSyncedTo(&bs)
-			if err != nil {
-				return err
-			}
-
-			err = txStore.Rollback(b.Height)
-			if err != nil {
-				return err
-			}
-		}
+	addrmgrNs := dbtx.ReadWriteBucket(waddrmgrNamespaceKey)
+	txmgrNs := dbtx.ReadWriteBucket(wtxmgrNamespaceKey)
+	if b.Height > w.Manager.SyncedTo().Height {
+		return nil
 	}
 
-	// Notify interested clients of the disconnected block.
-	w.NtfnServer.notifyDetachedBlock(&b.Hash)
+	hash, err := w.Manager.BlockHash(addrmgrNs, b.Height)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(hash[:], b.Hash[:]) {
+		return nil
+	}
 
+	stamp := waddrmgr.BlockStamp{Height: b.Height - 1}
+	hash, err = w.Manager.BlockHash(addrmgrNs, stamp.Height)
+	if err != nil {
+		return err
+	}
+	header, err := w.ChainClient().GetBlockHeader(hash)
+	if err != nil {
+		return err
+	}
+	b.Hash = *hash
+	stamp.Hash = *hash
+	stamp.Timestamp = header.Timestamp
+
+	if err := w.Manager.SetSyncedTo(addrmgrNs, &stamp); err != nil {
+		return err
+	}
+	if err := w.TxStore.Rollback(txmgrNs, b.Height); err != nil {
+		return err
+	}
+
+	w.NtfnServer.notifyDetachedBlock(&b.Hash)
 	return nil
 }
 
+// disconnectBlockFromStore prepares a parent stamp without a transaction and
+// atomically rewinds manager and transaction state if the exact tip is current.
+func (w *Wallet) disconnectBlockFromStore(client chain.Interface,
+	b wtxmgr.BlockMeta) (bool, error) {
+
+	if !w.ChainSynced() || b.Height <= 0 {
+		return false, nil
+	}
+
+	var (
+		start       waddrmgr.BlockStamp
+		blockHash   chainhash.Hash
+		parentHash  chainhash.Hash
+		shouldApply bool
+	)
+	err := w.store.View(
+		context.Background(), func(tx walletstore.ReadTx) error {
+			state, err := tx.Addr().SyncState()
+			if err != nil {
+				return err
+			}
+			start = state.SyncedTo
+			if b.Height > start.Height {
+				return nil
+			}
+
+			durableHash, err := tx.Addr().BlockHash(b.Height)
+			if err != nil {
+				return err
+			}
+			blockHash = *durableHash
+			if blockHash != b.Hash {
+				return nil
+			}
+
+			durableParent, err := tx.Addr().BlockHash(b.Height - 1)
+			if err != nil {
+				return err
+			}
+			parentHash = *durableParent
+			shouldApply = true
+
+			return nil
+		}, func() {
+			start = waddrmgr.BlockStamp{}
+			blockHash = chainhash.Hash{}
+			parentHash = chainhash.Hash{}
+			shouldApply = false
+		},
+	)
+	if err != nil || !shouldApply {
+		return false, err
+	}
+
+	header, err := client.GetBlockHeader(&parentHash)
+	if err != nil {
+		return false, err
+	}
+	if header.BlockHash() != parentHash {
+		return false, fmt.Errorf("parent header hash does not match %v",
+			parentHash)
+	}
+	target := waddrmgr.BlockStamp{
+		Height:    b.Height - 1,
+		Hash:      parentHash,
+		Timestamp: header.Timestamp,
+	}
+
+	err = w.applyStorePlan(
+		context.Background(), "disconnect",
+		func(tx walletstore.ReadWriteTx) error {
+			state, err := tx.Addr().SyncState()
+			if err != nil {
+				return err
+			}
+			if !sameBlockPosition(state.SyncedTo, start) {
+				return &StorePlanStaleError{
+					Operation: "disconnect",
+					Reason: fmt.Sprintf("starting tip is %d:%v, want %d:%v",
+						state.SyncedTo.Height, state.SyncedTo.Hash,
+						start.Height, start.Hash),
+				}
+			}
+
+			currentHash, err := tx.Addr().BlockHash(b.Height)
+			if err != nil {
+				return err
+			}
+			if *currentHash != blockHash || *currentHash != b.Hash {
+				return &StorePlanStaleError{
+					Operation: "disconnect",
+					Reason:    "disconnected block hash changed",
+				}
+			}
+			currentParent, err := tx.Addr().BlockHash(target.Height)
+			if err != nil {
+				return err
+			}
+			if *currentParent != parentHash {
+				return &StorePlanStaleError{
+					Operation: "disconnect",
+					Reason:    "parent block hash changed",
+				}
+			}
+
+			if err := w.Manager.SetSyncedToFromStore(
+				tx.Addr(), &target,
+			); err != nil {
+
+				return err
+			}
+
+			return tx.Tx().Rollback(b.Height)
+		}, func(tx walletstore.ReadTx) (storePlanStatus, error) {
+			return storePlanCommitStatus(tx, start, target)
+		}, nil,
+	)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// addRelevantTx records a relevant transaction and marks wallet-owned outputs
+// and spent inputs.
+//
+//nolint:cyclop // The branches preserve existing output classification.
 func (w *Wallet) addRelevantTx(dbtx walletdb.ReadWriteTx, rec *wtxmgr.TxRecord,
 	block *wtxmgr.BlockMeta) error {
 
@@ -348,6 +961,7 @@ func (w *Wallet) addRelevantTx(dbtx walletdb.ReadWriteTx, rec *wtxmgr.TxRecord,
 	// Check every output to determine whether it is controlled by a wallet
 	// key.  If so, mark the output as a credit.
 	for i, output := range rec.MsgTx.TxOut {
+		credited := false
 		_, addrs, _, err := txscript.ExtractPkScriptAddrs(output.PkScript,
 			w.chainParams)
 		if err != nil {
@@ -376,7 +990,7 @@ func (w *Wallet) addRelevantTx(dbtx walletdb.ReadWriteTx, rec *wtxmgr.TxRecord,
 			// non-default scopes in other places either, so
 			// detecting them here would mean we'd also not properly
 			// detect them as spent later.
-			scopedManager, _, err := w.Manager.AddrAccount(
+			scopedManager, account, err := w.Manager.AddrAccount(
 				addrmgrNs, addr,
 			)
 			if err != nil {
@@ -398,6 +1012,16 @@ func (w *Wallet) addRelevantTx(dbtx walletdb.ReadWriteTx, rec *wtxmgr.TxRecord,
 			if err != nil {
 				return err
 			}
+			if !credited {
+				hash := rec.Hash
+				index := uint32(i)
+				dbtx.OnCommit(func() {
+					w.NtfnServer.notifyUnspentOutput(
+						account, &hash, index,
+					)
+				})
+				credited = true
+			}
 			err = w.Manager.MarkUsed(addrmgrNs, addr)
 			if err != nil {
 				return err
@@ -417,6 +1041,95 @@ func (w *Wallet) addRelevantTx(dbtx walletdb.ReadWriteTx, rec *wtxmgr.TxRecord,
 			dbtx, txmgrNs, rec.Hash, block,
 		)
 	}
+
+	return nil
+}
+
+// addRelevantTxFromStore records a relevant transaction and wallet credits
+// through the backend-neutral manager transaction.
+//
+//nolint:cyclop // The branches preserve existing output classification.
+func (w *Wallet) addRelevantTxFromStore(dbtx walletstore.ReadWriteTx,
+	rec *wtxmgr.TxRecord, block *wtxmgr.BlockMeta) error {
+
+	addrStore := dbtx.Addr()
+	txStore := dbtx.Tx()
+	exists, err := txStore.InsertTxCheckIfExists(rec, block)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
+	for i, output := range rec.MsgTx.TxOut {
+		_, addrs, _, err := txscript.ExtractPkScriptAddrs(
+			output.PkScript, w.chainParams,
+		)
+		if err != nil {
+			log.Warnf("Cannot extract non-std pkScript=%x",
+				output.PkScript)
+			continue
+		}
+
+		for _, addr := range addrs {
+			managed, err := w.Manager.AddressFromStore(addrStore, addr)
+			switch {
+			case waddrmgr.IsError(err, waddrmgr.ErrAddressNotFound):
+				continue
+
+			case err != nil:
+				return err
+			}
+
+			scopedManager, account, err := w.Manager.AddrAccountFromStore(
+				addrStore, addr,
+			)
+			if err != nil {
+				return err
+			}
+			if !waddrmgr.IsDefaultScope(scopedManager.Scope()) {
+				log.Debugf("Skipping non-default scope address %v", addr)
+				continue
+			}
+
+			isNew, err := txStore.AddCredit(
+				rec, block, uint32(i), managed.Internal(),
+			)
+			if err != nil {
+
+				return err
+			}
+			if isNew {
+				hash := rec.Hash
+				index := uint32(i)
+				addrStore.OnCommit(func() {
+					w.NtfnServer.notifyUnspentOutput(
+						account, &hash, index,
+					)
+				})
+			}
+			if err := w.Manager.MarkUsedFromStore(addrStore, addr); err != nil {
+				return err
+			}
+			log.Debugf("Marked address %v used", addr)
+		}
+	}
+
+	hash := rec.Hash
+	var committedBlock *wtxmgr.BlockMeta
+	if block != nil {
+		blockCopy := *block
+		committedBlock = &blockCopy
+	}
+	addrStore.OnCommit(func() {
+		if committedBlock == nil {
+			w.NtfnServer.notifyUnminedTransactionFromStore(hash)
+			return
+		}
+
+		w.NtfnServer.notifyMinedTransactionFromStore(hash, committedBlock)
+	})
 
 	return nil
 }
@@ -460,6 +1173,7 @@ type birthdayStore interface {
 // manager that satisfies the birthdayStore interface.
 type walletBirthdayStore struct {
 	db      walletdb.DB
+	store   walletstore.Store
 	manager *waddrmgr.Manager
 }
 
@@ -471,18 +1185,36 @@ func (s *walletBirthdayStore) Birthday() time.Time {
 }
 
 // BirthdayBlock returns the birthday block of the wallet.
-func (s *walletBirthdayStore) BirthdayBlock() (waddrmgr.BlockStamp, bool, error) {
+func (s *walletBirthdayStore) BirthdayBlock() (waddrmgr.BlockStamp, bool,
+	error) {
+
 	var (
 		birthdayBlock         waddrmgr.BlockStamp
 		birthdayBlockVerified bool
 	)
 
-	err := walletdb.View(s.db, func(tx walletdb.ReadTx) error {
-		var err error
-		ns := tx.ReadBucket(waddrmgrNamespaceKey)
-		birthdayBlock, birthdayBlockVerified, err = s.manager.BirthdayBlock(ns)
-		return err
-	})
+	var err error
+	if s.db != nil {
+		err = walletdb.View(s.db, func(tx walletdb.ReadTx) error {
+			var err error
+			ns := tx.ReadBucket(waddrmgrNamespaceKey)
+			birthdayBlock, birthdayBlockVerified, err =
+				s.manager.BirthdayBlock(ns)
+			return err
+		})
+	} else {
+		err = s.store.View(
+			context.Background(), func(tx walletstore.ReadTx) error {
+				var err error
+				birthdayBlock, birthdayBlockVerified, err =
+					s.manager.BirthdayBlockFromStore(tx.Addr())
+				return err
+			}, func() {
+				birthdayBlock = waddrmgr.BlockStamp{}
+				birthdayBlockVerified = false
+			},
+		)
+	}
 
 	return birthdayBlock, birthdayBlockVerified, err
 }
@@ -494,7 +1226,27 @@ func (s *walletBirthdayStore) BirthdayBlock() (waddrmgr.BlockStamp, bool, error)
 // NOTE: This should also set the wallet's synced tip to reflect the new
 // birthday block. This will allow the wallet to rescan from this point
 // to detect any potentially missed events.
-func (s *walletBirthdayStore) SetBirthdayBlock(block waddrmgr.BlockStamp) error {
+func (s *walletBirthdayStore) SetBirthdayBlock(
+	block waddrmgr.BlockStamp) error {
+
+	if s.db == nil {
+		return s.store.UpdateOnce(
+			context.Background(),
+			func(tx walletstore.ReadWriteTx) error {
+				err := s.manager.SetBirthdayBlockFromStore(
+					tx.Addr(), block, true,
+				)
+				if err != nil {
+					return err
+				}
+
+				return s.manager.SetSyncedToFromStore(
+					tx.Addr(), &block,
+				)
+			}, nil,
+		)
+	}
+
 	return walletdb.Update(s.db, func(tx walletdb.ReadWriteTx) error {
 		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
 		err := s.manager.SetBirthdayBlock(ns, block, true)

--- a/wallet/chainntfns_test.go
+++ b/wallet/chainntfns_test.go
@@ -8,9 +8,13 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/walletdb"
 	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -36,6 +40,57 @@ type mockChainConn struct {
 }
 
 var _ chainConn = (*mockChainConn)(nil)
+
+// TestKVNonDefaultAccountNotification verifies that the legacy transaction
+// manager routes a newly committed credit to its controlling account.
+func TestKVNonDefaultAccountNotification(t *testing.T) {
+	t.Parallel()
+
+	wallet, teardown := testWallet(t)
+	defer teardown()
+
+	account, err := wallet.NextAccount(
+		waddrmgr.KeyScopeBIP0044, "notification account",
+	)
+	require.NoError(t, err)
+	require.NotEqual(t, waddrmgr.DefaultAccountNum, account)
+	addr, err := wallet.NewAddress(account, waddrmgr.KeyScopeBIP0044)
+	require.NoError(t, err)
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	msgTx := wire.NewMsgTx(2)
+	msgTx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash:  chainhash.Hash{1},
+		Index: 1,
+	}})
+	msgTx.AddTxOut(&wire.TxOut{Value: 10_000, PkScript: pkScript})
+	record, err := wtxmgr.NewTxRecordFromMsgTx(msgTx, time.Unix(1, 0))
+	require.NoError(t, err)
+
+	spentness := wallet.NtfnServer.AccountSpentnessNotifications(account)
+	updateErr := make(chan error, 1)
+
+	go func() {
+		updateErr <- walletdb.Update(
+			wallet.Database(), func(tx walletdb.ReadWriteTx) error {
+				return wallet.addRelevantTx(tx, record, nil)
+			},
+		)
+	}()
+
+	select {
+	case notification := <-spentness.C:
+		require.Equal(t, record.Hash, *notification.Hash())
+		require.Equal(t, uint32(0), notification.Index())
+
+	case <-time.After(time.Second):
+		t.Fatal("non-default KV account did not receive notification")
+	}
+
+	require.NoError(t, <-updateErr)
+	spentness.Done()
+}
 
 // createMockChainConn creates a new mock chain connection backed by a chain
 // with N blocks. Each block has a timestamp that is exactly blockInterval after
@@ -101,7 +156,8 @@ func (c *mockChainConn) GetBlockHeader(hash *chainhash.Hash) (*wire.BlockHeader,
 	return &block.Header, nil
 }
 
-// mockBirthdayStore is a mock in-memory implementation of the birthdayStore interface
+// mockBirthdayStore is a mock in-memory implementation of the birthdayStore
+// interface.
 // that will be used for the birthday block sanity check tests.
 type mockBirthdayStore struct {
 	birthday              time.Time

--- a/wallet/comparative_validation_test.go
+++ b/wallet/comparative_validation_test.go
@@ -1,0 +1,1086 @@
+package wallet
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/integration/rpctest"
+	"github.com/btcsuite/btcd/psbt/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btcwallet/chain"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	walletstore "github.com/btcsuite/btcwallet/wallet/internal/db"
+	dbsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlite"
+	storesqlite "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+	"github.com/stretchr/testify/require"
+)
+
+type validationFixture struct {
+	t          *testing.T
+	backend    string
+	dir        string
+	dbPath     string
+	walletName string
+	params     *chaincfg.Params
+	recovery   uint32
+	conn       *sql.DB
+	loader     *Loader
+	wallet     *Wallet
+}
+
+type validationLifecycleDigest struct {
+	// WrongPrivatePassphrase records the private passphrase error.
+	WrongPrivatePassphrase string `json:"wrong_private_passphrase"`
+	// WrongPublicPassphrase records the public passphrase error.
+	WrongPublicPassphrase string `json:"wrong_public_passphrase"`
+	// ExtendedKeyRestart records whether extended keys survive restart.
+	ExtendedKeyRestart bool `json:"extended_key_restart"`
+	// WatchOnlyRestart records whether watch-only state survives restart.
+	WatchOnlyRestart bool `json:"watch_only_restart"`
+	// WatchOnlyUnlock records the watch-only unlock result.
+	WatchOnlyUnlock string `json:"watch_only_unlock"`
+	// BirthdayUnix records the wallet birthday as a Unix timestamp.
+	BirthdayUnix int64 `json:"birthday_unix"`
+	// Scopes records the wallet's key scopes.
+	Scopes []string `json:"scopes"`
+	// Accounts records the wallet's accounts.
+	Accounts []string `json:"accounts"`
+	// Addresses records the wallet's addresses.
+	Addresses []string `json:"addresses"`
+	// AddressTypes records the wallet's address types.
+	AddressTypes []string `json:"address_types"`
+}
+
+type validationTxCheckpoint struct {
+	// Name identifies the checkpoint.
+	Name string `json:"name"`
+	// Balance records the wallet balance at the checkpoint.
+	Balance int64 `json:"balance"`
+	// Unspent records the unspent outputs at the checkpoint.
+	Unspent []string `json:"unspent"`
+	// Leases records the leased output count at the checkpoint.
+	Leases int `json:"leases"`
+	// TxHeight records the transaction height at the checkpoint.
+	TxHeight int32 `json:"tx_height"`
+	// Label records the transaction label at the checkpoint.
+	Label string `json:"label"`
+	// AddressUsed records whether the address is marked used.
+	AddressUsed bool `json:"address_used"`
+	// SyncedHeight records the wallet sync height at the checkpoint.
+	SyncedHeight int32 `json:"synced_height"`
+}
+
+type validationFundingDigest struct {
+	// DryRunStatus records the dry-run funding result.
+	DryRunStatus string `json:"dry_run_status"`
+	// DryRunInputs records the number of dry-run inputs.
+	DryRunInputs int `json:"dry_run_inputs"`
+	// DryRunSigned records whether the dry-run transaction was signed.
+	DryRunSigned bool `json:"dry_run_signed"`
+	// ExplicitP2WPKHStatus records the explicit P2WPKH funding result.
+	ExplicitP2WPKHStatus string `json:"explicit_p2wpkh_status"`
+	// ExplicitP2WPKHValid records whether the P2WPKH spend is valid.
+	ExplicitP2WPKHValid bool `json:"explicit_p2wpkh_valid"`
+	// ExplicitP2TRStatus records the explicit P2TR funding result.
+	ExplicitP2TRStatus string `json:"explicit_p2tr_status"`
+	// ExplicitP2TRValid records whether the P2TR spend is valid.
+	ExplicitP2TRValid bool `json:"explicit_p2tr_valid"`
+	// ImportedSigningStatus records the imported-key signing result.
+	ImportedSigningStatus string `json:"imported_signing_status"`
+	// ImportedSigningValid records whether the imported-key spend is valid.
+	ImportedSigningValid bool `json:"imported_signing_valid"`
+	// FundPsbtStatus records the PSBT funding result.
+	FundPsbtStatus string `json:"fund_psbt_status"`
+	// DecorateInputsStatus records the PSBT input decoration result.
+	DecorateInputsStatus string `json:"decorate_inputs_status"`
+	// FinalizePsbtStatus records the PSBT finalization result.
+	FinalizePsbtStatus string `json:"finalize_psbt_status"`
+	// PsbtValid records whether the finalized PSBT is valid.
+	PsbtValid bool `json:"psbt_valid"`
+	// PsbtChangeType records the PSBT change output type.
+	PsbtChangeType string `json:"psbt_change_type"`
+	// CallerInputMetadata records whether caller input metadata is retained.
+	CallerInputMetadata bool `json:"caller_input_metadata"`
+	// CallerOutputMetadata records whether caller output metadata is retained.
+	CallerOutputMetadata bool `json:"caller_output_metadata"`
+	// BIP69Outputs records whether outputs follow BIP 69 ordering.
+	BIP69Outputs bool `json:"bip69_outputs"`
+}
+
+type validationSemanticDigest struct {
+	// Lifecycle records lifecycle validation results.
+	Lifecycle validationLifecycleDigest `json:"lifecycle"`
+	// Transaction records transaction checkpoints.
+	Transaction []validationTxCheckpoint `json:"transaction"`
+	// Funding records funding validation results.
+	Funding validationFundingDigest `json:"funding"`
+}
+
+type validationResult struct {
+	// Semantic records backend-independent validation results.
+	Semantic validationSemanticDigest `json:"semantic"`
+	// RuntimeKVSidecar records whether a runtime KV sidecar exists.
+	RuntimeKVSidecar bool `json:"runtime_kv_sidecar"`
+}
+
+type validationBTCDDigest struct {
+	// RecoveryBalance records the recovered wallet balance.
+	RecoveryBalance int64 `json:"recovery_balance"`
+	// RecoveryBeyondLookahead records recovery beyond the lookahead window.
+	RecoveryBeyondLookahead bool `json:"recovery_beyond_lookahead"`
+	// RestartBalance records the wallet balance after restart.
+	RestartBalance int64 `json:"restart_balance"`
+	// AdditionalBalance records the balance after additional funding.
+	AdditionalBalance int64 `json:"additional_balance"`
+	// SpendCreated records whether the spend was created.
+	SpendCreated bool `json:"spend_created"`
+	// SpendConfirmed records whether the spend was confirmed.
+	SpendConfirmed bool `json:"spend_confirmed"`
+	// ReorgUnconfirmed records whether the reorg unconfirmed the spend.
+	ReorgUnconfirmed bool `json:"reorg_unconfirmed"`
+	// ReplacementConfirmed records whether the replacement was confirmed.
+	ReplacementConfirmed bool `json:"replacement_confirmed"`
+}
+
+// TestComparativeValidationGates1To4 records equivalent KV and Store-backed
+// SQLite behavior at compact Gate 1-4 checkpoints.
+func TestComparativeValidationGates1To4(t *testing.T) {
+	seed := bytes.Repeat([]byte{0x2a}, hdkeychain.RecommendedSeedLen)
+	results := make(map[string]validationResult)
+
+	for _, backend := range []string{"kv", "sqlite"} {
+		backend := backend
+		t.Run(backend, func(t *testing.T) {
+			results[backend] = runValidationScenario(t, backend, seed)
+		})
+	}
+
+	require.Equal(t, results["kv"].Semantic, results["sqlite"].Semantic)
+	require.True(t, results["kv"].RuntimeKVSidecar)
+	require.False(t, results["sqlite"].RuntimeKVSidecar)
+}
+
+// TestComparativeValidationRealBTCD exercises recovery and a reorg across
+// restart against one real btcd regtest fixture.
+func TestComparativeValidationRealBTCD(t *testing.T) {
+	if os.Getenv("BTCWALLET_REAL_BTCD") != "1" {
+		t.Skip("set BTCWALLET_REAL_BTCD=1 to run the real btcd fixture")
+	}
+
+	params := &chaincfg.RegressionNetParams
+	miner, err := rpctest.New(params, nil, nil, "")
+	require.NoError(t, err)
+	require.NoError(t, miner.SetUp(true, 8))
+	t.Cleanup(func() {
+		require.NoError(t, miner.TearDown())
+	})
+
+	results := make(map[string]validationBTCDDigest)
+	for index, backend := range []string{"kv", "sqlite"} {
+		backend := backend
+		index := index
+		t.Run(backend, func(t *testing.T) {
+			seed := bytes.Repeat(
+				[]byte{byte(0x31 + index)},
+				hdkeychain.RecommendedSeedLen,
+			)
+			results[backend] = runValidationBTCDScenario(
+				t, miner, backend, seed,
+			)
+		})
+	}
+
+	require.Equal(t, results["kv"], results["sqlite"])
+	require.True(t, results["kv"].RecoveryBeyondLookahead)
+}
+
+// runValidationBTCDScenario runs one backend through real recovery, restart,
+// spend, and reorg transitions.
+func runValidationBTCDScenario(t *testing.T, miner *rpctest.Harness,
+	backend string, seed []byte) validationBTCDDigest {
+
+	t.Helper()
+
+	params := &chaincfg.RegressionNetParams
+	recoveryAddresses := make([]address.Address, 0, 2)
+	for _, index := range []uint32{0, 1, 2} {
+		recoveryAddresses = append(recoveryAddresses,
+			validationDerivedAddress(t, seed, params, index))
+	}
+
+	outputs := make([]*wire.TxOut, 0, len(recoveryAddresses))
+	for _, addr := range recoveryAddresses {
+		script, err := txscript.PayToAddrScript(addr)
+		require.NoError(t, err)
+		outputs = append(outputs, wire.NewTxOut(100_000, script))
+	}
+	// Recovering beyond the initial lookahead requires a later block. A new
+	// horizon cannot discover another address in a block already filtered.
+	_, err := miner.SendOutputs(outputs[:2], 1_000)
+	require.NoError(t, err)
+	_, err = miner.Client.Generate(1)
+	require.NoError(t, err)
+	_, err = miner.SendOutputs(outputs[2:], 1_000)
+	require.NoError(t, err)
+	_, err = miner.Client.Generate(1)
+	require.NoError(t, err)
+
+	fixture := newValidationFixtureForParams(
+		t, backend, "real-btcd", params, 2,
+		func(loader *Loader) (*Wallet, error) {
+			return loader.CreateNewWallet(
+				[]byte("public"), []byte("private"), seed,
+				params.GenesisBlock.Header.Timestamp,
+			)
+		},
+	)
+	defer fixture.close()
+	wallet := fixture.wallet
+	require.NoError(t, wallet.Unlock([]byte("private"), nil))
+	validationStartRPC(t, miner, wallet, params)
+
+	digest := validationBTCDDigest{}
+	balance, err := wallet.CalculateBalance(1)
+	require.NoError(t, err)
+	digest.RecoveryBalance = int64(balance)
+	digest.RecoveryBeyondLookahead = balance == 300_000
+
+	allocated, err := wallet.NewAddress(
+		waddrmgr.DefaultAccountNum, waddrmgr.KeyScopeBIP0084,
+	)
+	require.NoError(t, err)
+	fixture.restart([]byte("public"), []byte("private"))
+	wallet = fixture.wallet
+	wallet.chainClient = nil
+	validationStartRPC(t, miner, wallet, params)
+	require.Eventually(t, func() bool {
+		balance, err := wallet.CalculateBalance(1)
+		digest.RestartBalance = int64(balance)
+
+		return err == nil && int64(balance) == digest.RecoveryBalance &&
+			wallet.ChainSynced()
+	}, 30*time.Second, 100*time.Millisecond)
+
+	allocatedScript, err := txscript.PayToAddrScript(allocated)
+	require.NoError(t, err)
+	_, err = miner.SendOutputs(
+		[]*wire.TxOut{wire.NewTxOut(300_000, allocatedScript)}, 1_000,
+	)
+	require.NoError(t, err)
+	_, err = miner.Client.Generate(1)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		balance, err := wallet.CalculateBalance(1)
+		digest.AdditionalBalance = int64(balance)
+
+		return err == nil && int64(balance) ==
+			digest.RecoveryBalance+300_000
+	}, 30*time.Second, 100*time.Millisecond)
+
+	destination, err := miner.NewAddress()
+	require.NoError(t, err)
+	destinationScript, err := txscript.PayToAddrScript(destination)
+	require.NoError(t, err)
+	authored, err := wallet.CreateSimpleTx(
+		&waddrmgr.KeyScopeBIP0084, waddrmgr.DefaultAccountNum,
+		[]*wire.TxOut{wire.NewTxOut(100_000, destinationScript)}, 1,
+		1_000, CoinSelectionLargest, false,
+	)
+	digest.SpendCreated = err == nil
+	require.NoError(t, err)
+	require.NoError(t, wallet.PublishTransaction(
+		authored.Tx, "comparative real spend",
+	))
+	spendHash := authored.Tx.TxHash()
+	blocks, err := miner.Client.Generate(1)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	require.Eventually(t, func() bool {
+		tx, err := wallet.GetTransaction(spendHash)
+		digest.SpendConfirmed = err == nil && tx.Height >= 0
+
+		return digest.SpendConfirmed
+	}, 30*time.Second, 100*time.Millisecond)
+
+	fixture.restart([]byte("public"), []byte("private"))
+	wallet = fixture.wallet
+	wallet.chainClient = nil
+	validationStartRPC(t, miner, wallet, params)
+	require.NoError(t, miner.Client.InvalidateBlock(blocks[0]))
+	require.Eventually(t, func() bool {
+		tx, err := wallet.GetTransaction(spendHash)
+		digest.ReorgUnconfirmed = err == nil && tx.Height == -1
+
+		return digest.ReorgUnconfirmed
+	}, 30*time.Second, 100*time.Millisecond)
+
+	_, err = miner.Client.Generate(1)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		tx, err := wallet.GetTransaction(spendHash)
+		digest.ReplacementConfirmed = err == nil && tx.Height >= 0
+
+		return digest.ReplacementConfirmed
+	}, 30*time.Second, 100*time.Millisecond)
+
+	payload, err := json.Marshal(digest)
+	require.NoError(t, err)
+	sum := sha256.Sum256(payload)
+	t.Logf("BTCD_SEMANTIC_DIGEST backend=%s sha256=%x json=%s", backend,
+		sum, payload)
+
+	return digest
+}
+
+// validationDerivedAddress derives one BIP84 external address from a seed.
+func validationDerivedAddress(t *testing.T, seed []byte,
+	params *chaincfg.Params, index uint32) address.Address {
+
+	t.Helper()
+
+	key, err := hdkeychain.NewMaster(seed, params)
+	require.NoError(t, err)
+	defer key.Zero()
+	for _, child := range []uint32{
+		waddrmgr.KeyScopeBIP0084.Purpose + hdkeychain.HardenedKeyStart,
+		waddrmgr.KeyScopeBIP0084.Coin + hdkeychain.HardenedKeyStart,
+		hdkeychain.HardenedKeyStart, 0, index,
+	} {
+		key, err = key.DeriveNonStandard(child)
+		require.NoError(t, err)
+	}
+	pubKey, err := key.ECPubKey()
+	require.NoError(t, err)
+	addr, err := address.NewAddressWitnessPubKeyHash(
+		address.Hash160(pubKey.SerializeCompressed()), params,
+	)
+	require.NoError(t, err)
+
+	return addr
+}
+
+// validationStartRPC attaches a wallet to a fresh client for the test miner.
+func validationStartRPC(t *testing.T, miner *rpctest.Harness, wallet *Wallet,
+	params *chaincfg.Params) {
+
+	t.Helper()
+
+	rpcConfig := miner.RPCConfig()
+	client, err := chain.NewRPCClientWithConfig(&chain.RPCClientConfig{
+		Conn:              &rpcConfig,
+		Chain:             params,
+		ReconnectAttempts: 3,
+	})
+	require.NoError(t, err)
+	require.NoError(t, client.Start(t.Context()))
+	wallet.SynchronizeRPC(client)
+
+	_, bestHeight, err := miner.Client.GetBestBlock()
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		return wallet.ChainSynced() &&
+			wallet.Manager.SyncedTo().Height == bestHeight
+	}, 30*time.Second, 100*time.Millisecond)
+}
+
+// runValidationScenario executes the shared semantic scenario for one backend.
+func runValidationScenario(t *testing.T, backend string,
+	seed []byte) validationResult {
+
+	t.Helper()
+
+	variants := validationCreationVariants(t, backend, seed)
+	birthday := time.Unix(1_700_000_000, 0)
+	fixture := newValidationFixture(
+		t, backend, "comparative", func(loader *Loader) (*Wallet, error) {
+			return loader.CreateNewWallet(
+				[]byte("public-pass"), []byte("private-pass"), seed,
+				birthday,
+			)
+		},
+	)
+	defer fixture.close()
+
+	wallet := fixture.wallet
+	wallet.chainClient = &mockChainClient{}
+	wallet.Lock()
+	require.Eventually(t, wallet.Locked, time.Second, 10*time.Millisecond)
+	wrongPrivate := validationError(wallet.Unlock([]byte("wrong"), nil))
+	require.NoError(t, wallet.Unlock([]byte("private-pass"), nil))
+
+	account, err := wallet.NextAccount(
+		waddrmgr.KeyScopeBIP0084, "secondary",
+	)
+	require.NoError(t, err)
+	require.NoError(t, wallet.RenameAccount(
+		waddrmgr.KeyScopeBIP0084, account, "renamed",
+	))
+
+	customScope := waddrmgr.KeyScope{Purpose: 1_017, Coin: 1}
+	customSchema := waddrmgr.ScopeAddrSchema{
+		ExternalAddrType: waddrmgr.WitnessPubKey,
+		InternalAddrType: waddrmgr.TaprootPubKey,
+	}
+	_, err = wallet.AddScopeManager(customScope, customSchema)
+	require.NoError(t, err)
+
+	addresses := make(map[waddrmgr.KeyScope]address.Address)
+	var addressTypes []string
+	for _, scope := range append(
+		append([]waddrmgr.KeyScope{}, waddrmgr.DefaultKeyScopes...),
+		customScope,
+	) {
+		scopeAccount := uint32(waddrmgr.DefaultAccountNum)
+		if scope == waddrmgr.KeyScopeBIP0084 {
+			scopeAccount = account
+		}
+
+		external, err := wallet.NewAddress(scopeAccount, scope)
+		require.NoError(t, err)
+		addresses[scope] = external
+		managed, err := wallet.AddressInfo(external)
+		require.NoError(t, err)
+		addressTypes = append(addressTypes, fmt.Sprint(managed.AddrType()))
+
+		internal, err := wallet.NewChangeAddress(scopeAccount, scope)
+		require.NoError(t, err)
+		managed, err = wallet.AddressInfo(internal)
+		require.NoError(t, err)
+		addressTypes = append(addressTypes, fmt.Sprint(managed.AddrType()))
+	}
+
+	privateKey, _ := btcec.PrivKeyFromBytes(bytes.Repeat([]byte{0x03}, 32))
+	wif, err := btcutil.NewWIF(privateKey, &chaincfg.TestNet3Params, true)
+	require.NoError(t, err)
+	importBlock := &waddrmgr.BlockStamp{
+		Hash:      *chaincfg.TestNet3Params.GenesisHash,
+		Height:    0,
+		Timestamp: chaincfg.TestNet3Params.GenesisBlock.Header.Timestamp,
+	}
+	require.NoError(t, wallet.store.UpdateOnce(
+		t.Context(), func(tx walletstore.ReadWriteTx) error {
+			return wallet.Manager.SetBirthdayBlockFromStore(
+				tx.Addr(), *importBlock, false,
+			)
+		}, nil,
+	))
+	importedString, err := wallet.ImportPrivateKey(
+		waddrmgr.KeyScopeBIP0044, wif, importBlock, false,
+	)
+	require.NoError(t, err)
+	importedAddress, err := address.DecodeAddress(
+		importedString, &chaincfg.TestNet3Params,
+	)
+	require.NoError(t, err)
+
+	publicKey, _ := btcec.PrivKeyFromBytes(bytes.Repeat([]byte{0x04}, 32))
+	require.NoError(t, wallet.ImportPublicKey(
+		publicKey.PubKey(), waddrmgr.TaprootPubKey,
+	))
+	_, err = wallet.ImportP2SHRedeemScript([]byte{txscript.OP_TRUE})
+	require.NoError(t, err)
+
+	require.NoError(t, wallet.ChangePassphrases(
+		[]byte("public-pass"), []byte("new-public-pass"),
+		[]byte("private-pass"), []byte("new-private-pass"),
+	))
+	fixture.unload()
+	if fixture.backend == "sqlite" {
+		fixture.openSQLite()
+	}
+
+	wrongLoader := fixture.newLoader()
+	_, err = wrongLoader.OpenExistingWallet([]byte("public-pass"), false)
+	wrongPublic := validationError(err)
+	fixture.restart([]byte("new-public-pass"), []byte("new-private-pass"))
+	wallet = fixture.wallet
+
+	lifecycle := validationLifecycleDigest{
+		WrongPrivatePassphrase: wrongPrivate,
+		WrongPublicPassphrase:  wrongPublic,
+		ExtendedKeyRestart:     variants.ExtendedKeyRestart,
+		WatchOnlyRestart:       variants.WatchOnlyRestart,
+		WatchOnlyUnlock:        variants.WatchOnlyUnlock,
+		BirthdayUnix:           wallet.Manager.Birthday().Unix(),
+		AddressTypes:           addressTypes,
+	}
+	for _, manager := range wallet.Manager.ActiveScopedKeyManagers() {
+		lifecycle.Scopes = append(
+			lifecycle.Scopes, manager.Scope().String(),
+		)
+	}
+	sort.Strings(lifecycle.Scopes)
+	for _, scope := range []waddrmgr.KeyScope{
+		waddrmgr.KeyScopeBIP0044, waddrmgr.KeyScopeBIP0084, customScope,
+	} {
+		result, err := wallet.Accounts(scope)
+		require.NoError(t, err)
+		for _, item := range result.Accounts {
+			lifecycle.Accounts = append(lifecycle.Accounts, fmt.Sprintf(
+				"%s:%d:%s:%d:%d", scope, item.AccountNumber,
+				item.AccountName, item.ExternalKeyCount,
+				item.InternalKeyCount,
+			))
+		}
+	}
+	sort.Strings(lifecycle.Accounts)
+	lifecycle.Addresses, err = wallet.SortedActivePaymentAddresses()
+	require.NoError(t, err)
+	sort.Strings(lifecycle.AddressTypes)
+
+	fundingTx := wire.NewMsgTx(2)
+	fundingTx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{0x10}, Index: 1,
+	}})
+	fundingScripts := make([][]byte, 0, 3)
+	for _, addr := range []address.Address{
+		addresses[waddrmgr.KeyScopeBIP0084],
+		addresses[waddrmgr.KeyScopeBIP0086], importedAddress,
+	} {
+		script, err := txscript.PayToAddrScript(addr)
+		require.NoError(t, err)
+		fundingScripts = append(fundingScripts, script)
+	}
+	for index, amount := range []int64{1_000_000, 2_000_000, 300_000} {
+		fundingTx.AddTxOut(wire.NewTxOut(amount, fundingScripts[index]))
+	}
+	funding, err := wtxmgr.NewTxRecordFromMsgTx(
+		fundingTx, time.Unix(1_700_000_100, 0),
+	)
+	require.NoError(t, err)
+	require.NoError(t, wallet.store.UpdateOnce(
+		t.Context(), func(tx walletstore.ReadWriteTx) error {
+			return wallet.addRelevantTxFromStore(tx, funding, nil)
+		}, nil,
+	))
+	require.NoError(t, wallet.LabelTransaction(
+		funding.Hash, "comparative funding", false,
+	))
+
+	outpoint84 := wire.OutPoint{Hash: funding.Hash, Index: 0}
+	outpoint86 := wire.OutPoint{Hash: funding.Hash, Index: 1}
+	importedOutpoint := wire.OutPoint{Hash: funding.Hash, Index: 2}
+	lockID := wtxmgr.LockID{0x20}
+	_, err = wallet.LeaseOutput(lockID, outpoint84, time.Hour)
+	require.NoError(t, err)
+
+	checkpoints := []validationTxCheckpoint{
+		validationTransactionCheckpoint(
+			t, wallet, "unconfirmed_leased", funding.Hash,
+			waddrmgr.KeyScopeBIP0084,
+			addresses[waddrmgr.KeyScopeBIP0084],
+		),
+	}
+	fixture.restart([]byte("new-public-pass"), []byte("new-private-pass"))
+	wallet = fixture.wallet
+	checkpoints = append(checkpoints, validationTransactionCheckpoint(
+		t, wallet, "lease_restart", funding.Hash,
+		waddrmgr.KeyScopeBIP0084,
+		addresses[waddrmgr.KeyScopeBIP0084],
+	))
+	require.NoError(t, wallet.ReleaseOutput(lockID, outpoint84))
+
+	block := wtxmgr.BlockMeta{
+		Block: wtxmgr.Block{Hash: chainhash.Hash{0x21}, Height: 1},
+		Time:  time.Unix(1_700_000_200, 0),
+	}
+	require.NoError(t, wallet.store.UpdateOnce(
+		t.Context(), func(tx walletstore.ReadWriteTx) error {
+			if err := wallet.addRelevantTxFromStore(
+				tx, funding, &block,
+			); err != nil {
+
+				return err
+			}
+
+			return wallet.connectBlockFromStore(tx, block)
+		}, nil,
+	))
+	wallet.chainClient = &mockChainClient{getBestBlockHeight: 1}
+	checkpoints = append(checkpoints, validationTransactionCheckpoint(
+		t, wallet, "confirmed", funding.Hash,
+		waddrmgr.KeyScopeBIP0084,
+		addresses[waddrmgr.KeyScopeBIP0084],
+	))
+
+	fixture.restart([]byte("new-public-pass"), []byte("new-private-pass"))
+	wallet = fixture.wallet
+	wallet.chainClient = &mockChainClient{
+		getBlockHeader: &chaincfg.TestNet3Params.GenesisBlock.Header,
+	}
+	wallet.SetChainSynced(true)
+	rewound, err := wallet.disconnectBlockFromStore(wallet.chainClient, block)
+	require.NoError(t, err)
+	require.True(t, rewound)
+	checkpoints = append(checkpoints, validationTransactionCheckpoint(
+		t, wallet, "reorg_after_restart", funding.Hash,
+		waddrmgr.KeyScopeBIP0084,
+		addresses[waddrmgr.KeyScopeBIP0084],
+	))
+
+	fundingDigest := validationFundingScenario(
+		t, wallet, outpoint84, outpoint86, importedOutpoint,
+		fundingScripts, account,
+	)
+	result := validationResult{
+		Semantic: validationSemanticDigest{
+			Lifecycle:   lifecycle,
+			Transaction: checkpoints,
+			Funding:     fundingDigest,
+		},
+	}
+	_, statErr := os.Stat(filepath.Join(fixture.dir, WalletDBName))
+	result.RuntimeKVSidecar = statErr == nil
+
+	payload, err := json.Marshal(result.Semantic)
+	require.NoError(t, err)
+	digest := sha256.Sum256(payload)
+	t.Logf("SEMANTIC_DIGEST backend=%s sha256=%x json=%s", backend,
+		digest, payload)
+	t.Logf("SETUP_OBSERVATION backend=%s runtime_kv_sidecar=%t", backend,
+		result.RuntimeKVSidecar)
+
+	return result
+}
+
+// validationCreationVariants checks extended-key and watch-only restart paths.
+func validationCreationVariants(t *testing.T, backend string,
+	seed []byte) validationLifecycleDigest {
+
+	t.Helper()
+
+	rootKey, err := hdkeychain.NewMaster(seed, &chaincfg.TestNet3Params)
+	require.NoError(t, err)
+	extended := newValidationFixture(
+		t, backend, "extended", func(loader *Loader) (*Wallet, error) {
+			return loader.CreateNewWalletExtendedKey(
+				[]byte("public"), []byte("private"), rootKey,
+				time.Unix(1_700_000_000, 0),
+			)
+		},
+	)
+	extended.wallet.chainClient = &mockChainClient{}
+	require.NoError(t, extended.wallet.Unlock([]byte("private"), nil))
+	extendedAddress, err := extended.wallet.NewAddress(
+		waddrmgr.DefaultAccountNum, waddrmgr.KeyScopeBIP0084,
+	)
+	require.NoError(t, err)
+	extended.restart([]byte("public"), []byte("private"))
+	haveExtended, err := extended.wallet.HaveAddress(extendedAddress)
+	require.NoError(t, err)
+	extended.close()
+	rootKey.Zero()
+
+	watchOnly := newValidationFixture(
+		t, backend, "watch-only", func(loader *Loader) (*Wallet, error) {
+			return loader.CreateNewWatchingOnlyWallet(
+				[]byte("public"), time.Unix(1_700_000_000, 0),
+			)
+		},
+	)
+	unlockStatus := validationError(
+		watchOnly.wallet.Unlock([]byte("private"), nil),
+	)
+	watchOnly.restart([]byte("public"), nil)
+	watchOnlyRestart := watchOnly.wallet.Manager.WatchOnly()
+	watchOnly.close()
+
+	return validationLifecycleDigest{
+		ExtendedKeyRestart: haveExtended,
+		WatchOnlyRestart:   watchOnlyRestart,
+		WatchOnlyUnlock:    unlockStatus,
+	}
+}
+
+// newValidationFixture creates one test wallet using the selected backend.
+func newValidationFixture(t *testing.T, backend, walletName string,
+	create func(*Loader) (*Wallet, error)) *validationFixture {
+
+	t.Helper()
+	return newValidationFixtureForParams(
+		t, backend, walletName, &chaincfg.TestNet3Params, 0, create,
+	)
+}
+
+// newValidationFixtureForParams creates a wallet with explicit chain and
+// recovery settings.
+func newValidationFixtureForParams(t *testing.T, backend, walletName string,
+	params *chaincfg.Params, recovery uint32,
+	create func(*Loader) (*Wallet, error)) *validationFixture {
+
+	t.Helper()
+
+	dir := t.TempDir()
+	fixture := &validationFixture{
+		t:          t,
+		backend:    backend,
+		dir:        dir,
+		dbPath:     filepath.Join(dir, "wallet.sqlite"),
+		walletName: walletName,
+		params:     params,
+		recovery:   recovery,
+	}
+	if backend == "sqlite" {
+		fixture.openSQLite()
+	}
+	fixture.loader = fixture.newLoader()
+	wallet, err := create(fixture.loader)
+	require.NoError(t, err)
+	fixture.wallet = wallet
+
+	return fixture
+}
+
+// newLoader constructs a fresh loader over the fixture's durable backend.
+func (f *validationFixture) newLoader() *Loader {
+	f.t.Helper()
+
+	if f.backend == "kv" {
+		return NewLoader(
+			f.params, f.dir, true, DefaultDBTimeout, f.recovery,
+		)
+	}
+
+	store := dbsqlite.NewNamedStore(f.conn, f.walletName)
+	loader, err := NewLoaderWithStore(f.params, f.recovery, store)
+	require.NoError(f.t, err)
+
+	return loader
+}
+
+// openSQLite opens and migrates the fixture's SQLite database.
+func (f *validationFixture) openSQLite() {
+	f.t.Helper()
+
+	conn, err := storesqlite.Open(context.Background(), storesqlite.Config{
+		DBPath: f.dbPath,
+	})
+	require.NoError(f.t, err)
+	require.NoError(f.t, storesqlite.ApplyMigrations(conn))
+	f.conn = conn
+}
+
+// unload stops the wallet and closes externally owned SQLite connections.
+func (f *validationFixture) unload() {
+	f.t.Helper()
+
+	if f.loader != nil {
+		if _, loaded := f.loader.LoadedWallet(); loaded {
+			require.NoError(f.t, f.loader.UnloadWallet())
+		}
+	}
+	f.wallet = nil
+	f.loader = nil
+	if f.conn != nil {
+		require.NoError(f.t, f.conn.Close())
+		f.conn = nil
+	}
+}
+
+// restart closes and reopens the backend before unlocking the wallet.
+func (f *validationFixture) restart(pubPass, privPass []byte) {
+	f.t.Helper()
+
+	f.unload()
+	if f.backend == "sqlite" {
+		f.openSQLite()
+	}
+	f.loader = f.newLoader()
+	wallet, err := f.loader.OpenExistingWallet(pubPass, false)
+	require.NoError(f.t, err)
+	wallet.chainClient = &mockChainClient{}
+	if privPass != nil {
+		require.NoError(f.t, wallet.Unlock(privPass, nil))
+	}
+	f.wallet = wallet
+}
+
+// close releases any resources still held by the fixture.
+func (f *validationFixture) close() {
+	f.t.Helper()
+	f.unload()
+}
+
+// validationTransactionCheckpoint captures backend-neutral wallet state.
+func validationTransactionCheckpoint(t *testing.T, wallet *Wallet, name string,
+	hash chainhash.Hash, usedScope waddrmgr.KeyScope,
+	usedAddress address.Address) validationTxCheckpoint {
+
+	t.Helper()
+
+	balance, err := wallet.CalculateBalance(0)
+	require.NoError(t, err)
+	unspent, err := wallet.ListUnspent(0, 1_000_000, "")
+	require.NoError(t, err)
+	leases, err := wallet.ListLeasedOutputs()
+	require.NoError(t, err)
+	tx, err := wallet.GetTransaction(hash)
+	require.NoError(t, err)
+	var addressUsed bool
+	err = wallet.store.View(
+		t.Context(), func(tx walletstore.ReadTx) error {
+			state, err := tx.Addr().Address(
+				usedScope, usedAddress.ScriptAddress(),
+			)
+			if err != nil {
+				return err
+			}
+			addressUsed = state.Used
+
+			return nil
+		}, func() {
+			addressUsed = false
+		},
+	)
+	require.NoError(t, err)
+
+	digest := validationTxCheckpoint{
+		Name:         name,
+		Balance:      int64(balance),
+		Leases:       len(leases),
+		TxHeight:     tx.Height,
+		Label:        tx.Summary.Label,
+		AddressUsed:  addressUsed,
+		SyncedHeight: wallet.Manager.SyncedTo().Height,
+	}
+	for _, output := range unspent {
+		digest.Unspent = append(digest.Unspent, fmt.Sprintf(
+			"%d:%d:%s", output.Vout,
+			btcutil.Amount(output.Amount*btcutil.SatoshiPerBitcoin),
+			output.ScriptPubKey,
+		))
+	}
+	sort.Strings(digest.Unspent)
+
+	return digest
+}
+
+// validationFundingScenario records transaction creation, signing, and PSBT
+// behavior without publishing any authored transaction.
+func validationFundingScenario(t *testing.T, wallet *Wallet,
+	outpoint84, outpoint86, importedOutpoint wire.OutPoint,
+	fundingScripts [][]byte, p2wpkhAccount uint32) validationFundingDigest {
+
+	t.Helper()
+
+	destination, err := address.NewAddressWitnessPubKeyHash(
+		bytes.Repeat([]byte{0x05}, 20), &chaincfg.TestNet3Params,
+	)
+	require.NoError(t, err)
+	destinationScript, err := txscript.PayToAddrScript(destination)
+	require.NoError(t, err)
+
+	digest := validationFundingDigest{}
+	dryRun, err := wallet.CreateSimpleTx(
+		&waddrmgr.KeyScopeBIP0084, p2wpkhAccount,
+		[]*wire.TxOut{wire.NewTxOut(100_000, destinationScript)}, 0,
+		1_000, CoinSelectionLargest, true,
+		WithCustomSelectUtxos([]wire.OutPoint{outpoint84}),
+	)
+	digest.DryRunStatus = validationError(err)
+	if dryRun != nil {
+		digest.DryRunInputs = len(dryRun.Tx.TxIn)
+		digest.DryRunSigned = transactionSigned(dryRun.Tx)
+	}
+
+	p2wpkh, err := wallet.CreateSimpleTx(
+		&waddrmgr.KeyScopeBIP0084, p2wpkhAccount,
+		[]*wire.TxOut{wire.NewTxOut(100_000, destinationScript)}, 0,
+		1_000, CoinSelectionLargest, false,
+		WithCustomSelectUtxos([]wire.OutPoint{outpoint84}),
+	)
+	digest.ExplicitP2WPKHStatus = validationError(err)
+	if p2wpkh != nil {
+		digest.ExplicitP2WPKHValid = validateMsgTx(
+			p2wpkh.Tx, p2wpkh.PrevScripts, p2wpkh.PrevInputValues,
+		) == nil
+	}
+
+	p2tr, err := wallet.CreateSimpleTx(
+		&waddrmgr.KeyScopeBIP0086, waddrmgr.DefaultAccountNum,
+		[]*wire.TxOut{wire.NewTxOut(100_000, destinationScript)}, 0,
+		1_000, CoinSelectionLargest, false,
+		WithCustomSelectUtxos([]wire.OutPoint{outpoint86}),
+	)
+	digest.ExplicitP2TRStatus = validationError(err)
+	if p2tr != nil {
+		digest.ExplicitP2TRValid = validateMsgTx(
+			p2tr.Tx, p2tr.PrevScripts, p2tr.PrevInputValues,
+		) == nil
+	}
+
+	importedSpend := wire.NewMsgTx(2)
+	importedSpend.AddTxIn(&wire.TxIn{PreviousOutPoint: importedOutpoint})
+	importedSpend.AddTxOut(wire.NewTxOut(250_000, destinationScript))
+	signErrors, err := wallet.SignTransaction(
+		importedSpend, txscript.SigHashAll, nil, nil, nil,
+	)
+	digest.ImportedSigningStatus = validationError(err)
+	if err == nil && len(signErrors) == 0 {
+		digest.ImportedSigningValid = validateMsgTx(
+			importedSpend, [][]byte{fundingScripts[2]},
+			[]btcutil.Amount{300_000},
+		) == nil
+	}
+
+	inputMetadata := &psbt.Unknown{Key: []byte{0xfc, 0x01}, Value: []byte{1}}
+	outputMetadata := &psbt.Unknown{Key: []byte{0xfc, 0x02}, Value: []byte{2}}
+	packet := &psbt.Packet{
+		UnsignedTx: &wire.MsgTx{
+			Version: 2,
+			TxIn:    []*wire.TxIn{{PreviousOutPoint: outpoint84}},
+			TxOut: []*wire.TxOut{
+				wire.NewTxOut(100_000, destinationScript),
+			},
+		},
+		Inputs:  []psbt.PInput{{Unknowns: []*psbt.Unknown{inputMetadata}}},
+		Outputs: []psbt.POutput{{Unknowns: []*psbt.Unknown{outputMetadata}}},
+	}
+	changeIndex, err := wallet.FundPsbt(
+		packet, &waddrmgr.KeyScopeBIP0084, 0,
+		p2wpkhAccount, 1_000, CoinSelectionLargest,
+	)
+	digest.FundPsbtStatus = validationError(err)
+	if err == nil {
+		digest.CallerInputMetadata = packetHasUnknown(
+			packet.Inputs[0].Unknowns, inputMetadata,
+		)
+		digest.CallerOutputMetadata = packetOutputHasUnknown(
+			packet.Outputs, outputMetadata,
+		)
+		digest.BIP69Outputs = validationOutputsSorted(packet.UnsignedTx.TxOut)
+		if changeIndex >= 0 {
+			digest.PsbtChangeType = validationScriptType(
+				packet.UnsignedTx.TxOut[changeIndex].PkScript,
+			)
+		}
+
+		err = wallet.DecorateInputs(packet, true)
+		digest.DecorateInputsStatus = validationError(err)
+		if err == nil {
+			err = wallet.FinalizePsbt(
+				&waddrmgr.KeyScopeBIP0084,
+				p2wpkhAccount, packet,
+			)
+			digest.FinalizePsbtStatus = validationError(err)
+			if err == nil {
+				finalTx, extractErr := psbt.Extract(packet)
+				if extractErr == nil {
+					digest.PsbtValid = validateMsgTx(
+						finalTx, [][]byte{fundingScripts[0]},
+						[]btcutil.Amount{1_000_000},
+					) == nil
+				}
+			}
+		}
+	}
+
+	return digest
+}
+
+// validationError reduces errors to stable semantic categories.
+func validationError(err error) string {
+	switch {
+	case err == nil:
+		return "ok"
+
+	case waddrmgr.IsError(err, waddrmgr.ErrWrongPassphrase):
+		return "wrong passphrase"
+
+	case waddrmgr.IsError(err, waddrmgr.ErrWatchingOnly):
+		return "watching only"
+
+	default:
+		return err.Error()
+	}
+}
+
+// transactionSigned reports whether any transaction input contains a script.
+func transactionSigned(tx *wire.MsgTx) bool {
+	for _, input := range tx.TxIn {
+		if len(input.SignatureScript) > 0 || len(input.Witness) > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+// packetHasUnknown reports whether one PSBT unknown field remains present.
+func packetHasUnknown(unknowns []*psbt.Unknown, want *psbt.Unknown) bool {
+	for _, unknown := range unknowns {
+		if bytes.Equal(unknown.Key, want.Key) &&
+			bytes.Equal(unknown.Value, want.Value) {
+
+			return true
+		}
+	}
+
+	return false
+}
+
+// packetOutputHasUnknown searches all PSBT outputs for one unknown field.
+func packetOutputHasUnknown(outputs []psbt.POutput, want *psbt.Unknown) bool {
+	for _, output := range outputs {
+		if packetHasUnknown(output.Unknowns, want) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// validationOutputsSorted reports whether outputs use BIP69 value/script order.
+func validationOutputsSorted(outputs []*wire.TxOut) bool {
+	for index := 1; index < len(outputs); index++ {
+		previous := outputs[index-1]
+		current := outputs[index]
+		if previous.Value > current.Value {
+			return false
+		}
+		if previous.Value == current.Value &&
+			bytes.Compare(previous.PkScript, current.PkScript) > 0 {
+
+			return false
+		}
+	}
+
+	return true
+}
+
+// validationScriptType returns a stable name for a standard output script.
+func validationScriptType(script []byte) string {
+	switch {
+	case txscript.IsPayToPubKeyHash(script):
+		return "p2pkh"
+
+	case txscript.IsPayToScriptHash(script):
+		return "p2sh"
+
+	case txscript.IsPayToWitnessPubKeyHash(script):
+		return "p2wpkh"
+
+	case txscript.IsPayToTaproot(script):
+		return "p2tr"
+
+	default:
+		return "other"
+	}
+}

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -24,6 +24,8 @@ import (
 	"github.com/lightningnetwork/lnd/fn/v2"
 )
 
+// makeInputSource creates an input source that consumes eligible coins in
+// their arranged order.
 func makeInputSource(eligible []Coin) txauthor.InputSource {
 	// Current inputs and their total value. These are closed over by the
 	// returned input source and reused across multiple calls.
@@ -88,10 +90,12 @@ func constantInputSource(eligible []wtxmgr.Credit) txauthor.InputSource {
 // secretSource is an implementation of txauthor.SecretSource for the wallet's
 // address manager.
 type secretSource struct {
+	// Manager supplies address and key operations to the secret source.
 	*waddrmgr.Manager
 	addrmgrNs walletdb.ReadBucket
 }
 
+// GetKey returns the wallet private key controlling an address.
 func (s secretSource) GetKey(
 	addr address.Address) (*btcec.PrivateKey, bool, error) {
 
@@ -113,6 +117,7 @@ func (s secretSource) GetKey(
 	return privKey, ma.Compressed(), nil
 }
 
+// GetScript returns the wallet redeem script controlling an address.
 func (s secretSource) GetScript(addr address.Address) ([]byte, error) {
 	ma, err := s.Address(s.addrmgrNs, addr)
 	if err != nil {
@@ -175,6 +180,13 @@ func (w *Wallet) txToOutputs(outputs []*wire.TxOut,
 	// with a lock.
 	w.newAddrMtx.Lock()
 	defer w.newAddrMtx.Unlock()
+	if w.db == nil {
+		return w.txToOutputsFromStore(
+			outputs, coinSelectKeyScope, changeKeyScope, account,
+			minconf, feeSatPerKb, strategy, dryRun, selectedUtxos,
+			allowUtxo, chainClient, bs,
+		)
+	}
 
 	var tx *txauthor.AuthoredTx
 	err = walletdb.Update(w.db, func(dbtx walletdb.ReadWriteTx) error {
@@ -345,6 +357,7 @@ func (w *Wallet) txToOutputs(outputs []*wire.TxOut,
 	return tx, nil
 }
 
+// findEligibleOutputs filters spendable credits through walletdb views.
 func (w *Wallet) findEligibleOutputs(dbtx walletdb.ReadTx,
 	keyScope *waddrmgr.KeyScope, account uint32, minconf int32,
 	bs *waddrmgr.BlockStamp,
@@ -540,10 +553,15 @@ func validateMsgTx(tx *wire.MsgTx, prevScripts [][]byte,
 // sortByAmount is a generic sortable type for sorting coins by their amount.
 type sortByAmount []Coin
 
+// Len returns the number of coins available for sorting.
 func (s sortByAmount) Len() int { return len(s) }
+
+// Less reports whether one coin has a lower value than another.
 func (s sortByAmount) Less(i, j int) bool {
 	return s[i].Value < s[j].Value
 }
+
+// Swap exchanges two coins in the sortable slice.
 func (s sortByAmount) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 
 // LargestFirstCoinSelector is an implementation of the CoinSelectionStrategy

--- a/wallet/fair_sqlite_sync_benchmark_test.go
+++ b/wallet/fair_sqlite_sync_benchmark_test.go
@@ -1,0 +1,1119 @@
+package wallet
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/integration/rpctest"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btcwallet/chain"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	dbsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlite"
+	storesqlite "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite"
+	"github.com/stretchr/testify/require"
+	modernsqlite "modernc.org/sqlite"
+	sqlite3 "modernc.org/sqlite/lib"
+)
+
+const (
+	fairWalletName        = "fair-sqlite-sync"
+	fairPublicPass        = "public-pass"
+	fairPrivatePass       = "private-pass"
+	fairRecoveryWindow    = uint32(100)
+	fairSQLiteConnections = 1
+	fairBaseMatureOutputs = uint32(10)
+	fairSparsePayments    = 10
+	fairPaymentAmount     = int64(100_000)
+	fairPollInterval      = 5 * time.Millisecond
+	fairSyncTimeout       = 10 * time.Minute
+	fairSQLiteFileMarker  = "fair-sync-"
+)
+
+var fairSeed = [32]byte{
+	0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+	0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+	0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+	0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+}
+
+var fairSQLiteHookOnce sync.Once
+
+// fairExpectedState describes the wallet semantics a workload must produce.
+type fairExpectedState struct {
+	Transactions int   `json:"transactions"`
+	UTXOs        int   `json:"utxos"`
+	Balance      int64 `json:"balance"`
+}
+
+// fairWorkloadOutput describes one deterministic wallet payment in the chain.
+type fairWorkloadOutput struct {
+	BlockOffset int    `json:"block_offset"`
+	PkScript    string `json:"pk_script"`
+	Amount      int64  `json:"amount"`
+}
+
+// fairWorkloadShape commits to chain shape without committing to block hashes.
+type fairWorkloadShape struct {
+	Blocks         int                  `json:"blocks"`
+	PaymentOutputs []fairWorkloadOutput `json:"payment_outputs"`
+	ExpectedWallet fairExpectedState    `json:"expected_wallet"`
+}
+
+// fairUTXOIdentity is the stable outpoint and amount identity of one UTXO.
+type fairUTXOIdentity struct {
+	OutPoint string `json:"outpoint"`
+	Amount   int64  `json:"amount"`
+}
+
+// fairSyncSemantic is the complete public wallet state committed by one sync.
+type fairSyncSemantic struct {
+	TargetHeight   int32              `json:"target_height"`
+	TargetHash     string             `json:"target_hash"`
+	TransactionIDs []string           `json:"transaction_ids"`
+	UTXOs          []fairUTXOIdentity `json:"utxos"`
+	Balance        int64              `json:"balance"`
+	WorkloadDigest string             `json:"workload_digest"`
+}
+
+// fairHashIndependentSemantic omits all chain-derived hash identities.
+type fairHashIndependentSemantic struct {
+	TargetHeight   int32   `json:"target_height"`
+	Transactions   int     `json:"transactions"`
+	UTXOAmounts    []int64 `json:"utxo_amounts"`
+	Balance        int64   `json:"balance"`
+	WorkloadDigest string  `json:"workload_digest"`
+}
+
+// fairDigestPair contains hash-specific and hash-independent state digests.
+type fairDigestPair struct {
+	semantic        [sha256.Size]byte
+	hashIndependent [sha256.Size]byte
+}
+
+// fairSQLitePragmas records the effective settings of an independent open.
+type fairSQLitePragmas struct {
+	journalMode    string
+	foreignKeys    int
+	busyTimeout    int
+	synchronous    int
+	fullFSync      int
+	autoVacuum     int
+	txLock         string
+	maxConnections int
+}
+
+// fairSyncFixture owns one btcd node and one closed base database snapshot.
+type fairSyncFixture struct {
+	miner        *rpctest.Harness
+	snapshotPath string
+	base         waddrmgr.BlockStamp
+	target       waddrmgr.BlockStamp
+	expected     fairExpectedState
+	workload     [sha256.Size]byte
+	pragmas      fairSQLitePragmas
+}
+
+// fairWalletHandle owns one opened wallet, SQLite pool, and chain client.
+type fairWalletHandle struct {
+	wallet *Wallet
+	conn   *sql.DB
+	client *chain.RPCClient
+}
+
+// fairMemoryDelta accumulates process allocation counters over timed regions.
+type fairMemoryDelta struct {
+	mallocs    uint64
+	totalAlloc uint64
+}
+
+// BenchmarkFairSQLiteSync measures equivalent SQLite lifecycle and full-block
+// synchronization boundaries against a real btcd regtest node.
+func BenchmarkFairSQLiteSync(b *testing.B) {
+	fairUseFastScrypt(b)
+	fairConfigureSQLiteConnections()
+	b.Log("busy/retry counters are not reported because internal retry " +
+		"counts are not comparably exposed; every returned error fails " +
+		"the sample")
+
+	b.Run("OpenOnly", benchmarkFairOpenOnly)
+	b.Run("ActivationOneBlock", benchmarkFairActivationOneBlock)
+
+	b.Run("Backlog", func(b *testing.B) {
+		b.Run("Empty", func(b *testing.B) {
+			for _, blocks := range []int{100, 1000, 10000} {
+				b.Run(fmt.Sprintf("Blocks-%d", blocks),
+					func(b *testing.B) {
+
+						benchmarkFairBacklog(
+							b, blocks, false, false,
+						)
+					})
+			}
+		})
+
+		b.Run("Sparse10", func(b *testing.B) {
+			b.Run("Blocks-1000", func(b *testing.B) {
+				benchmarkFairBacklog(b, 1000, true, false)
+			})
+		})
+	})
+
+	b.Run("ColdOpenBacklog", func(b *testing.B) {
+		b.Run("Empty", func(b *testing.B) {
+			for _, blocks := range []int{100, 1000, 10000} {
+				b.Run(fmt.Sprintf("Blocks-%d", blocks),
+					func(b *testing.B) {
+
+						benchmarkFairBacklog(
+							b, blocks, false, true,
+						)
+					})
+			}
+		})
+	})
+}
+
+// fairConfigureSQLiteConnections pins connection-local settings that the role
+// configuration cannot expose without changing production code.
+func fairConfigureSQLiteConnections() {
+	fairSQLiteHookOnce.Do(func() {
+		modernsqlite.RegisterConnectionHook(func(
+			conn modernsqlite.ExecQuerierContext, dsn string) error {
+
+			if !strings.Contains(dsn, fairSQLiteFileMarker) {
+				return nil
+			}
+
+			_, err := conn.ExecContext(
+				context.Background(), "PRAGMA synchronous=normal; "+
+					"PRAGMA fullfsync=false; "+
+					"PRAGMA auto_vacuum=none", nil,
+			)
+
+			return err
+		})
+	})
+}
+
+// fairUseFastScrypt pins identical low-cost KDF settings for benchmark wallets.
+func fairUseFastScrypt(b *testing.B) {
+	b.Helper()
+	defaultOptions := waddrmgr.DefaultScryptOptions
+	waddrmgr.DefaultScryptOptions = waddrmgr.FastScryptOptions
+	b.Cleanup(func() {
+		waddrmgr.DefaultScryptOptions = defaultOptions
+	})
+}
+
+// benchmarkFairOpenOnly measures only loading a closed, already-synced SQLite
+// snapshot into an unstarted wallet object.
+func benchmarkFairOpenOnly(b *testing.B) {
+	b.StopTimer()
+	b.Log("scope=route-specific lifecycle latency; not cross-route " +
+		"throughput")
+	fixture := newFairSyncFixture(b, 0, false)
+	baseSize := fairFileSize(b, fixture.snapshotPath)
+
+	var (
+		digest      fairDigestPair
+		digestSet   bool
+		totalGrowth int64
+	)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		dbPath := fairIterationPath(b, i)
+		fairCopySnapshot(b, fixture.snapshotPath, dbPath)
+		client := fairNewChainClient(b, fixture.miner)
+
+		b.StartTimer()
+		handle, err := fairOpenWallet(dbPath, client)
+		b.StopTimer()
+		if err != nil {
+			fairStopChainClient(client)
+		}
+		require.NoError(b, err)
+
+		fairRequireUnsynced(b, handle.wallet)
+		require.NoError(b, fairActivateWallet(b.Context(), handle))
+		require.NoError(b, fairWaitForMemorySync(handle.wallet))
+		fairRequireTip(b, handle.wallet, fixture.target)
+		gotDigest := fairValidateState(
+			b, handle.wallet, fixture.target, fixture.expected,
+			fixture.workload,
+		)
+		fairAccumulateDigests(b, &digest, &digestSet, gotDigest)
+
+		require.NoError(b, fairCloseWallet(handle))
+		gotPragmas := fairVerifySQLitePragmas(b, dbPath)
+		require.Equal(b, fixture.pragmas, gotPragmas)
+		totalGrowth += fairFileSize(b, dbPath) - baseSize
+		fairRequireClosedSQLite(b, dbPath)
+	}
+
+	b.ReportMetric(
+		float64(totalGrowth)/float64(b.N), "db-growth-bytes",
+	)
+	fairLogDigests(
+		b, digest, fixture.target, fixture.expected, fixture.workload,
+	)
+	fairLogSQLitePragmas(b, fixture.pragmas)
+}
+
+// benchmarkFairActivationOneBlock measures activation through a guaranteed
+// unsynced-to-synced in-memory transition over one block.
+func benchmarkFairActivationOneBlock(b *testing.B) {
+	b.StopTimer()
+	b.Log("scope=route-specific activation latency; not cross-route " +
+		"throughput")
+	fixture := newFairSyncFixture(b, 1, false)
+	baseSize := fairFileSize(b, fixture.snapshotPath)
+
+	var (
+		digest      fairDigestPair
+		digestSet   bool
+		totalGrowth int64
+	)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		dbPath := fairIterationPath(b, i)
+		fairCopySnapshot(b, fixture.snapshotPath, dbPath)
+		client := fairNewChainClient(b, fixture.miner)
+		handle, err := fairOpenWallet(dbPath, client)
+		require.NoError(b, err)
+		fairRequireTip(b, handle.wallet, fixture.base)
+		fairRequireUnsynced(b, handle.wallet)
+
+		b.StartTimer()
+		err = fairActivateWallet(b.Context(), handle)
+		if err == nil {
+			err = fairWaitForMemorySync(handle.wallet)
+		}
+		b.StopTimer()
+		require.NoError(b, err)
+
+		fairRequireTip(b, handle.wallet, fixture.target)
+		gotDigest := fairValidateState(
+			b, handle.wallet, fixture.target, fixture.expected,
+			fixture.workload,
+		)
+		fairAccumulateDigests(b, &digest, &digestSet, gotDigest)
+
+		require.NoError(b, fairCloseWallet(handle))
+		gotPragmas := fairVerifySQLitePragmas(b, dbPath)
+		require.Equal(b, fixture.pragmas, gotPragmas)
+		totalGrowth += fairFileSize(b, dbPath) - baseSize
+		fairRequireClosedSQLite(b, dbPath)
+	}
+
+	b.ReportMetric(
+		float64(totalGrowth)/float64(b.N), "db-growth-bytes",
+	)
+	fairLogDigests(
+		b, digest, fixture.target, fixture.expected, fixture.workload,
+	)
+	fairLogSQLitePragmas(b, fixture.pragmas)
+}
+
+// benchmarkFairBacklog measures activation and exact-tip catch-up from one
+// closed base snapshot. Cold samples include the database open in the timer.
+func benchmarkFairBacklog(b *testing.B, blocks int, sparse, cold bool) {
+	b.StopTimer()
+	if cold {
+		b.Log("scope=route-specific open+activation+sync lifecycle " +
+			"latency; not cross-route throughput")
+	} else {
+		b.Log("scope=strict cross-route sync-throughput comparison")
+	}
+	fixture := newFairSyncFixture(b, blocks, sparse)
+	baseSize := fairFileSize(b, fixture.snapshotPath)
+
+	var (
+		digest       fairDigestPair
+		digestSet    bool
+		totalElapsed time.Duration
+		totalGrowth  int64
+		memory       fairMemoryDelta
+	)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		dbPath := fairIterationPath(b, i)
+		fairCopySnapshot(b, fixture.snapshotPath, dbPath)
+		client := fairNewChainClient(b, fixture.miner)
+
+		var handle *fairWalletHandle
+		if !cold {
+			var err error
+			handle, err = fairOpenWallet(dbPath, client)
+			require.NoError(b, err)
+			fairRequireTip(b, handle.wallet, fixture.base)
+			fairRequireUnsynced(b, handle.wallet)
+		}
+
+		var before runtime.MemStats
+		if !cold {
+			runtime.GC()
+			runtime.ReadMemStats(&before)
+		}
+
+		b.StartTimer()
+		started := time.Now()
+		var err error
+		if cold {
+			handle, err = fairOpenWallet(dbPath, client)
+			if err == nil {
+				err = fairCheckUnsynced(handle.wallet)
+			}
+		}
+		if err == nil {
+			err = fairActivateWallet(b.Context(), handle)
+		}
+		if err == nil {
+			err = fairWaitForMemorySync(handle.wallet)
+		}
+		totalElapsed += time.Since(started)
+		b.StopTimer()
+		if err != nil && handle == nil {
+			fairStopChainClient(client)
+		}
+		require.NoError(b, err)
+
+		if !cold {
+			var after runtime.MemStats
+			runtime.ReadMemStats(&after)
+			memory.mallocs += after.Mallocs - before.Mallocs
+			memory.totalAlloc += after.TotalAlloc - before.TotalAlloc
+		}
+
+		fairRequireTip(b, handle.wallet, fixture.target)
+		gotDigest := fairValidateState(
+			b, handle.wallet, fixture.target, fixture.expected,
+			fixture.workload,
+		)
+		fairAccumulateDigests(b, &digest, &digestSet, gotDigest)
+
+		require.NoError(b, fairCloseWallet(handle))
+		gotPragmas := fairVerifySQLitePragmas(b, dbPath)
+		require.Equal(b, fixture.pragmas, gotPragmas)
+		totalGrowth += fairFileSize(b, dbPath) - baseSize
+		fairRequireClosedSQLite(b, dbPath)
+	}
+
+	b.ReportMetric(
+		float64(totalGrowth)/float64(b.N), "db-growth-bytes",
+	)
+	if !cold {
+		fairReportBlockMetrics(
+			b, blocks, totalElapsed, memory,
+		)
+	}
+	fairLogDigests(
+		b, digest, fixture.target, fixture.expected, fixture.workload,
+	)
+	fairLogSQLitePragmas(b, fixture.pragmas)
+}
+
+// newFairSyncFixture creates, syncs, closes, and snapshots a deterministic
+// SQLite wallet before mining the requested deterministic backlog.
+func newFairSyncFixture(b *testing.B, blocks int,
+	sparse bool) *fairSyncFixture {
+
+	b.Helper()
+	params := &chaincfg.RegressionNetParams
+	miner, err := rpctest.New(params, nil, []string{
+		"--txindex",
+		"--minrelaytxfee=0.00000001",
+	}, "")
+	require.NoError(b, err)
+	require.NoError(b, miner.SetUp(true, fairBaseMatureOutputs))
+	b.Cleanup(func() {
+		require.NoError(b, miner.TearDown())
+	})
+
+	base := fairMinerTip(b, miner)
+	dir := b.TempDir()
+	livePath := filepath.Join(dir, fairSQLiteFileMarker+"live.sqlite")
+	fairPrepareSQLiteFile(b, livePath)
+	preparedPragmas := fairVerifySQLitePragmas(b, livePath)
+	fairRequireClosedSQLite(b, livePath)
+	loader, err := NewSQLiteLoader(
+		b.Context(), params, fairRecoveryWindow,
+		fairSQLiteLoaderConfig(livePath),
+		WithWalletSyncRetryInterval(10*time.Millisecond),
+	)
+	require.NoError(b, err)
+	wallet, err := loader.CreateNewWallet(
+		[]byte(fairPublicPass), []byte(fairPrivatePass), fairSeed[:],
+		params.GenesisBlock.Header.Timestamp,
+	)
+	require.NoError(b, err)
+	client := fairNewChainClient(b, miner)
+	wallet.SynchronizeRPC(client)
+	require.NoError(b, fairWaitForMemorySync(wallet))
+	fairRequireTip(b, wallet, base)
+
+	addresses := fairAllocateSparseAddresses(b, wallet, sparse)
+	empty := fairExpectedState{}
+	baseWorkload := fairWorkloadDigest(b, fairWorkloadShape{
+		ExpectedWallet: empty,
+	})
+	fairValidateState(b, wallet, base, empty, baseWorkload)
+	require.NoError(b, loader.UnloadWallet())
+	fairStopChainClient(client)
+	livePragmas := fairVerifySQLitePragmas(b, livePath)
+	require.Equal(b, preparedPragmas, livePragmas)
+	fairRequireClosedSQLite(b, livePath)
+
+	snapshotPath := filepath.Join(dir, fairSQLiteFileMarker+"base.sqlite")
+	fairCopySnapshot(b, livePath, snapshotPath)
+	snapshotPragmas := fairVerifySQLitePragmas(b, snapshotPath)
+	require.Equal(b, livePragmas, snapshotPragmas)
+	fairRequireClosedSQLite(b, snapshotPath)
+
+	expected := fairExpectedState{}
+	if sparse {
+		expected.Transactions = fairSparsePayments
+		expected.UTXOs = fairSparsePayments
+		expected.Balance = fairPaymentAmount * fairSparsePayments
+	}
+	workloadShape := fairMineBacklog(
+		b, miner, blocks, addresses, expected,
+	)
+	workload := fairWorkloadDigest(b, workloadShape)
+	target := fairMinerTip(b, miner)
+	require.Equal(b, base.Height+int32(blocks), target.Height)
+
+	return &fairSyncFixture{
+		miner:        miner,
+		snapshotPath: snapshotPath,
+		base:         base,
+		target:       target,
+		expected:     expected,
+		workload:     workload,
+		pragmas:      snapshotPragmas,
+	}
+}
+
+// fairSQLiteLoaderConfig returns the common SQLite connection and pragma
+// settings used to create the base wallet.
+func fairSQLiteLoaderConfig(dbPath string) SQLiteLoaderConfig {
+	return SQLiteLoaderConfig{
+		DBPath:             dbPath,
+		WalletName:         fairWalletName,
+		BusyTimeout:        5 * time.Second,
+		MaxConnections:     fairSQLiteConnections,
+		MaxIdleConnections: fairSQLiteConnections,
+		Pragmas: []string{
+			"synchronous=normal",
+			"fullfsync=false",
+			"auto_vacuum=none",
+		},
+	}
+}
+
+// fairSQLiteStoreConfig returns matching settings for snapshot opens.
+func fairSQLiteStoreConfig(dbPath string) storesqlite.Config {
+	loaderConfig := fairSQLiteLoaderConfig(dbPath)
+
+	return storesqlite.Config{
+		DBPath:             loaderConfig.DBPath,
+		BusyTimeout:        loaderConfig.BusyTimeout,
+		MaxConnections:     loaderConfig.MaxConnections,
+		MaxIdleConnections: loaderConfig.MaxIdleConnections,
+		Pragmas:            loaderConfig.Pragmas,
+	}
+}
+
+// fairOpenWallet opens one copied SQLite snapshot without starting sync.
+func fairOpenWallet(dbPath string,
+	client *chain.RPCClient) (*fairWalletHandle, error) {
+
+	conn, err := storesqlite.Open(
+		context.Background(), fairSQLiteStoreConfig(dbPath),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := storesqlite.ApplyMigrations(conn); err != nil {
+		_ = conn.Close()
+
+		return nil, err
+	}
+
+	store := dbsqlite.NewNamedStore(conn, fairWalletName)
+	wallet, err := OpenFromStore(
+		store, []byte(fairPublicPass), &chaincfg.RegressionNetParams,
+		fairRecoveryWindow, 10*time.Millisecond,
+	)
+	if err != nil {
+		_ = conn.Close()
+
+		return nil, err
+	}
+
+	return &fairWalletHandle{
+		wallet: wallet,
+		conn:   conn,
+		client: client,
+	}, nil
+}
+
+// fairActivateWallet performs the minimum candidate runtime activation needed
+// to begin synchronization.
+func fairActivateWallet(_ context.Context, handle *fairWalletHandle) error {
+	handle.wallet.Start()
+	handle.wallet.SynchronizeRPC(handle.client)
+
+	return nil
+}
+
+// fairCloseWallet cleanly stops the wallet, SQLite pool, and client outside
+// timing.
+func fairCloseWallet(handle *fairWalletHandle) error {
+	handle.wallet.Stop()
+	handle.wallet.WaitForShutdown()
+	fairStopChainClient(handle.client)
+
+	return handle.conn.Close()
+}
+
+// fairNewChainClient constructs and starts one btcd RPC client outside timing.
+func fairNewChainClient(tb testing.TB,
+	miner *rpctest.Harness) *chain.RPCClient {
+
+	tb.Helper()
+	rpcConfig := miner.RPCConfig()
+	client, err := chain.NewRPCClientWithConfig(&chain.RPCClientConfig{
+		Conn:              &rpcConfig,
+		Chain:             &chaincfg.RegressionNetParams,
+		ReconnectAttempts: 3,
+	})
+	require.NoError(tb, err)
+	require.NoError(tb, client.Start(tb.Context()))
+
+	return client
+}
+
+// fairStopChainClient stops one client and waits for all of its goroutines.
+func fairStopChainClient(client *chain.RPCClient) {
+	client.Stop()
+	client.WaitForShutdown()
+}
+
+// fairAllocateSparseAddresses uses the public wallet API to create ten fixed
+// BIP84 addresses and verifies their seed-derived identity.
+func fairAllocateSparseAddresses(b *testing.B, wallet *Wallet,
+	sparse bool) []address.Address {
+
+	b.Helper()
+	if !sparse {
+		return nil
+	}
+
+	addresses := make([]address.Address, 0, fairSparsePayments)
+	for i := 0; i < fairSparsePayments; i++ {
+		addr, err := wallet.NewAddress(
+			waddrmgr.DefaultAccountNum, waddrmgr.KeyScopeBIP0084,
+		)
+		require.NoError(b, err)
+		require.Equal(
+			b, fairExpectedAddress(b, uint32(i)).String(),
+			addr.String(),
+		)
+		addresses = append(addresses, addr)
+	}
+
+	return addresses
+}
+
+// fairExpectedAddress derives one BIP84 external address from the shared seed.
+func fairExpectedAddress(tb testing.TB, index uint32) address.Address {
+	tb.Helper()
+	params := &chaincfg.RegressionNetParams
+	key, err := hdkeychain.NewMaster(fairSeed[:], params)
+	require.NoError(tb, err)
+	defer key.Zero()
+
+	for _, child := range []uint32{
+		waddrmgr.KeyScopeBIP0084.Purpose + hdkeychain.HardenedKeyStart,
+		waddrmgr.KeyScopeBIP0084.Coin + hdkeychain.HardenedKeyStart,
+		hdkeychain.HardenedKeyStart, 0, index,
+	} {
+		key, err = key.Derive(child)
+		require.NoError(tb, err)
+	}
+
+	pubKey, err := key.ECPubKey()
+	require.NoError(tb, err)
+	addr, err := address.NewAddressWitnessPubKeyHash(
+		address.Hash160(pubKey.SerializeCompressed()), params,
+	)
+	require.NoError(tb, err)
+
+	return addr
+}
+
+// fairMineBacklog mines empty blocks or ten evenly spaced wallet payments and
+// returns a hash-independent description of the resulting workload.
+func fairMineBacklog(b *testing.B, miner *rpctest.Harness, blocks int,
+	addresses []address.Address,
+	expected fairExpectedState) fairWorkloadShape {
+
+	b.Helper()
+	shape := fairWorkloadShape{
+		Blocks:         blocks,
+		ExpectedWallet: expected,
+	}
+	if blocks == 0 {
+		return shape
+	}
+	if len(addresses) == 0 {
+		_, err := miner.Client.Generate(uint32(blocks))
+		require.NoError(b, err)
+
+		return shape
+	}
+
+	require.Len(b, addresses, fairSparsePayments)
+	require.Zero(b, blocks%len(addresses))
+	stride := blocks / len(addresses)
+	for i, addr := range addresses {
+		if stride > 1 {
+			_, err := miner.Client.Generate(uint32(stride - 1))
+			require.NoError(b, err)
+		}
+
+		pkScript, err := txscript.PayToAddrScript(addr)
+		require.NoError(b, err)
+		shape.PaymentOutputs = append(
+			shape.PaymentOutputs, fairWorkloadOutput{
+				BlockOffset: (i + 1) * stride,
+				PkScript:    fmt.Sprintf("%x", pkScript),
+				Amount:      fairPaymentAmount,
+			},
+		)
+		_, err = miner.SendOutputs(
+			[]*wire.TxOut{wire.NewTxOut(
+				fairPaymentAmount, pkScript,
+			)}, 1,
+		)
+		require.NoError(b, err)
+		_, err = miner.Client.Generate(1)
+		require.NoError(b, err)
+	}
+
+	return shape
+}
+
+// fairMinerTip returns the exact current btcd hash and height.
+func fairMinerTip(tb testing.TB,
+	miner *rpctest.Harness) waddrmgr.BlockStamp {
+
+	tb.Helper()
+	hash, height, err := miner.Client.GetBestBlock()
+	require.NoError(tb, err)
+
+	return waddrmgr.BlockStamp{Hash: *hash, Height: height}
+}
+
+// fairCheckUnsynced verifies that a sample has not already reached the synced
+// state.
+func fairCheckUnsynced(wallet *Wallet) error {
+	if wallet.ChainSynced() {
+		return errors.New("wallet unexpectedly started in synced state")
+	}
+
+	return nil
+}
+
+// fairRequireUnsynced requires an in-memory unsynced state before activation.
+func fairRequireUnsynced(tb testing.TB, wallet *Wallet) {
+	tb.Helper()
+	require.NoError(tb, fairCheckUnsynced(wallet))
+}
+
+// fairWaitForMemorySync polls only ChainSynced until synchronization completes.
+func fairWaitForMemorySync(wallet *Wallet) error {
+	deadline := time.NewTimer(fairSyncTimeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(fairPollInterval)
+	defer ticker.Stop()
+
+	for {
+		if wallet.ChainSynced() {
+			return nil
+		}
+
+		select {
+		case <-ticker.C:
+
+		case <-deadline.C:
+			return errors.New("wallet in-memory sync timeout")
+		}
+	}
+}
+
+// fairRequireTip checks one exact stored hash and height without waiting.
+func fairRequireTip(tb testing.TB, wallet *Wallet,
+	target waddrmgr.BlockStamp) {
+
+	tb.Helper()
+	stamp := wallet.SyncedTo()
+	require.Equal(tb, target.Height, stamp.Height)
+	require.Equal(tb, target.Hash, stamp.Hash)
+}
+
+// fairValidateState reads transaction, UTXO, and balance semantics only through
+// public wallet APIs and returns full and hash-independent digests.
+func fairValidateState(tb testing.TB, wallet *Wallet,
+	target waddrmgr.BlockStamp, expected fairExpectedState,
+	workload [sha256.Size]byte) fairDigestPair {
+
+	tb.Helper()
+
+	transactions, err := wallet.GetTransactions(
+		NewBlockIdentifierFromHeight(0),
+		NewBlockIdentifierFromHeight(target.Height), "", nil,
+	)
+	require.NoError(tb, err)
+	txIDs := make([]string, 0, expected.Transactions)
+	for _, transaction := range transactions.UnminedTransactions {
+		require.NotNil(tb, transaction.Hash)
+		txIDs = append(txIDs, transaction.Hash.String())
+	}
+	for _, block := range transactions.MinedTransactions {
+		for _, transaction := range block.Transactions {
+			require.NotNil(tb, transaction.Hash)
+			txIDs = append(txIDs, transaction.Hash.String())
+		}
+	}
+	sort.Strings(txIDs)
+
+	utxos, err := wallet.UnspentOutputs(OutputSelectionPolicy{
+		Account:               waddrmgr.DefaultAccountNum,
+		RequiredConfirmations: 1,
+	})
+	require.NoError(tb, err)
+	utxoIDs := make([]fairUTXOIdentity, 0, len(utxos))
+	for _, utxo := range utxos {
+		utxoIDs = append(utxoIDs, fairUTXOIdentity{
+			OutPoint: fmt.Sprintf(
+				"%s:%d", utxo.OutPoint.Hash, utxo.OutPoint.Index,
+			),
+			Amount: utxo.Output.Value,
+		})
+	}
+	sort.Slice(utxoIDs, func(i, j int) bool {
+		if utxoIDs[i].OutPoint == utxoIDs[j].OutPoint {
+			return utxoIDs[i].Amount < utxoIDs[j].Amount
+		}
+
+		return utxoIDs[i].OutPoint < utxoIDs[j].OutPoint
+	})
+
+	balance, err := wallet.CalculateBalance(1)
+	require.NoError(tb, err)
+	require.Len(tb, txIDs, expected.Transactions)
+	require.Len(tb, utxoIDs, expected.UTXOs)
+	require.Equal(tb, expected.Balance, int64(balance))
+
+	actual := fairSyncSemantic{
+		TargetHeight:   target.Height,
+		TargetHash:     target.Hash.String(),
+		TransactionIDs: txIDs,
+		UTXOs:          utxoIDs,
+		Balance:        int64(balance),
+		WorkloadDigest: fmt.Sprintf("%x", workload),
+	}
+	payload, err := json.Marshal(actual)
+	require.NoError(tb, err)
+
+	utxoAmounts := make([]int64, 0, len(utxoIDs))
+	for _, utxo := range utxoIDs {
+		utxoAmounts = append(utxoAmounts, utxo.Amount)
+	}
+	sort.Slice(utxoAmounts, func(i, j int) bool {
+		return utxoAmounts[i] < utxoAmounts[j]
+	})
+	hashIndependent := fairHashIndependentSemantic{
+		TargetHeight:   target.Height,
+		Transactions:   len(txIDs),
+		UTXOAmounts:    utxoAmounts,
+		Balance:        int64(balance),
+		WorkloadDigest: fmt.Sprintf("%x", workload),
+	}
+	independentPayload, err := json.Marshal(hashIndependent)
+	require.NoError(tb, err)
+
+	return fairDigestPair{
+		semantic:        sha256.Sum256(payload),
+		hashIndependent: sha256.Sum256(independentPayload),
+	}
+}
+
+// fairWorkloadDigest hashes one deterministic, hash-independent workload shape.
+func fairWorkloadDigest(tb testing.TB,
+	shape fairWorkloadShape) [sha256.Size]byte {
+
+	tb.Helper()
+	payload, err := json.Marshal(shape)
+	require.NoError(tb, err)
+
+	return sha256.Sum256(payload)
+}
+
+// fairAccumulateDigests requires every sample to produce identical semantics.
+func fairAccumulateDigests(tb testing.TB, digest *fairDigestPair,
+	digestSet *bool, got fairDigestPair) {
+
+	tb.Helper()
+	if !*digestSet {
+		*digest = got
+		*digestSet = true
+
+		return
+	}
+
+	require.Equal(tb, *digest, got)
+}
+
+// fairLogDigests records full, hash-independent, and workload digests.
+func fairLogDigests(b *testing.B, digest fairDigestPair,
+	target waddrmgr.BlockStamp, expected fairExpectedState,
+	workload [sha256.Size]byte) {
+
+	b.Helper()
+	b.Logf("semantic-digest=%x hash-independent-digest=%x "+
+		"workload-digest=%x target=%d:%s txs=%d utxos=%d balance=%d",
+		digest.semantic, digest.hashIndependent, workload, target.Height,
+		target.Hash, expected.Transactions, expected.UTXOs,
+		expected.Balance)
+}
+
+// fairReportBlockMetrics reports throughput and process allocation deltas only
+// for warm-open backlog rows.
+func fairReportBlockMetrics(b *testing.B, blocks int,
+	elapsed time.Duration, memory fairMemoryDelta) {
+
+	b.Helper()
+	totalBlocks := float64(blocks * b.N)
+	b.ReportMetric(totalBlocks/elapsed.Seconds(), "blocks/s")
+	b.ReportMetric(
+		elapsed.Seconds()*1_000_000/totalBlocks, "us/block",
+	)
+	b.ReportMetric(float64(memory.totalAlloc)/totalBlocks, "bytes/block")
+	b.ReportMetric(float64(memory.mallocs)/totalBlocks, "allocs/block")
+}
+
+// fairSQLiteRoleDSN returns the role route's SQLite DSN settings.
+func fairSQLiteRoleDSN(dbPath string, busyTimeout int) string {
+	options := url.Values{}
+	for _, pragma := range []string{
+		"foreign_keys=on",
+		"journal_mode=WAL",
+		fmt.Sprintf("busy_timeout=%d", busyTimeout),
+	} {
+		options.Add("_pragma", pragma)
+	}
+
+	return fmt.Sprintf(
+		"%s?%s&_txlock=immediate&_time_format=sqlite", dbPath,
+		options.Encode(),
+	)
+}
+
+// fairPrepareSQLiteFile creates a role-configured database before the salvage
+// opener can persist its incompatible incremental auto-vacuum default.
+func fairPrepareSQLiteFile(tb testing.TB, dbPath string) {
+	tb.Helper()
+	conn, err := sql.Open("sqlite", fairSQLiteRoleDSN(dbPath, 5000))
+	require.NoError(tb, err)
+	conn.SetMaxOpenConns(fairSQLiteConnections)
+	conn.SetMaxIdleConns(fairSQLiteConnections)
+	require.NoError(tb, conn.PingContext(tb.Context()))
+	require.NoError(tb, conn.Close())
+}
+
+// fairSQLiteVerificationDSN reproduces the salvage opener's defaults followed
+// by the benchmark overrides on an independent connection.
+func fairSQLiteVerificationDSN(dbPath string, busyTimeout int) string {
+	options := url.Values{}
+	for _, pragma := range []string{
+		"foreign_keys=on",
+		"journal_mode=WAL",
+		fmt.Sprintf("busy_timeout=%d", busyTimeout),
+		"synchronous=full",
+		"fullfsync=true",
+		"auto_vacuum=incremental",
+		"synchronous=normal",
+		"fullfsync=false",
+		"auto_vacuum=none",
+	} {
+		options.Add("_pragma", pragma)
+	}
+
+	return fmt.Sprintf(
+		"%s?%s&_txlock=immediate&_time_format=sqlite", dbPath,
+		options.Encode(),
+	)
+}
+
+// fairVerifySQLitePragmas checks effective settings and proves that BEGIN uses
+// an immediate write lock on a closed candidate database.
+func fairVerifySQLitePragmas(tb testing.TB,
+	dbPath string) fairSQLitePragmas {
+
+	tb.Helper()
+	conn, err := sql.Open(
+		"sqlite", fairSQLiteVerificationDSN(dbPath, 5000),
+	)
+	require.NoError(tb, err)
+	conn.SetMaxOpenConns(fairSQLiteConnections)
+	conn.SetMaxIdleConns(fairSQLiteConnections)
+	require.NoError(tb, conn.PingContext(tb.Context()))
+
+	result := fairSQLitePragmas{
+		txLock:         "immediate",
+		maxConnections: conn.Stats().MaxOpenConnections,
+	}
+	require.NoError(tb, conn.QueryRowContext(
+		tb.Context(), "PRAGMA journal_mode",
+	).Scan(&result.journalMode))
+	require.NoError(tb, conn.QueryRowContext(
+		tb.Context(), "PRAGMA foreign_keys",
+	).Scan(&result.foreignKeys))
+	require.NoError(tb, conn.QueryRowContext(
+		tb.Context(), "PRAGMA busy_timeout",
+	).Scan(&result.busyTimeout))
+	require.NoError(tb, conn.QueryRowContext(
+		tb.Context(), "PRAGMA synchronous",
+	).Scan(&result.synchronous))
+	require.NoError(tb, conn.QueryRowContext(
+		tb.Context(), "PRAGMA fullfsync",
+	).Scan(&result.fullFSync))
+	require.NoError(tb, conn.QueryRowContext(
+		tb.Context(), "PRAGMA auto_vacuum",
+	).Scan(&result.autoVacuum))
+
+	require.Equal(tb, "wal", result.journalMode)
+	require.Equal(tb, 1, result.foreignKeys)
+	require.Equal(tb, 5000, result.busyTimeout)
+	require.Equal(tb, 1, result.synchronous)
+	require.Zero(tb, result.fullFSync)
+	require.Zero(tb, result.autoVacuum)
+	require.Equal(tb, fairSQLiteConnections, result.maxConnections)
+
+	contender, err := sql.Open(
+		"sqlite", fairSQLiteVerificationDSN(dbPath, 0),
+	)
+	require.NoError(tb, err)
+	contender.SetMaxOpenConns(fairSQLiteConnections)
+	contender.SetMaxIdleConns(fairSQLiteConnections)
+	require.NoError(tb, contender.PingContext(tb.Context()))
+
+	tx, err := conn.BeginTx(tb.Context(), nil)
+	require.NoError(tb, err)
+	contenderTx, contenderErr := contender.BeginTx(tb.Context(), nil)
+	if contenderErr == nil {
+		require.NoError(tb, contenderTx.Rollback())
+	}
+	require.Error(tb, contenderErr, "second BEGIN must observe immediate lock")
+	var sqliteErr *modernsqlite.Error
+	require.ErrorAs(tb, contenderErr, &sqliteErr)
+	require.Equal(tb, sqlite3.SQLITE_BUSY, sqliteErr.Code()&0xff)
+	require.NoError(tb, tx.Rollback())
+	require.NoError(tb, contender.Close())
+	require.NoError(tb, conn.Close())
+
+	return result
+}
+
+// fairLogSQLitePragmas records settings verified after candidate close.
+func fairLogSQLitePragmas(b *testing.B, pragmas fairSQLitePragmas) {
+	b.Helper()
+	b.Logf("effective-pragmas journal_mode=%s foreign_keys=%d "+
+		"busy_timeout=%d synchronous=%d fullfsync=%d auto_vacuum=%d "+
+		"txlock=%s max_connections=%d verified=post-close-independent",
+		pragmas.journalMode, pragmas.foreignKeys, pragmas.busyTimeout,
+		pragmas.synchronous, pragmas.fullFSync, pragmas.autoVacuum,
+		pragmas.txLock, pragmas.maxConnections)
+}
+
+// fairIterationPath returns a fresh destination for one snapshot copy.
+func fairIterationPath(tb testing.TB, iteration int) string {
+	tb.Helper()
+
+	return filepath.Join(
+		tb.TempDir(), fmt.Sprintf(
+			"%siteration-%d.sqlite", fairSQLiteFileMarker, iteration,
+		),
+	)
+}
+
+// fairCopySnapshot copies one closed SQLite main database outside timing.
+func fairCopySnapshot(tb testing.TB, source, destination string) {
+	tb.Helper()
+	src, err := os.Open(source)
+	require.NoError(tb, err)
+	defer func() {
+		require.NoError(tb, src.Close())
+	}()
+
+	dst, err := os.OpenFile(
+		destination, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600,
+	)
+	require.NoError(tb, err)
+	_, copyErr := io.Copy(dst, src)
+	closeErr := dst.Close()
+	require.NoError(tb, copyErr)
+	require.NoError(tb, closeErr)
+}
+
+// fairFileSize returns the SQLite main database size.
+func fairFileSize(tb testing.TB, dbPath string) int64 {
+	tb.Helper()
+	info, err := os.Stat(dbPath)
+	require.NoError(tb, err)
+
+	return info.Size()
+}
+
+// fairRequireClosedSQLite verifies closed-snapshot files and no KV sidecar.
+func fairRequireClosedSQLite(tb testing.TB, dbPath string) {
+	tb.Helper()
+	paths := []string{
+		dbPath + "-wal",
+		dbPath + "-shm",
+		filepath.Join(filepath.Dir(dbPath), WalletDBName),
+	}
+	for _, path := range paths {
+		_, err := os.Stat(path)
+		require.Truef(
+			tb, errors.Is(err, os.ErrNotExist),
+			"unexpected SQLite or KV sidecar %s: %v", path, err,
+		)
+	}
+}

--- a/wallet/history.go
+++ b/wallet/history.go
@@ -25,6 +25,12 @@ var (
 // a full chain rescan of all wallet transaction and UTXO data. User-defined
 // transaction labels can optionally be kept by setting keepLabels to true.
 func DropTransactionHistory(db walletdb.DB, keepLabels bool) error {
+	if db == nil {
+		return &UnsupportedStoreOperationError{
+			Operation: "DropTransactionHistory",
+		}
+	}
+
 	log.Infof("Dropping btcwallet transaction history")
 
 	err := walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
@@ -92,6 +98,19 @@ func DropTransactionHistory(db walletdb.DB, keepLabels bool) error {
 	}
 
 	return nil
+}
+
+// DropTransactionHistory removes this wallet's transaction state while
+// optionally retaining labels. Store-backed wallets return a typed unsupported
+// operation error before any walletdb access.
+func (w *Wallet) DropTransactionHistory(keepLabels bool) error {
+	if w.db == nil {
+		return &UnsupportedStoreOperationError{
+			Operation: "DropTransactionHistory",
+		}
+	}
+
+	return DropTransactionHistory(w.db, keepLabels)
 }
 
 // fetchAllLabels returns a map of hex-encoded txid to label.

--- a/wallet/import.go
+++ b/wallet/import.go
@@ -1,6 +1,7 @@
 package wallet
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/netparams"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	walletstore "github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 )
 
@@ -214,14 +216,37 @@ func (w *Wallet) ImportAccount(name string, accountPubKey *hdkeychain.ExtendedKe
 	*waddrmgr.AccountProperties, error) {
 
 	var accountProps *waddrmgr.AccountProperties
-	err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		var err error
-		accountProps, err = w.importAccount(
-			ns, name, accountPubKey, masterKeyFingerprint, addrType,
+	var err error
+	if w.db != nil {
+		err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+			ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+			var err error
+			accountProps, err = w.importAccount(
+				ns, name, accountPubKey, masterKeyFingerprint, addrType,
+			)
+			return err
+		})
+	} else {
+		err = w.store.UpdateOnce(
+			context.Background(),
+			func(tx walletstore.ReadWriteTx) error {
+				var err error
+				accountProps, _, err = w.importAccountFromStore(
+					tx.Addr(), name, accountPubKey,
+					masterKeyFingerprint, addrType,
+				)
+				return err
+			}, func() {
+				accountProps = nil
+			},
 		)
-		return err
-	})
+	}
+	if err != nil {
+		keyScope, _, scopeErr := keyScopeFromPubKey(accountPubKey, addrType)
+		if scopeErr == nil {
+			_, _ = w.attachStoreScopeAfterAmbiguous(err, keyScope)
+		}
+	}
 	return accountProps, err
 }
 
@@ -236,17 +261,101 @@ func (w *Wallet) ImportAccountWithScope(name string,
 	keyScope waddrmgr.KeyScope, addrSchema waddrmgr.ScopeAddrSchema) (
 	*waddrmgr.AccountProperties, error) {
 
+	if accountPubKey.IsPrivate() {
+		return nil, errors.New("private keys cannot be imported")
+	}
+
 	var accountProps *waddrmgr.AccountProperties
-	err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		var err error
-		accountProps, err = w.importAccountScope(
-			ns, name, accountPubKey, masterKeyFingerprint, keyScope,
-			&addrSchema,
+	var err error
+	if w.db != nil {
+		err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+			ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+			var err error
+			accountProps, err = w.importAccountScope(
+				ns, name, accountPubKey, masterKeyFingerprint, keyScope,
+				&addrSchema,
+			)
+			return err
+		})
+	} else {
+		err = w.store.UpdateOnce(
+			context.Background(),
+			func(tx walletstore.ReadWriteTx) error {
+				var err error
+				accountProps, _, err = w.importAccountScopeFromStore(
+					tx.Addr(), name, accountPubKey,
+					masterKeyFingerprint, keyScope, &addrSchema,
+				)
+				return err
+			}, func() {
+				accountProps = nil
+			},
 		)
-		return err
-	})
+	}
+	if err != nil {
+		_, _ = w.attachStoreScopeAfterAmbiguous(err, keyScope)
+	}
 	return accountProps, err
+}
+
+// importAccountFromStore validates and imports an account through a Store.
+func (w *Wallet) importAccountFromStore(tx waddrmgr.ManagerReadWriteTx,
+	name string, accountPubKey *hdkeychain.ExtendedKey,
+	masterKeyFingerprint uint32, addrType *waddrmgr.AddressType) (
+	*waddrmgr.AccountProperties, *waddrmgr.ScopedKeyManager, error) {
+
+	if err := w.validateExtendedPubKey(accountPubKey, true); err != nil {
+		return nil, nil, err
+	}
+
+	keyScope, addrSchema, err := keyScopeFromPubKey(accountPubKey, addrType)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return w.importAccountScopeFromStore(
+		tx, name, accountPubKey, masterKeyFingerprint, keyScope,
+		addrSchema,
+	)
+}
+
+// importAccountScopeFromStore imports an extended-public-key account into a
+// known Store-backed key scope.
+func (w *Wallet) importAccountScopeFromStore(
+	tx waddrmgr.ManagerReadWriteTx, name string,
+	accountPubKey *hdkeychain.ExtendedKey, masterKeyFingerprint uint32,
+	keyScope waddrmgr.KeyScope, addrSchema *waddrmgr.ScopeAddrSchema) (
+	*waddrmgr.AccountProperties, *waddrmgr.ScopedKeyManager, error) {
+
+	scopedManager, err := w.Manager.FetchScopedKeyManager(keyScope)
+	if err != nil {
+		schema := addrSchema
+		if schema == nil {
+			defaultSchema, ok := waddrmgr.ScopeAddrMap[keyScope]
+			if !ok {
+				return nil, nil, fmt.Errorf(
+					"address schema for scope %v is required", keyScope,
+				)
+			}
+			schema = &defaultSchema
+		}
+
+		scopedManager, err = w.Manager.NewScopedKeyManagerFromStore(
+			tx, keyScope, *schema,
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	_, props, err := scopedManager.NewAccountWatchingOnlyFromStore(
+		tx, name, accountPubKey, masterKeyFingerprint, addrSchema,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return props, scopedManager, nil
 }
 
 // importAccount is the internal implementation of ImportAccount -- one should
@@ -281,6 +390,10 @@ func (w *Wallet) importAccountScope(ns walletdb.ReadWriteBucket, name string,
 
 	scopedMgr, err := w.Manager.FetchScopedKeyManager(keyScope)
 	if err != nil {
+		if addrSchema == nil {
+			schema := waddrmgr.ScopeAddrMap[keyScope]
+			addrSchema = &schema
+		}
 		scopedMgr, err = w.Manager.NewScopedKeyManager(
 			ns, keyScope, *addrSchema,
 		)
@@ -322,6 +435,55 @@ func (w *Wallet) ImportAccountDryRun(name string,
 		externalAddrs []waddrmgr.ManagedAddress
 		internalAddrs []waddrmgr.ManagedAddress
 	)
+
+	if w.db == nil {
+		err := w.store.UpdateOnce(
+			context.Background(),
+			func(tx walletstore.ReadWriteTx) error {
+				props, manager, err := w.importAccountFromStore(
+					tx.Addr(), name, accountPubKey,
+					masterKeyFingerprint, addrType,
+				)
+				if err != nil {
+					return err
+				}
+				accountProps = props
+
+				for i := uint32(0); i < numAddrs; i++ {
+					external, props, err :=
+						manager.NextExternalAddressFromStore(
+							tx.Addr(), accountProps.AccountNumber,
+						)
+					if err != nil {
+						return err
+					}
+					externalAddrs = append(externalAddrs, external)
+					accountProps = props
+
+					internal, props, err :=
+						manager.NextInternalAddressFromStore(
+							tx.Addr(), accountProps.AccountNumber,
+						)
+					if err != nil {
+						return err
+					}
+					internalAddrs = append(internalAddrs, internal)
+					accountProps = props
+				}
+
+				return walletdb.ErrDryRunRollBack
+			}, func() {
+				accountProps = nil
+				externalAddrs = nil
+				internalAddrs = nil
+			},
+		)
+		if err != nil && !errors.Is(err, walletdb.ErrDryRunRollBack) {
+			return nil, nil, nil, err
+		}
+
+		return accountProps, externalAddrs, internalAddrs, nil
+	}
 
 	// Start a database transaction that we'll never commit and always
 	// rollback because we'll return a specific error in the end.
@@ -419,11 +581,26 @@ func (w *Wallet) ImportPublicKey(pubKey *btcec.PublicKey,
 
 	// TODO: Perform rescan if requested.
 	var addr waddrmgr.ManagedAddress
-	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		addr, err = scopedKeyManager.ImportPublicKey(ns, pubKey, nil)
-		return err
-	})
+	if w.db != nil {
+		err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+			ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+			addr, err = scopedKeyManager.ImportPublicKey(ns, pubKey, nil)
+			return err
+		})
+	} else {
+		err = w.store.UpdateOnce(
+			context.Background(),
+			func(tx walletstore.ReadWriteTx) error {
+				var err error
+				addr, err = scopedKeyManager.ImportPublicKeyFromStore(
+					tx.Addr(), pubKey, nil,
+				)
+				return err
+			}, func() {
+				addr = nil
+			},
+		)
+	}
 	if err != nil {
 		return err
 	}
@@ -470,13 +647,30 @@ func (w *Wallet) ImportTaprootScript(scope waddrmgr.KeyScope,
 
 	// TODO: Perform rescan if requested.
 	var addr waddrmgr.ManagedAddress
-	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		addr, err = manager.ImportTaprootScript(
-			ns, tapscript, bs, witnessVersion, isSecretScript,
+	if w.db != nil {
+		err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+			ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+			addr, err = manager.ImportTaprootScript(
+				ns, tapscript, bs, witnessVersion, isSecretScript,
+			)
+			return err
+		})
+	} else {
+		err = w.store.UpdateOnce(
+			context.Background(),
+			func(tx walletstore.ReadWriteTx) error {
+				var err error
+				addr, err = manager.ImportTaprootScriptFromStore(
+					tx.Addr(), tapscript, bs, witnessVersion,
+					isSecretScript,
+				)
+				return err
+			}, func() {
+				addr = nil
+			},
 		)
-		return err
-	})
+	}
+	w.refreshStartBlockAfterAmbiguous(err)
 	if err != nil {
 		return nil, err
 	}
@@ -525,42 +719,91 @@ func (w *Wallet) ImportPrivateKey(scope waddrmgr.KeyScope, wif *btcutil.WIF,
 	// Attempt to import private key into wallet.
 	var addr address.Address
 	var props *waddrmgr.AccountProperties
-	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		maddr, err := manager.ImportPrivateKey(addrmgrNs, wif, bs)
-		if err != nil {
-			return err
-		}
-		addr = maddr.Address()
-		props, err = manager.AccountProperties(
-			addrmgrNs, waddrmgr.ImportedAddrAccount,
+	if w.db != nil {
+		err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+			addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+			maddr, err := manager.ImportPrivateKey(addrmgrNs, wif, bs)
+			if err != nil {
+				return err
+			}
+			addr = maddr.Address()
+			props, err = manager.AccountProperties(
+				addrmgrNs, waddrmgr.ImportedAddrAccount,
+			)
+			if err != nil {
+				return err
+			}
+
+			birthdayBlock, _, err := w.Manager.BirthdayBlock(addrmgrNs)
+			if err != nil {
+				return err
+			}
+			if bs.Height >= birthdayBlock.Height {
+				return nil
+			}
+
+			err = w.Manager.SetBirthday(addrmgrNs, bs.Timestamp)
+			if err != nil {
+				return err
+			}
+
+			return w.Manager.SetBirthdayBlock(addrmgrNs, *bs, false)
+		})
+	} else {
+		err = w.store.UpdateOnce(
+			context.Background(),
+			func(tx walletstore.ReadWriteTx) error {
+				maddr, err := manager.ImportPrivateKeyFromStore(
+					tx.Addr(), wif, bs,
+				)
+				if err != nil {
+					return err
+				}
+				addr = maddr.Address()
+
+				state, err := tx.Addr().SyncState()
+				if err != nil {
+					return err
+				}
+				if state.BirthdayBlock == nil ||
+					bs.Height < state.BirthdayBlock.Height {
+
+					err = w.Manager.SetBirthdayFromStore(
+						tx.Addr(), bs.Timestamp,
+					)
+					if err != nil {
+						return err
+					}
+					err = w.Manager.SetBirthdayBlockFromStore(
+						tx.Addr(), *bs, false,
+					)
+					if err != nil {
+						return err
+					}
+				}
+
+				addresses, err := tx.Addr().AccountAddresses(
+					scope, waddrmgr.ImportedAddrAccount,
+				)
+				if err != nil {
+					return err
+				}
+				props = &waddrmgr.AccountProperties{
+					AccountNumber:    waddrmgr.ImportedAddrAccount,
+					AccountName:      waddrmgr.ImportedAddrAccountName,
+					ImportedKeyCount: uint32(len(addresses)),
+					KeyScope:         scope,
+					IsWatchOnly:      w.Manager.WatchOnly(),
+				}
+
+				return nil
+			}, func() {
+				addr = nil
+				props = nil
+			},
 		)
-		if err != nil {
-			return err
-		}
-
-		// We'll only update our birthday with the new one if it is
-		// before our current one. Otherwise, if we do, we can
-		// potentially miss detecting relevant chain events that
-		// occurred between them while rescanning.
-		birthdayBlock, _, err := w.Manager.BirthdayBlock(addrmgrNs)
-		if err != nil {
-			return err
-		}
-		if bs.Height >= birthdayBlock.Height {
-			return nil
-		}
-
-		err = w.Manager.SetBirthday(addrmgrNs, bs.Timestamp)
-		if err != nil {
-			return err
-		}
-
-		// To ensure this birthday block is correct, we'll mark it as
-		// unverified to prompt a sanity check at the next restart to
-		// ensure it is correct as it was provided by the caller.
-		return w.Manager.SetBirthdayBlock(addrmgrNs, *bs, false)
-	})
+	}
+	w.refreshStartBlockAfterAmbiguous(err)
 	if err != nil {
 		return "", err
 	}

--- a/wallet/import_test.go
+++ b/wallet/import_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
@@ -13,10 +14,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// hardenedKey converts a child index to its hardened form.
 func hardenedKey(key uint32) uint32 {
 	return key + hdkeychain.HardenedKeyStart
 }
 
+// deriveAcctPubKey derives an account public key for an import test.
 func deriveAcctPubKey(t *testing.T, root *hdkeychain.ExtendedKey,
 	scope waddrmgr.KeyScope, paths ...uint32) *hdkeychain.ExtendedKey {
 
@@ -154,6 +157,61 @@ func TestImportAccount(t *testing.T) {
 	}
 }
 
+// TestImportAccountWithScopeRejectsPrivateKey verifies explicit-scope imports
+// reject private extended keys before creating any durable scope state.
+func TestImportAccountWithScopeRejectsPrivateKey(t *testing.T) {
+	t.Parallel()
+
+	wallet, cleanup := testWallet(t)
+	defer cleanup()
+
+	root, err := hdkeychain.NewKeyFromString(testCases[0].masterPriv)
+	require.NoError(t, err)
+	defer root.Zero()
+
+	accountKey := root
+	for _, child := range []uint32{
+		hardenedKey(waddrmgr.KeyScopeBIP0084.Purpose),
+		hardenedKey(waddrmgr.KeyScopeBIP0084.Coin), hardenedKey(0),
+	} {
+		accountKey, err = accountKey.Derive(child)
+		require.NoError(t, err)
+	}
+	defer accountKey.Zero()
+
+	scope := waddrmgr.KeyScope{Purpose: 1_018, Coin: 1}
+	_, err = wallet.ImportAccountWithScope(
+		"private", accountKey, 0, scope,
+		waddrmgr.ScopeAddrMap[waddrmgr.KeyScopeBIP0084],
+	)
+	require.ErrorContains(t, err, "private keys cannot be imported")
+	_, err = wallet.Manager.FetchScopedKeyManager(scope)
+	require.True(t, waddrmgr.IsError(err, waddrmgr.ErrScopeNotFound))
+}
+
+// TestImportTaprootScriptRejectsInvalidVersion verifies taproot imports reject
+// non-v1 witness versions without a failed type assertion.
+func TestImportTaprootScriptRejectsInvalidVersion(t *testing.T) {
+	t.Parallel()
+
+	wallet, cleanup := testWallet(t)
+	defer cleanup()
+
+	privateKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	tapscript := &waddrmgr.Tapscript{
+		Type:          waddrmgr.TaprootFullKeyOnly,
+		FullOutputKey: privateKey.PubKey(),
+	}
+	for _, version := range []byte{0, 2} {
+		_, err := wallet.ImportTaprootScript(
+			waddrmgr.KeyScopeBIP0086, tapscript, nil, version, true,
+		)
+		require.ErrorContains(t, err, "invalid witness version")
+	}
+}
+
+// testImportAccount verifies one imported account test case.
 func testImportAccount(t *testing.T, w *Wallet, tc *testCase, watchOnly bool,
 	name string) {
 

--- a/wallet/interface.go
+++ b/wallet/interface.go
@@ -47,6 +47,9 @@ type Interface interface {
 	// will fail.
 	Locked() bool
 
+	// WatchOnly returns whether the wallet contains no private key material.
+	WatchOnly() bool
+
 	// Unlock unlocks the wallet with a passphrase. The wallet will
 	// automatically re-lock after the timeout has expired. If the timeout
 	// channel is nil, the wallet remains unlocked indefinitely.
@@ -72,7 +75,8 @@ type Interface interface {
 
 	// Database returns the underlying walletdb database. This method is
 	// provided in order to allow applications wrapping btcwallet to store
-	// app-specific data with the wallet's database.
+	// app-specific data with the wallet's database. It returns nil for a
+	// Store-backed wallet.
 	Database() walletdb.DB
 
 	// ChainParams returns the chain parameters for the wallet.
@@ -136,6 +140,13 @@ type Interface interface {
 	InitAccounts(scope *waddrmgr.ScopedKeyManager, convertToWatchOnly bool,
 		account uint32) error
 
+	// InitializeKeyScope ensures that a key scope and the exact requested
+	// accounts exist. Private key material is removed after initialization
+	// when convertToWatchOnly is true.
+	InitializeKeyScope(scope waddrmgr.KeyScope,
+		addrSchema waddrmgr.ScopeAddrSchema, accounts []uint32,
+		convertToWatchOnly bool) error
+
 	// AddScopeManager adds a new scope manager to the wallet.
 	AddScopeManager(scope waddrmgr.KeyScope,
 		addrSchema waddrmgr.ScopeAddrSchema) (
@@ -155,6 +166,16 @@ type Interface interface {
 	// and scope.
 	NewChangeAddress(account uint32, scope waddrmgr.KeyScope) (
 		address.Address, error)
+
+	// NextExternalKey derives and persists the next external public key for
+	// an account, returning its child index.
+	NextExternalKey(scope waddrmgr.KeyScope, account uint32) (
+		*btcec.PublicKey, uint32, error)
+
+	// DeriveManagedPubKey derives an arbitrary managed public key. The
+	// account is created when possible if it does not exist.
+	DeriveManagedPubKey(scope waddrmgr.KeyScope,
+		path waddrmgr.DerivationPath) (*btcec.PublicKey, error)
 
 	// AddressInfo returns detailed information about a managed address,
 	// including its derivation path and whether it's compressed.
@@ -293,6 +314,10 @@ type Interface interface {
 	// RemoveDescendants removes all transactions from the wallet that
 	// spend outputs from the passed transaction.
 	RemoveDescendants(tx *wire.MsgTx) error
+
+	// DropTransactionHistory removes all wallet transaction state while
+	// optionally retaining labels.
+	DropTransactionHistory(keepLabels bool) error
 
 	// PrivKeyForAddress returns the private key for a given address.
 	PrivKeyForAddress(a address.Address) (*btcec.PrivateKey, error)

--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -8,6 +8,8 @@ package db
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil/v2"
@@ -20,13 +22,15 @@ import (
 // AddrReadStore exposes address-manager reads within an existing wallet
 // transaction. Backend transaction handles remain private to the adapter.
 type AddrReadStore interface {
+	// ManagerReadStore provides the address-manager read surface.
 	waddrmgr.ManagerReadStore
 }
 
 // AddrReadWriteStore exposes address-manager reads and writes within an
 // existing wallet transaction.
 type AddrReadWriteStore interface {
-	waddrmgr.ManagerReadWriteStore
+	// ManagerReadWriteTx provides the address-manager write surface.
+	waddrmgr.ManagerReadWriteTx
 }
 
 // TxReadStore exposes the existing transaction-manager read surface within an
@@ -76,11 +80,13 @@ type TxReadStore interface {
 // TxReadWriteStore exposes the existing transaction-manager read/write surface
 // within an existing wallet transaction.
 type TxReadWriteStore interface {
+	// TxReadStore provides the transaction-manager read surface.
 	TxReadStore
 
-	// AddCredit marks an output of a recorded transaction as wallet-owned.
+	// AddCredit marks an output of a recorded transaction as wallet-owned and
+	// reports whether a new credit was added.
 	AddCredit(rec *wtxmgr.TxRecord, block *wtxmgr.BlockMeta, index uint32,
-		change bool) error
+		change bool) (bool, error)
 
 	// DeleteExpiredLockedOutputs removes all expired output leases.
 	DeleteExpiredLockedOutputs() error
@@ -140,4 +146,88 @@ type Store interface {
 	// Update executes body in a read/write transaction.
 	Update(ctx context.Context, body func(ReadWriteTx) error,
 		reset func()) error
+
+	// UpdateOnce executes body in a single read/write transaction attempt.
+	// It is intended for legacy callbacks whose side effects cannot be
+	// replayed safely.
+	UpdateOnce(ctx context.Context, body func(ReadWriteTx) error,
+		reset func()) error
+}
+
+// LifecycleStore extends a manager Store with wallet existence and creation
+// operations. A lifecycle store may begin unbound and become bound to the
+// wallet created or resolved by its backend-specific identity.
+type LifecycleStore interface {
+	// Store provides the backend transaction execution surface.
+	Store
+
+	// WalletExists reports whether the configured wallet exists. A successful
+	// lookup binds an initially unbound store to the durable wallet.
+	WalletExists(ctx context.Context) (bool, error)
+
+	// Create executes body in the single transaction that creates and binds
+	// the configured wallet. The callback is never replayed.
+	Create(ctx context.Context, body func(ReadWriteTx) error,
+		reset func()) error
+}
+
+// AmbiguousCommitError reports a commit failure for which the caller cannot
+// safely assume whether the transaction became durable.
+type AmbiguousCommitError struct {
+	// Err is the backend error returned while committing the transaction.
+	Err error
+
+	hooks     []func()
+	hooksOnce sync.Once
+}
+
+// NewAmbiguousCommitError records a commit failure and the post-commit hooks
+// that can be applied if the caller later proves the transaction became
+// durable.
+func NewAmbiguousCommitError(err error,
+	hooks ...func()) *AmbiguousCommitError {
+
+	return &AmbiguousCommitError{
+		Err:   err,
+		hooks: append([]func(){}, hooks...),
+	}
+}
+
+// Error describes the ambiguous commit failure.
+func (e *AmbiguousCommitError) Error() string {
+	return fmt.Sprintf("transaction commit outcome is ambiguous: %v", e.Err)
+}
+
+// Unwrap returns the commit error reported by the backend.
+func (e *AmbiguousCommitError) Unwrap() error {
+	return e.Err
+}
+
+// ApplyCommitHooks publishes deferred in-memory state after the caller proves
+// an ambiguously acknowledged transaction committed. Hooks are applied at most
+// once.
+func (e *AmbiguousCommitError) ApplyCommitHooks() {
+	e.hooksOnce.Do(func() {
+		for _, hook := range e.hooks {
+			hook()
+		}
+	})
+}
+
+// RetryableTransactionError reports a failure known to have left no durable
+// transaction changes. The caller may safely retry the whole operation.
+type RetryableTransactionError struct {
+	// Err is the backend error that prevented the transaction from committing.
+	Err error
+}
+
+// Error describes the definitely uncommitted transaction failure.
+func (e *RetryableTransactionError) Error() string {
+	return fmt.Sprintf("transaction did not commit and may be retried: %v",
+		e.Err)
+}
+
+// Unwrap returns the retryable backend error.
+func (e *RetryableTransactionError) Unwrap() error {
+	return e.Err
 }

--- a/wallet/internal/db/itest/manager_store_test.go
+++ b/wallet/internal/db/itest/manager_store_test.go
@@ -19,9 +19,10 @@ import (
 )
 
 type managerStoreHarness struct {
-	conn     *sql.DB
-	postgres bool
-	newStore func(int64) db.Store
+	conn              *sql.DB
+	postgres          bool
+	newStore          func(int64) db.Store
+	newLifecycleStore func(string) db.LifecycleStore
 }
 
 // testManagerStore runs the shared manager-store conformance cases against one
@@ -32,6 +33,12 @@ func testManagerStore(t *testing.T, harness *managerStoreHarness) {
 	t.Run("manager transaction", func(t *testing.T) {
 		testManagerTransaction(t, harness)
 	})
+	t.Run("wallet lifecycle", func(t *testing.T) {
+		testWalletLifecycle(t, harness)
+	})
+	t.Run("account zero sentinel", func(t *testing.T) {
+		testAccountZeroSentinel(t, harness)
+	})
 	t.Run("address manager persistence", func(t *testing.T) {
 		testAddressManagerPersistence(t, harness)
 	})
@@ -40,6 +47,9 @@ func testManagerStore(t *testing.T, harness *managerStoreHarness) {
 	})
 	t.Run("rollback transaction", func(t *testing.T) {
 		testRollbackTransaction(t, harness)
+	})
+	t.Run("wallet block isolation", func(t *testing.T) {
+		testWalletBlockIsolation(t, harness)
 	})
 	t.Run("duplicate incidence", func(t *testing.T) {
 		testDuplicateIncidence(t, harness)
@@ -52,8 +62,127 @@ func testManagerStore(t *testing.T, harness *managerStoreHarness) {
 	})
 }
 
+// testWalletLifecycle verifies name binding and single-attempt wallet creation
+// against one SQL backend.
+//
+//nolint:noinlineerr // Each setup write retains operation-local context.
+func testWalletLifecycle(t *testing.T, harness *managerStoreHarness) {
+	t.Helper()
+
+	ctx := t.Context()
+	store := harness.newLifecycleStore("store-lifecycle")
+	exists, err := store.WalletExists(ctx)
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	managerState := waddrmgr.ManagerState{
+		Version:               9,
+		CreatedAt:             time.Unix(7_001, 0),
+		WatchOnly:             true,
+		MasterPubParams:       []byte{1},
+		EncryptedCryptoPubKey: []byte{2},
+	}
+	genesis := testBlock(0)
+	syncState := waddrmgr.SyncState{
+		StartBlock: genesis,
+		SyncedTo:   genesis,
+		Birthday:   time.Unix(7_002, 0),
+	}
+	msgTx := wire.NewMsgTx(2)
+	msgTx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash:  testHash(70),
+		Index: 1,
+	}})
+	msgTx.AddTxOut(&wire.TxOut{Value: 70_000, PkScript: []byte{0x51}})
+	record, err := wtxmgr.NewTxRecordFromMsgTx(msgTx, time.Unix(7_003, 0))
+	require.NoError(t, err)
+
+	var bodyCalls, resetCalls int
+	err = store.Create(ctx, func(tx db.ReadWriteTx) error {
+		bodyCalls++
+		if err := tx.Addr().PutManagerState(managerState); err != nil {
+			return err
+		}
+
+		if err := tx.Addr().PutSyncState(syncState); err != nil {
+			return err
+		}
+
+		return tx.Tx().InsertTx(record, nil)
+	}, func() {
+		resetCalls++
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, bodyCalls)
+	require.Equal(t, 1, resetCalls)
+
+	exists, err = store.WalletExists(ctx)
+	require.NoError(t, err)
+	require.True(t, exists)
+
+	resolvedStore := harness.newLifecycleStore("store-lifecycle")
+	exists, err = resolvedStore.WalletExists(ctx)
+	require.NoError(t, err)
+	require.True(t, exists)
+	err = resolvedStore.View(ctx, func(tx db.ReadTx) error {
+		gotManager, err := tx.Addr().ManagerState()
+		require.NoError(t, err)
+		require.Equal(t, managerState, gotManager)
+
+		gotSync, err := tx.Addr().SyncState()
+		require.NoError(t, err)
+		require.Equal(t, syncState, gotSync)
+		details, err := tx.Tx().TxDetails(&record.Hash)
+		require.NoError(t, err)
+		require.Equal(t, record.Hash, details.Hash)
+
+		return nil
+	}, nil)
+	require.NoError(t, err)
+
+	err = harness.newLifecycleStore("store-lifecycle").Create(
+		ctx, func(db.ReadWriteTx) error {
+			return nil
+		}, nil,
+	)
+	require.True(t, waddrmgr.IsError(err, waddrmgr.ErrAlreadyExists))
+}
+
+// testAccountZeroSentinel verifies SQL NULL round trips as the legacy
+// unallocated-account sentinel so the first imported account remains zero.
+func testAccountZeroSentinel(t *testing.T, harness *managerStoreHarness) {
+	t.Helper()
+
+	walletID := harness.createWallet(
+		t, "account-zero-sentinel", testBlock(10), testBlock(10),
+	)
+	store := harness.newStore(walletID)
+	scope := waddrmgr.KeyScope{Purpose: 1_017, Coin: 1}
+	want := waddrmgr.KeyScopeState{
+		Scope:       scope,
+		AddrSchema:  waddrmgr.ScopeAddrMap[waddrmgr.KeyScopeBIP0084],
+		LastAccount: waddrmgr.NoAccount,
+	}
+
+	err := store.Update(t.Context(), func(tx db.ReadWriteTx) error {
+		return tx.Addr().PutKeyScope(want)
+	}, nil)
+	require.NoError(t, err)
+
+	err = store.View(t.Context(), func(tx db.ReadTx) error {
+		got, err := tx.Addr().KeyScope(scope)
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+
+		return nil
+	}, nil)
+	require.NoError(t, err)
+}
+
 // testWtxmgrCompatibility verifies the complete wtxmgr surface against one SQL
 // backend.
+//
+//nolint:maintidx // One vector covers the full manager surface.
 func testWtxmgrCompatibility(t *testing.T, harness *managerStoreHarness) {
 	t.Helper()
 
@@ -83,10 +212,15 @@ func testWtxmgrCompatibility(t *testing.T, harness *managerStoreHarness) {
 		require.NoError(t, err)
 		require.True(t, exists)
 
-		err = tx.Tx().AddCredit(funding, nil, 0, false)
+		isNew, err := tx.Tx().AddCredit(funding, nil, 0, false)
 		if err != nil {
 			return err
 		}
+		require.True(t, isNew)
+
+		isNew, err = tx.Tx().AddCredit(funding, nil, 0, false)
+		require.NoError(t, err)
+		require.False(t, isNew)
 
 		return tx.Tx().PutTxLabel(funding.Hash, "funding")
 	}, func() {})
@@ -127,17 +261,32 @@ func testWtxmgrCompatibility(t *testing.T, harness *managerStoreHarness) {
 
 	lockID := wtxmgr.LockID{1, 2, 3}
 	output := wire.OutPoint{Hash: funding.Hash, Index: 0}
+	var lockExpiry time.Time
 	err = store.Update(ctx, func(tx db.ReadWriteTx) error {
-		_, err := tx.Tx().LockOutput(lockID, output, time.Hour)
+		var err error
+		lockExpiry, err = tx.Tx().LockOutput(lockID, output, time.Hour)
 		return err
 	}, func() {})
 	require.NoError(t, err)
+	require.WithinDuration(
+		t, time.Now().Add(time.Hour), lockExpiry, time.Second,
+	)
+
+	err = store.Update(ctx, func(tx db.ReadWriteTx) error {
+		_, err := tx.Tx().LockOutput(
+			wtxmgr.LockID{9}, output, time.Hour,
+		)
+
+		return err
+	}, func() {})
+	require.ErrorIs(t, err, wtxmgr.ErrOutputAlreadyLocked)
 
 	err = store.View(ctx, func(tx db.ReadTx) error {
 		locked, err := tx.Tx().ListLockedOutputs()
 		require.NoError(t, err)
 		require.Len(t, locked, 1)
 		require.Equal(t, output, locked[0].Outpoint)
+		require.True(t, lockExpiry.Equal(locked[0].Expiration))
 
 		unspent, err := tx.Tx().UnspentOutputs()
 		require.NoError(t, err)
@@ -150,6 +299,11 @@ func testWtxmgrCompatibility(t *testing.T, harness *managerStoreHarness) {
 		return nil
 	}, func() {})
 	require.NoError(t, err)
+
+	err = store.Update(ctx, func(tx db.ReadWriteTx) error {
+		return tx.Tx().UnlockOutput(wtxmgr.LockID{9}, output)
+	}, func() {})
+	require.ErrorIs(t, err, wtxmgr.ErrOutputUnlockNotAllowed)
 
 	err = store.Update(ctx, func(tx db.ReadWriteTx) error {
 		return tx.Tx().UnlockOutput(lockID, output)
@@ -187,13 +341,47 @@ func testWtxmgrCompatibility(t *testing.T, harness *managerStoreHarness) {
 		require.NoError(t, err)
 		require.True(t, details.Credits[0].Spent)
 
+		spenderDetails, err := tx.Tx().TxDetails(&spender.Hash)
+		require.NoError(t, err)
+		require.Equal(t, []wtxmgr.DebitRecord{{
+			Amount: 50_000,
+			Index:  0,
+		}}, spenderDetails.Debits)
+
 		return nil
+	}, func() {})
+	require.NoError(t, err)
+
+	childTx := wire.NewMsgTx(2)
+	childTx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash:  spender.Hash,
+		Index: 0,
+	}})
+	childTx.AddTxOut(&wire.TxOut{Value: 48_000, PkScript: []byte{0x51}})
+	child, err := wtxmgr.NewTxRecordFromMsgTx(
+		childTx, time.Unix(3_002, 0),
+	)
+	require.NoError(t, err)
+	err = store.Update(ctx, func(tx db.ReadWriteTx) error {
+		return tx.Tx().InsertTx(child, nil)
 	}, func() {})
 	require.NoError(t, err)
 
 	err = store.Update(ctx, func(tx db.ReadWriteTx) error {
 		return tx.Tx().RemoveUnminedTx(spender)
 	}, func() {})
+	require.NoError(t, err)
+	err = store.View(ctx, func(tx db.ReadTx) error {
+		details, err := tx.Tx().TxDetails(&spender.Hash)
+		require.NoError(t, err)
+		require.Nil(t, details)
+
+		details, err = tx.Tx().TxDetails(&child.Hash)
+		require.NoError(t, err)
+		require.Nil(t, details)
+
+		return nil
+	}, nil)
 	require.NoError(t, err)
 
 	err = store.Update(ctx, func(tx db.ReadWriteTx) error {
@@ -207,6 +395,11 @@ func testWtxmgrCompatibility(t *testing.T, harness *managerStoreHarness) {
 	}, func() {})
 	require.NoError(t, err)
 
+	err = store.Update(ctx, func(tx db.ReadWriteTx) error {
+		return tx.Tx().PutTxLabel(funding.Hash, "funding updated")
+	}, nil)
+	require.NoError(t, err)
+
 	err = store.View(ctx, func(tx db.ReadTx) error {
 		details, err := tx.Tx().UniqueTxDetails(
 			&funding.Hash, &wtxmgr.Block{
@@ -216,6 +409,7 @@ func testWtxmgrCompatibility(t *testing.T, harness *managerStoreHarness) {
 		)
 		require.NoError(t, err)
 		require.Equal(t, synced.Height, details.Block.Height)
+		require.Equal(t, "funding updated", details.Label)
 
 		var visited []wtxmgr.TxDetails
 
@@ -233,12 +427,131 @@ func testWtxmgrCompatibility(t *testing.T, harness *managerStoreHarness) {
 		return nil
 	}, func() {})
 	require.NoError(t, err)
+
+	independentTx := wire.NewMsgTx(2)
+	independentTx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash:  testHash(61),
+		Index: 1,
+	}})
+	independentTx.AddTxOut(&wire.TxOut{
+		Value: 1_000, PkScript: []byte{0x51},
+	})
+	independent, err := wtxmgr.NewTxRecordFromMsgTx(
+		independentTx, time.Unix(3_003, 0),
+	)
+	require.NoError(t, err)
+	err = store.Update(ctx, func(tx db.ReadWriteTx) error {
+		return tx.Tx().InsertTx(independent, nil)
+	}, nil)
+	require.NoError(t, err)
+
+	assertRange := func(begin, end int32, wantHeights []int32) {
+		t.Helper()
+
+		var heights []int32
+		err := store.View(ctx, func(tx db.ReadTx) error {
+			return tx.Tx().RangeTransactions(
+				begin, end,
+				func(details []wtxmgr.TxDetails) (bool, error) {
+					heights = append(heights, details[0].Block.Height)
+					return false, nil
+				},
+			)
+		}, func() {
+			heights = nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, wantHeights, heights)
+	}
+	assertRange(0, -1, []int32{synced.Height, -1})
+	assertRange(-1, 0, []int32{-1, synced.Height})
+
+	conflictATx := wire.NewMsgTx(2)
+	conflictATx.AddTxIn(&wire.TxIn{PreviousOutPoint: output})
+	conflictATx.AddTxOut(&wire.TxOut{
+		Value: 49_000, PkScript: []byte{0x51},
+	})
+	conflictA, err := wtxmgr.NewTxRecordFromMsgTx(
+		conflictATx, time.Unix(3_004, 0),
+	)
+	require.NoError(t, err)
+
+	conflictBTx := wire.NewMsgTx(2)
+	conflictBTx.AddTxIn(&wire.TxIn{PreviousOutPoint: output})
+	conflictBTx.AddTxOut(&wire.TxOut{
+		Value: 48_000, PkScript: []byte{0x51},
+	})
+	conflictB, err := wtxmgr.NewTxRecordFromMsgTx(
+		conflictBTx, time.Unix(3_005, 0),
+	)
+	require.NoError(t, err)
+
+	conflictChildTx := wire.NewMsgTx(2)
+	conflictChildTx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: conflictB.Hash,
+	}})
+	conflictChildTx.AddTxOut(&wire.TxOut{
+		Value: 47_000, PkScript: []byte{0x51},
+	})
+	conflictChild, err := wtxmgr.NewTxRecordFromMsgTx(
+		conflictChildTx, time.Unix(3_006, 0),
+	)
+	require.NoError(t, err)
+
+	err = store.Update(ctx, func(tx db.ReadWriteTx) error {
+		for _, record := range []*wtxmgr.TxRecord{
+			conflictA, conflictB, conflictChild,
+		} {
+			if err := tx.Tx().InsertTx(record, nil); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}, nil)
+	require.NoError(t, err)
+
+	conflictBlock := wtxmgr.BlockMeta{
+		Block: wtxmgr.Block{
+			Hash:   testHash(62),
+			Height: synced.Height + 1,
+		},
+		Time: time.Unix(3_007, 0),
+	}
+	err = store.Update(ctx, func(tx db.ReadWriteTx) error {
+		return tx.Tx().InsertTx(conflictA, &conflictBlock)
+	}, nil)
+	require.NoError(t, err)
+	err = store.View(ctx, func(tx db.ReadTx) error {
+		details, err := tx.Tx().TxDetails(&conflictA.Hash)
+		require.NoError(t, err)
+		require.Equal(t, conflictBlock.Height, details.Block.Height)
+		require.Equal(t, []wtxmgr.DebitRecord{{
+			Amount: 50_000,
+			Index:  0,
+		}}, details.Debits)
+
+		details, err = tx.Tx().TxDetails(&conflictB.Hash)
+		require.NoError(t, err)
+		require.Nil(t, details)
+		details, err = tx.Tx().TxDetails(&conflictChild.Hash)
+		require.NoError(t, err)
+		require.Nil(t, details)
+
+		fundingDetails, err := tx.Tx().TxDetails(&funding.Hash)
+		require.NoError(t, err)
+		require.True(t, fundingDetails.Credits[0].Spent)
+		require.Equal(t, "funding updated", fundingDetails.Label)
+
+		return nil
+	}, nil)
+	require.NoError(t, err)
 }
 
 // testAddressManagerPersistence verifies the complete waddrmgr persistence
 // surface against one SQL backend.
 //
-//nolint:maintidx // One vector deliberately covers the complete store surface.
+//nolint:maintidx // One vector covers the complete store surface.
 func testAddressManagerPersistence(t *testing.T,
 	harness *managerStoreHarness) {
 
@@ -326,6 +639,19 @@ func testAddressManagerPersistence(t *testing.T,
 		IsSecretScript:  &secret,
 		Used:            true,
 	}
+	taprootVersion := uint8(1)
+	taprootAddressID := []byte("taproot-address")
+	taprootAddress := waddrmgr.AddressState{
+		Scope:           scope,
+		Account:         watchOnlyAccount.Account,
+		Type:            waddrmgr.AddressTaprootScript,
+		AddedAt:         time.Unix(6_005, 0),
+		SyncStatus:      waddrmgr.AddressSyncNone,
+		EncryptedHash:   []byte{16},
+		EncryptedScript: []byte{17},
+		WitnessVersion:  &taprootVersion,
+		IsSecretScript:  &secret,
+	}
 
 	err := store.Update(ctx, func(tx db.ReadWriteTx) error {
 		addr := tx.Addr()
@@ -341,6 +667,9 @@ func testAddressManagerPersistence(t *testing.T,
 			},
 			func() error {
 				return addr.PutAddress(witnessAddressID, witnessAddress)
+			},
+			func() error {
+				return addr.PutAddress(taprootAddressID, taprootAddress)
 			},
 		}
 		for _, operation := range operations {
@@ -401,6 +730,12 @@ func testAddressManagerPersistence(t *testing.T,
 		witnessAddress.Hash = gotWitness.Hash
 		require.Equal(t, witnessAddress, gotWitness)
 
+		gotTaproot, err := addr.Address(scope, taprootAddressID)
+		require.NoError(t, err)
+
+		taprootAddress.Hash = gotTaproot.Hash
+		require.Equal(t, taprootAddress, gotTaproot)
+
 		accountAddresses, err := addr.AccountAddresses(
 			scope, defaultAccount.Account,
 		)
@@ -412,8 +747,9 @@ func testAddressManagerPersistence(t *testing.T,
 		activeAddresses, err := addr.ActiveAddresses(scope)
 		require.NoError(t, err)
 		require.ElementsMatch(
-			t, []waddrmgr.AddressState{chainAddress, witnessAddress},
-			activeAddresses,
+			t, []waddrmgr.AddressState{
+				chainAddress, witnessAddress, taprootAddress,
+			}, activeAddresses,
 		)
 
 		_, err = addr.KeyScope(waddrmgr.KeyScope{Purpose: 999, Coin: 1})
@@ -505,6 +841,10 @@ func testAddressManagerPersistence(t *testing.T,
 		require.NoError(t, err)
 		require.Nil(t, gotWitness.EncryptedScript)
 
+		gotTaproot, err := addr.Address(scope, taprootAddressID)
+		require.NoError(t, err)
+		require.Nil(t, gotTaproot.EncryptedScript)
+
 		return nil
 	}, func() {})
 	require.NoError(t, err)
@@ -553,7 +893,10 @@ func testManagerTransaction(t *testing.T, harness *managerStoreHarness) {
 	require.NoError(t, err)
 
 	require.Equal(t, replacement.Height, harness.syncedHeight(t, walletID))
-	require.Equal(t, replacement.Hash, harness.blockHash(t, replacement.Height))
+	require.Equal(
+		t, replacement.Hash,
+		harness.blockHash(t, walletID, replacement.Height),
+	)
 
 	err = store.Update(ctx, func(tx db.ReadWriteTx) error {
 		return tx.Addr().SetSyncedTo(nil)
@@ -670,6 +1013,108 @@ func testRollbackTransaction(t *testing.T, harness *managerStoreHarness) {
 	require.True(t, harness.transactionMined(t, txID))
 }
 
+// testWalletBlockIsolation verifies that a same-height reorg in one wallet does
+// not replace another wallet's active block identity or transaction incidence.
+func testWalletBlockIsolation(t *testing.T, harness *managerStoreHarness) {
+	t.Helper()
+
+	startA := testBlock(699)
+	blockA := testBlock(700)
+	startB := startA
+	startB.Hash = testHash(71)
+	blockB := blockA
+	blockB.Hash = testHash(72)
+
+	walletA := harness.createWallet(
+		t, "block-isolation-a", startA, blockA,
+	)
+	walletB := harness.createWallet(
+		t, "block-isolation-b", startB, blockB,
+	)
+	storeA := harness.newStore(walletA)
+	storeB := harness.newStore(walletB)
+
+	newRecord := func(marker byte) *wtxmgr.TxRecord {
+		t.Helper()
+
+		msgTx := wire.NewMsgTx(2)
+		msgTx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+			Hash:  testHash(marker),
+			Index: 1,
+		}})
+		msgTx.AddTxOut(&wire.TxOut{
+			Value:    10_000,
+			PkScript: []byte{0x51},
+		})
+		record, err := wtxmgr.NewTxRecordFromMsgTx(
+			msgTx, time.Unix(7_000+int64(marker), 0),
+		)
+		require.NoError(t, err)
+
+		return record
+	}
+	recordA := newRecord(73)
+	recordB := newRecord(74)
+	metaA := &wtxmgr.BlockMeta{
+		Block: wtxmgr.Block{
+			Hash:   blockA.Hash,
+			Height: blockA.Height,
+		},
+		Time: blockA.Timestamp,
+	}
+	metaB := &wtxmgr.BlockMeta{
+		Block: wtxmgr.Block{
+			Hash:   blockB.Hash,
+			Height: blockB.Height,
+		},
+		Time: blockB.Timestamp,
+	}
+
+	require.NoError(t, storeA.Update(
+		t.Context(), func(tx db.ReadWriteTx) error {
+			return tx.Tx().InsertTx(recordA, metaA)
+		}, nil,
+	))
+	require.NoError(t, storeB.Update(
+		t.Context(), func(tx db.ReadWriteTx) error {
+			return tx.Tx().InsertTx(recordB, metaB)
+		}, nil,
+	))
+
+	require.NoError(t, storeA.Update(
+		t.Context(), func(tx db.ReadWriteTx) error {
+			if err := tx.Addr().SetSyncedTo(&startA); err != nil {
+				return err
+			}
+
+			return tx.Tx().Rollback(blockA.Height)
+		}, nil,
+	))
+
+	require.NoError(t, storeB.View(
+		t.Context(), func(tx db.ReadTx) error {
+			state, err := tx.Addr().SyncState()
+			require.NoError(t, err)
+			require.Equal(t, blockB, state.SyncedTo)
+
+			details, err := tx.Tx().UniqueTxDetails(
+				&recordB.Hash, &metaB.Block,
+			)
+			require.NoError(t, err)
+			require.NotNil(t, details)
+			require.Equal(t, blockB.Hash, details.Block.Hash)
+
+			return nil
+		}, nil,
+	))
+	require.Equal(
+		t, blockA.Hash, harness.blockHash(t, walletA, blockA.Height),
+	)
+	require.Equal(
+		t, blockB.Hash, harness.blockHash(t, walletB, blockB.Height),
+	)
+}
+
 // testDuplicateIncidence verifies rollback behavior when a transaction has
 // mined and unmined incidences.
 func testDuplicateIncidence(t *testing.T, harness *managerStoreHarness) {
@@ -738,8 +1183,6 @@ func (h *managerStoreHarness) createWallet(t *testing.T, name string,
 	start, synced waddrmgr.BlockStamp) int64 {
 
 	t.Helper()
-	h.putBlock(t, start)
-	h.putBlock(t, synced)
 
 	var walletID int64
 
@@ -751,6 +1194,8 @@ func (h *managerStoreHarness) createWallet(t *testing.T, name string,
 		RETURNING id
 	`, name, []byte{1}, []byte{2}).Scan(&walletID)
 	require.NoError(t, err)
+	h.putBlock(t, walletID, start)
+	h.putBlock(t, walletID, synced)
 
 	h.exec(t, `
 		INSERT INTO wallet_sync_states (
@@ -763,17 +1208,23 @@ func (h *managerStoreHarness) createWallet(t *testing.T, name string,
 }
 
 // putBlock stores one block fixture for a conformance case.
-func (h *managerStoreHarness) putBlock(t *testing.T,
+func (h *managerStoreHarness) putBlock(t *testing.T, walletID int64,
 	block waddrmgr.BlockStamp) {
 
 	t.Helper()
 	h.exec(t, `
 		INSERT INTO blocks (block_height, header_hash, block_timestamp)
 		VALUES (?, ?, ?)
-		ON CONFLICT (block_height) DO UPDATE SET
+		ON CONFLICT (block_height) DO NOTHING
+	`, block.Height, block.Hash[:], block.Timestamp.Unix())
+	h.exec(t, `
+		INSERT INTO wallet_blocks (
+			wallet_id, block_height, header_hash, block_timestamp
+		) VALUES (?, ?, ?, ?)
+		ON CONFLICT (wallet_id, block_height) DO UPDATE SET
 			header_hash = excluded.header_hash,
 			block_timestamp = excluded.block_timestamp
-	`, block.Height, block.Hash[:], block.Timestamp.Unix())
+	`, walletID, block.Height, block.Hash[:], block.Timestamp.Unix())
 }
 
 // insertTransaction inserts the transaction row and all of its input
@@ -862,7 +1313,8 @@ func (h *managerStoreHarness) setActiveCredit(t *testing.T, walletID,
 		)
 		SELECT c.wallet_id, tx.tx_hash, c.output_index, c.id
 		FROM credits AS c
-		INNER JOIN transactions AS tx ON tx.id = c.transaction_id
+		INNER JOIN transactions AS tx
+			ON tx.wallet_id = c.wallet_id AND tx.id = c.transaction_id
 		WHERE c.wallet_id = ? AND c.id = ?
 		ON CONFLICT (wallet_id, tx_hash, output_index) DO UPDATE SET
 			credit_id = excluded.credit_id
@@ -899,7 +1351,7 @@ func (h *managerStoreHarness) syncedHeight(t *testing.T,
 }
 
 // blockHash returns the block hash recorded for a height fixture.
-func (h *managerStoreHarness) blockHash(t *testing.T,
+func (h *managerStoreHarness) blockHash(t *testing.T, walletID int64,
 	height int32) chainhash.Hash {
 
 	t.Helper()
@@ -907,8 +1359,9 @@ func (h *managerStoreHarness) blockHash(t *testing.T,
 	var hashBytes []byte
 
 	err := h.queryRow(t, `
-		SELECT header_hash FROM blocks WHERE block_height = ?
-	`, height).Scan(&hashBytes)
+		SELECT header_hash FROM wallet_blocks
+		WHERE wallet_id = ? AND block_height = ?
+	`, walletID, height).Scan(&hashBytes)
 	require.NoError(t, err)
 
 	hash, err := chainhash.NewHash(hashBytes)

--- a/wallet/internal/db/itest/pg_test.go
+++ b/wallet/internal/db/itest/pg_test.go
@@ -56,5 +56,8 @@ func TestPostgresManagerStore(t *testing.T) {
 		newStore: func(walletID int64) db.Store {
 			return dbpg.NewStore(conn, walletID)
 		},
+		newLifecycleStore: func(name string) db.LifecycleStore {
+			return dbpg.NewNamedStore(conn, name)
+		},
 	})
 }

--- a/wallet/internal/db/itest/sqlite_test.go
+++ b/wallet/internal/db/itest/sqlite_test.go
@@ -32,5 +32,8 @@ func TestSQLiteManagerStore(t *testing.T) {
 		newStore: func(walletID int64) db.Store {
 			return dbsqlite.NewStore(conn, walletID)
 		},
+		newLifecycleStore: func(name string) db.LifecycleStore {
+			return dbsqlite.NewNamedStore(conn, name)
+		},
 	})
 }

--- a/wallet/internal/db/kvdb/store.go
+++ b/wallet/internal/db/kvdb/store.go
@@ -138,7 +138,7 @@ func (s *Store) View(ctx context.Context, body func(walletstore.ReadTx) error,
 			return err
 		}
 
-		reset()
+		nonNilReset(reset)()
 
 		return body(&readTx{
 			addrStore: &addrReadStore{
@@ -165,28 +165,131 @@ func (s *Store) Update(ctx context.Context,
 		return err
 	}
 
-	return walletdb.Update(s.db, func(tx walletdb.ReadWriteTx) error {
+	var (
+		hooks         []func()
+		bodyCompleted bool
+	)
+
+	err = s.db.Update(func(tx walletdb.ReadWriteTx) error {
 		err := ctx.Err()
 		if err != nil {
 			return err
 		}
 
-		reset()
+		hooks = nil
+		bodyCompleted = false
 
-		return body(&readWriteTx{
+		nonNilReset(reset)()
+
+		bodyErr := body(&readWriteTx{
 			addrStore: &addrReadWriteStore{
 				ManagerReadWriteStore: waddrmgr.BindManagerReadWriteStore(
 					tx.ReadWriteBucket(addrmgrNamespaceKey),
 				),
+				tx:    tx,
 				ns:    tx.ReadWriteBucket(addrmgrNamespaceKey),
 				store: s.addrStore,
+				onCommit: func(callback func()) {
+					hooks = append(hooks, callback)
+				},
 			},
 			txStore: &txReadWriteStore{
 				ns:    tx.ReadWriteBucket(txmgrNamespaceKey),
 				store: s.txStore,
 			},
 		})
+		bodyCompleted = bodyErr == nil
+
+		return bodyErr
+	}, func() {})
+	if err != nil {
+		if bodyCompleted {
+			return walletstore.NewAmbiguousCommitError(err, hooks...)
+		}
+
+		return err
+	}
+
+	for _, hook := range hooks {
+		hook()
+	}
+
+	return nil
+}
+
+// UpdateOnce executes body using the primitive walletdb transaction methods so
+// a backend cannot replay it through DB.Update.
+func (s *Store) UpdateOnce(ctx context.Context,
+	body func(walletstore.ReadWriteTx) error, reset func()) error {
+
+	err := ctx.Err()
+	if err != nil {
+		return err
+	}
+
+	tx, err := s.db.BeginReadWriteTx()
+	if err != nil {
+		return err
+	}
+
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	nonNilReset(reset)()
+
+	err = ctx.Err()
+	if err != nil {
+		return err
+	}
+
+	var hooks []func()
+
+	err = body(&readWriteTx{
+		addrStore: &addrReadWriteStore{
+			ManagerReadWriteStore: waddrmgr.BindManagerReadWriteStore(
+				tx.ReadWriteBucket(addrmgrNamespaceKey),
+			),
+			tx:    tx,
+			ns:    tx.ReadWriteBucket(addrmgrNamespaceKey),
+			store: s.addrStore,
+			onCommit: func(callback func()) {
+				hooks = append(hooks, callback)
+			},
+		},
+		txStore: &txReadWriteStore{
+			ns:    tx.ReadWriteBucket(txmgrNamespaceKey),
+			store: s.txStore,
+		},
 	})
+	if err != nil {
+		return err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return walletstore.NewAmbiguousCommitError(err, hooks...)
+	}
+
+	committed = true
+
+	for _, hook := range hooks {
+		hook()
+	}
+
+	return nil
+}
+
+// nonNilReset normalizes an optional transaction reset callback.
+func nonNilReset(reset func()) func() {
+	if reset != nil {
+		return reset
+	}
+
+	return func() {}
 }
 
 type readTx struct {
@@ -228,6 +331,7 @@ func (t *readWriteTx) Tx() walletstore.TxReadWriteStore {
 }
 
 type addrReadStore struct {
+	// ManagerReadStore provides the legacy address-manager reads.
 	waddrmgr.ManagerReadStore
 
 	ns    walletdb.ReadBucket
@@ -240,10 +344,23 @@ func (s *addrReadStore) BlockHash(height int32) (*chainhash.Hash, error) {
 }
 
 type addrReadWriteStore struct {
+	// ManagerReadWriteStore provides the legacy manager operations.
 	waddrmgr.ManagerReadWriteStore
 
-	ns    walletdb.ReadWriteBucket
-	store legacyAddrStore
+	tx       walletdb.ReadWriteTx
+	ns       walletdb.ReadWriteBucket
+	store    legacyAddrStore
+	onCommit func(func())
+}
+
+// OnCommit registers a callback with the enclosing walletdb transaction.
+func (s *addrReadWriteStore) OnCommit(callback func()) {
+	if s.onCommit != nil {
+		s.onCommit(callback)
+		return
+	}
+
+	s.tx.OnCommit(callback)
 }
 
 // BlockHash returns the block hash at a particular block height.
@@ -396,11 +513,43 @@ func (s *txReadWriteStore) UnspentOutputs() ([]wtxmgr.Credit, error) {
 	return s.store.UnspentOutputs(s.ns)
 }
 
-// AddCredit marks a recorded output as wallet-owned.
+// AddCredit marks a recorded output as wallet-owned and reports whether the
+// credit is new.
 func (s *txReadWriteStore) AddCredit(rec *wtxmgr.TxRecord,
-	block *wtxmgr.BlockMeta, index uint32, change bool) error {
+	block *wtxmgr.BlockMeta, index uint32, change bool) (bool, error) {
 
-	return s.store.AddCredit(s.ns, rec, block, index, change)
+	var (
+		details *wtxmgr.TxDetails
+		err     error
+	)
+	if block == nil {
+		details, err = s.store.TxDetails(s.ns, &rec.Hash)
+	} else {
+		details, err = s.store.UniqueTxDetails(
+			s.ns, &rec.Hash, &block.Block,
+		)
+	}
+	if err != nil {
+		return false, err
+	}
+
+	isNew := details == nil
+	if details != nil && (block != nil || details.Block.Height < 0) {
+		isNew = true
+		for _, credit := range details.Credits {
+			if credit.Index == index {
+				isNew = false
+				break
+			}
+		}
+	}
+
+	err = s.store.AddCredit(s.ns, rec, block, index, change)
+	if err != nil {
+		return false, err
+	}
+
+	return isNew, nil
 }
 
 // DeleteExpiredLockedOutputs removes expired output leases.

--- a/wallet/internal/db/kvdb/store_test.go
+++ b/wallet/internal/db/kvdb/store_test.go
@@ -12,11 +12,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	walletstore "github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
+	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/stretchr/testify/require"
 )
 
@@ -57,6 +60,59 @@ type testTxStore struct {
 // Rollback rewinds mined transaction incidences at and above the given height.
 func (testTxStore) Rollback(ns walletdb.ReadWriteBucket, height int32) error {
 	return ns.Put(rollbackHeightKey, encodeHeight(height))
+}
+
+// replayingDB records use of the replay-capable DB.Update method.
+type replayingDB struct {
+	// DB delegates database operations other than Update.
+	walletdb.DB
+
+	updateCalls int
+}
+
+// Update records an unexpected call to the replay-capable transaction API.
+func (d *replayingDB) Update(func(walletdb.ReadWriteTx) error,
+	func()) error {
+
+	d.updateCalls++
+	return errors.New("replaying update called")
+}
+
+// commitErrorDB replaces transaction commit with a deterministic failure.
+type commitErrorDB struct {
+	// DB delegates database operations not involved in commit injection.
+	walletdb.DB
+
+	commitErr error
+}
+
+// BeginReadWriteTx wraps a real transaction with the configured commit error.
+//
+//nolint:ireturn // The wrapper must implement the walletdb transaction API.
+func (d *commitErrorDB) BeginReadWriteTx() (walletdb.ReadWriteTx, error) {
+	tx, err := d.DB.BeginReadWriteTx()
+	if err != nil {
+		return nil, err
+	}
+
+	return &commitErrorTx{
+		ReadWriteTx: tx,
+		commitErr:   d.commitErr,
+	}, nil
+}
+
+// commitErrorTx fails commit after rolling back its underlying transaction.
+type commitErrorTx struct {
+	// ReadWriteTx delegates transaction operations other than Commit.
+	walletdb.ReadWriteTx
+
+	commitErr error
+}
+
+// Commit rolls back the fixture transaction and returns its configured error.
+func (t *commitErrorTx) Commit() error {
+	_ = t.ReadWriteTx.Rollback()
+	return t.commitErr
 }
 
 // TestStoreUpdateSharesTransaction verifies that both manager adapters share
@@ -176,6 +232,104 @@ func TestStoreView(t *testing.T) {
 	require.Equal(t, 1, resetCount)
 }
 
+// TestTransactionStoreCompatibility verifies that the KV adapter preserves new
+// credit reporting and unmined debit reconstruction used by wallet APIs.
+func TestTransactionStoreCompatibility(t *testing.T) {
+	t.Parallel()
+
+	database := testDB(t)
+	err := walletdb.Update(database, func(tx walletdb.ReadWriteTx) error {
+		return wtxmgr.Create(tx.ReadWriteBucket(txmgrNamespaceKey))
+	})
+	require.NoError(t, err)
+
+	var txManager *wtxmgr.Store
+	err = walletdb.View(database, func(tx walletdb.ReadTx) error {
+		var err error
+		txManager, err = wtxmgr.Open(
+			tx.ReadBucket(txmgrNamespaceKey), &chaincfg.TestNet3Params,
+		)
+
+		return err
+	})
+	require.NoError(t, err)
+
+	store := newStore(database, testAddrStore{}, txManager)
+	fundingTx := wire.NewMsgTx(2)
+	fundingTx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash:  chainhash.Hash{1},
+		Index: 1,
+	}})
+	fundingTx.AddTxOut(&wire.TxOut{Value: 50_000, PkScript: []byte{0x51}})
+	funding, err := wtxmgr.NewTxRecordFromMsgTx(
+		fundingTx, time.Unix(1_000, 0),
+	)
+	require.NoError(t, err)
+
+	err = store.Update(t.Context(), func(tx walletstore.ReadWriteTx) error {
+		err := tx.Tx().InsertTx(funding, nil)
+		if err != nil {
+			return err
+		}
+
+		isNew, err := tx.Tx().AddCredit(funding, nil, 0, false)
+		require.NoError(t, err)
+		require.True(t, isNew)
+
+		isNew, err = tx.Tx().AddCredit(funding, nil, 0, false)
+		require.NoError(t, err)
+		require.False(t, isNew)
+
+		return nil
+	}, nil)
+	require.NoError(t, err)
+
+	spenderTx := wire.NewMsgTx(2)
+	spenderTx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash:  funding.Hash,
+		Index: 0,
+	}})
+	spenderTx.AddTxOut(&wire.TxOut{Value: 49_000, PkScript: []byte{0x51}})
+	spender, err := wtxmgr.NewTxRecordFromMsgTx(
+		spenderTx, time.Unix(1_001, 0),
+	)
+	require.NoError(t, err)
+	err = store.Update(t.Context(), func(tx walletstore.ReadWriteTx) error {
+		return tx.Tx().InsertTx(spender, nil)
+	}, nil)
+	require.NoError(t, err)
+
+	err = store.View(t.Context(), func(tx walletstore.ReadTx) error {
+		details, err := tx.Tx().TxDetails(&spender.Hash)
+		require.NoError(t, err)
+		require.Equal(t, []wtxmgr.DebitRecord{{
+			Amount: 50_000,
+			Index:  0,
+		}}, details.Debits)
+
+		return nil
+	}, nil)
+	require.NoError(t, err)
+}
+
+// TestStoreAcceptsNilReset verifies optional reset callbacks are normalized for
+// both replay-capable KV transaction methods.
+func TestStoreAcceptsNilReset(t *testing.T) {
+	t.Parallel()
+
+	store := newStore(testDB(t), testAddrStore{}, testTxStore{})
+	require.NoError(t, store.View(
+		t.Context(), func(walletstore.ReadTx) error {
+			return nil
+		}, nil,
+	))
+	require.NoError(t, store.Update(
+		t.Context(), func(walletstore.ReadWriteTx) error {
+			return nil
+		}, nil,
+	))
+}
+
 // TestStoreRejectsCanceledContext verifies that a canceled context prevents a
 // walletdb transaction from starting.
 func TestStoreRejectsCanceledContext(t *testing.T) {
@@ -204,6 +358,88 @@ func TestStoreRejectsCanceledContext(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 	require.False(t, bodyCalled)
 	require.False(t, resetCalled)
+}
+
+// TestUpdateOnceBypassesReplay verifies that the KV adapter invokes body once
+// without using a backend's replay-capable Update method.
+func TestUpdateOnceBypassesReplay(t *testing.T) {
+	t.Parallel()
+
+	database := &replayingDB{DB: testDB(t)}
+	store := newStore(database, testAddrStore{}, testTxStore{})
+	var bodyCalls, resetCalls, hookCalls int
+
+	err := store.UpdateOnce(
+		t.Context(), func(tx walletstore.ReadWriteTx) error {
+			bodyCalls++
+			tx.Addr().OnCommit(func() {
+				hookCalls++
+			})
+			return nil
+		}, func() {
+			resetCalls++
+		},
+	)
+	require.NoError(t, err)
+	require.Zero(t, database.updateCalls)
+	require.Equal(t, 1, bodyCalls)
+	require.Equal(t, 1, resetCalls)
+	require.Equal(t, 1, hookCalls)
+}
+
+// TestUpdateOnceReturnsRetryableBodyError verifies that a definitely
+// uncommitted retryable body error is preserved without replay.
+func TestUpdateOnceReturnsRetryableBodyError(t *testing.T) {
+	t.Parallel()
+
+	store := newStore(testDB(t), testAddrStore{}, testTxStore{})
+	wantErr := &walletstore.RetryableTransactionError{
+		Err: errors.New("retry transaction"),
+	}
+	var bodyCalls int
+	err := store.UpdateOnce(
+		t.Context(), func(walletstore.ReadWriteTx) error {
+			bodyCalls++
+			return wantErr
+		}, nil,
+	)
+
+	var retryable *walletstore.RetryableTransactionError
+	require.ErrorAs(t, err, &retryable)
+	require.Same(t, wantErr, retryable)
+	require.Equal(t, 1, bodyCalls)
+}
+
+// TestUpdateOnceReturnsAmbiguousCommit verifies that a KV commit failure is
+// conservatively reported as ambiguous and retains repairable commit hooks.
+func TestUpdateOnceReturnsAmbiguousCommit(t *testing.T) {
+	t.Parallel()
+
+	database := &commitErrorDB{
+		DB:        testDB(t),
+		commitErr: errors.New("commit failed"),
+	}
+	store := newStore(database, testAddrStore{}, testTxStore{})
+	var bodyCalls, hookCalls int
+	err := store.UpdateOnce(
+		t.Context(), func(tx walletstore.ReadWriteTx) error {
+			bodyCalls++
+			tx.Addr().OnCommit(func() {
+				hookCalls++
+			})
+			return nil
+		}, nil,
+	)
+
+	var ambiguous *walletstore.AmbiguousCommitError
+	require.ErrorAs(t, err, &ambiguous)
+	var retryable *walletstore.RetryableTransactionError
+	require.NotErrorAs(t, err, &retryable)
+	require.Equal(t, 1, bodyCalls)
+	require.Zero(t, hookCalls)
+	ambiguous.ApplyCommitHooks()
+	ambiguous.ApplyCommitHooks()
+	require.Equal(t, 1, hookCalls)
 }
 
 // testDB creates a walletdb fixture with initialized manager namespaces.

--- a/wallet/internal/db/pg/store.go
+++ b/wallet/internal/db/pg/store.go
@@ -11,6 +11,7 @@ import (
 
 // Store is the PostgreSQL manager transaction store.
 type Store struct {
+	// Store supplies the backend-neutral SQL transaction implementation.
 	*sqlstore.Store
 }
 
@@ -27,15 +28,41 @@ func NewStore(conn *sql.DB, walletID int64, maturity ...uint16) *Store {
 	}
 }
 
+// NewNamedStore creates a PostgreSQL manager store that resolves or creates one
+// wallet by name.
+func NewNamedStore(conn *sql.DB, walletName string,
+	maturity ...uint16) *Store {
+
+	return &Store{
+		Store: sqlstore.NewNamed(
+			conn, walletName, func(tx *sql.Tx) sqlstore.Queries {
+				return &queryAdapter{
+					queries: pgdb.New(tx),
+				}
+			}, maturity...,
+		),
+	}
+}
+
 type queryAdapter struct {
 	queries *pgdb.Queries
 }
 
 // PutBlock stores block through the transaction-bound backend.
-func (q *queryAdapter) PutBlock(ctx context.Context,
+func (q *queryAdapter) PutBlock(ctx context.Context, walletID int64,
 	row sqlstore.BlockRow) error {
 
+	err := q.queries.EnsureBlockHeight(ctx, pgdb.EnsureBlockHeightParams{
+		BlockHeight:    row.Height,
+		HeaderHash:     row.Hash,
+		BlockTimestamp: row.Timestamp,
+	})
+	if err != nil {
+		return err
+	}
+
 	return q.queries.PutBlock(ctx, pgdb.PutBlockParams{
+		WalletID:       walletID,
 		BlockHeight:    row.Height,
 		HeaderHash:     row.Hash,
 		BlockTimestamp: row.Timestamp,
@@ -43,10 +70,15 @@ func (q *queryAdapter) PutBlock(ctx context.Context,
 }
 
 // GetBlockByHeight reads block by height from the transaction-bound backend.
-func (q *queryAdapter) GetBlockByHeight(ctx context.Context,
+func (q *queryAdapter) GetBlockByHeight(ctx context.Context, walletID int64,
 	height int32) (sqlstore.BlockRow, error) {
 
-	row, err := q.queries.GetBlockByHeight(ctx, height)
+	row, err := q.queries.GetBlockByHeight(
+		ctx, pgdb.GetBlockByHeightParams{
+			WalletID:    walletID,
+			BlockHeight: height,
+		},
+	)
 	if err != nil {
 		return sqlstore.BlockRow{}, err
 	}

--- a/wallet/internal/db/pg/waddrmgr_queries.go
+++ b/wallet/internal/db/pg/waddrmgr_queries.go
@@ -50,7 +50,7 @@ func pgKeyScope(row pgdb.KeyScope) (waddrmgr.KeyScopeState, error) {
 		return waddrmgr.KeyScopeState{}, err
 	}
 
-	var lastAccount uint32
+	lastAccount := uint32(waddrmgr.NoAccount)
 	if row.LastAccountNumber.Valid {
 		lastAccount, err = sqlstore.CheckedUint32(
 			row.LastAccountNumber.Int64, "last account number",
@@ -268,6 +268,57 @@ func pgBlockStamp(height int32, hashBytes []byte,
 	}, nil
 }
 
+// WalletIDByName resolves a PostgreSQL wallet row identifier by name.
+func (q *queryAdapter) WalletIDByName(ctx context.Context,
+	name string) (int64, error) {
+
+	row, err := q.queries.GetWalletByName(ctx, name)
+	return row.ID, err
+}
+
+// CreateWallet creates the PostgreSQL root manager row.
+func (q *queryAdapter) CreateWallet(ctx context.Context, name string,
+	state waddrmgr.ManagerState) (int64, error) {
+
+	return q.queries.CreateWallet(ctx, pgdb.CreateWalletParams{
+		WalletName:               name,
+		ManagerVersion:           int64(state.Version),
+		ManagerCreatedAt:         state.CreatedAt.Unix(),
+		IsWatchOnly:              state.WatchOnly,
+		MasterPubParams:          state.MasterPubParams,
+		MasterPrivParams:         state.MasterPrivParams,
+		EncryptedCryptoPubKey:    state.EncryptedCryptoPubKey,
+		EncryptedCryptoPrivKey:   state.EncryptedCryptoPrivKey,
+		EncryptedCryptoScriptKey: state.EncryptedCryptoScriptKey,
+		EncryptedMasterHdPubKey:  state.EncryptedMasterHDPubKey,
+		EncryptedMasterHdPrivKey: state.EncryptedMasterHDPrivKey,
+	})
+}
+
+// CreateSyncState creates the initial PostgreSQL wallet synchronization row.
+func (q *queryAdapter) CreateSyncState(ctx context.Context, walletID int64,
+	state waddrmgr.SyncState) error {
+
+	birthdayHeight := sql.NullInt32{}
+	if state.BirthdayBlock != nil {
+		birthdayHeight = sql.NullInt32{
+			Int32: state.BirthdayBlock.Height,
+			Valid: true,
+		}
+	}
+
+	return q.queries.PutWalletSyncState(
+		ctx, pgdb.PutWalletSyncStateParams{
+			WalletID:              walletID,
+			StartBlockHeight:      state.StartBlock.Height,
+			SyncedBlockHeight:     state.SyncedTo.Height,
+			BirthdayTimestamp:     state.Birthday.Unix(),
+			BirthdayBlockHeight:   birthdayHeight,
+			BirthdayBlockVerified: state.BirthdayBlockVerified,
+		},
+	)
+}
+
 // GetManagerState reads manager state from the transaction-bound backend.
 func (q *queryAdapter) GetManagerState(ctx context.Context,
 	walletID int64) (waddrmgr.ManagerState, error) {
@@ -469,18 +520,23 @@ func (q *queryAdapter) ListKeyScopes(ctx context.Context,
 func (q *queryAdapter) PutKeyScope(ctx context.Context, walletID int64,
 	state waddrmgr.KeyScopeState) error {
 
+	lastAccount := sql.NullInt64{}
+	if state.LastAccount != waddrmgr.NoAccount {
+		lastAccount = sql.NullInt64{
+			Int64: int64(state.LastAccount),
+			Valid: true,
+		}
+	}
+
 	_, err := q.queries.PutKeyScope(ctx, pgdb.PutKeyScopeParams{
 		WalletID:             walletID,
 		Purpose:              int64(state.Scope.Purpose),
 		CoinType:             int64(state.Scope.Coin),
 		EncryptedCoinPubKey:  state.EncryptedCoinPubKey,
 		EncryptedCoinPrivKey: state.EncryptedCoinPrivKey,
-		LastAccountNumber: sql.NullInt64{
-			Int64: int64(state.LastAccount),
-			Valid: true,
-		},
-		ExternalAddrType: int16(state.AddrSchema.ExternalAddrType),
-		InternalAddrType: int16(state.AddrSchema.InternalAddrType),
+		LastAccountNumber:    lastAccount,
+		ExternalAddrType:     int16(state.AddrSchema.ExternalAddrType),
+		InternalAddrType:     int16(state.AddrSchema.InternalAddrType),
 	})
 
 	return err

--- a/wallet/internal/db/pg/wtxmgr_queries.go
+++ b/wallet/internal/db/pg/wtxmgr_queries.go
@@ -157,8 +157,8 @@ func (q *queryAdapter) ListTransactionDebits(ctx context.Context,
 
 	rows, err := q.queries.ListTransactionDebits(
 		ctx, pgdb.ListTransactionDebitsParams{
-			WalletID:     walletID,
-			SpendingTxID: transactionID,
+			WalletID:      walletID,
+			TransactionID: transactionID,
 		},
 	)
 	if err != nil {
@@ -506,10 +506,11 @@ func (q *queryAdapter) DeleteOutputLeaseAnyOwner(ctx context.Context,
 }
 
 // GetCreditID reads credit id from the transaction-bound backend.
-func (q *queryAdapter) GetCreditID(ctx context.Context, transactionID int64,
-	index uint32) (int64, error) {
+func (q *queryAdapter) GetCreditID(ctx context.Context, walletID,
+	transactionID int64, index uint32) (int64, error) {
 
 	row, err := q.queries.GetCredit(ctx, pgdb.GetCreditParams{
+		WalletID:      walletID,
 		TransactionID: transactionID,
 		OutputIndex:   int64(index),
 	})

--- a/wallet/internal/db/sqlite/store.go
+++ b/wallet/internal/db/sqlite/store.go
@@ -11,6 +11,7 @@ import (
 
 // Store is the SQLite manager transaction store.
 type Store struct {
+	// Store supplies the backend-neutral SQL transaction implementation.
 	*sqlstore.Store
 }
 
@@ -27,15 +28,43 @@ func NewStore(conn *sql.DB, walletID int64, maturity ...uint16) *Store {
 	}
 }
 
+// NewNamedStore creates a SQLite manager store that resolves or creates one
+// wallet by name.
+func NewNamedStore(conn *sql.DB, walletName string,
+	maturity ...uint16) *Store {
+
+	return &Store{
+		Store: sqlstore.NewNamed(
+			conn, walletName, func(tx *sql.Tx) sqlstore.Queries {
+				return &queryAdapter{
+					queries: sqlitedb.New(tx),
+				}
+			}, maturity...,
+		),
+	}
+}
+
 type queryAdapter struct {
 	queries *sqlitedb.Queries
 }
 
 // PutBlock stores block through the transaction-bound backend.
-func (q *queryAdapter) PutBlock(ctx context.Context,
+func (q *queryAdapter) PutBlock(ctx context.Context, walletID int64,
 	row sqlstore.BlockRow) error {
 
+	err := q.queries.EnsureBlockHeight(
+		ctx, sqlitedb.EnsureBlockHeightParams{
+			BlockHeight:    int64(row.Height),
+			HeaderHash:     row.Hash,
+			BlockTimestamp: row.Timestamp,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
 	return q.queries.PutBlock(ctx, sqlitedb.PutBlockParams{
+		WalletID:       walletID,
 		BlockHeight:    int64(row.Height),
 		HeaderHash:     row.Hash,
 		BlockTimestamp: row.Timestamp,
@@ -43,10 +72,15 @@ func (q *queryAdapter) PutBlock(ctx context.Context,
 }
 
 // GetBlockByHeight reads block by height from the transaction-bound backend.
-func (q *queryAdapter) GetBlockByHeight(ctx context.Context,
+func (q *queryAdapter) GetBlockByHeight(ctx context.Context, walletID int64,
 	height int32) (sqlstore.BlockRow, error) {
 
-	row, err := q.queries.GetBlockByHeight(ctx, int64(height))
+	row, err := q.queries.GetBlockByHeight(
+		ctx, sqlitedb.GetBlockByHeightParams{
+			WalletID:    walletID,
+			BlockHeight: int64(height),
+		},
+	)
 	if err != nil {
 		return sqlstore.BlockRow{}, err
 	}

--- a/wallet/internal/db/sqlite/waddrmgr_queries.go
+++ b/wallet/internal/db/sqlite/waddrmgr_queries.go
@@ -52,7 +52,7 @@ func sqliteKeyScope(
 		return waddrmgr.KeyScopeState{}, err
 	}
 
-	var lastAccount uint32
+	lastAccount := uint32(waddrmgr.NoAccount)
 	if row.LastAccountNumber.Valid {
 		lastAccount, err = sqlstore.CheckedUint32(
 			row.LastAccountNumber.Int64, "last account number",
@@ -271,6 +271,57 @@ func sqliteBlockStamp(height int64, hashBytes []byte,
 	}, nil
 }
 
+// WalletIDByName resolves a SQLite wallet row identifier by name.
+func (q *queryAdapter) WalletIDByName(ctx context.Context,
+	name string) (int64, error) {
+
+	row, err := q.queries.GetWalletByName(ctx, name)
+	return row.ID, err
+}
+
+// CreateWallet creates the SQLite root manager row.
+func (q *queryAdapter) CreateWallet(ctx context.Context, name string,
+	state waddrmgr.ManagerState) (int64, error) {
+
+	return q.queries.CreateWallet(ctx, sqlitedb.CreateWalletParams{
+		WalletName:               name,
+		ManagerVersion:           int64(state.Version),
+		ManagerCreatedAt:         state.CreatedAt.Unix(),
+		IsWatchOnly:              state.WatchOnly,
+		MasterPubParams:          state.MasterPubParams,
+		MasterPrivParams:         state.MasterPrivParams,
+		EncryptedCryptoPubKey:    state.EncryptedCryptoPubKey,
+		EncryptedCryptoPrivKey:   state.EncryptedCryptoPrivKey,
+		EncryptedCryptoScriptKey: state.EncryptedCryptoScriptKey,
+		EncryptedMasterHdPubKey:  state.EncryptedMasterHDPubKey,
+		EncryptedMasterHdPrivKey: state.EncryptedMasterHDPrivKey,
+	})
+}
+
+// CreateSyncState creates the initial SQLite wallet synchronization row.
+func (q *queryAdapter) CreateSyncState(ctx context.Context, walletID int64,
+	state waddrmgr.SyncState) error {
+
+	birthdayHeight := sql.NullInt64{}
+	if state.BirthdayBlock != nil {
+		birthdayHeight = sql.NullInt64{
+			Int64: int64(state.BirthdayBlock.Height),
+			Valid: true,
+		}
+	}
+
+	return q.queries.PutWalletSyncState(
+		ctx, sqlitedb.PutWalletSyncStateParams{
+			WalletID:              walletID,
+			StartBlockHeight:      int64(state.StartBlock.Height),
+			SyncedBlockHeight:     int64(state.SyncedTo.Height),
+			BirthdayTimestamp:     state.Birthday.Unix(),
+			BirthdayBlockHeight:   birthdayHeight,
+			BirthdayBlockVerified: state.BirthdayBlockVerified,
+		},
+	)
+}
+
 // GetManagerState reads manager state from the transaction-bound backend.
 func (q *queryAdapter) GetManagerState(ctx context.Context,
 	walletID int64) (waddrmgr.ManagerState, error) {
@@ -472,18 +523,23 @@ func (q *queryAdapter) ListKeyScopes(ctx context.Context,
 func (q *queryAdapter) PutKeyScope(ctx context.Context, walletID int64,
 	state waddrmgr.KeyScopeState) error {
 
+	lastAccount := sql.NullInt64{}
+	if state.LastAccount != waddrmgr.NoAccount {
+		lastAccount = sql.NullInt64{
+			Int64: int64(state.LastAccount),
+			Valid: true,
+		}
+	}
+
 	_, err := q.queries.PutKeyScope(ctx, sqlitedb.PutKeyScopeParams{
 		WalletID:             walletID,
 		Purpose:              int64(state.Scope.Purpose),
 		CoinType:             int64(state.Scope.Coin),
 		EncryptedCoinPubKey:  state.EncryptedCoinPubKey,
 		EncryptedCoinPrivKey: state.EncryptedCoinPrivKey,
-		LastAccountNumber: sql.NullInt64{
-			Int64: int64(state.LastAccount),
-			Valid: true,
-		},
-		ExternalAddrType: int64(state.AddrSchema.ExternalAddrType),
-		InternalAddrType: int64(state.AddrSchema.InternalAddrType),
+		LastAccountNumber:    lastAccount,
+		ExternalAddrType:     int64(state.AddrSchema.ExternalAddrType),
+		InternalAddrType:     int64(state.AddrSchema.InternalAddrType),
 	})
 
 	return err

--- a/wallet/internal/db/sqlite/wtxmgr_queries.go
+++ b/wallet/internal/db/sqlite/wtxmgr_queries.go
@@ -139,8 +139,8 @@ func (q *queryAdapter) ListTransactionDebits(ctx context.Context,
 
 	rows, err := q.queries.ListTransactionDebits(
 		ctx, sqlitedb.ListTransactionDebitsParams{
-			WalletID:     walletID,
-			SpendingTxID: transactionID,
+			WalletID:      walletID,
+			TransactionID: transactionID,
 		},
 	)
 	if err != nil {
@@ -490,10 +490,11 @@ func (q *queryAdapter) DeleteOutputLeaseAnyOwner(ctx context.Context,
 }
 
 // GetCreditID reads credit id from the transaction-bound backend.
-func (q *queryAdapter) GetCreditID(ctx context.Context, transactionID int64,
-	index uint32) (int64, error) {
+func (q *queryAdapter) GetCreditID(ctx context.Context, walletID,
+	transactionID int64, index uint32) (int64, error) {
 
 	row, err := q.queries.GetCredit(ctx, sqlitedb.GetCreditParams{
+		WalletID:      walletID,
 		TransactionID: transactionID,
 		OutputIndex:   int64(index),
 	})

--- a/wallet/internal/db/sqlstore/queries.go
+++ b/wallet/internal/db/sqlstore/queries.go
@@ -9,95 +9,180 @@ import (
 
 // BlockRow is the backend-neutral representation of a blocks table row.
 type BlockRow struct {
-	Height    int32
-	Hash      []byte
+	// Height is the block height.
+	Height int32
+
+	// Hash is the serialized block hash.
+	Hash []byte
+
+	// Timestamp is the block timestamp as Unix seconds.
 	Timestamp int64
 }
 
 // TransactionDetailsRow contains the generated columns used to reconstruct a
 // wtxmgr transaction detail.
 type TransactionDetailsRow struct {
-	ID             int64
-	RawTx          []byte
-	Received       int64
-	BlockHeight    sql.NullInt64
+	// ID is the transaction row identifier.
+	ID int64
+
+	// RawTx is the serialized transaction.
+	RawTx []byte
+
+	// Received is the transaction receive time as Unix seconds.
+	Received int64
+
+	// BlockHeight is the optional mined block height.
+	BlockHeight sql.NullInt64
+
+	// ConfirmedOrder is the optional transaction order within its block.
 	ConfirmedOrder sql.NullInt64
-	BlockHash      []byte
+
+	// BlockHash is the optional serialized mined block hash.
+	BlockHash []byte
+
+	// BlockTimestamp is the optional mined block time as Unix seconds.
 	BlockTimestamp sql.NullInt64
-	Label          []byte
+
+	// Label is the optional transaction label.
+	Label []byte
 }
 
 // TransactionRow contains one transaction incidence.
 type TransactionRow struct {
-	ID          int64
-	Hash        []byte
-	RawTx       []byte
+	// ID is the transaction row identifier.
+	ID int64
+
+	// Hash is the serialized transaction hash.
+	Hash []byte
+
+	// RawTx is the serialized transaction.
+	RawTx []byte
+
+	// BlockHeight is the optional mined block height.
 	BlockHeight sql.NullInt64
 }
 
 // TransactionIncidenceRow identifies one mined transaction incidence.
 type TransactionIncidenceRow struct {
-	ID     int64
+	// ID is the transaction row identifier.
+	ID int64
+
+	// Height is the mined block height.
 	Height int32
 }
 
 // TransactionCreditRow contains one credit attached to a transaction detail.
 type TransactionCreditRow struct {
+	// OutputIndex is the credited transaction output index.
 	OutputIndex int64
-	Amount      int64
-	IsChange    bool
-	IsSpent     bool
+
+	// Amount is the credited amount in satoshis.
+	Amount int64
+
+	// IsChange records whether the output is wallet change.
+	IsChange bool
+
+	// IsSpent records whether the credit is currently spent.
+	IsSpent bool
 }
 
 // TransactionDebitRow contains one debit attached to a transaction detail.
 type TransactionDebitRow struct {
+	// InputIndex is the debiting transaction input index.
 	InputIndex int64
-	Amount     int64
+
+	// Amount is the debited amount in satoshis.
+	Amount int64
 }
 
 // CreditRow contains the generated columns used by the wtxmgr credit views.
 type CreditRow struct {
-	Hash           []byte
-	OutputIndex    int64
-	Amount         int64
-	PkScript       []byte
-	Received       int64
-	BlockHeight    sql.NullInt64
-	IsCoinbase     bool
-	BlockHash      []byte
+	// Hash is the serialized transaction hash.
+	Hash []byte
+
+	// OutputIndex is the credited transaction output index.
+	OutputIndex int64
+
+	// Amount is the credited amount in satoshis.
+	Amount int64
+
+	// PkScript is the credited output's public-key script.
+	PkScript []byte
+
+	// Received is the transaction receive time as Unix seconds.
+	Received int64
+
+	// BlockHeight is the optional mined block height.
+	BlockHeight sql.NullInt64
+
+	// IsCoinbase records whether the transaction is a coinbase.
+	IsCoinbase bool
+
+	// BlockHash is the optional serialized mined block hash.
+	BlockHash []byte
+
+	// BlockTimestamp is the optional mined block time as Unix seconds.
 	BlockTimestamp sql.NullInt64
 }
 
 // MinedTransactionRow identifies a mined transaction being disconnected.
 type MinedTransactionRow struct {
-	ID         int64
-	Hash       []byte
+	// ID is the transaction row identifier.
+	ID int64
+
+	// Hash is the serialized transaction hash.
+	Hash []byte
+
+	// IsCoinbase records whether the transaction is a coinbase.
 	IsCoinbase bool
 }
 
 // UnminedSpenderRow identifies an unmined transaction that spends a hash.
 type UnminedSpenderRow struct {
-	ID   int64
+	// ID is the transaction row identifier.
+	ID int64
+
+	// Hash is the serialized transaction hash.
 	Hash []byte
 }
 
 // OutputLeaseRow contains one persisted output lease.
 type OutputLeaseRow struct {
-	Hash       []byte
-	Index      int64
-	LockID     []byte
+	// Hash is the serialized transaction hash.
+	Hash []byte
+
+	// Index is the leased transaction output index.
+	Index int64
+
+	// LockID identifies the lease owner.
+	LockID []byte
+
+	// Expiration is the lease expiration time as Unix nanoseconds.
 	Expiration int64
 }
 
 // InsertTransactionParams contains a transaction incidence to persist.
 type InsertTransactionParams struct {
-	WalletID       int64
-	Hash           []byte
-	RawTx          []byte
-	Received       int64
-	BlockHeight    sql.NullInt64
+	// WalletID identifies the wallet owning the transaction.
+	WalletID int64
+
+	// Hash is the serialized transaction hash.
+	Hash []byte
+
+	// RawTx is the serialized transaction.
+	RawTx []byte
+
+	// Received is the transaction receive time as Unix seconds.
+	Received int64
+
+	// BlockHeight is the optional mined block height.
+	BlockHeight sql.NullInt64
+
+	// ConfirmedOrder is the optional transaction order within its block.
 	ConfirmedOrder sql.NullInt64
-	IsCoinbase     bool
+
+	// IsCoinbase records whether the transaction is a coinbase.
+	IsCoinbase bool
 }
 
 // Queries is the sqlc-generated query subset required by the manager store.
@@ -105,11 +190,21 @@ type InsertTransactionParams struct {
 //
 //nolint:interfacebloat // One SQL transaction binds both manager domains.
 type Queries interface {
-	// PutBlock stores block through the transaction-bound backend.
-	PutBlock(ctx context.Context, row BlockRow) error
+	// WalletIDByName resolves a wallet's backend row identifier.
+	WalletIDByName(ctx context.Context, name string) (int64, error)
+	// CreateWallet creates the root manager row and returns its identifier.
+	CreateWallet(ctx context.Context, name string,
+		state waddrmgr.ManagerState) (int64, error)
+	// CreateSyncState creates the initial wallet synchronization row.
+	CreateSyncState(ctx context.Context, walletID int64,
+		state waddrmgr.SyncState) error
+	// PutBlock stores one wallet's block through the transaction-bound
+	// backend.
+	PutBlock(ctx context.Context, walletID int64, row BlockRow) error
 	// GetBlockByHeight reads block by height from the transaction-bound
 	// backend.
-	GetBlockByHeight(ctx context.Context, height int32) (BlockRow, error)
+	GetBlockByHeight(ctx context.Context, walletID int64,
+		height int32) (BlockRow, error)
 	// GetWalletStartBlock reads wallet start block from the transaction-bound
 	// backend.
 	GetWalletStartBlock(ctx context.Context, walletID int64) (BlockRow, error)
@@ -304,7 +399,7 @@ type Queries interface {
 	DeleteOutputLeaseAnyOwner(ctx context.Context, walletID int64,
 		hash []byte, index uint32) (int64, error)
 	// GetCreditID reads credit id from the transaction-bound backend.
-	GetCreditID(ctx context.Context, transactionID int64,
+	GetCreditID(ctx context.Context, walletID, transactionID int64,
 		index uint32) (int64, error)
 	// InsertCredit records credit through the transaction-bound backend.
 	InsertCredit(ctx context.Context, walletID, transactionID int64,

--- a/wallet/internal/db/sqlstore/store.go
+++ b/wallet/internal/db/sqlstore/store.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/btcsuite/btcd/chainhash/v2"
@@ -22,14 +23,33 @@ const defaultCoinbaseMaturity = 100
 // Store owns SQL transactions for one wallet's address and transaction
 // managers.
 type Store struct {
+	bindMu           sync.Mutex
 	walletID         int64
+	walletName       string
 	coinbaseMaturity int32
+	conn             *sql.DB
+	newQueries       func(*sql.Tx) Queries
 	executor         *sqldb.TransactionExecutor[Queries]
 }
 
 // New creates a manager store over an existing SQL connection. Connection
 // setup, migrations, and wallet creation remain owned by the backend package.
 func New(conn *sql.DB, walletID int64,
+	newQueries func(*sql.Tx) Queries, maturity ...uint16) *Store {
+
+	return newStore(conn, walletID, "", newQueries, maturity...)
+}
+
+// NewNamed creates an initially name-bound manager store. The store resolves an
+// existing wallet lazily and can create the wallet through its lifecycle API.
+func NewNamed(conn *sql.DB, walletName string,
+	newQueries func(*sql.Tx) Queries, maturity ...uint16) *Store {
+
+	return newStore(conn, 0, walletName, newQueries, maturity...)
+}
+
+// newStore initializes the common SQL manager store state.
+func newStore(conn *sql.DB, walletID int64, walletName string,
 	newQueries func(*sql.Tx) Queries, maturity ...uint16) *Store {
 
 	baseDB := &sqldb.BaseDB{
@@ -44,26 +64,103 @@ func New(conn *sql.DB, walletID int64,
 
 	return &Store{
 		walletID:         walletID,
+		walletName:       walletName,
 		coinbaseMaturity: coinbaseMaturity,
+		conn:             conn,
+		newQueries:       newQueries,
 		executor:         sqldb.NewTransactionExecutor(baseDB, newQueries),
 	}
+}
+
+// WalletExists reports whether the configured SQL wallet exists. A successful
+// name lookup binds the store to the wallet row for subsequent transactions.
+func (s *Store) WalletExists(ctx context.Context) (bool, error) {
+	s.bindMu.Lock()
+	defer s.bindMu.Unlock()
+
+	var resolvedID int64
+	err := s.executor.ExecTx(
+		ctx, sqldb.ReadTxOpt(), func(queries Queries) error {
+			if s.walletID != 0 {
+				_, err := queries.GetManagerState(ctx, s.walletID)
+				return err
+			}
+			if s.walletName == "" {
+				return sql.ErrNoRows
+			}
+
+			var err error
+			resolvedID, err = queries.WalletIDByName(
+				ctx, s.walletName,
+			)
+			return err
+		}, func() {
+			resolvedID = 0
+		},
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	if s.walletID == 0 {
+		s.walletID = resolvedID
+	}
+
+	return true, nil
+}
+
+// resolveWalletID requires the configured wallet and returns its durable row
+// identifier.
+func (s *Store) resolveWalletID(ctx context.Context) (int64, error) {
+	s.bindMu.Lock()
+	if s.walletID != 0 {
+		walletID := s.walletID
+		s.bindMu.Unlock()
+
+		return walletID, nil
+	}
+	s.bindMu.Unlock()
+
+	exists, err := s.WalletExists(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if !exists {
+		return 0, waddrmgr.ManagerError{
+			ErrorCode:   waddrmgr.ErrNoExist,
+			Description: "address manager does not exist",
+		}
+	}
+
+	s.bindMu.Lock()
+	walletID := s.walletID
+	s.bindMu.Unlock()
+
+	return walletID, nil
 }
 
 // View executes body in a read-only SQL transaction.
 func (s *Store) View(ctx context.Context,
 	body func(walletstore.ReadTx) error, reset func()) error {
+	walletID, err := s.resolveWalletID(ctx)
+	if err != nil {
+		return err
+	}
 
 	return s.executor.ExecTx(
 		ctx, sqldb.ReadTxOpt(), func(queries Queries) error {
 			return body(&readTx{
 				addrStore: &addrStore{
 					ctx:      ctx,
-					walletID: s.walletID,
+					walletID: walletID,
 					queries:  queries,
 				},
 				txStore: &txStore{
 					ctx:              ctx,
-					walletID:         s.walletID,
+					walletID:         walletID,
 					coinbaseMaturity: s.coinbaseMaturity,
 					queries:          queries,
 				},
@@ -75,24 +172,241 @@ func (s *Store) View(ctx context.Context,
 // Update executes body in a read/write SQL transaction.
 func (s *Store) Update(ctx context.Context,
 	body func(walletstore.ReadWriteTx) error, reset func()) error {
+	walletID, err := s.resolveWalletID(ctx)
+	if err != nil {
+		return err
+	}
 
-	return s.executor.ExecTx(
+	var (
+		hooks         []func()
+		bodyCompleted bool
+	)
+	err = s.executor.ExecTx(
 		ctx, sqldb.WriteTxOpt(), func(queries Queries) error {
-			return body(&readWriteTx{
+			bodyErr := body(&readWriteTx{
 				addrStore: &addrStore{
 					ctx:      ctx,
-					walletID: s.walletID,
+					walletID: walletID,
 					queries:  queries,
+					onCommit: func(callback func()) {
+						hooks = append(hooks, callback)
+					},
 				},
 				txStore: &txStore{
 					ctx:              ctx,
-					walletID:         s.walletID,
+					walletID:         walletID,
 					coinbaseMaturity: s.coinbaseMaturity,
 					queries:          queries,
 				},
 			})
-		}, nonNilReset(reset),
+			bodyCompleted = bodyErr == nil
+
+			return bodyErr
+		}, func() {
+			hooks = nil
+			bodyCompleted = false
+			nonNilReset(reset)()
+		},
 	)
+	if err != nil {
+		if bodyCompleted {
+			return mapCommitError(err, hooks...)
+		}
+
+		return mapUncommittedError(err)
+	}
+
+	for _, hook := range hooks {
+		hook()
+	}
+
+	return nil
+}
+
+// UpdateOnce executes body in one SQL transaction attempt and publishes commit
+// hooks only after Commit returns success. It never replays body internally.
+func (s *Store) UpdateOnce(ctx context.Context,
+	body func(walletstore.ReadWriteTx) error, reset func()) error {
+	walletID, err := s.resolveWalletID(ctx)
+	if err != nil {
+		return err
+	}
+
+	tx, err := s.conn.BeginTx(ctx, &sql.TxOptions{
+		Isolation: sql.LevelSerializable,
+	})
+	if err != nil {
+		return mapUncommittedError(err)
+	}
+
+	rollback := true
+	defer func() {
+		if rollback {
+			_ = tx.Rollback()
+		}
+	}()
+
+	nonNilReset(reset)()
+
+	var hooks []func()
+	addrStore := &addrStore{
+		ctx:      ctx,
+		walletID: walletID,
+		queries:  s.newQueries(tx),
+		onCommit: func(callback func()) {
+			hooks = append(hooks, callback)
+		},
+	}
+	txStore := &txStore{
+		ctx:              ctx,
+		walletID:         walletID,
+		coinbaseMaturity: s.coinbaseMaturity,
+		queries:          addrStore.queries,
+	}
+
+	err = body(&readWriteTx{
+		addrStore: addrStore,
+		txStore:   txStore,
+	})
+	if err != nil {
+		return mapUncommittedError(err)
+	}
+
+	err = tx.Commit()
+	rollback = false
+	if err != nil {
+		return mapCommitError(err, hooks...)
+	}
+
+	for _, hook := range hooks {
+		hook()
+	}
+
+	return nil
+}
+
+// Create executes the wallet creation callback exactly once and binds this
+// named store only after the transaction commits successfully.
+func (s *Store) Create(ctx context.Context,
+	body func(walletstore.ReadWriteTx) error, reset func()) error {
+
+	s.bindMu.Lock()
+	defer s.bindMu.Unlock()
+
+	if s.walletID != 0 {
+		return waddrmgr.ManagerError{
+			ErrorCode:   waddrmgr.ErrAlreadyExists,
+			Description: "address manager already exists",
+		}
+	}
+	if s.walletName == "" {
+		return errors.New("wallet name is required for SQL creation")
+	}
+
+	tx, err := s.conn.BeginTx(ctx, &sql.TxOptions{
+		Isolation: sql.LevelSerializable,
+	})
+	if err != nil {
+		return mapUncommittedError(err)
+	}
+
+	rollback := true
+	defer func() {
+		if rollback {
+			_ = tx.Rollback()
+		}
+	}()
+
+	nonNilReset(reset)()
+	queries := s.newQueries(tx)
+	_, err = queries.WalletIDByName(ctx, s.walletName)
+	switch {
+	case err == nil:
+		return waddrmgr.ManagerError{
+			ErrorCode:   waddrmgr.ErrAlreadyExists,
+			Description: "address manager already exists",
+		}
+
+	case !errors.Is(err, sql.ErrNoRows):
+		return mapUncommittedError(err)
+	}
+
+	var hooks []func()
+	txStore := &txStore{
+		ctx:              ctx,
+		coinbaseMaturity: s.coinbaseMaturity,
+		queries:          queries,
+	}
+	addrStore := &addrStore{
+		ctx:        ctx,
+		walletName: s.walletName,
+		creating:   true,
+		queries:    queries,
+		onWalletCreated: func(walletID int64) {
+			txStore.walletID = walletID
+		},
+		onCommit: func(callback func()) {
+			hooks = append(hooks, callback)
+		},
+	}
+
+	err = body(&readWriteTx{
+		addrStore: addrStore,
+		txStore:   txStore,
+	})
+	if err != nil {
+		return mapUncommittedError(err)
+	}
+	if addrStore.walletID == 0 {
+		return errors.New("wallet creation did not write manager state")
+	}
+
+	err = tx.Commit()
+	rollback = false
+	if err != nil {
+		return mapCommitError(err, hooks...)
+	}
+
+	s.walletID = addrStore.walletID
+	for _, hook := range hooks {
+		hook()
+	}
+
+	return nil
+}
+
+// mapUncommittedError marks serialization failures that occurred before commit
+// as safe for the caller to retry.
+func mapUncommittedError(err error) error {
+	var retryable *walletstore.RetryableTransactionError
+	if errors.As(err, &retryable) {
+		return err
+	}
+
+	var ambiguous *walletstore.AmbiguousCommitError
+	if errors.As(err, &ambiguous) {
+		return err
+	}
+
+	mappedErr := sqldb.MapSQLError(err)
+	if !sqldb.IsSerializationError(mappedErr) {
+		return mappedErr
+	}
+
+	return &walletstore.RetryableTransactionError{Err: mappedErr}
+}
+
+// mapCommitError distinguishes serialization failures known to abort the SQL
+// transaction from failures whose commit outcome cannot be determined.
+func mapCommitError(err error, hooks ...func()) error {
+	mappedErr := sqldb.MapSQLError(err)
+	if sqldb.IsSerializationError(mappedErr) ||
+		errors.Is(mappedErr, sqldb.ErrRetriesExceeded) {
+
+		return &walletstore.RetryableTransactionError{Err: mappedErr}
+	}
+
+	return walletstore.NewAmbiguousCommitError(mappedErr, hooks...)
 }
 
 // nonNilReset normalizes an optional reset callback for the SQL transaction
@@ -147,9 +461,19 @@ type addrStore struct {
 	// The manager view is scoped to the transaction callback that created it.
 	//
 	//nolint:containedctx // Domain methods intentionally omit backend context.
-	ctx      context.Context
-	walletID int64
-	queries  Queries
+	ctx             context.Context
+	walletID        int64
+	walletName      string
+	creating        bool
+	queries         Queries
+	onWalletCreated func(int64)
+	onCommit        func(func())
+}
+
+// OnCommit registers a callback for publication after the enclosing SQL
+// transaction commits successfully.
+func (s *addrStore) OnCommit(callback func()) {
+	s.onCommit(callback)
 }
 
 // expectWalletRow requires a manager update to affect exactly one wallet row.
@@ -284,6 +608,21 @@ func (s *addrStore) ActiveAddresses(
 
 // PutManagerState replaces the durable root address-manager state.
 func (s *addrStore) PutManagerState(state waddrmgr.ManagerState) error {
+	if s.creating && s.walletID == 0 {
+		walletID, err := s.queries.CreateWallet(
+			s.ctx, s.walletName, state,
+		)
+		if err != nil {
+			return fmt.Errorf("create manager state: %w", err)
+		}
+
+		s.walletID = walletID
+		if s.onWalletCreated != nil {
+			s.onWalletCreated(walletID)
+		}
+		return nil
+	}
+
 	rows, err := s.queries.PutManagerState(s.ctx, s.walletID, state)
 	if err != nil {
 		return fmt.Errorf("put manager state: %w", err)
@@ -300,7 +639,7 @@ func (s *addrStore) PutSyncState(state waddrmgr.SyncState) error {
 	}
 
 	for _, block := range blocks {
-		err := s.queries.PutBlock(s.ctx, BlockRow{
+		err := s.queries.PutBlock(s.ctx, s.walletID, BlockRow{
 			Height:    block.Height,
 			Hash:      block.Hash[:],
 			Timestamp: block.Timestamp.Unix(),
@@ -308,6 +647,15 @@ func (s *addrStore) PutSyncState(state waddrmgr.SyncState) error {
 		if err != nil {
 			return fmt.Errorf("put sync block %d: %w", block.Height, err)
 		}
+	}
+
+	if s.creating {
+		err := s.queries.CreateSyncState(s.ctx, s.walletID, state)
+		if err != nil {
+			return fmt.Errorf("create sync state: %w", err)
+		}
+
+		return nil
 	}
 
 	rows, err := s.queries.PutSyncState(s.ctx, s.walletID, state)
@@ -334,7 +682,7 @@ func (s *addrStore) SetBirthday(birthday time.Time) error {
 func (s *addrStore) SetBirthdayBlock(block *waddrmgr.BlockStamp) error {
 	var height *int32
 	if block != nil {
-		err := s.queries.PutBlock(s.ctx, BlockRow{
+		err := s.queries.PutBlock(s.ctx, s.walletID, BlockRow{
 			Height:    block.Height,
 			Hash:      block.Hash[:],
 			Timestamp: block.Timestamp.Unix(),
@@ -550,7 +898,7 @@ func (s *addrStore) DeletePrivateKeys() error {
 
 // BlockHash returns the block hash at a particular block height.
 func (s *addrStore) BlockHash(height int32) (*chainhash.Hash, error) {
-	row, err := s.queries.GetBlockByHeight(s.ctx, height)
+	row, err := s.queries.GetBlockByHeight(s.ctx, s.walletID, height)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, waddrmgr.ManagerError{
 			ErrorCode: waddrmgr.ErrBlockNotFound,
@@ -593,7 +941,7 @@ func (s *addrStore) SetSyncedTo(block *waddrmgr.BlockStamp) error {
 		}
 	}
 
-	err := s.queries.PutBlock(s.ctx, BlockRow{
+	err := s.queries.PutBlock(s.ctx, s.walletID, BlockRow{
 		Height:    block.Height,
 		Hash:      block.Hash[:],
 		Timestamp: block.Timestamp.Unix(),
@@ -789,6 +1137,7 @@ func (s *txStore) deleteTransaction(transactionID int64) error {
 
 var (
 	_ walletstore.Store              = (*Store)(nil)
+	_ walletstore.LifecycleStore     = (*Store)(nil)
 	_ walletstore.ReadTx             = (*readTx)(nil)
 	_ walletstore.ReadWriteTx        = (*readWriteTx)(nil)
 	_ walletstore.AddrReadStore      = (*addrStore)(nil)

--- a/wallet/internal/db/sqlstore/store_test.go
+++ b/wallet/internal/db/sqlstore/store_test.go
@@ -1,0 +1,88 @@
+package sqlstore
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+
+	walletstore "github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+// TestUpdateOnceRunsBodyOnce verifies that a retryable body failure is
+// returned to the caller without replaying the callback.
+func TestUpdateOnceRunsBodyOnce(t *testing.T) {
+	t.Parallel()
+
+	conn, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+
+	store := New(conn, 1, func(*sql.Tx) Queries {
+		return nil
+	})
+	var bodyCalls, resetCalls int
+	err = store.UpdateOnce(
+		t.Context(), func(walletstore.ReadWriteTx) error {
+			bodyCalls++
+			return errors.New("SQLITE_BUSY")
+		}, func() {
+			resetCalls++
+		},
+	)
+
+	var retryable *walletstore.RetryableTransactionError
+	require.ErrorAs(t, err, &retryable)
+	var ambiguous *walletstore.AmbiguousCommitError
+	require.NotErrorAs(t, err, &ambiguous)
+	require.Equal(t, 1, bodyCalls)
+	require.Equal(t, 1, resetCalls)
+}
+
+// TestUpdateOncePublishesHooks verifies that commit hooks run once and only
+// after the single SQL attempt commits successfully.
+func TestUpdateOncePublishesHooks(t *testing.T) {
+	t.Parallel()
+
+	conn, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+
+	store := New(conn, 1, func(*sql.Tx) Queries {
+		return nil
+	})
+	var bodyCalls, hookCalls int
+	err = store.UpdateOnce(
+		t.Context(), func(tx walletstore.ReadWriteTx) error {
+			bodyCalls++
+			tx.Addr().OnCommit(func() {
+				hookCalls++
+			})
+			return nil
+		}, nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, bodyCalls)
+	require.Equal(t, 1, hookCalls)
+}
+
+// TestMapCommitError verifies that only definitely aborted serialization
+// failures are retryable and ordinary commit failures are ambiguous.
+func TestMapCommitError(t *testing.T) {
+	t.Parallel()
+
+	retryableErr := mapCommitError(errors.New("SQLITE_BUSY"))
+	var retryable *walletstore.RetryableTransactionError
+	require.ErrorAs(t, retryableErr, &retryable)
+	var ambiguous *walletstore.AmbiguousCommitError
+	require.NotErrorAs(t, retryableErr, &ambiguous)
+
+	ambiguousErr := mapCommitError(errors.New("connection lost"))
+	require.ErrorAs(t, ambiguousErr, &ambiguous)
+	require.NotErrorAs(t, ambiguousErr, &retryable)
+}

--- a/wallet/internal/db/sqlstore/tx_read.go
+++ b/wallet/internal/db/sqlstore/tx_read.go
@@ -238,10 +238,7 @@ func (s *txStore) rangeUnmined(
 func (s *txStore) rangeMined(begin, end int32,
 	visit func([]wtxmgr.TxDetails) (bool, error)) (bool, error) {
 
-	forward := begin < end
-
 	// wtxmgr uses a negative height as the unbounded chain tip. Normalize it
-	// only for the mined query because unmined placement is handled by the
 	// caller.
 	if begin < 0 {
 		begin = int32(^uint32(0) >> 1)
@@ -250,6 +247,7 @@ func (s *txStore) rangeMined(begin, end int32,
 	if end < 0 {
 		end = int32(^uint32(0) >> 1)
 	}
+	forward := begin < end
 
 	// Preserve wtxmgr's caller-selected traversal direction in SQL so each
 	// callback sees heights in the expected order.
@@ -451,7 +449,7 @@ func (s *txStore) OutputsToWatch() ([]wtxmgr.Credit, error) {
 // UnspentOutputs returns all currently spendable credits.
 func (s *txStore) UnspentOutputs() ([]wtxmgr.Credit, error) {
 	rows, err := s.queries.ListUnspentCredits(
-		s.ctx, s.walletID, time.Now().Unix(),
+		s.ctx, s.walletID, time.Now().UnixNano(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("list unspent outputs: %w", err)

--- a/wallet/internal/db/sqlstore/tx_write.go
+++ b/wallet/internal/db/sqlstore/tx_write.go
@@ -82,7 +82,9 @@ func (s *txStore) transactionID(hash chainhash.Hash,
 func (s *txStore) insertUnmined(record *wtxmgr.TxRecord,
 	rawTx []byte) (bool, error) {
 
-	_, err := s.transactionID(record.Hash, nil)
+	_, err := s.queries.GetTransactionDetailsByHash(
+		s.ctx, s.walletID, record.Hash[:],
+	)
 	if err == nil {
 		return true, nil
 	}
@@ -122,7 +124,7 @@ func (s *txStore) insertMined(record *wtxmgr.TxRecord, rawTx []byte,
 	}
 
 	// Materialize the containing block before any transaction references it.
-	err = s.queries.PutBlock(s.ctx, BlockRow{
+	err = s.queries.PutBlock(s.ctx, s.walletID, BlockRow{
 		Height:    block.Height,
 		Hash:      block.Hash[:],
 		Timestamp: block.Time.Unix(),
@@ -322,13 +324,14 @@ func (s *txStore) recordMinedSpends(transactionID int64,
 	return nil
 }
 
-// AddCredit marks a recorded output as wallet-owned. Repeated calls for the
-// same transaction incidence and output index are idempotent.
+// AddCredit marks a recorded output as wallet-owned and reports whether the
+// credit is new. Repeated calls for the same transaction incidence and output
+// index are idempotent.
 func (s *txStore) AddCredit(record *wtxmgr.TxRecord,
-	block *wtxmgr.BlockMeta, index uint32, change bool) error {
+	block *wtxmgr.BlockMeta, index uint32, change bool) (bool, error) {
 
 	if index >= uint32(len(record.MsgTx.TxOut)) {
-		return fmt.Errorf("transaction output %d does not exist", index)
+		return false, fmt.Errorf("transaction output %d does not exist", index)
 	}
 
 	var incidence *wtxmgr.Block
@@ -338,18 +341,20 @@ func (s *txStore) AddCredit(record *wtxmgr.TxRecord,
 
 	transactionID, err := s.transactionID(record.Hash, incidence)
 	if err != nil {
-		return fmt.Errorf("find credit transaction: %w", err)
+		return false, fmt.Errorf("find credit transaction: %w", err)
 	}
 
 	// Preserve the existing wtxmgr behavior where adding the same credit more
 	// than once succeeds without rewriting it.
-	_, err = s.queries.GetCreditID(s.ctx, transactionID, index)
+	_, err = s.queries.GetCreditID(
+		s.ctx, s.walletID, transactionID, index,
+	)
 	if err == nil {
-		return nil
+		return false, nil
 	}
 
 	if !errors.Is(err, sql.ErrNoRows) {
-		return fmt.Errorf("check transaction credit: %w", err)
+		return false, fmt.Errorf("check transaction credit: %w", err)
 	}
 
 	output := record.MsgTx.TxOut[index]
@@ -359,17 +364,17 @@ func (s *txStore) AddCredit(record *wtxmgr.TxRecord,
 		output.PkScript, change,
 	)
 	if err != nil {
-		return fmt.Errorf("insert transaction credit: %w", err)
+		return false, fmt.Errorf("insert transaction credit: %w", err)
 	}
 
 	// A credit may appear in multiple transaction incidences. The newly added
 	// incidence becomes the active wallet output.
 	err = s.queries.SetActiveCreditIncidence(s.ctx, s.walletID, creditID)
 	if err != nil {
-		return fmt.Errorf("activate transaction credit: %w", err)
+		return false, fmt.Errorf("activate transaction credit: %w", err)
 	}
 
-	return nil
+	return true, nil
 }
 
 // PutTxLabel validates and stores a transaction label.
@@ -450,7 +455,7 @@ func (s *txStore) LockOutput(id wtxmgr.LockID, output wire.OutPoint,
 
 	rows, err := s.queries.AcquireOutputLease(
 		s.ctx, s.walletID, output.Hash[:], output.Index, id[:],
-		expires.Unix(), now.Unix(),
+		expires.UnixNano(), now.UnixNano(),
 	)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("lock output: %w", err)
@@ -487,7 +492,7 @@ func (s *txStore) outputLease(output wire.OutPoint) (wtxmgr.LockID,
 	var id wtxmgr.LockID
 	copy(id[:], row.LockID)
 
-	return id, time.Unix(row.Expiration, 0), true, nil
+	return id, time.Unix(0, row.Expiration), true, nil
 }
 
 // UnlockOutput releases an output lease held by the owner. Missing and expired
@@ -526,7 +531,7 @@ func (s *txStore) UnlockOutput(id wtxmgr.LockID, output wire.OutPoint) error {
 // DeleteExpiredLockedOutputs removes expired output leases.
 func (s *txStore) DeleteExpiredLockedOutputs() error {
 	_, err := s.queries.DeleteExpiredOutputLeases(
-		s.ctx, s.walletID, time.Now().Unix(),
+		s.ctx, s.walletID, time.Now().UnixNano(),
 	)
 
 	return err
@@ -535,7 +540,7 @@ func (s *txStore) DeleteExpiredLockedOutputs() error {
 // ListLockedOutputs returns all currently active output leases.
 func (s *txStore) ListLockedOutputs() ([]*wtxmgr.LockedOutput, error) {
 	rows, err := s.queries.ListActiveOutputLeases(
-		s.ctx, s.walletID, time.Now().Unix(),
+		s.ctx, s.walletID, time.Now().UnixNano(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("list output leases: %w", err)
@@ -566,7 +571,7 @@ func (s *txStore) ListLockedOutputs() ([]*wtxmgr.LockedOutput, error) {
 				Index: uint32(row.Index),
 			},
 			LockID:     id,
-			Expiration: time.Unix(row.Expiration, 0),
+			Expiration: time.Unix(0, row.Expiration),
 		})
 	}
 

--- a/wallet/internal/sql/pg/legacy_schema_test.go
+++ b/wallet/internal/sql/pg/legacy_schema_test.go
@@ -52,17 +52,6 @@ func TestLegacySchemaQueries(t *testing.T) {
 	queries := sqlc.New(db)
 	genesisHash := pgBytesOf(0x01, 32)
 	birthdayHash := pgBytesOf(0x02, 32)
-	require.NoError(t, queries.InsertBlock(ctx, sqlc.InsertBlockParams{
-		BlockHeight:    0,
-		HeaderHash:     genesisHash,
-		BlockTimestamp: 1,
-	}))
-	require.NoError(t, queries.InsertBlock(ctx, sqlc.InsertBlockParams{
-		BlockHeight:    100,
-		HeaderHash:     birthdayHash,
-		BlockTimestamp: 2,
-	}))
-
 	walletID, err := queries.CreateWallet(ctx, sqlc.CreateWalletParams{
 		WalletName:            "watch-only",
 		ManagerVersion:        8,
@@ -72,6 +61,28 @@ func TestLegacySchemaQueries(t *testing.T) {
 		EncryptedCryptoPubKey: []byte("encrypted-crypto-public-key"),
 	})
 	require.NoError(t, err)
+	for _, block := range []sqlc.EnsureBlockHeightParams{
+		{
+			BlockHeight:    0,
+			HeaderHash:     genesisHash,
+			BlockTimestamp: 1,
+		},
+		{
+			BlockHeight:    100,
+			HeaderHash:     birthdayHash,
+			BlockTimestamp: 2,
+		},
+	} {
+		require.NoError(t, queries.EnsureBlockHeight(ctx, block))
+		require.NoError(t, queries.InsertBlock(
+			ctx, sqlc.InsertBlockParams{
+				WalletID:       walletID,
+				BlockHeight:    block.BlockHeight,
+				HeaderHash:     block.HeaderHash,
+				BlockTimestamp: block.BlockTimestamp,
+			},
+		))
+	}
 	wallet, err := queries.GetWalletByName(ctx, "watch-only")
 	require.NoError(t, err)
 	require.Equal(t, int64(123), wallet.ManagerCreatedAt)
@@ -180,6 +191,8 @@ func TestLegacySchemaQueries(t *testing.T) {
 	require.ErrorContains(t, err, "address used state cannot be cleared")
 }
 
+// requireNoPostgresPlaintextColumns verifies that secret manager values have no
+// clear text PostgreSQL schema representation.
 func requireNoPostgresPlaintextColumns(t *testing.T, db *sql.DB) {
 	t.Helper()
 
@@ -206,6 +219,8 @@ func requireNoPostgresPlaintextColumns(t *testing.T, db *sql.DB) {
 	}
 }
 
+// pgBytesOf returns a deterministic PostgreSQL byte fixture of the requested
+// length.
 func pgBytesOf(value byte, count int) []byte {
 	b := make([]byte, count)
 	for i := range b {

--- a/wallet/internal/sql/pg/migrations/000011_wallet_blocks.down.sql
+++ b/wallet/internal/sql/pg/migrations/000011_wallet_blocks.down.sql
@@ -1,0 +1,13 @@
+ALTER TABLE transactions
+DROP CONSTRAINT transactions_wallet_block_fkey;
+
+ALTER TABLE wallet_sync_states
+DROP CONSTRAINT wallet_sync_states_birthday_wallet_block_fkey;
+
+ALTER TABLE wallet_sync_states
+DROP CONSTRAINT wallet_sync_states_synced_wallet_block_fkey;
+
+ALTER TABLE wallet_sync_states
+DROP CONSTRAINT wallet_sync_states_start_wallet_block_fkey;
+
+DROP TABLE wallet_blocks;

--- a/wallet/internal/sql/pg/migrations/000011_wallet_blocks.up.sql
+++ b/wallet/internal/sql/pg/migrations/000011_wallet_blocks.up.sql
@@ -1,0 +1,40 @@
+-- Active block identities belong to one wallet. The original blocks table is
+-- retained as a height registry for foreign keys created by shipped migrations.
+CREATE TABLE wallet_blocks (
+    wallet_id BIGINT NOT NULL,
+    block_height INTEGER NOT NULL CHECK (block_height >= 0),
+    header_hash BYTEA NOT NULL CHECK (length(header_hash) = 32),
+    block_timestamp BIGINT NOT NULL CHECK (block_timestamp >= 0),
+    PRIMARY KEY (wallet_id, block_height),
+    UNIQUE (wallet_id, header_hash),
+    FOREIGN KEY (wallet_id) REFERENCES wallets (id) ON DELETE RESTRICT
+);
+
+-- Existing global identities are valid candidates for every existing wallet.
+-- Future writes replace them independently in wallet_blocks.
+INSERT INTO wallet_blocks (
+    wallet_id, block_height, header_hash, block_timestamp
+)
+SELECT w.id, b.block_height, b.header_hash, b.block_timestamp
+FROM wallets AS w
+CROSS JOIN blocks AS b;
+
+ALTER TABLE wallet_sync_states
+ADD CONSTRAINT wallet_sync_states_start_wallet_block_fkey
+FOREIGN KEY (wallet_id, start_block_height)
+REFERENCES wallet_blocks (wallet_id, block_height) ON DELETE RESTRICT;
+
+ALTER TABLE wallet_sync_states
+ADD CONSTRAINT wallet_sync_states_synced_wallet_block_fkey
+FOREIGN KEY (wallet_id, synced_block_height)
+REFERENCES wallet_blocks (wallet_id, block_height) ON DELETE RESTRICT;
+
+ALTER TABLE wallet_sync_states
+ADD CONSTRAINT wallet_sync_states_birthday_wallet_block_fkey
+FOREIGN KEY (wallet_id, birthday_block_height)
+REFERENCES wallet_blocks (wallet_id, block_height) ON DELETE RESTRICT;
+
+ALTER TABLE transactions
+ADD CONSTRAINT transactions_wallet_block_fkey
+FOREIGN KEY (wallet_id, block_height)
+REFERENCES wallet_blocks (wallet_id, block_height) ON DELETE RESTRICT;

--- a/wallet/internal/sql/pg/migrations/000012_lease_nanoseconds.down.sql
+++ b/wallet/internal/sql/pg/migrations/000012_lease_nanoseconds.down.sql
@@ -1,0 +1,2 @@
+UPDATE utxo_leases
+SET expires_unix = expires_unix / 1000000000;

--- a/wallet/internal/sql/pg/migrations/000012_lease_nanoseconds.up.sql
+++ b/wallet/internal/sql/pg/migrations/000012_lease_nanoseconds.up.sql
@@ -1,0 +1,4 @@
+-- Lease expirations in migration 000009 were stored as Unix seconds. Convert
+-- existing rows before runtime code starts comparing nanosecond timestamps.
+UPDATE utxo_leases
+SET expires_unix = expires_unix * 1000000000;

--- a/wallet/internal/sql/pg/migrations_test.go
+++ b/wallet/internal/sql/pg/migrations_test.go
@@ -3,6 +3,7 @@
 package pg
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"testing"
@@ -46,7 +47,7 @@ func TestMigrationsRoundTrip(t *testing.T) {
 		require.NoError(t, db.Close())
 	})
 
-	require.NoError(t, ApplyMigrations(db))
+	requireLeaseUpgrade(t, db)
 	require.Zero(t, db.Stats().InUse)
 	require.NoError(t, db.PingContext(ctx))
 	requireSchemaTables(t, db, true)
@@ -61,11 +62,50 @@ func TestMigrationsRoundTrip(t *testing.T) {
 	requireSchemaTables(t, db, true)
 }
 
+// requireLeaseUpgrade verifies that the forward precision migration converts
+// leases written by migration 000009 before nanosecond comparisons begin.
+func requireLeaseUpgrade(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	migration, err := newMigrationInstance(db)
+	require.NoError(t, err)
+	require.NoError(t, migration.Migrate(11))
+
+	_, err = db.ExecContext(t.Context(), `
+		INSERT INTO wallets (
+			id, wallet_name, manager_version, manager_created_at,
+			is_watch_only, master_pub_params, encrypted_crypto_pub_key
+		) VALUES (99, 'lease-upgrade', 1, 1, TRUE, $1, $2)
+	`, []byte{1}, []byte{2})
+	require.NoError(t, err)
+
+	const expiresSeconds = int64(1_700_000_000)
+	_, err = db.ExecContext(t.Context(), `
+		INSERT INTO utxo_leases (
+			wallet_id, tx_hash, output_index, lock_id, expires_unix
+		) VALUES ($1, $2, 0, $3, $4)
+	`, 99, bytes.Repeat([]byte{1}, 32), bytes.Repeat([]byte{2}, 32),
+		expiresSeconds)
+	require.NoError(t, err)
+
+	require.NoError(t, ApplyMigrations(db))
+
+	var expiresNanoseconds int64
+	err = db.QueryRowContext(t.Context(), `
+		SELECT expires_unix FROM utxo_leases WHERE wallet_id = 99
+	`).Scan(&expiresNanoseconds)
+	require.NoError(t, err)
+	require.Equal(t, expiresSeconds*int64(1_000_000_000),
+		expiresNanoseconds)
+}
+
+// requireSchemaTables verifies whether every wallet schema table exists.
 func requireSchemaTables(t *testing.T, db *sql.DB, expected bool) {
 	t.Helper()
 
 	tables := []string{
-		"blocks", "wallets", "wallet_sync_states", "address_types",
+		"blocks", "wallet_blocks", "wallets", "wallet_sync_states",
+		"address_types",
 		"key_scopes", "accounts", "addresses",
 		"transactions", "transaction_inputs", "transaction_labels",
 		"credits", "active_credit_incidences", "credit_spends",

--- a/wallet/internal/sql/pg/queries/addresses.sql
+++ b/wallet/internal/sql/pg/queries/addresses.sql
@@ -200,7 +200,7 @@ SET
     encrypted_priv_key = NULL,
     encrypted_script = CASE
         WHEN address_type = 2 THEN NULL
-        WHEN address_type = 3 AND is_secret_script = TRUE THEN NULL
+        WHEN address_type IN (3, 4) AND is_secret_script = TRUE THEN NULL
         ELSE encrypted_script
     END
 WHERE wallet_id = $1;

--- a/wallet/internal/sql/pg/queries/blocks.sql
+++ b/wallet/internal/sql/pg/queries/blocks.sql
@@ -3,33 +3,44 @@ SELECT
     block_height,
     header_hash,
     block_timestamp
-FROM blocks
-WHERE block_height = $1;
+FROM wallet_blocks
+WHERE wallet_id = sqlc.arg('wallet_id')
+  AND block_height = sqlc.arg('block_height');
 
 -- name: GetBlocksInRange :many
 SELECT
     block_height,
     header_hash,
     block_timestamp
-FROM blocks
+FROM wallet_blocks
 WHERE
-    block_height BETWEEN
+    wallet_id = sqlc.arg('wallet_id')
+    AND block_height BETWEEN
     sqlc.arg('start_height')::INTEGER
     AND sqlc.arg('end_height')::INTEGER
 ORDER BY block_height;
 
--- name: InsertBlock :exec
+-- name: EnsureBlockHeight :exec
 INSERT INTO blocks (block_height, header_hash, block_timestamp)
 VALUES ($1, $2, $3)
 ON CONFLICT (block_height) DO NOTHING;
 
+-- name: InsertBlock :exec
+INSERT INTO wallet_blocks (
+    wallet_id, block_height, header_hash, block_timestamp
+)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (wallet_id, block_height) DO NOTHING;
+
 -- name: PutBlock :exec
-INSERT INTO blocks (block_height, header_hash, block_timestamp)
-VALUES ($1, $2, $3)
-ON CONFLICT (block_height) DO UPDATE SET
+INSERT INTO wallet_blocks (
+    wallet_id, block_height, header_hash, block_timestamp
+)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (wallet_id, block_height) DO UPDATE SET
     header_hash = excluded.header_hash,
     block_timestamp = excluded.block_timestamp;
 
 -- name: DeleteBlock :exec
-DELETE FROM blocks
-WHERE block_height = $1;
+DELETE FROM wallet_blocks
+WHERE wallet_id = $1 AND block_height = $2;

--- a/wallet/internal/sql/pg/queries/credits.sql
+++ b/wallet/internal/sql/pg/queries/credits.sql
@@ -16,7 +16,8 @@ INSERT INTO active_credit_incidences (
 )
 SELECT c.wallet_id, funding.tx_hash, c.output_index, c.id
 FROM credits AS c
-INNER JOIN transactions AS funding ON funding.id = c.transaction_id
+INNER JOIN transactions AS funding
+    ON funding.wallet_id = c.wallet_id AND funding.id = c.transaction_id
 WHERE c.wallet_id = $1 AND c.id = $2
 ON CONFLICT (wallet_id, tx_hash, output_index) DO UPDATE SET
     credit_id = excluded.credit_id;
@@ -27,11 +28,13 @@ INSERT INTO credit_spends (
 )
 SELECT c.wallet_id, c.id, i.spending_tx_id, i.input_index
 FROM credits AS c
-INNER JOIN transactions AS funding ON funding.id = c.transaction_id
+INNER JOIN transactions AS funding
+    ON funding.wallet_id = c.wallet_id AND funding.id = c.transaction_id
 INNER JOIN transaction_inputs AS i
     ON i.prev_tx_hash = funding.tx_hash
     AND i.prev_output_index = c.output_index
-INNER JOIN transactions AS spender ON spender.id = i.spending_tx_id
+INNER JOIN transactions AS spender
+    ON spender.wallet_id = c.wallet_id AND spender.id = i.spending_tx_id
 WHERE c.wallet_id = $1
   AND c.id = $2
   AND i.spending_tx_id = $3
@@ -51,7 +54,7 @@ WHERE wallet_id = $1 AND credit_id = $2
 SELECT id, wallet_id, transaction_id, output_index, amount, pk_script,
        is_change, address_scope_id, address_id
 FROM credits
-WHERE transaction_id = $1 AND output_index = $2;
+WHERE wallet_id = $1 AND transaction_id = $2 AND output_index = $3;
 
 -- name: ListTransactionCredits :many
 SELECT c.id, c.output_index, c.amount, c.pk_script, c.is_change,
@@ -59,14 +62,16 @@ SELECT c.id, c.output_index, c.amount, c.pk_script, c.is_change,
        EXISTS (
            SELECT 1
            FROM credit_spends AS spend
-           WHERE spend.credit_id = c.id
+           WHERE spend.wallet_id = c.wallet_id AND spend.credit_id = c.id
        ) OR EXISTS (
            SELECT 1
            FROM transaction_inputs AS input
            INNER JOIN transactions AS spender
-               ON spender.id = input.spending_tx_id
+               ON spender.wallet_id = c.wallet_id
+               AND spender.id = input.spending_tx_id
            INNER JOIN transactions AS funding
-               ON funding.id = c.transaction_id
+               ON funding.wallet_id = c.wallet_id
+               AND funding.id = c.transaction_id
            WHERE spender.wallet_id = c.wallet_id
              AND spender.block_height IS NULL
              AND input.prev_tx_hash = funding.tx_hash
@@ -82,17 +87,24 @@ SELECT c.id, funding.tx_hash, c.output_index, c.amount, c.pk_script,
        funding.is_coinbase, c.address_scope_id, c.address_id,
        block.header_hash, block.block_timestamp
 FROM credits AS c
-INNER JOIN transactions AS funding ON funding.id = c.transaction_id
-INNER JOIN active_credit_incidences AS active ON active.credit_id = c.id
-LEFT JOIN blocks AS block ON block.block_height = funding.block_height
+INNER JOIN transactions AS funding
+    ON funding.wallet_id = c.wallet_id AND funding.id = c.transaction_id
+INNER JOIN active_credit_incidences AS active
+    ON active.wallet_id = c.wallet_id AND active.credit_id = c.id
+LEFT JOIN wallet_blocks AS block
+    ON block.wallet_id = funding.wallet_id
+    AND block.block_height = funding.block_height
 WHERE c.wallet_id = sqlc.arg('wallet_id')
   AND NOT EXISTS (
-      SELECT 1 FROM credit_spends AS spend WHERE spend.credit_id = c.id
+      SELECT 1 FROM credit_spends AS spend
+      WHERE spend.wallet_id = c.wallet_id AND spend.credit_id = c.id
   )
   AND NOT EXISTS (
       SELECT 1
       FROM transaction_inputs AS i
-      INNER JOIN transactions AS spender ON spender.id = i.spending_tx_id
+      INNER JOIN transactions AS spender
+          ON spender.wallet_id = c.wallet_id
+          AND spender.id = i.spending_tx_id
       WHERE spender.wallet_id = c.wallet_id
         AND spender.block_height IS NULL
         AND i.prev_tx_hash = funding.tx_hash
@@ -111,27 +123,51 @@ ORDER BY funding.tx_hash, c.output_index;
 -- name: ListOutputsToWatch :many
 SELECT funding.tx_hash, c.output_index, c.pk_script
 FROM credits AS c
-INNER JOIN transactions AS funding ON funding.id = c.transaction_id
-INNER JOIN active_credit_incidences AS active ON active.credit_id = c.id
+INNER JOIN transactions AS funding
+    ON funding.wallet_id = c.wallet_id AND funding.id = c.transaction_id
+INNER JOIN active_credit_incidences AS active
+    ON active.wallet_id = c.wallet_id AND active.credit_id = c.id
 WHERE c.wallet_id = sqlc.arg('wallet_id')
   AND NOT EXISTS (
       SELECT 1
       FROM credit_spends AS spend
-      WHERE spend.credit_id = c.id
+      WHERE spend.wallet_id = c.wallet_id AND spend.credit_id = c.id
   )
 ORDER BY funding.tx_hash, c.output_index;
 
 -- name: ListTransactionDebits :many
-SELECT spend.input_index, credit.amount
-FROM credit_spends AS spend
-INNER JOIN credits AS credit ON credit.id = spend.credit_id
-WHERE spend.wallet_id = $1 AND spend.spending_tx_id = $2
-ORDER BY spend.input_index;
+SELECT debit.input_index, debit.amount
+FROM (
+    SELECT spend.input_index, credit.amount
+    FROM credit_spends AS spend
+    INNER JOIN credits AS credit
+        ON credit.wallet_id = spend.wallet_id AND credit.id = spend.credit_id
+    WHERE spend.wallet_id = sqlc.arg('wallet_id')
+      AND spend.spending_tx_id = sqlc.arg('transaction_id')
+
+    UNION ALL
+
+    SELECT input.input_index, credit.amount
+    FROM transactions AS spender
+    INNER JOIN transaction_inputs AS input
+        ON input.spending_tx_id = spender.id
+    INNER JOIN active_credit_incidences AS active
+        ON active.wallet_id = spender.wallet_id
+        AND active.tx_hash = input.prev_tx_hash
+        AND active.output_index = input.prev_output_index
+    INNER JOIN credits AS credit
+        ON credit.wallet_id = active.wallet_id AND credit.id = active.credit_id
+    WHERE spender.wallet_id = sqlc.arg('wallet_id')
+      AND spender.id = sqlc.arg('transaction_id')
+      AND spender.block_height IS NULL
+) AS debit
+ORDER BY debit.input_index;
 
 -- name: GetActiveCreditID :one
 SELECT credit.id
 FROM active_credit_incidences AS active
-INNER JOIN credits AS credit ON credit.id = active.credit_id
+INNER JOIN credits AS credit
+    ON credit.wallet_id = active.wallet_id AND credit.id = active.credit_id
 WHERE active.wallet_id = $1 AND active.tx_hash = $2
   AND active.output_index = $3;
 
@@ -139,29 +175,34 @@ WHERE active.wallet_id = $1 AND active.tx_hash = $2
 SELECT EXISTS (
     SELECT 1
     FROM active_credit_incidences AS active
-    INNER JOIN credits AS credit ON credit.id = active.credit_id
+    INNER JOIN credits AS credit
+        ON credit.wallet_id = active.wallet_id AND credit.id = active.credit_id
     WHERE active.wallet_id = $1 AND active.tx_hash = $2
       AND active.output_index = $3
       AND NOT EXISTS (
           SELECT 1 FROM credit_spends AS spend
-          WHERE spend.credit_id = credit.id
+          WHERE spend.wallet_id = credit.wallet_id
+            AND spend.credit_id = credit.id
       )
 );
 
 -- name: GetUnminedPreviousPkScript :one
 SELECT credit.pk_script
 FROM active_credit_incidences AS active
-INNER JOIN credits AS credit ON credit.id = active.credit_id
+INNER JOIN credits AS credit
+    ON credit.wallet_id = active.wallet_id AND credit.id = active.credit_id
 WHERE active.wallet_id = $1 AND active.tx_hash = $2
   AND active.output_index = $3
   AND NOT EXISTS (
       SELECT 1 FROM credit_spends AS spend
-      WHERE spend.credit_id = credit.id
+      WHERE spend.wallet_id = credit.wallet_id
+        AND spend.credit_id = credit.id
   );
 
 -- name: GetMinedPreviousPkScript :one
 SELECT credit.pk_script
 FROM credit_spends AS spend
-INNER JOIN credits AS credit ON credit.id = spend.credit_id
+INNER JOIN credits AS credit
+    ON credit.wallet_id = spend.wallet_id AND credit.id = spend.credit_id
 WHERE spend.wallet_id = $1 AND spend.spending_tx_id = $2
   AND spend.input_index = $3;

--- a/wallet/internal/sql/pg/queries/transactions.sql
+++ b/wallet/internal/sql/pg/queries/transactions.sql
@@ -24,7 +24,8 @@ WHERE wallet_id = $1 AND tx_hash = $2 AND block_height IS NULL;
 SELECT t.id, t.raw_tx, t.received_unix, t.block_height,
        t.confirmed_order, b.header_hash, b.block_timestamp, l.label
 FROM transactions AS t
-LEFT JOIN blocks AS b ON b.block_height = t.block_height
+LEFT JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 LEFT JOIN transaction_labels AS l
     ON l.wallet_id = t.wallet_id AND l.tx_hash = t.tx_hash
 WHERE t.wallet_id = $1 AND t.tx_hash = $2
@@ -35,7 +36,8 @@ LIMIT 1;
 SELECT t.id, t.raw_tx, t.received_unix, t.block_height,
        t.confirmed_order, b.header_hash, b.block_timestamp, l.label
 FROM transactions AS t
-LEFT JOIN blocks AS b ON b.block_height = t.block_height
+LEFT JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 LEFT JOIN transaction_labels AS l
     ON l.wallet_id = t.wallet_id AND l.tx_hash = t.tx_hash
 WHERE t.wallet_id = $1 AND t.tx_hash = $2 AND t.block_height IS NULL
@@ -45,7 +47,8 @@ LIMIT 1;
 SELECT t.id, t.raw_tx, t.received_unix, t.block_height,
        t.confirmed_order, b.header_hash, b.block_timestamp, l.label
 FROM transactions AS t
-INNER JOIN blocks AS b ON b.block_height = t.block_height
+INNER JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 LEFT JOIN transaction_labels AS l
     ON l.wallet_id = t.wallet_id AND l.tx_hash = t.tx_hash
 WHERE t.wallet_id = sqlc.arg('wallet_id')
@@ -58,7 +61,8 @@ LIMIT 1;
 SELECT t.id, t.raw_tx, t.received_unix, t.block_height,
        t.confirmed_order, b.header_hash, b.block_timestamp, l.label
 FROM transactions AS t
-LEFT JOIN blocks AS b ON b.block_height = t.block_height
+LEFT JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 LEFT JOIN transaction_labels AS l
     ON l.wallet_id = t.wallet_id AND l.tx_hash = t.tx_hash
 WHERE t.wallet_id = $1 AND t.id = $2
@@ -88,7 +92,9 @@ WHERE wallet_id = $1 AND spending_tx_id = $2;
 -- name: ListUnminedSpendersByPrevHash :many
 SELECT DISTINCT spender.id, spender.tx_hash
 FROM transaction_inputs AS input
-INNER JOIN transactions AS spender ON spender.id = input.spending_tx_id
+INNER JOIN transactions AS spender
+    ON spender.id = input.spending_tx_id
+    AND spender.wallet_id = sqlc.arg('wallet_id')
 WHERE spender.wallet_id = sqlc.arg('wallet_id')
   AND spender.block_height IS NULL
   AND input.prev_tx_hash = sqlc.arg('prev_tx_hash')
@@ -98,7 +104,8 @@ ORDER BY spender.id;
 SELECT t.id, t.wallet_id, t.tx_hash, t.raw_tx, t.received_unix,
        t.block_height, t.confirmed_order, t.is_coinbase
 FROM transactions AS t
-INNER JOIN blocks AS b ON b.block_height = t.block_height
+INNER JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 WHERE t.wallet_id = sqlc.arg('wallet_id')
   AND t.tx_hash = sqlc.arg('tx_hash')
   AND t.block_height = sqlc.arg('block_height')
@@ -123,7 +130,8 @@ SELECT t.id, t.wallet_id, t.tx_hash, t.raw_tx, t.received_unix,
        t.block_height, t.confirmed_order, t.is_coinbase,
        b.header_hash, b.block_timestamp
 FROM transactions AS t
-INNER JOIN blocks AS b ON b.block_height = t.block_height
+INNER JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 WHERE t.wallet_id = sqlc.arg('wallet_id')
   AND t.block_height BETWEEN sqlc.arg('start_height')::INTEGER
                          AND sqlc.arg('end_height')::INTEGER
@@ -134,7 +142,8 @@ SELECT t.id, t.wallet_id, t.tx_hash, t.raw_tx, t.received_unix,
        t.block_height, t.confirmed_order, t.is_coinbase,
        b.header_hash, b.block_timestamp
 FROM transactions AS t
-INNER JOIN blocks AS b ON b.block_height = t.block_height
+INNER JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 WHERE t.wallet_id = sqlc.arg('wallet_id')
   AND t.block_height BETWEEN sqlc.arg('end_height')::INTEGER
                          AND sqlc.arg('start_height')::INTEGER
@@ -149,7 +158,9 @@ RETURNING id;
 -- name: ListUnminedSpenders :many
 SELECT t.id, t.tx_hash, i.input_index
 FROM transaction_inputs AS i
-INNER JOIN transactions AS t ON t.id = i.spending_tx_id
+INNER JOIN transactions AS t
+    ON t.id = i.spending_tx_id
+    AND t.wallet_id = sqlc.arg('wallet_id')
 WHERE t.wallet_id = sqlc.arg('wallet_id')
   AND t.block_height IS NULL
   AND i.prev_tx_hash = sqlc.arg('prev_tx_hash')
@@ -171,7 +182,8 @@ SELECT label FROM transaction_labels WHERE wallet_id = $1 AND tx_hash = $2;
 -- name: GetMinedTransactionID :one
 SELECT t.id
 FROM transactions AS t
-INNER JOIN blocks AS b ON b.block_height = t.block_height
+INNER JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 WHERE t.wallet_id = sqlc.arg('wallet_id')
   AND t.tx_hash = sqlc.arg('tx_hash')
   AND t.block_height = sqlc.arg('block_height')::INTEGER

--- a/wallet/internal/sql/pg/queries/wallets.sql
+++ b/wallet/internal/sql/pg/queries/wallets.sql
@@ -107,12 +107,15 @@ SELECT
     birthday_block.block_timestamp AS birthday_block_timestamp,
     s.birthday_block_verified
 FROM wallet_sync_states AS s
-INNER JOIN blocks AS start_block
-    ON s.start_block_height = start_block.block_height
-INNER JOIN blocks AS synced_block
-    ON s.synced_block_height = synced_block.block_height
-LEFT JOIN blocks AS birthday_block
-    ON s.birthday_block_height = birthday_block.block_height
+INNER JOIN wallet_blocks AS start_block
+    ON start_block.wallet_id = s.wallet_id
+    AND start_block.block_height = s.start_block_height
+INNER JOIN wallet_blocks AS synced_block
+    ON synced_block.wallet_id = s.wallet_id
+    AND synced_block.block_height = s.synced_block_height
+LEFT JOIN wallet_blocks AS birthday_block
+    ON birthday_block.wallet_id = s.wallet_id
+    AND birthday_block.block_height = s.birthday_block_height
 WHERE s.wallet_id = $1;
 
 -- name: SetWalletBirthday :execrows
@@ -133,7 +136,9 @@ WHERE wallet_id = $2;
 -- name: GetWalletStartBlock :one
 SELECT b.block_height, b.header_hash, b.block_timestamp
 FROM wallet_sync_states AS s
-INNER JOIN blocks AS b ON b.block_height = s.start_block_height
+INNER JOIN wallet_blocks AS b
+    ON b.wallet_id = s.wallet_id
+    AND b.block_height = s.start_block_height
 WHERE s.wallet_id = $1;
 
 -- name: UpdateWalletSyncState :execrows

--- a/wallet/internal/sql/pg/sqlc/addresses.sql.go
+++ b/wallet/internal/sql/pg/sqlc/addresses.sql.go
@@ -81,7 +81,7 @@ SET
     encrypted_priv_key = NULL,
     encrypted_script = CASE
         WHEN address_type = 2 THEN NULL
-        WHEN address_type = 3 AND is_secret_script = TRUE THEN NULL
+        WHEN address_type IN (3, 4) AND is_secret_script = TRUE THEN NULL
         ELSE encrypted_script
     END
 WHERE wallet_id = $1

--- a/wallet/internal/sql/pg/sqlc/blocks.sql.go
+++ b/wallet/internal/sql/pg/sqlc/blocks.sql.go
@@ -10,12 +10,34 @@ import (
 )
 
 const DeleteBlock = `-- name: DeleteBlock :exec
-DELETE FROM blocks
-WHERE block_height = $1
+DELETE FROM wallet_blocks
+WHERE wallet_id = $1 AND block_height = $2
 `
 
-func (q *Queries) DeleteBlock(ctx context.Context, blockHeight int32) error {
-	_, err := q.exec(ctx, q.deleteBlockStmt, DeleteBlock, blockHeight)
+type DeleteBlockParams struct {
+	WalletID    int64
+	BlockHeight int32
+}
+
+func (q *Queries) DeleteBlock(ctx context.Context, arg DeleteBlockParams) error {
+	_, err := q.exec(ctx, q.deleteBlockStmt, DeleteBlock, arg.WalletID, arg.BlockHeight)
+	return err
+}
+
+const EnsureBlockHeight = `-- name: EnsureBlockHeight :exec
+INSERT INTO blocks (block_height, header_hash, block_timestamp)
+VALUES ($1, $2, $3)
+ON CONFLICT (block_height) DO NOTHING
+`
+
+type EnsureBlockHeightParams struct {
+	BlockHeight    int32
+	HeaderHash     []byte
+	BlockTimestamp int64
+}
+
+func (q *Queries) EnsureBlockHeight(ctx context.Context, arg EnsureBlockHeightParams) error {
+	_, err := q.exec(ctx, q.ensureBlockHeightStmt, EnsureBlockHeight, arg.BlockHeight, arg.HeaderHash, arg.BlockTimestamp)
 	return err
 }
 
@@ -24,13 +46,25 @@ SELECT
     block_height,
     header_hash,
     block_timestamp
-FROM blocks
-WHERE block_height = $1
+FROM wallet_blocks
+WHERE wallet_id = $1
+  AND block_height = $2
 `
 
-func (q *Queries) GetBlockByHeight(ctx context.Context, blockHeight int32) (Block, error) {
-	row := q.queryRow(ctx, q.getBlockByHeightStmt, GetBlockByHeight, blockHeight)
-	var i Block
+type GetBlockByHeightParams struct {
+	WalletID    int64
+	BlockHeight int32
+}
+
+type GetBlockByHeightRow struct {
+	BlockHeight    int32
+	HeaderHash     []byte
+	BlockTimestamp int64
+}
+
+func (q *Queries) GetBlockByHeight(ctx context.Context, arg GetBlockByHeightParams) (GetBlockByHeightRow, error) {
+	row := q.queryRow(ctx, q.getBlockByHeightStmt, GetBlockByHeight, arg.WalletID, arg.BlockHeight)
+	var i GetBlockByHeightRow
 	err := row.Scan(&i.BlockHeight, &i.HeaderHash, &i.BlockTimestamp)
 	return i, err
 }
@@ -40,28 +74,36 @@ SELECT
     block_height,
     header_hash,
     block_timestamp
-FROM blocks
+FROM wallet_blocks
 WHERE
-    block_height BETWEEN
-    $1::INTEGER
-    AND $2::INTEGER
+    wallet_id = $1
+    AND block_height BETWEEN
+    $2::INTEGER
+    AND $3::INTEGER
 ORDER BY block_height
 `
 
 type GetBlocksInRangeParams struct {
+	WalletID    int64
 	StartHeight int32
 	EndHeight   int32
 }
 
-func (q *Queries) GetBlocksInRange(ctx context.Context, arg GetBlocksInRangeParams) ([]Block, error) {
-	rows, err := q.query(ctx, q.getBlocksInRangeStmt, GetBlocksInRange, arg.StartHeight, arg.EndHeight)
+type GetBlocksInRangeRow struct {
+	BlockHeight    int32
+	HeaderHash     []byte
+	BlockTimestamp int64
+}
+
+func (q *Queries) GetBlocksInRange(ctx context.Context, arg GetBlocksInRangeParams) ([]GetBlocksInRangeRow, error) {
+	rows, err := q.query(ctx, q.getBlocksInRangeStmt, GetBlocksInRange, arg.WalletID, arg.StartHeight, arg.EndHeight)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []Block
+	var items []GetBlocksInRangeRow
 	for rows.Next() {
-		var i Block
+		var i GetBlocksInRangeRow
 		if err := rows.Scan(&i.BlockHeight, &i.HeaderHash, &i.BlockTimestamp); err != nil {
 			return nil, err
 		}
@@ -77,37 +119,53 @@ func (q *Queries) GetBlocksInRange(ctx context.Context, arg GetBlocksInRangePara
 }
 
 const InsertBlock = `-- name: InsertBlock :exec
-INSERT INTO blocks (block_height, header_hash, block_timestamp)
-VALUES ($1, $2, $3)
-ON CONFLICT (block_height) DO NOTHING
+INSERT INTO wallet_blocks (
+    wallet_id, block_height, header_hash, block_timestamp
+)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (wallet_id, block_height) DO NOTHING
 `
 
 type InsertBlockParams struct {
+	WalletID       int64
 	BlockHeight    int32
 	HeaderHash     []byte
 	BlockTimestamp int64
 }
 
 func (q *Queries) InsertBlock(ctx context.Context, arg InsertBlockParams) error {
-	_, err := q.exec(ctx, q.insertBlockStmt, InsertBlock, arg.BlockHeight, arg.HeaderHash, arg.BlockTimestamp)
+	_, err := q.exec(ctx, q.insertBlockStmt, InsertBlock,
+		arg.WalletID,
+		arg.BlockHeight,
+		arg.HeaderHash,
+		arg.BlockTimestamp,
+	)
 	return err
 }
 
 const PutBlock = `-- name: PutBlock :exec
-INSERT INTO blocks (block_height, header_hash, block_timestamp)
-VALUES ($1, $2, $3)
-ON CONFLICT (block_height) DO UPDATE SET
+INSERT INTO wallet_blocks (
+    wallet_id, block_height, header_hash, block_timestamp
+)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (wallet_id, block_height) DO UPDATE SET
     header_hash = excluded.header_hash,
     block_timestamp = excluded.block_timestamp
 `
 
 type PutBlockParams struct {
+	WalletID       int64
 	BlockHeight    int32
 	HeaderHash     []byte
 	BlockTimestamp int64
 }
 
 func (q *Queries) PutBlock(ctx context.Context, arg PutBlockParams) error {
-	_, err := q.exec(ctx, q.putBlockStmt, PutBlock, arg.BlockHeight, arg.HeaderHash, arg.BlockTimestamp)
+	_, err := q.exec(ctx, q.putBlockStmt, PutBlock,
+		arg.WalletID,
+		arg.BlockHeight,
+		arg.HeaderHash,
+		arg.BlockTimestamp,
+	)
 	return err
 }

--- a/wallet/internal/sql/pg/sqlc/credits.sql.go
+++ b/wallet/internal/sql/pg/sqlc/credits.sql.go
@@ -39,7 +39,8 @@ func (q *Queries) DeleteCreditSpend(ctx context.Context, arg DeleteCreditSpendPa
 const GetActiveCreditID = `-- name: GetActiveCreditID :one
 SELECT credit.id
 FROM active_credit_incidences AS active
-INNER JOIN credits AS credit ON credit.id = active.credit_id
+INNER JOIN credits AS credit
+    ON credit.wallet_id = active.wallet_id AND credit.id = active.credit_id
 WHERE active.wallet_id = $1 AND active.tx_hash = $2
   AND active.output_index = $3
 `
@@ -61,16 +62,17 @@ const GetCredit = `-- name: GetCredit :one
 SELECT id, wallet_id, transaction_id, output_index, amount, pk_script,
        is_change, address_scope_id, address_id
 FROM credits
-WHERE transaction_id = $1 AND output_index = $2
+WHERE wallet_id = $1 AND transaction_id = $2 AND output_index = $3
 `
 
 type GetCreditParams struct {
+	WalletID      int64
 	TransactionID int64
 	OutputIndex   int64
 }
 
 func (q *Queries) GetCredit(ctx context.Context, arg GetCreditParams) (Credit, error) {
-	row := q.queryRow(ctx, q.getCreditStmt, GetCredit, arg.TransactionID, arg.OutputIndex)
+	row := q.queryRow(ctx, q.getCreditStmt, GetCredit, arg.WalletID, arg.TransactionID, arg.OutputIndex)
 	var i Credit
 	err := row.Scan(
 		&i.ID,
@@ -89,7 +91,8 @@ func (q *Queries) GetCredit(ctx context.Context, arg GetCreditParams) (Credit, e
 const GetMinedPreviousPkScript = `-- name: GetMinedPreviousPkScript :one
 SELECT credit.pk_script
 FROM credit_spends AS spend
-INNER JOIN credits AS credit ON credit.id = spend.credit_id
+INNER JOIN credits AS credit
+    ON credit.wallet_id = spend.wallet_id AND credit.id = spend.credit_id
 WHERE spend.wallet_id = $1 AND spend.spending_tx_id = $2
   AND spend.input_index = $3
 `
@@ -110,12 +113,14 @@ func (q *Queries) GetMinedPreviousPkScript(ctx context.Context, arg GetMinedPrev
 const GetUnminedPreviousPkScript = `-- name: GetUnminedPreviousPkScript :one
 SELECT credit.pk_script
 FROM active_credit_incidences AS active
-INNER JOIN credits AS credit ON credit.id = active.credit_id
+INNER JOIN credits AS credit
+    ON credit.wallet_id = active.wallet_id AND credit.id = active.credit_id
 WHERE active.wallet_id = $1 AND active.tx_hash = $2
   AND active.output_index = $3
   AND NOT EXISTS (
       SELECT 1 FROM credit_spends AS spend
-      WHERE spend.credit_id = credit.id
+      WHERE spend.wallet_id = credit.wallet_id
+        AND spend.credit_id = credit.id
   )
 `
 
@@ -176,12 +181,14 @@ const IsKnownOutput = `-- name: IsKnownOutput :one
 SELECT EXISTS (
     SELECT 1
     FROM active_credit_incidences AS active
-    INNER JOIN credits AS credit ON credit.id = active.credit_id
+    INNER JOIN credits AS credit
+        ON credit.wallet_id = active.wallet_id AND credit.id = active.credit_id
     WHERE active.wallet_id = $1 AND active.tx_hash = $2
       AND active.output_index = $3
       AND NOT EXISTS (
           SELECT 1 FROM credit_spends AS spend
-          WHERE spend.credit_id = credit.id
+          WHERE spend.wallet_id = credit.wallet_id
+            AND spend.credit_id = credit.id
       )
 )
 `
@@ -202,13 +209,15 @@ func (q *Queries) IsKnownOutput(ctx context.Context, arg IsKnownOutputParams) (b
 const ListOutputsToWatch = `-- name: ListOutputsToWatch :many
 SELECT funding.tx_hash, c.output_index, c.pk_script
 FROM credits AS c
-INNER JOIN transactions AS funding ON funding.id = c.transaction_id
-INNER JOIN active_credit_incidences AS active ON active.credit_id = c.id
+INNER JOIN transactions AS funding
+    ON funding.wallet_id = c.wallet_id AND funding.id = c.transaction_id
+INNER JOIN active_credit_incidences AS active
+    ON active.wallet_id = c.wallet_id AND active.credit_id = c.id
 WHERE c.wallet_id = $1
   AND NOT EXISTS (
       SELECT 1
       FROM credit_spends AS spend
-      WHERE spend.credit_id = c.id
+      WHERE spend.wallet_id = c.wallet_id AND spend.credit_id = c.id
   )
 ORDER BY funding.tx_hash, c.output_index
 `
@@ -248,14 +257,16 @@ SELECT c.id, c.output_index, c.amount, c.pk_script, c.is_change,
        EXISTS (
            SELECT 1
            FROM credit_spends AS spend
-           WHERE spend.credit_id = c.id
+           WHERE spend.wallet_id = c.wallet_id AND spend.credit_id = c.id
        ) OR EXISTS (
            SELECT 1
            FROM transaction_inputs AS input
            INNER JOIN transactions AS spender
-               ON spender.id = input.spending_tx_id
+               ON spender.wallet_id = c.wallet_id
+               AND spender.id = input.spending_tx_id
            INNER JOIN transactions AS funding
-               ON funding.id = c.transaction_id
+               ON funding.wallet_id = c.wallet_id
+               AND funding.id = c.transaction_id
            WHERE spender.wallet_id = c.wallet_id
              AND spender.block_height IS NULL
              AND input.prev_tx_hash = funding.tx_hash
@@ -315,16 +326,37 @@ func (q *Queries) ListTransactionCredits(ctx context.Context, arg ListTransactio
 }
 
 const ListTransactionDebits = `-- name: ListTransactionDebits :many
-SELECT spend.input_index, credit.amount
-FROM credit_spends AS spend
-INNER JOIN credits AS credit ON credit.id = spend.credit_id
-WHERE spend.wallet_id = $1 AND spend.spending_tx_id = $2
-ORDER BY spend.input_index
+SELECT debit.input_index, debit.amount
+FROM (
+    SELECT spend.input_index, credit.amount
+    FROM credit_spends AS spend
+    INNER JOIN credits AS credit
+        ON credit.wallet_id = spend.wallet_id AND credit.id = spend.credit_id
+    WHERE spend.wallet_id = $1
+      AND spend.spending_tx_id = $2
+
+    UNION ALL
+
+    SELECT input.input_index, credit.amount
+    FROM transactions AS spender
+    INNER JOIN transaction_inputs AS input
+        ON input.spending_tx_id = spender.id
+    INNER JOIN active_credit_incidences AS active
+        ON active.wallet_id = spender.wallet_id
+        AND active.tx_hash = input.prev_tx_hash
+        AND active.output_index = input.prev_output_index
+    INNER JOIN credits AS credit
+        ON credit.wallet_id = active.wallet_id AND credit.id = active.credit_id
+    WHERE spender.wallet_id = $1
+      AND spender.id = $2
+      AND spender.block_height IS NULL
+) AS debit
+ORDER BY debit.input_index
 `
 
 type ListTransactionDebitsParams struct {
-	WalletID     int64
-	SpendingTxID int64
+	WalletID      int64
+	TransactionID int64
 }
 
 type ListTransactionDebitsRow struct {
@@ -333,7 +365,7 @@ type ListTransactionDebitsRow struct {
 }
 
 func (q *Queries) ListTransactionDebits(ctx context.Context, arg ListTransactionDebitsParams) ([]ListTransactionDebitsRow, error) {
-	rows, err := q.query(ctx, q.listTransactionDebitsStmt, ListTransactionDebits, arg.WalletID, arg.SpendingTxID)
+	rows, err := q.query(ctx, q.listTransactionDebitsStmt, ListTransactionDebits, arg.WalletID, arg.TransactionID)
 	if err != nil {
 		return nil, err
 	}
@@ -361,17 +393,24 @@ SELECT c.id, funding.tx_hash, c.output_index, c.amount, c.pk_script,
        funding.is_coinbase, c.address_scope_id, c.address_id,
        block.header_hash, block.block_timestamp
 FROM credits AS c
-INNER JOIN transactions AS funding ON funding.id = c.transaction_id
-INNER JOIN active_credit_incidences AS active ON active.credit_id = c.id
-LEFT JOIN blocks AS block ON block.block_height = funding.block_height
+INNER JOIN transactions AS funding
+    ON funding.wallet_id = c.wallet_id AND funding.id = c.transaction_id
+INNER JOIN active_credit_incidences AS active
+    ON active.wallet_id = c.wallet_id AND active.credit_id = c.id
+LEFT JOIN wallet_blocks AS block
+    ON block.wallet_id = funding.wallet_id
+    AND block.block_height = funding.block_height
 WHERE c.wallet_id = $1
   AND NOT EXISTS (
-      SELECT 1 FROM credit_spends AS spend WHERE spend.credit_id = c.id
+      SELECT 1 FROM credit_spends AS spend
+      WHERE spend.wallet_id = c.wallet_id AND spend.credit_id = c.id
   )
   AND NOT EXISTS (
       SELECT 1
       FROM transaction_inputs AS i
-      INNER JOIN transactions AS spender ON spender.id = i.spending_tx_id
+      INNER JOIN transactions AS spender
+          ON spender.wallet_id = c.wallet_id
+          AND spender.id = i.spending_tx_id
       WHERE spender.wallet_id = c.wallet_id
         AND spender.block_height IS NULL
         AND i.prev_tx_hash = funding.tx_hash
@@ -452,11 +491,13 @@ INSERT INTO credit_spends (
 )
 SELECT c.wallet_id, c.id, i.spending_tx_id, i.input_index
 FROM credits AS c
-INNER JOIN transactions AS funding ON funding.id = c.transaction_id
+INNER JOIN transactions AS funding
+    ON funding.wallet_id = c.wallet_id AND funding.id = c.transaction_id
 INNER JOIN transaction_inputs AS i
     ON i.prev_tx_hash = funding.tx_hash
     AND i.prev_output_index = c.output_index
-INNER JOIN transactions AS spender ON spender.id = i.spending_tx_id
+INNER JOIN transactions AS spender
+    ON spender.wallet_id = c.wallet_id AND spender.id = i.spending_tx_id
 WHERE c.wallet_id = $1
   AND c.id = $2
   AND i.spending_tx_id = $3
@@ -494,7 +535,8 @@ INSERT INTO active_credit_incidences (
 )
 SELECT c.wallet_id, funding.tx_hash, c.output_index, c.id
 FROM credits AS c
-INNER JOIN transactions AS funding ON funding.id = c.transaction_id
+INNER JOIN transactions AS funding
+    ON funding.wallet_id = c.wallet_id AND funding.id = c.transaction_id
 WHERE c.wallet_id = $1 AND c.id = $2
 ON CONFLICT (wallet_id, tx_hash, output_index) DO UPDATE SET
     credit_id = excluded.credit_id

--- a/wallet/internal/sql/pg/sqlc/db.go
+++ b/wallet/internal/sql/pg/sqlc/db.go
@@ -75,6 +75,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.detachMinedTransactionStmt, err = db.PrepareContext(ctx, DetachMinedTransaction); err != nil {
 		return nil, fmt.Errorf("error preparing query DetachMinedTransaction: %w", err)
 	}
+	if q.ensureBlockHeightStmt, err = db.PrepareContext(ctx, EnsureBlockHeight); err != nil {
+		return nil, fmt.Errorf("error preparing query EnsureBlockHeight: %w", err)
+	}
 	if q.getAccountStmt, err = db.PrepareContext(ctx, GetAccount); err != nil {
 		return nil, fmt.Errorf("error preparing query GetAccount: %w", err)
 	}
@@ -376,6 +379,11 @@ func (q *Queries) Close() error {
 	if q.detachMinedTransactionStmt != nil {
 		if cerr := q.detachMinedTransactionStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing detachMinedTransactionStmt: %w", cerr)
+		}
+	}
+	if q.ensureBlockHeightStmt != nil {
+		if cerr := q.ensureBlockHeightStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing ensureBlockHeightStmt: %w", cerr)
 		}
 	}
 	if q.getAccountStmt != nil {
@@ -789,6 +797,7 @@ type Queries struct {
 	deleteOutputLeaseAnyOwnerStmt       *sql.Stmt
 	deleteTransactionByIDStmt           *sql.Stmt
 	detachMinedTransactionStmt          *sql.Stmt
+	ensureBlockHeightStmt               *sql.Stmt
 	getAccountStmt                      *sql.Stmt
 	getActiveCreditIDStmt               *sql.Stmt
 	getAddressStmt                      *sql.Stmt
@@ -883,6 +892,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		deleteOutputLeaseAnyOwnerStmt:       q.deleteOutputLeaseAnyOwnerStmt,
 		deleteTransactionByIDStmt:           q.deleteTransactionByIDStmt,
 		detachMinedTransactionStmt:          q.detachMinedTransactionStmt,
+		ensureBlockHeightStmt:               q.ensureBlockHeightStmt,
 		getAccountStmt:                      q.getAccountStmt,
 		getActiveCreditIDStmt:               q.getActiveCreditIDStmt,
 		getAddressStmt:                      q.getAddressStmt,

--- a/wallet/internal/sql/pg/sqlc/models.go
+++ b/wallet/internal/sql/pg/sqlc/models.go
@@ -138,6 +138,13 @@ type Wallet struct {
 	EncryptedMasterHdPrivKey []byte
 }
 
+type WalletBlock struct {
+	WalletID       int64
+	BlockHeight    int32
+	HeaderHash     []byte
+	BlockTimestamp int64
+}
+
 type WalletSyncState struct {
 	WalletID              int64
 	StartBlockHeight      int32

--- a/wallet/internal/sql/pg/sqlc/querier.go
+++ b/wallet/internal/sql/pg/sqlc/querier.go
@@ -16,7 +16,7 @@ type Querier interface {
 	CreateWallet(ctx context.Context, arg CreateWalletParams) (int64, error)
 	DeleteAccountPrivateKeys(ctx context.Context, walletID int64) (int64, error)
 	DeleteAddressPrivateKeys(ctx context.Context, walletID int64) (int64, error)
-	DeleteBlock(ctx context.Context, blockHeight int32) error
+	DeleteBlock(ctx context.Context, arg DeleteBlockParams) error
 	DeleteCreditSpend(ctx context.Context, arg DeleteCreditSpendParams) (int64, error)
 	DeleteCreditSpendsBySpendingTx(ctx context.Context, arg DeleteCreditSpendsBySpendingTxParams) (int64, error)
 	DeleteExpiredOutputLeases(ctx context.Context, arg DeleteExpiredOutputLeasesParams) (int64, error)
@@ -26,11 +26,12 @@ type Querier interface {
 	DeleteOutputLeaseAnyOwner(ctx context.Context, arg DeleteOutputLeaseAnyOwnerParams) (int64, error)
 	DeleteTransactionByID(ctx context.Context, arg DeleteTransactionByIDParams) (int64, error)
 	DetachMinedTransaction(ctx context.Context, arg DetachMinedTransactionParams) (int64, error)
+	EnsureBlockHeight(ctx context.Context, arg EnsureBlockHeightParams) error
 	GetAccount(ctx context.Context, arg GetAccountParams) (Account, error)
 	GetActiveCreditID(ctx context.Context, arg GetActiveCreditIDParams) (int64, error)
 	GetAddress(ctx context.Context, arg GetAddressParams) (Address, error)
-	GetBlockByHeight(ctx context.Context, blockHeight int32) (Block, error)
-	GetBlocksInRange(ctx context.Context, arg GetBlocksInRangeParams) ([]Block, error)
+	GetBlockByHeight(ctx context.Context, arg GetBlockByHeightParams) (GetBlockByHeightRow, error)
+	GetBlocksInRange(ctx context.Context, arg GetBlocksInRangeParams) ([]GetBlocksInRangeRow, error)
 	GetCredit(ctx context.Context, arg GetCreditParams) (Credit, error)
 	GetKeyScope(ctx context.Context, arg GetKeyScopeParams) (KeyScope, error)
 	GetManagerAccount(ctx context.Context, arg GetManagerAccountParams) (Account, error)
@@ -49,7 +50,7 @@ type Querier interface {
 	GetUnminedTransactionByHash(ctx context.Context, arg GetUnminedTransactionByHashParams) (Transaction, error)
 	GetUnminedTransactionDetails(ctx context.Context, arg GetUnminedTransactionDetailsParams) (GetUnminedTransactionDetailsRow, error)
 	GetWalletByName(ctx context.Context, walletName string) (Wallet, error)
-	GetWalletStartBlock(ctx context.Context, walletID int64) (Block, error)
+	GetWalletStartBlock(ctx context.Context, walletID int64) (GetWalletStartBlockRow, error)
 	GetWalletSyncState(ctx context.Context, walletID int64) (GetWalletSyncStateRow, error)
 	InsertBlock(ctx context.Context, arg InsertBlockParams) error
 	InsertCredit(ctx context.Context, arg InsertCreditParams) (int64, error)

--- a/wallet/internal/sql/pg/sqlc/transactions.sql.go
+++ b/wallet/internal/sql/pg/sqlc/transactions.sql.go
@@ -68,7 +68,8 @@ const GetMinedTransactionByIncidence = `-- name: GetMinedTransactionByIncidence 
 SELECT t.id, t.wallet_id, t.tx_hash, t.raw_tx, t.received_unix,
        t.block_height, t.confirmed_order, t.is_coinbase
 FROM transactions AS t
-INNER JOIN blocks AS b ON b.block_height = t.block_height
+INNER JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 WHERE t.wallet_id = $1
   AND t.tx_hash = $2
   AND t.block_height = $3
@@ -107,7 +108,8 @@ const GetMinedTransactionDetails = `-- name: GetMinedTransactionDetails :one
 SELECT t.id, t.raw_tx, t.received_unix, t.block_height,
        t.confirmed_order, b.header_hash, b.block_timestamp, l.label
 FROM transactions AS t
-INNER JOIN blocks AS b ON b.block_height = t.block_height
+INNER JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 LEFT JOIN transaction_labels AS l
     ON l.wallet_id = t.wallet_id AND l.tx_hash = t.tx_hash
 WHERE t.wallet_id = $1
@@ -159,7 +161,8 @@ func (q *Queries) GetMinedTransactionDetails(ctx context.Context, arg GetMinedTr
 const GetMinedTransactionID = `-- name: GetMinedTransactionID :one
 SELECT t.id
 FROM transactions AS t
-INNER JOIN blocks AS b ON b.block_height = t.block_height
+INNER JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 WHERE t.wallet_id = $1
   AND t.tx_hash = $2
   AND t.block_height = $3::INTEGER
@@ -189,7 +192,8 @@ const GetTransactionDetailsByHash = `-- name: GetTransactionDetailsByHash :one
 SELECT t.id, t.raw_tx, t.received_unix, t.block_height,
        t.confirmed_order, b.header_hash, b.block_timestamp, l.label
 FROM transactions AS t
-LEFT JOIN blocks AS b ON b.block_height = t.block_height
+LEFT JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 LEFT JOIN transaction_labels AS l
     ON l.wallet_id = t.wallet_id AND l.tx_hash = t.tx_hash
 WHERE t.wallet_id = $1 AND t.tx_hash = $2
@@ -233,7 +237,8 @@ const GetTransactionDetailsByID = `-- name: GetTransactionDetailsByID :one
 SELECT t.id, t.raw_tx, t.received_unix, t.block_height,
        t.confirmed_order, b.header_hash, b.block_timestamp, l.label
 FROM transactions AS t
-LEFT JOIN blocks AS b ON b.block_height = t.block_height
+LEFT JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 LEFT JOIN transaction_labels AS l
     ON l.wallet_id = t.wallet_id AND l.tx_hash = t.tx_hash
 WHERE t.wallet_id = $1 AND t.id = $2
@@ -320,7 +325,8 @@ const GetUnminedTransactionDetails = `-- name: GetUnminedTransactionDetails :one
 SELECT t.id, t.raw_tx, t.received_unix, t.block_height,
        t.confirmed_order, b.header_hash, b.block_timestamp, l.label
 FROM transactions AS t
-LEFT JOIN blocks AS b ON b.block_height = t.block_height
+LEFT JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 LEFT JOIN transaction_labels AS l
     ON l.wallet_id = t.wallet_id AND l.tx_hash = t.tx_hash
 WHERE t.wallet_id = $1 AND t.tx_hash = $2 AND t.block_height IS NULL
@@ -424,7 +430,8 @@ SELECT t.id, t.wallet_id, t.tx_hash, t.raw_tx, t.received_unix,
        t.block_height, t.confirmed_order, t.is_coinbase,
        b.header_hash, b.block_timestamp
 FROM transactions AS t
-INNER JOIN blocks AS b ON b.block_height = t.block_height
+INNER JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 WHERE t.wallet_id = $1
   AND t.block_height BETWEEN $2::INTEGER
                          AND $3::INTEGER
@@ -531,7 +538,8 @@ SELECT t.id, t.wallet_id, t.tx_hash, t.raw_tx, t.received_unix,
        t.block_height, t.confirmed_order, t.is_coinbase,
        b.header_hash, b.block_timestamp
 FROM transactions AS t
-INNER JOIN blocks AS b ON b.block_height = t.block_height
+INNER JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 WHERE t.wallet_id = $1
   AND t.block_height BETWEEN $2::INTEGER
                          AND $3::INTEGER
@@ -639,7 +647,9 @@ func (q *Queries) ListTransactionIncidencesByHash(ctx context.Context, arg ListT
 const ListUnminedSpenders = `-- name: ListUnminedSpenders :many
 SELECT t.id, t.tx_hash, i.input_index
 FROM transaction_inputs AS i
-INNER JOIN transactions AS t ON t.id = i.spending_tx_id
+INNER JOIN transactions AS t
+    ON t.id = i.spending_tx_id
+    AND t.wallet_id = $1
 WHERE t.wallet_id = $1
   AND t.block_height IS NULL
   AND i.prev_tx_hash = $2
@@ -692,7 +702,9 @@ func (q *Queries) ListUnminedSpenders(ctx context.Context, arg ListUnminedSpende
 const ListUnminedSpendersByPrevHash = `-- name: ListUnminedSpendersByPrevHash :many
 SELECT DISTINCT spender.id, spender.tx_hash
 FROM transaction_inputs AS input
-INNER JOIN transactions AS spender ON spender.id = input.spending_tx_id
+INNER JOIN transactions AS spender
+    ON spender.id = input.spending_tx_id
+    AND spender.wallet_id = $1
 WHERE spender.wallet_id = $1
   AND spender.block_height IS NULL
   AND input.prev_tx_hash = $2

--- a/wallet/internal/sql/pg/sqlc/wallets.sql.go
+++ b/wallet/internal/sql/pg/sqlc/wallets.sql.go
@@ -166,13 +166,21 @@ func (q *Queries) GetWalletByName(ctx context.Context, walletName string) (Walle
 const GetWalletStartBlock = `-- name: GetWalletStartBlock :one
 SELECT b.block_height, b.header_hash, b.block_timestamp
 FROM wallet_sync_states AS s
-INNER JOIN blocks AS b ON b.block_height = s.start_block_height
+INNER JOIN wallet_blocks AS b
+    ON b.wallet_id = s.wallet_id
+    AND b.block_height = s.start_block_height
 WHERE s.wallet_id = $1
 `
 
-func (q *Queries) GetWalletStartBlock(ctx context.Context, walletID int64) (Block, error) {
+type GetWalletStartBlockRow struct {
+	BlockHeight    int32
+	HeaderHash     []byte
+	BlockTimestamp int64
+}
+
+func (q *Queries) GetWalletStartBlock(ctx context.Context, walletID int64) (GetWalletStartBlockRow, error) {
 	row := q.queryRow(ctx, q.getWalletStartBlockStmt, GetWalletStartBlock, walletID)
-	var i Block
+	var i GetWalletStartBlockRow
 	err := row.Scan(&i.BlockHeight, &i.HeaderHash, &i.BlockTimestamp)
 	return i, err
 }
@@ -192,12 +200,15 @@ SELECT
     birthday_block.block_timestamp AS birthday_block_timestamp,
     s.birthday_block_verified
 FROM wallet_sync_states AS s
-INNER JOIN blocks AS start_block
-    ON s.start_block_height = start_block.block_height
-INNER JOIN blocks AS synced_block
-    ON s.synced_block_height = synced_block.block_height
-LEFT JOIN blocks AS birthday_block
-    ON s.birthday_block_height = birthday_block.block_height
+INNER JOIN wallet_blocks AS start_block
+    ON start_block.wallet_id = s.wallet_id
+    AND start_block.block_height = s.start_block_height
+INNER JOIN wallet_blocks AS synced_block
+    ON synced_block.wallet_id = s.wallet_id
+    AND synced_block.block_height = s.synced_block_height
+LEFT JOIN wallet_blocks AS birthday_block
+    ON birthday_block.wallet_id = s.wallet_id
+    AND birthday_block.block_height = s.birthday_block_height
 WHERE s.wallet_id = $1
 `
 

--- a/wallet/internal/sql/pg/transaction_schema_test.go
+++ b/wallet/internal/sql/pg/transaction_schema_test.go
@@ -28,10 +28,17 @@ func testTransactionSchema(t *testing.T, db *sql.DB) {
 
 	q := sqlc.New(db)
 	for height := int32(100); height <= 101; height++ {
-		require.NoError(t, q.InsertBlock(ctx, sqlc.InsertBlockParams{
+		block := sqlc.EnsureBlockHeightParams{
 			BlockHeight:    height,
 			HeaderHash:     testHash(byte(height)),
 			BlockTimestamp: 1000 + int64(height),
+		}
+		require.NoError(t, q.EnsureBlockHeight(ctx, block))
+		require.NoError(t, q.InsertBlock(ctx, sqlc.InsertBlockParams{
+			WalletID:       1,
+			BlockHeight:    height,
+			HeaderHash:     block.HeaderHash,
+			BlockTimestamp: block.BlockTimestamp,
 		}))
 	}
 
@@ -120,7 +127,10 @@ func testTransactionSchema(t *testing.T, db *sql.DB) {
 	require.NoError(t, err)
 	require.Len(t, unspent, 1)
 	require.Equal(t, minedCreditIDs[1], unspent[0].ID)
-	require.Error(t, q.DeleteBlock(ctx, 100))
+	require.Error(t, q.DeleteBlock(ctx, sqlc.DeleteBlockParams{
+		WalletID:    1,
+		BlockHeight: 100,
+	}))
 
 	unminedHash := testHash(2)
 	unminedID := insertUnminedTransaction(t, ctx, q, unminedHash)
@@ -182,7 +192,7 @@ func testTransactionSchema(t *testing.T, db *sql.DB) {
 		},
 	))
 	credit, err := q.GetCredit(ctx, sqlc.GetCreditParams{
-		TransactionID: fundingID, OutputIndex: 0,
+		WalletID: 1, TransactionID: fundingID, OutputIndex: 0,
 	})
 	require.NoError(t, err)
 	require.Equal(t, pkScript, credit.PkScript)

--- a/wallet/internal/sql/sqlite/legacy_schema_test.go
+++ b/wallet/internal/sql/sqlite/legacy_schema_test.go
@@ -31,17 +31,6 @@ func TestLegacySchemaQueries(t *testing.T) {
 	genesisHash := bytesOf(0x01, 32)
 	birthdayHash := bytesOf(0x02, 32)
 
-	require.NoError(t, queries.InsertBlock(ctx, sqlc.InsertBlockParams{
-		BlockHeight:    0,
-		HeaderHash:     genesisHash,
-		BlockTimestamp: 1,
-	}))
-	require.NoError(t, queries.InsertBlock(ctx, sqlc.InsertBlockParams{
-		BlockHeight:    100,
-		HeaderHash:     birthdayHash,
-		BlockTimestamp: 2,
-	}))
-
 	walletID, err := queries.CreateWallet(ctx, sqlc.CreateWalletParams{
 		WalletName:            "watch-only",
 		ManagerVersion:        8,
@@ -51,6 +40,29 @@ func TestLegacySchemaQueries(t *testing.T) {
 		EncryptedCryptoPubKey: []byte("encrypted-crypto-public-key"),
 	})
 	require.NoError(t, err)
+
+	for _, block := range []sqlc.EnsureBlockHeightParams{
+		{
+			BlockHeight:    0,
+			HeaderHash:     genesisHash,
+			BlockTimestamp: 1,
+		},
+		{
+			BlockHeight:    100,
+			HeaderHash:     birthdayHash,
+			BlockTimestamp: 2,
+		},
+	} {
+		require.NoError(t, queries.EnsureBlockHeight(ctx, block))
+		require.NoError(t, queries.InsertBlock(
+			ctx, sqlc.InsertBlockParams{
+				WalletID:       walletID,
+				BlockHeight:    block.BlockHeight,
+				HeaderHash:     block.HeaderHash,
+				BlockTimestamp: block.BlockTimestamp,
+			},
+		))
+	}
 
 	wallet, err := queries.GetWalletByName(ctx, "watch-only")
 	require.NoError(t, err)
@@ -140,6 +152,8 @@ func TestLegacySchemaQueries(t *testing.T) {
 	createLegacyAddressRows(t, ctx, db, queries, walletID, scopeID)
 }
 
+// requireNoPlaintextColumns verifies that secret manager values have no clear
+// text schema representation.
 func requireNoPlaintextColumns(t *testing.T, db *sql.DB) {
 	t.Helper()
 
@@ -164,6 +178,8 @@ func requireNoPlaintextColumns(t *testing.T, db *sql.DB) {
 	}
 }
 
+// createLegacyAddressRows verifies every legacy address variant and sticky used
+// state through generated queries.
 func createLegacyAddressRows(t *testing.T, ctx context.Context, db *sql.DB,
 	queries *sqlc.Queries, walletID, scopeID int64) {
 
@@ -287,6 +303,7 @@ func createLegacyAddressRows(t *testing.T, ctx context.Context, db *sql.DB,
 	require.Error(t, err)
 }
 
+// bytesOf returns a deterministic byte fixture of the requested length.
 func bytesOf(value byte, count int) []byte {
 	b := make([]byte, count)
 	for i := range b {

--- a/wallet/internal/sql/sqlite/migrations/000011_wallet_blocks.down.sql
+++ b/wallet/internal/sql/sqlite/migrations/000011_wallet_blocks.down.sql
@@ -1,0 +1,6 @@
+DROP TRIGGER wallet_blocks_delete_restrict;
+DROP TRIGGER transactions_update_block;
+DROP TRIGGER transactions_insert_block;
+DROP TRIGGER wallet_sync_states_update_blocks;
+DROP TRIGGER wallet_sync_states_insert_blocks;
+DROP TABLE wallet_blocks;

--- a/wallet/internal/sql/sqlite/migrations/000011_wallet_blocks.up.sql
+++ b/wallet/internal/sql/sqlite/migrations/000011_wallet_blocks.up.sql
@@ -1,0 +1,105 @@
+-- Active block identities belong to one wallet. The original blocks table is
+-- retained as a height registry for foreign keys created by shipped migrations.
+CREATE TABLE wallet_blocks (
+    wallet_id INTEGER NOT NULL,
+    block_height INTEGER NOT NULL CHECK (block_height >= 0),
+    header_hash BLOB NOT NULL CHECK (length(header_hash) = 32),
+    block_timestamp INTEGER NOT NULL CHECK (block_timestamp >= 0),
+    PRIMARY KEY (wallet_id, block_height),
+    UNIQUE (wallet_id, header_hash),
+    FOREIGN KEY (wallet_id) REFERENCES wallets (id) ON DELETE RESTRICT
+);
+
+-- Existing global identities are valid candidates for every existing wallet.
+-- Future writes replace them independently in wallet_blocks.
+INSERT INTO wallet_blocks (
+    wallet_id, block_height, header_hash, block_timestamp
+)
+SELECT w.id, b.block_height, b.header_hash, b.block_timestamp
+FROM wallets AS w
+CROSS JOIN blocks AS b;
+
+-- SQLite cannot add composite foreign keys without rebuilding shipped tables.
+-- These triggers enforce the wallet-scoped relationships without changing the
+-- semantics of prior migrations.
+CREATE TRIGGER wallet_sync_states_insert_blocks
+BEFORE INSERT ON wallet_sync_states
+BEGIN
+    SELECT CASE WHEN NOT EXISTS (
+        SELECT 1 FROM wallet_blocks
+        WHERE wallet_id = NEW.wallet_id
+          AND block_height = NEW.start_block_height
+    ) THEN RAISE(ABORT, 'wallet start block not found') END;
+    SELECT CASE WHEN NOT EXISTS (
+        SELECT 1 FROM wallet_blocks
+        WHERE wallet_id = NEW.wallet_id
+          AND block_height = NEW.synced_block_height
+    ) THEN RAISE(ABORT, 'wallet synced block not found') END;
+    SELECT CASE WHEN NEW.birthday_block_height IS NOT NULL AND NOT EXISTS (
+        SELECT 1 FROM wallet_blocks
+        WHERE wallet_id = NEW.wallet_id
+          AND block_height = NEW.birthday_block_height
+    ) THEN RAISE(ABORT, 'wallet birthday block not found') END;
+END;
+
+CREATE TRIGGER wallet_sync_states_update_blocks
+BEFORE UPDATE OF wallet_id, start_block_height, synced_block_height,
+    birthday_block_height ON wallet_sync_states
+BEGIN
+    SELECT CASE WHEN NOT EXISTS (
+        SELECT 1 FROM wallet_blocks
+        WHERE wallet_id = NEW.wallet_id
+          AND block_height = NEW.start_block_height
+    ) THEN RAISE(ABORT, 'wallet start block not found') END;
+    SELECT CASE WHEN NOT EXISTS (
+        SELECT 1 FROM wallet_blocks
+        WHERE wallet_id = NEW.wallet_id
+          AND block_height = NEW.synced_block_height
+    ) THEN RAISE(ABORT, 'wallet synced block not found') END;
+    SELECT CASE WHEN NEW.birthday_block_height IS NOT NULL AND NOT EXISTS (
+        SELECT 1 FROM wallet_blocks
+        WHERE wallet_id = NEW.wallet_id
+          AND block_height = NEW.birthday_block_height
+    ) THEN RAISE(ABORT, 'wallet birthday block not found') END;
+END;
+
+CREATE TRIGGER transactions_insert_block
+BEFORE INSERT ON transactions
+WHEN NEW.block_height IS NOT NULL
+BEGIN
+    SELECT CASE WHEN NOT EXISTS (
+        SELECT 1 FROM wallet_blocks
+        WHERE wallet_id = NEW.wallet_id
+          AND block_height = NEW.block_height
+    ) THEN RAISE(ABORT, 'transaction block not found') END;
+END;
+
+CREATE TRIGGER transactions_update_block
+BEFORE UPDATE OF wallet_id, block_height ON transactions
+WHEN NEW.block_height IS NOT NULL
+BEGIN
+    SELECT CASE WHEN NOT EXISTS (
+        SELECT 1 FROM wallet_blocks
+        WHERE wallet_id = NEW.wallet_id
+          AND block_height = NEW.block_height
+    ) THEN RAISE(ABORT, 'transaction block not found') END;
+END;
+
+CREATE TRIGGER wallet_blocks_delete_restrict
+BEFORE DELETE ON wallet_blocks
+WHEN EXISTS (
+    SELECT 1 FROM wallet_sync_states
+    WHERE wallet_id = OLD.wallet_id
+      AND (
+          start_block_height = OLD.block_height
+          OR synced_block_height = OLD.block_height
+          OR birthday_block_height = OLD.block_height
+      )
+    UNION ALL
+    SELECT 1 FROM transactions
+    WHERE wallet_id = OLD.wallet_id
+      AND block_height = OLD.block_height
+)
+BEGIN
+    SELECT RAISE(ABORT, 'wallet block is still referenced');
+END;

--- a/wallet/internal/sql/sqlite/migrations/000012_lease_nanoseconds.down.sql
+++ b/wallet/internal/sql/sqlite/migrations/000012_lease_nanoseconds.down.sql
@@ -1,0 +1,2 @@
+UPDATE utxo_leases
+SET expires_unix = expires_unix / 1000000000;

--- a/wallet/internal/sql/sqlite/migrations/000012_lease_nanoseconds.up.sql
+++ b/wallet/internal/sql/sqlite/migrations/000012_lease_nanoseconds.up.sql
@@ -1,0 +1,4 @@
+-- Lease expirations in migration 000009 were stored as Unix seconds. Convert
+-- existing rows before runtime code starts comparing nanosecond timestamps.
+UPDATE utxo_leases
+SET expires_unix = expires_unix * 1000000000;

--- a/wallet/internal/sql/sqlite/migrations_test.go
+++ b/wallet/internal/sql/sqlite/migrations_test.go
@@ -1,6 +1,7 @@
 package sqlite
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"path/filepath"
@@ -22,7 +23,7 @@ func TestMigrationsRoundTrip(t *testing.T) {
 		require.NoError(t, db.Close())
 	})
 
-	require.NoError(t, ApplyMigrations(db))
+	requireLeaseUpgrade(t, db)
 	requireSchemaTables(t, db, true)
 	testTransactionSchema(t, db)
 
@@ -33,11 +34,52 @@ func TestMigrationsRoundTrip(t *testing.T) {
 	requireSchemaTables(t, db, true)
 }
 
+// requireLeaseUpgrade verifies that the forward precision migration converts
+// leases written by migration 000009 before nanosecond comparisons begin.
+func requireLeaseUpgrade(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	migration, err := newMigrationInstance(db)
+	require.NoError(t, err)
+	require.NoError(t, migration.Migrate(11))
+
+	_, err = db.ExecContext(t.Context(), `
+		INSERT INTO wallets (
+			id, wallet_name, manager_version, manager_created_at,
+			is_watch_only, master_pub_params, encrypted_crypto_pub_key
+		) VALUES (99, 'lease-upgrade', 1, 1, TRUE, x'01', x'02')
+	`)
+	require.NoError(t, err)
+
+	const expiresSeconds = int64(1_700_000_000)
+
+	_, err = db.ExecContext(t.Context(), `
+		INSERT INTO utxo_leases (
+			wallet_id, tx_hash, output_index, lock_id, expires_unix
+		) VALUES (?, ?, 0, ?, ?)
+	`, 99, bytes.Repeat([]byte{1}, 32), bytes.Repeat([]byte{2}, 32),
+		expiresSeconds)
+	require.NoError(t, err)
+
+	require.NoError(t, ApplyMigrations(db))
+
+	var expiresNanoseconds int64
+
+	err = db.QueryRowContext(t.Context(), `
+		SELECT expires_unix FROM utxo_leases WHERE wallet_id = 99
+	`).Scan(&expiresNanoseconds)
+	require.NoError(t, err)
+	require.Equal(t, expiresSeconds*int64(1_000_000_000),
+		expiresNanoseconds)
+}
+
+// requireSchemaTables verifies whether every wallet schema table exists.
 func requireSchemaTables(t *testing.T, db *sql.DB, expected bool) {
 	t.Helper()
 
 	tables := []string{
-		"blocks", "wallets", "wallet_sync_states", "address_types",
+		"blocks", "wallet_blocks", "wallets", "wallet_sync_states",
+		"address_types",
 		"key_scopes", "accounts", "addresses",
 		"transactions", "transaction_inputs", "transaction_labels",
 		"credits", "active_credit_incidences", "credit_spends",

--- a/wallet/internal/sql/sqlite/queries/addresses.sql
+++ b/wallet/internal/sql/sqlite/queries/addresses.sql
@@ -197,7 +197,7 @@ SET
     encrypted_priv_key = NULL,
     encrypted_script = CASE
         WHEN address_type = 2 THEN NULL
-        WHEN address_type = 3 AND is_secret_script = TRUE THEN NULL
+        WHEN address_type IN (3, 4) AND is_secret_script = TRUE THEN NULL
         ELSE encrypted_script
     END
 WHERE wallet_id = ?;

--- a/wallet/internal/sql/sqlite/queries/blocks.sql
+++ b/wallet/internal/sql/sqlite/queries/blocks.sql
@@ -3,31 +3,41 @@ SELECT
     block_height,
     header_hash,
     block_timestamp
-FROM blocks
-WHERE block_height = ?;
+FROM wallet_blocks
+WHERE wallet_id = sqlc.arg('wallet_id')
+  AND block_height = sqlc.arg('block_height');
 
 -- name: GetBlocksInRange :many
 SELECT
     block_height,
     header_hash,
     block_timestamp
-FROM blocks
+FROM wallet_blocks
 WHERE
-    block_height >= cast(sqlc.arg('start_height') AS INTEGER)
+    wallet_id = sqlc.arg('wallet_id')
+    AND block_height >= cast(sqlc.arg('start_height') AS INTEGER)
     AND block_height <= cast(sqlc.arg('end_height') AS INTEGER)
 ORDER BY block_height;
 
--- name: InsertBlock :exec
+-- name: EnsureBlockHeight :exec
 INSERT OR IGNORE INTO blocks (block_height, header_hash, block_timestamp)
 VALUES (?, ?, ?);
 
+-- name: InsertBlock :exec
+INSERT OR IGNORE INTO wallet_blocks (
+    wallet_id, block_height, header_hash, block_timestamp
+)
+VALUES (?, ?, ?, ?);
+
 -- name: PutBlock :exec
-INSERT INTO blocks (block_height, header_hash, block_timestamp)
-VALUES (?, ?, ?)
-ON CONFLICT (block_height) DO UPDATE SET
+INSERT INTO wallet_blocks (
+    wallet_id, block_height, header_hash, block_timestamp
+)
+VALUES (?, ?, ?, ?)
+ON CONFLICT (wallet_id, block_height) DO UPDATE SET
     header_hash = excluded.header_hash,
     block_timestamp = excluded.block_timestamp;
 
 -- name: DeleteBlock :exec
-DELETE FROM blocks
-WHERE block_height = ?;
+DELETE FROM wallet_blocks
+WHERE wallet_id = ? AND block_height = ?;

--- a/wallet/internal/sql/sqlite/queries/credits.sql
+++ b/wallet/internal/sql/sqlite/queries/credits.sql
@@ -17,7 +17,8 @@ INSERT INTO active_credit_incidences (
 )
 SELECT c.wallet_id, funding.tx_hash, c.output_index, c.id
 FROM credits AS c
-INNER JOIN transactions AS funding ON funding.id = c.transaction_id
+INNER JOIN transactions AS funding
+    ON funding.wallet_id = c.wallet_id AND funding.id = c.transaction_id
 WHERE c.wallet_id = ? AND c.id = ?
 ON CONFLICT (wallet_id, tx_hash, output_index) DO UPDATE SET
     credit_id = excluded.credit_id;
@@ -28,11 +29,13 @@ INSERT INTO credit_spends (
 )
 SELECT c.wallet_id, c.id, i.spending_tx_id, i.input_index
 FROM credits AS c
-INNER JOIN transactions AS funding ON funding.id = c.transaction_id
+INNER JOIN transactions AS funding
+    ON funding.wallet_id = c.wallet_id AND funding.id = c.transaction_id
 INNER JOIN transaction_inputs AS i
     ON i.prev_tx_hash = funding.tx_hash
     AND i.prev_output_index = c.output_index
-INNER JOIN transactions AS spender ON spender.id = i.spending_tx_id
+INNER JOIN transactions AS spender
+    ON spender.wallet_id = c.wallet_id AND spender.id = i.spending_tx_id
 WHERE c.wallet_id = ?
   AND c.id = ?
   AND i.spending_tx_id = ?
@@ -52,7 +55,7 @@ WHERE wallet_id = ? AND credit_id = ?
 SELECT id, wallet_id, transaction_id, output_index, amount, pk_script,
        is_change, address_scope_id, address_id
 FROM credits
-WHERE transaction_id = ? AND output_index = ?;
+WHERE wallet_id = ? AND transaction_id = ? AND output_index = ?;
 
 -- name: ListTransactionCredits :many
 SELECT c.id, c.output_index, c.amount, c.pk_script, c.is_change,
@@ -60,14 +63,16 @@ SELECT c.id, c.output_index, c.amount, c.pk_script, c.is_change,
        EXISTS (
            SELECT 1
            FROM credit_spends AS spend
-           WHERE spend.credit_id = c.id
+           WHERE spend.wallet_id = c.wallet_id AND spend.credit_id = c.id
        ) OR EXISTS (
            SELECT 1
            FROM transaction_inputs AS input
            INNER JOIN transactions AS spender
-               ON spender.id = input.spending_tx_id
+               ON spender.wallet_id = c.wallet_id
+               AND spender.id = input.spending_tx_id
            INNER JOIN transactions AS funding
-               ON funding.id = c.transaction_id
+               ON funding.wallet_id = c.wallet_id
+               AND funding.id = c.transaction_id
            WHERE spender.wallet_id = c.wallet_id
              AND spender.block_height IS NULL
              AND input.prev_tx_hash = funding.tx_hash
@@ -86,18 +91,25 @@ SELECT c.id, funding.tx_hash, c.output_index, c.amount, c.pk_script,
        funding.is_coinbase, c.address_scope_id, c.address_id,
        block.header_hash, block.block_timestamp
 FROM credits AS c
-INNER JOIN transactions AS funding ON funding.id = c.transaction_id
-INNER JOIN active_credit_incidences AS active ON active.credit_id = c.id
-LEFT JOIN blocks AS block ON block.block_height = funding.block_height
+INNER JOIN transactions AS funding
+    ON funding.wallet_id = c.wallet_id AND funding.id = c.transaction_id
+INNER JOIN active_credit_incidences AS active
+    ON active.wallet_id = c.wallet_id AND active.credit_id = c.id
+LEFT JOIN wallet_blocks AS block
+    ON block.wallet_id = funding.wallet_id
+    AND block.block_height = funding.block_height
 INNER JOIN query_params
 WHERE c.wallet_id = sqlc.arg('wallet_id')
   AND NOT EXISTS (
-      SELECT 1 FROM credit_spends AS spend WHERE spend.credit_id = c.id
+      SELECT 1 FROM credit_spends AS spend
+      WHERE spend.wallet_id = c.wallet_id AND spend.credit_id = c.id
   )
   AND NOT EXISTS (
       SELECT 1
       FROM transaction_inputs AS i
-      INNER JOIN transactions AS spender ON spender.id = i.spending_tx_id
+      INNER JOIN transactions AS spender
+          ON spender.wallet_id = c.wallet_id
+          AND spender.id = i.spending_tx_id
       WHERE spender.wallet_id = c.wallet_id
         AND spender.block_height IS NULL
         AND i.prev_tx_hash = funding.tx_hash
@@ -116,27 +128,51 @@ ORDER BY funding.tx_hash, c.output_index;
 -- name: ListOutputsToWatch :many
 SELECT funding.tx_hash, c.output_index, c.pk_script
 FROM credits AS c
-INNER JOIN transactions AS funding ON funding.id = c.transaction_id
-INNER JOIN active_credit_incidences AS active ON active.credit_id = c.id
+INNER JOIN transactions AS funding
+    ON funding.wallet_id = c.wallet_id AND funding.id = c.transaction_id
+INNER JOIN active_credit_incidences AS active
+    ON active.wallet_id = c.wallet_id AND active.credit_id = c.id
 WHERE c.wallet_id = sqlc.arg('wallet_id')
   AND NOT EXISTS (
       SELECT 1
       FROM credit_spends AS spend
-      WHERE spend.credit_id = c.id
+      WHERE spend.wallet_id = c.wallet_id AND spend.credit_id = c.id
   )
 ORDER BY funding.tx_hash, c.output_index;
 
 -- name: ListTransactionDebits :many
-SELECT spend.input_index, credit.amount
-FROM credit_spends AS spend
-INNER JOIN credits AS credit ON credit.id = spend.credit_id
-WHERE spend.wallet_id = ? AND spend.spending_tx_id = ?
-ORDER BY spend.input_index;
+SELECT debit.input_index, debit.amount
+FROM (
+    SELECT spend.input_index, credit.amount
+    FROM credit_spends AS spend
+    INNER JOIN credits AS credit
+        ON credit.wallet_id = spend.wallet_id AND credit.id = spend.credit_id
+    WHERE spend.wallet_id = sqlc.arg('wallet_id')
+      AND spend.spending_tx_id = sqlc.arg('transaction_id')
+
+    UNION ALL
+
+    SELECT input.input_index, credit.amount
+    FROM transactions AS spender
+    INNER JOIN transaction_inputs AS input
+        ON input.spending_tx_id = spender.id
+    INNER JOIN active_credit_incidences AS active
+        ON active.wallet_id = spender.wallet_id
+        AND active.tx_hash = input.prev_tx_hash
+        AND active.output_index = input.prev_output_index
+    INNER JOIN credits AS credit
+        ON credit.wallet_id = active.wallet_id AND credit.id = active.credit_id
+    WHERE spender.wallet_id = sqlc.arg('wallet_id')
+      AND spender.id = sqlc.arg('transaction_id')
+      AND spender.block_height IS NULL
+) AS debit
+ORDER BY debit.input_index;
 
 -- name: GetActiveCreditID :one
 SELECT credit.id
 FROM active_credit_incidences AS active
-INNER JOIN credits AS credit ON credit.id = active.credit_id
+INNER JOIN credits AS credit
+    ON credit.wallet_id = active.wallet_id AND credit.id = active.credit_id
 WHERE active.wallet_id = ? AND active.tx_hash = ?
   AND active.output_index = ?;
 
@@ -144,29 +180,34 @@ WHERE active.wallet_id = ? AND active.tx_hash = ?
 SELECT EXISTS (
     SELECT 1
     FROM active_credit_incidences AS active
-    INNER JOIN credits AS credit ON credit.id = active.credit_id
+    INNER JOIN credits AS credit
+        ON credit.wallet_id = active.wallet_id AND credit.id = active.credit_id
     WHERE active.wallet_id = ? AND active.tx_hash = ?
       AND active.output_index = ?
       AND NOT EXISTS (
           SELECT 1 FROM credit_spends AS spend
-          WHERE spend.credit_id = credit.id
+          WHERE spend.wallet_id = credit.wallet_id
+            AND spend.credit_id = credit.id
       )
 );
 
 -- name: GetUnminedPreviousPkScript :one
 SELECT credit.pk_script
 FROM active_credit_incidences AS active
-INNER JOIN credits AS credit ON credit.id = active.credit_id
+INNER JOIN credits AS credit
+    ON credit.wallet_id = active.wallet_id AND credit.id = active.credit_id
 WHERE active.wallet_id = ? AND active.tx_hash = ?
   AND active.output_index = ?
   AND NOT EXISTS (
       SELECT 1 FROM credit_spends AS spend
-      WHERE spend.credit_id = credit.id
+      WHERE spend.wallet_id = credit.wallet_id
+        AND spend.credit_id = credit.id
   );
 
 -- name: GetMinedPreviousPkScript :one
 SELECT credit.pk_script
 FROM credit_spends AS spend
-INNER JOIN credits AS credit ON credit.id = spend.credit_id
+INNER JOIN credits AS credit
+    ON credit.wallet_id = spend.wallet_id AND credit.id = spend.credit_id
 WHERE spend.wallet_id = ? AND spend.spending_tx_id = ?
   AND spend.input_index = ?;

--- a/wallet/internal/sql/sqlite/queries/transactions.sql
+++ b/wallet/internal/sql/sqlite/queries/transactions.sql
@@ -26,7 +26,8 @@ WHERE wallet_id = ? AND tx_hash = ? AND block_height IS NULL;
 SELECT t.id, t.raw_tx, t.received_unix, t.block_height,
        t.confirmed_order, b.header_hash, b.block_timestamp, l.label
 FROM transactions AS t
-LEFT JOIN blocks AS b ON b.block_height = t.block_height
+LEFT JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 LEFT JOIN transaction_labels AS l
     ON l.wallet_id = t.wallet_id AND l.tx_hash = t.tx_hash
 WHERE t.wallet_id = ? AND t.tx_hash = ?
@@ -37,7 +38,8 @@ LIMIT 1;
 SELECT t.id, t.raw_tx, t.received_unix, t.block_height,
        t.confirmed_order, b.header_hash, b.block_timestamp, l.label
 FROM transactions AS t
-LEFT JOIN blocks AS b ON b.block_height = t.block_height
+LEFT JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 LEFT JOIN transaction_labels AS l
     ON l.wallet_id = t.wallet_id AND l.tx_hash = t.tx_hash
 WHERE t.wallet_id = ? AND t.tx_hash = ? AND t.block_height IS NULL
@@ -47,7 +49,8 @@ LIMIT 1;
 SELECT t.id, t.raw_tx, t.received_unix, t.block_height,
        t.confirmed_order, b.header_hash, b.block_timestamp, l.label
 FROM transactions AS t
-INNER JOIN blocks AS b ON b.block_height = t.block_height
+INNER JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 LEFT JOIN transaction_labels AS l
     ON l.wallet_id = t.wallet_id AND l.tx_hash = t.tx_hash
 WHERE t.wallet_id = sqlc.arg('wallet_id')
@@ -60,7 +63,8 @@ LIMIT 1;
 SELECT t.id, t.raw_tx, t.received_unix, t.block_height,
        t.confirmed_order, b.header_hash, b.block_timestamp, l.label
 FROM transactions AS t
-LEFT JOIN blocks AS b ON b.block_height = t.block_height
+LEFT JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 LEFT JOIN transaction_labels AS l
     ON l.wallet_id = t.wallet_id AND l.tx_hash = t.tx_hash
 WHERE t.wallet_id = ? AND t.id = ?
@@ -90,7 +94,9 @@ WHERE wallet_id = ? AND spending_tx_id = ?;
 -- name: ListUnminedSpendersByPrevHash :many
 SELECT DISTINCT spender.id, spender.tx_hash
 FROM transaction_inputs AS input
-INNER JOIN transactions AS spender ON spender.id = input.spending_tx_id
+INNER JOIN transactions AS spender
+    ON spender.id = input.spending_tx_id
+    AND spender.wallet_id = sqlc.arg('wallet_id')
 WHERE spender.wallet_id = sqlc.arg('wallet_id')
   AND spender.block_height IS NULL
   AND input.prev_tx_hash = sqlc.arg('prev_tx_hash')
@@ -100,7 +106,8 @@ ORDER BY spender.id;
 SELECT t.id, t.wallet_id, t.tx_hash, t.raw_tx, t.received_unix,
        t.block_height, t.confirmed_order, t.is_coinbase
 FROM transactions AS t
-INNER JOIN blocks AS b ON b.block_height = t.block_height
+INNER JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 WHERE t.wallet_id = sqlc.arg('wallet_id')
   AND t.tx_hash = sqlc.arg('tx_hash')
   AND t.block_height = sqlc.arg('block_height')
@@ -125,7 +132,8 @@ SELECT t.id, t.wallet_id, t.tx_hash, t.raw_tx, t.received_unix,
        t.block_height, t.confirmed_order, t.is_coinbase,
        b.header_hash, b.block_timestamp
 FROM transactions AS t
-INNER JOIN blocks AS b ON b.block_height = t.block_height
+INNER JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 WHERE t.wallet_id = sqlc.arg('wallet_id')
   AND t.block_height BETWEEN cast(sqlc.arg('start_height') AS INTEGER)
                          AND cast(sqlc.arg('end_height') AS INTEGER)
@@ -136,7 +144,8 @@ SELECT t.id, t.wallet_id, t.tx_hash, t.raw_tx, t.received_unix,
        t.block_height, t.confirmed_order, t.is_coinbase,
        b.header_hash, b.block_timestamp
 FROM transactions AS t
-INNER JOIN blocks AS b ON b.block_height = t.block_height
+INNER JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 WHERE t.wallet_id = sqlc.arg('wallet_id')
   AND t.block_height BETWEEN cast(sqlc.arg('end_height') AS INTEGER)
                          AND cast(sqlc.arg('start_height') AS INTEGER)
@@ -151,7 +160,9 @@ RETURNING id;
 -- name: ListUnminedSpenders :many
 SELECT t.id, t.tx_hash, i.input_index
 FROM transaction_inputs AS i
-INNER JOIN transactions AS t ON t.id = i.spending_tx_id
+INNER JOIN transactions AS t
+    ON t.id = i.spending_tx_id
+    AND t.wallet_id = sqlc.arg('wallet_id')
 WHERE t.wallet_id = sqlc.arg('wallet_id')
   AND t.block_height IS NULL
   AND i.prev_tx_hash = sqlc.arg('prev_tx_hash')
@@ -173,7 +184,8 @@ SELECT label FROM transaction_labels WHERE wallet_id = ? AND tx_hash = ?;
 -- name: GetMinedTransactionID :one
 SELECT t.id
 FROM transactions AS t
-INNER JOIN blocks AS b ON b.block_height = t.block_height
+INNER JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 WHERE t.wallet_id = sqlc.arg('wallet_id')
   AND t.tx_hash = sqlc.arg('tx_hash')
   AND t.block_height = cast(sqlc.arg('block_height') AS INTEGER)

--- a/wallet/internal/sql/sqlite/queries/wallets.sql
+++ b/wallet/internal/sql/sqlite/queries/wallets.sql
@@ -107,12 +107,15 @@ SELECT
     birthday_block.block_timestamp AS birthday_block_timestamp,
     s.birthday_block_verified
 FROM wallet_sync_states AS s
-INNER JOIN blocks AS start_block
-    ON s.start_block_height = start_block.block_height
-INNER JOIN blocks AS synced_block
-    ON s.synced_block_height = synced_block.block_height
-LEFT JOIN blocks AS birthday_block
-    ON s.birthday_block_height = birthday_block.block_height
+INNER JOIN wallet_blocks AS start_block
+    ON start_block.wallet_id = s.wallet_id
+    AND start_block.block_height = s.start_block_height
+INNER JOIN wallet_blocks AS synced_block
+    ON synced_block.wallet_id = s.wallet_id
+    AND synced_block.block_height = s.synced_block_height
+LEFT JOIN wallet_blocks AS birthday_block
+    ON birthday_block.wallet_id = s.wallet_id
+    AND birthday_block.block_height = s.birthday_block_height
 WHERE s.wallet_id = ?;
 
 -- name: SetWalletBirthday :execrows
@@ -133,7 +136,9 @@ WHERE wallet_id = ?;
 -- name: GetWalletStartBlock :one
 SELECT b.block_height, b.header_hash, b.block_timestamp
 FROM wallet_sync_states AS s
-INNER JOIN blocks AS b ON b.block_height = s.start_block_height
+INNER JOIN wallet_blocks AS b
+    ON b.wallet_id = s.wallet_id
+    AND b.block_height = s.start_block_height
 WHERE s.wallet_id = ?;
 
 -- name: UpdateWalletSyncState :execrows

--- a/wallet/internal/sql/sqlite/sqlc/addresses.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/addresses.sql.go
@@ -78,7 +78,7 @@ SET
     encrypted_priv_key = NULL,
     encrypted_script = CASE
         WHEN address_type = 2 THEN NULL
-        WHEN address_type = 3 AND is_secret_script = TRUE THEN NULL
+        WHEN address_type IN (3, 4) AND is_secret_script = TRUE THEN NULL
         ELSE encrypted_script
     END
 WHERE wallet_id = ?

--- a/wallet/internal/sql/sqlite/sqlc/blocks.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/blocks.sql.go
@@ -10,12 +10,33 @@ import (
 )
 
 const DeleteBlock = `-- name: DeleteBlock :exec
-DELETE FROM blocks
-WHERE block_height = ?
+DELETE FROM wallet_blocks
+WHERE wallet_id = ? AND block_height = ?
 `
 
-func (q *Queries) DeleteBlock(ctx context.Context, blockHeight int64) error {
-	_, err := q.exec(ctx, q.deleteBlockStmt, DeleteBlock, blockHeight)
+type DeleteBlockParams struct {
+	WalletID    int64
+	BlockHeight int64
+}
+
+func (q *Queries) DeleteBlock(ctx context.Context, arg DeleteBlockParams) error {
+	_, err := q.exec(ctx, q.deleteBlockStmt, DeleteBlock, arg.WalletID, arg.BlockHeight)
+	return err
+}
+
+const EnsureBlockHeight = `-- name: EnsureBlockHeight :exec
+INSERT OR IGNORE INTO blocks (block_height, header_hash, block_timestamp)
+VALUES (?, ?, ?)
+`
+
+type EnsureBlockHeightParams struct {
+	BlockHeight    int64
+	HeaderHash     []byte
+	BlockTimestamp int64
+}
+
+func (q *Queries) EnsureBlockHeight(ctx context.Context, arg EnsureBlockHeightParams) error {
+	_, err := q.exec(ctx, q.ensureBlockHeightStmt, EnsureBlockHeight, arg.BlockHeight, arg.HeaderHash, arg.BlockTimestamp)
 	return err
 }
 
@@ -24,13 +45,25 @@ SELECT
     block_height,
     header_hash,
     block_timestamp
-FROM blocks
-WHERE block_height = ?
+FROM wallet_blocks
+WHERE wallet_id = ?1
+  AND block_height = ?2
 `
 
-func (q *Queries) GetBlockByHeight(ctx context.Context, blockHeight int64) (Block, error) {
-	row := q.queryRow(ctx, q.getBlockByHeightStmt, GetBlockByHeight, blockHeight)
-	var i Block
+type GetBlockByHeightParams struct {
+	WalletID    int64
+	BlockHeight int64
+}
+
+type GetBlockByHeightRow struct {
+	BlockHeight    int64
+	HeaderHash     []byte
+	BlockTimestamp int64
+}
+
+func (q *Queries) GetBlockByHeight(ctx context.Context, arg GetBlockByHeightParams) (GetBlockByHeightRow, error) {
+	row := q.queryRow(ctx, q.getBlockByHeightStmt, GetBlockByHeight, arg.WalletID, arg.BlockHeight)
+	var i GetBlockByHeightRow
 	err := row.Scan(&i.BlockHeight, &i.HeaderHash, &i.BlockTimestamp)
 	return i, err
 }
@@ -40,27 +73,35 @@ SELECT
     block_height,
     header_hash,
     block_timestamp
-FROM blocks
+FROM wallet_blocks
 WHERE
-    block_height >= cast(?1 AS INTEGER)
-    AND block_height <= cast(?2 AS INTEGER)
+    wallet_id = ?1
+    AND block_height >= cast(?2 AS INTEGER)
+    AND block_height <= cast(?3 AS INTEGER)
 ORDER BY block_height
 `
 
 type GetBlocksInRangeParams struct {
+	WalletID    int64
 	StartHeight int64
 	EndHeight   int64
 }
 
-func (q *Queries) GetBlocksInRange(ctx context.Context, arg GetBlocksInRangeParams) ([]Block, error) {
-	rows, err := q.query(ctx, q.getBlocksInRangeStmt, GetBlocksInRange, arg.StartHeight, arg.EndHeight)
+type GetBlocksInRangeRow struct {
+	BlockHeight    int64
+	HeaderHash     []byte
+	BlockTimestamp int64
+}
+
+func (q *Queries) GetBlocksInRange(ctx context.Context, arg GetBlocksInRangeParams) ([]GetBlocksInRangeRow, error) {
+	rows, err := q.query(ctx, q.getBlocksInRangeStmt, GetBlocksInRange, arg.WalletID, arg.StartHeight, arg.EndHeight)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []Block
+	var items []GetBlocksInRangeRow
 	for rows.Next() {
-		var i Block
+		var i GetBlocksInRangeRow
 		if err := rows.Scan(&i.BlockHeight, &i.HeaderHash, &i.BlockTimestamp); err != nil {
 			return nil, err
 		}
@@ -76,36 +117,52 @@ func (q *Queries) GetBlocksInRange(ctx context.Context, arg GetBlocksInRangePara
 }
 
 const InsertBlock = `-- name: InsertBlock :exec
-INSERT OR IGNORE INTO blocks (block_height, header_hash, block_timestamp)
-VALUES (?, ?, ?)
+INSERT OR IGNORE INTO wallet_blocks (
+    wallet_id, block_height, header_hash, block_timestamp
+)
+VALUES (?, ?, ?, ?)
 `
 
 type InsertBlockParams struct {
+	WalletID       int64
 	BlockHeight    int64
 	HeaderHash     []byte
 	BlockTimestamp int64
 }
 
 func (q *Queries) InsertBlock(ctx context.Context, arg InsertBlockParams) error {
-	_, err := q.exec(ctx, q.insertBlockStmt, InsertBlock, arg.BlockHeight, arg.HeaderHash, arg.BlockTimestamp)
+	_, err := q.exec(ctx, q.insertBlockStmt, InsertBlock,
+		arg.WalletID,
+		arg.BlockHeight,
+		arg.HeaderHash,
+		arg.BlockTimestamp,
+	)
 	return err
 }
 
 const PutBlock = `-- name: PutBlock :exec
-INSERT INTO blocks (block_height, header_hash, block_timestamp)
-VALUES (?, ?, ?)
-ON CONFLICT (block_height) DO UPDATE SET
+INSERT INTO wallet_blocks (
+    wallet_id, block_height, header_hash, block_timestamp
+)
+VALUES (?, ?, ?, ?)
+ON CONFLICT (wallet_id, block_height) DO UPDATE SET
     header_hash = excluded.header_hash,
     block_timestamp = excluded.block_timestamp
 `
 
 type PutBlockParams struct {
+	WalletID       int64
 	BlockHeight    int64
 	HeaderHash     []byte
 	BlockTimestamp int64
 }
 
 func (q *Queries) PutBlock(ctx context.Context, arg PutBlockParams) error {
-	_, err := q.exec(ctx, q.putBlockStmt, PutBlock, arg.BlockHeight, arg.HeaderHash, arg.BlockTimestamp)
+	_, err := q.exec(ctx, q.putBlockStmt, PutBlock,
+		arg.WalletID,
+		arg.BlockHeight,
+		arg.HeaderHash,
+		arg.BlockTimestamp,
+	)
 	return err
 }

--- a/wallet/internal/sql/sqlite/sqlc/credits.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/credits.sql.go
@@ -39,7 +39,8 @@ func (q *Queries) DeleteCreditSpend(ctx context.Context, arg DeleteCreditSpendPa
 const GetActiveCreditID = `-- name: GetActiveCreditID :one
 SELECT credit.id
 FROM active_credit_incidences AS active
-INNER JOIN credits AS credit ON credit.id = active.credit_id
+INNER JOIN credits AS credit
+    ON credit.wallet_id = active.wallet_id AND credit.id = active.credit_id
 WHERE active.wallet_id = ? AND active.tx_hash = ?
   AND active.output_index = ?
 `
@@ -61,16 +62,17 @@ const GetCredit = `-- name: GetCredit :one
 SELECT id, wallet_id, transaction_id, output_index, amount, pk_script,
        is_change, address_scope_id, address_id
 FROM credits
-WHERE transaction_id = ? AND output_index = ?
+WHERE wallet_id = ? AND transaction_id = ? AND output_index = ?
 `
 
 type GetCreditParams struct {
+	WalletID      int64
 	TransactionID int64
 	OutputIndex   int64
 }
 
 func (q *Queries) GetCredit(ctx context.Context, arg GetCreditParams) (Credit, error) {
-	row := q.queryRow(ctx, q.getCreditStmt, GetCredit, arg.TransactionID, arg.OutputIndex)
+	row := q.queryRow(ctx, q.getCreditStmt, GetCredit, arg.WalletID, arg.TransactionID, arg.OutputIndex)
 	var i Credit
 	err := row.Scan(
 		&i.ID,
@@ -89,7 +91,8 @@ func (q *Queries) GetCredit(ctx context.Context, arg GetCreditParams) (Credit, e
 const GetMinedPreviousPkScript = `-- name: GetMinedPreviousPkScript :one
 SELECT credit.pk_script
 FROM credit_spends AS spend
-INNER JOIN credits AS credit ON credit.id = spend.credit_id
+INNER JOIN credits AS credit
+    ON credit.wallet_id = spend.wallet_id AND credit.id = spend.credit_id
 WHERE spend.wallet_id = ? AND spend.spending_tx_id = ?
   AND spend.input_index = ?
 `
@@ -110,12 +113,14 @@ func (q *Queries) GetMinedPreviousPkScript(ctx context.Context, arg GetMinedPrev
 const GetUnminedPreviousPkScript = `-- name: GetUnminedPreviousPkScript :one
 SELECT credit.pk_script
 FROM active_credit_incidences AS active
-INNER JOIN credits AS credit ON credit.id = active.credit_id
+INNER JOIN credits AS credit
+    ON credit.wallet_id = active.wallet_id AND credit.id = active.credit_id
 WHERE active.wallet_id = ? AND active.tx_hash = ?
   AND active.output_index = ?
   AND NOT EXISTS (
       SELECT 1 FROM credit_spends AS spend
-      WHERE spend.credit_id = credit.id
+      WHERE spend.wallet_id = credit.wallet_id
+        AND spend.credit_id = credit.id
   )
 `
 
@@ -177,12 +182,14 @@ const IsKnownOutput = `-- name: IsKnownOutput :one
 SELECT EXISTS (
     SELECT 1
     FROM active_credit_incidences AS active
-    INNER JOIN credits AS credit ON credit.id = active.credit_id
+    INNER JOIN credits AS credit
+        ON credit.wallet_id = active.wallet_id AND credit.id = active.credit_id
     WHERE active.wallet_id = ? AND active.tx_hash = ?
       AND active.output_index = ?
       AND NOT EXISTS (
           SELECT 1 FROM credit_spends AS spend
-          WHERE spend.credit_id = credit.id
+          WHERE spend.wallet_id = credit.wallet_id
+            AND spend.credit_id = credit.id
       )
 )
 `
@@ -203,13 +210,15 @@ func (q *Queries) IsKnownOutput(ctx context.Context, arg IsKnownOutputParams) (i
 const ListOutputsToWatch = `-- name: ListOutputsToWatch :many
 SELECT funding.tx_hash, c.output_index, c.pk_script
 FROM credits AS c
-INNER JOIN transactions AS funding ON funding.id = c.transaction_id
-INNER JOIN active_credit_incidences AS active ON active.credit_id = c.id
+INNER JOIN transactions AS funding
+    ON funding.wallet_id = c.wallet_id AND funding.id = c.transaction_id
+INNER JOIN active_credit_incidences AS active
+    ON active.wallet_id = c.wallet_id AND active.credit_id = c.id
 WHERE c.wallet_id = ?1
   AND NOT EXISTS (
       SELECT 1
       FROM credit_spends AS spend
-      WHERE spend.credit_id = c.id
+      WHERE spend.wallet_id = c.wallet_id AND spend.credit_id = c.id
   )
 ORDER BY funding.tx_hash, c.output_index
 `
@@ -249,14 +258,16 @@ SELECT c.id, c.output_index, c.amount, c.pk_script, c.is_change,
        EXISTS (
            SELECT 1
            FROM credit_spends AS spend
-           WHERE spend.credit_id = c.id
+           WHERE spend.wallet_id = c.wallet_id AND spend.credit_id = c.id
        ) OR EXISTS (
            SELECT 1
            FROM transaction_inputs AS input
            INNER JOIN transactions AS spender
-               ON spender.id = input.spending_tx_id
+               ON spender.wallet_id = c.wallet_id
+               AND spender.id = input.spending_tx_id
            INNER JOIN transactions AS funding
-               ON funding.id = c.transaction_id
+               ON funding.wallet_id = c.wallet_id
+               AND funding.id = c.transaction_id
            WHERE spender.wallet_id = c.wallet_id
              AND spender.block_height IS NULL
              AND input.prev_tx_hash = funding.tx_hash
@@ -316,16 +327,37 @@ func (q *Queries) ListTransactionCredits(ctx context.Context, arg ListTransactio
 }
 
 const ListTransactionDebits = `-- name: ListTransactionDebits :many
-SELECT spend.input_index, credit.amount
-FROM credit_spends AS spend
-INNER JOIN credits AS credit ON credit.id = spend.credit_id
-WHERE spend.wallet_id = ? AND spend.spending_tx_id = ?
-ORDER BY spend.input_index
+SELECT debit.input_index, debit.amount
+FROM (
+    SELECT spend.input_index, credit.amount
+    FROM credit_spends AS spend
+    INNER JOIN credits AS credit
+        ON credit.wallet_id = spend.wallet_id AND credit.id = spend.credit_id
+    WHERE spend.wallet_id = ?1
+      AND spend.spending_tx_id = ?2
+
+    UNION ALL
+
+    SELECT input.input_index, credit.amount
+    FROM transactions AS spender
+    INNER JOIN transaction_inputs AS input
+        ON input.spending_tx_id = spender.id
+    INNER JOIN active_credit_incidences AS active
+        ON active.wallet_id = spender.wallet_id
+        AND active.tx_hash = input.prev_tx_hash
+        AND active.output_index = input.prev_output_index
+    INNER JOIN credits AS credit
+        ON credit.wallet_id = active.wallet_id AND credit.id = active.credit_id
+    WHERE spender.wallet_id = ?1
+      AND spender.id = ?2
+      AND spender.block_height IS NULL
+) AS debit
+ORDER BY debit.input_index
 `
 
 type ListTransactionDebitsParams struct {
-	WalletID     int64
-	SpendingTxID int64
+	WalletID      int64
+	TransactionID int64
 }
 
 type ListTransactionDebitsRow struct {
@@ -334,7 +366,7 @@ type ListTransactionDebitsRow struct {
 }
 
 func (q *Queries) ListTransactionDebits(ctx context.Context, arg ListTransactionDebitsParams) ([]ListTransactionDebitsRow, error) {
-	rows, err := q.query(ctx, q.listTransactionDebitsStmt, ListTransactionDebits, arg.WalletID, arg.SpendingTxID)
+	rows, err := q.query(ctx, q.listTransactionDebitsStmt, ListTransactionDebits, arg.WalletID, arg.TransactionID)
 	if err != nil {
 		return nil, err
 	}
@@ -365,18 +397,25 @@ SELECT c.id, funding.tx_hash, c.output_index, c.amount, c.pk_script,
        funding.is_coinbase, c.address_scope_id, c.address_id,
        block.header_hash, block.block_timestamp
 FROM credits AS c
-INNER JOIN transactions AS funding ON funding.id = c.transaction_id
-INNER JOIN active_credit_incidences AS active ON active.credit_id = c.id
-LEFT JOIN blocks AS block ON block.block_height = funding.block_height
+INNER JOIN transactions AS funding
+    ON funding.wallet_id = c.wallet_id AND funding.id = c.transaction_id
+INNER JOIN active_credit_incidences AS active
+    ON active.wallet_id = c.wallet_id AND active.credit_id = c.id
+LEFT JOIN wallet_blocks AS block
+    ON block.wallet_id = funding.wallet_id
+    AND block.block_height = funding.block_height
 INNER JOIN query_params
 WHERE c.wallet_id = ?1
   AND NOT EXISTS (
-      SELECT 1 FROM credit_spends AS spend WHERE spend.credit_id = c.id
+      SELECT 1 FROM credit_spends AS spend
+      WHERE spend.wallet_id = c.wallet_id AND spend.credit_id = c.id
   )
   AND NOT EXISTS (
       SELECT 1
       FROM transaction_inputs AS i
-      INNER JOIN transactions AS spender ON spender.id = i.spending_tx_id
+      INNER JOIN transactions AS spender
+          ON spender.wallet_id = c.wallet_id
+          AND spender.id = i.spending_tx_id
       WHERE spender.wallet_id = c.wallet_id
         AND spender.block_height IS NULL
         AND i.prev_tx_hash = funding.tx_hash
@@ -457,11 +496,13 @@ INSERT INTO credit_spends (
 )
 SELECT c.wallet_id, c.id, i.spending_tx_id, i.input_index
 FROM credits AS c
-INNER JOIN transactions AS funding ON funding.id = c.transaction_id
+INNER JOIN transactions AS funding
+    ON funding.wallet_id = c.wallet_id AND funding.id = c.transaction_id
 INNER JOIN transaction_inputs AS i
     ON i.prev_tx_hash = funding.tx_hash
     AND i.prev_output_index = c.output_index
-INNER JOIN transactions AS spender ON spender.id = i.spending_tx_id
+INNER JOIN transactions AS spender
+    ON spender.wallet_id = c.wallet_id AND spender.id = i.spending_tx_id
 WHERE c.wallet_id = ?
   AND c.id = ?
   AND i.spending_tx_id = ?
@@ -499,7 +540,8 @@ INSERT INTO active_credit_incidences (
 )
 SELECT c.wallet_id, funding.tx_hash, c.output_index, c.id
 FROM credits AS c
-INNER JOIN transactions AS funding ON funding.id = c.transaction_id
+INNER JOIN transactions AS funding
+    ON funding.wallet_id = c.wallet_id AND funding.id = c.transaction_id
 WHERE c.wallet_id = ? AND c.id = ?
 ON CONFLICT (wallet_id, tx_hash, output_index) DO UPDATE SET
     credit_id = excluded.credit_id

--- a/wallet/internal/sql/sqlite/sqlc/db.go
+++ b/wallet/internal/sql/sqlite/sqlc/db.go
@@ -75,6 +75,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.detachMinedTransactionStmt, err = db.PrepareContext(ctx, DetachMinedTransaction); err != nil {
 		return nil, fmt.Errorf("error preparing query DetachMinedTransaction: %w", err)
 	}
+	if q.ensureBlockHeightStmt, err = db.PrepareContext(ctx, EnsureBlockHeight); err != nil {
+		return nil, fmt.Errorf("error preparing query EnsureBlockHeight: %w", err)
+	}
 	if q.getAccountStmt, err = db.PrepareContext(ctx, GetAccount); err != nil {
 		return nil, fmt.Errorf("error preparing query GetAccount: %w", err)
 	}
@@ -376,6 +379,11 @@ func (q *Queries) Close() error {
 	if q.detachMinedTransactionStmt != nil {
 		if cerr := q.detachMinedTransactionStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing detachMinedTransactionStmt: %w", cerr)
+		}
+	}
+	if q.ensureBlockHeightStmt != nil {
+		if cerr := q.ensureBlockHeightStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing ensureBlockHeightStmt: %w", cerr)
 		}
 	}
 	if q.getAccountStmt != nil {
@@ -789,6 +797,7 @@ type Queries struct {
 	deleteOutputLeaseAnyOwnerStmt       *sql.Stmt
 	deleteTransactionByIDStmt           *sql.Stmt
 	detachMinedTransactionStmt          *sql.Stmt
+	ensureBlockHeightStmt               *sql.Stmt
 	getAccountStmt                      *sql.Stmt
 	getActiveCreditIDStmt               *sql.Stmt
 	getAddressStmt                      *sql.Stmt
@@ -883,6 +892,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		deleteOutputLeaseAnyOwnerStmt:       q.deleteOutputLeaseAnyOwnerStmt,
 		deleteTransactionByIDStmt:           q.deleteTransactionByIDStmt,
 		detachMinedTransactionStmt:          q.detachMinedTransactionStmt,
+		ensureBlockHeightStmt:               q.ensureBlockHeightStmt,
 		getAccountStmt:                      q.getAccountStmt,
 		getActiveCreditIDStmt:               q.getActiveCreditIDStmt,
 		getAddressStmt:                      q.getAddressStmt,

--- a/wallet/internal/sql/sqlite/sqlc/models.go
+++ b/wallet/internal/sql/sqlite/sqlc/models.go
@@ -138,6 +138,13 @@ type Wallet struct {
 	EncryptedMasterHdPrivKey []byte
 }
 
+type WalletBlock struct {
+	WalletID       int64
+	BlockHeight    int64
+	HeaderHash     []byte
+	BlockTimestamp int64
+}
+
 type WalletSyncState struct {
 	WalletID              int64
 	StartBlockHeight      int64

--- a/wallet/internal/sql/sqlite/sqlc/querier.go
+++ b/wallet/internal/sql/sqlite/sqlc/querier.go
@@ -16,7 +16,7 @@ type Querier interface {
 	CreateWallet(ctx context.Context, arg CreateWalletParams) (int64, error)
 	DeleteAccountPrivateKeys(ctx context.Context, walletID int64) (int64, error)
 	DeleteAddressPrivateKeys(ctx context.Context, walletID int64) (int64, error)
-	DeleteBlock(ctx context.Context, blockHeight int64) error
+	DeleteBlock(ctx context.Context, arg DeleteBlockParams) error
 	DeleteCreditSpend(ctx context.Context, arg DeleteCreditSpendParams) (int64, error)
 	DeleteCreditSpendsBySpendingTx(ctx context.Context, arg DeleteCreditSpendsBySpendingTxParams) (int64, error)
 	DeleteExpiredOutputLeases(ctx context.Context, arg DeleteExpiredOutputLeasesParams) (int64, error)
@@ -26,11 +26,12 @@ type Querier interface {
 	DeleteOutputLeaseAnyOwner(ctx context.Context, arg DeleteOutputLeaseAnyOwnerParams) (int64, error)
 	DeleteTransactionByID(ctx context.Context, arg DeleteTransactionByIDParams) (int64, error)
 	DetachMinedTransaction(ctx context.Context, arg DetachMinedTransactionParams) (int64, error)
+	EnsureBlockHeight(ctx context.Context, arg EnsureBlockHeightParams) error
 	GetAccount(ctx context.Context, arg GetAccountParams) (Account, error)
 	GetActiveCreditID(ctx context.Context, arg GetActiveCreditIDParams) (int64, error)
 	GetAddress(ctx context.Context, arg GetAddressParams) (Address, error)
-	GetBlockByHeight(ctx context.Context, blockHeight int64) (Block, error)
-	GetBlocksInRange(ctx context.Context, arg GetBlocksInRangeParams) ([]Block, error)
+	GetBlockByHeight(ctx context.Context, arg GetBlockByHeightParams) (GetBlockByHeightRow, error)
+	GetBlocksInRange(ctx context.Context, arg GetBlocksInRangeParams) ([]GetBlocksInRangeRow, error)
 	GetCredit(ctx context.Context, arg GetCreditParams) (Credit, error)
 	GetKeyScope(ctx context.Context, arg GetKeyScopeParams) (KeyScope, error)
 	GetManagerAccount(ctx context.Context, arg GetManagerAccountParams) (Account, error)
@@ -49,7 +50,7 @@ type Querier interface {
 	GetUnminedTransactionByHash(ctx context.Context, arg GetUnminedTransactionByHashParams) (Transaction, error)
 	GetUnminedTransactionDetails(ctx context.Context, arg GetUnminedTransactionDetailsParams) (GetUnminedTransactionDetailsRow, error)
 	GetWalletByName(ctx context.Context, walletName string) (Wallet, error)
-	GetWalletStartBlock(ctx context.Context, walletID int64) (Block, error)
+	GetWalletStartBlock(ctx context.Context, walletID int64) (GetWalletStartBlockRow, error)
 	GetWalletSyncState(ctx context.Context, walletID int64) (GetWalletSyncStateRow, error)
 	InsertBlock(ctx context.Context, arg InsertBlockParams) error
 	InsertCredit(ctx context.Context, arg InsertCreditParams) (int64, error)

--- a/wallet/internal/sql/sqlite/sqlc/transactions.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/transactions.sql.go
@@ -68,7 +68,8 @@ const GetMinedTransactionByIncidence = `-- name: GetMinedTransactionByIncidence 
 SELECT t.id, t.wallet_id, t.tx_hash, t.raw_tx, t.received_unix,
        t.block_height, t.confirmed_order, t.is_coinbase
 FROM transactions AS t
-INNER JOIN blocks AS b ON b.block_height = t.block_height
+INNER JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 WHERE t.wallet_id = ?1
   AND t.tx_hash = ?2
   AND t.block_height = ?3
@@ -107,7 +108,8 @@ const GetMinedTransactionDetails = `-- name: GetMinedTransactionDetails :one
 SELECT t.id, t.raw_tx, t.received_unix, t.block_height,
        t.confirmed_order, b.header_hash, b.block_timestamp, l.label
 FROM transactions AS t
-INNER JOIN blocks AS b ON b.block_height = t.block_height
+INNER JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 LEFT JOIN transaction_labels AS l
     ON l.wallet_id = t.wallet_id AND l.tx_hash = t.tx_hash
 WHERE t.wallet_id = ?1
@@ -159,7 +161,8 @@ func (q *Queries) GetMinedTransactionDetails(ctx context.Context, arg GetMinedTr
 const GetMinedTransactionID = `-- name: GetMinedTransactionID :one
 SELECT t.id
 FROM transactions AS t
-INNER JOIN blocks AS b ON b.block_height = t.block_height
+INNER JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 WHERE t.wallet_id = ?1
   AND t.tx_hash = ?2
   AND t.block_height = cast(?3 AS INTEGER)
@@ -189,7 +192,8 @@ const GetTransactionDetailsByHash = `-- name: GetTransactionDetailsByHash :one
 SELECT t.id, t.raw_tx, t.received_unix, t.block_height,
        t.confirmed_order, b.header_hash, b.block_timestamp, l.label
 FROM transactions AS t
-LEFT JOIN blocks AS b ON b.block_height = t.block_height
+LEFT JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 LEFT JOIN transaction_labels AS l
     ON l.wallet_id = t.wallet_id AND l.tx_hash = t.tx_hash
 WHERE t.wallet_id = ? AND t.tx_hash = ?
@@ -233,7 +237,8 @@ const GetTransactionDetailsByID = `-- name: GetTransactionDetailsByID :one
 SELECT t.id, t.raw_tx, t.received_unix, t.block_height,
        t.confirmed_order, b.header_hash, b.block_timestamp, l.label
 FROM transactions AS t
-LEFT JOIN blocks AS b ON b.block_height = t.block_height
+LEFT JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 LEFT JOIN transaction_labels AS l
     ON l.wallet_id = t.wallet_id AND l.tx_hash = t.tx_hash
 WHERE t.wallet_id = ? AND t.id = ?
@@ -320,7 +325,8 @@ const GetUnminedTransactionDetails = `-- name: GetUnminedTransactionDetails :one
 SELECT t.id, t.raw_tx, t.received_unix, t.block_height,
        t.confirmed_order, b.header_hash, b.block_timestamp, l.label
 FROM transactions AS t
-LEFT JOIN blocks AS b ON b.block_height = t.block_height
+LEFT JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 LEFT JOIN transaction_labels AS l
     ON l.wallet_id = t.wallet_id AND l.tx_hash = t.tx_hash
 WHERE t.wallet_id = ? AND t.tx_hash = ? AND t.block_height IS NULL
@@ -426,7 +432,8 @@ SELECT t.id, t.wallet_id, t.tx_hash, t.raw_tx, t.received_unix,
        t.block_height, t.confirmed_order, t.is_coinbase,
        b.header_hash, b.block_timestamp
 FROM transactions AS t
-INNER JOIN blocks AS b ON b.block_height = t.block_height
+INNER JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 WHERE t.wallet_id = ?1
   AND t.block_height BETWEEN cast(?2 AS INTEGER)
                          AND cast(?3 AS INTEGER)
@@ -533,7 +540,8 @@ SELECT t.id, t.wallet_id, t.tx_hash, t.raw_tx, t.received_unix,
        t.block_height, t.confirmed_order, t.is_coinbase,
        b.header_hash, b.block_timestamp
 FROM transactions AS t
-INNER JOIN blocks AS b ON b.block_height = t.block_height
+INNER JOIN wallet_blocks AS b
+    ON b.wallet_id = t.wallet_id AND b.block_height = t.block_height
 WHERE t.wallet_id = ?1
   AND t.block_height BETWEEN cast(?2 AS INTEGER)
                          AND cast(?3 AS INTEGER)
@@ -641,7 +649,9 @@ func (q *Queries) ListTransactionIncidencesByHash(ctx context.Context, arg ListT
 const ListUnminedSpenders = `-- name: ListUnminedSpenders :many
 SELECT t.id, t.tx_hash, i.input_index
 FROM transaction_inputs AS i
-INNER JOIN transactions AS t ON t.id = i.spending_tx_id
+INNER JOIN transactions AS t
+    ON t.id = i.spending_tx_id
+    AND t.wallet_id = ?1
 WHERE t.wallet_id = ?1
   AND t.block_height IS NULL
   AND i.prev_tx_hash = ?2
@@ -694,7 +704,9 @@ func (q *Queries) ListUnminedSpenders(ctx context.Context, arg ListUnminedSpende
 const ListUnminedSpendersByPrevHash = `-- name: ListUnminedSpendersByPrevHash :many
 SELECT DISTINCT spender.id, spender.tx_hash
 FROM transaction_inputs AS input
-INNER JOIN transactions AS spender ON spender.id = input.spending_tx_id
+INNER JOIN transactions AS spender
+    ON spender.id = input.spending_tx_id
+    AND spender.wallet_id = ?1
 WHERE spender.wallet_id = ?1
   AND spender.block_height IS NULL
   AND input.prev_tx_hash = ?2

--- a/wallet/internal/sql/sqlite/sqlc/wallets.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/wallets.sql.go
@@ -166,13 +166,21 @@ func (q *Queries) GetWalletByName(ctx context.Context, walletName string) (Walle
 const GetWalletStartBlock = `-- name: GetWalletStartBlock :one
 SELECT b.block_height, b.header_hash, b.block_timestamp
 FROM wallet_sync_states AS s
-INNER JOIN blocks AS b ON b.block_height = s.start_block_height
+INNER JOIN wallet_blocks AS b
+    ON b.wallet_id = s.wallet_id
+    AND b.block_height = s.start_block_height
 WHERE s.wallet_id = ?
 `
 
-func (q *Queries) GetWalletStartBlock(ctx context.Context, walletID int64) (Block, error) {
+type GetWalletStartBlockRow struct {
+	BlockHeight    int64
+	HeaderHash     []byte
+	BlockTimestamp int64
+}
+
+func (q *Queries) GetWalletStartBlock(ctx context.Context, walletID int64) (GetWalletStartBlockRow, error) {
 	row := q.queryRow(ctx, q.getWalletStartBlockStmt, GetWalletStartBlock, walletID)
-	var i Block
+	var i GetWalletStartBlockRow
 	err := row.Scan(&i.BlockHeight, &i.HeaderHash, &i.BlockTimestamp)
 	return i, err
 }
@@ -192,12 +200,15 @@ SELECT
     birthday_block.block_timestamp AS birthday_block_timestamp,
     s.birthday_block_verified
 FROM wallet_sync_states AS s
-INNER JOIN blocks AS start_block
-    ON s.start_block_height = start_block.block_height
-INNER JOIN blocks AS synced_block
-    ON s.synced_block_height = synced_block.block_height
-LEFT JOIN blocks AS birthday_block
-    ON s.birthday_block_height = birthday_block.block_height
+INNER JOIN wallet_blocks AS start_block
+    ON start_block.wallet_id = s.wallet_id
+    AND start_block.block_height = s.start_block_height
+INNER JOIN wallet_blocks AS synced_block
+    ON synced_block.wallet_id = s.wallet_id
+    AND synced_block.block_height = s.synced_block_height
+LEFT JOIN wallet_blocks AS birthday_block
+    ON birthday_block.wallet_id = s.wallet_id
+    AND birthday_block.block_height = s.birthday_block_height
 WHERE s.wallet_id = ?
 `
 

--- a/wallet/internal/sql/sqlite/transaction_schema_test.go
+++ b/wallet/internal/sql/sqlite/transaction_schema_test.go
@@ -28,10 +28,17 @@ func testTransactionSchema(t *testing.T, db *sql.DB) {
 
 	q := sqlc.New(db)
 	for height := int64(100); height <= 101; height++ {
-		require.NoError(t, q.InsertBlock(ctx, sqlc.InsertBlockParams{
+		block := sqlc.EnsureBlockHeightParams{
 			BlockHeight:    height,
 			HeaderHash:     testHash(byte(height)),
 			BlockTimestamp: 1000 + height,
+		}
+		require.NoError(t, q.EnsureBlockHeight(ctx, block))
+		require.NoError(t, q.InsertBlock(ctx, sqlc.InsertBlockParams{
+			WalletID:       1,
+			BlockHeight:    height,
+			HeaderHash:     block.HeaderHash,
+			BlockTimestamp: block.BlockTimestamp,
 		}))
 	}
 
@@ -131,7 +138,10 @@ func testTransactionSchema(t *testing.T, db *sql.DB) {
 
 	// A block cannot disappear while confirmed transaction incidences still
 	// reference it. Rollback code must first detach or delete each incidence.
-	require.Error(t, q.DeleteBlock(ctx, 100))
+	require.Error(t, q.DeleteBlock(ctx, sqlc.DeleteBlockParams{
+		WalletID:    1,
+		BlockHeight: 100,
+	}))
 
 	unminedHash := testHash(2)
 	unminedID := insertUnminedTransaction(t, ctx, q, unminedHash)
@@ -208,6 +218,7 @@ func testTransactionSchema(t *testing.T, db *sql.DB) {
 		},
 	))
 	credit, err := q.GetCredit(ctx, sqlc.GetCreditParams{
+		WalletID:      1,
 		TransactionID: fundingID,
 		OutputIndex:   0,
 	})

--- a/wallet/lnd_adapter_test.go
+++ b/wallet/lnd_adapter_test.go
@@ -1,0 +1,243 @@
+package wallet
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	dbsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlite"
+	storesqlite "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStoreLndKeyAdapterRestart verifies concurrent key allocation and key
+// recovery across restart without exposing a walletdb database to the caller.
+func TestStoreLndKeyAdapterRestart(t *testing.T) {
+	t.Parallel()
+
+	params := &chaincfg.TestNet3Params
+	pubPass := []byte("public-pass")
+	privPass := []byte("private-pass")
+	scope := waddrmgr.KeyScope{
+		Purpose: 1017,
+		Coin:    1,
+	}
+	schema := waddrmgr.ScopeAddrSchema{
+		ExternalAddrType: waddrmgr.WitnessPubKey,
+		InternalAddrType: waddrmgr.WitnessPubKey,
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "wallet.sqlite")
+	conn, err := storesqlite.Open(context.Background(), storesqlite.Config{
+		DBPath: dbPath,
+	})
+	require.NoError(t, err)
+	require.NoError(t, storesqlite.ApplyMigrations(conn))
+
+	store := dbsqlite.NewNamedStore(conn, "lnd-adapter")
+	loader, err := NewLoaderWithStore(params, 0, store)
+	require.NoError(t, err)
+	wallet, err := loader.CreateNewWallet(
+		pubPass, privPass, nil, time.Unix(1_700_000_000, 0),
+	)
+	require.NoError(t, err)
+	require.Nil(t, wallet.Database())
+	require.NoError(t, wallet.Unlock(privPass, nil))
+	require.NoError(t, wallet.InitializeKeyScope(
+		scope, schema, []uint32{0, 1}, false,
+	))
+
+	const numKeys = 8
+	type keyResult struct {
+		index uint32
+		key   []byte
+		err   error
+	}
+	results := make(chan keyResult, numKeys)
+	var workers sync.WaitGroup
+	for i := 0; i < numKeys; i++ {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+
+			pubKey, index, err := wallet.NextExternalKey(scope, 1)
+			var serialized []byte
+			if pubKey != nil {
+				serialized = pubKey.SerializeCompressed()
+			}
+			results <- keyResult{
+				index: index,
+				key:   serialized,
+				err:   err,
+			}
+		}()
+	}
+	workers.Wait()
+	close(results)
+
+	keys := make(map[uint32][]byte, numKeys)
+	for result := range results {
+		require.NoError(t, result.err)
+		require.NotContains(t, keys, result.index)
+		keys[result.index] = result.key
+	}
+	for index := uint32(0); index < numKeys; index++ {
+		require.Contains(t, keys, index)
+
+		pubKey, err := wallet.DeriveManagedPubKey(
+			scope, waddrmgr.DerivationPath{
+				InternalAccount: 1,
+				Account:         1,
+				Index:           index,
+			},
+		)
+		require.NoError(t, err)
+		require.Equal(t, keys[index], pubKey.SerializeCompressed())
+	}
+
+	privKey, err := wallet.DeriveFromKeyPath(
+		scope, waddrmgr.DerivationPath{
+			InternalAccount: 1,
+			Account:         1,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, keys[0], privKey.PubKey().SerializeCompressed())
+
+	var unsupported *UnsupportedStoreOperationError
+	err = wallet.DropTransactionHistory(true)
+	require.ErrorAs(t, err, &unsupported)
+	require.Equal(t, "DropTransactionHistory", unsupported.Operation)
+
+	require.NoError(t, loader.UnloadWallet())
+	require.NoError(t, conn.Close())
+
+	conn, err = storesqlite.Open(context.Background(), storesqlite.Config{
+		DBPath: dbPath,
+	})
+	require.NoError(t, err)
+	store = dbsqlite.NewNamedStore(conn, "lnd-adapter")
+	loader, err = NewLoaderWithStore(params, 0, store)
+	require.NoError(t, err)
+	wallet, err = loader.OpenExistingWallet(pubPass, false)
+	require.NoError(t, err)
+	require.NoError(t, wallet.Unlock(privPass, nil))
+	require.NoError(t, wallet.InitializeKeyScope(
+		scope, schema, []uint32{0, 1}, false,
+	))
+
+	pubKey, index, err := wallet.NextExternalKey(scope, 1)
+	require.NoError(t, err)
+	require.Equal(t, uint32(numKeys), index)
+	rederived, err := wallet.DeriveManagedPubKey(
+		scope, waddrmgr.DerivationPath{
+			InternalAccount: 1,
+			Account:         1,
+			Index:           index,
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, pubKey.IsEqual(rederived))
+
+	require.NoError(t, loader.UnloadWallet())
+	require.NoError(t, conn.Close())
+}
+
+// TestStoreLndWatchOnlyKeyAdapter verifies that imported remote-signer family
+// accounts support public allocation and derivation without private keys.
+func TestStoreLndWatchOnlyKeyAdapter(t *testing.T) {
+	t.Parallel()
+
+	params := &chaincfg.TestNet3Params
+	pubPass := []byte("public-pass")
+	scope := waddrmgr.KeyScope{
+		Purpose: 1017,
+		Coin:    1,
+	}
+	schema := waddrmgr.ScopeAddrSchema{
+		ExternalAddrType: waddrmgr.WitnessPubKey,
+		InternalAddrType: waddrmgr.WitnessPubKey,
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "watch-only.sqlite")
+	conn, err := storesqlite.Open(context.Background(), storesqlite.Config{
+		DBPath: dbPath,
+	})
+	require.NoError(t, err)
+	require.NoError(t, storesqlite.ApplyMigrations(conn))
+
+	store := dbsqlite.NewNamedStore(conn, "lnd-watch-only")
+	loader, err := NewLoaderWithStore(params, 0, store)
+	require.NoError(t, err)
+	wallet, err := loader.CreateNewWatchingOnlyWallet(
+		pubPass, time.Unix(1_700_000_000, 0),
+	)
+	require.NoError(t, err)
+	require.True(t, wallet.WatchOnly())
+
+	seed, err := hdkeychain.GenerateSeed(hdkeychain.MinSeedBytes)
+	require.NoError(t, err)
+	rootKey, err := hdkeychain.NewMaster(seed, params)
+	require.NoError(t, err)
+	defer rootKey.Zero()
+	purposeKey, err := rootKey.DeriveNonStandard(
+		scope.Purpose + hdkeychain.HardenedKeyStart,
+	)
+	require.NoError(t, err)
+	defer purposeKey.Zero()
+	coinKey, err := purposeKey.DeriveNonStandard(
+		scope.Coin + hdkeychain.HardenedKeyStart,
+	)
+	require.NoError(t, err)
+	defer coinKey.Zero()
+
+	for _, account := range []uint32{0, 1} {
+		accountKey, err := coinKey.DeriveNonStandard(
+			account + hdkeychain.HardenedKeyStart,
+		)
+		require.NoError(t, err)
+		accountPubKey, err := accountKey.Neuter()
+		require.NoError(t, err)
+
+		_, err = wallet.ImportAccountWithScope(
+			fmt.Sprintf("family-%d", account), accountPubKey, 0,
+			scope, schema,
+		)
+		accountPubKey.Zero()
+		accountKey.Zero()
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, wallet.InitializeKeyScope(
+		scope, schema, []uint32{0, 1}, false,
+	))
+	pubKey, index, err := wallet.NextExternalKey(scope, 1)
+	require.NoError(t, err)
+	require.Zero(t, index)
+	rederived, err := wallet.DeriveManagedPubKey(
+		scope, waddrmgr.DerivationPath{
+			InternalAccount: 1,
+			Account:         1,
+			Index:           index,
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, pubKey.IsEqual(rederived))
+
+	_, err = wallet.DeriveFromKeyPathAddAccount(
+		scope, waddrmgr.DerivationPath{
+			InternalAccount: 1,
+			Account:         1,
+		},
+	)
+	require.True(t, waddrmgr.IsError(err, waddrmgr.ErrWatchingOnly))
+
+	require.NoError(t, loader.UnloadWallet())
+	require.NoError(t, conn.Close())
+}

--- a/wallet/loader.go
+++ b/wallet/loader.go
@@ -5,6 +5,7 @@
 package wallet
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -16,6 +17,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcwallet/internal/prompt"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	walletstore "github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 )
 
@@ -40,6 +42,16 @@ var (
 	// ErrExists describes the error condition of attempting to create a new
 	// wallet when one exists already.
 	ErrExists = errors.New("wallet already exists")
+
+	// ErrStoreCreateUnsupported reports that a bound Store does not expose
+	// wallet lifecycle creation.
+	ErrStoreCreateUnsupported = errors.New(
+		"wallet creation is unsupported for a bound Store",
+	)
+
+	// ErrLoaderClosed describes an operation attempted after the loader has
+	// released an owned backend.
+	ErrLoaderClosed = errors.New("wallet loader is closed")
 )
 
 // loaderConfig contains the configuration options for the loader.
@@ -85,6 +97,9 @@ type Loader struct {
 	walletExists   func() (bool, error)
 	walletCreated  func(db walletdb.ReadWriteTx) error
 	db             walletdb.DB
+	store          walletstore.Store
+	storeClose     func() error
+	closed         bool
 	mu             sync.Mutex
 }
 
@@ -139,6 +154,30 @@ func NewLoaderWithDB(chainParams *chaincfg.Params, recoveryWindow uint32,
 		localDB:        false,
 		walletExists:   walletExists,
 		db:             db,
+	}, nil
+}
+
+// NewLoaderWithStore constructs a Loader for a wallet in a backend-neutral
+// Store. LifecycleStore implementations also support wallet creation. The Store
+// and its underlying connection remain caller-owned.
+func NewLoaderWithStore(chainParams *chaincfg.Params, recoveryWindow uint32,
+	store walletstore.Store, opts ...LoaderOption) (*Loader, error) {
+
+	if store == nil {
+		return nil, errors.New("no Store provided")
+	}
+
+	cfg := defaultLoaderConfig()
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	return &Loader{
+		cfg:            cfg,
+		chainParams:    chainParams,
+		recoveryWindow: recoveryWindow,
+		localDB:        false,
+		store:          store,
 	}, nil
 }
 
@@ -233,6 +272,7 @@ func (l *Loader) CreateNewWatchingOnlyWallet(pubPassphrase []byte,
 	)
 }
 
+// createNewWallet creates and starts a wallet using the configured backend.
 func (l *Loader) createNewWallet(pubPassphrase, privPassphrase []byte,
 	rootKey *hdkeychain.ExtendedKey, bday time.Time,
 	isWatchingOnly bool) (*Wallet, error) {
@@ -240,16 +280,78 @@ func (l *Loader) createNewWallet(pubPassphrase, privPassphrase []byte,
 	defer l.mu.Unlock()
 	l.mu.Lock()
 
+	if l.closed {
+		return nil, ErrLoaderClosed
+	}
+
 	if l.wallet != nil {
 		return nil, ErrLoaded
 	}
 
-	exists, err := l.WalletExists()
+	exists, err := l.walletExistsLocked()
 	if err != nil {
 		return nil, err
 	}
 	if exists {
 		return nil, ErrExists
+	}
+
+	if l.store != nil {
+		lifecycle, ok := l.store.(walletstore.LifecycleStore)
+		if !ok {
+			return nil, ErrStoreCreateUnsupported
+		}
+		if l.walletCreated != nil {
+			return nil, errors.New(
+				"OnWalletCreated requires a walletdb backend",
+			)
+		}
+
+		if !isWatchingOnly && rootKey == nil {
+			seed, err := hdkeychain.GenerateSeed(
+				hdkeychain.RecommendedSeedLen,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			rootKey, err = hdkeychain.NewMaster(seed, l.chainParams)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"failed to derive master extended key",
+				)
+			}
+		}
+		if !isWatchingOnly && !rootKey.IsPrivate() {
+			return nil, errors.New(
+				"need extended private key for non-watch-only wallet",
+			)
+		}
+
+		err = lifecycle.Create(
+			context.Background(),
+			func(tx walletstore.ReadWriteTx) error {
+				return waddrmgr.CreateFromStore(
+					tx.Addr(), rootKey, pubPassphrase,
+					privPassphrase, l.chainParams, nil, bday,
+				)
+			}, nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		w, err := OpenFromStore(
+			l.store, pubPassphrase, l.chainParams, l.recoveryWindow,
+			l.cfg.walletSyncRetryInterval,
+		)
+		if err != nil {
+			return nil, err
+		}
+		w.Start()
+		l.onLoaded(w)
+
+		return w, nil
 	}
 
 	if l.localDB {
@@ -303,6 +405,7 @@ func (l *Loader) createNewWallet(pubPassphrase, privPassphrase []byte,
 
 var errNoConsole = errors.New("db upgrade requires console access for additional input")
 
+// noConsole rejects an upgrade request that requires interactive input.
 func noConsole() ([]byte, error) {
 	return nil, errNoConsole
 }
@@ -317,12 +420,16 @@ func (l *Loader) OpenExistingWallet(pubPassphrase []byte,
 	defer l.mu.Unlock()
 	l.mu.Lock()
 
+	if l.closed {
+		return nil, ErrLoaderClosed
+	}
+
 	if l.wallet != nil {
 		return nil, ErrLoaded
 	}
 
+	var err error
 	if l.localDB {
-		var err error
 		// Ensure that the network directory exists.
 		if err = checkCreateDir(l.dbDirPath); err != nil {
 			return nil, err
@@ -351,10 +458,18 @@ func (l *Loader) OpenExistingWallet(pubPassphrase []byte,
 			ObtainPrivatePass: noConsole,
 		}
 	}
-	w, err := OpenWithRetry(
-		l.db, pubPassphrase, cbs, l.chainParams, l.recoveryWindow,
-		l.cfg.walletSyncRetryInterval,
-	)
+	var w *Wallet
+	if l.store != nil {
+		w, err = OpenFromStore(
+			l.store, pubPassphrase, l.chainParams, l.recoveryWindow,
+			l.cfg.walletSyncRetryInterval,
+		)
+	} else {
+		w, err = OpenWithRetry(
+			l.db, pubPassphrase, cbs, l.chainParams,
+			l.recoveryWindow, l.cfg.walletSyncRetryInterval,
+		)
+	}
 	if err != nil {
 		// If opening the wallet fails (e.g. because of wrong
 		// passphrase), we must close the backing database to
@@ -374,15 +489,37 @@ func (l *Loader) OpenExistingWallet(pubPassphrase []byte,
 	return w, nil
 }
 
-// WalletExists returns whether a file exists at the loader's database path.
-// This may return an error for unexpected I/O failures.
-func (l *Loader) WalletExists() (bool, error) {
+// walletExistsLocked reports whether the configured wallet exists. The loader
+// mutex must be held by the caller.
+func (l *Loader) walletExistsLocked() (bool, error) {
+	if l.store != nil {
+		lifecycle, ok := l.store.(walletstore.LifecycleStore)
+		if !ok {
+			return true, nil
+		}
+
+		return lifecycle.WalletExists(context.Background())
+	}
+
 	if l.localDB {
 		dbPath := filepath.Join(l.dbDirPath, WalletDBName)
 		return fileExists(dbPath)
 	}
 
 	return l.walletExists()
+}
+
+// WalletExists returns whether a wallet exists in the configured backend. This
+// may return an error for unexpected I/O failures.
+func (l *Loader) WalletExists() (bool, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.closed {
+		return false, ErrLoaderClosed
+	}
+
+	return l.walletExistsLocked()
 }
 
 // LoadedWallet returns the loaded wallet, if any, and a bool for whether the
@@ -395,10 +532,11 @@ func (l *Loader) LoadedWallet() (*Wallet, bool) {
 	return w, w != nil
 }
 
-// UnloadWallet stops the loaded wallet, if any, and closes the wallet database.
+// UnloadWallet stops the loaded wallet, if any, and closes its owned database.
 // This returns ErrNotLoaded if the wallet has not been loaded with
-// CreateNewWallet or LoadExistingWallet.  The Loader may be reused if this
-// function returns without error.
+// CreateNewWallet or LoadExistingWallet. A Loader with a caller-owned backend
+// may be reused. A Loader created by NewSQLiteLoader releases its connection
+// and is closed permanently.
 func (l *Loader) UnloadWallet() error {
 	defer l.mu.Unlock()
 	l.mu.Lock()
@@ -415,12 +553,59 @@ func (l *Loader) UnloadWallet() error {
 			return err
 		}
 	}
+	if l.storeClose != nil {
+		err := l.storeClose()
+		if err != nil {
+			return err
+		}
+
+		l.storeClose = nil
+		l.store = nil
+		l.closed = true
+	}
 
 	l.wallet = nil
 	l.db = nil
 	return nil
 }
 
+// Close stops a loaded wallet and releases any backend owned by the loader. It
+// is safe to call when no wallet was loaded and more than once. The loader must
+// not be reused after Close.
+func (l *Loader) Close() error {
+	defer l.mu.Unlock()
+	l.mu.Lock()
+
+	if l.closed {
+		return nil
+	}
+
+	if l.wallet != nil {
+		l.wallet.Stop()
+		l.wallet.WaitForShutdown()
+	}
+
+	if l.localDB && l.db != nil {
+		if err := l.db.Close(); err != nil {
+			return err
+		}
+	}
+	if l.storeClose != nil {
+		if err := l.storeClose(); err != nil {
+			return err
+		}
+	}
+
+	l.wallet = nil
+	l.db = nil
+	l.store = nil
+	l.storeClose = nil
+	l.closed = true
+
+	return nil
+}
+
+// fileExists reports whether the path names an existing file.
 func fileExists(filePath string) (bool, error) {
 	_, err := os.Stat(filePath)
 	if err != nil {

--- a/wallet/mock.go
+++ b/wallet/mock.go
@@ -13,52 +13,112 @@ import (
 )
 
 type mockChainClient struct {
+	getBestBlockHash   *chainhash.Hash
 	getBestBlockHeight int32
+	getBestBlockErr    error
 	getBlockHashFunc   func() (*chainhash.Hash, error)
+	getBlockHashAt     func(int64) (*chainhash.Hash, error)
 	getBlockHeader     *wire.BlockHeader
+	getBlockHeaderFunc func(*chainhash.Hash) (*wire.BlockHeader, error)
+	filterBlocksFunc   func(*chain.FilterBlocksRequest) (
+		*chain.FilterBlocksResponse, error)
+	notifications chan interface{}
+	rpcGuard      func() error
 }
 
 var _ chain.Interface = (*mockChainClient)(nil)
 
-func (m *mockChainClient) Start(_ context.Context) error {
-	return nil
+// guardRPC rejects a mock RPC when a test marks a Store callback active.
+func (m *mockChainClient) guardRPC() error {
+	if m.rpcGuard == nil {
+		return nil
+	}
+
+	return m.rpcGuard()
 }
 
+// Start starts the mock chain client.
+func (m *mockChainClient) Start(_ context.Context) error {
+	return m.guardRPC()
+}
+
+// Stop stops the mock chain client.
 func (m *mockChainClient) Stop() {
 }
 
+// WaitForShutdown waits for the mock chain client to stop.
 func (m *mockChainClient) WaitForShutdown() {}
 
+// GetBestBlock returns the configured mock chain tip.
 func (m *mockChainClient) GetBestBlock() (*chainhash.Hash, int32, error) {
-	return nil, m.getBestBlockHeight, nil
+	if err := m.guardRPC(); err != nil {
+		return nil, 0, err
+	}
+
+	return m.getBestBlockHash, m.getBestBlockHeight, m.getBestBlockErr
 }
 
+// GetBlock returns no block data from the mock chain client.
 func (m *mockChainClient) GetBlock(*chainhash.Hash) (*wire.MsgBlock, error) {
+	if err := m.guardRPC(); err != nil {
+		return nil, err
+	}
+
 	return nil, nil
 }
 
-func (m *mockChainClient) GetBlockHash(int64) (*chainhash.Hash, error) {
+// GetBlockHash returns the configured hash for a block height.
+func (m *mockChainClient) GetBlockHash(height int64) (*chainhash.Hash, error) {
+	if err := m.guardRPC(); err != nil {
+		return nil, err
+	}
+	if m.getBlockHashAt != nil {
+		return m.getBlockHashAt(height)
+	}
 	if m.getBlockHashFunc != nil {
 		return m.getBlockHashFunc()
 	}
 	return nil, nil
 }
 
-func (m *mockChainClient) GetBlockHeader(*chainhash.Hash) (*wire.BlockHeader,
-	error) {
+// GetBlockHeader returns the configured block header.
+func (m *mockChainClient) GetBlockHeader(
+	hash *chainhash.Hash) (*wire.BlockHeader, error) {
+
+	if err := m.guardRPC(); err != nil {
+		return nil, err
+	}
+	if m.getBlockHeaderFunc != nil {
+		return m.getBlockHeaderFunc(hash)
+	}
+
 	return m.getBlockHeader, nil
 }
 
+// IsCurrent reports that the mock backend is not current.
 func (m *mockChainClient) IsCurrent() bool {
 	return false
 }
 
-func (m *mockChainClient) FilterBlocks(*chain.FilterBlocksRequest) (
+// FilterBlocks returns the configured mock filter response.
+func (m *mockChainClient) FilterBlocks(request *chain.FilterBlocksRequest) (
 	*chain.FilterBlocksResponse, error) {
+	if err := m.guardRPC(); err != nil {
+		return nil, err
+	}
+	if m.filterBlocksFunc != nil {
+		return m.filterBlocksFunc(request)
+	}
+
 	return nil, nil
 }
 
+// BlockStamp returns a fixed mock block stamp.
 func (m *mockChainClient) BlockStamp() (*waddrmgr.BlockStamp, error) {
+	if err := m.guardRPC(); err != nil {
+		return nil, err
+	}
+
 	return &waddrmgr.BlockStamp{
 		Height:    500000,
 		Hash:      chainhash.Hash{},
@@ -66,39 +126,52 @@ func (m *mockChainClient) BlockStamp() (*waddrmgr.BlockStamp, error) {
 	}, nil
 }
 
+// SendRawTransaction accepts a transaction without broadcasting it.
 func (m *mockChainClient) SendRawTransaction(*wire.MsgTx, bool) (
 	*chainhash.Hash, error) {
+	if err := m.guardRPC(); err != nil {
+		return nil, err
+	}
+
 	return nil, nil
 }
 
+// Rescan accepts a mock rescan request.
 func (m *mockChainClient) Rescan(*chainhash.Hash, []address.Address,
 	map[wire.OutPoint]address.Address) error {
 
-	return nil
+	return m.guardRPC()
 }
 
+// NotifyReceived accepts a mock address notification request.
 func (m *mockChainClient) NotifyReceived([]address.Address) error {
-	return nil
+	return m.guardRPC()
 }
 
+// NotifyBlocks accepts a mock block notification request.
 func (m *mockChainClient) NotifyBlocks() error {
-	return nil
+	return m.guardRPC()
 }
 
+// Notifications returns the configured mock notification channel.
 func (m *mockChainClient) Notifications() <-chan interface{} {
-	return nil
+	return m.notifications
 }
 
+// BackEnd identifies the mock chain backend.
 func (m *mockChainClient) BackEnd() string {
 	return "mock"
 }
 
-// TestMempoolAcceptCmd returns result of mempool acceptance tests indicating
-// if raw transaction(s) would be accepted by mempool.
+// TestMempoolAccept returns the mempool acceptance result for raw transactions.
 //
 // NOTE: This is part of the chain.Interface interface.
 func (m *mockChainClient) TestMempoolAccept(txns []*wire.MsgTx,
 	maxFeeRate float64) ([]*btcjson.TestMempoolAcceptResult, error) {
+
+	if err := m.guardRPC(); err != nil {
+		return nil, err
+	}
 
 	return nil, nil
 }
@@ -107,9 +180,18 @@ func (m *mockChainClient) TestMempoolAccept(txns []*wire.MsgTx,
 func (m *mockChainClient) SubmitPackage(txns []*wire.MsgTx,
 	maxFeeRate *float64) (*btcjson.SubmitPackageResult, error) {
 
+	if err := m.guardRPC(); err != nil {
+		return nil, err
+	}
+
 	return &btcjson.SubmitPackageResult{}, nil
 }
 
+// MapRPCErr maps no errors for the mock chain client.
 func (m *mockChainClient) MapRPCErr(err error) error {
+	if guardErr := m.guardRPC(); guardErr != nil {
+		return guardErr
+	}
+
 	return nil
 }

--- a/wallet/multisig.go
+++ b/wallet/multisig.go
@@ -6,12 +6,14 @@
 package wallet
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
 	"github.com/btcsuite/btcd/address/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	walletstore "github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 )
 
@@ -47,7 +49,7 @@ func (w *Wallet) MakeMultiSigScript(addrs []address.Address,
 			pubKeys[i] = addr
 
 		case *address.AddressPubKeyHash:
-			if dbtx == nil {
+			if dbtx == nil && w.db != nil {
 				var err error
 				dbtx, err = w.db.BeginReadTx()
 				if err != nil {
@@ -55,7 +57,13 @@ func (w *Wallet) MakeMultiSigScript(addrs []address.Address,
 				}
 				addrmgrNs = dbtx.ReadBucket(waddrmgrNamespaceKey)
 			}
-			addrInfo, err := w.Manager.Address(addrmgrNs, addr)
+			var addrInfo waddrmgr.ManagedAddress
+			var err error
+			if w.db != nil {
+				addrInfo, err = w.Manager.Address(addrmgrNs, addr)
+			} else {
+				addrInfo, err = w.AddressInfo(addr)
+			}
 			if err != nil {
 				return nil, err
 			}
@@ -79,17 +87,10 @@ func (w *Wallet) ImportP2SHRedeemScript(
 	script []byte) (*address.AddressScriptHash, error) {
 
 	var p2shAddr *address.AddressScriptHash
-	err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+	importScript := func(
+		importer func(*waddrmgr.ScopedKeyManager) (
+			waddrmgr.ManagedScriptAddress, error)) error {
 
-		// TODO(oga) blockstamp current block?
-		bs := &waddrmgr.BlockStamp{
-			Hash:   *w.ChainParams().GenesisHash,
-			Height: 0,
-		}
-
-		// As this is a regular P2SH script, we'll import this into the
-		// BIP0044 scope.
 		bip44Mgr, err := w.Manager.FetchScopedKeyManager(
 			waddrmgr.KeyScopeBIP0084,
 		)
@@ -97,16 +98,12 @@ func (w *Wallet) ImportP2SHRedeemScript(
 			return err
 		}
 
-		addrInfo, err := bip44Mgr.ImportScript(addrmgrNs, script, bs)
+		addrInfo, err := importer(bip44Mgr)
 		if err != nil {
-			// Don't care if it's already there, but still have to
-			// set the p2shAddr since the address manager didn't
-			// return anything useful.
 			if waddrmgr.IsError(err, waddrmgr.ErrDuplicateAddress) {
-				// This function will never error as it always
-				// hashes the script to the correct length.
-				p2shAddr, _ = address.NewAddressScriptHash(script,
-					w.chainParams)
+				p2shAddr, _ = address.NewAddressScriptHash(
+					script, w.chainParams,
+				)
 				return nil
 			}
 			return err
@@ -114,12 +111,56 @@ func (w *Wallet) ImportP2SHRedeemScript(
 
 		castAddr, ok := addrInfo.Address().(*address.AddressScriptHash)
 		if !ok {
-			return fmt.Errorf("unexpected address type: %T", addrInfo.Address())
+			return fmt.Errorf(
+				"unexpected address type: %T", addrInfo.Address(),
+			)
 		}
-
 		p2shAddr = castAddr
 
 		return nil
-	})
+	}
+
+	var err error
+	if w.db != nil {
+		err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+			addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+			// TODO(oga) blockstamp current block?
+			bs := &waddrmgr.BlockStamp{
+				Hash:   *w.ChainParams().GenesisHash,
+				Height: 0,
+			}
+
+			return importScript(func(manager *waddrmgr.ScopedKeyManager) (
+				waddrmgr.ManagedScriptAddress, error) {
+
+				return manager.ImportScript(addrmgrNs, script, bs)
+			})
+		})
+	} else {
+		err = w.store.UpdateOnce(
+			context.Background(),
+			func(tx walletstore.ReadWriteTx) error {
+				bs := &waddrmgr.BlockStamp{
+					Hash:      *w.ChainParams().GenesisHash,
+					Height:    0,
+					Timestamp: w.ChainParams().GenesisBlock.Header.Timestamp,
+				}
+
+				return importScript(
+					func(manager *waddrmgr.ScopedKeyManager) (
+						waddrmgr.ManagedScriptAddress, error) {
+
+						return manager.ImportScriptFromStore(
+							tx.Addr(), script, bs,
+						)
+					},
+				)
+			}, func() {
+				p2shAddr = nil
+			},
+		)
+	}
+	w.refreshStartBlockAfterAmbiguous(err)
 	return p2shAddr, err
 }

--- a/wallet/open_split_test.go
+++ b/wallet/open_split_test.go
@@ -1,0 +1,258 @@
+package wallet
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	walletstore "github.com/btcsuite/btcwallet/wallet/internal/db"
+	dbsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlite"
+	storesqlite "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite"
+	"github.com/stretchr/testify/require"
+)
+
+// openSplitBoundaryStore records whether snapshot capture returned an error
+// from inside the delegated Store callback.
+type openSplitBoundaryStore struct {
+	// Store delegates the underlying transaction execution.
+	walletstore.Store
+
+	wrap       func(walletstore.ReadTx) walletstore.ReadTx
+	bodyErrors []error
+	viewExited bool
+}
+
+// View records callback results and marks the transaction exited only after
+// the delegated Store returns.
+func (s *openSplitBoundaryStore) View(ctx context.Context,
+	body func(walletstore.ReadTx) error, reset func()) error {
+
+	err := s.Store.View(ctx, func(tx walletstore.ReadTx) error {
+		if s.wrap != nil {
+			tx = s.wrap(tx)
+		}
+
+		bodyErr := body(tx)
+		s.bodyErrors = append(s.bodyErrors, bodyErr)
+
+		return bodyErr
+	}, reset)
+	s.viewExited = true
+
+	return err
+}
+
+// openSplitReadTx replaces the address read surface for one Store attempt.
+type openSplitReadTx struct {
+	// ReadTx delegates transaction-manager reads.
+	walletstore.ReadTx
+
+	addr walletstore.AddrReadStore
+}
+
+// Addr returns the test-controlled address-manager read surface.
+//
+//nolint:ireturn // The test wrapper implements the transaction contract.
+func (t *openSplitReadTx) Addr() walletstore.AddrReadStore {
+	return t.addr
+}
+
+// openSplitAddressStore can corrupt or fail active-address reads for one scope.
+type openSplitAddressStore struct {
+	// AddrReadStore delegates address reads not overridden by the fixture.
+	walletstore.AddrReadStore
+
+	scope       waddrmgr.KeyScope
+	failure     error
+	malformed   bool
+	matchedRead bool
+}
+
+// ActiveAddresses delegates one scope read before optionally failing or
+// removing required chain-address metadata.
+func (s *openSplitAddressStore) ActiveAddresses(
+	scope waddrmgr.KeyScope) ([]waddrmgr.AddressState, error) {
+
+	states, err := s.AddrReadStore.ActiveAddresses(scope)
+	if err != nil || scope != s.scope {
+		return states, err
+	}
+	s.matchedRead = true
+
+	if s.failure != nil {
+		return nil, s.failure
+	}
+	if !s.malformed {
+		return states, nil
+	}
+
+	for i := range states {
+		if states[i].Type == waddrmgr.AddressChain {
+			states[i].Branch = nil
+			return states, nil
+		}
+	}
+
+	return nil, errors.New("chain address fixture not found")
+}
+
+// openSplitRetryStore simulates a Store retry after a late snapshot read
+// failure and records reset behavior for both attempts.
+type openSplitRetryStore struct {
+	// Store delegates the underlying transaction execution.
+	walletstore.Store
+
+	scope      waddrmgr.KeyScope
+	failure    error
+	bodyErrors []error
+	resets     int
+}
+
+// View runs one failing snapshot attempt followed by one successful attempt in
+// the same real read transaction.
+func (s *openSplitRetryStore) View(ctx context.Context,
+	body func(walletstore.ReadTx) error, reset func()) error {
+
+	return s.Store.View(ctx, func(tx walletstore.ReadTx) error {
+		resetAttempt := func() {
+			s.resets++
+			if reset != nil {
+				reset()
+			}
+		}
+
+		resetAttempt()
+		failingAddr := &openSplitAddressStore{
+			AddrReadStore: tx.Addr(),
+			scope:         s.scope,
+			failure:       s.failure,
+		}
+		firstErr := body(&openSplitReadTx{
+			ReadTx: tx,
+			addr:   failingAddr,
+		})
+		s.bodyErrors = append(s.bodyErrors, firstErr)
+		if !errors.Is(firstErr, s.failure) {
+			return firstErr
+		}
+
+		resetAttempt()
+		secondErr := body(tx)
+		s.bodyErrors = append(s.bodyErrors, secondErr)
+
+		return secondErr
+	}, nil)
+}
+
+// newOpenSplitStore creates a wallet with one active chain address and returns
+// its caller-owned SQLite Store after unloading the initial wallet.
+//
+//nolint:ireturn // The test helper intentionally hides the concrete backend.
+func newOpenSplitStore(t *testing.T) walletstore.Store {
+	t.Helper()
+
+	conn, err := storesqlite.Open(context.Background(), storesqlite.Config{
+		DBPath: filepath.Join(t.TempDir(), "wallet.sqlite"),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+	require.NoError(t, storesqlite.ApplyMigrations(conn))
+
+	store := dbsqlite.NewNamedStore(conn, "open-split")
+	loader, err := NewLoaderWithStore(&chaincfg.TestNet3Params, 0, store)
+	require.NoError(t, err)
+
+	wallet, err := loader.CreateNewWallet(
+		[]byte("public-pass"), []byte("private-pass"), nil,
+		time.Unix(1_700_000_000, 0),
+	)
+	require.NoError(t, err)
+	wallet.chainClient = &mockChainClient{}
+	_, err = wallet.NewAddress(
+		waddrmgr.DefaultAccountNum, waddrmgr.KeyScopeBIP0084,
+	)
+	require.NoError(t, err)
+	require.NoError(t, loader.UnloadWallet())
+
+	return store
+}
+
+// TestStoreOpenReconstructsAfterView verifies passphrase checking and malformed
+// address validation occur only after the Store callback has returned.
+func TestStoreOpenReconstructsAfterView(t *testing.T) {
+	store := newOpenSplitStore(t)
+
+	wrongPassStore := &openSplitBoundaryStore{Store: store}
+	wallet, err := OpenFromStore(
+		wrongPassStore, []byte("wrong-pass"), &chaincfg.TestNet3Params, 0,
+		defaultSyncRetryInterval,
+	)
+	require.Nil(t, wallet)
+	require.True(t, wrongPassStore.viewExited)
+	require.Equal(t, []error{nil}, wrongPassStore.bodyErrors)
+	require.True(t, waddrmgr.IsError(err, waddrmgr.ErrWrongPassphrase))
+
+	malformedAddr := &openSplitAddressStore{
+		scope:     waddrmgr.KeyScopeBIP0084,
+		malformed: true,
+	}
+	malformedStore := &openSplitBoundaryStore{
+		Store: store,
+		wrap: func(tx walletstore.ReadTx) walletstore.ReadTx {
+			malformedAddr.AddrReadStore = tx.Addr()
+			return &openSplitReadTx{
+				ReadTx: tx,
+				addr:   malformedAddr,
+			}
+		},
+	}
+	wallet, err = OpenFromStore(
+		malformedStore, []byte("public-pass"),
+		&chaincfg.TestNet3Params, 0, defaultSyncRetryInterval,
+	)
+	require.Nil(t, wallet)
+	require.True(t, malformedStore.viewExited)
+	require.True(t, malformedAddr.matchedRead)
+	require.Equal(t, []error{nil}, malformedStore.bodyErrors)
+	require.ErrorContains(t, err, "stored chain address path is missing")
+}
+
+// TestStoreOpenSnapshotRetryReset verifies a failed snapshot attempt is cleared
+// before a successful retry and no partially reconstructed manager is returned.
+func TestStoreOpenSnapshotRetryReset(t *testing.T) {
+	store := newOpenSplitStore(t)
+	readErr := errors.New("retry snapshot read")
+	retryStore := &openSplitRetryStore{
+		Store:   store,
+		scope:   waddrmgr.KeyScopeBIP0084,
+		failure: readErr,
+	}
+
+	wallet, err := OpenFromStore(
+		retryStore, []byte("public-pass"), &chaincfg.TestNet3Params, 0,
+		defaultSyncRetryInterval,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, wallet)
+	require.Equal(t, 2, retryStore.resets)
+	require.Len(t, retryStore.bodyErrors, 2)
+	require.ErrorIs(t, retryStore.bodyErrors[0], readErr)
+	require.NoError(t, retryStore.bodyErrors[1])
+
+	scopedManager, err := wallet.Manager.FetchScopedKeyManager(
+		waddrmgr.KeyScopeBIP0084,
+	)
+	require.NoError(t, err)
+	lastAddress, err := scopedManager.LastExternalAddress(
+		nil, waddrmgr.DefaultAccountNum,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, lastAddress)
+	wallet.Manager.Close()
+}

--- a/wallet/psbt.go
+++ b/wallet/psbt.go
@@ -6,6 +6,7 @@ package wallet
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	walletstore "github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wallet/txauthor"
 	"github.com/btcsuite/btcwallet/wallet/txrules"
 	"github.com/btcsuite/btcwallet/walletdb"
@@ -122,6 +124,12 @@ func (w *Wallet) FundPsbt(packet *psbt.Packet, keyScope *waddrmgr.KeyScope,
 	// If there are inputs, we need to check if they're sufficient and add
 	// a change output if necessary.
 	default:
+		if w.db == nil {
+			return w.fundPsbtExplicitFromStore(
+				packet, keyScope, account, feeSatPerKB, optFuncs...,
+			)
+		}
+
 		// Make sure all inputs provided are actually ours.
 		packet.Inputs = make([]psbt.PInput, len(packet.UnsignedTx.TxIn))
 
@@ -180,27 +188,26 @@ func (w *Wallet) FundPsbt(packet *psbt.Packet, keyScope *waddrmgr.KeyScope,
 
 		// We also need a change source which needs to be able to insert
 		// a new change address into the database.
-		err = walletdb.Update(w.db, func(dbtx walletdb.ReadWriteTx) error {
-			_, changeSource, err := w.addrMgrWithChangeSource(
-				dbtx, opts.changeKeyScope, account,
-			)
-			if err != nil {
-				return err
-			}
+		err = walletdb.Update(
+			w.db, func(dbtx walletdb.ReadWriteTx) error {
+				_, changeSource, err := w.addrMgrWithChangeSource(
+					dbtx, opts.changeKeyScope, account,
+				)
+				if err != nil {
+					return err
+				}
 
-			// Ask the txauthor to create a transaction with our
-			// selected coins. This will perform fee estimation and
-			// add a change output if necessary.
-			tx, err = txauthor.NewUnsignedTransaction(
-				txOut, feeSatPerKB, inputSource, changeSource,
-			)
-			if err != nil {
-				return fmt.Errorf("fee estimation not "+
-					"successful: %w", err)
-			}
+				tx, err = txauthor.NewUnsignedTransaction(
+					txOut, feeSatPerKB, inputSource, changeSource,
+				)
+				if err != nil {
+					return fmt.Errorf("fee estimation not successful: %w",
+						err)
+				}
 
-			return nil
-		})
+				return nil
+			},
+		)
 		w.newAddrMtx.Unlock()
 
 		if err != nil {
@@ -331,7 +338,7 @@ func addInputInfoSegWitV0(in *psbt.PInput, prevTx *wire.MsgTx, utxo *wire.TxOut,
 	}
 }
 
-// addInputInfoSegWitV0 adds the UTXO and BIP32 derivation info for a SegWit v1
+// addInputInfoSegWitV1 adds the UTXO and BIP32 derivation info for a SegWit v1
 // PSBT input (p2tr) from the given wallet information.
 func addInputInfoSegWitV1(in *psbt.PInput, utxo *wire.TxOut,
 	derivationInfo *psbt.Bip32Derivation) {
@@ -491,26 +498,35 @@ func (w *Wallet) FinalizePsbt(keyScope *waddrmgr.KeyScope, account uint32,
 		// Finally, if the input doesn't belong to a watch-only account,
 		// then we'll sign it as is, and populate the input with the
 		// witness and sigScript (if needed).
+		watchOnlyScope := waddrmgr.KeyScopeBIP0084
+		if keyScope != nil {
+			watchOnlyScope = *keyScope
+		}
+
 		watchOnly := false
-		err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-			ns := tx.ReadBucket(waddrmgrNamespaceKey)
-			var err error
-			if keyScope == nil {
-				// If a key scope wasn't specified, then coin
-				// selection was performed from the default
-				// wallet accounts (NP2WKH, P2WKH, P2TR), so any
-				// key scope provided doesn't impact the result
-				// of this call.
+		if w.db != nil {
+			err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+				ns := tx.ReadBucket(waddrmgrNamespaceKey)
+				var err error
 				watchOnly, err = w.Manager.IsWatchOnlyAccount(
-					ns, waddrmgr.KeyScopeBIP0084, account,
+					ns, watchOnlyScope, account,
 				)
-			} else {
-				watchOnly, err = w.Manager.IsWatchOnlyAccount(
-					ns, *keyScope, account,
-				)
-			}
-			return err
-		})
+				return err
+			})
+		} else {
+			err = w.store.View(
+				context.Background(), func(tx walletstore.ReadTx) error {
+					var err error
+					watchOnly, err =
+						w.Manager.IsWatchOnlyAccountFromStore(
+							tx.Addr(), watchOnlyScope, account,
+						)
+					return err
+				}, func() {
+					watchOnly = false
+				},
+			)
+		}
 		if err != nil {
 			return fmt.Errorf("unable to determine if account is "+
 				"watch-only: %w", err)

--- a/wallet/recovery.go
+++ b/wallet/recovery.go
@@ -1,6 +1,8 @@
 package wallet
 
 import (
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/btcsuite/btcd/address/v2"
@@ -143,6 +145,77 @@ func (rm *RecoveryManager) Resurrect(ns walletdb.ReadBucket,
 	return nil
 }
 
+// resurrectFromAccountStates restores recovery state from detached account
+// rows and credits while no Store transaction is active.
+func (rm *RecoveryManager) resurrectFromAccountStates(
+	accounts map[waddrmgr.KeyScope]waddrmgr.AccountState,
+	scopedMgrs map[waddrmgr.KeyScope]*waddrmgr.ScopedKeyManager,
+	credits []wtxmgr.Credit) error {
+
+	for keyScope, scopedMgr := range scopedMgrs {
+		account, ok := accounts[keyScope]
+		if !ok {
+			return fmt.Errorf("recovery account for scope %s is missing",
+				keyScope)
+		}
+
+		scopeState := rm.state.StateForScope(keyScope)
+		for i := uint32(0); i < account.NextExternalIndex; i++ {
+			addr, err := scopedMgr.DeriveFromKeyPathFromAccountState(
+				account, externalKeyPath(i),
+			)
+			if errors.Is(err, hdkeychain.ErrInvalidChild) {
+				scopeState.ExternalBranch.MarkInvalidChild(i)
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			scopeState.ExternalBranch.AddAddr(i, addr.Address())
+		}
+
+		for i := uint32(0); i < account.NextInternalIndex; i++ {
+			addr, err := scopedMgr.DeriveFromKeyPathFromAccountState(
+				account, internalKeyPath(i),
+			)
+			if errors.Is(err, hdkeychain.ErrInvalidChild) {
+				scopeState.InternalBranch.MarkInvalidChild(i)
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			scopeState.InternalBranch.AddAddr(i, addr.Address())
+		}
+
+		if account.NextExternalIndex > 0 {
+			scopeState.ExternalBranch.ReportFound(
+				account.NextExternalIndex - 1,
+			)
+		}
+		if account.NextInternalIndex > 0 {
+			scopeState.InternalBranch.ReportFound(
+				account.NextInternalIndex - 1,
+			)
+		}
+	}
+
+	for _, credit := range credits {
+		_, addrs, _, err := txscript.ExtractPkScriptAddrs(
+			credit.PkScript, rm.chainParams,
+		)
+		if err != nil {
+			return err
+		}
+		if len(addrs) == 0 {
+			continue
+		}
+		rm.state.AddWatchedOutPoint(&credit.OutPoint, addrs[0])
+	}
+
+	return nil
+}
+
 // AddToBlockBatch appends the block information, consisting of hash and height,
 // to the batch of blocks to be searched.
 func (rm *RecoveryManager) AddToBlockBatch(hash *chainhash.Hash, height int32,
@@ -223,6 +296,20 @@ func NewRecoveryState(recoveryWindow uint32) *RecoveryState {
 	}
 }
 
+// Clone returns a detached deep copy that can be advanced while a recovery
+// batch is planned without mutating the live recovery state.
+func (rs *RecoveryState) Clone() *RecoveryState {
+	clone := NewRecoveryState(rs.recoveryWindow)
+	for scope, state := range rs.scopes {
+		clone.scopes[scope] = state.Clone()
+	}
+	for outPoint, addr := range rs.watchedOutPoints {
+		clone.watchedOutPoints[outPoint] = addr
+	}
+
+	return clone
+}
+
 // StateForScope returns a ScopeRecoveryState for the provided key scope. If one
 // does not already exist, a new one will be generated with the RecoveryState's
 // recoveryWindow.
@@ -277,6 +364,14 @@ func NewScopeRecoveryState(recoveryWindow uint32) *ScopeRecoveryState {
 	}
 }
 
+// Clone returns a detached deep copy of both branch recovery states.
+func (s *ScopeRecoveryState) Clone() *ScopeRecoveryState {
+	return &ScopeRecoveryState{
+		ExternalBranch: s.ExternalBranch.Clone(),
+		InternalBranch: s.InternalBranch.Clone(),
+	}
+}
+
 // BranchRecoveryState maintains the required state in-order to properly
 // recover addresses derived from a particular account's internal or external
 // derivation branch.
@@ -317,6 +412,25 @@ func NewBranchRecoveryState(recoveryWindow uint32) *BranchRecoveryState {
 		addresses:       make(map[uint32]address.Address),
 		invalidChildren: make(map[uint32]struct{}),
 	}
+}
+
+// Clone returns a detached deep copy of the branch horizon and address sets.
+func (brs *BranchRecoveryState) Clone() *BranchRecoveryState {
+	clone := &BranchRecoveryState{
+		recoveryWindow:  brs.recoveryWindow,
+		horizon:         brs.horizon,
+		nextUnfound:     brs.nextUnfound,
+		addresses:       make(map[uint32]address.Address, len(brs.addresses)),
+		invalidChildren: make(map[uint32]struct{}, len(brs.invalidChildren)),
+	}
+	for index, addr := range brs.addresses {
+		clone.addresses[index] = addr
+	}
+	for index := range brs.invalidChildren {
+		clone.invalidChildren[index] = struct{}{}
+	}
+
+	return clone
 }
 
 // ExtendHorizon returns the current horizon and the number of addresses that

--- a/wallet/salvage_benchmark_test.go
+++ b/wallet/salvage_benchmark_test.go
@@ -1,0 +1,799 @@
+package wallet
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/integration/rpctest"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btcwallet/chain"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	walletstore "github.com/btcsuite/btcwallet/wallet/internal/db"
+	dbsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlite"
+	storesqlite "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+)
+
+const (
+	salvageBenchmarkWalletName = "sqlite-route-benchmark"
+	salvageBenchmarkPubPass    = "public-pass"
+	salvageBenchmarkPrivPass   = "private-pass"
+	salvageBenchmarkAccount    = uint32(1)
+	salvageBenchmarkPathIndex  = uint32(7)
+)
+
+var (
+	salvageBenchmarkSeed = [32]byte{
+		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+		0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+		0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+		0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+	}
+	salvageBenchmarkScope = waddrmgr.KeyScope{
+		Purpose: 1017,
+		Coin:    1,
+	}
+	salvageBenchmarkSchema = waddrmgr.ScopeAddrSchema{
+		ExternalAddrType: waddrmgr.WitnessPubKey,
+		InternalAddrType: waddrmgr.WitnessPubKey,
+	}
+	salvageBenchmarkPath = waddrmgr.DerivationPath{
+		InternalAccount: salvageBenchmarkAccount,
+		Account:         salvageBenchmarkAccount,
+		Branch:          0,
+		Index:           salvageBenchmarkPathIndex,
+	}
+)
+
+// salvageBenchmarkKeyResult holds one allocation for untimed validation.
+type salvageBenchmarkKeyResult struct {
+	index     uint32
+	publicKey [33]byte
+	err       error
+}
+
+// salvageBenchmarkFixture owns one deterministic Store-backed SQLite wallet.
+type salvageBenchmarkFixture struct {
+	dbPath          string
+	conn            *sql.DB
+	loader          *Loader
+	wallet          *Wallet
+	openViewElapsed time.Duration
+}
+
+// salvageTimedViewStore records how long an open holds its Store view.
+type salvageTimedViewStore struct {
+	// Store delegates the measured transaction execution.
+	walletstore.Store
+
+	elapsed time.Duration
+}
+
+// salvageFundingTimedStore records complete Store transaction duration for the
+// split funding benchmark.
+type salvageFundingTimedStore struct {
+	// Store delegates the measured transaction execution.
+	walletstore.Store
+
+	viewNanos   atomic.Int64
+	updateNanos atomic.Int64
+}
+
+// View records one funding snapshot transaction.
+func (s *salvageFundingTimedStore) View(ctx context.Context,
+	body func(walletstore.ReadTx) error, reset func()) error {
+
+	start := time.Now()
+	err := s.Store.View(ctx, body, reset)
+	s.viewNanos.Add(time.Since(start).Nanoseconds())
+
+	return err
+}
+
+// UpdateOnce records one funding apply transaction.
+func (s *salvageFundingTimedStore) UpdateOnce(ctx context.Context,
+	body func(walletstore.ReadWriteTx) error, reset func()) error {
+
+	start := time.Now()
+	err := s.Store.UpdateOnce(ctx, body, reset)
+	s.updateNanos.Add(time.Since(start).Nanoseconds())
+
+	return err
+}
+
+// View records the complete duration of one delegated read transaction.
+func (s *salvageTimedViewStore) View(ctx context.Context,
+	body func(walletstore.ReadTx) error, reset func()) error {
+
+	start := time.Now()
+	err := s.Store.View(ctx, body, reset)
+	s.elapsed += time.Since(start)
+
+	return err
+}
+
+// useSalvageBenchmarkScrypt excludes production-strength scrypt setup from
+// benchmark wall time while leaving the measured wallet routes unchanged.
+func useSalvageBenchmarkScrypt(b *testing.B) {
+	b.Helper()
+
+	defaultOptions := waddrmgr.DefaultScryptOptions
+	waddrmgr.DefaultScryptOptions = waddrmgr.FastScryptOptions
+	b.Cleanup(func() {
+		waddrmgr.DefaultScryptOptions = defaultOptions
+	})
+}
+
+// newSalvageBenchmarkFixture creates and unlocks a deterministic SQLite wallet
+// with the lnd key scope and accounts already initialized.
+func newSalvageBenchmarkFixture(b *testing.B) *salvageBenchmarkFixture {
+	b.Helper()
+
+	dbPath := filepath.Join(b.TempDir(), "wallet.sqlite")
+	conn, err := storesqlite.Open(context.Background(), storesqlite.Config{
+		DBPath: dbPath,
+	})
+	if err != nil {
+		b.Fatalf("open SQLite fixture: %v", err)
+	}
+	if err := storesqlite.ApplyMigrations(conn); err != nil {
+		_ = conn.Close()
+		b.Fatalf("apply SQLite migrations: %v", err)
+	}
+
+	store := dbsqlite.NewNamedStore(conn, salvageBenchmarkWalletName)
+	loader, err := NewLoaderWithStore(&chaincfg.TestNet3Params, 0, store)
+	if err != nil {
+		_ = conn.Close()
+		b.Fatalf("create Store loader: %v", err)
+	}
+
+	wallet, err := loader.CreateNewWallet(
+		[]byte(salvageBenchmarkPubPass),
+		[]byte(salvageBenchmarkPrivPass), salvageBenchmarkSeed[:],
+		time.Unix(1_700_000_000, 0),
+	)
+	if err != nil {
+		_ = conn.Close()
+		b.Fatalf("create SQLite wallet: %v", err)
+	}
+	if err := wallet.Unlock([]byte(salvageBenchmarkPrivPass), nil); err != nil {
+		_ = loader.UnloadWallet()
+		_ = conn.Close()
+		b.Fatalf("unlock SQLite wallet: %v", err)
+	}
+	if err := wallet.InitializeKeyScope(
+		salvageBenchmarkScope, salvageBenchmarkSchema,
+		[]uint32{0, 1}, false,
+	); err != nil {
+
+		_ = loader.UnloadWallet()
+		_ = conn.Close()
+		b.Fatalf("initialize lnd key scope: %v", err)
+	}
+
+	fixture := &salvageBenchmarkFixture{
+		dbPath: dbPath,
+		conn:   conn,
+		loader: loader,
+		wallet: wallet,
+	}
+	b.Cleanup(func() {
+		fixture.close(b)
+	})
+
+	return fixture
+}
+
+// close stops the fixture wallet and closes its caller-owned SQLite pool.
+func (f *salvageBenchmarkFixture) close(b *testing.B) {
+	b.Helper()
+
+	if f.loader != nil {
+		if err := f.loader.UnloadWallet(); err != nil {
+			b.Errorf("unload SQLite wallet: %v", err)
+		}
+		f.loader = nil
+		f.wallet = nil
+	}
+	if f.conn != nil {
+		if err := f.conn.Close(); err != nil {
+			b.Errorf("close SQLite fixture: %v", err)
+		}
+		f.conn = nil
+	}
+}
+
+// openExisting reopens the fixture through the Store-backed loader.
+func (f *salvageBenchmarkFixture) openExisting(b *testing.B) Interface {
+	b.Helper()
+
+	conn, err := storesqlite.Open(context.Background(), storesqlite.Config{
+		DBPath: f.dbPath,
+	})
+	if err != nil {
+		b.Fatalf("reopen SQLite fixture: %v", err)
+	}
+
+	store := &salvageTimedViewStore{
+		Store: dbsqlite.NewNamedStore(conn, salvageBenchmarkWalletName),
+	}
+	loader, err := NewLoaderWithStore(&chaincfg.TestNet3Params, 0, store)
+	if err != nil {
+		_ = conn.Close()
+		b.Fatalf("recreate Store loader: %v", err)
+	}
+	wallet, err := loader.OpenExistingWallet(
+		[]byte(salvageBenchmarkPubPass), false,
+	)
+	if err != nil {
+		_ = conn.Close()
+		b.Fatalf("reopen Store wallet: %v", err)
+	}
+
+	f.conn = conn
+	f.loader = loader
+	f.wallet = wallet
+	f.openViewElapsed = store.elapsed
+
+	return wallet
+}
+
+// BenchmarkSQLiteRoute measures the unoptimized Store-backed SQLite routes used
+// by lnd with the same names and fixed fixtures as the role benchmark.
+func BenchmarkSQLiteRoute(b *testing.B) {
+	useSalvageBenchmarkScrypt(b)
+
+	b.Run(
+		"SequentialExternalKeyAllocation",
+		benchmarkSalvageSequentialExternalKey,
+	)
+	b.Run(
+		"ConcurrentExternalKeyAllocation",
+		benchmarkSalvageConcurrentExternalKey,
+	)
+	b.Run("ArbitraryPublicDerivation", benchmarkSalvagePublicDerivation)
+	b.Run(
+		"ArbitraryPrivateDerivation",
+		benchmarkSalvagePrivateDerivation,
+	)
+	b.Run("ArbitrarySigning", benchmarkSalvageSigning)
+
+	for _, numKeys := range []int{100, 1000} {
+		name := fmt.Sprintf("RestartOpen/Keys-%d", numKeys)
+		b.Run(name, func(b *testing.B) {
+			benchmarkSalvageRestartOpen(b, numKeys)
+		})
+
+		name = fmt.Sprintf("ManagerOpenSplit/Keys-%d", numKeys)
+		b.Run(name, func(b *testing.B) {
+			benchmarkSalvageManagerOpenSplit(b, numKeys)
+		})
+	}
+
+	benchmarkSalvageControllerSync(b)
+}
+
+// BenchmarkStoreFundingTransactionDuration compares the old monolithic hold
+// estimate, represented by full operation time, with the measured read and
+// final-update transaction durations after the split.
+func BenchmarkStoreFundingTransactionDuration(b *testing.B) {
+	b.StopTimer()
+	fixture := newSalvageBenchmarkFixture(b)
+	wallet := fixture.wallet
+	wallet.chainClient = &mockChainClient{}
+	receive, err := wallet.NewAddress(
+		waddrmgr.DefaultAccountNum, waddrmgr.KeyScopeBIP0084,
+	)
+	if err != nil {
+		b.Fatalf("allocate funding address: %v", err)
+	}
+	prevScript, err := txscript.PayToAddrScript(receive)
+	if err != nil {
+		b.Fatalf("create funding script: %v", err)
+	}
+	fundingTx := wire.NewMsgTx(2)
+	fundingTx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash:  chainhash.Hash{0x51},
+		Index: 1,
+	}})
+	fundingTx.AddTxOut(wire.NewTxOut(1_000_000, prevScript))
+	funding, err := wtxmgr.NewTxRecordFromMsgTx(
+		fundingTx, time.Unix(1_700_000_100, 0),
+	)
+	if err != nil {
+		b.Fatalf("create funding record: %v", err)
+	}
+	if err := wallet.store.UpdateOnce(
+		b.Context(), func(tx walletstore.ReadWriteTx) error {
+			return wallet.addRelevantTxFromStore(tx, funding, nil)
+		}, nil,
+	); err != nil {
+
+		b.Fatalf("insert funding transaction: %v", err)
+	}
+
+	destination, err := address.NewAddressWitnessPubKeyHash(
+		make([]byte, 20), &chaincfg.TestNet3Params,
+	)
+	if err != nil {
+		b.Fatalf("create destination: %v", err)
+	}
+	destinationScript, err := txscript.PayToAddrScript(destination)
+	if err != nil {
+		b.Fatalf("create destination script: %v", err)
+	}
+	timedStore := &salvageFundingTimedStore{Store: wallet.store}
+	wallet.store = timedStore
+	outpoint := wire.OutPoint{Hash: funding.Hash, Index: 0}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	start := time.Now()
+	for i := 0; i < b.N; i++ {
+		_, err := wallet.CreateSimpleTx(
+			&waddrmgr.KeyScopeBIP0084, waddrmgr.DefaultAccountNum,
+			[]*wire.TxOut{wire.NewTxOut(100_000, destinationScript)}, 0,
+			1_000, CoinSelectionLargest, false,
+			WithCustomSelectUtxos([]wire.OutPoint{outpoint}),
+		)
+		if err != nil {
+			b.Fatalf("create transaction: %v", err)
+		}
+	}
+	operationNanos := time.Since(start).Nanoseconds()
+	b.StopTimer()
+
+	b.ReportMetric(
+		float64(operationNanos)/float64(b.N),
+		"monolithic-hold-estimate-ns/op",
+	)
+	b.ReportMetric(
+		float64(timedStore.viewNanos.Load())/float64(b.N),
+		"split-read-tx-ns/op",
+	)
+	b.ReportMetric(
+		float64(timedStore.updateNanos.Load())/float64(b.N),
+		"split-write-tx-ns/op",
+	)
+}
+
+// benchmarkSalvageManagerOpenSplit measures detached snapshot reads and manager
+// reconstruction separately for a fixed number of durable keys.
+func benchmarkSalvageManagerOpenSplit(b *testing.B, numKeys int) {
+	b.StopTimer()
+	fixture := newSalvageBenchmarkFixture(b)
+	var lndWallet Interface = fixture.wallet
+	for i := 0; i < numKeys; i++ {
+		_, _, err := lndWallet.NextExternalKey(
+			salvageBenchmarkScope, salvageBenchmarkAccount,
+		)
+		if err != nil {
+			b.Fatalf("preallocate external key %d: %v", i, err)
+		}
+	}
+	fixture.close(b)
+
+	conn, err := storesqlite.Open(context.Background(), storesqlite.Config{
+		DBPath: fixture.dbPath,
+	})
+	if err != nil {
+		b.Fatalf("reopen SQLite fixture: %v", err)
+	}
+	fixture.conn = conn
+	store := dbsqlite.NewNamedStore(conn, salvageBenchmarkWalletName)
+
+	var (
+		snapshotElapsed    time.Duration
+		reconstructElapsed time.Duration
+	)
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		var snapshot *waddrmgr.ManagerSnapshot
+		start := time.Now()
+		err := store.View(
+			b.Context(), func(tx walletstore.ReadTx) error {
+				var err error
+				snapshot, err = waddrmgr.ReadManagerSnapshot(tx.Addr())
+				return err
+			}, func() {
+				snapshot = nil
+			},
+		)
+		snapshotElapsed += time.Since(start)
+		if err != nil {
+			b.Fatalf("read manager snapshot: %v", err)
+		}
+
+		start = time.Now()
+		manager, err := waddrmgr.OpenFromSnapshot(
+			snapshot, []byte(salvageBenchmarkPubPass),
+			&chaincfg.TestNet3Params,
+		)
+		reconstructElapsed += time.Since(start)
+		if err != nil {
+			b.Fatalf("reconstruct manager: %v", err)
+		}
+		manager.Close()
+	}
+	b.StopTimer()
+
+	b.ReportMetric(
+		float64(snapshotElapsed.Nanoseconds())/float64(b.N),
+		"snapshot-read-ns/op",
+	)
+	b.ReportMetric(
+		float64(reconstructElapsed.Nanoseconds())/float64(b.N),
+		"reconstruct-ns/op",
+	)
+}
+
+// benchmarkSalvageSequentialExternalKey measures durable external public-key
+// allocation through the backend-neutral wallet interface.
+func benchmarkSalvageSequentialExternalKey(b *testing.B) {
+	b.StopTimer()
+	fixture := newSalvageBenchmarkFixture(b)
+	var lndWallet Interface = fixture.wallet
+
+	var (
+		lastKey   *btcec.PublicKey
+		lastIndex uint32
+		err       error
+	)
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		lastKey, lastIndex, err = lndWallet.NextExternalKey(
+			salvageBenchmarkScope, salvageBenchmarkAccount,
+		)
+		if err != nil {
+			b.Fatalf("allocate external key: %v", err)
+		}
+	}
+	b.StopTimer()
+
+	if lastKey == nil {
+		b.Fatal("external allocation returned a nil public key")
+	}
+	if lastIndex != uint32(b.N-1) {
+		b.Fatalf("last external index: got %d, want %d", lastIndex, b.N-1)
+	}
+}
+
+// benchmarkSalvageConcurrentExternalKey measures contended durable key
+// allocation and validates all returned indexes after timed work.
+func benchmarkSalvageConcurrentExternalKey(b *testing.B) {
+	b.StopTimer()
+	fixture := newSalvageBenchmarkFixture(b)
+	var lndWallet Interface = fixture.wallet
+
+	results := make([]salvageBenchmarkKeyResult, b.N)
+	var resultIndex atomic.Uint64
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.StartTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			key, index, err := lndWallet.NextExternalKey(
+				salvageBenchmarkScope, salvageBenchmarkAccount,
+			)
+			slot := resultIndex.Add(1) - 1
+			result := salvageBenchmarkKeyResult{
+				index: index,
+				err:   err,
+			}
+			if err == nil && key != nil {
+				copy(result.publicKey[:], key.SerializeCompressed())
+			}
+			results[slot] = result
+		}
+	})
+	b.StopTimer()
+
+	if resultIndex.Load() != uint64(b.N) {
+		b.Fatalf("parallel result count: got %d, want %d",
+			resultIndex.Load(), b.N)
+	}
+	indexes := make(map[uint32]struct{}, b.N)
+	publicKeys := make(map[[33]byte]struct{}, b.N)
+	for i, result := range results {
+		if result.err != nil {
+			b.Fatalf("parallel allocation %d: %v", i, result.err)
+		}
+		if result.publicKey == [33]byte{} {
+			b.Fatalf("parallel allocation %d returned a nil key", i)
+		}
+		if _, ok := indexes[result.index]; ok {
+			b.Fatalf("duplicate external index %d", result.index)
+		}
+		indexes[result.index] = struct{}{}
+		if _, ok := publicKeys[result.publicKey]; ok {
+			b.Fatalf("duplicate external public key at result %d", i)
+		}
+		publicKeys[result.publicKey] = struct{}{}
+	}
+	for i := 0; i < b.N; i++ {
+		if _, ok := indexes[uint32(i)]; !ok {
+			b.Fatalf("missing external index %d", i)
+		}
+	}
+}
+
+// benchmarkSalvagePublicDerivation measures arbitrary public derivation for a
+// fixed existing lnd account and path.
+func benchmarkSalvagePublicDerivation(b *testing.B) {
+	b.StopTimer()
+	fixture := newSalvageBenchmarkFixture(b)
+	var lndWallet Interface = fixture.wallet
+
+	var (
+		publicKey *btcec.PublicKey
+		err       error
+	)
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		publicKey, err = lndWallet.DeriveManagedPubKey(
+			salvageBenchmarkScope, salvageBenchmarkPath,
+		)
+		if err != nil {
+			b.Fatalf("derive managed public key: %v", err)
+		}
+	}
+	b.StopTimer()
+
+	if publicKey == nil {
+		b.Fatal("public derivation returned a nil key")
+	}
+}
+
+// benchmarkSalvagePrivateDerivation measures private derivation for the fixed
+// existing lnd account and path.
+func benchmarkSalvagePrivateDerivation(b *testing.B) {
+	b.StopTimer()
+	fixture := newSalvageBenchmarkFixture(b)
+	var lndWallet Interface = fixture.wallet
+
+	var (
+		privateKey *btcec.PrivateKey
+		err        error
+	)
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		privateKey, err = lndWallet.DeriveFromKeyPath(
+			salvageBenchmarkScope, salvageBenchmarkPath,
+		)
+		if err != nil {
+			b.Fatalf("derive private key: %v", err)
+		}
+	}
+	b.StopTimer()
+
+	if privateKey == nil {
+		b.Fatal("private derivation returned a nil key")
+	}
+}
+
+// benchmarkSalvageSigning measures fixed-path private derivation followed by
+// deterministic ECDSA signing.
+func benchmarkSalvageSigning(b *testing.B) {
+	b.StopTimer()
+	fixture := newSalvageBenchmarkFixture(b)
+	var lndWallet Interface = fixture.wallet
+	hash := sha256.Sum256([]byte("sqlite route benchmark"))
+
+	var (
+		privateKey *btcec.PrivateKey
+		signature  *ecdsa.Signature
+		err        error
+	)
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		privateKey, err = lndWallet.DeriveFromKeyPath(
+			salvageBenchmarkScope, salvageBenchmarkPath,
+		)
+		if err != nil {
+			b.Fatalf("derive signing key: %v", err)
+		}
+		signature = ecdsa.Sign(privateKey, hash[:])
+	}
+	b.StopTimer()
+
+	if signature == nil || !signature.Verify(hash[:], privateKey.PubKey()) {
+		b.Fatal("private derivation produced an invalid signature")
+	}
+}
+
+// benchmarkSalvageRestartOpen measures connection and wallet open after a
+// fixed number of durable allocations. Preallocation and shutdown are untimed.
+func benchmarkSalvageRestartOpen(b *testing.B, numKeys int) {
+	b.StopTimer()
+	fixture := newSalvageBenchmarkFixture(b)
+	var lndWallet Interface = fixture.wallet
+	for i := 0; i < numKeys; i++ {
+		_, _, err := lndWallet.NextExternalKey(
+			salvageBenchmarkScope, salvageBenchmarkAccount,
+		)
+		if err != nil {
+			b.Fatalf("preallocate external key %d: %v", i, err)
+		}
+	}
+	fixture.close(b)
+
+	info, err := os.Stat(fixture.dbPath)
+	if err != nil {
+		b.Fatalf("stat SQLite fixture: %v", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	var (
+		openElapsed time.Duration
+		viewElapsed time.Duration
+	)
+	for i := 0; i < b.N; i++ {
+		start := time.Now()
+		b.StartTimer()
+		lndWallet = fixture.openExisting(b)
+		b.StopTimer()
+		openElapsed += time.Since(start)
+		viewElapsed += fixture.openViewElapsed
+
+		if lndWallet.Database() != nil {
+			b.Fatal("Store-backed wallet exposed a walletdb database")
+		}
+		fixture.close(b)
+	}
+	b.ReportMetric(float64(info.Size()), "bytes/file")
+	b.ReportMetric(
+		float64(openElapsed.Nanoseconds())/float64(b.N),
+		"open-ns/op",
+	)
+	b.ReportMetric(
+		float64(viewElapsed.Nanoseconds())/float64(b.N),
+		"store-view-ns/op",
+	)
+}
+
+// benchmarkSalvageControllerSync adds real-btcd full-block rows matching the
+// role benchmark hierarchy. This candidate has no compact-filter controller.
+func benchmarkSalvageControllerSync(b *testing.B) {
+	for _, numBlocks := range []uint32{10, 100} {
+		name := fmt.Sprintf("ControllerSync/Blocks-%d", numBlocks)
+		b.Run(name, func(b *testing.B) {
+			b.Run("FullBlocks", func(b *testing.B) {
+				if os.Getenv("BTCWALLET_REAL_BTCD") != "1" {
+					b.Skip("set BTCWALLET_REAL_BTCD=1 to run btcd")
+				}
+
+				benchmarkSalvageRealBTCDSync(b, numBlocks)
+			})
+		})
+	}
+}
+
+// benchmarkSalvageRealBTCDSync times only synchronization from genesis to a
+// pre-mined real-btcd tip, using a fresh SQLite wallet for every iteration.
+func benchmarkSalvageRealBTCDSync(b *testing.B, numBlocks uint32) {
+	b.StopTimer()
+	params := &chaincfg.RegressionNetParams
+	miner, err := rpctest.New(params, nil, nil, "")
+	if err != nil {
+		b.Fatalf("create btcd harness: %v", err)
+	}
+	if err := miner.SetUp(false, 0); err != nil {
+		_ = miner.TearDown()
+		b.Fatalf("start btcd harness: %v", err)
+	}
+	defer func() {
+		if err := miner.TearDown(); err != nil {
+			b.Errorf("tear down btcd harness: %v", err)
+		}
+	}()
+
+	if _, err := miner.Client.Generate(numBlocks); err != nil {
+		b.Fatalf("mine %d empty blocks: %v", numBlocks, err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		fixture := newSalvageBenchmarkFixtureForParams(b, params)
+		rpcConfig := miner.RPCConfig()
+		client, err := chain.NewRPCClientWithConfig(&chain.RPCClientConfig{
+			Conn:              &rpcConfig,
+			Chain:             params,
+			ReconnectAttempts: 3,
+		})
+		if err != nil {
+			b.Fatalf("create btcd RPC client: %v", err)
+		}
+		if err := client.Start(b.Context()); err != nil {
+			b.Fatalf("start btcd RPC client: %v", err)
+		}
+
+		b.StartTimer()
+		fixture.wallet.SynchronizeRPC(client)
+		deadline := time.Now().Add(30 * time.Second)
+		for !fixture.wallet.ChainSynced() ||
+			fixture.wallet.SyncedTo().Height != int32(numBlocks) {
+
+			if time.Now().After(deadline) {
+				b.StopTimer()
+				b.Fatalf("wallet did not sync to height %d", numBlocks)
+			}
+			time.Sleep(time.Millisecond)
+		}
+		b.StopTimer()
+
+		fixture.close(b)
+	}
+}
+
+// newSalvageBenchmarkFixtureForParams creates a deterministic Store wallet for
+// the real-btcd benchmark without allocating keys before synchronization.
+func newSalvageBenchmarkFixtureForParams(b *testing.B,
+	params *chaincfg.Params) *salvageBenchmarkFixture {
+
+	b.Helper()
+	dbPath := filepath.Join(b.TempDir(), "wallet.sqlite")
+	conn, err := storesqlite.Open(context.Background(), storesqlite.Config{
+		DBPath: dbPath,
+	})
+	if err != nil {
+		b.Fatalf("open sync SQLite fixture: %v", err)
+	}
+	if err := storesqlite.ApplyMigrations(conn); err != nil {
+		_ = conn.Close()
+		b.Fatalf("apply sync SQLite migrations: %v", err)
+	}
+
+	store := dbsqlite.NewNamedStore(conn, salvageBenchmarkWalletName)
+	loader, err := NewLoaderWithStore(params, 0, store)
+	if err != nil {
+		_ = conn.Close()
+		b.Fatalf("create sync Store loader: %v", err)
+	}
+	wallet, err := loader.CreateNewWallet(
+		[]byte(salvageBenchmarkPubPass),
+		[]byte(salvageBenchmarkPrivPass), salvageBenchmarkSeed[:],
+		params.GenesisBlock.Header.Timestamp,
+	)
+	if err != nil {
+		_ = conn.Close()
+		b.Fatalf("create sync SQLite wallet: %v", err)
+	}
+
+	fixture := &salvageBenchmarkFixture{
+		dbPath: dbPath,
+		conn:   conn,
+		loader: loader,
+		wallet: wallet,
+	}
+	b.Cleanup(func() {
+		fixture.close(b)
+	})
+
+	return fixture
+}

--- a/wallet/salvage_contention_benchmark_test.go
+++ b/wallet/salvage_contention_benchmark_test.go
@@ -1,0 +1,601 @@
+package wallet
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btcwallet/chain"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	walletstore "github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+)
+
+const salvageContentionTimeout = 2 * time.Second
+
+// salvageContentionStore counts one-shot writer calls and SQLite contention
+// results without changing the delegated transaction behavior.
+type salvageContentionStore struct {
+	// Store delegates the measured transaction execution.
+	walletstore.Store
+
+	updateCalls atomic.Int64
+	busyEvents  atomic.Int64
+}
+
+// UpdateOnce records writer calls and retryable SQLite contention results.
+func (s *salvageContentionStore) UpdateOnce(ctx context.Context,
+	body func(walletstore.ReadWriteTx) error, reset func()) error {
+
+	s.updateCalls.Add(1)
+	err := s.Store.UpdateOnce(ctx, body, reset)
+	var retryable *walletstore.RetryableTransactionError
+	if errors.As(err, &retryable) {
+		s.busyEvents.Add(1)
+	}
+
+	return err
+}
+
+// salvageFundingBenchmarkFixture owns the common spend used by blocked and
+// mixed funding measurements.
+type salvageFundingBenchmarkFixture struct {
+	fixture          *salvageBenchmarkFixture
+	output           *wire.TxOut
+	outpoint         wire.OutPoint
+	startExternal    uint32
+	startInternal    uint32
+	notificationSink *splitChainClient
+}
+
+// newSalvageFundingBenchmarkFixture creates one repeatable SQLite funding
+// workload. Authored transactions are not published, so the UTXO stays usable.
+func newSalvageFundingBenchmarkFixture(
+	b *testing.B) *salvageFundingBenchmarkFixture {
+
+	b.Helper()
+	fixture := newSalvageBenchmarkFixture(b)
+	wallet := fixture.wallet
+	wallet.chainClient = &mockChainClient{}
+
+	receive, err := wallet.NewAddress(
+		waddrmgr.DefaultAccountNum, waddrmgr.KeyScopeBIP0084,
+	)
+	if err != nil {
+		b.Fatalf("allocate funding address: %v", err)
+	}
+	prevScript, err := txscript.PayToAddrScript(receive)
+	if err != nil {
+		b.Fatalf("create funding script: %v", err)
+	}
+	fundingTx := wire.NewMsgTx(2)
+	fundingTx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash:  chainhash.Hash{0x61},
+		Index: 1,
+	}})
+	fundingTx.AddTxOut(wire.NewTxOut(1_000_000, prevScript))
+	funding, err := wtxmgr.NewTxRecordFromMsgTx(
+		fundingTx, time.Unix(1_700_000_100, 0),
+	)
+	if err != nil {
+		b.Fatalf("create funding record: %v", err)
+	}
+	if err := wallet.store.UpdateOnce(
+		b.Context(), func(tx walletstore.ReadWriteTx) error {
+			return wallet.addRelevantTxFromStore(tx, funding, nil)
+		}, nil,
+	); err != nil {
+
+		b.Fatalf("insert funding transaction: %v", err)
+	}
+
+	destination, err := txscript.PayToAddrScript(receive)
+	if err != nil {
+		b.Fatalf("create destination script: %v", err)
+	}
+	startExternal, startInternal := salvageBenchmarkAccountIndexes(
+		b, wallet.store, waddrmgr.KeyScopeBIP0084,
+		waddrmgr.DefaultAccountNum,
+	)
+	notificationSink := &splitChainClient{
+		mockChainClient: &mockChainClient{},
+	}
+	wallet.chainClient = notificationSink
+
+	return &salvageFundingBenchmarkFixture{
+		fixture:          fixture,
+		output:           wire.NewTxOut(100_000, destination),
+		outpoint:         wire.OutPoint{Hash: funding.Hash, Index: 0},
+		startExternal:    startExternal,
+		startInternal:    startInternal,
+		notificationSink: notificationSink,
+	}
+}
+
+// createSimpleTx authors one transaction against the fixture's reusable UTXO.
+func (f *salvageFundingBenchmarkFixture) createSimpleTx(
+	strategy CoinSelectionStrategy,
+	options ...TxCreateOption) (*wire.MsgTx, error) {
+
+	authored, err := f.fixture.wallet.CreateSimpleTx(
+		&waddrmgr.KeyScopeBIP0084, waddrmgr.DefaultAccountNum,
+		[]*wire.TxOut{{
+			Value:    f.output.Value,
+			PkScript: append([]byte(nil), f.output.PkScript...),
+		}}, 0, 1_000, strategy, false, options...,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return authored.Tx, nil
+}
+
+// salvageBenchmarkAccountIndexes reads the durable branch indexes used to
+// validate mixed-writer allocation continuity after timing stops.
+func salvageBenchmarkAccountIndexes(b *testing.B, store walletstore.Store,
+	scope waddrmgr.KeyScope, account uint32) (uint32, uint32) {
+
+	b.Helper()
+	var state waddrmgr.AccountState
+	err := store.View(b.Context(), func(tx walletstore.ReadTx) error {
+		var err error
+		state, err = tx.Addr().Account(scope, account)
+		return err
+	}, func() {
+		state = waddrmgr.AccountState{}
+	})
+	if err != nil {
+		b.Fatalf("read benchmark account indexes: %v", err)
+	}
+
+	return state.NextExternalIndex, state.NextInternalIndex
+}
+
+// salvageDurationPercentile returns the nearest-rank latency percentile.
+func salvageDurationPercentile(values []time.Duration,
+	percentile int) time.Duration {
+
+	ordered := append([]time.Duration(nil), values...)
+	sort.Slice(ordered, func(i, j int) bool {
+		return ordered[i] < ordered[j]
+	})
+	rank := (len(ordered)*percentile + 99) / 100
+	if rank < 1 {
+		rank = 1
+	}
+
+	return ordered[rank-1]
+}
+
+// salvageBlockedRun starts one wallet operation that announces when its
+// selected external seam has blocked.
+type salvageBlockedRun func(started, release chan struct{}) <-chan error
+
+// benchmarkSalvageBlockedWrite measures an unrelated same-wallet write while
+// the selected wallet seam is blocked outside a Store transaction.
+func benchmarkSalvageBlockedWrite(b *testing.B, store walletstore.Store,
+	prepare func() error, run salvageBlockedRun) {
+
+	b.Helper()
+	durations := make([]time.Duration, b.N)
+	var busyEvents int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if prepare != nil {
+			if err := prepare(); err != nil {
+				b.Fatalf("prepare blocked operation: %v", err)
+			}
+		}
+
+		started := make(chan struct{})
+		release := make(chan struct{})
+		result := run(started, release)
+		select {
+		case <-started:
+
+		case <-time.After(salvageContentionTimeout):
+			close(release)
+			b.Fatal("wallet seam did not block")
+		}
+
+		start := time.Now()
+		err := store.UpdateOnce(
+			b.Context(), func(tx walletstore.ReadWriteTx) error {
+				return tx.Addr().SetBirthday(
+					time.Unix(1_700_001_000+int64(i), 0),
+				)
+			}, nil,
+		)
+		durations[i] = time.Since(start)
+		var retryable *walletstore.RetryableTransactionError
+		if errors.As(err, &retryable) {
+			busyEvents++
+		}
+		close(release)
+		if err != nil {
+			b.Fatalf("unrelated SQLite write: %v", err)
+		}
+
+		select {
+		case err := <-result:
+			if err != nil {
+				b.Fatalf("blocked wallet operation: %v", err)
+			}
+
+		case <-time.After(salvageContentionTimeout):
+			b.Fatal("released wallet operation did not finish")
+		}
+	}
+	b.StopTimer()
+
+	b.ReportMetric(float64(salvageDurationPercentile(
+		durations, 50,
+	).Microseconds()), "write-p50-us")
+	b.ReportMetric(float64(salvageDurationPercentile(
+		durations, 100,
+	).Microseconds()), "write-max-us")
+	b.ReportMetric(float64(busyEvents), "sqlite-busy/run")
+}
+
+// BenchmarkSQLiteBlockedSeamContention measures same-wallet writes while each
+// external, policy, or cryptographic seam is deliberately blocked.
+func BenchmarkSQLiteBlockedSeamContention(b *testing.B) {
+	useSalvageBenchmarkScrypt(b)
+
+	b.Run("FilterBlocks", benchmarkSalvageFilterBlocksContention)
+	b.Run("GetBlockHeader", benchmarkSalvageGetBlockHeaderContention)
+	b.Run("NotifyReceived", benchmarkSalvageNotifyReceivedContention)
+	b.Run("AllowUtxo", benchmarkSalvageAllowUtxoContention)
+	b.Run("CoinStrategy", benchmarkSalvageCoinStrategyContention)
+	b.Run("Signing", benchmarkSalvageSigningContention)
+}
+
+// benchmarkSalvageFilterBlocksContention blocks recovery filtering after its
+// durable snapshot and lookahead preparation have completed.
+func benchmarkSalvageFilterBlocksContention(b *testing.B) {
+	b.StopTimer()
+	fixture := newSalvageBenchmarkFixture(b)
+	wallet := fixture.wallet
+	params := &chaincfg.TestNet3Params
+	header := wire.BlockHeader{
+		Version:   1,
+		PrevBlock: params.GenesisBlock.BlockHash(),
+		Timestamp: params.GenesisBlock.Header.Timestamp.Add(time.Minute),
+		Nonce:     1,
+	}
+	hash := header.BlockHash()
+	block := wtxmgr.BlockMeta{
+		Block: wtxmgr.Block{Hash: hash, Height: 1},
+		Time:  header.Timestamp,
+	}
+	stamp := &waddrmgr.BlockStamp{
+		Hash: hash, Height: 1, Timestamp: header.Timestamp,
+	}
+	managers := make(map[waddrmgr.KeyScope]*waddrmgr.ScopedKeyManager)
+	for _, manager := range wallet.Manager.ActiveScopedKeyManagers() {
+		managers[manager.Scope()] = manager
+	}
+	client := &mockChainClient{getBlockHeader: &header}
+
+	benchmarkSalvageBlockedWrite(
+		b, wallet.store, nil,
+		func(started, release chan struct{}) <-chan error {
+			client.filterBlocksFunc = func(*chain.FilterBlocksRequest) (
+				*chain.FilterBlocksResponse, error) {
+
+				close(started)
+				<-release
+				return nil, nil
+			}
+			result := make(chan error, 1)
+			go func() {
+				_, err := wallet.prepareRecoveryStorePlan(
+					client, NewRecoveryState(1),
+					[]wtxmgr.BlockMeta{block},
+					[]*waddrmgr.BlockStamp{stamp}, managers,
+				)
+				result <- err
+			}()
+
+			return result
+		},
+	)
+}
+
+// benchmarkSalvageGetBlockHeaderContention blocks parent-header retrieval
+// during a Store-backed disconnect after its read snapshot has closed.
+func benchmarkSalvageGetBlockHeaderContention(b *testing.B) {
+	b.StopTimer()
+	fixture := newSalvageBenchmarkFixture(b)
+	wallet := fixture.wallet
+	hashes, headers := syncTestChain(&chaincfg.TestNet3Params, 1)
+	block := wtxmgr.BlockMeta{
+		Block: wtxmgr.Block{Hash: hashes[1], Height: 1},
+		Time:  headers[hashes[1]].Timestamp,
+	}
+	wallet.SetChainSynced(true)
+	client := &mockChainClient{}
+	prepare := func() error {
+		return wallet.store.UpdateOnce(
+			b.Context(), func(tx walletstore.ReadWriteTx) error {
+				return wallet.connectBlockFromStore(tx, block)
+			}, nil,
+		)
+	}
+
+	benchmarkSalvageBlockedWrite(
+		b, wallet.store, prepare,
+		func(started, release chan struct{}) <-chan error {
+			client.getBlockHeaderFunc = func(hash *chainhash.Hash) (
+				*wire.BlockHeader, error) {
+
+				close(started)
+				<-release
+				header := headers[*hash]
+				return &header, nil
+			}
+			result := make(chan error, 1)
+			go func() {
+				_, err := wallet.disconnectBlockFromStore(client, block)
+				result <- err
+			}()
+
+			return result
+		},
+	)
+}
+
+// benchmarkSalvageNotifyReceivedContention blocks post-commit watcher
+// registration while another same-wallet write executes.
+func benchmarkSalvageNotifyReceivedContention(b *testing.B) {
+	b.StopTimer()
+	fixture := newSalvageFundingBenchmarkFixture(b)
+	wallet := fixture.fixture.wallet
+
+	benchmarkSalvageBlockedWrite(
+		b, wallet.store, nil,
+		func(started, release chan struct{}) <-chan error {
+			client := &splitChainClient{
+				mockChainClient: &mockChainClient{},
+				started:         started,
+				release:         release,
+			}
+			wallet.chainClient = client
+			result := make(chan error, 1)
+			go func() {
+				_, err := fixture.createSimpleTx(CoinSelectionLargest)
+				if err == nil && client.notifications.Load() != 1 {
+					err = fmt.Errorf("watcher calls: got %d, want 1",
+						client.notifications.Load())
+				}
+				result <- err
+			}()
+
+			return result
+		},
+	)
+}
+
+// benchmarkSalvageAllowUtxoContention blocks caller UTXO policy after the
+// funding snapshot has closed.
+func benchmarkSalvageAllowUtxoContention(b *testing.B) {
+	b.StopTimer()
+	fixture := newSalvageFundingBenchmarkFixture(b)
+	wallet := fixture.fixture.wallet
+
+	benchmarkSalvageBlockedWrite(
+		b, wallet.store, nil,
+		func(started, release chan struct{}) <-chan error {
+			var once sync.Once
+			result := make(chan error, 1)
+			go func() {
+				_, err := fixture.createSimpleTx(
+					CoinSelectionLargest,
+					WithUtxoFilter(func(wtxmgr.Credit) bool {
+						once.Do(func() { close(started) })
+						<-release
+						return true
+					}),
+				)
+				result <- err
+			}()
+
+			return result
+		},
+	)
+}
+
+// benchmarkSalvageCoinStrategyContention blocks caller coin ordering after the
+// funding snapshot has closed.
+func benchmarkSalvageCoinStrategyContention(b *testing.B) {
+	b.StopTimer()
+	fixture := newSalvageFundingBenchmarkFixture(b)
+	wallet := fixture.fixture.wallet
+
+	benchmarkSalvageBlockedWrite(
+		b, wallet.store, nil,
+		func(started, release chan struct{}) <-chan error {
+			var once sync.Once
+			strategy := fundingStrategyFunc(func(coins []Coin,
+				_ btcutil.Amount) ([]Coin, error) {
+
+				once.Do(func() { close(started) })
+				<-release
+				return coins, nil
+			})
+			result := make(chan error, 1)
+			go func() {
+				_, err := fixture.createSimpleTx(strategy)
+				result <- err
+			}()
+
+			return result
+		},
+	)
+}
+
+// benchmarkSalvageSigningContention blocks transaction signing after all
+// durable funding and key material has been detached.
+func benchmarkSalvageSigningContention(b *testing.B) {
+	b.StopTimer()
+	fixture := newSalvageFundingBenchmarkFixture(b)
+	wallet := fixture.fixture.wallet
+
+	benchmarkSalvageBlockedWrite(
+		b, wallet.store, nil,
+		func(started, release chan struct{}) <-chan error {
+			var once sync.Once
+			previous := activeStoreTxObserver.Swap(&storeTxObserver{
+				observe: func(stage storeTxStage) {
+					if stage != storeTxStageSigning {
+						return
+					}
+					once.Do(func() { close(started) })
+					<-release
+				},
+			})
+			result := make(chan error, 1)
+			go func() {
+				defer activeStoreTxObserver.Store(previous)
+				_, err := fixture.createSimpleTx(CoinSelectionLargest)
+				result <- err
+			}()
+
+			return result
+		},
+	)
+}
+
+// BenchmarkSQLiteMixedWalletWriters runs equal external-key and funding
+// writers against one SQLite wallet and one BIP84 account.
+func BenchmarkSQLiteMixedWalletWriters(b *testing.B) {
+	useSalvageBenchmarkScrypt(b)
+	b.StopTimer()
+	fixture := newSalvageFundingBenchmarkFixture(b)
+	wallet := fixture.fixture.wallet
+	store := &salvageContentionStore{Store: wallet.store}
+	wallet.store = store
+
+	externalCount := b.N / 2
+	fundingCount := b.N - externalCount
+	externalResults := make([]salvageBenchmarkKeyResult, externalCount)
+	externalDurations := make([]time.Duration, externalCount)
+	fundingDurations := make([]time.Duration, fundingCount)
+	fundingErrors := make([]error, fundingCount)
+	start := make(chan struct{})
+	var ready sync.WaitGroup
+	var workers sync.WaitGroup
+	ready.Add(2)
+	workers.Add(2)
+	go func() {
+		defer workers.Done()
+		ready.Done()
+		<-start
+		for i := 0; i < externalCount; i++ {
+			begin := time.Now()
+			key, index, err := wallet.NextExternalKey(
+				waddrmgr.KeyScopeBIP0084,
+				waddrmgr.DefaultAccountNum,
+			)
+			externalDurations[i] = time.Since(begin)
+			externalResults[i] = salvageBenchmarkKeyResult{
+				index: index,
+				err:   err,
+			}
+			if err == nil && key != nil {
+				copy(externalResults[i].publicKey[:],
+					key.SerializeCompressed())
+			}
+		}
+	}()
+	go func() {
+		defer workers.Done()
+		ready.Done()
+		<-start
+		for i := 0; i < fundingCount; i++ {
+			begin := time.Now()
+			_, fundingErrors[i] = fixture.createSimpleTx(
+				CoinSelectionLargest,
+			)
+			fundingDurations[i] = time.Since(begin)
+		}
+	}()
+	ready.Wait()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	begin := time.Now()
+	close(start)
+	workers.Wait()
+	elapsed := time.Since(begin)
+	b.StopTimer()
+
+	publicKeys := make(map[[33]byte]struct{}, externalCount)
+	for i, result := range externalResults {
+		if result.err != nil {
+			b.Fatalf("external allocation %d: %v", i, result.err)
+		}
+		wantIndex := fixture.startExternal + uint32(i)
+		if result.index != wantIndex {
+			b.Fatalf("external index %d: got %d, want %d", i,
+				result.index, wantIndex)
+		}
+		if _, ok := publicKeys[result.publicKey]; ok {
+			b.Fatalf("duplicate external key at allocation %d", i)
+		}
+		publicKeys[result.publicKey] = struct{}{}
+	}
+	for i, err := range fundingErrors {
+		if err != nil {
+			b.Fatalf("funding operation %d: %v", i, err)
+		}
+	}
+	gotNotifications := fixture.notificationSink.notifications.Load()
+	if gotNotifications != int32(fundingCount) {
+
+		b.Fatalf("watcher callbacks: got %d, want %d", gotNotifications,
+			fundingCount)
+	}
+	afterExternal, afterInternal := salvageBenchmarkAccountIndexes(
+		b, store, waddrmgr.KeyScopeBIP0084,
+		waddrmgr.DefaultAccountNum,
+	)
+	wantExternal := fixture.startExternal + uint32(externalCount)
+	if afterExternal != wantExternal {
+
+		b.Fatalf("final external index: got %d, want %d",
+			afterExternal, wantExternal)
+	}
+	wantInternal := fixture.startInternal + uint32(fundingCount)
+	if afterInternal != wantInternal {
+
+		b.Fatalf("final internal index: got %d, want %d",
+			afterInternal, wantInternal)
+	}
+
+	durations := append(externalDurations, fundingDurations...)
+	retries := store.updateCalls.Load() - int64(b.N)
+	b.ReportMetric(float64(b.N)/elapsed.Seconds(), "aggregate-ops/s")
+	b.ReportMetric(float64(salvageDurationPercentile(
+		durations, 50,
+	).Microseconds()), "latency-p50-us")
+	b.ReportMetric(float64(salvageDurationPercentile(
+		durations, 95,
+	).Microseconds()), "latency-p95-us")
+	b.ReportMetric(float64(salvageDurationPercentile(
+		durations, 99,
+	).Microseconds()), "latency-p99-us")
+	b.ReportMetric(float64(store.busyEvents.Load()), "writer-busy/run")
+	b.ReportMetric(float64(retries), "writer-retries/run")
+}

--- a/wallet/sql_lifecycle_test.go
+++ b/wallet/sql_lifecycle_test.go
@@ -1,0 +1,1577 @@
+package wallet
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	walletstore "github.com/btcsuite/btcwallet/wallet/internal/db"
+	dbsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlite"
+	storesqlite "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+	"github.com/stretchr/testify/require"
+)
+
+// ambiguousCommitStore commits one selected transaction without publishing its
+// manager hooks, then reports that commit as ambiguous.
+type ambiguousCommitStore struct {
+	// Store delegates transactions not selected for ambiguity injection.
+	walletstore.Store
+
+	ambiguousNextUpdate     bool
+	ambiguousNextUpdateOnce bool
+}
+
+// Update simulates a durable replay-capable transaction whose acknowledgement
+// and commit-hook publication were lost.
+func (s *ambiguousCommitStore) Update(ctx context.Context,
+	body func(walletstore.ReadWriteTx) error, reset func()) error {
+
+	if !s.ambiguousNextUpdate {
+		return s.Store.Update(ctx, body, reset)
+	}
+
+	s.ambiguousNextUpdate = false
+
+	var hooks []func()
+
+	err := s.Store.Update(ctx, func(tx walletstore.ReadWriteTx) error {
+		return body(&capturedCommitHooksTx{
+			ReadWriteTx: tx,
+			hooks:       &hooks,
+		})
+	}, func() {
+		hooks = nil
+		if reset != nil {
+			reset()
+		}
+	})
+	if err != nil {
+		return err
+	}
+
+	return walletstore.NewAmbiguousCommitError(
+		errors.New("commit acknowledgement lost"), hooks...,
+	)
+}
+
+// UpdateOnce simulates a durable transaction whose commit acknowledgement was
+// lost before in-memory hooks could be published.
+func (s *ambiguousCommitStore) UpdateOnce(ctx context.Context,
+	body func(walletstore.ReadWriteTx) error, reset func()) error {
+
+	if !s.ambiguousNextUpdateOnce {
+		return s.Store.UpdateOnce(ctx, body, reset)
+	}
+
+	s.ambiguousNextUpdateOnce = false
+
+	err := s.Store.UpdateOnce(ctx, func(tx walletstore.ReadWriteTx) error {
+		return body(&noCommitHooksTx{ReadWriteTx: tx})
+	}, reset)
+	if err != nil {
+		return err
+	}
+
+	return &walletstore.AmbiguousCommitError{
+		Err: errors.New("commit acknowledgement lost"),
+	}
+}
+
+// noCommitHooksTx suppresses manager commit hooks while delegating all durable
+// operations to the real transaction.
+type noCommitHooksTx struct {
+	// ReadWriteTx delegates transaction operations other than Addr.
+	walletstore.ReadWriteTx
+}
+
+// Addr returns an address store that ignores commit hook registration.
+//
+//nolint:ireturn // The test wrapper implements the transaction contract.
+func (t *noCommitHooksTx) Addr() walletstore.AddrReadWriteStore {
+	return &noCommitHooksAddr{
+		AddrReadWriteStore: t.ReadWriteTx.Addr(),
+	}
+}
+
+// noCommitHooksAddr delegates durable address operations and drops cache hooks.
+type noCommitHooksAddr struct {
+	// AddrReadWriteStore delegates address operations other than OnCommit.
+	walletstore.AddrReadWriteStore
+}
+
+// OnCommit intentionally suppresses publication to simulate an ambiguous SQL
+// commit result.
+func (*noCommitHooksAddr) OnCommit(func()) {}
+
+// capturedCommitHooksTx diverts manager hooks from a durable transaction so an
+// ambiguous result can return them to the reconciliation path.
+type capturedCommitHooksTx struct {
+	// ReadWriteTx delegates transaction operations other than Addr.
+	walletstore.ReadWriteTx
+
+	hooks *[]func()
+}
+
+// Addr returns an address store that captures commit hooks for later repair.
+//
+//nolint:ireturn // The test wrapper implements the transaction contract.
+func (t *capturedCommitHooksTx) Addr() walletstore.AddrReadWriteStore {
+	return &capturedCommitHooksAddr{
+		AddrReadWriteStore: t.ReadWriteTx.Addr(),
+		hooks:              t.hooks,
+	}
+}
+
+// capturedCommitHooksAddr diverts hook registration into a test-owned slice.
+type capturedCommitHooksAddr struct {
+	// AddrReadWriteStore delegates address operations other than OnCommit.
+	walletstore.AddrReadWriteStore
+
+	hooks *[]func()
+}
+
+// OnCommit records a hook without publishing it after the underlying commit.
+func (a *capturedCommitHooksAddr) OnCommit(callback func()) {
+	*a.hooks = append(*a.hooks, callback)
+}
+
+// rejectingChainClient returns a configured broadcast failure while delegating
+// the remaining chain interface to the standard wallet test client.
+type rejectingChainClient struct {
+	*mockChainClient
+
+	err error
+}
+
+// SendRawTransaction returns the configured broadcast failure.
+func (c *rejectingChainClient) SendRawTransaction(*wire.MsgTx, bool) (
+	*chainhash.Hash, error) {
+
+	return nil, c.err
+}
+
+// TestSQLWalletCreateAccountAddressRestart verifies SQL-native creation and the
+// account and derived-address lifecycle through the existing Loader and Wallet.
+func TestSQLWalletCreateAccountAddressRestart(t *testing.T) {
+	t.Parallel()
+
+	params := &chaincfg.TestNet3Params
+	pubPass := []byte("public-pass")
+	privPass := []byte("private-pass")
+	seed, err := hdkeychain.GenerateSeed(hdkeychain.MinSeedBytes)
+	require.NoError(t, err)
+
+	dbPath := filepath.Join(t.TempDir(), "wallet.sqlite")
+	conn, err := storesqlite.Open(context.Background(), storesqlite.Config{
+		DBPath: dbPath,
+	})
+	require.NoError(t, err)
+	require.NoError(t, storesqlite.ApplyMigrations(conn))
+
+	store := dbsqlite.NewNamedStore(conn, "lifecycle")
+	loader, err := NewLoaderWithStore(params, 0, store)
+	require.NoError(t, err)
+	exists, err := loader.WalletExists()
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	wallet, err := loader.CreateNewWallet(
+		pubPass, privPass, seed, time.Unix(1_700_000_000, 0),
+	)
+	require.NoError(t, err)
+	wallet.chainClient = &mockChainClient{}
+	require.NoError(t, wallet.Unlock(privPass, nil))
+
+	scopedManager, err := wallet.Manager.FetchScopedKeyManager(
+		waddrmgr.KeyScopeBIP0084,
+	)
+	require.NoError(t, err)
+	rollbackErr := errors.New("account rollback")
+	err = store.UpdateOnce(
+		t.Context(), func(tx walletstore.ReadWriteTx) error {
+			_, _, err := scopedManager.NewAccountFromStore(
+				tx.Addr(), "rolled back",
+			)
+			if err != nil {
+				return err
+			}
+
+			return rollbackErr
+		}, nil,
+	)
+	require.ErrorIs(t, err, rollbackErr)
+	_, err = wallet.AccountNumber(
+		waddrmgr.KeyScopeBIP0084, "rolled back",
+	)
+	require.True(t, waddrmgr.IsError(err, waddrmgr.ErrAccountNotFound))
+
+	account, err := wallet.NextAccount(
+		waddrmgr.KeyScopeBIP0084, "secondary",
+	)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, account)
+	require.NoError(t, wallet.RenameAccount(
+		waddrmgr.KeyScopeBIP0084, account, "renamed",
+	))
+	accountNumber, err := wallet.AccountNumber(
+		waddrmgr.KeyScopeBIP0084, "renamed",
+	)
+	require.NoError(t, err)
+	require.Equal(t, account, accountNumber)
+
+	customScope := waddrmgr.KeyScope{Purpose: 1017, Coin: 1}
+	customSchema := waddrmgr.ScopeAddrSchema{
+		ExternalAddrType: waddrmgr.WitnessPubKey,
+		InternalAddrType: waddrmgr.TaprootPubKey,
+	}
+	_, err = wallet.AddScopeManager(customScope, customSchema)
+	require.NoError(t, err)
+
+	addresses := make([]string, 0, len(waddrmgr.DefaultKeyScopes)*2)
+	for _, scope := range waddrmgr.DefaultKeyScopes {
+		scopeAccount := uint32(waddrmgr.DefaultAccountNum)
+		if scope == waddrmgr.KeyScopeBIP0084 {
+			scopeAccount = account
+		}
+
+		external, err := wallet.NewAddress(scopeAccount, scope)
+		require.NoError(t, err)
+		addresses = append(addresses, external.String())
+
+		managed, err := wallet.AddressInfo(external)
+		require.NoError(t, err)
+		require.Equal(t, waddrmgr.ScopeAddrMap[scope].ExternalAddrType,
+			managed.AddrType())
+
+		internal, err := wallet.NewChangeAddress(scopeAccount, scope)
+		require.NoError(t, err)
+		addresses = append(addresses, internal.String())
+
+		managed, err = wallet.AddressInfo(internal)
+		require.NoError(t, err)
+		require.Equal(t, waddrmgr.ScopeAddrMap[scope].InternalAddrType,
+			managed.AddrType())
+	}
+	customExternal, err := wallet.NewAddress(
+		waddrmgr.DefaultAccountNum, customScope,
+	)
+	require.NoError(t, err)
+	addresses = append(addresses, customExternal.String())
+	customInternal, err := wallet.NewChangeAddress(
+		waddrmgr.DefaultAccountNum, customScope,
+	)
+	require.NoError(t, err)
+	addresses = append(addresses, customInternal.String())
+
+	result, err := wallet.Accounts(waddrmgr.KeyScopeBIP0084)
+	require.NoError(t, err)
+	require.Len(t, result.Accounts, 3)
+	balances, err := wallet.AccountBalances(waddrmgr.KeyScopeBIP0084, 0)
+	require.NoError(t, err)
+	require.Len(t, balances, 3)
+
+	require.NoError(t, loader.UnloadWallet())
+	require.NoError(t, conn.Close())
+
+	conn, err = storesqlite.Open(context.Background(), storesqlite.Config{
+		DBPath: dbPath,
+	})
+	require.NoError(t, err)
+	store = dbsqlite.NewNamedStore(conn, "lifecycle")
+	loader, err = NewLoaderWithStore(params, 0, store)
+	require.NoError(t, err)
+	wallet, err = loader.OpenExistingWallet(pubPass, false)
+	require.NoError(t, err)
+	wallet.chainClient = &mockChainClient{}
+	_, err = wallet.Manager.FetchScopedKeyManager(customScope)
+	require.NoError(t, err)
+
+	require.NoError(t, wallet.Unlock(privPass, nil))
+	for _, addressString := range addresses {
+		managedAddresses, err := wallet.SortedActivePaymentAddresses()
+		require.NoError(t, err)
+		require.Contains(t, managedAddresses, addressString)
+	}
+
+	props, err := wallet.AccountProperties(
+		waddrmgr.KeyScopeBIP0084, account,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "renamed", props.AccountName)
+	require.EqualValues(t, 1, props.ExternalKeyCount)
+	require.EqualValues(t, 1, props.InternalKeyCount)
+
+	require.NoError(t, loader.UnloadWallet())
+	require.NoError(t, conn.Close())
+}
+
+// TestSQLWalletPassphraseLifecycle verifies private, public, and atomic dual
+// passphrase changes remain usable across lock and restart.
+func TestSQLWalletPassphraseLifecycle(t *testing.T) {
+	t.Parallel()
+
+	params := &chaincfg.TestNet3Params
+	pubPass := []byte("public-pass")
+	privPass := []byte("private-pass")
+	newPubPass := []byte("new-public-pass")
+	newPrivPass := []byte("new-private-pass")
+	finalPubPass := []byte("final-public-pass")
+	finalPrivPass := []byte("final-private-pass")
+
+	conn, err := storesqlite.Open(
+		context.Background(), storesqlite.Config{
+			DBPath: filepath.Join(t.TempDir(), "wallet.sqlite"),
+		},
+	)
+	require.NoError(t, err)
+	require.NoError(t, storesqlite.ApplyMigrations(conn))
+
+	store := dbsqlite.NewNamedStore(conn, "passphrases")
+	loader, err := NewLoaderWithStore(params, 0, store)
+	require.NoError(t, err)
+	wallet, err := loader.CreateNewWallet(
+		pubPass, privPass, nil, time.Unix(1_700_000_000, 0),
+	)
+	require.NoError(t, err)
+	wallet.chainClient = &mockChainClient{}
+	require.NoError(t, wallet.Unlock(privPass, nil))
+
+	require.NoError(t, wallet.ChangePrivatePassphrase(
+		privPass, newPrivPass,
+	))
+	wallet.Lock()
+	require.Eventually(t, wallet.Locked, time.Second, 10*time.Millisecond)
+	err = wallet.Unlock(privPass, nil)
+	require.True(t, waddrmgr.IsError(err, waddrmgr.ErrWrongPassphrase))
+	require.NoError(t, wallet.Unlock(newPrivPass, nil))
+
+	require.NoError(t, wallet.ChangePublicPassphrase(pubPass, newPubPass))
+	require.NoError(t, wallet.ChangePassphrases(
+		newPubPass, finalPubPass, newPrivPass, finalPrivPass,
+	))
+	require.NoError(t, loader.UnloadWallet())
+
+	wrongLoader, err := NewLoaderWithStore(params, 0, store)
+	require.NoError(t, err)
+	_, err = wrongLoader.OpenExistingWallet(newPubPass, false)
+	require.True(t, waddrmgr.IsError(err, waddrmgr.ErrWrongPassphrase))
+
+	loader, err = NewLoaderWithStore(params, 0, store)
+	require.NoError(t, err)
+	wallet, err = loader.OpenExistingWallet(finalPubPass, false)
+	require.NoError(t, err)
+	wallet.chainClient = &mockChainClient{}
+	err = wallet.Unlock(newPrivPass, nil)
+	require.True(t, waddrmgr.IsError(err, waddrmgr.ErrWrongPassphrase))
+	require.NoError(t, wallet.Unlock(finalPrivPass, nil))
+
+	require.NoError(t, loader.UnloadWallet())
+	require.NoError(t, conn.Close())
+}
+
+// TestSQLWalletImportWatchOnlyRestart verifies imported key and script
+// reconstruction, lock behavior, and permanent watch-only conversion.
+func TestSQLWalletImportWatchOnlyRestart(t *testing.T) {
+	t.Parallel()
+
+	params := &chaincfg.TestNet3Params
+	pubPass := []byte("public-pass")
+	privPass := []byte("private-pass")
+	dbPath := filepath.Join(t.TempDir(), "wallet.sqlite")
+	conn, err := storesqlite.Open(context.Background(), storesqlite.Config{
+		DBPath: dbPath,
+	})
+	require.NoError(t, err)
+	require.NoError(t, storesqlite.ApplyMigrations(conn))
+
+	store := dbsqlite.NewNamedStore(conn, "imports")
+	loader, err := NewLoaderWithStore(params, 0, store)
+	require.NoError(t, err)
+	wallet, err := loader.CreateNewWallet(
+		pubPass, privPass, nil, time.Unix(1_700_000_000, 0),
+	)
+	require.NoError(t, err)
+	wallet.chainClient = &mockChainClient{}
+	require.NoError(t, wallet.Unlock(privPass, nil))
+
+	privateKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	wif, err := btcutil.NewWIF(privateKey, params, true)
+	require.NoError(t, err)
+	privateAddress, err := wallet.ImportPrivateKey(
+		waddrmgr.KeyScopeBIP0084, wif, nil, false,
+	)
+	require.NoError(t, err)
+
+	publicKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	require.NoError(t, wallet.ImportPublicKey(
+		publicKey.PubKey(), waddrmgr.TaprootPubKey,
+	))
+
+	legacyScript := []byte{txscript.OP_TRUE}
+	legacyAddress, err := wallet.ImportP2SHRedeemScript(legacyScript)
+	require.NoError(t, err)
+
+	block := &waddrmgr.BlockStamp{
+		Hash:      *params.GenesisHash,
+		Height:    0,
+		Timestamp: params.GenesisBlock.Header.Timestamp,
+	}
+	scopedManager, err := wallet.Manager.FetchScopedKeyManager(
+		waddrmgr.KeyScopeBIP0084,
+	)
+	require.NoError(t, err)
+	witnessScript := []byte{txscript.OP_TRUE, txscript.OP_DROP}
+	var witnessAddress waddrmgr.ManagedScriptAddress
+	err = store.UpdateOnce(
+		t.Context(), func(tx walletstore.ReadWriteTx) error {
+			var err error
+			witnessAddress, err =
+				scopedManager.ImportWitnessScriptFromStore(
+					tx.Addr(), witnessScript, block, 0, true,
+				)
+			return err
+		}, func() {
+			witnessAddress = nil
+		},
+	)
+	require.NoError(t, err)
+
+	taprootPrivateKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	tapscript := &waddrmgr.Tapscript{
+		Type:          waddrmgr.TaprootFullKeyOnly,
+		FullOutputKey: taprootPrivateKey.PubKey(),
+	}
+	taprootAddress, err := wallet.ImportTaprootScript(
+		waddrmgr.KeyScopeBIP0086, tapscript, block, 1, true,
+	)
+	require.NoError(t, err)
+
+	wallet.Lock()
+	require.Eventually(t, wallet.Locked, time.Second, 10*time.Millisecond)
+	_, err = witnessAddress.Script()
+	require.True(t, waddrmgr.IsError(err, waddrmgr.ErrLocked))
+	_, err = taprootAddress.(waddrmgr.ManagedScriptAddress).Script()
+	require.True(t, waddrmgr.IsError(err, waddrmgr.ErrLocked))
+	require.NoError(t, wallet.Unlock(privPass, nil))
+
+	require.NoError(t, loader.UnloadWallet())
+	require.NoError(t, conn.Close())
+
+	conn, err = storesqlite.Open(context.Background(), storesqlite.Config{
+		DBPath: dbPath,
+	})
+	require.NoError(t, err)
+	store = dbsqlite.NewNamedStore(conn, "imports")
+	loader, err = NewLoaderWithStore(params, 0, store)
+	require.NoError(t, err)
+	wallet, err = loader.OpenExistingWallet(pubPass, false)
+	require.NoError(t, err)
+	wallet.chainClient = &mockChainClient{}
+	require.NoError(t, wallet.Unlock(privPass, nil))
+
+	privateManaged, err := wallet.AddressInfo(wifAddress(t, privateAddress,
+		params))
+	require.NoError(t, err)
+	_, err = privateManaged.(waddrmgr.ManagedPubKeyAddress).PrivKey()
+	require.NoError(t, err)
+
+	legacyManaged, err := wallet.AddressInfo(legacyAddress)
+	require.NoError(t, err)
+	require.Equal(t, legacyScript,
+		requireScript(t, legacyManaged.(waddrmgr.ManagedScriptAddress)))
+	witnessManaged, err := wallet.AddressInfo(witnessAddress.Address())
+	require.NoError(t, err)
+	require.Equal(t, witnessScript,
+		requireScript(t, witnessManaged.(waddrmgr.ManagedScriptAddress)))
+	taprootManaged, err := wallet.AddressInfo(taprootAddress.Address())
+	require.NoError(t, err)
+	_, err = taprootManaged.(waddrmgr.ManagedTaprootScriptAddress).
+		TaprootScript()
+	require.NoError(t, err)
+
+	scopedManager, err = wallet.Manager.FetchScopedKeyManager(
+		waddrmgr.KeyScopeBIP0084,
+	)
+	require.NoError(t, err)
+	stopReads := make(chan struct{})
+	readErr := make(chan error, 1)
+	var readWorkers sync.WaitGroup
+	readWorkers.Add(1)
+	go func() {
+		defer readWorkers.Done()
+		for {
+			select {
+			case <-stopReads:
+				return
+
+			default:
+				_, err := wallet.AccountProperties(
+					waddrmgr.KeyScopeBIP0084,
+					waddrmgr.DefaultAccountNum,
+				)
+				if err != nil {
+					select {
+					case readErr <- err:
+					default:
+					}
+					return
+				}
+			}
+		}
+	}()
+	require.NoError(t, wallet.InitAccounts(scopedManager, true, 0))
+	close(stopReads)
+	readWorkers.Wait()
+	select {
+	case err := <-readErr:
+		require.NoError(t, err)
+
+	default:
+	}
+	require.True(t, wallet.Manager.WatchOnly())
+	_, err = privateManaged.(waddrmgr.ManagedPubKeyAddress).PrivKey()
+	require.True(t, waddrmgr.IsError(err, waddrmgr.ErrWatchingOnly))
+
+	var privateRows int
+	require.NoError(t, conn.QueryRowContext(t.Context(), `
+		SELECT
+			(SELECT COUNT(*) FROM wallets
+			 WHERE master_priv_params IS NOT NULL
+				OR encrypted_crypto_priv_key IS NOT NULL
+				OR encrypted_crypto_script_key IS NOT NULL
+				OR encrypted_master_hd_priv_key IS NOT NULL) +
+			(SELECT COUNT(*) FROM key_scopes
+			 WHERE encrypted_coin_priv_key IS NOT NULL) +
+			(SELECT COUNT(*) FROM accounts
+			 WHERE encrypted_priv_key IS NOT NULL) +
+			(SELECT COUNT(*) FROM addresses
+			 WHERE encrypted_priv_key IS NOT NULL
+				OR (is_secret_script = TRUE
+					AND encrypted_script IS NOT NULL))
+	`).Scan(&privateRows))
+	require.Zero(t, privateRows)
+
+	require.NoError(t, loader.UnloadWallet())
+	require.NoError(t, conn.Close())
+}
+
+// TestSQLWatchingOnlyWalletLifecycle verifies native watch-only creation,
+// account import, derivation, private-key downgrading, and restart.
+func TestSQLWatchingOnlyWalletLifecycle(t *testing.T) {
+	t.Parallel()
+
+	params := &chaincfg.TestNet3Params
+	pubPass := []byte("public-pass")
+	dbPath := filepath.Join(t.TempDir(), "wallet.sqlite")
+	conn, err := storesqlite.Open(context.Background(), storesqlite.Config{
+		DBPath: dbPath,
+	})
+	require.NoError(t, err)
+	require.NoError(t, storesqlite.ApplyMigrations(conn))
+
+	store := dbsqlite.NewNamedStore(conn, "watch-only")
+	loader, err := NewLoaderWithStore(params, 0, store)
+	require.NoError(t, err)
+	wallet, err := loader.CreateNewWatchingOnlyWallet(
+		pubPass, time.Unix(1_700_000_000, 0),
+	)
+	require.NoError(t, err)
+	wallet.chainClient = &mockChainClient{}
+	require.True(t, wallet.Manager.WatchOnly())
+	require.Empty(t, wallet.Manager.ActiveScopedKeyManagers())
+	err = wallet.Unlock([]byte("unused"), nil)
+	require.True(t, waddrmgr.IsError(err, waddrmgr.ErrWatchingOnly))
+
+	seed, err := hdkeychain.GenerateSeed(hdkeychain.MinSeedBytes)
+	require.NoError(t, err)
+	rootKey, err := hdkeychain.NewMaster(seed, params)
+	require.NoError(t, err)
+	defer rootKey.Zero()
+	purposeKey, err := rootKey.DeriveNonStandard(
+		waddrmgr.KeyScopeBIP0084.Purpose + hdkeychain.HardenedKeyStart,
+	)
+	require.NoError(t, err)
+	defer purposeKey.Zero()
+	coinKey, err := purposeKey.DeriveNonStandard(
+		waddrmgr.KeyScopeBIP0084.Coin + hdkeychain.HardenedKeyStart,
+	)
+	require.NoError(t, err)
+	defer coinKey.Zero()
+	accountKey, err := coinKey.DeriveNonStandard(
+		hdkeychain.HardenedKeyStart,
+	)
+	require.NoError(t, err)
+	defer accountKey.Zero()
+	accountPubKey, err := accountKey.Neuter()
+	require.NoError(t, err)
+	defer accountPubKey.Zero()
+
+	addrType := waddrmgr.WitnessPubKey
+	dryProps, external, internal, err := wallet.ImportAccountDryRun(
+		"watch account", accountPubKey, 0, &addrType, 2,
+	)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, dryProps.ExternalKeyCount)
+	require.EqualValues(t, 2, dryProps.InternalKeyCount)
+	require.Len(t, external, 2)
+	require.Len(t, internal, 2)
+	_, err = wallet.AccountNumber(
+		waddrmgr.KeyScopeBIP0084, "watch account",
+	)
+	require.True(t, waddrmgr.IsError(err, waddrmgr.ErrScopeNotFound))
+
+	props, err := wallet.ImportAccount(
+		"watch account", accountPubKey, 0, &addrType,
+	)
+	require.NoError(t, err)
+	require.True(t, props.IsWatchOnly)
+	require.Equal(t, uint32(0), props.AccountNumber)
+	watchAddress, err := wallet.NewAddress(
+		props.AccountNumber, waddrmgr.KeyScopeBIP0084,
+	)
+	require.NoError(t, err)
+
+	scopedManager, err := wallet.Manager.FetchScopedKeyManager(
+		waddrmgr.KeyScopeBIP0084,
+	)
+	require.NoError(t, err)
+	block := &waddrmgr.BlockStamp{
+		Hash:      *params.GenesisHash,
+		Height:    0,
+		Timestamp: params.GenesisBlock.Header.Timestamp,
+	}
+	publicScript := []byte{txscript.OP_TRUE, txscript.OP_TRUE}
+	var publicScriptAddress waddrmgr.ManagedScriptAddress
+	err = store.UpdateOnce(
+		t.Context(), func(tx walletstore.ReadWriteTx) error {
+			var err error
+			publicScriptAddress, err =
+				scopedManager.ImportWitnessScriptFromStore(
+					tx.Addr(), publicScript, block, 0, false,
+				)
+			return err
+		}, func() {
+			publicScriptAddress = nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, publicScript, requireScript(t, publicScriptAddress))
+
+	taprootPrivateKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	publicTapscript := &waddrmgr.Tapscript{
+		Type:          waddrmgr.TaprootFullKeyOnly,
+		FullOutputKey: taprootPrivateKey.PubKey(),
+	}
+	publicTaprootAddress, err := wallet.ImportTaprootScript(
+		waddrmgr.KeyScopeBIP0084, publicTapscript, block, 1, false,
+	)
+	require.NoError(t, err)
+
+	privateKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	wif, err := btcutil.NewWIF(privateKey, params, true)
+	require.NoError(t, err)
+	importedAddress, err := wallet.ImportPrivateKey(
+		waddrmgr.KeyScopeBIP0084, wif, nil, false,
+	)
+	require.NoError(t, err)
+	managed, err := wallet.AddressInfo(wifAddress(t, importedAddress, params))
+	require.NoError(t, err)
+	_, err = managed.(waddrmgr.ManagedPubKeyAddress).PrivKey()
+	require.True(t, waddrmgr.IsError(err, waddrmgr.ErrWatchingOnly))
+
+	require.NoError(t, loader.UnloadWallet())
+	require.NoError(t, conn.Close())
+
+	conn, err = storesqlite.Open(context.Background(), storesqlite.Config{
+		DBPath: dbPath,
+	})
+	require.NoError(t, err)
+	store = dbsqlite.NewNamedStore(conn, "watch-only")
+	loader, err = NewLoaderWithStore(params, 0, store)
+	require.NoError(t, err)
+	wallet, err = loader.OpenExistingWallet(pubPass, false)
+	require.NoError(t, err)
+	wallet.chainClient = &mockChainClient{}
+	require.True(t, wallet.Manager.WatchOnly())
+
+	have, err := wallet.HaveAddress(watchAddress)
+	require.NoError(t, err)
+	require.True(t, have)
+	have, err = wallet.HaveAddress(wifAddress(t, importedAddress, params))
+	require.NoError(t, err)
+	require.True(t, have)
+	publicManaged, err := wallet.AddressInfo(publicScriptAddress.Address())
+	require.NoError(t, err)
+	require.Equal(t, publicScript,
+		requireScript(t, publicManaged.(waddrmgr.ManagedScriptAddress)))
+	publicTaprootManaged, err := wallet.AddressInfo(
+		publicTaprootAddress.Address(),
+	)
+	require.NoError(t, err)
+	_, err = publicTaprootManaged.(waddrmgr.ManagedTaprootScriptAddress).
+		TaprootScript()
+	require.NoError(t, err)
+
+	require.NoError(t, loader.UnloadWallet())
+	require.NoError(t, conn.Close())
+}
+
+// TestSQLLifecycleCommitSafety verifies allocation rollback, ambiguous import
+// refresh, durable start-block monotonicity, and ambiguous scope attachment.
+func TestSQLLifecycleCommitSafety(t *testing.T) {
+	t.Parallel()
+
+	params := &chaincfg.TestNet3Params
+	pubPass := []byte("public-pass")
+	privPass := []byte("private-pass")
+	dbPath := filepath.Join(t.TempDir(), "wallet.sqlite")
+	conn, err := storesqlite.Open(context.Background(), storesqlite.Config{
+		DBPath: dbPath,
+	})
+	require.NoError(t, err)
+	require.NoError(t, storesqlite.ApplyMigrations(conn))
+
+	store := dbsqlite.NewNamedStore(conn, "commit-safety")
+	loader, err := NewLoaderWithStore(params, 0, store)
+	require.NoError(t, err)
+	wallet, err := loader.CreateNewWallet(
+		pubPass, privPass, nil, time.Unix(1_700_000_000, 0),
+	)
+	require.NoError(t, err)
+	wallet.chainClient = &mockChainClient{}
+	require.NoError(t, wallet.Unlock(privPass, nil))
+
+	scopedManager, err := wallet.Manager.FetchScopedKeyManager(
+		waddrmgr.KeyScopeBIP0084,
+	)
+	require.NoError(t, err)
+	rollbackErr := errors.New("rollback two allocations")
+	var attempted []address.Address
+	err = store.UpdateOnce(
+		t.Context(), func(tx walletstore.ReadWriteTx) error {
+			for range 2 {
+				managed, _, err :=
+					scopedManager.NextExternalAddressFromStore(
+						tx.Addr(), waddrmgr.DefaultAccountNum,
+					)
+				if err != nil {
+					return err
+				}
+				attempted = append(attempted, managed.Address())
+			}
+
+			return rollbackErr
+		}, func() {
+			attempted = nil
+		},
+	)
+	require.ErrorIs(t, err, rollbackErr)
+	require.Len(t, attempted, 2)
+	props, err := wallet.AccountProperties(
+		waddrmgr.KeyScopeBIP0084, waddrmgr.DefaultAccountNum,
+	)
+	require.NoError(t, err)
+	require.Zero(t, props.ExternalKeyCount)
+	first, err := wallet.NewAddress(
+		waddrmgr.DefaultAccountNum, waddrmgr.KeyScopeBIP0084,
+	)
+	require.NoError(t, err)
+	second, err := wallet.NewAddress(
+		waddrmgr.DefaultAccountNum, waddrmgr.KeyScopeBIP0084,
+	)
+	require.NoError(t, err)
+	require.Equal(t, attempted[0].String(), first.String())
+	require.Equal(t, attempted[1].String(), second.String())
+
+	seed, err := hdkeychain.GenerateSeed(hdkeychain.MinSeedBytes)
+	require.NoError(t, err)
+	rootKey, err := hdkeychain.NewMaster(seed, params)
+	require.NoError(t, err)
+	defer rootKey.Zero()
+	accountKey := rootKey
+	for _, child := range []uint32{
+		waddrmgr.KeyScopeBIP0084.Purpose + hdkeychain.HardenedKeyStart,
+		waddrmgr.KeyScopeBIP0084.Coin + hdkeychain.HardenedKeyStart,
+		hdkeychain.HardenedKeyStart,
+	} {
+		accountKey, err = accountKey.DeriveNonStandard(child)
+		require.NoError(t, err)
+	}
+	defer accountKey.Zero()
+	privateScope := waddrmgr.KeyScope{Purpose: 1_019, Coin: 1}
+	_, err = wallet.ImportAccountWithScope(
+		"private", accountKey, 0, privateScope,
+		waddrmgr.ScopeAddrMap[waddrmgr.KeyScopeBIP0084],
+	)
+	require.ErrorContains(t, err, "private keys cannot be imported")
+	_, err = wallet.Manager.FetchScopedKeyManager(privateScope)
+	require.True(t, waddrmgr.IsError(err, waddrmgr.ErrScopeNotFound))
+
+	taprootKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	tapscript := &waddrmgr.Tapscript{
+		Type:          waddrmgr.TaprootFullKeyOnly,
+		FullOutputKey: taprootKey.PubKey(),
+	}
+	for _, version := range []byte{0, 2} {
+		_, err := wallet.ImportTaprootScript(
+			waddrmgr.KeyScopeBIP0086, tapscript, nil, version, true,
+		)
+		require.ErrorContains(t, err, "invalid witness version")
+	}
+
+	highStart := waddrmgr.BlockStamp{
+		Hash:      chainhash.Hash{10},
+		Height:    10,
+		Timestamp: time.Unix(10, 0),
+	}
+	err = store.UpdateOnce(
+		t.Context(), func(tx walletstore.ReadWriteTx) error {
+			state, err := tx.Addr().SyncState()
+			if err != nil {
+				return err
+			}
+			state.StartBlock = highStart
+			return tx.Addr().PutSyncState(state)
+		}, nil,
+	)
+	require.NoError(t, err)
+	require.NoError(t, loader.UnloadWallet())
+
+	loader, err = NewLoaderWithStore(params, 0, store)
+	require.NoError(t, err)
+	wallet, err = loader.OpenExistingWallet(pubPass, false)
+	require.NoError(t, err)
+	wallet.chainClient = &mockChainClient{}
+	require.NoError(t, wallet.Unlock(privPass, nil))
+
+	ambiguousStore := &ambiguousCommitStore{
+		Store:                   store,
+		ambiguousNextUpdateOnce: true,
+	}
+	wallet.store = ambiguousStore
+	privateKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	wif, err := btcutil.NewWIF(privateKey, params, true)
+	require.NoError(t, err)
+	lowerStart := &waddrmgr.BlockStamp{
+		Hash:      chainhash.Hash{5},
+		Height:    5,
+		Timestamp: time.Unix(5, 0),
+	}
+	_, err = wallet.ImportPrivateKey(
+		waddrmgr.KeyScopeBIP0084, wif, lowerStart, false,
+	)
+	var ambiguous *walletstore.AmbiguousCommitError
+	require.ErrorAs(t, err, &ambiguous)
+
+	err = store.View(t.Context(), func(tx walletstore.ReadTx) error {
+		state, err := tx.Addr().SyncState()
+		require.NoError(t, err)
+		require.Equal(t, lowerStart.Height, state.StartBlock.Height)
+		return nil
+	}, nil)
+	require.NoError(t, err)
+
+	durableStart := waddrmgr.BlockStamp{
+		Hash:      chainhash.Hash{3},
+		Height:    3,
+		Timestamp: time.Unix(3, 0),
+	}
+	err = store.UpdateOnce(
+		t.Context(), func(tx walletstore.ReadWriteTx) error {
+			state, err := tx.Addr().SyncState()
+			if err != nil {
+				return err
+			}
+			state.StartBlock = durableStart
+			return tx.Addr().PutSyncState(state)
+		}, nil,
+	)
+	require.NoError(t, err)
+
+	secondPrivateKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	secondWIF, err := btcutil.NewWIF(secondPrivateKey, params, true)
+	require.NoError(t, err)
+	staleCacheStart := &waddrmgr.BlockStamp{
+		Hash:      chainhash.Hash{4},
+		Height:    4,
+		Timestamp: time.Unix(4, 0),
+	}
+	_, err = wallet.ImportPrivateKey(
+		waddrmgr.KeyScopeBIP0084, secondWIF, staleCacheStart, false,
+	)
+	require.NoError(t, err)
+	err = store.View(t.Context(), func(tx walletstore.ReadTx) error {
+		state, err := tx.Addr().SyncState()
+		require.NoError(t, err)
+		require.Equal(t, durableStart.Height, state.StartBlock.Height)
+		return nil
+	}, nil)
+	require.NoError(t, err)
+
+	customScope := waddrmgr.KeyScope{Purpose: 1_020, Coin: 1}
+	customSchema := waddrmgr.ScopeAddrSchema{
+		ExternalAddrType: waddrmgr.WitnessPubKey,
+		InternalAddrType: waddrmgr.TaprootPubKey,
+	}
+	ambiguousStore.ambiguousNextUpdateOnce = true
+	attached, err := wallet.AddScopeManager(customScope, customSchema)
+	require.NoError(t, err)
+	require.Equal(t, customScope, attached.Scope())
+	fetched, err := wallet.Manager.FetchScopedKeyManager(customScope)
+	require.NoError(t, err)
+	require.Same(t, attached, fetched)
+
+	require.NoError(t, loader.UnloadWallet())
+	require.NoError(t, conn.Close())
+}
+
+// TestSQLChainLifecycleEntryPoints verifies Store-backed connected, relevant,
+// and disconnected notifications mutate both manager domains without walletdb.
+func TestSQLChainLifecycleEntryPoints(t *testing.T) {
+	t.Parallel()
+
+	params := &chaincfg.TestNet3Params
+	conn, err := storesqlite.Open(
+		context.Background(), storesqlite.Config{
+			DBPath: filepath.Join(t.TempDir(), "wallet.sqlite"),
+		},
+	)
+	require.NoError(t, err)
+	require.NoError(t, storesqlite.ApplyMigrations(conn))
+
+	store := dbsqlite.NewNamedStore(conn, "chain-lifecycle")
+	loader, err := NewLoaderWithStore(params, 0, store)
+	require.NoError(t, err)
+	wallet, err := loader.CreateNewWallet(
+		[]byte("public-pass"), []byte("private-pass"), nil,
+		time.Unix(1_700_000_000, 0),
+	)
+	require.NoError(t, err)
+	client := &mockChainClient{
+		getBlockHeader: &params.GenesisBlock.Header,
+	}
+	wallet.chainClient = client
+
+	receiveAddress, err := wallet.NewAddress(
+		waddrmgr.DefaultAccountNum, waddrmgr.KeyScopeBIP0084,
+	)
+	require.NoError(t, err)
+	pkScript, err := txscript.PayToAddrScript(receiveAddress)
+	require.NoError(t, err)
+
+	block := wtxmgr.BlockMeta{
+		Block: wtxmgr.Block{
+			Hash:   chainhash.Hash{1},
+			Height: 1,
+		},
+		Time: time.Unix(1, 0),
+	}
+	ambiguousStore := &ambiguousCommitStore{
+		Store:               store,
+		ambiguousNextUpdate: true,
+	}
+	wallet.store = ambiguousStore
+	err = wallet.updateChainStore(
+		t.Context(), func(tx walletstore.ReadWriteTx) error {
+			return wallet.connectBlockFromStore(tx, block)
+		}, func(tx walletstore.ReadTx) (bool, error) {
+			return syncBlockCommitted(tx, block)
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, block.Height, wallet.Manager.SyncedTo().Height)
+
+	msgTx := wire.NewMsgTx(2)
+	msgTx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash:  chainhash.Hash{9},
+		Index: 0,
+	}})
+	msgTx.AddTxOut(&wire.TxOut{Value: 50_000, PkScript: pkScript})
+	record, err := wtxmgr.NewTxRecordFromMsgTx(msgTx, time.Unix(1, 0))
+	require.NoError(t, err)
+	err = store.UpdateOnce(
+		t.Context(), func(tx walletstore.ReadWriteTx) error {
+			return wallet.addRelevantTxFromStore(tx, record, &block)
+		}, nil,
+	)
+	require.NoError(t, err)
+
+	managed, err := wallet.AddressInfo(receiveAddress)
+	require.NoError(t, err)
+	require.True(t, managed.Used(nil))
+	wallet.SetChainSynced(true)
+	rewound, err := wallet.disconnectBlockFromStore(client, block)
+	require.NoError(t, err)
+	require.True(t, rewound)
+	require.Zero(t, wallet.Manager.SyncedTo().Height)
+
+	err = store.View(t.Context(), func(tx walletstore.ReadTx) error {
+		details, err := tx.Tx().TxDetails(&record.Hash)
+		require.NoError(t, err)
+		require.Equal(t, int32(-1), details.Block.Height)
+		return nil
+	}, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, loader.UnloadWallet())
+	require.NoError(t, conn.Close())
+}
+
+// TestSQLWalletTransactionLifecycle verifies the public transaction, balance,
+// UTXO, label, lease, and descendant-removal APIs across a SQLite restart.
+//
+//nolint:cyclop,maintidx,noinlineerr // One lifecycle covers one wallet.
+func TestSQLWalletTransactionLifecycle(t *testing.T) {
+	t.Parallel()
+
+	params := &chaincfg.TestNet3Params
+	dbPath := filepath.Join(t.TempDir(), "wallet.sqlite")
+	conn, err := storesqlite.Open(context.Background(), storesqlite.Config{
+		DBPath: dbPath,
+	})
+	require.NoError(t, err)
+	require.NoError(t, storesqlite.ApplyMigrations(conn))
+
+	store := dbsqlite.NewNamedStore(conn, "transactions")
+	loader, err := NewLoaderWithStore(params, 0, store)
+	require.NoError(t, err)
+	wallet, err := loader.CreateNewWallet(
+		[]byte("public-pass"), []byte("private-pass"), nil,
+		time.Unix(1_700_000_000, 0),
+	)
+	require.NoError(t, err)
+	wallet.chainClient = &mockChainClient{getBestBlockHeight: 1}
+
+	receiveAddress, err := wallet.NewAddress(
+		waddrmgr.DefaultAccountNum, waddrmgr.KeyScopeBIP0044,
+	)
+	require.NoError(t, err)
+	pkScript, err := txscript.PayToAddrScript(receiveAddress)
+	require.NoError(t, err)
+
+	rollbackAddress, err := wallet.NewAddress(
+		waddrmgr.DefaultAccountNum, waddrmgr.KeyScopeBIP0044,
+	)
+	require.NoError(t, err)
+	rollbackScript, err := txscript.PayToAddrScript(rollbackAddress)
+	require.NoError(t, err)
+	rollbackTx := wire.NewMsgTx(2)
+	rollbackTx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{7},
+	}})
+	rollbackTx.AddTxOut(&wire.TxOut{
+		Value: 25_000, PkScript: rollbackScript,
+	})
+	rollbackRecord, err := wtxmgr.NewTxRecordFromMsgTx(
+		rollbackTx, time.Unix(10, 0),
+	)
+	require.NoError(t, err)
+	rollbackErr := errors.New("rollback relevant transaction")
+	err = store.UpdateOnce(
+		t.Context(), func(tx walletstore.ReadWriteTx) error {
+			if err := wallet.addRelevantTxFromStore(
+				tx, rollbackRecord, nil,
+			); err != nil {
+
+				return err
+			}
+
+			return rollbackErr
+		}, nil,
+	)
+	require.ErrorIs(t, err, rollbackErr)
+	rollbackManaged, err := wallet.AddressInfo(rollbackAddress)
+	require.NoError(t, err)
+	require.False(t, rollbackManaged.Used(nil))
+	err = store.View(t.Context(), func(tx walletstore.ReadTx) error {
+		state, err := tx.Addr().Address(
+			waddrmgr.KeyScopeBIP0044, rollbackAddress.ScriptAddress(),
+		)
+		require.NoError(t, err)
+		require.False(t, state.Used)
+
+		return nil
+	}, nil)
+	require.NoError(t, err)
+	_, err = wallet.GetTransaction(rollbackRecord.Hash)
+	require.ErrorIs(t, err, ErrNoTx)
+
+	fundingTx := wire.NewMsgTx(2)
+	fundingTx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash:  chainhash.Hash{8},
+		Index: 1,
+	}})
+	fundingTx.AddTxOut(&wire.TxOut{Value: 50_000, PkScript: pkScript})
+	funding, err := wtxmgr.NewTxRecordFromMsgTx(
+		fundingTx, time.Unix(11, 0),
+	)
+	require.NoError(t, err)
+
+	spentness := wallet.NtfnServer.AccountSpentnessNotifications(0)
+	transactions := wallet.NtfnServer.TransactionNotifications()
+	updateErr := make(chan error, 1)
+	go func() {
+		updateErr <- store.UpdateOnce(
+			t.Context(), func(tx walletstore.ReadWriteTx) error {
+				return wallet.addRelevantTxFromStore(tx, funding, nil)
+			}, nil,
+		)
+	}()
+	select {
+	case notification := <-spentness.C:
+		require.Equal(t, funding.Hash, *notification.Hash())
+		require.Equal(t, uint32(0), notification.Index())
+
+	case <-time.After(time.Second):
+		t.Fatal("unspent notification not published after commit")
+	}
+	select {
+	case notification := <-transactions.C:
+		require.Len(t, notification.UnminedTransactions, 1)
+		require.Equal(
+			t, funding.Hash,
+			*notification.UnminedTransactions[0].Hash,
+		)
+
+	case <-time.After(time.Second):
+		t.Fatal("transaction notification not published after commit")
+	}
+	require.NoError(t, <-updateErr)
+	spentness.Done()
+	transactions.Done()
+
+	balance, err := wallet.CalculateBalance(0)
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(50_000), balance)
+	accountBalances, err := wallet.CalculateAccountBalances(
+		waddrmgr.DefaultAccountNum, 0,
+	)
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(50_000), accountBalances.Total)
+	require.Equal(t, btcutil.Amount(50_000), accountBalances.Spendable)
+
+	balances, err := wallet.AccountBalances(waddrmgr.KeyScopeBIP0044, 0)
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(50_000), balances[0].AccountBalance)
+	accounts, err := wallet.Accounts(waddrmgr.KeyScopeBIP0044)
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(50_000), accounts.Accounts[0].TotalBalance)
+
+	unspent, err := wallet.ListUnspent(0, 1, "")
+	require.NoError(t, err)
+	require.Len(t, unspent, 1)
+	outputs, err := wallet.UnspentOutputs(OutputSelectionPolicy{
+		Account: waddrmgr.DefaultAccountNum,
+	})
+	require.NoError(t, err)
+	require.Len(t, outputs, 1)
+
+	outpoint := wire.OutPoint{Hash: funding.Hash, Index: 0}
+	knownTx, knownOutput, confirmations, err := wallet.FetchOutpointInfo(
+		&outpoint,
+	)
+	require.NoError(t, err)
+	require.Equal(t, funding.Hash, knownTx.TxHash())
+	require.Equal(t, int64(50_000), knownOutput.Value)
+	require.Zero(t, confirmations)
+
+	result, err := wallet.GetTransaction(funding.Hash)
+	require.NoError(t, err)
+	require.Equal(t, int32(-1), result.Height)
+	require.Len(t, result.Summary.MyOutputs, 1)
+	allTransactions, err := wallet.ListAllTransactions()
+	require.NoError(t, err)
+	require.Len(t, allTransactions, 1)
+	recentTransactions, err := wallet.ListTransactions(0, 10)
+	require.NoError(t, err)
+	require.Len(t, recentTransactions, 1)
+	sinceBlock, err := wallet.ListSinceBlock(0, -1, 0)
+	require.NoError(t, err)
+	require.Len(t, sinceBlock, 1)
+	rangeResult, err := wallet.GetTransactions(nil, nil, "", nil)
+	require.NoError(t, err)
+	require.Len(t, rangeResult.UnminedTransactions, 1)
+	pubKeyHash, ok := receiveAddress.(*address.AddressPubKeyHash)
+	require.True(t, ok)
+	addressTransactions, err := wallet.ListAddressTransactions(
+		map[string]struct{}{string(pubKeyHash.ScriptAddress()): {}},
+	)
+	require.NoError(t, err)
+	require.Len(t, addressTransactions, 1)
+
+	totals, err := wallet.TotalReceivedForAccounts(
+		waddrmgr.KeyScopeBIP0044, 0,
+	)
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(50_000), totals[0].TotalReceived)
+
+	total, err := wallet.TotalReceivedForAddr(receiveAddress, 0)
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(50_000), total)
+
+	details, err := UnstableAPI(wallet).TxDetails(&funding.Hash)
+	require.NoError(t, err)
+	require.Equal(t, funding.Hash, details.Hash)
+
+	var ranged []chainhash.Hash
+
+	err = UnstableAPI(wallet).RangeTransactions(
+		0, -1, func(details []wtxmgr.TxDetails) (bool, error) {
+			for _, detail := range details {
+				ranged = append(ranged, detail.Hash)
+			}
+
+			return false, nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, []chainhash.Hash{funding.Hash}, ranged)
+
+	require.NoError(t, wallet.LabelTransaction(
+		funding.Hash, "funding", false,
+	))
+	err = wallet.LabelTransaction(funding.Hash, "duplicate", false)
+	require.ErrorIs(t, err, ErrTxLabelExists)
+	require.NoError(t, wallet.LabelTransaction(
+		funding.Hash, "funding updated", true,
+	))
+	result, err = wallet.GetTransaction(funding.Hash)
+	require.NoError(t, err)
+	require.Equal(t, "funding updated", result.Summary.Label)
+
+	lockID := wtxmgr.LockID{1}
+	expiry, err := wallet.LeaseOutput(lockID, outpoint, time.Hour)
+	require.NoError(t, err)
+	require.True(t, expiry.After(time.Now()))
+	_, err = wallet.LeaseOutput(wtxmgr.LockID{2}, outpoint, time.Hour)
+	require.ErrorIs(t, err, wtxmgr.ErrOutputAlreadyLocked)
+	leased, err := wallet.ListLeasedOutputs()
+	require.NoError(t, err)
+	require.Len(t, leased, 1)
+	balance, err = wallet.CalculateBalance(0)
+	require.NoError(t, err)
+	require.Zero(t, balance)
+	err = wallet.ReleaseOutput(wtxmgr.LockID{2}, outpoint)
+	require.ErrorIs(t, err, wtxmgr.ErrOutputUnlockNotAllowed)
+	require.NoError(t, wallet.ReleaseOutput(lockID, outpoint))
+
+	_, err = wallet.LeaseOutput(lockID, outpoint, time.Millisecond)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		leased, err := wallet.ListLeasedOutputs()
+		return err == nil && len(leased) == 0
+	}, time.Second, 10*time.Millisecond)
+
+	spenderTx := wire.NewMsgTx(2)
+	spenderTx.AddTxIn(&wire.TxIn{PreviousOutPoint: outpoint})
+	spenderTx.AddTxOut(&wire.TxOut{Value: 49_000, PkScript: []byte{0x51}})
+	spender, err := wtxmgr.NewTxRecordFromMsgTx(
+		spenderTx, time.Unix(12, 0),
+	)
+	require.NoError(t, err)
+	rejectedTx := spenderTx.Copy()
+	rejectedTx.TxOut[0].Value = 48_500
+	rejectedRecord, err := wtxmgr.NewTxRecordFromMsgTx(
+		rejectedTx, time.Unix(12, 0),
+	)
+	require.NoError(t, err)
+	broadcastErr := errors.New("transaction rejected")
+	wallet.chainClient = &rejectingChainClient{
+		mockChainClient: &mockChainClient{getBestBlockHeight: 1},
+		err:             broadcastErr,
+	}
+	err = wallet.PublishTransaction(rejectedTx, "")
+	require.ErrorIs(t, err, broadcastErr)
+	_, err = wallet.GetTransaction(rejectedRecord.Hash)
+	require.ErrorIs(t, err, ErrNoTx)
+	balance, err = wallet.CalculateBalance(0)
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(50_000), balance)
+	wallet.chainClient = &mockChainClient{getBestBlockHeight: 1}
+
+	err = store.UpdateOnce(t.Context(), func(tx walletstore.ReadWriteTx) error {
+		return wallet.addRelevantTxFromStore(tx, spender, nil)
+	}, nil)
+	require.NoError(t, err)
+	spenderResult, err := wallet.GetTransaction(spender.Hash)
+	require.NoError(t, err)
+	require.Len(t, spenderResult.Summary.MyInputs, 1)
+	balance, err = wallet.CalculateBalance(0)
+	require.NoError(t, err)
+	require.Zero(t, balance)
+
+	childTx := wire.NewMsgTx(2)
+	childTx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: spender.Hash,
+	}})
+	childTx.AddTxOut(&wire.TxOut{Value: 48_000, PkScript: []byte{0x51}})
+	child, err := wtxmgr.NewTxRecordFromMsgTx(childTx, time.Unix(13, 0))
+	require.NoError(t, err)
+	err = store.UpdateOnce(t.Context(), func(tx walletstore.ReadWriteTx) error {
+		return wallet.addRelevantTxFromStore(tx, child, nil)
+	}, nil)
+	require.NoError(t, err)
+	require.NoError(t, wallet.RemoveDescendants(spenderTx))
+	_, err = wallet.GetTransaction(spender.Hash)
+	require.ErrorIs(t, err, ErrNoTx)
+	_, err = wallet.GetTransaction(child.Hash)
+	require.ErrorIs(t, err, ErrNoTx)
+	balance, err = wallet.CalculateBalance(0)
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(50_000), balance)
+
+	block := wtxmgr.BlockMeta{
+		Block: wtxmgr.Block{Hash: chainhash.Hash{1}, Height: 1},
+		Time:  time.Unix(14, 0),
+	}
+	blockNotifications := wallet.NtfnServer.TransactionNotifications()
+	blockErr := make(chan error, 1)
+	go func() {
+		blockErr <- store.UpdateOnce(
+			t.Context(), func(tx walletstore.ReadWriteTx) error {
+				if err := wallet.addRelevantTxFromStore(
+					tx, funding, &block,
+				); err != nil {
+
+					return err
+				}
+
+				return wallet.connectBlockFromStore(tx, block)
+			}, nil,
+		)
+	}()
+	select {
+	case notification := <-blockNotifications.C:
+		require.Len(t, notification.AttachedBlocks, 1)
+		require.Len(t, notification.AttachedBlocks[0].Transactions, 1)
+		require.Equal(
+			t, funding.Hash,
+			*notification.AttachedBlocks[0].Transactions[0].Hash,
+		)
+
+	case <-time.After(time.Second):
+		t.Fatal("block notification not published after commit")
+	}
+	require.NoError(t, <-blockErr)
+	blockNotifications.Done()
+	result, err = wallet.GetTransaction(funding.Hash)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), result.Height)
+	require.Equal(t, int32(1), result.Confirmations)
+
+	require.NoError(t, loader.UnloadWallet())
+	require.NoError(t, conn.Close())
+	conn, err = storesqlite.Open(context.Background(), storesqlite.Config{
+		DBPath: dbPath,
+	})
+	require.NoError(t, err)
+	store = dbsqlite.NewNamedStore(conn, "transactions")
+	loader, err = NewLoaderWithStore(params, 0, store)
+	require.NoError(t, err)
+	wallet, err = loader.OpenExistingWallet([]byte("public-pass"), false)
+	require.NoError(t, err)
+	result, err = wallet.GetTransaction(funding.Hash)
+	require.NoError(t, err)
+	require.Equal(t, "funding updated", result.Summary.Label)
+	require.Equal(t, int32(1), result.Height)
+	require.NoError(t, loader.UnloadWallet())
+	require.NoError(t, conn.Close())
+}
+
+// TestSQLAccountScopesAndNotifications verifies sparse account aggregation,
+// scope isolation, and spentness notification routing for a non-default
+// account.
+func TestSQLAccountScopesAndNotifications(t *testing.T) {
+	t.Parallel()
+
+	params := &chaincfg.TestNet3Params
+	conn, err := storesqlite.Open(
+		context.Background(), storesqlite.Config{
+			DBPath: filepath.Join(t.TempDir(), "wallet.sqlite"),
+		},
+	)
+	require.NoError(t, err)
+	require.NoError(t, storesqlite.ApplyMigrations(conn))
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+
+	store := dbsqlite.NewNamedStore(conn, "account-scopes")
+	loader, err := NewLoaderWithStore(params, 0, store)
+	require.NoError(t, err)
+	wallet, err := loader.CreateNewWallet(
+		[]byte("public-pass"), []byte("private-pass"), nil,
+		time.Unix(1_700_000_000, 0),
+	)
+	require.NoError(t, err)
+
+	wallet.chainClient = &mockChainClient{}
+	require.NoError(t, wallet.Unlock([]byte("private-pass"), nil))
+	t.Cleanup(func() {
+		require.NoError(t, loader.UnloadWallet())
+	})
+
+	const sparseAccount = uint32(7)
+
+	manager, err := wallet.Manager.FetchScopedKeyManager(
+		waddrmgr.KeyScopeBIP0044,
+	)
+	require.NoError(t, err)
+	require.NoError(t, store.UpdateOnce(
+		t.Context(), func(tx walletstore.ReadWriteTx) error {
+			return manager.NewRawAccountFromStore(tx.Addr(), sparseAccount)
+		}, nil,
+	))
+
+	sparseAddress, err := wallet.NewAddress(
+		sparseAccount, waddrmgr.KeyScopeBIP0044,
+	)
+	require.NoError(t, err)
+	otherScopeAddress, err := wallet.NewAddress(
+		waddrmgr.DefaultAccountNum, waddrmgr.KeyScopeBIP0084,
+	)
+	require.NoError(t, err)
+
+	newFunding := func(marker byte, value int64,
+		addr address.Address) *wtxmgr.TxRecord {
+
+		t.Helper()
+
+		pkScript, err := txscript.PayToAddrScript(addr)
+		require.NoError(t, err)
+
+		msgTx := wire.NewMsgTx(2)
+		msgTx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+			Hash:  chainhash.Hash{marker},
+			Index: 1,
+		}})
+		msgTx.AddTxOut(&wire.TxOut{Value: value, PkScript: pkScript})
+		record, err := wtxmgr.NewTxRecordFromMsgTx(
+			msgTx, time.Unix(100+int64(marker), 0),
+		)
+		require.NoError(t, err)
+
+		return record
+	}
+	sparseFunding := newFunding(1, 70_000, sparseAddress)
+	otherFunding := newFunding(2, 80_000, otherScopeAddress)
+
+	spentness := wallet.NtfnServer.AccountSpentnessNotifications(
+		sparseAccount,
+	)
+	updateErr := make(chan error, 1)
+
+	go func() {
+		updateErr <- store.UpdateOnce(
+			t.Context(), func(tx walletstore.ReadWriteTx) error {
+				return wallet.addRelevantTxFromStore(
+					tx, sparseFunding, nil,
+				)
+			}, nil,
+		)
+	}()
+
+	select {
+	case notification := <-spentness.C:
+		require.Equal(t, sparseFunding.Hash, *notification.Hash())
+		require.Equal(t, uint32(0), notification.Index())
+
+	case <-time.After(time.Second):
+		t.Fatal("non-default account did not receive unspent notification")
+	}
+
+	require.NoError(t, <-updateErr)
+	spentness.Done()
+
+	require.NoError(t, store.UpdateOnce(
+		t.Context(), func(tx walletstore.ReadWriteTx) error {
+			return wallet.addRelevantTxFromStore(tx, otherFunding, nil)
+		}, nil,
+	))
+
+	accounts, err := wallet.Accounts(waddrmgr.KeyScopeBIP0044)
+	require.NoError(t, err)
+
+	accountBalances := make(map[uint32]btcutil.Amount)
+	for _, account := range accounts.Accounts {
+		accountBalances[account.AccountNumber] = account.TotalBalance
+	}
+
+	require.Equal(t, btcutil.Amount(70_000),
+		accountBalances[sparseAccount])
+	require.Zero(t, accountBalances[waddrmgr.DefaultAccountNum])
+
+	totals, err := wallet.TotalReceivedForAccounts(
+		waddrmgr.KeyScopeBIP0044, 0,
+	)
+	require.NoError(t, err)
+
+	received := make(map[uint32]btcutil.Amount)
+	for _, total := range totals {
+		received[total.AccountNumber] = total.TotalReceived
+	}
+
+	require.Equal(t, btcutil.Amount(70_000), received[sparseAccount])
+	require.Zero(t, received[waddrmgr.DefaultAccountNum])
+
+	otherTotals, err := wallet.TotalReceivedForAccounts(
+		waddrmgr.KeyScopeBIP0084, 0,
+	)
+	require.NoError(t, err)
+
+	otherReceived := make(map[uint32]btcutil.Amount)
+	for _, total := range otherTotals {
+		otherReceived[total.AccountNumber] = total.TotalReceived
+	}
+
+	require.Equal(t, btcutil.Amount(80_000),
+		otherReceived[waddrmgr.DefaultAccountNum])
+
+}
+
+// wifAddress decodes an address returned by ImportPrivateKey for a test.
+//
+//nolint:ireturn // The helper returns the decoded address interface.
+func wifAddress(t *testing.T, encoded string,
+	params *chaincfg.Params) address.Address {
+
+	t.Helper()
+
+	addr, err := address.DecodeAddress(encoded, params)
+	require.NoError(t, err)
+
+	return addr
+}
+
+// requireScript returns a managed script's clear text for a test.
+func requireScript(t *testing.T,
+	managed waddrmgr.ManagedScriptAddress) []byte {
+
+	t.Helper()
+
+	script, err := managed.Script()
+	require.NoError(t, err)
+
+	return script
+}

--- a/wallet/sqlite_loader.go
+++ b/wallet/sqlite_loader.go
@@ -1,0 +1,82 @@
+package wallet
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	dbsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlite"
+	storesqlite "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite"
+)
+
+// SQLiteLoaderConfig holds the public settings for a Store-backed SQLite
+// wallet loader.
+type SQLiteLoaderConfig struct {
+	// DBPath is the path to the SQLite database file.
+	DBPath string
+
+	// WalletName is the durable identity of the wallet within the database.
+	WalletName string
+
+	// BusyTimeout is the time SQLite waits for a locked database.
+	BusyTimeout time.Duration
+
+	// MaxConnections is the maximum number of open connections.
+	MaxConnections int
+
+	// MaxIdleConnections is the maximum number of idle connections.
+	MaxIdleConnections int
+
+	// ConnectionLifetime bounds connection reuse in the pool.
+	ConnectionLifetime time.Duration
+
+	// Pragmas contains additional SQLite pragma settings.
+	Pragmas []string
+}
+
+// NewSQLiteLoader opens a Store-backed SQLite wallet loader and applies the
+// embedded btcwallet schema. The returned Loader owns the connection pool.
+// UnloadWallet closes it after a wallet is loaded; callers must use Close when
+// abandoning the loader before a wallet is loaded.
+func NewSQLiteLoader(ctx context.Context, chainParams *chaincfg.Params,
+	recoveryWindow uint32, cfg SQLiteLoaderConfig,
+	opts ...LoaderOption) (*Loader, error) {
+
+	if cfg.WalletName == "" {
+		return nil, errors.New("wallet name is required")
+	}
+
+	conn, err := storesqlite.Open(ctx, storesqlite.Config{
+		DBPath:             cfg.DBPath,
+		BusyTimeout:        cfg.BusyTimeout,
+		MaxConnections:     cfg.MaxConnections,
+		MaxIdleConnections: cfg.MaxIdleConnections,
+		ConnectionLifetime: cfg.ConnectionLifetime,
+		Pragmas:            cfg.Pragmas,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := storesqlite.ApplyMigrations(conn); err != nil {
+		_ = conn.Close()
+
+		return nil, fmt.Errorf("apply SQLite wallet schema: %w", err)
+	}
+
+	store := dbsqlite.NewNamedStore(conn, cfg.WalletName)
+	loader, err := NewLoaderWithStore(
+		chainParams, recoveryWindow, store, opts...,
+	)
+	if err != nil {
+		_ = conn.Close()
+
+		return nil, err
+	}
+
+	loader.storeClose = conn.Close
+
+	return loader, nil
+}

--- a/wallet/store_createtx.go
+++ b/wallet/store_createtx.go
@@ -1,0 +1,939 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/psbt/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btcwallet/chain"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	walletstore "github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/txauthor"
+	"github.com/btcsuite/btcwallet/wallet/txsizes"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+	"github.com/lightningnetwork/lnd/fn/v2"
+)
+
+// storeTxStage identifies expensive or externally controlled funding work that
+// must execute with no Store callback active.
+type storeTxStage uint8
+
+const (
+	storeTxStageCrypto storeTxStage = iota
+	storeTxStageSigning
+	storeTxStageVM
+)
+
+// storeTxObserver provides transaction-scope diagnostics for tests and
+// benchmarks without changing transaction behavior.
+type storeTxObserver struct {
+	observe func(storeTxStage)
+}
+
+var activeStoreTxObserver atomic.Pointer[storeTxObserver]
+
+// observeStoreTxStage reports one transaction-independent preparation stage.
+func observeStoreTxStage(stage storeTxStage) {
+	observer := activeStoreTxObserver.Load()
+	if observer != nil && observer.observe != nil {
+		observer.observe(stage)
+	}
+}
+
+const (
+	// maxStoreFundingAttempts bounds complete snapshot and preparation retries
+	// when durable UTXOs or change indexes race the final write transaction.
+	maxStoreFundingAttempts = 3
+
+	// maxStoreCommitAttempts bounds retries of the database-only final plan.
+	// No caller callback or cryptographic work is repeated by these retries.
+	maxStoreCommitAttempts = 3
+)
+
+// storeChangePlan is the non-cryptographic surface exposed by waddrmgr's
+// private prepared next-address plan.
+type storeChangePlan interface {
+	// Address returns the managed change address reserved by the plan.
+	Address() waddrmgr.ManagedAddress
+
+	// Commit persists the reserved change address.
+	Commit(waddrmgr.ManagerReadWriteTx) error
+
+	// Reconcile determines whether an ambiguous commit applied the plan.
+	Reconcile(waddrmgr.ManagerReadStore) (bool, bool, bool, error)
+
+	// Apply publishes the committed plan to in-memory manager state.
+	Apply()
+}
+
+// storeTxSnapshot owns the transaction data needed to decorate one explicit
+// funding input after the Store callback returns.
+type storeTxSnapshot struct {
+	tx      *wire.MsgTx
+	credits []wtxmgr.CreditRecord
+}
+
+// storeFundingSnapshot owns UTXOs, transaction details, and address-manager
+// rows read during one short Store view.
+type storeFundingSnapshot struct {
+	unspent      []wtxmgr.Credit
+	transactions map[chainhash.Hash]storeTxSnapshot
+	addresses    storeAddressSnapshot
+}
+
+// preparedStoreChange couples an out-of-transaction change source with the
+// private address plan created only if txauthor actually needs change.
+type preparedStoreChange struct {
+	scope   waddrmgr.KeyScope
+	account uint32
+	source  *txauthor.ChangeSource
+	plan    storeChangePlan
+}
+
+// copyStoreCredit detaches a UTXO script from backend-owned memory.
+func copyStoreCredit(credit wtxmgr.Credit) wtxmgr.Credit {
+	credit.PkScript = append([]byte(nil), credit.PkScript...)
+
+	return credit
+}
+
+// readStoreFundingSnapshot copies all durable funding state without parsing
+// scripts, deriving keys, invoking callbacks, or changing caller-owned values.
+func (w *Wallet) readStoreFundingSnapshot(ctx context.Context,
+	inputs []wire.OutPoint) (storeFundingSnapshot, error) {
+
+	var snapshot storeFundingSnapshot
+	err := w.store.View(ctx, func(tx walletstore.ReadTx) error {
+		unspent, err := tx.Tx().UnspentOutputs()
+		if err != nil {
+			return err
+		}
+		snapshot.unspent = make([]wtxmgr.Credit, len(unspent))
+		for i := range unspent {
+			snapshot.unspent[i] = copyStoreCredit(unspent[i])
+		}
+
+		snapshot.addresses, err = readStoreAddressSnapshot(tx.Addr())
+		if err != nil {
+			return err
+		}
+
+		snapshot.transactions = make(
+			map[chainhash.Hash]storeTxSnapshot, len(inputs),
+		)
+		for _, input := range inputs {
+			if _, ok := snapshot.transactions[input.Hash]; ok {
+				continue
+			}
+
+			details, err := tx.Tx().TxDetails(&input.Hash)
+			if err != nil {
+				return err
+			}
+			if details == nil {
+				return fmt.Errorf("%v not found", input)
+			}
+			snapshot.transactions[input.Hash] = storeTxSnapshot{
+				tx: details.MsgTx.Copy(),
+				credits: append(
+					[]wtxmgr.CreditRecord(nil), details.Credits...,
+				),
+			}
+		}
+
+		return nil
+	}, func() {
+		snapshot = storeFundingSnapshot{}
+	})
+
+	return snapshot, err
+}
+
+// accountState returns one detached account row from the funding snapshot.
+func (s storeFundingSnapshot) accountState(scope waddrmgr.KeyScope,
+	account uint32) (waddrmgr.AccountState, error) {
+
+	state, ok := s.addresses.accounts[storeAccountKey{
+		scope:   scope,
+		account: account,
+	}]
+	if !ok {
+		return waddrmgr.AccountState{}, fmt.Errorf(
+			"account %d not found in scope %s", account, scope,
+		)
+	}
+
+	return state, nil
+}
+
+// newPreparedStoreChange creates a lazy change source from a detached account
+// row. Its NewScript closure performs all derivation outside Store callbacks.
+func (w *Wallet) newPreparedStoreChange(snapshot storeFundingSnapshot,
+	changeKeyScope *waddrmgr.KeyScope,
+	account uint32) (*preparedStoreChange, error) {
+
+	scope := waddrmgr.KeyScopeBIP0086
+	if changeKeyScope != nil {
+		scope = *changeKeyScope
+	}
+	changeAccount := account
+	if account == waddrmgr.ImportedAddrAccount {
+		changeAccount = waddrmgr.DefaultAccountNum
+	}
+
+	state, err := snapshot.accountState(scope, changeAccount)
+	if err != nil {
+		return nil, err
+	}
+	addrType := waddrmgr.ScopeAddrMap[scope].InternalAddrType
+	if state.AddrSchema != nil {
+		addrType = state.AddrSchema.InternalAddrType
+	}
+
+	var scriptSize int
+	switch addrType {
+	case waddrmgr.PubKeyHash:
+		scriptSize = txsizes.P2PKHPkScriptSize
+
+	case waddrmgr.NestedWitnessPubKey:
+		scriptSize = txsizes.NestedP2WPKHPkScriptSize
+
+	case waddrmgr.WitnessPubKey:
+		scriptSize = txsizes.P2WPKHPkScriptSize
+
+	case waddrmgr.TaprootPubKey:
+		scriptSize = txsizes.P2TRPkScriptSize
+
+	default:
+		return nil, fmt.Errorf("unsupported address type: %v", addrType)
+	}
+
+	manager, err := w.Manager.FetchScopedKeyManager(scope)
+	if err != nil {
+		return nil, err
+	}
+	change := &preparedStoreChange{
+		scope:   scope,
+		account: changeAccount,
+	}
+	change.source = &txauthor.ChangeSource{
+		ScriptSize: scriptSize,
+		NewScript: func() ([]byte, error) {
+			if change.plan == nil {
+				observeStoreTxStage(storeTxStageCrypto)
+				plan, err := manager.PrepareNextInternalAddress(state)
+				if err != nil {
+					return nil, err
+				}
+				change.plan = plan
+			}
+
+			return txscript.PayToAddrScript(
+				change.plan.Address().Address(),
+			)
+		},
+	}
+
+	return change, nil
+}
+
+// findEligibleOutputsFromSnapshot filters detached UTXOs after the Store view
+// has closed, so caller policy and script parsing cannot extend its lifetime.
+func (w *Wallet) findEligibleOutputsFromSnapshot(
+	snapshot storeFundingSnapshot, keyScope *waddrmgr.KeyScope,
+	account uint32, minconf int32, blockStamp *waddrmgr.BlockStamp,
+	allowUtxo func(wtxmgr.Credit) bool) []wtxmgr.Credit {
+
+	eligible := make([]wtxmgr.Credit, 0, len(snapshot.unspent))
+	for i := range snapshot.unspent {
+		output := snapshot.unspent[i]
+		if allowUtxo != nil && !allowUtxo(output) {
+			continue
+		}
+		if !hasMinConfs(minconf, output.Height, blockStamp.Height) {
+			continue
+		}
+		if output.FromCoinBase {
+			target := int32(w.chainParams.CoinbaseMaturity)
+			if !hasMinConfs(target, output.Height, blockStamp.Height) {
+				continue
+			}
+		}
+		if w.LockedOutpoint(output.OutPoint) {
+			continue
+		}
+
+		_, addrs, _, err := txscript.ExtractPkScriptAddrs(
+			output.PkScript, w.chainParams,
+		)
+		if err != nil || len(addrs) != 1 {
+			continue
+		}
+		_, ok := snapshot.addresses.material(
+			addrs[0], keyScope, &account,
+		)
+		if !ok {
+			continue
+		}
+
+		eligible = append(eligible, output)
+	}
+
+	return eligible
+}
+
+// storeInputSource chooses either the caller's exact UTXOs or coins arranged by
+// the caller's strategy. Both callbacks run after the snapshot transaction.
+func storeInputSource(eligible []wtxmgr.Credit,
+	selectedUtxos []wire.OutPoint, strategy CoinSelectionStrategy,
+	feeSatPerKb btcutil.Amount) (txauthor.InputSource, error) {
+
+	if len(selectedUtxos) > 0 {
+		dedupUtxos := fn.NewSet(selectedUtxos...)
+		if len(dedupUtxos) != len(selectedUtxos) {
+			return nil, errors.New("selected UTXOs contain duplicate values")
+		}
+
+		eligibleByOutpoint := make(
+			map[wire.OutPoint]wtxmgr.Credit, len(eligible),
+		)
+		for _, output := range eligible {
+			eligibleByOutpoint[output.OutPoint] = output
+		}
+
+		selected := make([]wtxmgr.Credit, 0, len(selectedUtxos))
+		for _, outpoint := range selectedUtxos {
+			output, ok := eligibleByOutpoint[outpoint]
+			if !ok {
+				return nil, fmt.Errorf("selected outpoint not eligible for "+
+					"spending: %v", outpoint)
+			}
+			selected = append(selected, output)
+		}
+
+		return constantInputSource(selected), nil
+	}
+
+	coins := make([]Coin, len(eligible))
+	for i := range eligible {
+		coins[i] = Coin{
+			TxOut: wire.TxOut{
+				Value:    int64(eligible[i].Amount),
+				PkScript: eligible[i].PkScript,
+			},
+			OutPoint: eligible[i].OutPoint,
+		}
+	}
+	arranged, err := strategy.ArrangeCoins(coins, feeSatPerKb)
+	if err != nil {
+		return nil, err
+	}
+
+	return makeInputSource(arranged), nil
+}
+
+// selectedStoreCredits returns the exact detached UTXOs consumed by an authored
+// transaction.
+func selectedStoreCredits(authored *txauthor.AuthoredTx,
+	unspent []wtxmgr.Credit) ([]wtxmgr.Credit, error) {
+
+	byOutpoint := make(map[wire.OutPoint]wtxmgr.Credit, len(unspent))
+	for _, credit := range unspent {
+		byOutpoint[credit.OutPoint] = credit
+	}
+
+	selected := make([]wtxmgr.Credit, len(authored.Tx.TxIn))
+	for i, input := range authored.Tx.TxIn {
+		credit, ok := byOutpoint[input.PreviousOutPoint]
+		if !ok {
+			return nil, fmt.Errorf("selected outpoint disappeared from "+
+				"snapshot: %v", input.PreviousOutPoint)
+		}
+		selected[i] = credit
+	}
+
+	return selected, nil
+}
+
+// sameStoreCredit reports whether every spend-relevant durable UTXO field is
+// unchanged.
+func sameStoreCredit(a, b wtxmgr.Credit) bool {
+	return a.OutPoint == b.OutPoint && a.Block == b.Block &&
+		a.Time.Equal(b.Time) && a.Amount == b.Amount &&
+		bytes.Equal(a.PkScript, b.PkScript) &&
+		a.Received.Equal(b.Received) && a.FromCoinBase == b.FromCoinBase
+}
+
+// revalidateStoreCredits requires every selected UTXO to remain exactly
+// spendable in the final transaction snapshot.
+func revalidateStoreCredits(store walletstore.TxReadStore,
+	selected []wtxmgr.Credit) error {
+
+	current, err := store.UnspentOutputs()
+	if err != nil {
+		return err
+	}
+	byOutpoint := make(map[wire.OutPoint]wtxmgr.Credit, len(current))
+	for _, credit := range current {
+		byOutpoint[credit.OutPoint] = credit
+	}
+	for _, expected := range selected {
+		credit, ok := byOutpoint[expected.OutPoint]
+		if !ok || !sameStoreCredit(credit, expected) {
+			return &StorePlanStaleError{
+				Operation: "transaction funding",
+				Reason: fmt.Sprintf(
+					"selected UTXO %v changed", expected.OutPoint,
+				),
+			}
+		}
+	}
+
+	return nil
+}
+
+// commitStoreFundingPlan applies only exact prepared database state. Retryable
+// Store failures repeat this database-only phase, never external callbacks.
+func (w *Wallet) commitStoreFundingPlan(selected []wtxmgr.Credit,
+	change *preparedStoreChange) error {
+
+	for attempt := 0; attempt < maxStoreCommitAttempts; attempt++ {
+		err := w.store.UpdateOnce(
+			context.Background(), func(tx walletstore.ReadWriteTx) error {
+				if err := revalidateStoreCredits(
+					tx.Tx(), selected,
+				); err != nil {
+
+					return err
+				}
+				if change == nil || change.plan == nil {
+					return nil
+				}
+
+				err := change.plan.Commit(tx.Addr())
+				var conflict *waddrmgr.AddressPlanConflictError
+				if errors.As(err, &conflict) {
+					return &StorePlanStaleError{
+						Operation: "transaction funding",
+						Reason:    conflict.Error(),
+					}
+				}
+
+				return err
+			}, nil,
+		)
+		if err == nil {
+			return nil
+		}
+
+		var retryable *walletstore.RetryableTransactionError
+		if errors.As(err, &retryable) {
+			continue
+		}
+
+		var ambiguous *walletstore.AmbiguousCommitError
+		if !errors.As(err, &ambiguous) {
+			return err
+		}
+
+		var (
+			creditsCurrent bool
+			durable        bool
+			absent         bool
+			exact          bool
+		)
+		viewErr := w.store.View(
+			context.Background(), func(tx walletstore.ReadTx) error {
+				creditErr := revalidateStoreCredits(tx.Tx(), selected)
+				creditsCurrent = creditErr == nil
+				if creditErr != nil {
+					var stale *StorePlanStaleError
+					if !errors.As(creditErr, &stale) {
+						return creditErr
+					}
+				}
+
+				if change == nil || change.plan == nil {
+					durable = creditsCurrent
+					return nil
+				}
+
+				var err error
+				durable, absent, exact, err =
+					change.plan.Reconcile(tx.Addr())
+				return err
+			}, func() {
+				creditsCurrent = false
+				durable = false
+				absent = false
+				exact = false
+			},
+		)
+		if viewErr != nil {
+			w.markStoreChangeStale(change)
+			return &UnresolvedStoreCommitError{
+				Operation: "transaction funding",
+				Err: errors.Join(
+					ambiguous, fmt.Errorf(
+						"reconcile commit: %w", viewErr,
+					),
+				),
+			}
+		}
+
+		switch {
+		case durable:
+			if exact && change != nil && change.plan != nil {
+				ambiguous.ApplyCommitHooks()
+				change.plan.Apply()
+			} else {
+				w.markStoreChangeStale(change)
+			}
+
+			return nil
+
+		case absent && creditsCurrent:
+			continue
+
+		default:
+			w.markStoreChangeStale(change)
+			return &UnresolvedStoreCommitError{
+				Operation: "transaction funding",
+				Err:       ambiguous,
+			}
+		}
+	}
+
+	return &walletstore.RetryableTransactionError{
+		Err: errors.New("transaction funding commit retries exhausted"),
+	}
+}
+
+// markStoreChangeStale prevents uncertain change indexes from being reported
+// through an optimistic manager cache.
+func (w *Wallet) markStoreChangeStale(change *preparedStoreChange) {
+	if change == nil || change.plan == nil {
+		return
+	}
+
+	w.Manager.MarkAccountCacheStale(change.scope, change.account)
+}
+
+// copyTxOutputs owns output scripts before txauthor may reorder output
+// pointers.
+func copyTxOutputs(outputs []*wire.TxOut) []*wire.TxOut {
+	result := make([]*wire.TxOut, len(outputs))
+	for i, output := range outputs {
+		result[i] = &wire.TxOut{
+			Value:    output.Value,
+			PkScript: append([]byte(nil), output.PkScript...),
+		}
+	}
+
+	return result
+}
+
+// prepareStoreAuthoredTx performs policy callbacks, coin arrangement, change
+// derivation, fee calculation, signing, and VM validation after snapshot exit.
+func (w *Wallet) prepareStoreAuthoredTx(snapshot storeFundingSnapshot,
+	outputs []*wire.TxOut, coinSelectKeyScope,
+	changeKeyScope *waddrmgr.KeyScope, account uint32, minconf int32,
+	feeSatPerKb btcutil.Amount, strategy CoinSelectionStrategy,
+	selectedUtxos []wire.OutPoint,
+	allowUtxo func(wtxmgr.Credit) bool, dryRun bool,
+	blockStamp *waddrmgr.BlockStamp) (*txauthor.AuthoredTx,
+	[]wtxmgr.Credit, *preparedStoreChange, error) {
+
+	change, err := w.newPreparedStoreChange(
+		snapshot, changeKeyScope, account,
+	)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	eligible := w.findEligibleOutputsFromSnapshot(
+		snapshot, coinSelectKeyScope, account, minconf, blockStamp,
+		allowUtxo,
+	)
+	inputSource, err := storeInputSource(
+		eligible, selectedUtxos, strategy, feeSatPerKb,
+	)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	authored, err := txauthor.NewUnsignedTransaction(
+		copyTxOutputs(outputs), feeSatPerKb, inputSource, change.source,
+	)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if authored.ChangeIndex >= 0 {
+		authored.RandomizeChangePosition()
+	}
+	selected, err := selectedStoreCredits(authored, snapshot.unspent)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if dryRun {
+		return authored, selected, change, nil
+	}
+
+	watchOnlyScope := waddrmgr.KeyScopeBIP0086
+	if coinSelectKeyScope != nil {
+		watchOnlyScope = *coinSelectKeyScope
+	}
+	watchOnly := w.Manager.WatchOnly() ||
+		account == waddrmgr.ImportedAddrAccount
+	if !watchOnly {
+		state, err := snapshot.accountState(watchOnlyScope, account)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		watchOnly = len(state.EncryptedPrivKey) == 0
+	}
+	if !watchOnly {
+		secrets := &detachedStoreSecretSource{
+			wallet:   w,
+			snapshot: snapshot.addresses,
+			managed: make(
+				map[[32]byte]waddrmgr.ManagedAddress,
+			),
+		}
+		observeStoreTxStage(storeTxStageSigning)
+		if err := authored.AddAllInputScripts(secrets); err != nil {
+			return nil, nil, nil, err
+		}
+		observeStoreTxStage(storeTxStageVM)
+		if err := validateMsgTx(
+			authored.Tx, authored.PrevScripts,
+			authored.PrevInputValues,
+		); err != nil {
+
+			return nil, nil, nil, err
+		}
+	}
+
+	return authored, selected, change, nil
+}
+
+// cloneStorePsbt serializes a caller packet into an independently mutable
+// packet while preserving all standard and unknown metadata.
+func cloneStorePsbt(packet *psbt.Packet) (*psbt.Packet, error) {
+	var buffer bytes.Buffer
+	if err := packet.Serialize(&buffer); err != nil {
+		return nil, err
+	}
+
+	return psbt.NewFromRawBytes(bytes.NewReader(buffer.Bytes()), false)
+}
+
+// storeManagedOutput resolves a wallet output from detached address rows.
+func (w *Wallet) storeManagedOutput(snapshot storeAddressSnapshot,
+	output *wire.TxOut) (waddrmgr.ManagedAddress, error) {
+
+	_, addrs, _, err := txscript.ExtractPkScriptAddrs(
+		output.PkScript, w.chainParams,
+	)
+	if err != nil {
+		return nil, err
+	}
+	for _, addr := range addrs {
+		managed, err := snapshot.resolve(w, addr)
+		if err == nil {
+			return managed, nil
+		}
+	}
+
+	return nil, ErrNotMine
+}
+
+// storeBip32Derivation constructs PSBT key-origin metadata from a detached
+// managed address without reading a Store.
+func storeBip32Derivation(
+	managed waddrmgr.ManagedPubKeyAddress) (*psbt.Bip32Derivation, error) {
+
+	scope, path, known := managed.DerivationInfo()
+	if !known {
+		return nil, ErrNotMine
+	}
+
+	return &psbt.Bip32Derivation{
+		PubKey:               managed.PubKey().SerializeCompressed(),
+		MasterKeyFingerprint: path.MasterKeyFingerprint,
+		Bip32Path: []uint32{
+			scope.Purpose + hdkeychain.HardenedKeyStart,
+			scope.Coin + hdkeychain.HardenedKeyStart,
+			path.Account,
+			path.Branch,
+			path.Index,
+		},
+	}, nil
+}
+
+// explicitStoreCredits decorates a PSBT working copy and returns the exact
+// detached UTXOs that its caller selected.
+func (w *Wallet) explicitStoreCredits(packet *psbt.Packet,
+	snapshot storeFundingSnapshot) ([]wtxmgr.Credit, error) {
+
+	// Preserve the legacy explicit-input behavior, which replaces rather
+	// than augments input metadata while decorating selected wallet UTXOs.
+	packet.Inputs = make([]psbt.PInput, len(packet.UnsignedTx.TxIn))
+
+	byOutpoint := make(
+		map[wire.OutPoint]wtxmgr.Credit, len(snapshot.unspent),
+	)
+	for _, credit := range snapshot.unspent {
+		byOutpoint[credit.OutPoint] = credit
+	}
+
+	credits := make([]wtxmgr.Credit, len(packet.UnsignedTx.TxIn))
+	for index, input := range packet.UnsignedTx.TxIn {
+		input.Witness = nil
+		input.SignatureScript = nil
+
+		details, ok := snapshot.transactions[input.PreviousOutPoint.Hash]
+		if !ok {
+			return nil, fmt.Errorf("%v not found", input.PreviousOutPoint)
+		}
+		outputIndex := input.PreviousOutPoint.Index
+		if outputIndex >= uint32(len(details.tx.TxOut)) {
+			return nil, fmt.Errorf("previous output %v is out of range",
+				input.PreviousOutPoint)
+		}
+		owned := false
+		for _, credit := range details.credits {
+			if credit.Index == outputIndex {
+				owned = true
+				break
+			}
+		}
+		if !owned {
+			return nil, ErrNotMine
+		}
+
+		credit, ok := byOutpoint[input.PreviousOutPoint]
+		if !ok {
+			return nil, fmt.Errorf("selected input %v is not unspent: %w",
+				input.PreviousOutPoint, ErrNotMine)
+		}
+		credits[index] = credit
+		output := &wire.TxOut{
+			Value:    int64(credit.Amount),
+			PkScript: append([]byte(nil), credit.PkScript...),
+		}
+		managed, err := w.storeManagedOutput(snapshot.addresses, output)
+		if err != nil {
+			return nil, err
+		}
+		pubKeyAddr, witnessProgram, _, err := scriptForStoreOutput(
+			output, managed, w.chainParams,
+		)
+		if err != nil {
+			return nil, err
+		}
+		derivation, err := storeBip32Derivation(pubKeyAddr)
+		if err != nil {
+			return nil, err
+		}
+
+		if txscript.IsPayToTaproot(output.PkScript) {
+			addInputInfoSegWitV1(
+				&packet.Inputs[index], output, derivation,
+			)
+		} else {
+			addInputInfoSegWitV0(
+				&packet.Inputs[index], details.tx, output,
+				derivation, pubKeyAddr, witnessProgram,
+			)
+		}
+	}
+
+	return credits, nil
+}
+
+// fundPsbtExplicitFromStore funds an explicit-input PSBT working copy and
+// replaces the caller packet only after prepared change state commits.
+func (w *Wallet) fundPsbtExplicitFromStore(packet *psbt.Packet,
+	keyScope *waddrmgr.KeyScope, account uint32,
+	feeSatPerKB btcutil.Amount,
+	optFuncs ...TxCreateOption) (int32, error) {
+
+	var lastConflict error
+	for attempt := 0; attempt < maxStoreFundingAttempts; attempt++ {
+		working, err := cloneStorePsbt(packet)
+		if err != nil {
+			return 0, err
+		}
+		inputs := make([]wire.OutPoint, len(working.UnsignedTx.TxIn))
+		for i, input := range working.UnsignedTx.TxIn {
+			inputs[i] = input.PreviousOutPoint
+		}
+		snapshot, err := w.readStoreFundingSnapshot(
+			context.Background(), inputs,
+		)
+		if err != nil {
+			return 0, err
+		}
+		credits, err := w.explicitStoreCredits(working, snapshot)
+		if err != nil {
+			return 0, fmt.Errorf("error fetching UTXO: %w", err)
+		}
+
+		opts := defaultTxCreateOptions()
+		for _, optFunc := range optFuncs {
+			optFunc(opts)
+		}
+		if opts.changeKeyScope == nil {
+			opts.changeKeyScope = keyScope
+		}
+		change, err := w.newPreparedStoreChange(
+			snapshot, opts.changeKeyScope, account,
+		)
+		if err != nil {
+			return 0, err
+		}
+		authored, err := txauthor.NewUnsignedTransaction(
+			copyTxOutputs(working.UnsignedTx.TxOut), feeSatPerKB,
+			constantInputSource(credits), change.source,
+		)
+		if err != nil {
+			return 0, fmt.Errorf("fee estimation not successful: %w", err)
+		}
+
+		var changeOutput *wire.TxOut
+		if authored.ChangeIndex >= 0 {
+			changeOutput = authored.Tx.TxOut[authored.ChangeIndex]
+			working.UnsignedTx.TxOut = append(
+				working.UnsignedTx.TxOut, changeOutput,
+			)
+			pubKeyAddr, ok := change.plan.Address().(waddrmgr.ManagedPubKeyAddress)
+			if !ok {
+				return 0, errors.New("change address is not a pubkey address")
+			}
+			outputInfo, err := createOutputInfo(changeOutput, pubKeyAddr)
+			if err != nil {
+				return 0, fmt.Errorf("error adding output info to change "+
+					"output: %w", err)
+			}
+			working.Outputs = append(working.Outputs, *outputInfo)
+		}
+
+		if err := psbt.InPlaceSort(working); err != nil {
+			return 0, fmt.Errorf("could not sort PSBT: %w", err)
+		}
+		changeIndex := int32(-1)
+		if changeOutput != nil {
+			for index, output := range working.UnsignedTx.TxOut {
+				if psbt.TxOutsEqual(changeOutput, output) {
+					changeIndex = int32(index)
+					break
+				}
+			}
+		}
+
+		err = w.commitStoreFundingPlan(credits, change)
+		var stale *StorePlanStaleError
+		if errors.As(err, &stale) {
+			lastConflict = err
+			continue
+		}
+		if err != nil {
+			return 0, fmt.Errorf("could not add change address to "+
+				"database: %w", err)
+		}
+
+		*packet = *working
+		return changeIndex, nil
+	}
+
+	return 0, fmt.Errorf("PSBT funding conflicts exceeded %d attempts: %w",
+		maxStoreFundingAttempts, lastConflict)
+}
+
+// txToOutputsFromStore creates a transaction from detached durable snapshots.
+// Change watcher registration occurs only after a normal commit or after an
+// ambiguous commit is proven durable. A watcher error therefore means the
+// address remains durable even though this method returns an error.
+func (w *Wallet) txToOutputsFromStore(outputs []*wire.TxOut,
+	coinSelectKeyScope, changeKeyScope *waddrmgr.KeyScope,
+	account uint32, minconf int32, feeSatPerKb btcutil.Amount,
+	strategy CoinSelectionStrategy, dryRun bool,
+	selectedUtxos []wire.OutPoint,
+	allowUtxo func(utxo wtxmgr.Credit) bool, chainClient chain.Interface,
+	blockStamp *waddrmgr.BlockStamp) (*txauthor.AuthoredTx, error) {
+
+	var lastConflict error
+	for attempt := 0; attempt < maxStoreFundingAttempts; attempt++ {
+		snapshot, err := w.readStoreFundingSnapshot(
+			context.Background(), nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		authored, selected, change, err := w.prepareStoreAuthoredTx(
+			snapshot, outputs, coinSelectKeyScope, changeKeyScope,
+			account, minconf, feeSatPerKb, strategy, selectedUtxos,
+			allowUtxo, dryRun, blockStamp,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if dryRun {
+			for _, input := range authored.Tx.TxIn {
+				input.SignatureScript = nil
+				input.Witness = nil
+			}
+
+			return authored, nil
+		}
+
+		err = w.commitStoreFundingPlan(selected, change)
+		var stale *StorePlanStaleError
+		if errors.As(err, &stale) {
+			lastConflict = err
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		if authored.ChangeIndex >= 0 &&
+			account == waddrmgr.ImportedAddrAccount {
+
+			changeAmount := btcutil.Amount(
+				authored.Tx.TxOut[authored.ChangeIndex].Value,
+			)
+			log.Warnf("Spend from imported account produced change: "+
+				"moving %v from imported account into default account.",
+				changeAmount)
+		}
+		if change.plan != nil {
+			addr := change.plan.Address().Address()
+			if err := chainClient.NotifyReceived(
+				[]address.Address{addr},
+			); err != nil {
+
+				return nil, fmt.Errorf("change address %v is durable but "+
+					"watcher registration failed: %w", addr, err)
+			}
+		}
+
+		return authored, nil
+	}
+
+	return nil, fmt.Errorf("transaction funding conflicts exceeded %d "+
+		"attempts: %w", maxStoreFundingAttempts, lastConflict)
+}

--- a/wallet/store_funding_split_test.go
+++ b/wallet/store_funding_split_test.go
@@ -1,0 +1,991 @@
+package wallet
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/psbt/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	walletstore "github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+	"github.com/stretchr/testify/require"
+)
+
+// splitFundingFixture owns one unlocked SQLite Store wallet and spendable
+// P2WPKH output.
+type splitFundingFixture struct {
+	validation  *validationFixture
+	wallet      *Wallet
+	store       walletstore.Store
+	outpoint    wire.OutPoint
+	prevScript  []byte
+	destination []byte
+}
+
+// newSplitFundingFixture creates one deterministic Store funding fixture.
+func newSplitFundingFixture(t *testing.T) *splitFundingFixture {
+	t.Helper()
+
+	seed := bytes.Repeat([]byte{0x61}, hdkeychain.RecommendedSeedLen)
+	validation := newValidationFixture(
+		t, "sqlite", "funding-split", func(loader *Loader) (*Wallet, error) {
+			return loader.CreateNewWallet(
+				[]byte("public"), []byte("private"), seed,
+				time.Unix(1_700_000_000, 0),
+			)
+		},
+	)
+	t.Cleanup(validation.close)
+	wallet := validation.wallet
+	wallet.chainClient = &mockChainClient{}
+	require.NoError(t, wallet.Unlock([]byte("private"), nil))
+
+	receive, err := wallet.NewAddress(
+		waddrmgr.DefaultAccountNum, waddrmgr.KeyScopeBIP0084,
+	)
+	require.NoError(t, err)
+	prevScript, err := txscript.PayToAddrScript(receive)
+	require.NoError(t, err)
+	fundingTx := wire.NewMsgTx(2)
+	fundingTx.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash:  chainhash.Hash{0x71},
+		Index: 1,
+	}})
+	fundingTx.AddTxOut(wire.NewTxOut(1_000_000, prevScript))
+	funding, err := wtxmgr.NewTxRecordFromMsgTx(
+		fundingTx, time.Unix(1_700_000_100, 0),
+	)
+	require.NoError(t, err)
+	require.NoError(t, wallet.store.UpdateOnce(
+		t.Context(), func(tx walletstore.ReadWriteTx) error {
+			return wallet.addRelevantTxFromStore(tx, funding, nil)
+		}, nil,
+	))
+
+	destination, err := address.NewAddressWitnessPubKeyHash(
+		bytes.Repeat([]byte{0x72}, 20), &chaincfg.TestNet3Params,
+	)
+	require.NoError(t, err)
+	destinationScript, err := txscript.PayToAddrScript(destination)
+	require.NoError(t, err)
+
+	return &splitFundingFixture{
+		validation:  validation,
+		wallet:      wallet,
+		store:       wallet.store,
+		outpoint:    wire.OutPoint{Hash: funding.Hash, Index: 0},
+		prevScript:  prevScript,
+		destination: destinationScript,
+	}
+}
+
+// output returns the standard destination used by split funding tests.
+func (f *splitFundingFixture) output() *wire.TxOut {
+	return wire.NewTxOut(100_000, append([]byte(nil), f.destination...))
+}
+
+// packet returns an explicit-input PSBT owned by the caller.
+func (f *splitFundingFixture) packet() *psbt.Packet {
+	return &psbt.Packet{
+		UnsignedTx: &wire.MsgTx{
+			Version: 2,
+			TxIn: []*wire.TxIn{{
+				PreviousOutPoint: f.outpoint,
+			}},
+			TxOut: []*wire.TxOut{f.output()},
+		},
+		Inputs:  []psbt.PInput{{}},
+		Outputs: []psbt.POutput{{}},
+	}
+}
+
+// serializeTx returns the canonical bytes used to detect caller mutation.
+func serializeTx(t *testing.T, tx *wire.MsgTx) []byte {
+	t.Helper()
+
+	var buffer bytes.Buffer
+	require.NoError(t, tx.Serialize(&buffer))
+
+	return buffer.Bytes()
+}
+
+// serializePacket returns the canonical bytes used to detect caller mutation.
+func serializePacket(t *testing.T, packet *psbt.Packet) []byte {
+	t.Helper()
+
+	var buffer bytes.Buffer
+	require.NoError(t, packet.Serialize(&buffer))
+
+	return buffer.Bytes()
+}
+
+// installStoreTxObserver installs one process-wide stage observer for a serial
+// test and restores the previous observer during cleanup.
+func installStoreTxObserver(t *testing.T, observe func(storeTxStage)) {
+	t.Helper()
+
+	previous := activeStoreTxObserver.Swap(&storeTxObserver{observe: observe})
+	t.Cleanup(func() {
+		activeStoreTxObserver.Store(previous)
+	})
+}
+
+// fundingStrategyFunc adapts a test function to CoinSelectionStrategy.
+type fundingStrategyFunc func([]Coin, btcutil.Amount) ([]Coin, error)
+
+// ArrangeCoins invokes the test strategy.
+func (f fundingStrategyFunc) ArrangeCoins(coins []Coin,
+	feeRate btcutil.Amount) ([]Coin, error) {
+
+	return f(coins, feeRate)
+}
+
+// splitChainClient records and optionally blocks change watcher registration.
+type splitChainClient struct {
+	*mockChainClient
+
+	notifications atomic.Int32
+	started       chan struct{}
+	release       chan struct{}
+	once          sync.Once
+	notifyErr     error
+}
+
+// NotifyReceived records one post-commit watcher registration.
+func (c *splitChainClient) NotifyReceived([]address.Address) error {
+	if err := c.guardRPC(); err != nil {
+		return err
+	}
+	c.notifications.Add(1)
+	if c.started != nil {
+		c.once.Do(func() {
+			close(c.started)
+		})
+		<-c.release
+	}
+
+	return c.notifyErr
+}
+
+// beforeUpdateStore runs one test mutation before the next final write begins.
+type beforeUpdateStore struct {
+	// Store delegates the final transaction after mutation injection.
+	walletstore.Store
+
+	once sync.Once
+	hook func()
+}
+
+// UpdateOnce runs the configured mutation before delegating the transaction.
+func (s *beforeUpdateStore) UpdateOnce(ctx context.Context,
+	body func(walletstore.ReadWriteTx) error, reset func()) error {
+
+	s.once.Do(s.hook)
+	return s.Store.UpdateOnce(ctx, body, reset)
+}
+
+// retryUpdateStore injects one known-uncommitted final write failure.
+type retryUpdateStore struct {
+	// Store delegates final transactions after the injected failure.
+	walletstore.Store
+
+	updates atomic.Int32
+}
+
+// UpdateOnce fails before the first body and delegates later attempts.
+func (s *retryUpdateStore) UpdateOnce(ctx context.Context,
+	body func(walletstore.ReadWriteTx) error, reset func()) error {
+
+	if s.updates.Add(1) == 1 {
+		return &walletstore.RetryableTransactionError{
+			Err: errors.New("retry final write"),
+		}
+	}
+
+	return s.Store.UpdateOnce(ctx, body, reset)
+}
+
+// failingViewStore rejects every funding or signing snapshot.
+type failingViewStore struct {
+	// Store supplies operations not overridden by the fixture.
+	walletstore.Store
+	err error
+}
+
+// View returns the configured read failure without invoking body.
+func (s *failingViewStore) View(ctx context.Context,
+	body func(walletstore.ReadTx) error, reset func()) error {
+
+	_, _, _ = ctx, body, reset
+	return s.err
+}
+
+// failingUpdateStore rejects every final funding write.
+type failingUpdateStore struct {
+	// Store supplies operations not overridden by the fixture.
+	walletstore.Store
+	err error
+}
+
+// UpdateOnce returns the configured write failure without invoking body.
+func (s *failingUpdateStore) UpdateOnce(ctx context.Context,
+	body func(walletstore.ReadWriteTx) error, reset func()) error {
+
+	_, _, _ = ctx, body, reset
+	return s.err
+}
+
+// retryingViewStore invokes a successful read body twice with reset between
+// attempts to model a replaying Store implementation.
+type retryingViewStore struct {
+	// Store delegates the replayed transaction execution.
+	walletstore.Store
+}
+
+// View replays the snapshot callback before returning its second result.
+func (s *retryingViewStore) View(ctx context.Context,
+	body func(walletstore.ReadTx) error, reset func()) error {
+
+	return s.Store.View(ctx, func(tx walletstore.ReadTx) error {
+		if reset != nil {
+			reset()
+		}
+		if err := body(tx); err != nil {
+			return err
+		}
+		if reset != nil {
+			reset()
+		}
+
+		return body(tx)
+	}, nil)
+}
+
+// absentAmbiguousStore reports an ambiguous commit without starting the
+// selected transaction, so reconciliation must prove the plan absent.
+type absentAmbiguousStore struct {
+	// Store supplies operations not overridden by the fixture.
+	walletstore.Store
+
+	updates atomic.Int32
+}
+
+// UpdateOnce returns an ambiguous error while leaving durable state unchanged.
+func (s *absentAmbiguousStore) UpdateOnce(ctx context.Context,
+	body func(walletstore.ReadWriteTx) error, reset func()) error {
+
+	_, _, _ = ctx, body, reset
+	s.updates.Add(1)
+	return walletstore.NewAmbiguousCommitError(
+		errors.New("commit acknowledgement lost"),
+	)
+}
+
+// failingReconcileStore fails the first read after an ambiguous final write.
+type failingReconcileStore struct {
+	// Store delegates operations after reconciliation failure injection.
+	walletstore.Store
+
+	err       error
+	reconcile atomic.Bool
+}
+
+// UpdateOnce arms the reconciliation failure after an ambiguous result.
+func (s *failingReconcileStore) UpdateOnce(ctx context.Context,
+	body func(walletstore.ReadWriteTx) error, reset func()) error {
+
+	err := s.Store.UpdateOnce(ctx, body, reset)
+	var ambiguous *walletstore.AmbiguousCommitError
+	if errors.As(err, &ambiguous) {
+		s.reconcile.Store(true)
+	}
+
+	return err
+}
+
+// View injects the armed reconciliation failure before delegating later reads.
+func (s *failingReconcileStore) View(ctx context.Context,
+	body func(walletstore.ReadTx) error, reset func()) error {
+
+	if s.reconcile.Swap(false) {
+		return s.err
+	}
+
+	return s.Store.View(ctx, body, reset)
+}
+
+// storeAccountIndexes reads exact durable account indexes.
+func storeAccountIndexes(t *testing.T, store walletstore.Store,
+	scope waddrmgr.KeyScope, account uint32) (uint32, uint32) {
+
+	t.Helper()
+	var state waddrmgr.AccountState
+	err := store.View(t.Context(), func(tx walletstore.ReadTx) error {
+		var err error
+		state, err = tx.Addr().Account(scope, account)
+		return err
+	}, func() {
+		state = waddrmgr.AccountState{}
+	})
+	require.NoError(t, err)
+
+	return state.NextExternalIndex, state.NextInternalIndex
+}
+
+// unrelatedSQLiteWrite requires a same-wallet write to finish while expensive
+// transaction preparation is blocked.
+func unrelatedSQLiteWrite(t *testing.T, store walletstore.Store) {
+	t.Helper()
+
+	result := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		result <- store.UpdateOnce(
+			ctx, func(tx walletstore.ReadWriteTx) error {
+				return tx.Addr().SetBirthday(time.Unix(1_700_000_001, 0))
+			}, nil,
+		)
+	}()
+
+	select {
+	case err := <-result:
+		require.NoError(t, err)
+
+	case <-time.After(2 * time.Second):
+		t.Fatal("unrelated SQLite write blocked by transaction preparation")
+	}
+}
+
+// testSigningTransaction creates a P2PKH spend using only caller-provided key
+// and previous-script material.
+func testSigningTransaction(t *testing.T) (*wire.MsgTx,
+	map[wire.OutPoint][]byte, map[string]*btcutil.WIF) {
+
+	t.Helper()
+	privateKey, _ := btcec.PrivKeyFromBytes(bytes.Repeat([]byte{0x73}, 32))
+	wif, err := btcutil.NewWIF(privateKey, &chaincfg.TestNet3Params, true)
+	require.NoError(t, err)
+	addr, err := address.NewAddressPubKeyHash(
+		address.Hash160(privateKey.PubKey().SerializeCompressed()),
+		&chaincfg.TestNet3Params,
+	)
+	require.NoError(t, err)
+	prevScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+	outpoint := wire.OutPoint{Hash: chainhash.Hash{0x74}, Index: 1}
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(&wire.TxIn{PreviousOutPoint: outpoint})
+	tx.AddTxOut(wire.NewTxOut(1_000, []byte{txscript.OP_TRUE}))
+
+	return tx, map[wire.OutPoint][]byte{outpoint: prevScript},
+		map[string]*btcutil.WIF{addr.EncodeAddress(): wif}
+}
+
+// TestStoreFundingTransactionScope verifies every instrumented expensive
+// stage, callback, strategy, VM, and watcher runs after Store callback exit.
+func TestStoreFundingTransactionScope(t *testing.T) {
+	fixture := newSplitFundingFixture(t)
+	guard := &callbackGuardStore{Store: fixture.store}
+	fixture.wallet.store = guard
+	client := &splitChainClient{mockChainClient: &mockChainClient{}}
+	client.rpcGuard = func() error {
+		if guard.active.Load() != 0 {
+			return errRPCInStoreCallback
+		}
+
+		return nil
+	}
+	fixture.wallet.chainClient = client
+
+	var (
+		violations atomic.Int32
+		crypto     atomic.Int32
+		signing    atomic.Int32
+		vm         atomic.Int32
+	)
+	installStoreTxObserver(t, func(stage storeTxStage) {
+		if guard.active.Load() != 0 {
+			violations.Add(1)
+		}
+		switch stage {
+		case storeTxStageCrypto:
+			crypto.Add(1)
+
+		case storeTxStageSigning:
+			signing.Add(1)
+
+		case storeTxStageVM:
+			vm.Add(1)
+		}
+	})
+	strategy := fundingStrategyFunc(func(coins []Coin,
+		_ btcutil.Amount) ([]Coin, error) {
+
+		if guard.active.Load() != 0 {
+			violations.Add(1)
+		}
+
+		return coins, nil
+	})
+	allow := func(wtxmgr.Credit) bool {
+		if guard.active.Load() != 0 {
+			violations.Add(1)
+		}
+
+		return true
+	}
+
+	_, err := fixture.wallet.CreateSimpleTx(
+		&waddrmgr.KeyScopeBIP0084, waddrmgr.DefaultAccountNum,
+		[]*wire.TxOut{fixture.output()}, 0, 1_000, strategy, false,
+		WithUtxoFilter(allow),
+	)
+	require.NoError(t, err)
+
+	signingTx, prevScripts, keys := testSigningTransaction(t)
+	_, err = fixture.wallet.SignTransaction(
+		signingTx, txscript.SigHashAll, prevScripts, keys, nil,
+	)
+	require.NoError(t, err)
+
+	packet := fixture.packet()
+	_, err = fixture.wallet.FundPsbt(
+		packet, &waddrmgr.KeyScopeBIP0084, 0,
+		waddrmgr.DefaultAccountNum, 1_000, CoinSelectionLargest,
+	)
+	require.NoError(t, err)
+	require.Zero(t, violations.Load())
+	require.Positive(t, crypto.Load())
+	require.Positive(t, signing.Load())
+	require.Positive(t, vm.Load())
+	require.Equal(t, int32(1), client.notifications.Load())
+}
+
+// TestStoreFundingPreparationDoesNotBlockWrites verifies blocked external and
+// cryptographic stages hold no SQLite transaction or write lock.
+func TestStoreFundingPreparationDoesNotBlockWrites(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(
+			*testing.T, *splitFundingFixture, chan struct{}, chan struct{},
+		)
+	}{
+		{
+			name: "allow UTXO",
+			run: func(t *testing.T, fixture *splitFundingFixture, started,
+				release chan struct{}) {
+
+				var once sync.Once
+				result := make(chan error, 1)
+				go func() {
+					_, err := fixture.wallet.CreateSimpleTx(
+						&waddrmgr.KeyScopeBIP0084,
+						waddrmgr.DefaultAccountNum,
+						[]*wire.TxOut{fixture.output()}, 0, 1_000,
+						CoinSelectionLargest, false,
+						WithUtxoFilter(func(wtxmgr.Credit) bool {
+							once.Do(func() { close(started) })
+							<-release
+							return true
+						}),
+					)
+					result <- err
+				}()
+				require.NoError(t, <-result)
+			},
+		},
+		{
+			name: "strategy",
+			run: func(t *testing.T, fixture *splitFundingFixture, started,
+				release chan struct{}) {
+
+				var once sync.Once
+				strategy := fundingStrategyFunc(func(coins []Coin,
+					_ btcutil.Amount) ([]Coin, error) {
+
+					once.Do(func() { close(started) })
+					<-release
+					return coins, nil
+				})
+				result := make(chan error, 1)
+				go func() {
+					_, err := fixture.wallet.CreateSimpleTx(
+						&waddrmgr.KeyScopeBIP0084,
+						waddrmgr.DefaultAccountNum,
+						[]*wire.TxOut{fixture.output()}, 0, 1_000,
+						strategy, false,
+					)
+					result <- err
+				}()
+				require.NoError(t, <-result)
+			},
+		},
+		{
+			name: "signing",
+			run: func(t *testing.T, fixture *splitFundingFixture, started,
+				release chan struct{}) {
+
+				var once sync.Once
+				installStoreTxObserver(t, func(stage storeTxStage) {
+					if stage != storeTxStageSigning {
+						return
+					}
+					once.Do(func() { close(started) })
+					<-release
+				})
+				tx, scripts, keys := testSigningTransaction(t)
+				result := make(chan error, 1)
+				go func() {
+					_, err := fixture.wallet.SignTransaction(
+						tx, txscript.SigHashAll, scripts, keys, nil,
+					)
+					result <- err
+				}()
+				require.NoError(t, <-result)
+			},
+		},
+		{
+			name: "NotifyReceived",
+			run: func(t *testing.T, fixture *splitFundingFixture, started,
+				release chan struct{}) {
+
+				fixture.wallet.chainClient = &splitChainClient{
+					mockChainClient: &mockChainClient{},
+					started:         started,
+					release:         release,
+				}
+				result := make(chan error, 1)
+				go func() {
+					_, err := fixture.wallet.CreateSimpleTx(
+						&waddrmgr.KeyScopeBIP0084,
+						waddrmgr.DefaultAccountNum,
+						[]*wire.TxOut{fixture.output()}, 0, 1_000,
+						CoinSelectionLargest, false,
+					)
+					result <- err
+				}()
+				require.NoError(t, <-result)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newSplitFundingFixture(t)
+			started := make(chan struct{})
+			release := make(chan struct{})
+			finished := make(chan struct{})
+			go func() {
+				test.run(t, fixture, started, release)
+				close(finished)
+			}()
+			select {
+			case <-started:
+
+			case <-time.After(2 * time.Second):
+				close(release)
+				t.Fatal("preparation stage did not block")
+			}
+			unrelatedSQLiteWrite(t, fixture.store)
+			close(release)
+			select {
+			case <-finished:
+
+			case <-time.After(2 * time.Second):
+				t.Fatal("preparation stage did not finish")
+			}
+		})
+	}
+}
+
+// TestStoreFundingConflictsAndRetries verifies stale UTXO and index plans are
+// rebuilt, while Store retries repeat only the database apply phase.
+func TestStoreFundingConflictsAndRetries(t *testing.T) {
+	t.Run("change index", func(t *testing.T) {
+		fixture := newSplitFundingFixture(t)
+		var strategyCalls atomic.Int32
+		strategy := fundingStrategyFunc(func(coins []Coin,
+			_ btcutil.Amount) ([]Coin, error) {
+
+			strategyCalls.Add(1)
+			return coins, nil
+		})
+		fixture.wallet.store = &beforeUpdateStore{
+			Store: fixture.store,
+			hook: func() {
+				require.NoError(t, fixture.store.UpdateOnce(
+					t.Context(), func(tx walletstore.ReadWriteTx) error {
+						state, err := tx.Addr().Account(
+							waddrmgr.KeyScopeBIP0084,
+							waddrmgr.DefaultAccountNum,
+						)
+						if err != nil {
+							return err
+						}
+
+						return tx.Addr().SetAccountIndexes(
+							state.Scope, state.Account,
+							state.NextExternalIndex,
+							state.NextInternalIndex+1,
+						)
+					}, nil,
+				))
+			},
+		}
+		_, err := fixture.wallet.CreateSimpleTx(
+			&waddrmgr.KeyScopeBIP0084, waddrmgr.DefaultAccountNum,
+			[]*wire.TxOut{fixture.output()}, 0, 1_000, strategy, false,
+		)
+		require.NoError(t, err)
+		require.Equal(t, int32(2), strategyCalls.Load())
+	})
+
+	t.Run("stale UTXO", func(t *testing.T) {
+		fixture := newSplitFundingFixture(t)
+		client := &splitChainClient{mockChainClient: &mockChainClient{}}
+		fixture.wallet.chainClient = client
+		fixture.wallet.store = &beforeUpdateStore{
+			Store: fixture.store,
+			hook: func() {
+				spender := wire.NewMsgTx(2)
+				spender.AddTxIn(&wire.TxIn{
+					PreviousOutPoint: fixture.outpoint,
+				})
+				spender.AddTxOut(wire.NewTxOut(
+					900_000, []byte{txscript.OP_TRUE},
+				))
+				record, err := wtxmgr.NewTxRecordFromMsgTx(
+					spender, time.Unix(1_700_000_200, 0),
+				)
+				require.NoError(t, err)
+				require.NoError(t, fixture.store.UpdateOnce(
+					t.Context(), func(tx walletstore.ReadWriteTx) error {
+						return fixture.wallet.addRelevantTxFromStore(
+							tx, record, nil,
+						)
+					}, nil,
+				))
+			},
+		}
+		_, err := fixture.wallet.CreateSimpleTx(
+			&waddrmgr.KeyScopeBIP0084, waddrmgr.DefaultAccountNum,
+			[]*wire.TxOut{fixture.output()}, 0, 1_000,
+			CoinSelectionLargest, false,
+		)
+		require.Error(t, err)
+		require.Zero(t, client.notifications.Load())
+	})
+
+	t.Run("Store retry", func(t *testing.T) {
+		fixture := newSplitFundingFixture(t)
+		retryStore := &retryUpdateStore{Store: fixture.store}
+		fixture.wallet.store = retryStore
+		client := &splitChainClient{mockChainClient: &mockChainClient{}}
+		fixture.wallet.chainClient = client
+		var strategyCalls atomic.Int32
+		strategy := fundingStrategyFunc(func(coins []Coin,
+			_ btcutil.Amount) ([]Coin, error) {
+
+			strategyCalls.Add(1)
+			return coins, nil
+		})
+		_, err := fixture.wallet.CreateSimpleTx(
+			&waddrmgr.KeyScopeBIP0084, waddrmgr.DefaultAccountNum,
+			[]*wire.TxOut{fixture.output()}, 0, 1_000, strategy, false,
+		)
+		require.NoError(t, err)
+		require.Equal(t, int32(1), strategyCalls.Load())
+		require.Equal(t, int32(2), retryStore.updates.Load())
+		require.Equal(t, int32(1), client.notifications.Load())
+	})
+}
+
+// TestStoreSigningSnapshotFailureAndRetry verifies fatal snapshot outcomes do
+// not mutate the caller and read retries never repeat signing or VM work.
+func TestStoreSigningSnapshotFailureAndRetry(t *testing.T) {
+	t.Run("read failure", func(t *testing.T) {
+		fixture := newSplitFundingFixture(t)
+		tx, scripts, keys := testSigningTransaction(t)
+		before := serializeTx(t, tx)
+		readErr := errors.New("snapshot read failed")
+		fixture.wallet.store = &failingViewStore{
+			Store: fixture.store,
+			err:   readErr,
+		}
+		_, err := fixture.wallet.SignTransaction(
+			tx, txscript.SigHashAll, scripts, keys, nil,
+		)
+		require.ErrorIs(t, err, readErr)
+		require.Equal(t, before, serializeTx(t, tx))
+	})
+
+	t.Run("read retry", func(t *testing.T) {
+		fixture := newSplitFundingFixture(t)
+		fixture.wallet.store = &retryingViewStore{Store: fixture.store}
+		tx, scripts, keys := testSigningTransaction(t)
+		var signing atomic.Int32
+		installStoreTxObserver(t, func(stage storeTxStage) {
+			if stage == storeTxStageSigning {
+				signing.Add(1)
+			}
+		})
+		_, err := fixture.wallet.SignTransaction(
+			tx, txscript.SigHashAll, scripts, keys, nil,
+		)
+		require.NoError(t, err)
+		require.Equal(t, int32(1), signing.Load())
+	})
+}
+
+// TestStoreFundingFailuresKeepCallersAtomic verifies write failures leave exact
+// caller PSBT bytes and durable change indexes unchanged.
+func TestStoreFundingFailuresKeepCallersAtomic(t *testing.T) {
+	fixture := newSplitFundingFixture(t)
+	beforeExternal, beforeInternal := storeAccountIndexes(
+		t, fixture.store, waddrmgr.KeyScopeBIP0084,
+		waddrmgr.DefaultAccountNum,
+	)
+	packet := fixture.packet()
+	beforePacket := serializePacket(t, packet)
+	readErr := errors.New("funding snapshot failed")
+	fixture.wallet.store = &failingViewStore{
+		Store: fixture.store,
+		err:   readErr,
+	}
+	_, err := fixture.wallet.FundPsbt(
+		packet, &waddrmgr.KeyScopeBIP0084, 0,
+		waddrmgr.DefaultAccountNum, 1_000, CoinSelectionLargest,
+	)
+	require.ErrorIs(t, err, readErr)
+	require.Equal(t, beforePacket, serializePacket(t, packet))
+
+	writeErr := errors.New("final write failed")
+	fixture.wallet.store = &failingUpdateStore{
+		Store: fixture.store,
+		err:   writeErr,
+	}
+
+	_, err = fixture.wallet.CreateSimpleTx(
+		&waddrmgr.KeyScopeBIP0084, waddrmgr.DefaultAccountNum,
+		[]*wire.TxOut{fixture.output()}, 0, 1_000,
+		CoinSelectionLargest, false,
+	)
+	require.ErrorIs(t, err, writeErr)
+
+	_, err = fixture.wallet.FundPsbt(
+		packet, &waddrmgr.KeyScopeBIP0084, 0,
+		waddrmgr.DefaultAccountNum, 1_000, CoinSelectionLargest,
+	)
+	require.ErrorIs(t, err, writeErr)
+	require.Equal(t, beforePacket, serializePacket(t, packet))
+	afterExternal, afterInternal := storeAccountIndexes(
+		t, fixture.store, waddrmgr.KeyScopeBIP0084,
+		waddrmgr.DefaultAccountNum,
+	)
+	require.Equal(t, beforeExternal, afterExternal)
+	require.Equal(t, beforeInternal, afterInternal)
+
+	rollbackErr := errors.New("rollback completed final write")
+	fixture.wallet.store = &failUpdateStore{
+		Store:    fixture.store,
+		err:      rollbackErr,
+		failNext: true,
+	}
+	_, err = fixture.wallet.FundPsbt(
+		packet, &waddrmgr.KeyScopeBIP0084, 0,
+		waddrmgr.DefaultAccountNum, 1_000, CoinSelectionLargest,
+	)
+	require.ErrorIs(t, err, rollbackErr)
+	require.Equal(t, beforePacket, serializePacket(t, packet))
+	afterExternal, afterInternal = storeAccountIndexes(
+		t, fixture.store, waddrmgr.KeyScopeBIP0084,
+		waddrmgr.DefaultAccountNum,
+	)
+	require.Equal(t, beforeExternal, afterExternal)
+	require.Equal(t, beforeInternal, afterInternal)
+}
+
+// TestStoreFundingAmbiguousCommitNotification verifies watcher registration is
+// withheld for rolled-back addresses and occurs once for a proven durable row.
+func TestStoreFundingAmbiguousCommitNotification(t *testing.T) {
+	t.Run("durable", func(t *testing.T) {
+		fixture := newSplitFundingFixture(t)
+		client := &splitChainClient{mockChainClient: &mockChainClient{}}
+		fixture.wallet.chainClient = client
+		_, beforeInternal := storeAccountIndexes(
+			t, fixture.store, waddrmgr.KeyScopeBIP0084,
+			waddrmgr.DefaultAccountNum,
+		)
+		fixture.wallet.store = &ambiguousCommitStore{
+			Store:                   fixture.store,
+			ambiguousNextUpdateOnce: true,
+		}
+		first, err := fixture.wallet.CreateSimpleTx(
+			&waddrmgr.KeyScopeBIP0084, waddrmgr.DefaultAccountNum,
+			[]*wire.TxOut{fixture.output()}, 0, 1_000,
+			CoinSelectionLargest, false,
+		)
+		require.NoError(t, err)
+		require.Equal(t, int32(1), client.notifications.Load())
+		require.True(t, first.ChangeIndex >= 0)
+		_, afterInternal := storeAccountIndexes(
+			t, fixture.store, waddrmgr.KeyScopeBIP0084,
+			waddrmgr.DefaultAccountNum,
+		)
+		require.Equal(t, beforeInternal+1, afterInternal)
+
+		second, err := fixture.wallet.CreateSimpleTx(
+			&waddrmgr.KeyScopeBIP0084, waddrmgr.DefaultAccountNum,
+			[]*wire.TxOut{fixture.output()}, 0, 1_000,
+			CoinSelectionLargest, false,
+		)
+		require.NoError(t, err)
+		require.True(t, second.ChangeIndex >= 0)
+		require.NotEqual(t,
+			first.Tx.TxOut[first.ChangeIndex].PkScript,
+			second.Tx.TxOut[second.ChangeIndex].PkScript,
+		)
+		require.Equal(t, int32(2), client.notifications.Load())
+		_, afterInternal = storeAccountIndexes(
+			t, fixture.store, waddrmgr.KeyScopeBIP0084,
+			waddrmgr.DefaultAccountNum,
+		)
+		require.Equal(t, beforeInternal+2, afterInternal)
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		fixture := newSplitFundingFixture(t)
+		client := &splitChainClient{mockChainClient: &mockChainClient{}}
+		fixture.wallet.chainClient = client
+		beforeExternal, beforeInternal := storeAccountIndexes(
+			t, fixture.store, waddrmgr.KeyScopeBIP0084,
+			waddrmgr.DefaultAccountNum,
+		)
+		ambiguous := &absentAmbiguousStore{Store: fixture.store}
+		fixture.wallet.store = ambiguous
+		var strategyCalls atomic.Int32
+		strategy := fundingStrategyFunc(func(coins []Coin,
+			_ btcutil.Amount) ([]Coin, error) {
+
+			strategyCalls.Add(1)
+			return coins, nil
+		})
+		_, err := fixture.wallet.CreateSimpleTx(
+			&waddrmgr.KeyScopeBIP0084, waddrmgr.DefaultAccountNum,
+			[]*wire.TxOut{fixture.output()}, 0, 1_000,
+			strategy, false,
+		)
+		require.Error(t, err)
+		require.Equal(t, int32(maxStoreCommitAttempts),
+			ambiguous.updates.Load())
+		require.Equal(t, int32(1), strategyCalls.Load())
+		require.Zero(t, client.notifications.Load())
+		afterExternal, afterInternal := storeAccountIndexes(
+			t, fixture.store, waddrmgr.KeyScopeBIP0084,
+			waddrmgr.DefaultAccountNum,
+		)
+		require.Equal(t, beforeExternal, afterExternal)
+		require.Equal(t, beforeInternal, afterInternal)
+
+		fixture.wallet.store = fixture.store
+		_, err = fixture.wallet.CreateSimpleTx(
+			&waddrmgr.KeyScopeBIP0084, waddrmgr.DefaultAccountNum,
+			[]*wire.TxOut{fixture.output()}, 0, 1_000,
+			CoinSelectionLargest, false,
+		)
+		require.NoError(t, err)
+		require.Equal(t, int32(1), client.notifications.Load())
+		_, afterInternal = storeAccountIndexes(
+			t, fixture.store, waddrmgr.KeyScopeBIP0084,
+			waddrmgr.DefaultAccountNum,
+		)
+		require.Equal(t, beforeInternal+1, afterInternal)
+	})
+
+	t.Run("unresolved durable", func(t *testing.T) {
+		fixture := newSplitFundingFixture(t)
+		beforeExternal, beforeInternal := storeAccountIndexes(
+			t, fixture.store, waddrmgr.KeyScopeBIP0084,
+			waddrmgr.DefaultAccountNum,
+		)
+		packet := fixture.packet()
+		beforePacket := serializePacket(t, packet)
+		reconcileErr := errors.New("reconciliation read failed")
+		fixture.wallet.store = &failingReconcileStore{
+			Store: &ambiguousCommitStore{
+				Store:                   fixture.store,
+				ambiguousNextUpdateOnce: true,
+			},
+			err: reconcileErr,
+		}
+
+		_, err := fixture.wallet.FundPsbt(
+			packet, &waddrmgr.KeyScopeBIP0084, 0,
+			waddrmgr.DefaultAccountNum, 1_000, CoinSelectionLargest,
+		)
+		var unresolved *UnresolvedStoreCommitError
+		require.ErrorAs(t, err, &unresolved)
+		require.ErrorIs(t, err, reconcileErr)
+		require.Equal(t, beforePacket, serializePacket(t, packet))
+		afterExternal, afterInternal := storeAccountIndexes(
+			t, fixture.store, waddrmgr.KeyScopeBIP0084,
+			waddrmgr.DefaultAccountNum,
+		)
+		require.Equal(t, beforeExternal, afterExternal)
+		require.Equal(t, beforeInternal+1, afterInternal)
+
+		fixture.wallet.store = fixture.store
+		_, err = fixture.wallet.FundPsbt(
+			packet, &waddrmgr.KeyScopeBIP0084, 0,
+			waddrmgr.DefaultAccountNum, 1_000, CoinSelectionLargest,
+		)
+		require.NoError(t, err)
+		_, afterInternal = storeAccountIndexes(
+			t, fixture.store, waddrmgr.KeyScopeBIP0084,
+			waddrmgr.DefaultAccountNum,
+		)
+		require.Equal(t, beforeInternal+2, afterInternal)
+	})
+
+	t.Run("watcher failure leaves durable address", func(t *testing.T) {
+		fixture := newSplitFundingFixture(t)
+		beforeExternal, beforeInternal := storeAccountIndexes(
+			t, fixture.store, waddrmgr.KeyScopeBIP0084,
+			waddrmgr.DefaultAccountNum,
+		)
+		notifyErr := errors.New("watcher unavailable")
+		client := &splitChainClient{
+			mockChainClient: &mockChainClient{},
+			notifyErr:       notifyErr,
+		}
+		fixture.wallet.chainClient = client
+		_, err := fixture.wallet.CreateSimpleTx(
+			&waddrmgr.KeyScopeBIP0084, waddrmgr.DefaultAccountNum,
+			[]*wire.TxOut{fixture.output()}, 0, 1_000,
+			CoinSelectionLargest, false,
+		)
+		require.ErrorIs(t, err, notifyErr)
+		require.ErrorContains(t, err, "is durable")
+		require.Equal(t, int32(1), client.notifications.Load())
+		afterExternal, afterInternal := storeAccountIndexes(
+			t, fixture.store, waddrmgr.KeyScopeBIP0084,
+			waddrmgr.DefaultAccountNum,
+		)
+		require.Equal(t, beforeExternal, afterExternal)
+		require.Equal(t, beforeInternal+1, afterInternal)
+	})
+}

--- a/wallet/store_notifications.go
+++ b/wallet/store_notifications.go
@@ -1,0 +1,213 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"context"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	walletstore "github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+)
+
+// notifyUnminedTransactionFromStore publishes a committed unmined transaction
+// and the resulting balances to transaction-notification clients.
+func (s *NotificationServer) notifyUnminedTransactionFromStore(
+	txHash chainhash.Hash) {
+
+	var notification *TransactionNotifications
+	err := s.wallet.store.View(
+		context.Background(), func(tx walletstore.ReadTx) error {
+			details, err := tx.Tx().UniqueTxDetails(&txHash, nil)
+			if err != nil || details == nil {
+				return err
+			}
+
+			summaries := []TransactionSummary{
+				makeTxSummaryFromStore(tx, s.wallet, details),
+			}
+			hashes, err := tx.Tx().UnminedTxHashes()
+			if err != nil {
+				return err
+			}
+
+			balances := make(map[uint32]btcutil.Amount)
+			relevantAccounts(s.wallet, balances, summaries)
+			if err := storeTotalBalances(tx, s.wallet, balances); err != nil {
+				return err
+			}
+
+			notification = &TransactionNotifications{
+				UnminedTransactions:      summaries,
+				UnminedTransactionHashes: hashes,
+				NewBalances: flattenBalanceMap(
+					balances,
+				),
+			}
+
+			return nil
+		}, func() {
+			notification = nil
+		},
+	)
+	if err != nil {
+		log.Errorf("Cannot create unmined transaction notification: %v", err)
+		return
+	}
+	if notification == nil {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.transactions) == 0 {
+		return
+	}
+	if s.currentTxNtfn != nil {
+		log.Errorf("Notifying unmined transaction %s while creating block "+
+			"notifications", txHash)
+	}
+
+	for _, client := range s.transactions {
+		client <- notification
+	}
+}
+
+// notifyMinedTransactionFromStore adds a committed mined transaction to the
+// block notification currently being coalesced.
+func (s *NotificationServer) notifyMinedTransactionFromStore(
+	txHash chainhash.Hash, block *wtxmgr.BlockMeta) {
+
+	var summary *TransactionSummary
+	err := s.wallet.store.View(
+		context.Background(), func(tx walletstore.ReadTx) error {
+			details, err := tx.Tx().UniqueTxDetails(
+				&txHash, &block.Block,
+			)
+			if err != nil || details == nil {
+				return err
+			}
+
+			result := makeTxSummaryFromStore(tx, s.wallet, details)
+			summary = &result
+
+			return nil
+		}, func() {
+			summary = nil
+		},
+	)
+	if err != nil {
+		log.Errorf("Cannot create mined transaction notification: %v", err)
+		return
+	}
+	if summary == nil {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.transactions) == 0 {
+		return
+	}
+	if s.currentTxNtfn == nil {
+		s.currentTxNtfn = &TransactionNotifications{}
+	}
+
+	count := len(s.currentTxNtfn.AttachedBlocks)
+	if count == 0 ||
+		*s.currentTxNtfn.AttachedBlocks[count-1].Hash != block.Hash {
+
+		hash := block.Hash
+		s.currentTxNtfn.AttachedBlocks = append(
+			s.currentTxNtfn.AttachedBlocks, Block{
+				Hash:      &hash,
+				Height:    block.Height,
+				Timestamp: block.Time.Unix(),
+			},
+		)
+		count++
+	}
+
+	attached := &s.currentTxNtfn.AttachedBlocks[count-1]
+	attached.Transactions = append(
+		attached.Transactions, *summary,
+	)
+}
+
+// notifyAttachedBlockFromStore completes and publishes the committed block
+// notification currently being coalesced.
+//
+//nolint:cyclop // The branches preserve notification coalescing semantics.
+func (s *NotificationServer) notifyAttachedBlockFromStore(
+	block *wtxmgr.BlockMeta) {
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	clients := s.transactions
+	if len(clients) == 0 {
+		s.currentTxNtfn = nil
+		return
+	}
+	if s.currentTxNtfn == nil {
+		s.currentTxNtfn = &TransactionNotifications{}
+	}
+
+	count := len(s.currentTxNtfn.AttachedBlocks)
+	if count == 0 ||
+		*s.currentTxNtfn.AttachedBlocks[count-1].Hash != block.Hash {
+
+		hash := block.Hash
+		s.currentTxNtfn.AttachedBlocks = append(
+			s.currentTxNtfn.AttachedBlocks, Block{
+				Hash:      &hash,
+				Height:    block.Height,
+				Timestamp: block.Time.Unix(),
+			},
+		)
+	}
+
+	if s.wallet.ChainSynced() &&
+		len(s.currentTxNtfn.DetachedBlocks) >=
+			len(s.currentTxNtfn.AttachedBlocks) {
+
+		return
+	}
+
+	err := s.wallet.store.View(
+		context.Background(), func(tx walletstore.ReadTx) error {
+			hashes, err := tx.Tx().UnminedTxHashes()
+			if err != nil {
+				return err
+			}
+			s.currentTxNtfn.UnminedTransactionHashes = hashes
+
+			balances := make(map[uint32]btcutil.Amount)
+			for _, attached := range s.currentTxNtfn.AttachedBlocks {
+				relevantAccounts(
+					s.wallet, balances, attached.Transactions,
+				)
+			}
+			if err := storeTotalBalances(tx, s.wallet, balances); err != nil {
+				return err
+			}
+			s.currentTxNtfn.NewBalances = flattenBalanceMap(balances)
+
+			return nil
+		}, nil,
+	)
+	if err != nil {
+		log.Errorf("Cannot complete attached block notification: %v", err)
+		return
+	}
+
+	for _, client := range clients {
+		client <- s.currentTxNtfn
+	}
+	s.currentTxNtfn = nil
+}

--- a/wallet/store_signing.go
+++ b/wallet/store_signing.go
@@ -1,0 +1,458 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	walletstore "github.com/btcsuite/btcwallet/wallet/internal/db"
+)
+
+// storeAccountKey identifies one detached account row.
+type storeAccountKey struct {
+	scope   waddrmgr.KeyScope
+	account uint32
+}
+
+// storeAddressMaterial couples one address row with the account row needed to
+// reconstruct chain-derived key material after a Store callback returns.
+type storeAddressMaterial struct {
+	account waddrmgr.AccountState
+	address waddrmgr.AddressState
+}
+
+// storeAddressSnapshot owns all durable address material read in one Store
+// transaction attempt.
+type storeAddressSnapshot struct {
+	accounts  map[storeAccountKey]waddrmgr.AccountState
+	addresses map[[sha256.Size]byte][]waddrmgr.AddressState
+}
+
+// copyStoreAccountState detaches account byte slices and optional schema state
+// from a backend-owned row.
+func copyStoreAccountState(
+	state waddrmgr.AccountState) waddrmgr.AccountState {
+
+	state.EncryptedPubKey = append([]byte(nil), state.EncryptedPubKey...)
+	state.EncryptedPrivKey = append([]byte(nil), state.EncryptedPrivKey...)
+	if state.AddrSchema != nil {
+		schema := *state.AddrSchema
+		state.AddrSchema = &schema
+	}
+
+	return state
+}
+
+// copyStoreAddressState detaches address byte slices and optional metadata from
+// a backend-owned row.
+func copyStoreAddressState(
+	state waddrmgr.AddressState) waddrmgr.AddressState {
+
+	state.Hash = append([]byte(nil), state.Hash...)
+	state.EncryptedPubKey = append([]byte(nil), state.EncryptedPubKey...)
+	state.EncryptedPrivKey = append([]byte(nil), state.EncryptedPrivKey...)
+	state.EncryptedHash = append([]byte(nil), state.EncryptedHash...)
+	state.EncryptedScript = append([]byte(nil), state.EncryptedScript...)
+	if state.Branch != nil {
+		branch := *state.Branch
+		state.Branch = &branch
+	}
+	if state.Index != nil {
+		index := *state.Index
+		state.Index = &index
+	}
+	if state.WitnessVersion != nil {
+		version := *state.WitnessVersion
+		state.WitnessVersion = &version
+	}
+	if state.IsSecretScript != nil {
+		secret := *state.IsSecretScript
+		state.IsSecretScript = &secret
+	}
+
+	return state
+}
+
+// readStoreAddressSnapshot copies durable account and address rows without
+// decrypting, deriving, validating, or publishing any manager state.
+func readStoreAddressSnapshot(
+	store walletstore.AddrReadStore) (storeAddressSnapshot, error) {
+
+	snapshot := storeAddressSnapshot{
+		accounts: make(map[storeAccountKey]waddrmgr.AccountState),
+		addresses: make(
+			map[[sha256.Size]byte][]waddrmgr.AddressState,
+		),
+	}
+	scopes, err := store.KeyScopes()
+	if err != nil {
+		return storeAddressSnapshot{}, err
+	}
+	for _, scope := range scopes {
+		accounts, err := store.Accounts(scope.Scope)
+		if err != nil {
+			return storeAddressSnapshot{}, err
+		}
+		for _, account := range accounts {
+			account = copyStoreAccountState(account)
+			key := storeAccountKey{
+				scope:   account.Scope,
+				account: account.Account,
+			}
+			snapshot.accounts[key] = account
+		}
+
+		addresses, err := store.ActiveAddresses(scope.Scope)
+		if err != nil {
+			return storeAddressSnapshot{}, err
+		}
+		for _, state := range addresses {
+			state = copyStoreAddressState(state)
+			if len(state.Hash) != sha256.Size {
+				return storeAddressSnapshot{}, fmt.Errorf(
+					"stored address hash has length %d", len(state.Hash),
+				)
+			}
+
+			var hash [sha256.Size]byte
+			copy(hash[:], state.Hash)
+			snapshot.addresses[hash] = append(
+				snapshot.addresses[hash], state,
+			)
+		}
+	}
+
+	return snapshot, nil
+}
+
+// normalizedStoreAddress converts a public-key address to the public-key-hash
+// identity used by durable manager rows.
+func normalizedStoreAddress(addr address.Address) address.Address {
+	if pubKeyAddr, ok := addr.(*address.AddressPubKey); ok {
+		return pubKeyAddr.AddressPubKeyHash()
+	}
+
+	return addr
+}
+
+// material returns detached durable material for an address, optionally
+// restricted to an exact key scope and account.
+func (s storeAddressSnapshot) material(addr address.Address,
+	scope *waddrmgr.KeyScope, account *uint32) (storeAddressMaterial, bool) {
+
+	addr = normalizedStoreAddress(addr)
+	hash := sha256.Sum256(addr.ScriptAddress())
+	for _, state := range s.addresses[hash] {
+		if scope != nil && state.Scope != *scope {
+			continue
+		}
+		if account != nil && state.Account != *account {
+			continue
+		}
+
+		accountState, ok := s.accounts[storeAccountKey{
+			scope:   state.Scope,
+			account: state.Account,
+		}]
+		if !ok {
+			continue
+		}
+
+		return storeAddressMaterial{
+			account: accountState,
+			address: state,
+		}, true
+	}
+
+	return storeAddressMaterial{}, false
+}
+
+// resolve reconstructs one managed address from detached durable state.
+func (s storeAddressSnapshot) resolve(w *Wallet,
+	addr address.Address) (waddrmgr.ManagedAddress, error) {
+
+	material, ok := s.material(addr, nil, nil)
+	if !ok {
+		return nil, fmt.Errorf("unable to find key for addr %v", addr)
+	}
+
+	observeStoreTxStage(storeTxStageCrypto)
+	return w.Manager.AddressFromStoreStates(
+		material.account, material.address,
+	)
+}
+
+// detachedStoreSecretSource resolves already-snapshotted wallet secrets while
+// no Store transaction is active.
+type detachedStoreSecretSource struct {
+	wallet   *Wallet
+	snapshot storeAddressSnapshot
+	managed  map[[sha256.Size]byte]waddrmgr.ManagedAddress
+}
+
+// ChainParams returns the network used to decode signing addresses.
+func (s *detachedStoreSecretSource) ChainParams() *chaincfg.Params {
+	return s.wallet.ChainParams()
+}
+
+// managedAddress resolves and caches one detached managed address.
+func (s *detachedStoreSecretSource) managedAddress(
+	addr address.Address) (waddrmgr.ManagedAddress, error) {
+
+	addr = normalizedStoreAddress(addr)
+	hash := sha256.Sum256(addr.ScriptAddress())
+	if managed := s.managed[hash]; managed != nil {
+		return managed, nil
+	}
+
+	managed, err := s.snapshot.resolve(s.wallet, addr)
+	if err != nil {
+		return nil, err
+	}
+	s.managed[hash] = managed
+
+	return managed, nil
+}
+
+// GetKey returns a private key reconstructed from detached durable state.
+func (s *detachedStoreSecretSource) GetKey(
+	addr address.Address) (*btcec.PrivateKey, bool, error) {
+
+	managed, err := s.managedAddress(addr)
+	if err != nil {
+		return nil, false, err
+	}
+	pubKeyAddr, ok := managed.(waddrmgr.ManagedPubKeyAddress)
+	if !ok {
+		return nil, false, fmt.Errorf("address %v is not a pubkey address",
+			managed.Address().EncodeAddress())
+	}
+
+	observeStoreTxStage(storeTxStageCrypto)
+	key, err := pubKeyAddr.PrivKey()
+	if err != nil {
+		return nil, false, err
+	}
+
+	return key, pubKeyAddr.Compressed(), nil
+}
+
+// GetScript returns a script decrypted from detached durable state.
+func (s *detachedStoreSecretSource) GetScript(
+	addr address.Address) ([]byte, error) {
+
+	managed, err := s.managedAddress(addr)
+	if err != nil {
+		return nil, err
+	}
+	scriptAddr, ok := managed.(waddrmgr.ManagedScriptAddress)
+	if !ok {
+		return nil, errors.New("address is not a script address")
+	}
+
+	observeStoreTxStage(storeTxStageCrypto)
+	return scriptAddr.Script()
+}
+
+// scriptForStoreOutput returns signing metadata for a managed pubkey address
+// reconstructed from detached durable state.
+func scriptForStoreOutput(output *wire.TxOut,
+	managed waddrmgr.ManagedAddress,
+	params *chaincfg.Params) (waddrmgr.ManagedPubKeyAddress, []byte, []byte,
+	error) {
+
+	pubKeyAddr, ok := managed.(waddrmgr.ManagedPubKeyAddress)
+	if !ok {
+		return nil, nil, nil, fmt.Errorf("address %s is not a pubkey "+
+			"address", managed.Address())
+	}
+
+	var (
+		witnessProgram []byte
+		sigScript      []byte
+	)
+	if managed.AddrType() == waddrmgr.NestedWitnessPubKey {
+		pubKeyHash := address.Hash160(
+			pubKeyAddr.PubKey().SerializeCompressed(),
+		)
+		witnessAddr, err := address.NewAddressWitnessPubKeyHash(
+			pubKeyHash, params,
+		)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		witnessProgram, err = txscript.PayToAddrScript(witnessAddr)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		sigScript, err = txscript.NewScriptBuilder().AddData(
+			witnessProgram,
+		).Script()
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	} else {
+		witnessProgram = append([]byte(nil), output.PkScript...)
+	}
+
+	return pubKeyAddr, witnessProgram, sigScript, nil
+}
+
+// signTransactionFromStore snapshots previous scripts and address rows, signs
+// and validates a transaction copy outside the Store view, then publishes only
+// completed input scripts to the caller transaction.
+func (w *Wallet) signTransactionFromStore(tx *wire.MsgTx,
+	hashType txscript.SigHashType,
+	additionalPrevScripts map[wire.OutPoint][]byte,
+	additionalKeysByAddress map[string]*btcutil.WIF,
+	p2shRedeemScriptsByAddress map[string][]byte) ([]SignatureError, error) {
+
+	workingTx := tx.Copy()
+	var (
+		prevScripts [][]byte
+		addresses   storeAddressSnapshot
+	)
+	err := w.store.View(
+		context.Background(), func(dbtx walletstore.ReadTx) error {
+			prevScripts = make([][]byte, len(workingTx.TxIn))
+			for i, txIn := range workingTx.TxIn {
+				prevOutScript, ok := additionalPrevScripts[txIn.PreviousOutPoint]
+				if !ok {
+					prevHash := &txIn.PreviousOutPoint.Hash
+					details, err := dbtx.Tx().TxDetails(prevHash)
+					if err != nil {
+						return fmt.Errorf("cannot query previous "+
+							"transaction details for %v: %w",
+							txIn.PreviousOutPoint, err)
+					}
+					if details == nil {
+						return fmt.Errorf("%v not found",
+							txIn.PreviousOutPoint)
+					}
+					prevIndex := txIn.PreviousOutPoint.Index
+					if prevIndex >= uint32(len(details.MsgTx.TxOut)) {
+						return fmt.Errorf("previous output %v is out of range",
+							txIn.PreviousOutPoint)
+					}
+					prevOutScript = details.MsgTx.TxOut[prevIndex].PkScript
+				}
+
+				prevScripts[i] = append([]byte(nil), prevOutScript...)
+			}
+
+			var err error
+			addresses, err = readStoreAddressSnapshot(dbtx.Addr())
+
+			return err
+		}, func() {
+			prevScripts = nil
+			addresses = storeAddressSnapshot{}
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	secrets := &detachedStoreSecretSource{
+		wallet:   w,
+		snapshot: addresses,
+		managed: make(
+			map[[sha256.Size]byte]waddrmgr.ManagedAddress,
+		),
+	}
+	inputFetcher := txscript.NewMultiPrevOutFetcher(nil)
+	for i, txIn := range workingTx.TxIn {
+		inputFetcher.AddPrevOut(txIn.PreviousOutPoint, &wire.TxOut{
+			PkScript: prevScripts[i],
+		})
+	}
+
+	var signErrors []SignatureError
+	for i, txIn := range workingTx.TxIn {
+		getKey := txscript.KeyClosure(func(
+			addr address.Address) (*btcec.PrivateKey, bool, error) {
+
+			if len(additionalKeysByAddress) != 0 {
+				wif, ok := additionalKeysByAddress[addr.EncodeAddress()]
+				if !ok {
+					return nil, false, errors.New("no key for address")
+				}
+
+				return wif.PrivKey, wif.CompressPubKey, nil
+			}
+
+			return secrets.GetKey(addr)
+		})
+		getScript := txscript.ScriptClosure(func(
+			addr address.Address) ([]byte, error) {
+
+			if len(additionalKeysByAddress) != 0 {
+				script, ok := p2shRedeemScriptsByAddress[addr.EncodeAddress()]
+				if !ok {
+					return nil, errors.New("no script for address")
+				}
+
+				return script, nil
+			}
+
+			return secrets.GetScript(addr)
+		})
+
+		if (hashType&txscript.SigHashSingle) != txscript.SigHashSingle ||
+			i < len(workingTx.TxOut) {
+
+			observeStoreTxStage(storeTxStageSigning)
+			script, err := txscript.SignTxOutput(
+				w.ChainParams(), workingTx, i, prevScripts[i], hashType,
+				getKey, getScript, txIn.SignatureScript,
+			)
+			if err != nil {
+				signErrors = append(signErrors, SignatureError{
+					InputIndex: uint32(i),
+					Error:      err,
+				})
+				continue
+			}
+			txIn.SignatureScript = script
+		}
+
+		observeStoreTxStage(storeTxStageVM)
+		vm, err := txscript.NewEngine(
+			prevScripts[i], workingTx, i, txscript.StandardVerifyFlags,
+			nil, nil, 0, inputFetcher,
+		)
+		if err == nil {
+			err = vm.Execute()
+		}
+		if err != nil {
+			signErrors = append(signErrors, SignatureError{
+				InputIndex: uint32(i),
+				Error:      err,
+			})
+		}
+	}
+
+	for i := range tx.TxIn {
+		tx.TxIn[i].SignatureScript = append(
+			tx.TxIn[i].SignatureScript[:0],
+			workingTx.TxIn[i].SignatureScript...,
+		)
+		tx.TxIn[i].Witness = append(
+			wire.TxWitness(nil), workingTx.TxIn[i].Witness...,
+		)
+	}
+
+	return signErrors, nil
+}

--- a/wallet/store_transactions.go
+++ b/wallet/store_transactions.go
@@ -1,0 +1,315 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"bytes"
+
+	"github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	walletstore "github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+)
+
+// storeAccountName returns the account name controlling an address. Address
+// lookup failures intentionally produce an empty name to preserve the legacy
+// transaction-listing behavior.
+func storeAccountName(tx walletstore.ReadTx, w *Wallet,
+	addr address.Address) string {
+
+	manager, account, err := w.Manager.AddrAccountFromStore(tx.Addr(), addr)
+	if err != nil {
+		return ""
+	}
+
+	name, err := manager.AccountNameFromStore(tx.Addr(), account)
+	if err != nil {
+		return ""
+	}
+
+	return name
+}
+
+// listTransactionsFromStore formats transaction details for the legacy JSON
+// transaction-listing APIs through a closure Store transaction.
+//
+//nolint:cyclop,gocognit // This mirrors the established result classification.
+func listTransactionsFromStore(tx walletstore.ReadTx, w *Wallet,
+	details *wtxmgr.TxDetails,
+	syncHeight int32) []btcjson.ListTransactionsResult {
+
+	var (
+		blockHashStr  string
+		blockTime     int64
+		confirmations int64
+	)
+	if details.Block.Height != -1 {
+		blockHashStr = details.Block.Hash.String()
+		blockTime = details.Block.Time.Unix()
+		confirmations = int64(calcConf(details.Block.Height, syncHeight))
+	}
+
+	results := []btcjson.ListTransactionsResult{}
+	txHashStr := details.Hash.String()
+	received := details.Received.Unix()
+	generated := blockchain.IsCoinBaseTx(&details.MsgTx)
+	recvCategory := RecvCategory(
+		details, syncHeight, w.chainParams,
+	).String()
+	send := len(details.Debits) != 0
+
+	// A fee is known only when every input debits a wallet credit.
+	var fee float64
+	if len(details.Debits) == len(details.MsgTx.TxIn) {
+		var debitTotal btcutil.Amount
+		for _, debit := range details.Debits {
+			debitTotal += debit.Amount
+		}
+
+		var outputTotal btcutil.Amount
+		for _, output := range details.MsgTx.TxOut {
+			outputTotal += btcutil.Amount(output.Value)
+		}
+
+		fee = (outputTotal - debitTotal).ToBTC()
+	}
+
+outputs:
+	for i, output := range details.MsgTx.TxOut {
+		var (
+			isCredit    bool
+			spentCredit bool
+		)
+		for _, credit := range details.Credits {
+			if credit.Index != uint32(i) {
+				continue
+			}
+			if credit.Change {
+				continue outputs
+			}
+
+			isCredit = true
+			spentCredit = credit.Spent
+
+			break
+		}
+
+		var (
+			addressString string
+			accountName   string
+		)
+		_, addrs, _, _ := txscript.ExtractPkScriptAddrs(
+			output.PkScript, w.chainParams,
+		)
+		if len(addrs) == 1 {
+			addressString = addrs[0].EncodeAddress()
+			accountName = storeAccountName(tx, w, addrs[0])
+		}
+
+		amount := btcutil.Amount(output.Value).ToBTC()
+		result := btcjson.ListTransactionsResult{
+			Address:         addressString,
+			Vout:            uint32(i),
+			Confirmations:   confirmations,
+			Generated:       generated,
+			BlockHash:       blockHashStr,
+			BlockTime:       blockTime,
+			TxID:            txHashStr,
+			WalletConflicts: []string{},
+			Time:            received,
+			TimeReceived:    received,
+		}
+
+		if send || spentCredit {
+			result.Category = "send"
+			result.Amount = -amount
+			result.Fee = &fee
+			results = append(results, result)
+		}
+		if isCredit {
+			result.Account = accountName
+			result.Category = recvCategory
+			result.Amount = amount
+			result.Fee = nil
+			results = append(results, result)
+		}
+	}
+
+	return results
+}
+
+// lookupInputAccountFromStore resolves the account debited by one transaction
+// input through the transaction and address views sharing the same snapshot.
+func lookupInputAccountFromStore(tx walletstore.ReadTx, w *Wallet,
+	details *wtxmgr.TxDetails, debit wtxmgr.DebitRecord) uint32 {
+
+	prevOut := &details.MsgTx.TxIn[debit.Index].PreviousOutPoint
+	previous, err := tx.Tx().TxDetails(&prevOut.Hash)
+	if err != nil {
+		log.Errorf("Cannot query previous transaction details for %v: %v",
+			prevOut.Hash, err)
+		return 0
+	}
+	if previous == nil {
+		log.Errorf("Missing previous transaction %v", prevOut.Hash)
+		return 0
+	}
+
+	output := previous.MsgTx.TxOut[prevOut.Index]
+	_, addrs, _, err := txscript.ExtractPkScriptAddrs(
+		output.PkScript, w.chainParams,
+	)
+	if err != nil || len(addrs) == 0 {
+		if err != nil {
+			log.Errorf("Cannot parse previous output %v: %v", prevOut, err)
+		}
+
+		return 0
+	}
+
+	_, account, err := w.Manager.AddrAccountFromStore(tx.Addr(), addrs[0])
+	if err != nil {
+		log.Errorf("Cannot fetch account for previous output %v: %v",
+			prevOut, err)
+		return 0
+	}
+
+	return account
+}
+
+// lookupOutputChainFromStore resolves the account and branch for one wallet
+// credit through the address view sharing the transaction snapshot.
+func lookupOutputChainFromStore(tx walletstore.ReadTx, w *Wallet,
+	details *wtxmgr.TxDetails,
+	credit wtxmgr.CreditRecord) (uint32, bool) {
+
+	output := details.MsgTx.TxOut[credit.Index]
+	_, addrs, _, err := txscript.ExtractPkScriptAddrs(
+		output.PkScript, w.chainParams,
+	)
+	if err != nil || len(addrs) == 0 {
+		if err != nil {
+			log.Errorf("Cannot parse wallet output: %v", err)
+		}
+
+		return 0, false
+	}
+
+	managed, err := w.Manager.AddressFromStore(tx.Addr(), addrs[0])
+	if err != nil {
+		log.Errorf("Cannot fetch account for wallet output: %v", err)
+		return 0, false
+	}
+
+	return managed.InternalAccount(), managed.Internal()
+}
+
+// makeTxSummaryFromStore creates the public transaction summary through a
+// closure Store snapshot.
+//
+//nolint:cyclop // This mirrors the established transaction summary logic.
+func makeTxSummaryFromStore(tx walletstore.ReadTx, w *Wallet,
+	details *wtxmgr.TxDetails) TransactionSummary {
+
+	serializedTx := details.SerializedTx
+	if serializedTx == nil {
+		var buffer bytes.Buffer
+		err := details.MsgTx.Serialize(&buffer)
+		if err != nil {
+			log.Errorf("Transaction serialization: %v", err)
+		}
+		serializedTx = buffer.Bytes()
+	}
+
+	var fee btcutil.Amount
+	if len(details.Debits) == len(details.MsgTx.TxIn) {
+		for _, debit := range details.Debits {
+			fee += debit.Amount
+		}
+		for _, output := range details.MsgTx.TxOut {
+			fee -= btcutil.Amount(output.Value)
+		}
+	}
+
+	var inputs []TransactionSummaryInput
+	if len(details.Debits) != 0 {
+		inputs = make([]TransactionSummaryInput, len(details.Debits))
+		for i, debit := range details.Debits {
+			inputs[i] = TransactionSummaryInput{
+				Index: debit.Index,
+				PreviousAccount: lookupInputAccountFromStore(
+					tx, w, details, debit,
+				),
+				PreviousAmount: debit.Amount,
+			}
+		}
+	}
+
+	outputs := make([]TransactionSummaryOutput, 0, len(details.MsgTx.TxOut))
+	for i := range details.MsgTx.TxOut {
+		creditIndex := len(outputs)
+		isCredit := len(details.Credits) > creditIndex &&
+			details.Credits[creditIndex].Index == uint32(i)
+		if !isCredit {
+			continue
+		}
+
+		account, internal := lookupOutputChainFromStore(
+			tx, w, details, details.Credits[creditIndex],
+		)
+		outputs = append(outputs, TransactionSummaryOutput{
+			Index:    uint32(i),
+			Account:  account,
+			Internal: internal,
+		})
+	}
+
+	return TransactionSummary{
+		Hash:        &details.Hash,
+		Transaction: serializedTx,
+		MyInputs:    inputs,
+		MyOutputs:   outputs,
+		Fee:         fee,
+		Timestamp:   details.Received.Unix(),
+		Label:       details.Label,
+		Tx:          &details.MsgTx,
+	}
+}
+
+// storeTotalBalances fills balances for the requested accounts from spendable
+// credits in the transaction snapshot.
+func storeTotalBalances(tx walletstore.ReadTx, w *Wallet,
+	balances map[uint32]btcutil.Amount) error {
+
+	unspent, err := tx.Tx().UnspentOutputs()
+	if err != nil {
+		return err
+	}
+
+	for i := range unspent {
+		output := &unspent[i]
+		_, addrs, _, err := txscript.ExtractPkScriptAddrs(
+			output.PkScript, w.chainParams,
+		)
+		if err != nil || len(addrs) == 0 {
+			continue
+		}
+
+		_, account, err := w.Manager.AddrAccountFromStore(
+			tx.Addr(), addrs[0],
+		)
+		if err != nil {
+			continue
+		}
+		if _, ok := balances[account]; ok {
+			balances[account] += output.Amount
+		}
+	}
+
+	return nil
+}

--- a/wallet/store_wallet_test.go
+++ b/wallet/store_wallet_test.go
@@ -1,0 +1,586 @@
+package wallet
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	walletstore "github.com/btcsuite/btcwallet/wallet/internal/db"
+	walletkvdb "github.com/btcsuite/btcwallet/wallet/internal/db/kvdb"
+	dbsqlite "github.com/btcsuite/btcwallet/wallet/internal/db/sqlite"
+	storesqlite "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite"
+	sqlitedb "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/stretchr/testify/require"
+)
+
+// managerFixture contains the durable address-manager state copied from a
+// normal KV wallet before the SQLite-only runtime starts.
+type managerFixture struct {
+	manager   waddrmgr.ManagerState
+	sync      waddrmgr.SyncState
+	scopes    []waddrmgr.KeyScopeState
+	accounts  []waddrmgr.AccountState
+	addresses []managerAddressFixture
+}
+
+// managerAddressFixture couples backend-neutral address state with the legacy
+// identifier whose digest is stored by SQL.
+type managerAddressFixture struct {
+	id    []byte
+	state waddrmgr.AddressState
+}
+
+// readManagerFixture copies manager state through the KV Store adapter and
+// resolves each address's legacy identifier through the real manager.
+func readManagerFixture(t *testing.T, store walletstore.Store,
+	database walletdb.DB, manager *waddrmgr.Manager) managerFixture {
+
+	t.Helper()
+
+	var fixture managerFixture
+	addressStates := make(map[string]waddrmgr.AddressState)
+	err := store.View(t.Context(), func(tx walletstore.ReadTx) error {
+		var err error
+		fixture.manager, err = tx.Addr().ManagerState()
+		if err != nil {
+			return err
+		}
+
+		fixture.sync, err = tx.Addr().SyncState()
+		if err != nil {
+			return err
+		}
+
+		fixture.scopes, err = tx.Addr().KeyScopes()
+		if err != nil {
+			return err
+		}
+
+		for _, scope := range fixture.scopes {
+			accounts, err := tx.Addr().Accounts(scope.Scope)
+			if err != nil {
+				return err
+			}
+
+			for _, account := range accounts {
+				// SQL represents the imported account's absent HD key as an
+				// empty, non-null blob.
+				if account.Account == waddrmgr.ImportedAddrAccount {
+					account.EncryptedPubKey = []byte{}
+				}
+
+				fixture.accounts = append(fixture.accounts, account)
+			}
+
+			addresses, err := tx.Addr().ActiveAddresses(scope.Scope)
+			if err != nil {
+				return err
+			}
+			for _, state := range addresses {
+				addressStates[string(state.Hash)] = state
+			}
+		}
+
+		return nil
+	}, func() {})
+	require.NoError(t, err)
+
+	err = walletdb.View(database, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+		for _, scope := range fixture.scopes {
+			scoped, err := manager.FetchScopedKeyManager(scope.Scope)
+			if err != nil {
+				return err
+			}
+
+			err = scoped.ForEachActiveAddress(
+				ns, func(addr address.Address) error {
+					id := addr.ScriptAddress()
+					hash := sha256.Sum256(id)
+					state, ok := addressStates[string(hash[:])]
+					if !ok {
+						return errors.New("address state not found")
+					}
+
+					fixture.addresses = append(
+						fixture.addresses, managerAddressFixture{
+							id:    append([]byte(nil), id...),
+							state: state,
+						},
+					)
+					delete(addressStates, string(hash[:]))
+
+					return nil
+				},
+			)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+	require.Empty(t, addressStates)
+
+	return fixture
+}
+
+// putFixtureBlock inserts one block required by the SQLite wallet lifecycle
+// foreign keys.
+func putFixtureBlock(t *testing.T, queries *sqlitedb.Queries, walletID int64,
+	block waddrmgr.BlockStamp) {
+
+	t.Helper()
+	require.NoError(t, queries.EnsureBlockHeight(
+		t.Context(), sqlitedb.EnsureBlockHeightParams{
+			BlockHeight:    int64(block.Height),
+			HeaderHash:     block.Hash[:],
+			BlockTimestamp: block.Timestamp.Unix(),
+		},
+	))
+	require.NoError(t, queries.InsertBlock(t.Context(),
+		sqlitedb.InsertBlockParams{
+			WalletID:       walletID,
+			BlockHeight:    int64(block.Height),
+			HeaderHash:     block.Hash[:],
+			BlockTimestamp: block.Timestamp.Unix(),
+		}))
+}
+
+// writeManagerFixture materializes the pre-migrated fixture through SQLite
+// lifecycle queries and the backend-neutral Store.
+func writeManagerFixture(t *testing.T, conn *sql.DB,
+	fixture managerFixture) (int64, walletstore.Store) {
+
+	t.Helper()
+	queries := sqlitedb.New(conn)
+
+	birthdayHeight := sql.NullInt64{}
+	if fixture.sync.BirthdayBlock != nil {
+		birthdayHeight = sql.NullInt64{
+			Int64: int64(fixture.sync.BirthdayBlock.Height),
+			Valid: true,
+		}
+	}
+
+	walletID, err := queries.CreateWallet(
+		t.Context(), sqlitedb.CreateWalletParams{
+			WalletName:               "store-wallet",
+			ManagerVersion:           int64(fixture.manager.Version),
+			ManagerCreatedAt:         fixture.manager.CreatedAt.Unix(),
+			IsWatchOnly:              fixture.manager.WatchOnly,
+			MasterPubParams:          fixture.manager.MasterPubParams,
+			MasterPrivParams:         fixture.manager.MasterPrivParams,
+			EncryptedCryptoPubKey:    fixture.manager.EncryptedCryptoPubKey,
+			EncryptedCryptoPrivKey:   fixture.manager.EncryptedCryptoPrivKey,
+			EncryptedCryptoScriptKey: fixture.manager.EncryptedCryptoScriptKey,
+			EncryptedMasterHdPubKey:  fixture.manager.EncryptedMasterHDPubKey,
+			EncryptedMasterHdPrivKey: fixture.manager.EncryptedMasterHDPrivKey,
+		},
+	)
+	require.NoError(t, err)
+	putFixtureBlock(t, queries, walletID, fixture.sync.StartBlock)
+	putFixtureBlock(t, queries, walletID, fixture.sync.SyncedTo)
+
+	if fixture.sync.BirthdayBlock != nil {
+		putFixtureBlock(t, queries, walletID, *fixture.sync.BirthdayBlock)
+	}
+
+	require.NoError(t, queries.PutWalletSyncState(
+		t.Context(), sqlitedb.PutWalletSyncStateParams{
+			WalletID:              walletID,
+			StartBlockHeight:      int64(fixture.sync.StartBlock.Height),
+			SyncedBlockHeight:     int64(fixture.sync.SyncedTo.Height),
+			BirthdayTimestamp:     fixture.sync.Birthday.Unix(),
+			BirthdayBlockHeight:   birthdayHeight,
+			BirthdayBlockVerified: fixture.sync.BirthdayBlockVerified,
+		},
+	))
+
+	store := dbsqlite.NewStore(conn, walletID)
+	err = store.Update(t.Context(), func(tx walletstore.ReadWriteTx) error {
+		for _, scope := range fixture.scopes {
+			if err := tx.Addr().PutKeyScope(scope); err != nil {
+				return err
+			}
+		}
+
+		for _, account := range fixture.accounts {
+			if err := tx.Addr().PutAccount(account); err != nil {
+				return err
+			}
+		}
+
+		for _, address := range fixture.addresses {
+			if err := tx.Addr().PutAddress(
+				address.id, address.state,
+			); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}, func() {})
+	require.NoError(t, err)
+
+	return walletID, store
+}
+
+// openStoreWallet opens and starts the existing Wallet through the Store-only
+// Loader mode.
+func openStoreWallet(t *testing.T, params *chaincfg.Params,
+	store walletstore.Store, pubPass []byte) (*Loader, *Wallet) {
+
+	t.Helper()
+	loader, err := NewLoaderWithStore(params, 0, store)
+	require.NoError(t, err)
+
+	wallet, err := loader.OpenExistingWallet(pubPass, false)
+	require.NoError(t, err)
+	wallet.chainClient = &mockChainClient{}
+
+	return loader, wallet
+}
+
+// requireManagedPrivateKey verifies that an address reconstructed or allocated
+// by the store-backed manager exposes its private key while unlocked.
+func requireManagedPrivateKey(t *testing.T, managed waddrmgr.ManagedAddress) {
+	t.Helper()
+
+	pubKeyAddr, ok := managed.(waddrmgr.ManagedPubKeyAddress)
+	require.True(t, ok)
+	privKey, err := pubKeyAddr.PrivKey()
+	require.NoError(t, err)
+	privKey.Zero()
+}
+
+// TestStoreBackedWalletAddressRestart verifies KV fixture migration, real
+// manager open, rollback-safe allocation, and durable SQLite restart without a
+// walletdb sidecar.
+func TestStoreBackedWalletAddressRestart(t *testing.T) {
+	t.Parallel()
+
+	params := &chaincfg.TestNet3Params
+	pubPass := []byte("public-pass")
+	privPass := []byte("private-pass")
+	seed, err := hdkeychain.GenerateSeed(hdkeychain.MinSeedBytes)
+	require.NoError(t, err)
+
+	kvDir := filepath.Join(t.TempDir(), "kv")
+	kvLoader := NewLoader(
+		params, kvDir, true, DefaultDBTimeout, 0,
+	)
+	kvWallet, err := kvLoader.CreateNewWallet(
+		pubPass, privPass, seed, time.Unix(1_700_000_000, 0),
+	)
+	require.NoError(t, err)
+
+	kvStore := walletkvdb.NewStore(
+		kvWallet.Database(), kvWallet.Manager, kvWallet.TxStore,
+	)
+	kvScoped, err := kvWallet.Manager.FetchScopedKeyManager(
+		waddrmgr.KeyScopeBIP0084,
+	)
+	require.NoError(t, err)
+	require.NoError(t, kvWallet.Unlock(privPass, nil))
+
+	var (
+		secondaryAccount uint32
+		kvExternal       waddrmgr.ManagedAddress
+		kvInternal       waddrmgr.ManagedAddress
+	)
+	require.NoError(t, walletdb.Update(
+		kvWallet.Database(), func(tx walletdb.ReadWriteTx) error {
+			ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+			secondaryAccount, err = kvScoped.NewAccount(ns, "secondary")
+			if err != nil {
+				return err
+			}
+
+			external, err := kvScoped.NextExternalAddresses(
+				ns, waddrmgr.DefaultAccountNum, 1,
+			)
+			if err != nil {
+				return err
+			}
+			kvExternal = external[0]
+
+			internal, err := kvScoped.NextInternalAddresses(
+				ns, waddrmgr.DefaultAccountNum, 1,
+			)
+			if err != nil {
+				return err
+			}
+			kvInternal = internal[0]
+
+			return nil
+		},
+	))
+	require.Equal(t, uint32(1), secondaryAccount)
+
+	fixture := readManagerFixture(
+		t, kvStore, kvWallet.Database(), kvWallet.Manager,
+	)
+	watchOnly := kvWallet.Manager.WatchOnly()
+
+	var kvProps *waddrmgr.AccountProperties
+	require.NoError(t, walletdb.View(
+		kvWallet.Database(), func(tx walletdb.ReadTx) error {
+			var err error
+			kvProps, err = kvScoped.AccountProperties(
+				tx.ReadBucket(waddrmgrNamespaceKey),
+				waddrmgr.DefaultAccountNum,
+			)
+			return err
+		},
+	))
+	require.NoError(t, kvLoader.UnloadWallet())
+	require.NoError(t, os.RemoveAll(kvDir))
+
+	sqlDir := filepath.Join(t.TempDir(), "sqlite")
+	require.NoError(t, os.MkdirAll(sqlDir, 0o700))
+	sqlPath := filepath.Join(sqlDir, "wallet.sqlite")
+	conn, err := storesqlite.Open(context.Background(), storesqlite.Config{
+		DBPath: sqlPath,
+	})
+	require.NoError(t, err)
+	require.NoError(t, storesqlite.ApplyMigrations(conn))
+
+	walletID, store := writeManagerFixture(t, conn, fixture)
+	createLoader, err := NewLoaderWithStore(params, 0, store)
+	require.NoError(t, err)
+	_, err = createLoader.CreateNewWallet(
+		pubPass, privPass, seed, fixture.sync.Birthday,
+	)
+	require.ErrorIs(t, err, ErrExists)
+
+	wrongLoader, err := NewLoaderWithStore(params, 0, store)
+	require.NoError(t, err)
+	_, err = wrongLoader.OpenExistingWallet([]byte("wrong"), false)
+	require.True(t, waddrmgr.IsError(err, waddrmgr.ErrWrongPassphrase))
+
+	loader, sqlWallet := openStoreWallet(t, params, store, pubPass)
+	require.Equal(
+		t, watchOnly, sqlWallet.Manager.WatchOnly(),
+	)
+	require.Equal(t, fixture.sync.Birthday, sqlWallet.Manager.Birthday())
+	require.Equal(t, fixture.sync.SyncedTo, sqlWallet.Manager.SyncedTo())
+	require.Len(t, sqlWallet.Manager.ActiveScopedKeyManagers(),
+		len(fixture.scopes))
+
+	sqlScoped, err := sqlWallet.Manager.FetchScopedKeyManager(
+		waddrmgr.KeyScopeBIP0084,
+	)
+	require.NoError(t, err)
+	var sqlProps *waddrmgr.AccountProperties
+	require.NoError(t, store.View(
+		t.Context(), func(tx walletstore.ReadTx) error {
+			var err error
+			sqlProps, err = sqlScoped.AccountPropertiesFromStore(
+				tx.Addr(), waddrmgr.DefaultAccountNum,
+			)
+			return err
+		}, func() {},
+	))
+	require.Equal(t, kvProps.ExternalKeyCount, sqlProps.ExternalKeyCount)
+	require.Equal(t, kvProps.InternalKeyCount, sqlProps.InternalKeyCount)
+	require.Equal(t, kvProps.AccountPubKey.String(),
+		sqlProps.AccountPubKey.String())
+
+	lastExternal, err := sqlScoped.LastExternalAddress(
+		nil, waddrmgr.DefaultAccountNum,
+	)
+	require.NoError(t, err)
+	require.Equal(t, kvExternal.Address().String(),
+		lastExternal.Address().String())
+	lastInternal, err := sqlScoped.LastInternalAddress(
+		nil, waddrmgr.DefaultAccountNum,
+	)
+	require.NoError(t, err)
+	require.Equal(t, kvInternal.Address().String(),
+		lastInternal.Address().String())
+
+	// Wallet.Unlock must use the store-backed path and derive private keys
+	// for chain addresses reconstructed during open.
+	require.NoError(t, sqlWallet.Unlock(privPass, nil))
+	requireManagedPrivateKey(t, lastExternal)
+	requireManagedPrivateKey(t, lastInternal)
+
+	secondaryAddr, err := sqlWallet.NewAddress(
+		secondaryAccount, waddrmgr.KeyScopeBIP0084,
+	)
+	require.NoError(t, err)
+	secondaryManaged, err := sqlScoped.Address(nil, secondaryAddr)
+	require.NoError(t, err)
+	requireManagedPrivateKey(t, secondaryManaged)
+
+	secondaryAddrTwo, err := sqlWallet.NewAddress(
+		secondaryAccount, waddrmgr.KeyScopeBIP0084,
+	)
+	require.NoError(t, err)
+	require.NotEqual(t, secondaryAddr.String(), secondaryAddrTwo.String())
+	requireManagedPrivateKey(t, secondaryManaged)
+
+	secondaryPub, ok := secondaryManaged.(waddrmgr.ManagedPubKeyAddress)
+	require.True(t, ok)
+	_, secondaryPath, ok := secondaryPub.DerivationInfo()
+	require.True(t, ok)
+	derivedSecondary, err := sqlScoped.DeriveFromKeyPath(
+		nil, secondaryPath,
+	)
+	require.NoError(t, err)
+	requireManagedPrivateKey(t, derivedSecondary)
+
+	// An ambiguous result refreshes durable indexes into the existing
+	// account object rather than evicting its decrypted private key.
+	sqlWallet.Manager.MarkAccountCacheStale(
+		waddrmgr.KeyScopeBIP0084, secondaryAccount,
+	)
+	require.NoError(t, store.View(
+		t.Context(), func(tx walletstore.ReadTx) error {
+			props, err := sqlScoped.AccountPropertiesFromStore(
+				tx.Addr(), secondaryAccount,
+			)
+			if err == nil {
+				require.EqualValues(t, 2, props.ExternalKeyCount)
+			}
+			return err
+		}, nil,
+	))
+	derivedSecondary, err = sqlScoped.DeriveFromKeyPath(nil, secondaryPath)
+	require.NoError(t, err)
+	requireManagedPrivateKey(t, derivedSecondary)
+
+	rollbackErr := errors.New("force address rollback")
+	var attempted address.Address
+	err = store.UpdateOnce(
+		t.Context(), func(tx walletstore.ReadWriteTx) error {
+			managed, _, err := sqlScoped.NextExternalAddressFromStore(
+				tx.Addr(), waddrmgr.DefaultAccountNum,
+			)
+			if err != nil {
+				return err
+			}
+			attempted = managed.Address()
+
+			return rollbackErr
+		}, func() {
+			attempted = nil
+		},
+	)
+	require.ErrorIs(t, err, rollbackErr)
+
+	var addressCount, nextExternal int64
+	require.NoError(t, conn.QueryRowContext(t.Context(), `
+		SELECT COUNT(*) FROM addresses WHERE wallet_id = ?
+	`, walletID).Scan(&addressCount))
+	require.EqualValues(t, len(fixture.addresses)+2, addressCount)
+	require.NoError(t, conn.QueryRowContext(t.Context(), `
+		SELECT a.next_external_index
+		FROM accounts AS a
+		JOIN key_scopes AS s ON s.id = a.scope_id
+		WHERE a.wallet_id = ? AND s.purpose = 84
+			AND a.account_number = 0
+	`, walletID).Scan(&nextExternal))
+	require.EqualValues(t, 1, nextExternal)
+	require.NoError(t, store.View(
+		t.Context(), func(tx walletstore.ReadTx) error {
+			props, err := sqlScoped.AccountPropertiesFromStore(
+				tx.Addr(), waddrmgr.DefaultAccountNum,
+			)
+			if err == nil {
+				require.EqualValues(t, 1, props.ExternalKeyCount)
+			}
+			return err
+		}, func() {},
+	))
+
+	addrOne, err := sqlWallet.NewAddress(
+		waddrmgr.DefaultAccountNum, waddrmgr.KeyScopeBIP0084,
+	)
+	require.NoError(t, err)
+	require.Equal(t, attempted.String(), addrOne.String())
+	require.NoError(t, loader.UnloadWallet())
+	require.NoError(t, conn.Close())
+
+	conn, err = storesqlite.Open(context.Background(), storesqlite.Config{
+		DBPath: sqlPath,
+	})
+	require.NoError(t, err)
+	store = dbsqlite.NewStore(conn, walletID)
+	loader, sqlWallet = openStoreWallet(t, params, store, pubPass)
+	sqlScoped, err = sqlWallet.Manager.FetchScopedKeyManager(
+		waddrmgr.KeyScopeBIP0084,
+	)
+	require.NoError(t, err)
+
+	lastExternal, err = sqlScoped.LastExternalAddress(
+		nil, waddrmgr.DefaultAccountNum,
+	)
+	require.NoError(t, err)
+	require.Equal(t, addrOne.String(), lastExternal.Address().String())
+	lastInternal, err = sqlScoped.LastInternalAddress(
+		nil, waddrmgr.DefaultAccountNum,
+	)
+	require.NoError(t, err)
+	require.Equal(t, kvInternal.Address().String(),
+		lastInternal.Address().String())
+	lastSecondary, err := sqlScoped.LastExternalAddress(
+		nil, secondaryAccount,
+	)
+	require.NoError(t, err)
+	require.Equal(t, secondaryAddrTwo.String(),
+		lastSecondary.Address().String())
+
+	require.NoError(t, sqlWallet.Unlock(privPass, nil))
+	requireManagedPrivateKey(t, lastExternal)
+	requireManagedPrivateKey(t, lastSecondary)
+
+	addrTwo, err := sqlWallet.NewAddress(
+		waddrmgr.DefaultAccountNum, waddrmgr.KeyScopeBIP0084,
+	)
+	require.NoError(t, err)
+	require.NotEqual(t, addrOne.String(), addrTwo.String())
+	require.NoError(t, loader.UnloadWallet())
+
+	rows, err := conn.QueryContext(t.Context(), `
+		SELECT address_index
+		FROM addresses
+		WHERE wallet_id = ? AND account_number = 0 AND branch = 0
+		ORDER BY address_index
+	`, walletID)
+	require.NoError(t, err)
+	defer rows.Close()
+	var indexes []int64
+	for rows.Next() {
+		var index int64
+		require.NoError(t, rows.Scan(&index))
+		indexes = append(indexes, index)
+	}
+	require.NoError(t, rows.Err())
+	require.NoError(t, rows.Close())
+	require.Equal(t, []int64{0, 1, 2}, indexes)
+	require.NoError(t, conn.QueryRowContext(t.Context(), `
+		SELECT a.next_external_index
+		FROM accounts AS a
+		JOIN key_scopes AS s ON s.id = a.scope_id
+		WHERE a.wallet_id = ? AND s.purpose = 84
+			AND a.account_number = 0
+	`, walletID).Scan(&nextExternal))
+	require.EqualValues(t, 3, nextExternal)
+	require.NoError(t, conn.Close())
+
+	_, err = os.Stat(filepath.Join(sqlDir, WalletDBName))
+	require.True(t, os.IsNotExist(err))
+}

--- a/wallet/sync_transactions_test.go
+++ b/wallet/sync_transactions_test.go
@@ -1,0 +1,576 @@
+package wallet
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btcwallet/chain"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	walletstore "github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+	"github.com/stretchr/testify/require"
+)
+
+var errRPCInStoreCallback = errors.New("chain RPC called in Store callback")
+
+// callbackGuardStore tracks when a Store callback is active so the chain mock
+// can reject transaction-bound RPC calls.
+type callbackGuardStore struct {
+	// Store delegates transaction execution while callbacks are tracked.
+	walletstore.Store
+
+	active atomic.Int32
+}
+
+// View tracks the lifetime of a read callback.
+func (s *callbackGuardStore) View(ctx context.Context,
+	body func(walletstore.ReadTx) error, reset func()) error {
+
+	return s.Store.View(ctx, func(tx walletstore.ReadTx) error {
+		s.active.Add(1)
+		defer s.active.Add(-1)
+		return body(tx)
+	}, reset)
+}
+
+// Update tracks the lifetime of a replayable write callback.
+func (s *callbackGuardStore) Update(ctx context.Context,
+	body func(walletstore.ReadWriteTx) error, reset func()) error {
+
+	return s.Store.Update(ctx, func(tx walletstore.ReadWriteTx) error {
+		s.active.Add(1)
+		defer s.active.Add(-1)
+		return body(tx)
+	}, reset)
+}
+
+// UpdateOnce tracks the lifetime of a one-shot write callback.
+func (s *callbackGuardStore) UpdateOnce(ctx context.Context,
+	body func(walletstore.ReadWriteTx) error, reset func()) error {
+
+	return s.Store.UpdateOnce(ctx, func(tx walletstore.ReadWriteTx) error {
+		s.active.Add(1)
+		defer s.active.Add(-1)
+		return body(tx)
+	}, reset)
+}
+
+// failUpdateStore injects one rollback after a Store plan body completes.
+type failUpdateStore struct {
+	// Store delegates transactions not selected for rollback injection.
+	walletstore.Store
+
+	err      error
+	failNext bool
+}
+
+// UpdateOnce rolls back the selected plan after all writes have been staged.
+func (s *failUpdateStore) UpdateOnce(ctx context.Context,
+	body func(walletstore.ReadWriteTx) error, reset func()) error {
+
+	if !s.failNext {
+		return s.Store.UpdateOnce(ctx, body, reset)
+	}
+	s.failNext = false
+
+	return s.Store.UpdateOnce(ctx, func(tx walletstore.ReadWriteTx) error {
+		if err := body(tx); err != nil {
+			return err
+		}
+
+		return s.err
+	}, reset)
+}
+
+// rpcBlocker pauses one or more mock RPCs until the test releases them.
+type rpcBlocker struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+// newRPCBlocker creates an unreleased RPC blocker.
+func newRPCBlocker() *rpcBlocker {
+	return &rpcBlocker{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+// wait announces the blocked RPC and waits for release.
+func (b *rpcBlocker) wait() {
+	b.once.Do(func() {
+		close(b.started)
+	})
+	<-b.release
+}
+
+// syncTestChain builds a valid in-memory header chain rooted at genesis.
+func syncTestChain(params *chaincfg.Params, count int32) (
+	map[int64]chainhash.Hash, map[chainhash.Hash]wire.BlockHeader) {
+
+	hashes := make(map[int64]chainhash.Hash, count+1)
+	headers := make(map[chainhash.Hash]wire.BlockHeader, count+1)
+	genesisHash := params.GenesisBlock.BlockHash()
+	hashes[0] = genesisHash
+	headers[genesisHash] = params.GenesisBlock.Header
+
+	previous := genesisHash
+	for height := int32(1); height <= count; height++ {
+		header := wire.BlockHeader{
+			Version:   1,
+			PrevBlock: previous,
+			Timestamp: params.GenesisBlock.Header.Timestamp.Add(
+				time.Duration(height) * time.Minute,
+			),
+			Nonce: uint32(height),
+		}
+		hash := header.BlockHash()
+		hashes[int64(height)] = hash
+		headers[hash] = header
+		previous = hash
+	}
+
+	return hashes, headers
+}
+
+// newGuardedChain returns a chain mock that rejects every guarded RPC while a
+// Store callback is active.
+func newGuardedChain(guard *callbackGuardStore, hashes map[int64]chainhash.Hash,
+	headers map[chainhash.Hash]wire.BlockHeader) *mockChainClient {
+
+	client := &mockChainClient{}
+	client.rpcGuard = func() error {
+		if guard.active.Load() != 0 {
+			return errRPCInStoreCallback
+		}
+		return nil
+	}
+	client.getBlockHashAt = func(height int64) (*chainhash.Hash, error) {
+		hash, ok := hashes[height]
+		if !ok {
+			return nil, fmt.Errorf("block %d not found", height)
+		}
+		return &hash, nil
+	}
+	client.getBlockHeaderFunc = func(hash *chainhash.Hash) (
+		*wire.BlockHeader, error) {
+
+		header, ok := headers[*hash]
+		if !ok {
+			return nil, fmt.Errorf("header %v not found", hash)
+		}
+		return &header, nil
+	}
+
+	return client
+}
+
+// newSyncStoreWallet creates a SQLite Store wallet and installs callback and
+// RPC guards around it.
+func newSyncStoreWallet(t *testing.T, recoveryWindow uint32) (
+	*validationFixture, *callbackGuardStore, *mockChainClient,
+	map[int64]chainhash.Hash, map[chainhash.Hash]wire.BlockHeader) {
+
+	t.Helper()
+	params := &chaincfg.TestNet3Params
+	seed := bytes.Repeat([]byte{0x41}, hdkeychain.RecommendedSeedLen)
+	fixture := newValidationFixtureForParams(
+		t, "sqlite", "sync-transactions", params, recoveryWindow,
+		func(loader *Loader) (*Wallet, error) {
+			return loader.CreateNewWallet(
+				[]byte("public"), []byte("private"), seed,
+				params.GenesisBlock.Header.Timestamp,
+			)
+		},
+	)
+	t.Cleanup(fixture.close)
+
+	guard := &callbackGuardStore{Store: fixture.wallet.store}
+	fixture.wallet.store = guard
+	hashes, headers := syncTestChain(params, 2)
+	client := newGuardedChain(guard, hashes, headers)
+	client.getBestBlockHash = ptrHash(hashes[2])
+	client.getBestBlockHeight = 2
+	fixture.wallet.chainClient = client
+
+	return fixture, guard, client, hashes, headers
+}
+
+// ptrHash returns a pointer to a copied hash.
+func ptrHash(hash chainhash.Hash) *chainhash.Hash {
+	return &hash
+}
+
+// requireUnrelatedWrite verifies that SQLite is writable while an RPC is
+// blocked, then releases the RPC regardless of the assertion result.
+func requireUnrelatedWrite(t *testing.T, store walletstore.Store,
+	blocker *rpcBlocker) {
+
+	t.Helper()
+	writeErr := make(chan error, 1)
+	go func() {
+		writeErr <- store.UpdateOnce(
+			t.Context(), func(tx walletstore.ReadWriteTx) error {
+				return tx.Addr().SetBirthday(time.Unix(1_700_000_001, 0))
+			}, nil,
+		)
+	}()
+
+	var err error
+	completed := false
+	select {
+	case err = <-writeErr:
+		completed = true
+	case <-time.After(2 * time.Second):
+	}
+	close(blocker.release)
+	require.True(t, completed, "unrelated SQLite write blocked behind RPC")
+	require.NoError(t, err)
+}
+
+// TestStoreRPCPlanningDoesNotBlockSQLiteWrites proves the three expensive RPC
+// phases execute without retaining a SQLite transaction.
+func TestStoreRPCPlanningDoesNotBlockSQLiteWrites(t *testing.T) {
+	t.Run("FilterBlocks", func(t *testing.T) {
+		fixture, _, client, hashes, _ := newSyncStoreWallet(t, 1)
+		wallet := fixture.wallet
+		client.getBestBlockHash = ptrHash(hashes[1])
+		client.getBestBlockHeight = 1
+		blocker := newRPCBlocker()
+		client.filterBlocksFunc = func(*chain.FilterBlocksRequest) (
+			*chain.FilterBlocksResponse, error) {
+
+			blocker.wait()
+			return nil, nil
+		}
+
+		birthday := waddrmgr.BlockStamp{
+			Hash:      hashes[0],
+			Height:    0,
+			Timestamp: fixture.params.GenesisBlock.Header.Timestamp,
+		}
+		recoveryErr := make(chan error, 1)
+		go func() {
+			recoveryErr <- wallet.recovery(client, &birthday)
+		}()
+		<-blocker.started
+		requireUnrelatedWrite(t, wallet.store, blocker)
+		require.NoError(t, <-recoveryErr)
+	})
+
+	t.Run("GetBlockHeader", func(t *testing.T) {
+		fixture, _, client, hashes, headers := newSyncStoreWallet(t, 0)
+		wallet := fixture.wallet
+		block := wtxmgr.BlockMeta{
+			Block: wtxmgr.Block{Hash: hashes[1], Height: 1},
+			Time:  headers[hashes[1]].Timestamp,
+		}
+		require.NoError(t, wallet.store.UpdateOnce(
+			t.Context(), func(tx walletstore.ReadWriteTx) error {
+				return wallet.connectBlockFromStore(tx, block)
+			}, nil,
+		))
+		wallet.SetChainSynced(true)
+
+		blocker := newRPCBlocker()
+		client.getBlockHeaderFunc = func(hash *chainhash.Hash) (
+			*wire.BlockHeader, error) {
+
+			blocker.wait()
+			header := headers[*hash]
+			return &header, nil
+		}
+		disconnectResult := make(chan error, 1)
+		go func() {
+			_, err := wallet.disconnectBlockFromStore(client, block)
+			disconnectResult <- err
+		}()
+		<-blocker.started
+		requireUnrelatedWrite(t, wallet.store, blocker)
+		require.NoError(t, <-disconnectResult)
+	})
+
+	t.Run("catch-up hash collection", func(t *testing.T) {
+		fixture, _, client, hashes, _ := newSyncStoreWallet(t, 0)
+		wallet := fixture.wallet
+		blocker := newRPCBlocker()
+		client.getBlockHashAt = func(height int64) (*chainhash.Hash, error) {
+			if height == 1 {
+				blocker.wait()
+			}
+			hash := hashes[height]
+			return &hash, nil
+		}
+
+		catchUpErr := make(chan error, 1)
+		go func() {
+			catchUpErr <- wallet.catchUpHashes(
+				client, 2, ptrHash(hashes[2]),
+			)
+		}()
+		<-blocker.started
+		requireUnrelatedWrite(t, wallet.store, blocker)
+		require.NoError(t, <-catchUpErr)
+	})
+}
+
+// TestStoreCatchUpRejectsStaleStartingTip verifies a plan cannot overwrite a
+// concurrent durable tip change.
+func TestStoreCatchUpRejectsStaleStartingTip(t *testing.T) {
+	fixture, _, client, hashes, headers := newSyncStoreWallet(t, 0)
+	wallet := fixture.wallet
+	blocker := newRPCBlocker()
+	client.getBlockHeaderFunc = func(hash *chainhash.Hash) (
+		*wire.BlockHeader, error) {
+
+		if *hash == hashes[1] {
+			blocker.wait()
+		}
+		header := headers[*hash]
+		return &header, nil
+	}
+
+	catchUpErr := make(chan error, 1)
+	go func() {
+		catchUpErr <- wallet.catchUpHashes(client, 2, ptrHash(hashes[2]))
+	}()
+	<-blocker.started
+	alternate := waddrmgr.BlockStamp{
+		Hash:      chainhash.Hash{0xaa},
+		Height:    1,
+		Timestamp: time.Unix(1_700_000_010, 0),
+	}
+	require.NoError(t, wallet.store.UpdateOnce(
+		t.Context(), func(tx walletstore.ReadWriteTx) error {
+			return wallet.Manager.SetSyncedToFromStore(tx.Addr(), &alternate)
+		}, nil,
+	))
+	close(blocker.release)
+
+	err := <-catchUpErr
+	var stale *StorePlanStaleError
+	require.ErrorAs(t, err, &stale)
+	require.Equal(t, alternate.Hash, wallet.Manager.SyncedTo().Hash)
+}
+
+// TestCatchUpFailureDoesNotFinishRescan verifies a failed catch-up neither
+// forwards completion nor marks the wallet chain-synced.
+func TestCatchUpFailureDoesNotFinishRescan(t *testing.T) {
+	fixture, _, client, hashes, _ := newSyncStoreWallet(t, 0)
+	wallet := fixture.wallet
+	rpcErr := errors.New("catch-up hash failure")
+	called := make(chan struct{})
+	client.getBlockHashAt = func(int64) (*chainhash.Hash, error) {
+		close(called)
+		return nil, rpcErr
+	}
+	client.notifications = make(chan interface{}, 1)
+	wallet.rescanNotifications = make(chan interface{}, 1)
+	wallet.chainClient = client
+
+	wallet.wg.Add(1)
+	go wallet.handleChainNotifications()
+	client.notifications <- &chain.RescanFinished{
+		Hash:   ptrHash(hashes[1]),
+		Height: 1,
+	}
+	<-called
+	close(client.notifications)
+	wallet.Stop()
+	wallet.WaitForShutdown()
+
+	require.False(t, wallet.ChainSynced())
+	select {
+	case notification := <-wallet.rescanNotifications:
+		t.Fatalf("unexpected rescan completion: %T", notification)
+	default:
+	}
+}
+
+// TestDisconnectNoOpDoesNotNotify verifies a future disconnect cannot create a
+// detached-block notification.
+func TestDisconnectNoOpDoesNotNotify(t *testing.T) {
+	fixture, _, client, hashes, headers := newSyncStoreWallet(t, 0)
+	wallet := fixture.wallet
+	wallet.SetChainSynced(true)
+	subscriber := wallet.NtfnServer.TransactionNotifications()
+	defer subscriber.Done()
+
+	block := wtxmgr.BlockMeta{
+		Block: wtxmgr.Block{Hash: hashes[1], Height: 1},
+		Time:  headers[hashes[1]].Timestamp,
+	}
+	require.NoError(t, wallet.processBlockDisconnected(client, block))
+
+	wallet.NtfnServer.mu.Lock()
+	defer wallet.NtfnServer.mu.Unlock()
+	require.Nil(t, wallet.NtfnServer.currentTxNtfn)
+}
+
+// TestRecoveryWriteFailureKeepsStateAtomic verifies a failed apply persists no
+// addresses, transactions, stamps, or cloned recovery-state advancement.
+func TestRecoveryWriteFailureKeepsStateAtomic(t *testing.T) {
+	fixture, guard, client, hashes, headers := newSyncStoreWallet(t, 1)
+	wallet := fixture.wallet
+	writeErr := errors.New("recovery write failure")
+	wallet.store = &failUpdateStore{
+		Store:    guard,
+		err:      writeErr,
+		failNext: true,
+	}
+
+	var (
+		recoveredAddrScript []byte
+		relevantHash        chainhash.Hash
+	)
+	client.filterBlocksFunc = func(request *chain.FilterBlocksRequest) (
+		*chain.FilterBlocksResponse, error) {
+
+		scopedIndex := waddrmgr.ScopedIndex{
+			Scope: waddrmgr.KeyScopeBIP0084,
+			Index: 0,
+		}
+		addr := request.ExternalAddrs[scopedIndex]
+		recoveredAddrScript = append(
+			[]byte(nil), addr.ScriptAddress()...,
+		)
+		pkScript, err := txscript.PayToAddrScript(addr)
+		if err != nil {
+			return nil, err
+		}
+		transaction := wire.NewMsgTx(2)
+		transaction.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+			Hash: chainhash.Hash{0x51},
+		}})
+		transaction.AddTxOut(wire.NewTxOut(50_000, pkScript))
+		relevantHash = transaction.TxHash()
+
+		return &chain.FilterBlocksResponse{
+			BatchIndex: 0,
+			BlockMeta:  request.Blocks[0],
+			FoundExternalAddrs: map[waddrmgr.KeyScope]map[uint32]struct{}{
+				waddrmgr.KeyScopeBIP0084: {0: {}},
+			},
+			FoundOutPoints: map[wire.OutPoint]address.Address{},
+			RelevantTxns:   []*wire.MsgTx{transaction},
+		}, nil
+	}
+
+	manager := NewRecoveryManager(1, 1, fixture.params)
+	batch := []wtxmgr.BlockMeta{{
+		Block: wtxmgr.Block{Hash: hashes[1], Height: 1},
+		Time:  headers[hashes[1]].Timestamp,
+	}}
+	blocks := []*waddrmgr.BlockStamp{{
+		Hash:      hashes[1],
+		Height:    1,
+		Timestamp: headers[hashes[1]].Timestamp,
+	}}
+	scopedMgrs := make(map[waddrmgr.KeyScope]*waddrmgr.ScopedKeyManager)
+	for _, scopedMgr := range wallet.Manager.ActiveScopedKeyManagers() {
+		scopedMgrs[scopedMgr.Scope()] = scopedMgr
+	}
+
+	err := wallet.recoverStoreBatch(
+		client, manager, batch, blocks, scopedMgrs,
+	)
+	require.ErrorIs(t, err, writeErr)
+	require.Zero(t, manager.State().StateForScope(
+		waddrmgr.KeyScopeBIP0084,
+	).ExternalBranch.NextUnfound())
+
+	require.NoError(t, guard.View(t.Context(), func(tx walletstore.ReadTx) error {
+		state, err := tx.Addr().SyncState()
+		require.NoError(t, err)
+		require.Zero(t, state.SyncedTo.Height)
+		account, err := tx.Addr().Account(
+			waddrmgr.KeyScopeBIP0084, waddrmgr.DefaultAccountNum,
+		)
+		require.NoError(t, err)
+		require.Zero(t, account.NextExternalIndex)
+		_, err = tx.Addr().Address(
+			waddrmgr.KeyScopeBIP0084, recoveredAddrScript,
+		)
+		require.True(t, waddrmgr.IsError(err, waddrmgr.ErrAddressNotFound))
+		details, err := tx.Tx().TxDetails(&relevantHash)
+		require.NoError(t, err)
+		require.Nil(t, details)
+		return nil
+	}, nil))
+}
+
+// TestRecoveryRejectsStaleAccountIndexes verifies address allocation between
+// planning and apply cannot be overwritten by a recovery batch.
+func TestRecoveryRejectsStaleAccountIndexes(t *testing.T) {
+	fixture, _, client, hashes, headers := newSyncStoreWallet(t, 1)
+	wallet := fixture.wallet
+	client.filterBlocksFunc = func(*chain.FilterBlocksRequest) (
+		*chain.FilterBlocksResponse, error) {
+
+		return nil, nil
+	}
+
+	manager := NewRecoveryManager(1, 1, fixture.params)
+	batch := []wtxmgr.BlockMeta{{
+		Block: wtxmgr.Block{Hash: hashes[1], Height: 1},
+		Time:  headers[hashes[1]].Timestamp,
+	}}
+	blocks := []*waddrmgr.BlockStamp{{
+		Hash:      hashes[1],
+		Height:    1,
+		Timestamp: headers[hashes[1]].Timestamp,
+	}}
+	scopedMgrs := make(map[waddrmgr.KeyScope]*waddrmgr.ScopedKeyManager)
+	for _, scopedMgr := range wallet.Manager.ActiveScopedKeyManagers() {
+		scopedMgrs[scopedMgr.Scope()] = scopedMgr
+	}
+	plan, err := wallet.prepareRecoveryStorePlan(
+		client, manager.State(), batch, blocks, scopedMgrs,
+	)
+	require.NoError(t, err)
+
+	_, err = wallet.NewAddress(
+		waddrmgr.DefaultAccountNum, waddrmgr.KeyScopeBIP0084,
+	)
+	require.NoError(t, err)
+	err = wallet.applyRecoveryStorePlan(plan)
+	var stale *StorePlanStaleError
+	require.ErrorAs(t, err, &stale)
+	require.Zero(t, wallet.Manager.SyncedTo().Height)
+}
+
+// TestCatchUpReconcilesDurableAmbiguity verifies an acknowledged failure does
+// not replay hash RPCs after the exact terminal tip proves the plan committed.
+func TestCatchUpReconcilesDurableAmbiguity(t *testing.T) {
+	fixture, guard, client, hashes, _ := newSyncStoreWallet(t, 0)
+	wallet := fixture.wallet
+	var hashCalls atomic.Int32
+	originalHash := client.getBlockHashAt
+	client.getBlockHashAt = func(height int64) (*chainhash.Hash, error) {
+		hashCalls.Add(1)
+		return originalHash(height)
+	}
+	wallet.store = &ambiguousCommitStore{
+		Store:                   guard,
+		ambiguousNextUpdateOnce: true,
+	}
+
+	require.NoError(t, wallet.catchUpHashes(
+		client, 2, ptrHash(hashes[2]),
+	))
+	require.EqualValues(t, 2, hashCalls.Load())
+	require.Equal(t, hashes[2], wallet.Manager.SyncedTo().Hash)
+}

--- a/wallet/unstable.go
+++ b/wallet/unstable.go
@@ -6,8 +6,10 @@
 package wallet
 
 import (
+	"context"
+
 	"github.com/btcsuite/btcd/chainhash/v2"
-	"github.com/btcsuite/btcwallet/walletdb"
+	walletstore "github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 )
 
@@ -20,25 +22,61 @@ type unstableAPI struct {
 // the transition (particularly for the legacy JSON-RPC server) from using
 // exported manager packages to a unified wallet package that exposes all
 // functionality by itself.  New code should not be written using this API.
-func UnstableAPI(w *Wallet) unstableAPI { return unstableAPI{w} } // nolint:golint
+func UnstableAPI(w *Wallet) unstableAPI { // nolint:golint
+	return unstableAPI{w}
+}
 
-// TxDetails calls wtxmgr.Store.TxDetails under a single database view transaction.
-func (u unstableAPI) TxDetails(txHash *chainhash.Hash) (*wtxmgr.TxDetails, error) {
+// TxDetails returns transaction details under a single Store view transaction.
+func (u unstableAPI) TxDetails(
+	txHash *chainhash.Hash) (*wtxmgr.TxDetails, error) {
+
 	var details *wtxmgr.TxDetails
-	err := walletdb.View(u.w.db, func(dbtx walletdb.ReadTx) error {
-		txmgrNs := dbtx.ReadBucket(wtxmgrNamespaceKey)
-		var err error
-		details, err = u.w.TxStore.TxDetails(txmgrNs, txHash)
-		return err
-	})
+
+	err := u.w.store.View(
+		context.Background(), func(tx walletstore.ReadTx) error {
+
+			var err error
+			details, err = tx.Tx().TxDetails(txHash)
+			return err
+		}, func() {
+			details = nil
+		})
+
 	return details, err
 }
 
-// RangeTransactions calls wtxmgr.Store.RangeTransactions under a single
-// database view tranasction.
-func (u unstableAPI) RangeTransactions(begin, end int32, f func([]wtxmgr.TxDetails) (bool, error)) error {
-	return walletdb.View(u.w.db, func(dbtx walletdb.ReadTx) error {
-		txmgrNs := dbtx.ReadBucket(wtxmgrNamespaceKey)
-		return u.w.TxStore.RangeTransactions(txmgrNs, begin, end, f)
-	})
+// RangeTransactions visits transaction details under a single Store view
+// transaction. The caller callback runs only after the read succeeds so SQL
+// transaction retries cannot replay caller side effects.
+func (u unstableAPI) RangeTransactions(begin, end int32,
+	visit func([]wtxmgr.TxDetails) (bool, error)) error {
+
+	var batches [][]wtxmgr.TxDetails
+	err := u.w.store.View(
+		context.Background(), func(tx walletstore.ReadTx) error {
+			return tx.Tx().RangeTransactions(
+				begin, end,
+				func(details []wtxmgr.TxDetails) (bool, error) {
+					batch := append([]wtxmgr.TxDetails(nil), details...)
+					batches = append(batches, batch)
+
+					return false, nil
+				},
+			)
+		}, func() {
+			batches = nil
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	for _, batch := range batches {
+		stop, err := visit(batch)
+		if err != nil || stop {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/wallet/utxos.go
+++ b/wallet/utxos.go
@@ -6,6 +6,7 @@
 package wallet
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -14,7 +15,7 @@ import (
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
-	"github.com/btcsuite/btcwallet/walletdb"
+	walletstore "github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 )
 
@@ -28,10 +29,15 @@ var (
 // OutputSelectionPolicy describes the rules for selecting an output from the
 // wallet.
 type OutputSelectionPolicy struct {
-	Account               uint32
+	// Account is the account from which outputs are selected.
+	Account uint32
+
+	// RequiredConfirmations is the minimum confirmation count.
 	RequiredConfirmations int32
 }
 
+// meetsRequiredConfs reports whether an output satisfies the policy's minimum
+// confirmation requirement.
 func (p *OutputSelectionPolicy) meetsRequiredConfs(txHeight,
 	curHeight int32) bool {
 
@@ -40,68 +46,74 @@ func (p *OutputSelectionPolicy) meetsRequiredConfs(txHeight,
 
 // UnspentOutputs fetches all unspent outputs from the wallet that match rules
 // described in the passed policy.
-func (w *Wallet) UnspentOutputs(policy OutputSelectionPolicy) ([]*TransactionOutput, error) {
+func (w *Wallet) UnspentOutputs(
+	policy OutputSelectionPolicy) ([]*TransactionOutput, error) {
+
 	var outputResults []*TransactionOutput
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
+	err := w.store.View(
+		context.Background(), func(tx walletstore.ReadTx) error {
+			syncBlock := w.Manager.SyncedTo()
 
-		syncBlock := w.Manager.SyncedTo()
-
-		// TODO: actually stream outputs from the db instead of fetching
-		// all of them at once.
-		outputs, err := w.TxStore.UnspentOutputs(txmgrNs)
-		if err != nil {
-			return err
-		}
-
-		for _, output := range outputs {
-			// Ignore outputs that haven't reached the required
-			// number of confirmations.
-			if !policy.meetsRequiredConfs(output.Height, syncBlock.Height) {
-				continue
-			}
-
-			// Ignore outputs that are not controlled by the account.
-			_, addrs, _, err := txscript.ExtractPkScriptAddrs(output.PkScript,
-				w.chainParams)
-			if err != nil || len(addrs) == 0 {
-				// Cannot determine which account this belongs
-				// to without a valid address.  TODO: Fix this
-				// by saving outputs per account, or accounts
-				// per output.
-				continue
-			}
-			_, outputAcct, err := w.Manager.AddrAccount(addrmgrNs, addrs[0])
+			// TODO: actually stream outputs from the db instead of fetching
+			// all of them at once.
+			outputs, err := tx.Tx().UnspentOutputs()
 			if err != nil {
 				return err
 			}
-			if outputAcct != policy.Account {
-				continue
+
+			for _, output := range outputs {
+				// Ignore outputs that haven't reached the required
+				// number of confirmations.
+				if !policy.meetsRequiredConfs(output.Height, syncBlock.Height) {
+					continue
+				}
+
+				// Ignore outputs that are not controlled by the account.
+				_, addrs, _, err := txscript.ExtractPkScriptAddrs(
+					output.PkScript, w.chainParams,
+				)
+				if err != nil || len(addrs) == 0 {
+					// Cannot determine which account this belongs
+					// to without a valid address.  TODO: Fix this
+					// by saving outputs per account, or accounts
+					// per output.
+					continue
+				}
+				_, outputAcct, err := w.Manager.AddrAccountFromStore(
+					tx.Addr(), addrs[0],
+				)
+				if err != nil {
+					return err
+				}
+				if outputAcct != policy.Account {
+					continue
+				}
+
+				// Stakebase isn't exposed by wtxmgr so those will be
+				// OutputKindNormal for now.
+				outputSource := OutputKindNormal
+				if output.FromCoinBase {
+					outputSource = OutputKindCoinbase
+				}
+
+				result := &TransactionOutput{
+					OutPoint: output.OutPoint,
+					Output: wire.TxOut{
+						Value:    int64(output.Amount),
+						PkScript: output.PkScript,
+					},
+					OutputKind:      outputSource,
+					ContainingBlock: BlockIdentity(output.Block),
+					ReceiveTime:     output.Received,
+				}
+				outputResults = append(outputResults, result)
 			}
 
-			// Stakebase isn't exposed by wtxmgr so those will be
-			// OutputKindNormal for now.
-			outputSource := OutputKindNormal
-			if output.FromCoinBase {
-				outputSource = OutputKindCoinbase
-			}
+			return nil
+		}, func() {
+			outputResults = nil
+		})
 
-			result := &TransactionOutput{
-				OutPoint: output.OutPoint,
-				Output: wire.TxOut{
-					Value:    int64(output.Amount),
-					PkScript: output.PkScript,
-				},
-				OutputKind:      outputSource,
-				ContainingBlock: BlockIdentity(output.Block),
-				ReceiveTime:     output.Received,
-			}
-			outputResults = append(outputResults, result)
-		}
-
-		return nil
-	})
 	return outputResults, err
 }
 
@@ -131,7 +143,9 @@ func (w *Wallet) FetchInputInfo(prevOut *wire.OutPoint) (*wire.MsgTx,
 // fetchOutputAddr attempts to fetch the managed address corresponding to the
 // passed output script. This function is used to look up the proper key which
 // should be used to sign a specified input.
-func (w *Wallet) fetchOutputAddr(script []byte) (waddrmgr.ManagedAddress, error) {
+func (w *Wallet) fetchOutputAddr(
+	script []byte) (waddrmgr.ManagedAddress, error) {
+
 	_, addrs, _, err := txscript.ExtractPkScriptAddrs(script, w.chainParams)
 	if err != nil {
 		return nil, err
@@ -234,7 +248,7 @@ func (w *Wallet) FetchDerivationInfo(pkScript []byte) (*psbt.Bip32Derivation,
 	return derivation, nil
 }
 
-// hasOutpoint takes an output identified by its output index and determines
+// hasOutput takes an output identified by its output index and determines
 // whether the TxDetails contains this output. If the TxDetails doesn't have
 // this output, it means this output doesn't belong to our wallet.
 //

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -7,6 +7,7 @@ package wallet
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -91,10 +92,24 @@ var (
 	wtxmgrNamespaceKey   = []byte("wtxmgr")
 )
 
+// UnsupportedStoreOperationError reports a transaction-domain operation that
+// has not yet been ported to store-backed wallets.
+type UnsupportedStoreOperationError struct {
+	// Operation identifies the unsupported public wallet method.
+	Operation string
+}
+
+// Error describes the unsupported store-backed wallet operation.
+func (e *UnsupportedStoreOperationError) Error() string {
+	return e.Operation + " is unsupported for store-backed wallets"
+}
+
 // Coin represents a spendable UTXO which is available for coin selection.
 type Coin struct {
+	// TxOut describes the spendable output value and script.
 	wire.TxOut
 
+	// OutPoint identifies the transaction output being spent.
 	wire.OutPoint
 }
 
@@ -127,9 +142,13 @@ type Wallet struct {
 	publicPassphrase []byte
 
 	// Data stores
-	db      walletdb.DB
-	store   walletstore.Store
+	db    walletdb.DB
+	store walletstore.Store
+	// Manager controls the wallet's address and key state.
 	Manager *waddrmgr.Manager
+
+	// TxStore controls the legacy wallet transaction state. It is nil for a
+	// Store-backed wallet.
 	TxStore *wtxmgr.Store
 
 	chainClient        chain.Interface
@@ -165,6 +184,7 @@ type Wallet struct {
 	changePassphrase   chan changePassphraseRequest
 	changePassphrases  chan changePassphrasesRequest
 
+	// NtfnServer publishes wallet state changes to subscribers.
 	NtfnServer *NotificationServer
 
 	chainParams *chaincfg.Params
@@ -350,9 +370,9 @@ func (w *Wallet) ChainSynced() bool {
 // with the latest block notified by the chain server.
 //
 // NOTE: Due to an API limitation with rpcclient, this may return true after
-// the client disconnected (and is attempting a reconnect).  This will be unknown
-// until the reconnect notification is received, at which point the wallet can be
-// marked out of sync again until after the next rescan completes.
+// the client disconnected (and is attempting a reconnect). This will be
+// unknown until the reconnect notification is received, at which point the
+// wallet can be marked out of sync again until after the next rescan completes.
 func (w *Wallet) SetChainSynced(synced bool) {
 	w.chainClientSyncMtx.Lock()
 	w.chainClientSynced = synced
@@ -390,6 +410,176 @@ func (w *Wallet) activeData(
 
 	unspent, err := w.TxStore.OutputsToWatch(txmgrNs)
 	return addrs, unspent, err
+}
+
+type rollbackBlockHash struct {
+	height int32
+	hash   chainhash.Hash
+}
+
+// readStoreRollbackSnapshot detaches the durable starting sync state and its
+// contiguous retained block hashes before any chain request is made.
+func (w *Wallet) readStoreRollbackSnapshot(ctx context.Context) (
+	waddrmgr.SyncState, []rollbackBlockHash, error) {
+
+	var (
+		state  waddrmgr.SyncState
+		blocks []rollbackBlockHash
+	)
+	err := w.store.View(ctx, func(tx walletstore.ReadTx) error {
+		var err error
+		state, err = tx.Addr().SyncState()
+		if err != nil {
+			return err
+		}
+
+		for height := state.SyncedTo.Height; ; height-- {
+			hash, err := tx.Addr().BlockHash(height)
+			if waddrmgr.IsError(err, waddrmgr.ErrBlockNotFound) {
+				break
+			}
+			if err != nil {
+				return err
+			}
+			blocks = append(blocks, rollbackBlockHash{
+				height: height,
+				hash:   *hash,
+			})
+			if height == 0 {
+				break
+			}
+		}
+
+		if len(blocks) == 0 || blocks[0].hash != state.SyncedTo.Hash {
+			return errors.New("durable synced tip has no matching block hash")
+		}
+
+		return nil
+	}, func() {
+		state = waddrmgr.SyncState{}
+		blocks = nil
+	})
+
+	return state, blocks, err
+}
+
+// findStoreRollbackTarget finds the newest retained wallet block on the
+// backend's active chain and validates the descending header linkage.
+func findStoreRollbackTarget(chainClient chain.Interface,
+	blocks []rollbackBlockHash) (waddrmgr.BlockStamp, error) {
+
+	var expectedHash *chainhash.Hash
+	for _, block := range blocks {
+		chainHash, err := chainClient.GetBlockHash(int64(block.height))
+		if err != nil {
+			return waddrmgr.BlockStamp{}, err
+		}
+		if expectedHash != nil && *chainHash != *expectedHash {
+			return waddrmgr.BlockStamp{}, fmt.Errorf(
+				"chain changed while finding rollback ancestor at height %d",
+				block.height,
+			)
+		}
+
+		header, err := chainClient.GetBlockHeader(chainHash)
+		if err != nil {
+			return waddrmgr.BlockStamp{}, err
+		}
+		if header.BlockHash() != *chainHash {
+			return waddrmgr.BlockStamp{}, fmt.Errorf(
+				"header hash does not match block %v", chainHash,
+			)
+		}
+
+		stamp := waddrmgr.BlockStamp{
+			Hash:      *chainHash,
+			Height:    block.height,
+			Timestamp: header.Timestamp,
+		}
+		if block.hash == *chainHash {
+			return stamp, nil
+		}
+
+		expectedHash = &header.PrevBlock
+	}
+
+	return waddrmgr.BlockStamp{}, errors.New(
+		"no retained wallet block is on the active chain",
+	)
+}
+
+// rollbackStoreToChain prepares a common-ancestor rollback without a Store
+// transaction and atomically applies it against the exact durable starting tip.
+func (w *Wallet) rollbackStoreToChain(chainClient chain.Interface,
+	birthdayStamp *waddrmgr.BlockStamp) (bool, error) {
+
+	ctx := context.Background()
+	state, blocks, err := w.readStoreRollbackSnapshot(ctx)
+	if err != nil {
+		return false, err
+	}
+	target, err := findStoreRollbackTarget(chainClient, blocks)
+	if err != nil {
+		return false, err
+	}
+	start := state.SyncedTo
+	if sameBlockPosition(start, target) {
+		return false, nil
+	}
+
+	err = w.applyStorePlan(
+		ctx, "initial rollback", func(tx walletstore.ReadWriteTx) error {
+			current, err := tx.Addr().SyncState()
+			if err != nil {
+				return err
+			}
+			if !sameBlockPosition(current.SyncedTo, start) {
+				return &StorePlanStaleError{
+					Operation: "initial rollback",
+					Reason: fmt.Sprintf("starting tip is %d:%v, want %d:%v",
+						current.SyncedTo.Height, current.SyncedTo.Hash,
+						start.Height, start.Hash),
+				}
+			}
+
+			startHash, err := tx.Addr().BlockHash(start.Height)
+			if err != nil {
+				return err
+			}
+			if *startHash != start.Hash {
+				return &StorePlanStaleError{
+					Operation: "initial rollback",
+					Reason:    "starting block hash changed",
+				}
+			}
+
+			if err := w.Manager.SetSyncedToFromStore(
+				tx.Addr(), &target,
+			); err != nil {
+
+				return err
+			}
+			if target.Height <= birthdayStamp.Height &&
+				target.Hash != birthdayStamp.Hash {
+
+				if err := w.Manager.SetBirthdayBlockFromStore(
+					tx.Addr(), target, true,
+				); err != nil {
+
+					return err
+				}
+			}
+
+			return tx.Tx().Rollback(target.Height + 1)
+		}, func(tx walletstore.ReadTx) (storePlanStatus, error) {
+			return storePlanCommitStatus(tx, start, target)
+		}, nil,
+	)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
 }
 
 // syncWithChain brings the wallet up to date with the current chain server
@@ -453,18 +643,42 @@ func (w *Wallet) syncWithChain(birthdayStamp *waddrmgr.BlockStamp) error {
 			return err
 		}
 
-		err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-			ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-			err := w.Manager.SetSyncedTo(ns, &waddrmgr.BlockStamp{
-				Hash:      *startHash,
-				Height:    startHeight,
-				Timestamp: startHeader.Timestamp,
+		if w.db != nil {
+			err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+				ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+				err := w.Manager.SetSyncedTo(ns, &waddrmgr.BlockStamp{
+					Hash:      *startHash,
+					Height:    startHeight,
+					Timestamp: startHeader.Timestamp,
+				})
+				if err != nil {
+					return err
+				}
+				return w.Manager.SetBirthdayBlock(
+					ns, *birthdayStamp, true,
+				)
 			})
-			if err != nil {
-				return err
-			}
-			return w.Manager.SetBirthdayBlock(ns, *birthdayStamp, true)
-		})
+		} else {
+			err = w.store.UpdateOnce(
+				context.Background(),
+				func(tx walletstore.ReadWriteTx) error {
+					err := w.Manager.SetSyncedToFromStore(
+						tx.Addr(), &waddrmgr.BlockStamp{
+							Hash:      *startHash,
+							Height:    startHeight,
+							Timestamp: startHeader.Timestamp,
+						},
+					)
+					if err != nil {
+						return err
+					}
+
+					return w.Manager.SetBirthdayBlockFromStore(
+						tx.Addr(), *birthdayStamp, true,
+					)
+				}, nil,
+			)
+		}
 		if err != nil {
 			return fmt.Errorf("unable to persist initial sync "+
 				"data: %w", err)
@@ -485,65 +699,61 @@ func (w *Wallet) syncWithChain(birthdayStamp *waddrmgr.BlockStamp) error {
 	// before catching up with the rescan.
 	rollback := false
 	rollbackStamp := w.Manager.SyncedTo()
-	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		txmgrNs := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+	if w.db != nil {
+		err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+			addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+			txmgrNs := tx.ReadWriteBucket(wtxmgrNamespaceKey)
 
-		for height := rollbackStamp.Height; true; height-- {
-			hash, err := w.Manager.BlockHash(addrmgrNs, height)
+			for height := rollbackStamp.Height; true; height-- {
+				hash, err := w.Manager.BlockHash(addrmgrNs, height)
+				if err != nil {
+					return err
+				}
+				chainHash, err := chainClient.GetBlockHash(int64(height))
+				if err != nil {
+					return err
+				}
+				header, err := chainClient.GetBlockHeader(chainHash)
+				if err != nil {
+					return err
+				}
+
+				rollbackStamp.Hash = *chainHash
+				rollbackStamp.Height = height
+				rollbackStamp.Timestamp = header.Timestamp
+
+				if bytes.Equal(hash[:], chainHash[:]) {
+					break
+				}
+				rollback = true
+			}
+
+			if !rollback {
+				return nil
+			}
+
+			err := w.Manager.SetSyncedTo(addrmgrNs, &rollbackStamp)
 			if err != nil {
 				return err
 			}
-			chainHash, err := chainClient.GetBlockHash(int64(height))
-			if err != nil {
-				return err
+			if rollbackStamp.Height <= birthdayStamp.Height &&
+				rollbackStamp.Hash != birthdayStamp.Hash {
+
+				err := w.Manager.SetBirthdayBlock(
+					addrmgrNs, rollbackStamp, true,
+				)
+				if err != nil {
+					return err
+				}
 			}
-			header, err := chainClient.GetBlockHeader(chainHash)
-			if err != nil {
-				return err
-			}
 
-			rollbackStamp.Hash = *chainHash
-			rollbackStamp.Height = height
-			rollbackStamp.Timestamp = header.Timestamp
-
-			if bytes.Equal(hash[:], chainHash[:]) {
-				break
-			}
-			rollback = true
-		}
-
-		// If a rollback did not happen, we can proceed safely.
-		if !rollback {
-			return nil
-		}
-
-		// Otherwise, we'll mark this as our new synced height.
-		err := w.Manager.SetSyncedTo(addrmgrNs, &rollbackStamp)
-		if err != nil {
-			return err
-		}
-
-		// If the rollback happened to go beyond our birthday stamp,
-		// we'll need to find a new one by syncing with the chain again
-		// until finding one.
-		if rollbackStamp.Height <= birthdayStamp.Height &&
-			rollbackStamp.Hash != birthdayStamp.Hash {
-
-			err := w.Manager.SetBirthdayBlock(
-				addrmgrNs, rollbackStamp, true,
+			return w.TxStore.Rollback(
+				txmgrNs, rollbackStamp.Height+1,
 			)
-			if err != nil {
-				return err
-			}
-		}
-
-		// Finally, we'll roll back our transaction store to reflect the
-		// stale state. `Rollback` unconfirms transactions at and beyond
-		// the passed height, so add one to the new synced-to height to
-		// prevent unconfirming transactions in the synced-to block.
-		return w.TxStore.Rollback(txmgrNs, rollbackStamp.Height+1)
-	})
+		})
+	} else {
+		rollback, err = w.rollbackStoreToChain(chainClient, birthdayStamp)
+	}
 	if err != nil {
 		return err
 	}
@@ -567,10 +777,37 @@ func (w *Wallet) syncWithChain(birthdayStamp *waddrmgr.BlockStamp) error {
 		addrs   []address.Address
 		unspent []wtxmgr.Credit
 	)
-	err = walletdb.Update(w.db, func(dbtx walletdb.ReadWriteTx) error {
-		addrs, unspent, err = w.activeData(dbtx)
-		return err
-	})
+	if w.db != nil {
+		err = walletdb.Update(w.db, func(dbtx walletdb.ReadWriteTx) error {
+			addrs, unspent, err = w.activeData(dbtx)
+			return err
+		})
+	} else {
+		err = w.store.UpdateOnce(
+			context.Background(),
+			func(tx walletstore.ReadWriteTx) error {
+				addrs = nil
+				unspent = nil
+				err := w.Manager.ForEachRelevantActiveAddressFromStore(
+					tx.Addr(), func(addr address.Address) error {
+						addrs = append(addrs, addr)
+						return nil
+					},
+				)
+				if err != nil {
+					return err
+				}
+				if err := tx.Tx().DeleteExpiredLockedOutputs(); err != nil {
+					return err
+				}
+				unspent, err = tx.Tx().OutputsToWatch()
+				return err
+			}, func() {
+				addrs = nil
+				unspent = nil
+			},
+		)
+	}
 	if err != nil {
 		return err
 	}
@@ -729,15 +966,67 @@ func (w *Wallet) recovery(chainClient chain.Interface,
 	for _, scopedMgr := range w.Manager.ActiveScopedKeyManagers() {
 		scopedMgrs[scopedMgr.Scope()] = scopedMgr
 	}
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		txMgrNS := tx.ReadBucket(wtxmgrNamespaceKey)
-		credits, err := w.TxStore.UnspentOutputs(txMgrNS)
-		if err != nil {
-			return err
+	var err error
+	var recoveryStart waddrmgr.BlockStamp
+	if w.db != nil {
+		err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+			txMgrNS := tx.ReadBucket(wtxmgrNamespaceKey)
+			credits, err := w.TxStore.UnspentOutputs(txMgrNS)
+			if err != nil {
+				return err
+			}
+			addrMgrNS := tx.ReadBucket(waddrmgrNamespaceKey)
+			return recoveryMgr.Resurrect(
+				addrMgrNS, scopedMgrs, credits,
+			)
+		})
+		recoveryStart = w.Manager.SyncedTo()
+	} else {
+		var (
+			credits  []wtxmgr.Credit
+			accounts map[waddrmgr.KeyScope]waddrmgr.AccountState
+		)
+		err = w.store.View(
+			context.Background(), func(tx walletstore.ReadTx) error {
+				var err error
+				credits, err = tx.Tx().UnspentOutputs()
+				if err != nil {
+					return err
+				}
+
+				accounts = make(
+					map[waddrmgr.KeyScope]waddrmgr.AccountState,
+					len(scopedMgrs),
+				)
+				for scope := range scopedMgrs {
+					account, err := tx.Addr().Account(
+						scope, waddrmgr.DefaultAccountNum,
+					)
+					if err != nil {
+						return err
+					}
+					accounts[scope] = account
+				}
+
+				state, err := tx.Addr().SyncState()
+				if err != nil {
+					return err
+				}
+				recoveryStart = state.SyncedTo
+
+				return nil
+			}, func() {
+				credits = nil
+				accounts = nil
+				recoveryStart = waddrmgr.BlockStamp{}
+			},
+		)
+		if err == nil {
+			err = recoveryMgr.resurrectFromAccountStates(
+				accounts, scopedMgrs, credits,
+			)
 		}
-		addrMgrNS := tx.ReadBucket(waddrmgrNamespaceKey)
-		return recoveryMgr.Resurrect(addrMgrNS, scopedMgrs, credits)
-	})
+	}
 	if err != nil {
 		return err
 	}
@@ -759,7 +1048,8 @@ func (w *Wallet) recovery(chainClient chain.Interface,
 	// that a wallet rescan will be performed from the wallet's tip, which
 	// will be of bestHeight after completing the recovery process.
 	var blocks []*waddrmgr.BlockStamp
-	startHeight := w.Manager.SyncedTo().Height + 1
+	startHeight := recoveryStart.Height + 1
+	previousHash := recoveryStart.Hash
 	for height := startHeight; height <= bestHeight; height++ {
 		if atomic.LoadUint32(&syncer.quit) == 1 {
 			return errors.New("recovery: forced shutdown")
@@ -772,6 +1062,17 @@ func (w *Wallet) recovery(chainClient chain.Interface,
 		header, err := chainClient.GetBlockHeader(hash)
 		if err != nil {
 			return err
+		}
+		if w.db == nil {
+			if header.BlockHash() != *hash {
+				return fmt.Errorf("recovery header hash does not match %v",
+					hash)
+			}
+			if header.PrevBlock != previousHash {
+				return fmt.Errorf("recovery block %d does not link to %v",
+					height, previousHash)
+			}
+			previousHash = *hash
 		}
 		blocks = append(blocks, &waddrmgr.BlockStamp{
 			Hash:      *hash,
@@ -794,28 +1095,39 @@ func (w *Wallet) recovery(chainClient chain.Interface,
 		// state to disk.
 		recoveryBatch := recoveryMgr.BlockBatch()
 		if len(recoveryBatch) == recoveryBatchSize || height == bestHeight {
-			err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-				ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-				if err := w.recoverScopedAddresses(
-					chainClient, tx, ns, recoveryBatch,
-					recoveryMgr.State(), scopedMgrs,
-				); err != nil {
-					return err
-				}
+			var err error
+			if w.db != nil {
+				err = walletdb.Update(
+					w.db, func(tx walletdb.ReadWriteTx) error {
+						ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+						if err := w.recoverScopedAddresses(
+							chainClient, tx, ns, recoveryBatch,
+							recoveryMgr.State(), scopedMgrs,
+						); err != nil {
 
-				// TODO: Any error here will roll back this
-				// entire tx. This may cause the in memory sync
-				// point to become desyncronized. Refactor so
-				// that this cannot happen.
-				for _, block := range blocks {
-					err := w.Manager.SetSyncedTo(ns, block)
-					if err != nil {
-						return err
-					}
-				}
+							return err
+						}
 
-				return nil
-			})
+						// TODO: Any error here will roll back this
+						// entire tx. This may cause the in memory sync
+						// point to become desyncronized. Refactor so
+						// that this cannot happen.
+						for _, block := range blocks {
+							err := w.Manager.SetSyncedTo(ns, block)
+							if err != nil {
+								return err
+							}
+						}
+
+						return nil
+					},
+				)
+			} else {
+				err = w.recoverStoreBatch(
+					chainClient, recoveryMgr, recoveryBatch, blocks,
+					scopedMgrs,
+				)
+			}
 			if err != nil {
 				return err
 			}
@@ -833,6 +1145,677 @@ func (w *Wallet) recovery(chainClient chain.Interface,
 		}
 	}
 
+	return nil
+}
+
+type recoveryStoreSnapshot struct {
+	tip      waddrmgr.BlockStamp
+	accounts map[waddrmgr.KeyScope]waddrmgr.AccountState
+}
+
+type recoveryPlannedTx struct {
+	record *wtxmgr.TxRecord
+	block  wtxmgr.BlockMeta
+}
+
+type recoveryAddressOwner struct {
+	manager  *waddrmgr.ScopedKeyManager
+	scope    waddrmgr.KeyScope
+	internal bool
+}
+
+type recoveryAddressOwners map[string]recoveryAddressOwner
+
+type recoveryScopedManagers map[waddrmgr.KeyScope]*waddrmgr.ScopedKeyManager
+
+type recoveryStorePlan struct {
+	start        recoveryStoreSnapshot
+	target       waddrmgr.BlockStamp
+	finalState   *RecoveryState
+	finalIndexes map[waddrmgr.KeyScope]waddrmgr.AccountState
+	blocks       []waddrmgr.BlockStamp
+	responses    []*chain.FilterBlocksResponse
+	transactions []recoveryPlannedTx
+	owners       recoveryAddressOwners
+	managers     map[waddrmgr.KeyScope]*waddrmgr.ScopedKeyManager
+	scopes       []waddrmgr.KeyScope
+}
+
+// readRecoveryStoreSnapshot detaches the exact tip and default-account indexes
+// needed to validate one recovery batch.
+func (w *Wallet) readRecoveryStoreSnapshot(ctx context.Context,
+	scopedMgrs map[waddrmgr.KeyScope]*waddrmgr.ScopedKeyManager) (
+	recoveryStoreSnapshot, error) {
+
+	snapshot := recoveryStoreSnapshot{}
+	err := w.store.View(ctx, func(tx walletstore.ReadTx) error {
+		state, err := tx.Addr().SyncState()
+		if err != nil {
+			return err
+		}
+		snapshot.tip = state.SyncedTo
+		snapshot.accounts = make(
+			map[waddrmgr.KeyScope]waddrmgr.AccountState,
+			len(scopedMgrs),
+		)
+		for scope := range scopedMgrs {
+			account, err := tx.Addr().Account(
+				scope, waddrmgr.DefaultAccountNum,
+			)
+			if err != nil {
+				return err
+			}
+			snapshot.accounts[scope] = account
+		}
+
+		return nil
+	}, func() {
+		snapshot = recoveryStoreSnapshot{}
+	})
+
+	return snapshot, err
+}
+
+// expandScopeHorizonsFromAccountState derives one scope's transient lookahead
+// from detached account state while no Store transaction is active.
+func expandScopeHorizonsFromAccountState(account waddrmgr.AccountState,
+	scopedMgr *waddrmgr.ScopedKeyManager,
+	scopeState *ScopeRecoveryState) error {
+
+	exHorizon, exWindow := scopeState.ExternalBranch.ExtendHorizon()
+	count, childIndex := uint32(0), exHorizon
+	for count < exWindow {
+		addr, err := scopedMgr.DeriveFromKeyPathFromAccountState(
+			account, externalKeyPath(childIndex),
+		)
+		switch {
+		case errors.Is(err, hdkeychain.ErrInvalidChild):
+			scopeState.ExternalBranch.MarkInvalidChild(childIndex)
+			childIndex++
+			continue
+
+		case err != nil:
+			return err
+		}
+
+		scopeState.ExternalBranch.AddAddr(childIndex, addr.Address())
+		childIndex++
+		count++
+	}
+
+	inHorizon, inWindow := scopeState.InternalBranch.ExtendHorizon()
+	count, childIndex = 0, inHorizon
+	for count < inWindow {
+		addr, err := scopedMgr.DeriveFromKeyPathFromAccountState(
+			account, internalKeyPath(childIndex),
+		)
+		switch {
+		case errors.Is(err, hdkeychain.ErrInvalidChild):
+			scopeState.InternalBranch.MarkInvalidChild(childIndex)
+			childIndex++
+			continue
+
+		case err != nil:
+			return err
+		}
+
+		scopeState.InternalBranch.AddAddr(childIndex, addr.Address())
+		childIndex++
+		count++
+	}
+
+	return nil
+}
+
+// cloneFilterBlocksResponse detaches all response maps and transactions from a
+// chain backend before they are retained in a recovery plan.
+func cloneFilterBlocksResponse(
+	response *chain.FilterBlocksResponse) *chain.FilterBlocksResponse {
+
+	clone := &chain.FilterBlocksResponse{
+		BatchIndex: response.BatchIndex,
+		BlockMeta:  response.BlockMeta,
+		FoundExternalAddrs: make(
+			map[waddrmgr.KeyScope]map[uint32]struct{},
+			len(response.FoundExternalAddrs),
+		),
+		FoundInternalAddrs: make(
+			map[waddrmgr.KeyScope]map[uint32]struct{},
+			len(response.FoundInternalAddrs),
+		),
+		FoundOutPoints: make(
+			map[wire.OutPoint]address.Address,
+			len(response.FoundOutPoints),
+		),
+		RelevantTxns: make([]*wire.MsgTx, 0, len(response.RelevantTxns)),
+	}
+	for scope, indexes := range response.FoundExternalAddrs {
+		clone.FoundExternalAddrs[scope] = make(
+			map[uint32]struct{}, len(indexes),
+		)
+		for index := range indexes {
+			clone.FoundExternalAddrs[scope][index] = struct{}{}
+		}
+	}
+	for scope, indexes := range response.FoundInternalAddrs {
+		clone.FoundInternalAddrs[scope] = make(
+			map[uint32]struct{}, len(indexes),
+		)
+		for index := range indexes {
+			clone.FoundInternalAddrs[scope][index] = struct{}{}
+		}
+	}
+	for outPoint, addr := range response.FoundOutPoints {
+		clone.FoundOutPoints[outPoint] = addr
+	}
+	for _, transaction := range response.RelevantTxns {
+		clone.RelevantTxns = append(clone.RelevantTxns, transaction.Copy())
+	}
+
+	return clone
+}
+
+// advanceRecoveryPlanState records one immutable filter response in the cloned
+// state used to prepare subsequent lookahead requests.
+func advanceRecoveryPlanState(response *chain.FilterBlocksResponse,
+	state *RecoveryState) {
+
+	for scope, indexes := range response.FoundExternalAddrs {
+		branch := state.StateForScope(scope).ExternalBranch
+		for index := range indexes {
+			branch.ReportFound(index)
+		}
+	}
+	for scope, indexes := range response.FoundInternalAddrs {
+		branch := state.StateForScope(scope).InternalBranch
+		for index := range indexes {
+			branch.ReportFound(index)
+		}
+	}
+	for outPoint, addr := range response.FoundOutPoints {
+		outPoint := outPoint
+		state.AddWatchedOutPoint(&outPoint, addr)
+	}
+}
+
+// validateRecoveryResponse ensures every found index was part of the request
+// and belongs to a scope included in the recovery plan.
+func validateRecoveryResponse(response *chain.FilterBlocksResponse,
+	state *RecoveryState,
+	scopedMgrs map[waddrmgr.KeyScope]*waddrmgr.ScopedKeyManager) error {
+
+	for scope, indexes := range response.FoundExternalAddrs {
+		if scopedMgrs[scope] == nil {
+			return fmt.Errorf("filter response contains unknown scope %s",
+				scope)
+		}
+		branch := state.StateForScope(scope).ExternalBranch
+		for index := range indexes {
+			if branch.GetAddr(index) == nil {
+				return fmt.Errorf("filter response external index %s:%d was "+
+					"not requested", scope, index)
+			}
+		}
+	}
+	for scope, indexes := range response.FoundInternalAddrs {
+		if scopedMgrs[scope] == nil {
+			return fmt.Errorf("filter response contains unknown scope %s",
+				scope)
+		}
+		branch := state.StateForScope(scope).InternalBranch
+		for index := range indexes {
+			if branch.GetAddr(index) == nil {
+				return fmt.Errorf("filter response internal index %s:%d was "+
+					"not requested", scope, index)
+			}
+		}
+	}
+
+	return nil
+}
+
+// recoveryPlanOwners indexes every transient derived address used to classify
+// relevant transaction outputs without mutating manager caches during apply.
+func recoveryPlanOwners(state *RecoveryState,
+	scopedMgrs recoveryScopedManagers) recoveryAddressOwners {
+
+	owners := make(recoveryAddressOwners)
+	for scope, manager := range scopedMgrs {
+		scopeState := state.StateForScope(scope)
+		for _, addr := range scopeState.ExternalBranch.Addrs() {
+			owners[string(addr.ScriptAddress())] = recoveryAddressOwner{
+				manager: manager,
+				scope:   scope,
+			}
+		}
+		for _, addr := range scopeState.InternalBranch.Addrs() {
+			owners[string(addr.ScriptAddress())] = recoveryAddressOwner{
+				manager:  manager,
+				scope:    scope,
+				internal: true,
+			}
+		}
+	}
+
+	return owners
+}
+
+// prepareRecoveryStorePlan performs lookahead derivation and all filter RPCs
+// against detached state, retaining immutable responses for atomic apply.
+func (w *Wallet) prepareRecoveryStorePlan(chainClient chain.Interface,
+	recoveryState *RecoveryState, batch []wtxmgr.BlockMeta,
+	blocks []*waddrmgr.BlockStamp,
+	scopedMgrs map[waddrmgr.KeyScope]*waddrmgr.ScopedKeyManager) (
+	*recoveryStorePlan, error) {
+
+	if len(blocks) == 0 {
+		return nil, errors.New("recovery Store plan has no block stamps")
+	}
+
+	ctx := context.Background()
+	snapshot, err := w.readRecoveryStoreSnapshot(ctx, scopedMgrs)
+	if err != nil {
+		return nil, err
+	}
+	if blocks[0].Height != snapshot.tip.Height+1 {
+		return nil, &StorePlanStaleError{
+			Operation: "recovery",
+			Reason: fmt.Sprintf("first block height is %d, want %d",
+				blocks[0].Height, snapshot.tip.Height+1),
+		}
+	}
+	firstHeader, err := chainClient.GetBlockHeader(&blocks[0].Hash)
+	if err != nil {
+		return nil, err
+	}
+	if firstHeader.BlockHash() != blocks[0].Hash ||
+		firstHeader.PrevBlock != snapshot.tip.Hash {
+
+		return nil, &StorePlanStaleError{
+			Operation: "recovery",
+			Reason:    "first block does not extend the starting tip",
+		}
+	}
+
+	plan := &recoveryStorePlan{
+		start:        snapshot,
+		finalState:   recoveryState.Clone(),
+		finalIndexes: make(map[waddrmgr.KeyScope]waddrmgr.AccountState),
+		blocks:       make([]waddrmgr.BlockStamp, len(blocks)),
+		managers: make(
+			map[waddrmgr.KeyScope]*waddrmgr.ScopedKeyManager,
+			len(scopedMgrs),
+		),
+	}
+	for scope, manager := range scopedMgrs {
+		plan.managers[scope] = manager
+	}
+	for i, block := range blocks {
+		plan.blocks[i] = *block
+	}
+	plan.target = plan.blocks[len(plan.blocks)-1]
+
+	remaining := append([]wtxmgr.BlockMeta(nil), batch...)
+	if len(remaining) > 0 {
+		log.Infof("Scanning %d blocks for recoverable addresses",
+			len(remaining))
+	}
+	for len(remaining) > 0 {
+		for scope, scopedMgr := range scopedMgrs {
+			account := snapshot.accounts[scope]
+			scopeState := plan.finalState.StateForScope(scope)
+			if err := expandScopeHorizonsFromAccountState(
+				account, scopedMgr, scopeState,
+			); err != nil {
+
+				return nil, err
+			}
+		}
+
+		request := newFilterBlocksRequest(
+			remaining, scopedMgrs, plan.finalState,
+		)
+		response, err := chainClient.FilterBlocks(request)
+		if err != nil {
+			return nil, err
+		}
+		if response == nil {
+			break
+		}
+		if int(response.BatchIndex) >= len(remaining) {
+			return nil, fmt.Errorf("filter response index %d exceeds batch %d",
+				response.BatchIndex, len(remaining))
+		}
+
+		block := remaining[response.BatchIndex]
+		if response.BlockMeta.Height != block.Height ||
+			response.BlockMeta.Hash != block.Hash {
+
+			return nil, fmt.Errorf("filter response block %d:%v does not "+
+				"match request %d:%v", response.BlockMeta.Height,
+				response.BlockMeta.Hash, block.Height, block.Hash)
+		}
+
+		immutable := cloneFilterBlocksResponse(response)
+		if err := validateRecoveryResponse(
+			immutable, plan.finalState, scopedMgrs,
+		); err != nil {
+
+			return nil, err
+		}
+		logFilterBlocksResp(block, immutable)
+		advanceRecoveryPlanState(immutable, plan.finalState)
+		plan.responses = append(plan.responses, immutable)
+		for _, transaction := range immutable.RelevantTxns {
+			record, err := wtxmgr.NewTxRecordFromMsgTx(
+				transaction, immutable.BlockMeta.Time,
+			)
+			if err != nil {
+				return nil, err
+			}
+			plan.transactions = append(plan.transactions, recoveryPlannedTx{
+				record: record,
+				block:  immutable.BlockMeta,
+			})
+		}
+
+		remaining = remaining[immutable.BatchIndex+1:]
+	}
+
+	for scope, account := range snapshot.accounts {
+		scopeState := plan.finalState.StateForScope(scope)
+		account.NextExternalIndex = max(
+			account.NextExternalIndex,
+			scopeState.ExternalBranch.NextUnfound(),
+		)
+		account.NextInternalIndex = max(
+			account.NextInternalIndex,
+			scopeState.InternalBranch.NextUnfound(),
+		)
+		plan.finalIndexes[scope] = account
+		plan.scopes = append(plan.scopes, scope)
+	}
+	plan.owners = recoveryPlanOwners(
+		plan.finalState, recoveryScopedManagers(scopedMgrs),
+	)
+
+	return plan, nil
+}
+
+// recoveryAccountsMatch reports whether all planned default-account indexes
+// match their durable values.
+func recoveryAccountsMatch(store walletstore.AddrReadStore,
+	accounts map[waddrmgr.KeyScope]waddrmgr.AccountState) (bool, error) {
+
+	for scope, expected := range accounts {
+		account, err := store.Account(scope, waddrmgr.DefaultAccountNum)
+		if err != nil {
+			return false, err
+		}
+		if account.NextExternalIndex != expected.NextExternalIndex ||
+			account.NextInternalIndex != expected.NextInternalIndex {
+
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// recoveryPlanDurable verifies all address, used-state, and transaction writes
+// that distinguish a committed recovery plan from an unrelated tip update.
+func recoveryPlanDurable(tx walletstore.ReadTx,
+	plan *recoveryStorePlan) (bool, error) {
+
+	matches, err := recoveryAccountsMatch(tx.Addr(), plan.finalIndexes)
+	if err != nil || !matches {
+		return false, err
+	}
+
+	for _, response := range plan.responses {
+		for scope, indexes := range response.FoundExternalAddrs {
+			branch := plan.finalState.scopes[scope].ExternalBranch
+			for index := range indexes {
+				state, err := tx.Addr().Address(
+					scope, branch.GetAddr(index).ScriptAddress(),
+				)
+				if err != nil || !state.Used {
+					return false, err
+				}
+			}
+		}
+		for scope, indexes := range response.FoundInternalAddrs {
+			branch := plan.finalState.scopes[scope].InternalBranch
+			for index := range indexes {
+				state, err := tx.Addr().Address(
+					scope, branch.GetAddr(index).ScriptAddress(),
+				)
+				if err != nil || !state.Used {
+					return false, err
+				}
+			}
+		}
+	}
+
+	for _, transaction := range plan.transactions {
+		details, err := tx.Tx().UniqueTxDetails(
+			&transaction.record.Hash, &transaction.block.Block,
+		)
+		if err != nil || details == nil {
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+// addRecoveryRelevantTxFromStore records a planned recovery transaction using
+// detached address ownership, avoiding manager cache reads before commit.
+func (w *Wallet) addRecoveryRelevantTxFromStore(
+	tx walletstore.ReadWriteTx, planned recoveryPlannedTx,
+	owners recoveryAddressOwners) error {
+
+	exists, err := tx.Tx().InsertTxCheckIfExists(
+		planned.record, &planned.block,
+	)
+	if err != nil || exists {
+		return err
+	}
+
+	for i, output := range planned.record.MsgTx.TxOut {
+		_, addrs, _, err := txscript.ExtractPkScriptAddrs(
+			output.PkScript, w.chainParams,
+		)
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			owner, ok := owners[string(addr.ScriptAddress())]
+			if !ok || !waddrmgr.IsDefaultScope(owner.scope) {
+				continue
+			}
+
+			isNew, err := tx.Tx().AddCredit(
+				planned.record, &planned.block, uint32(i), owner.internal,
+			)
+			if err != nil {
+				return err
+			}
+			if isNew {
+				hash := planned.record.Hash
+				index := uint32(i)
+				tx.Addr().OnCommit(func() {
+					w.NtfnServer.notifyUnspentOutput(
+						waddrmgr.DefaultAccountNum, &hash, index,
+					)
+				})
+			}
+			if err := owner.manager.MarkUsedFromStore(
+				tx.Addr(), addr,
+			); err != nil {
+
+				return err
+			}
+		}
+	}
+
+	hash := planned.record.Hash
+	block := planned.block
+	tx.Addr().OnCommit(func() {
+		w.NtfnServer.notifyMinedTransactionFromStore(hash, &block)
+	})
+
+	return nil
+}
+
+// applyRecoveryStorePlan atomically persists a prepared recovery plan after
+// revalidating its exact starting tip and all relevant account indexes.
+func (w *Wallet) applyRecoveryStorePlan(plan *recoveryStorePlan) error {
+	return w.applyStorePlan(
+		context.Background(), "recovery",
+		func(tx walletstore.ReadWriteTx) error {
+			state, err := tx.Addr().SyncState()
+			if err != nil {
+				return err
+			}
+			if !sameBlockPosition(state.SyncedTo, plan.start.tip) {
+				return &StorePlanStaleError{
+					Operation: "recovery",
+					Reason: fmt.Sprintf("starting tip is %d:%v, want %d:%v",
+						state.SyncedTo.Height, state.SyncedTo.Hash,
+						plan.start.tip.Height, plan.start.tip.Hash),
+				}
+			}
+
+			matches, err := recoveryAccountsMatch(
+				tx.Addr(), plan.start.accounts,
+			)
+			if err != nil {
+				return err
+			}
+			if !matches {
+				return &StorePlanStaleError{
+					Operation: "recovery",
+					Reason:    "default account indexes changed",
+				}
+			}
+
+			for scope, target := range plan.finalIndexes {
+				manager := plan.managers[scope]
+				if target.NextExternalIndex > 0 {
+					if err := extendScopeAddressesFromStore(
+						tx.Addr(), manager,
+						target.NextExternalIndex-1, false,
+					); err != nil {
+
+						return err
+					}
+				}
+				if target.NextInternalIndex > 0 {
+					if err := extendScopeAddressesFromStore(
+						tx.Addr(), manager,
+						target.NextInternalIndex-1, true,
+					); err != nil {
+
+						return err
+					}
+				}
+			}
+
+			for _, response := range plan.responses {
+				for scope, indexes := range response.FoundExternalAddrs {
+					manager := plan.managers[scope]
+					branch := plan.finalState.scopes[scope].ExternalBranch
+					for index := range indexes {
+						if err := manager.MarkUsedFromStore(
+							tx.Addr(), branch.GetAddr(index),
+						); err != nil {
+
+							return err
+						}
+					}
+				}
+				for scope, indexes := range response.FoundInternalAddrs {
+					manager := plan.managers[scope]
+					branch := plan.finalState.scopes[scope].InternalBranch
+					for index := range indexes {
+						if err := manager.MarkUsedFromStore(
+							tx.Addr(), branch.GetAddr(index),
+						); err != nil {
+
+							return err
+						}
+					}
+				}
+			}
+
+			for _, transaction := range plan.transactions {
+				if err := w.addRecoveryRelevantTxFromStore(
+					tx, transaction, plan.owners,
+				); err != nil {
+
+					return err
+				}
+			}
+
+			for i := range plan.blocks {
+				if err := w.Manager.SetSyncedToFromStore(
+					tx.Addr(), &plan.blocks[i],
+				); err != nil {
+
+					return err
+				}
+			}
+
+			return nil
+		}, func(tx walletstore.ReadTx) (storePlanStatus, error) {
+			state, err := tx.Addr().SyncState()
+			if err != nil {
+				return storePlanConflict, err
+			}
+
+			switch {
+			case sameBlockPosition(state.SyncedTo, plan.target):
+				durable, err := recoveryPlanDurable(tx, plan)
+				if err != nil || !durable {
+					return storePlanConflict, err
+				}
+				return storePlanCommitted, nil
+
+			case sameBlockPosition(state.SyncedTo, plan.start.tip):
+				matches, err := recoveryAccountsMatch(
+					tx.Addr(), plan.start.accounts,
+				)
+				if err != nil || !matches {
+					return storePlanConflict, err
+				}
+				return storePlanAbsent, nil
+
+			default:
+				return storePlanConflict, nil
+			}
+		}, plan.scopes,
+	)
+}
+
+// recoverStoreBatch prepares and commits one recovery batch, adopting its
+// cloned state only after the database transaction is known to be durable.
+func (w *Wallet) recoverStoreBatch(chainClient chain.Interface,
+	recoveryMgr *RecoveryManager, batch []wtxmgr.BlockMeta,
+	blocks []*waddrmgr.BlockStamp,
+	scopedMgrs map[waddrmgr.KeyScope]*waddrmgr.ScopedKeyManager) error {
+
+	plan, err := w.prepareRecoveryStorePlan(
+		chainClient, recoveryMgr.State(), batch, blocks, scopedMgrs,
+	)
+	if err != nil {
+		return err
+	}
+	if err := w.applyRecoveryStorePlan(plan); err != nil {
+		return err
+	}
+
+	recoveryMgr.state = plan.finalState
 	return nil
 }
 
@@ -1173,6 +2156,43 @@ func extendFoundAddresses(ns walletdb.ReadWriteBucket,
 	return nil
 }
 
+// extendScopeAddressesFromStore persists sequential addresses through the
+// requested child index using the existing Store-backed derivation methods.
+func extendScopeAddressesFromStore(tx waddrmgr.ManagerReadWriteTx,
+	scopedMgr *waddrmgr.ScopedKeyManager, lastIndex uint32,
+	internal bool) error {
+
+	for {
+		account, err := tx.Account(
+			scopedMgr.Scope(), waddrmgr.DefaultAccountNum,
+		)
+		if err != nil {
+			return err
+		}
+
+		nextIndex := account.NextExternalIndex
+		if internal {
+			nextIndex = account.NextInternalIndex
+		}
+		if nextIndex > lastIndex {
+			return nil
+		}
+
+		if internal {
+			_, _, err = scopedMgr.NextInternalAddressFromStore(
+				tx, waddrmgr.DefaultAccountNum,
+			)
+		} else {
+			_, _, err = scopedMgr.NextExternalAddressFromStore(
+				tx, waddrmgr.DefaultAccountNum,
+			)
+		}
+		if err != nil {
+			return err
+		}
+	}
+}
+
 // logFilterBlocksResp provides useful logging information when filtering
 // succeeded in finding relevant transactions.
 func logFilterBlocksResp(block wtxmgr.BlockMeta,
@@ -1322,9 +2342,9 @@ func WithUtxoFilter(allowUtxo func(utxo wtxmgr.Credit) bool) TxCreateOption {
 // CreateSimpleTx creates a new signed transaction spending unspent outputs with
 // at least minconf confirmations spending to any number of address/amount
 // pairs. Only unspent outputs belonging to the given key scope and account will
-// be selected, unless a key scope is not specified. In that case, inputs from all
-// accounts may be selected, no matter what key scope they belong to. This is
-// done to handle the default account case, where a user wants to fund a PSBT
+// be selected, unless a key scope is not specified. In that case, inputs from
+// all accounts may be selected, regardless of key scope. This handles the
+// default account case, where a user wants to fund a PSBT
 // with inputs regardless of their type (NP2WKH, P2WKH, etc.). Change and an
 // appropriate transaction fee are automatically included, if necessary. All
 // transaction creation through this function is serialized to prevent the
@@ -1423,10 +2443,17 @@ out:
 	for {
 		select {
 		case req := <-w.unlockRequests:
-			err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-				addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-				return w.Manager.Unlock(addrmgrNs, req.passphrase)
-			})
+			var err error
+			if w.db != nil {
+				err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+					addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+					return w.Manager.Unlock(
+						addrmgrNs, req.passphrase,
+					)
+				})
+			} else {
+				err = w.Manager.UnlockFromStore(req.passphrase)
+			}
 			if err != nil {
 				req.err <- err
 				continue
@@ -1441,32 +2468,99 @@ out:
 			continue
 
 		case req := <-w.changePassphrase:
-			err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-				addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-				return w.Manager.ChangePassphrase(
-					addrmgrNs, req.old, req.new, req.private,
-					&waddrmgr.DefaultScryptOptions,
+			var err error
+			if w.db != nil {
+				err = walletdb.Update(
+					w.db, func(tx walletdb.ReadWriteTx) error {
+						addrmgrNs := tx.ReadWriteBucket(
+							waddrmgrNamespaceKey,
+						)
+						return w.Manager.ChangePassphrase(
+							addrmgrNs, req.old, req.new, req.private,
+							&waddrmgr.DefaultScryptOptions,
+						)
+					},
 				)
-			})
+			} else {
+				var change *waddrmgr.PassphraseChange
+				err = w.store.UpdateOnce(
+					context.Background(),
+					func(tx walletstore.ReadWriteTx) error {
+						var err error
+						change, err =
+							w.Manager.ChangePassphraseFromStore(
+								tx.Addr(), req.old, req.new,
+								req.private,
+								&waddrmgr.DefaultScryptOptions,
+							)
+						return err
+					}, nil,
+				)
+				if err == nil {
+					change.Apply()
+				} else {
+					change.Close()
+				}
+			}
 			req.err <- err
 			continue
 
 		case req := <-w.changePassphrases:
-			err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-				addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-				err := w.Manager.ChangePassphrase(
-					addrmgrNs, req.publicOld, req.publicNew,
-					false, &waddrmgr.DefaultScryptOptions,
-				)
-				if err != nil {
-					return err
-				}
+			var err error
+			if w.db != nil {
+				err = walletdb.Update(
+					w.db, func(tx walletdb.ReadWriteTx) error {
+						addrmgrNs := tx.ReadWriteBucket(
+							waddrmgrNamespaceKey,
+						)
+						err := w.Manager.ChangePassphrase(
+							addrmgrNs, req.publicOld, req.publicNew,
+							false, &waddrmgr.DefaultScryptOptions,
+						)
+						if err != nil {
+							return err
+						}
 
-				return w.Manager.ChangePassphrase(
-					addrmgrNs, req.privateOld, req.privateNew,
-					true, &waddrmgr.DefaultScryptOptions,
+						return w.Manager.ChangePassphrase(
+							addrmgrNs, req.privateOld,
+							req.privateNew, true,
+							&waddrmgr.DefaultScryptOptions,
+						)
+					},
 				)
-			})
+			} else {
+				var publicChange, privateChange *waddrmgr.PassphraseChange
+				err = w.store.UpdateOnce(
+					context.Background(),
+					func(tx walletstore.ReadWriteTx) error {
+						var err error
+						publicChange, err =
+							w.Manager.ChangePassphraseFromStore(
+								tx.Addr(), req.publicOld,
+								req.publicNew, false,
+								&waddrmgr.DefaultScryptOptions,
+							)
+						if err != nil {
+							return err
+						}
+
+						privateChange, err =
+							w.Manager.ChangePassphraseFromStore(
+								tx.Addr(), req.privateOld,
+								req.privateNew, true,
+								&waddrmgr.DefaultScryptOptions,
+							)
+						return err
+					}, nil,
+				)
+				if err == nil {
+					publicChange.Apply()
+					privateChange.Apply()
+				} else {
+					publicChange.Close()
+					privateChange.Close()
+				}
+			}
 			req.err <- err
 			continue
 
@@ -1542,6 +2636,11 @@ func (w *Wallet) Lock() {
 // Locked returns whether the account manager for a wallet is locked.
 func (w *Wallet) Locked() bool {
 	return <-w.lockState
+}
+
+// WatchOnly returns whether the wallet contains no private key material.
+func (w *Wallet) WatchOnly() bool {
+	return w.Manager.WatchOnly()
 }
 
 // holdUnlock prevents the wallet from being locked.  The heldUnlock object
@@ -1620,16 +2719,34 @@ func (w *Wallet) ChangePassphrases(publicOld, publicNew, privateOld,
 func (w *Wallet) AccountAddresses(account uint32) ([]address.Address, error) {
 	var addrs []address.Address
 
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+	var err error
+	if w.db != nil {
+		err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+			addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
 
-		return w.Manager.ForEachAccountAddress(
-			addrmgrNs, account, func(maddr waddrmgr.ManagedAddress) error {
-				addrs = append(addrs, maddr.Address())
-				return nil
+			return w.Manager.ForEachAccountAddress(
+				addrmgrNs, account,
+				func(maddr waddrmgr.ManagedAddress) error {
+					addrs = append(addrs, maddr.Address())
+					return nil
+				},
+			)
+		})
+	} else {
+		err = w.store.View(
+			context.Background(), func(tx walletstore.ReadTx) error {
+				return w.Manager.ForEachAccountAddressFromStore(
+					tx.Addr(), account,
+					func(maddr waddrmgr.ManagedAddress) error {
+						addrs = append(addrs, maddr.Address())
+						return nil
+					},
+				)
+			}, func() {
+				addrs = nil
 			},
 		)
-	})
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -1649,19 +2766,34 @@ func (w *Wallet) AccountManagedAddresses(scope waddrmgr.KeyScope,
 
 	addrs := make([]waddrmgr.ManagedAddress, 0)
 
-	err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+	if w.db != nil {
+		err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+			addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
 
-		return scopedMgr.ForEachAccountAddress(
-			addrmgrNs, accountNum,
-			func(a waddrmgr.ManagedAddress) error {
-				addrs = append(addrs, a)
+			return scopedMgr.ForEachAccountAddress(
+				addrmgrNs, accountNum,
+				func(a waddrmgr.ManagedAddress) error {
+					addrs = append(addrs, a)
 
-				return nil
+					return nil
+				},
+			)
+		})
+	} else {
+		err = w.store.View(
+			context.Background(), func(tx walletstore.ReadTx) error {
+				return scopedMgr.ForEachAccountAddressFromStore(
+					tx.Addr(), accountNum,
+					func(a waddrmgr.ManagedAddress) error {
+						addrs = append(addrs, a)
+						return nil
+					},
+				)
+			}, func() {
+				addrs = nil
 			},
 		)
-	},
-	)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -1679,21 +2811,32 @@ func (w *Wallet) AccountManagedAddresses(scope waddrmgr.KeyScope,
 // include a UTXO.
 func (w *Wallet) CalculateBalance(confirms int32) (btcutil.Amount, error) {
 	var balance btcutil.Amount
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
-		var err error
-		blk := w.Manager.SyncedTo()
-		balance, err = w.TxStore.Balance(txmgrNs, confirms, blk.Height)
-		return err
-	})
+	err := w.store.View(
+		context.Background(), func(tx walletstore.ReadTx) error {
+			var err error
+			block := w.Manager.SyncedTo()
+			balance, err = tx.Tx().Balance(
+				confirms, block.Height,
+			)
+			return err
+		}, func() {
+			balance = 0
+		},
+	)
+
 	return balance, err
 }
 
 // Balances records total, spendable (by policy), and immature coinbase
 // reward balance amounts.
 type Balances struct {
-	Total          btcutil.Amount
-	Spendable      btcutil.Amount
+	// Total is the account's total unspent balance.
+	Total btcutil.Amount
+
+	// Spendable is the account balance available under current policy.
+	Spendable btcutil.Amount
+
+	// ImmatureReward is the account's immature coinbase balance.
 	ImmatureReward btcutil.Amount
 }
 
@@ -1707,47 +2850,50 @@ func (w *Wallet) CalculateAccountBalances(account uint32,
 	confirms int32) (Balances, error) {
 
 	var bals Balances
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
+	err := w.store.View(
+		context.Background(), func(tx walletstore.ReadTx) error {
+			// Get current block.  The block height used for calculating
+			// the number of tx confirmations.
+			syncBlock := w.Manager.SyncedTo()
 
-		// Get current block.  The block height used for calculating
-		// the number of tx confirmations.
-		syncBlock := w.Manager.SyncedTo()
-
-		unspent, err := w.TxStore.UnspentOutputs(txmgrNs)
-		if err != nil {
-			return err
-		}
-		for i := range unspent {
-			output := &unspent[i]
-
-			var outputAcct uint32
-			_, addrs, _, err := txscript.ExtractPkScriptAddrs(
-				output.PkScript, w.chainParams)
-			if err == nil && len(addrs) > 0 {
-				_, outputAcct, err = w.Manager.AddrAccount(addrmgrNs, addrs[0])
+			unspent, err := tx.Tx().UnspentOutputs()
+			if err != nil {
+				return err
 			}
-			if err != nil || outputAcct != account {
-				continue
+			for i := range unspent {
+				output := &unspent[i]
+
+				var outputAcct uint32
+				_, addrs, _, err := txscript.ExtractPkScriptAddrs(
+					output.PkScript, w.chainParams)
+				if err == nil && len(addrs) > 0 {
+					_, outputAcct, err = w.Manager.AddrAccountFromStore(
+						tx.Addr(), addrs[0],
+					)
+				}
+				if err != nil || outputAcct != account {
+					continue
+				}
+
+				bals.Total += output.Amount
+				if output.FromCoinBase && !hasMinConfs(
+					int32(w.chainParams.CoinbaseMaturity),
+					output.Height, syncBlock.Height,
+				) {
+
+					bals.ImmatureReward += output.Amount
+				} else if hasMinConfs(
+					confirms, output.Height, syncBlock.Height,
+				) {
+
+					bals.Spendable += output.Amount
+				}
 			}
+			return nil
+		}, func() {
+			bals = Balances{}
+		})
 
-			bals.Total += output.Amount
-			if output.FromCoinBase && !hasMinConfs(
-				int32(w.chainParams.CoinbaseMaturity),
-				output.Height, syncBlock.Height,
-			) {
-
-				bals.ImmatureReward += output.Amount
-			} else if hasMinConfs(
-				confirms, output.Height, syncBlock.Height,
-			) {
-
-				bals.Spendable += output.Amount
-			}
-		}
-		return nil
-	})
 	return bals, err
 }
 
@@ -1781,33 +2927,77 @@ func (w *Wallet) CurrentAddress(account uint32,
 		addr  address.Address
 		props *waddrmgr.AccountProperties
 	)
-	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		maddr, err := manager.LastExternalAddress(addrmgrNs, account)
-		if err != nil {
-			// If no address exists yet, create the first external
-			// address.
-			if waddrmgr.IsError(err, waddrmgr.ErrAddressNotFound) {
+	if w.db != nil {
+		err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+			addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+			maddr, err := manager.LastExternalAddress(addrmgrNs, account)
+			if err != nil {
+				// If no address exists yet, create the first external
+				// address.
+				if waddrmgr.IsError(err, waddrmgr.ErrAddressNotFound) {
+					addr, props, err = w.newAddress(
+						addrmgrNs, account, scope,
+					)
+				}
+				return err
+			}
+
+			// Get next chained address if the last one has already been
+			// used.
+			if maddr.Used(addrmgrNs) {
 				addr, props, err = w.newAddress(
 					addrmgrNs, account, scope,
 				)
+				return err
 			}
-			return err
-		}
 
-		// Get next chained address if the last one has already been
-		// used.
-		if maddr.Used(addrmgrNs) {
-			addr, props, err = w.newAddress(
-				addrmgrNs, account, scope,
-			)
-			return err
-		}
+			addr = maddr.Address()
+			return nil
+		})
+	} else {
+		err = w.store.UpdateOnce(
+			context.Background(),
+			func(tx walletstore.ReadWriteTx) error {
+				maddr, err := manager.LastExternalAddressFromStore(
+					tx.Addr(), account,
+				)
+				if waddrmgr.IsError(
+					err, waddrmgr.ErrAddressNotFound,
+				) {
 
-		addr = maddr.Address()
-		return nil
-	})
+					maddr, props, err =
+						manager.NextExternalAddressFromStore(
+							tx.Addr(), account,
+						)
+				}
+				if err != nil {
+					return err
+				}
+
+				if maddr.Used(nil) {
+					maddr, props, err =
+						manager.NextExternalAddressFromStore(
+							tx.Addr(), account,
+						)
+					if err != nil {
+						return err
+					}
+				}
+
+				addr = maddr.Address()
+				return nil
+			}, func() {
+				addr = nil
+				props = nil
+			},
+		)
+	}
 	if err != nil {
+		var ambiguous *walletstore.AmbiguousCommitError
+		if w.db == nil && errors.As(err, &ambiguous) {
+			w.Manager.MarkAccountCacheStale(scope, account)
+		}
+
 		return nil, err
 	}
 
@@ -1828,19 +3018,40 @@ func (w *Wallet) CurrentAddress(account uint32,
 // PubKeyForAddress looks up the associated public key for a P2PKH address.
 func (w *Wallet) PubKeyForAddress(a address.Address) (*btcec.PublicKey, error) {
 	var pubKey *btcec.PublicKey
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-		managedAddr, err := w.Manager.Address(addrmgrNs, a)
-		if err != nil {
-			return err
-		}
+	readAddress := func(managedAddr waddrmgr.ManagedAddress) error {
 		managedPubKeyAddr, ok := managedAddr.(waddrmgr.ManagedPubKeyAddress)
 		if !ok {
 			return errors.New("address does not have an associated public key")
 		}
 		pubKey = managedPubKeyAddr.PubKey()
 		return nil
-	})
+	}
+
+	var err error
+	if w.db != nil {
+		err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+			addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+			managedAddr, err := w.Manager.Address(addrmgrNs, a)
+			if err != nil {
+				return err
+			}
+
+			return readAddress(managedAddr)
+		})
+	} else {
+		err = w.store.View(
+			context.Background(), func(tx walletstore.ReadTx) error {
+				managedAddr, err := w.Manager.AddressFromStore(
+					tx.Addr(), a,
+				)
+				if err != nil {
+					return err
+				}
+
+				return readAddress(managedAddr)
+			}, nil,
+		)
+	}
 	return pubKey, err
 }
 
@@ -1850,50 +3061,26 @@ func (w *Wallet) PubKeyForAddress(a address.Address) (*btcec.PublicKey, error) {
 func (w *Wallet) LabelTransaction(hash chainhash.Hash, label string,
 	overwrite bool) error {
 
-	// Check that the transaction is known to the wallet, and fail if it is
-	// unknown. If the transaction is known, check whether it already has
-	// a label.
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
+	return w.store.UpdateOnce(
+		context.Background(), func(tx walletstore.ReadWriteTx) error {
+			details, err := tx.Tx().TxDetails(&hash)
+			if err != nil {
+				return err
+			}
+			if details == nil {
+				return ErrUnknownTransaction
+			}
 
-		dbTx, err := w.TxStore.TxDetails(txmgrNs, &hash)
-		if err != nil {
-			return err
-		}
+			existing, err := tx.Tx().TxLabel(hash)
+			if err != nil {
+				return err
+			}
+			if existing != "" && !overwrite {
+				return ErrTxLabelExists
+			}
 
-		// If the transaction looked up is nil, it was not found. We
-		// do not allow labelling of unknown transactions so we fail.
-		if dbTx == nil {
-			return ErrUnknownTransaction
-		}
-
-		_, err = wtxmgr.FetchTxLabel(txmgrNs, hash)
-		return err
-	})
-
-	switch err {
-	// If no labels have been written yet, we can silence the error.
-	// Likewise if there is no label, we do not need to do any overwrite
-	// checks.
-	case wtxmgr.ErrNoLabelBucket:
-	case wtxmgr.ErrTxLabelNotFound:
-
-	// If we successfully looked up a label, fail if the overwrite param
-	// is not set.
-	case nil:
-		if !overwrite {
-			return ErrTxLabelExists
-		}
-
-	// In another unrelated error occurred, return it.
-	default:
-		return err
-	}
-
-	return walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-		txmgrNs := tx.ReadWriteBucket(wtxmgrNamespaceKey)
-		return w.TxStore.PutTxLabel(txmgrNs, hash, label)
-	})
+			return tx.Tx().PutTxLabel(hash, label)
+		}, nil)
 }
 
 // PrivKeyForAddress looks up the associated private key for a P2PKH or P2PK
@@ -1902,29 +3089,61 @@ func (w *Wallet) PrivKeyForAddress(
 	a address.Address) (*btcec.PrivateKey, error) {
 
 	var privKey *btcec.PrivateKey
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-		managedAddr, err := w.Manager.Address(addrmgrNs, a)
-		if err != nil {
-			return err
-		}
+	readAddress := func(managedAddr waddrmgr.ManagedAddress) error {
 		managedPubKeyAddr, ok := managedAddr.(waddrmgr.ManagedPubKeyAddress)
 		if !ok {
 			return errors.New("address does not have an associated private key")
 		}
+		var err error
 		privKey, err = managedPubKeyAddr.PrivKey()
 		return err
-	})
+	}
+
+	var err error
+	if w.db != nil {
+		err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+			addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+			managedAddr, err := w.Manager.Address(addrmgrNs, a)
+			if err != nil {
+				return err
+			}
+
+			return readAddress(managedAddr)
+		})
+	} else {
+		err = w.store.View(
+			context.Background(), func(tx walletstore.ReadTx) error {
+				managedAddr, err := w.Manager.AddressFromStore(
+					tx.Addr(), a,
+				)
+				if err != nil {
+					return err
+				}
+
+				return readAddress(managedAddr)
+			}, nil,
+		)
+	}
 	return privKey, err
 }
 
 // HaveAddress returns whether the wallet is the owner of the address a.
 func (w *Wallet) HaveAddress(a address.Address) (bool, error) {
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-		_, err := w.Manager.Address(addrmgrNs, a)
-		return err
-	})
+	var err error
+	if w.db != nil {
+		err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+			addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+			_, err := w.Manager.Address(addrmgrNs, a)
+			return err
+		})
+	} else {
+		err = w.store.View(
+			context.Background(), func(tx walletstore.ReadTx) error {
+				_, err := w.Manager.AddressFromStore(tx.Addr(), a)
+				return err
+			}, nil,
+		)
+	}
 	if err == nil {
 		return true, nil
 	}
@@ -1937,12 +3156,27 @@ func (w *Wallet) HaveAddress(a address.Address) (bool, error) {
 // AccountOfAddress finds the account that an address is associated with.
 func (w *Wallet) AccountOfAddress(a address.Address) (uint32, error) {
 	var account uint32
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-		var err error
-		_, account, err = w.Manager.AddrAccount(addrmgrNs, a)
-		return err
-	})
+	var err error
+	if w.db != nil {
+		err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+			addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+			var err error
+			_, account, err = w.Manager.AddrAccount(addrmgrNs, a)
+			return err
+		})
+	} else {
+		err = w.store.View(
+			context.Background(), func(tx walletstore.ReadTx) error {
+				var err error
+				_, account, err = w.Manager.AddrAccountFromStore(
+					tx.Addr(), a,
+				)
+				return err
+			}, func() {
+				account = 0
+			},
+		)
+	}
 	return account, err
 }
 
@@ -1951,12 +3185,27 @@ func (w *Wallet) AddressInfo(
 	a address.Address) (waddrmgr.ManagedAddress, error) {
 
 	var managedAddress waddrmgr.ManagedAddress
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-		var err error
-		managedAddress, err = w.Manager.Address(addrmgrNs, a)
-		return err
-	})
+	var err error
+	if w.db != nil {
+		err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+			addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+			var err error
+			managedAddress, err = w.Manager.Address(addrmgrNs, a)
+			return err
+		})
+	} else {
+		err = w.store.View(
+			context.Background(), func(tx walletstore.ReadTx) error {
+				var err error
+				managedAddress, err = w.Manager.AddressFromStore(
+					tx.Addr(), a,
+				)
+				return err
+			}, func() {
+				managedAddress = nil
+			},
+		)
+	}
 	return managedAddress, err
 }
 
@@ -1971,12 +3220,26 @@ func (w *Wallet) AccountNumber(scope waddrmgr.KeyScope,
 	}
 
 	var account uint32
-	err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-		var err error
-		account, err = manager.LookupAccount(addrmgrNs, accountName)
-		return err
-	})
+	if w.db != nil {
+		err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+			addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+			var err error
+			account, err = manager.LookupAccount(addrmgrNs, accountName)
+			return err
+		})
+	} else {
+		err = w.store.View(
+			context.Background(), func(tx walletstore.ReadTx) error {
+				var err error
+				account, err = manager.LookupAccountFromStore(
+					tx.Addr(), accountName,
+				)
+				return err
+			}, func() {
+				account = 0
+			},
+		)
+	}
 	return account, err
 }
 
@@ -1990,12 +3253,28 @@ func (w *Wallet) AccountName(scope waddrmgr.KeyScope,
 	}
 
 	var accountName string
-	err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-		var err error
-		accountName, err = manager.AccountName(addrmgrNs, accountNumber)
-		return err
-	})
+	if w.db != nil {
+		err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+			addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+			var err error
+			accountName, err = manager.AccountName(
+				addrmgrNs, accountNumber,
+			)
+			return err
+		})
+	} else {
+		err = w.store.View(
+			context.Background(), func(tx walletstore.ReadTx) error {
+				var err error
+				accountName, err = manager.AccountNameFromStore(
+					tx.Addr(), accountNumber,
+				)
+				return err
+			}, func() {
+				accountName = ""
+			},
+		)
+	}
 	return accountName, err
 }
 
@@ -2011,12 +3290,26 @@ func (w *Wallet) AccountProperties(scope waddrmgr.KeyScope,
 	}
 
 	var props *waddrmgr.AccountProperties
-	err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		waddrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-		var err error
-		props, err = manager.AccountProperties(waddrmgrNs, acct)
-		return err
-	})
+	if w.db != nil {
+		err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+			waddrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+			var err error
+			props, err = manager.AccountProperties(waddrmgrNs, acct)
+			return err
+		})
+	} else {
+		err = w.store.View(
+			context.Background(), func(tx walletstore.ReadTx) error {
+				var err error
+				props, err = manager.AccountPropertiesFromStore(
+					tx.Addr(), acct,
+				)
+				return err
+			}, func() {
+				props = nil
+			},
+		)
+	}
 	return props, err
 }
 
@@ -2032,15 +3325,34 @@ func (w *Wallet) AccountPropertiesByName(scope waddrmgr.KeyScope,
 	}
 
 	var props *waddrmgr.AccountProperties
-	err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		waddrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-		acct, err := manager.LookupAccount(waddrmgrNs, name)
-		if err != nil {
+	if w.db != nil {
+		err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+			waddrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+			acct, err := manager.LookupAccount(waddrmgrNs, name)
+			if err != nil {
+				return err
+			}
+			props, err = manager.AccountProperties(waddrmgrNs, acct)
 			return err
-		}
-		props, err = manager.AccountProperties(waddrmgrNs, acct)
-		return err
-	})
+		})
+	} else {
+		err = w.store.View(
+			context.Background(), func(tx walletstore.ReadTx) error {
+				acct, err := manager.LookupAccountFromStore(
+					tx.Addr(), name,
+				)
+				if err != nil {
+					return err
+				}
+				props, err = manager.AccountPropertiesFromStore(
+					tx.Addr(), acct,
+				)
+				return err
+			}, func() {
+				props = nil
+			},
+		)
+	}
 	return props, err
 }
 
@@ -2051,12 +3363,27 @@ func (w *Wallet) LookupAccount(name string) (waddrmgr.KeyScope, uint32, error) {
 		keyScope waddrmgr.KeyScope
 		account  uint32
 	)
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		ns := tx.ReadBucket(waddrmgrNamespaceKey)
-		var err error
-		keyScope, account, err = w.Manager.LookupAccount(ns, name)
-		return err
-	})
+	var err error
+	if w.db != nil {
+		err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+			ns := tx.ReadBucket(waddrmgrNamespaceKey)
+			var err error
+			keyScope, account, err = w.Manager.LookupAccount(ns, name)
+			return err
+		})
+	} else {
+		err = w.store.View(
+			context.Background(), func(tx walletstore.ReadTx) error {
+				var err error
+				keyScope, account, err =
+					w.Manager.LookupAccountFromStore(tx.Addr(), name)
+				return err
+			}, func() {
+				keyScope = waddrmgr.KeyScope{}
+				account = 0
+			},
+		)
+	}
 	return keyScope, account, err
 }
 
@@ -2070,15 +3397,36 @@ func (w *Wallet) RenameAccount(scope waddrmgr.KeyScope, account uint32,
 	}
 
 	var props *waddrmgr.AccountProperties
-	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		err := manager.RenameAccount(addrmgrNs, account, newName)
-		if err != nil {
+	if w.db != nil {
+		err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+			addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+			err := manager.RenameAccount(addrmgrNs, account, newName)
+			if err != nil {
+				return err
+			}
+			props, err = manager.AccountProperties(addrmgrNs, account)
 			return err
+		})
+	} else {
+		err = w.store.UpdateOnce(
+			context.Background(),
+			func(tx walletstore.ReadWriteTx) error {
+				var err error
+				props, err = manager.RenameAccountFromStore(
+					tx.Addr(), account, newName,
+				)
+				return err
+			}, func() {
+				props = nil
+			},
+		)
+	}
+	if w.db == nil {
+		var ambiguous *walletstore.AmbiguousCommitError
+		if errors.As(err, &ambiguous) {
+			w.Manager.MarkAccountCacheStale(scope, account)
 		}
-		props, err = manager.AccountProperties(addrmgrNs, account)
-		return err
-	})
+	}
 	if err == nil {
 		w.NtfnServer.notifyAccountProperties(props)
 	}
@@ -2102,16 +3450,32 @@ func (w *Wallet) NextAccount(scope waddrmgr.KeyScope,
 		account uint32
 		props   *waddrmgr.AccountProperties
 	)
-	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		var err error
-		account, err = manager.NewAccount(addrmgrNs, name)
-		if err != nil {
+	if w.db != nil {
+		err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+			addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+			var err error
+			account, err = manager.NewAccount(addrmgrNs, name)
+			if err != nil {
+				return err
+			}
+			props, err = manager.AccountProperties(addrmgrNs, account)
 			return err
-		}
-		props, err = manager.AccountProperties(addrmgrNs, account)
-		return err
-	})
+		})
+	} else {
+		err = w.store.UpdateOnce(
+			context.Background(),
+			func(tx walletstore.ReadWriteTx) error {
+				var err error
+				account, props, err = manager.NewAccountFromStore(
+					tx.Addr(), name,
+				)
+				return err
+			}, func() {
+				account = 0
+				props = nil
+			},
+		)
+	}
 	if err != nil {
 		log.Errorf("Cannot fetch new account properties for notification "+
 			"after account creation: %v", err)
@@ -2128,10 +3492,14 @@ func (w *Wallet) NextAccount(scope waddrmgr.KeyScope,
 // TODO: This is a requirement of the RPC server and should be moved.
 type CreditCategory byte
 
-// These constants define the possible credit categories.
 const (
+	// CreditReceive identifies a non-coinbase received output.
 	CreditReceive CreditCategory = iota
+
+	// CreditGenerate identifies a mature coinbase output.
 	CreditGenerate
+
+	// CreditImmature identifies an immature coinbase output.
 	CreditImmature
 )
 
@@ -2314,24 +3682,25 @@ func (w *Wallet) ListSinceBlock(start, end,
 	syncHeight int32) ([]btcjson.ListTransactionsResult, error) {
 
 	txList := []btcjson.ListTransactionsResult{}
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
+	err := w.store.View(
+		context.Background(), func(tx walletstore.ReadTx) error {
+			rangeFn := func(details []wtxmgr.TxDetails) (bool, error) {
+				for _, detail := range details {
+					detail := detail
 
-		rangeFn := func(details []wtxmgr.TxDetails) (bool, error) {
-			for _, detail := range details {
-				detail := detail
-
-				jsonResults := listTransactions(
-					tx, &detail, w.Manager, syncHeight,
-					w.chainParams,
-				)
-				txList = append(txList, jsonResults...)
+					jsonResults := listTransactionsFromStore(
+						tx, w, &detail, syncHeight,
+					)
+					txList = append(txList, jsonResults...)
+				}
+				return false, nil
 			}
-			return false, nil
-		}
 
-		return w.TxStore.RangeTransactions(txmgrNs, start, end, rangeFn)
-	})
+			return tx.Tx().RangeTransactions(start, end, rangeFn)
+		}, func() {
+			txList = txList[:0]
+		})
+
 	return txList, err
 }
 
@@ -2343,50 +3712,53 @@ func (w *Wallet) ListTransactions(from,
 
 	txList := []btcjson.ListTransactionsResult{}
 
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
+	err := w.store.View(
+		context.Background(), func(tx walletstore.ReadTx) error {
+			// Get current block.  The block height used for calculating
+			// the number of tx confirmations.
+			syncBlock := w.Manager.SyncedTo()
 
-		// Get current block.  The block height used for calculating
-		// the number of tx confirmations.
-		syncBlock := w.Manager.SyncedTo()
+			// Need to skip the first from transactions, and after those, only
+			// include the next count transactions.
+			skipped := 0
+			n := 0
 
-		// Need to skip the first from transactions, and after those, only
-		// include the next count transactions.
-		skipped := 0
-		n := 0
+			rangeFn := func(details []wtxmgr.TxDetails) (bool, error) {
+				// Iterate over transactions at this height in reverse order.
+				// This does nothing for unmined transactions, which are
+				// unsorted, but it will process mined transactions in the
+				// reverse order they were marked mined.
+				for i := len(details) - 1; i >= 0; i-- {
+					if from > skipped {
+						skipped++
+						continue
+					}
 
-		rangeFn := func(details []wtxmgr.TxDetails) (bool, error) {
-			// Iterate over transactions at this height in reverse order.
-			// This does nothing for unmined transactions, which are
-			// unsorted, but it will process mined transactions in the
-			// reverse order they were marked mined.
-			for i := len(details) - 1; i >= 0; i-- {
-				if from > skipped {
-					skipped++
-					continue
-				}
-
-				n++
-				if n > count {
-					return true, nil
-				}
-
-				jsonResults := listTransactions(tx, &details[i],
-					w.Manager, syncBlock.Height, w.chainParams)
-				txList = append(txList, jsonResults...)
-
-				if len(jsonResults) > 0 {
 					n++
+					if n > count {
+						return true, nil
+					}
+
+					jsonResults := listTransactionsFromStore(
+						tx, w, &details[i], syncBlock.Height,
+					)
+					txList = append(txList, jsonResults...)
+
+					if len(jsonResults) > 0 {
+						n++
+					}
 				}
+
+				return false, nil
 			}
 
-			return false, nil
-		}
+			// Return newer results first by starting at mempool height and
+			// working down to the genesis block.
+			return tx.Tx().RangeTransactions(-1, 0, rangeFn)
+		}, func() {
+			txList = txList[:0]
+		})
 
-		// Return newer results first by starting at mempool height and working
-		// down to the genesis block.
-		return w.TxStore.RangeTransactions(txmgrNs, -1, 0, rangeFn)
-	})
 	return txList, err
 }
 
@@ -2397,45 +3769,48 @@ func (w *Wallet) ListAddressTransactions(
 	pkHashes map[string]struct{}) ([]btcjson.ListTransactionsResult, error) {
 
 	txList := []btcjson.ListTransactionsResult{}
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
+	err := w.store.View(
+		context.Background(), func(tx walletstore.ReadTx) error {
+			// Get current block.  The block height used for calculating
+			// the number of tx confirmations.
+			syncBlock := w.Manager.SyncedTo()
+			rangeFn := func(details []wtxmgr.TxDetails) (bool, error) {
+			loopDetails:
+				for i := range details {
+					detail := &details[i]
 
-		// Get current block.  The block height used for calculating
-		// the number of tx confirmations.
-		syncBlock := w.Manager.SyncedTo()
-		rangeFn := func(details []wtxmgr.TxDetails) (bool, error) {
-		loopDetails:
-			for i := range details {
-				detail := &details[i]
+					for _, cred := range detail.Credits {
+						pkScript := detail.MsgTx.TxOut[cred.Index].PkScript
+						_, addrs, _, err := txscript.ExtractPkScriptAddrs(
+							pkScript, w.chainParams)
+						if err != nil || len(addrs) != 1 {
+							continue
+						}
 
-				for _, cred := range detail.Credits {
-					pkScript := detail.MsgTx.TxOut[cred.Index].PkScript
-					_, addrs, _, err := txscript.ExtractPkScriptAddrs(
-						pkScript, w.chainParams)
-					if err != nil || len(addrs) != 1 {
-						continue
+						apkh, ok := addrs[0].(*address.AddressPubKeyHash)
+						if !ok {
+							continue
+						}
+						_, ok = pkHashes[string(apkh.ScriptAddress())]
+						if !ok {
+							continue
+						}
+
+						jsonResults := listTransactionsFromStore(
+							tx, w, detail, syncBlock.Height,
+						)
+						txList = append(txList, jsonResults...)
+						continue loopDetails
 					}
-
-					apkh, ok := addrs[0].(*address.AddressPubKeyHash)
-					if !ok {
-						continue
-					}
-					_, ok = pkHashes[string(apkh.ScriptAddress())]
-					if !ok {
-						continue
-					}
-
-					jsonResults := listTransactions(tx, detail,
-						w.Manager, syncBlock.Height, w.chainParams)
-					txList = append(txList, jsonResults...)
-					continue loopDetails
 				}
+				return false, nil
 			}
-			return false, nil
-		}
 
-		return w.TxStore.RangeTransactions(txmgrNs, 0, -1, rangeFn)
-	})
+			return tx.Tx().RangeTransactions(0, -1, rangeFn)
+		}, func() {
+			txList = txList[:0]
+		})
+
 	return txList, err
 }
 
@@ -2446,30 +3821,33 @@ func (w *Wallet) ListAllTransactions() ([]btcjson.ListTransactionsResult,
 	error) {
 
 	txList := []btcjson.ListTransactionsResult{}
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
+	err := w.store.View(
+		context.Background(), func(tx walletstore.ReadTx) error {
+			// Get current block.  The block height used for calculating
+			// the number of tx confirmations.
+			syncBlock := w.Manager.SyncedTo()
 
-		// Get current block.  The block height used for calculating
-		// the number of tx confirmations.
-		syncBlock := w.Manager.SyncedTo()
-
-		rangeFn := func(details []wtxmgr.TxDetails) (bool, error) {
-			// Iterate over transactions at this height in reverse order.
-			// This does nothing for unmined transactions, which are
-			// unsorted, but it will process mined transactions in the
-			// reverse order they were marked mined.
-			for i := len(details) - 1; i >= 0; i-- {
-				jsonResults := listTransactions(tx, &details[i], w.Manager,
-					syncBlock.Height, w.chainParams)
-				txList = append(txList, jsonResults...)
+			rangeFn := func(details []wtxmgr.TxDetails) (bool, error) {
+				// Iterate over transactions at this height in reverse order.
+				// This does nothing for unmined transactions, which are
+				// unsorted, but it will process mined transactions in the
+				// reverse order they were marked mined.
+				for i := len(details) - 1; i >= 0; i-- {
+					jsonResults := listTransactionsFromStore(
+						tx, w, &details[i], syncBlock.Height,
+					)
+					txList = append(txList, jsonResults...)
+				}
+				return false, nil
 			}
-			return false, nil
-		}
 
-		// Return newer results first by starting at mempool height and
-		// working down to the genesis block.
-		return w.TxStore.RangeTransactions(txmgrNs, -1, 0, rangeFn)
-	})
+			// Return newer results first by starting at mempool height and
+			// working down to the genesis block.
+			return tx.Tx().RangeTransactions(-1, 0, rangeFn)
+		}, func() {
+			txList = txList[:0]
+		})
+
 	return txList, err
 }
 
@@ -2492,7 +3870,10 @@ func NewBlockIdentifierFromHash(hash *chainhash.Hash) *BlockIdentifier {
 // GetTransactionsResult is the result of the wallet's GetTransactions method.
 // See GetTransactions for more details.
 type GetTransactionsResult struct {
-	MinedTransactions   []Block
+	// MinedTransactions groups confirmed transactions by block.
+	MinedTransactions []Block
+
+	// UnminedTransactions contains currently unconfirmed transactions.
 	UnminedTransactions []TransactionSummary
 }
 
@@ -2583,54 +3964,67 @@ func (w *Wallet) GetTransactions(startBlock, endBlock *BlockIdentifier,
 	}
 
 	var res GetTransactionsResult
-	err := walletdb.View(w.db, func(dbtx walletdb.ReadTx) error {
-		txmgrNs := dbtx.ReadBucket(wtxmgrNamespaceKey)
+	err := w.store.View(
+		context.Background(), func(tx walletstore.ReadTx) error {
+			rangeFn := func(details []wtxmgr.TxDetails) (bool, error) {
+				// TODO: probably should make RangeTransactions not reuse the
+				// details backing array memory.
+				dets := make([]wtxmgr.TxDetails, len(details))
+				copy(dets, details)
+				details = dets
 
-		rangeFn := func(details []wtxmgr.TxDetails) (bool, error) {
-			// TODO: probably should make RangeTransactions not reuse the
-			// details backing array memory.
-			dets := make([]wtxmgr.TxDetails, len(details))
-			copy(dets, details)
-			details = dets
+				txs := make([]TransactionSummary, 0, len(details))
+				for i := range details {
+					txs = append(
+						txs, makeTxSummaryFromStore(tx, w, &details[i]),
+					)
+				}
 
-			txs := make([]TransactionSummary, 0, len(details))
-			for i := range details {
-				txs = append(txs, makeTxSummary(dbtx, w, &details[i]))
+				if details[0].Block.Height != -1 {
+					blockHash := details[0].Block.Hash
+					res.MinedTransactions = append(res.MinedTransactions, Block{
+						Hash:         &blockHash,
+						Height:       details[0].Block.Height,
+						Timestamp:    details[0].Block.Time.Unix(),
+						Transactions: txs,
+					})
+				} else {
+					res.UnminedTransactions = txs
+				}
+
+				select {
+				case <-cancel:
+					return true, nil
+				default:
+					return false, nil
+				}
 			}
 
-			if details[0].Block.Height != -1 {
-				blockHash := details[0].Block.Hash
-				res.MinedTransactions = append(res.MinedTransactions, Block{
-					Hash:         &blockHash,
-					Height:       details[0].Block.Height,
-					Timestamp:    details[0].Block.Time.Unix(),
-					Transactions: txs,
-				})
-			} else {
-				res.UnminedTransactions = txs
-			}
+			return tx.Tx().RangeTransactions(start, end, rangeFn)
+		}, func() {
+			res = GetTransactionsResult{}
+		})
 
-			select {
-			case <-cancel:
-				return true, nil
-			default:
-				return false, nil
-			}
-		}
-
-		return w.TxStore.RangeTransactions(txmgrNs, start, end, rangeFn)
-	})
 	return &res, err
 }
 
 // GetTransactionResult returns a summary of the transaction along with
 // other block properties.
 type GetTransactionResult struct {
-	Summary       TransactionSummary
-	Height        int32
-	BlockHash     *chainhash.Hash
+	// Summary contains the transaction's wallet-relevant details.
+	Summary TransactionSummary
+
+	// Height is the transaction's block height or -1 when unmined.
+	Height int32
+
+	// BlockHash identifies the transaction's block when mined.
+	BlockHash *chainhash.Hash
+
+	// Confirmations is the transaction's current confirmation count.
 	Confirmations int32
-	Timestamp     int64
+
+	// Timestamp is the transaction's block time when mined.
+	Timestamp int64
 }
 
 // GetTransaction returns detailed data of a transaction given its id. In
@@ -2639,43 +4033,44 @@ func (w *Wallet) GetTransaction(txHash chainhash.Hash) (*GetTransactionResult,
 	error) {
 
 	var res GetTransactionResult
-	err := walletdb.View(w.db, func(dbtx walletdb.ReadTx) error {
-		txmgrNs := dbtx.ReadBucket(wtxmgrNamespaceKey)
+	err := w.store.View(
+		context.Background(), func(tx walletstore.ReadTx) error {
+			txDetail, err := tx.Tx().TxDetails(&txHash)
+			if err != nil {
+				return err
+			}
 
-		txDetail, err := w.TxStore.TxDetails(txmgrNs, &txHash)
-		if err != nil {
-			return err
-		}
+			// If the transaction was not found we return an error.
+			if txDetail == nil {
+				return fmt.Errorf("%w: txid %v", ErrNoTx, txHash)
+			}
 
-		// If the transaction was not found we return an error.
-		if txDetail == nil {
-			return fmt.Errorf("%w: txid %v", ErrNoTx, txHash)
-		}
+			res = GetTransactionResult{
+				Summary:       makeTxSummaryFromStore(tx, w, txDetail),
+				BlockHash:     nil,
+				Height:        -1,
+				Confirmations: 0,
+				Timestamp:     0,
+			}
 
-		res = GetTransactionResult{
-			Summary:       makeTxSummary(dbtx, w, txDetail),
-			BlockHash:     nil,
-			Height:        -1,
-			Confirmations: 0,
-			Timestamp:     0,
-		}
+			// If it is a confirmed transaction we set the corresponding
+			// block height, timestamp, hash, and confirmations.
+			if txDetail.Block.Height != -1 {
+				res.Height = txDetail.Block.Height
+				res.Timestamp = txDetail.Block.Time.Unix()
+				res.BlockHash = &txDetail.Block.Hash
 
-		// If it is a confirmed transaction we set the corresponding
-		// block height, timestamp, hash, and confirmations.
-		if txDetail.Block.Height != -1 {
-			res.Height = txDetail.Block.Height
-			res.Timestamp = txDetail.Block.Time.Unix()
-			res.BlockHash = &txDetail.Block.Hash
+				bestBlock := w.SyncedTo()
+				blockHeight := txDetail.Block.Height
+				res.Confirmations = calcConf(
+					blockHeight, bestBlock.Height,
+				)
+			}
 
-			bestBlock := w.SyncedTo()
-			blockHeight := txDetail.Block.Height
-			res.Confirmations = calcConf(
-				blockHeight, bestBlock.Height,
-			)
-		}
-
-		return nil
-	})
+			return nil
+		}, func() {
+			res = GetTransactionResult{}
+		})
 	if err != nil {
 		return nil, err
 	}
@@ -2684,15 +4079,23 @@ func (w *Wallet) GetTransaction(txHash chainhash.Hash) (*GetTransactionResult,
 
 // AccountResult is a single account result for the AccountsResult type.
 type AccountResult struct {
+	// AccountProperties contains the address manager's account metadata.
 	waddrmgr.AccountProperties
+
+	// TotalBalance is the account's total unspent balance.
 	TotalBalance btcutil.Amount
 }
 
 // AccountsResult is the result of the wallet's Accounts method.  See that
 // method for more details.
 type AccountsResult struct {
-	Accounts           []AccountResult
-	CurrentBlockHash   *chainhash.Hash
+	// Accounts contains the properties and balance of each account.
+	Accounts []AccountResult
+
+	// CurrentBlockHash identifies the chain tip used for the balances.
+	CurrentBlockHash *chainhash.Hash
+
+	// CurrentBlockHeight is the chain tip height used for the balances.
 	CurrentBlockHeight int32
 }
 
@@ -2713,6 +4116,77 @@ func (w *Wallet) Accounts(scope waddrmgr.KeyScope) (*AccountsResult, error) {
 		syncBlockHash   *chainhash.Hash
 		syncBlockHeight int32
 	)
+	if w.db == nil {
+		err = w.store.View(
+			context.Background(), func(tx walletstore.ReadTx) error {
+				syncBlock := w.Manager.SyncedTo()
+				syncBlockHash = &syncBlock.Hash
+				syncBlockHeight = syncBlock.Height
+
+				unspent, err := tx.Tx().UnspentOutputs()
+				if err != nil {
+					return err
+				}
+				err = manager.ForEachAccountFromStore(
+					tx.Addr(), func(account uint32) error {
+						props, err :=
+							manager.AccountPropertiesFromStore(
+								tx.Addr(), account,
+							)
+						if err != nil {
+							return err
+						}
+						accounts = append(accounts, AccountResult{
+							AccountProperties: *props,
+						})
+						return nil
+					},
+				)
+				if err != nil {
+					return err
+				}
+
+				balances := make(map[uint32]*btcutil.Amount)
+				for i := range accounts {
+					account := &accounts[i]
+					balances[account.AccountNumber] =
+						&account.TotalBalance
+				}
+				for i := range unspent {
+					output := unspent[i]
+					_, addrs, _, err := txscript.ExtractPkScriptAddrs(
+						output.PkScript, w.chainParams,
+					)
+					if err != nil || len(addrs) == 0 {
+						continue
+					}
+					outputAccount, err := manager.AddrAccountFromStore(
+						tx.Addr(), addrs[0],
+					)
+					if err != nil {
+						continue
+					}
+					balance := balances[outputAccount]
+					if balance != nil {
+						*balance += output.Amount
+					}
+				}
+
+				return nil
+			}, func() {
+				accounts = nil
+				syncBlockHash = nil
+				syncBlockHeight = 0
+			},
+		)
+
+		return &AccountsResult{
+			Accounts:           accounts,
+			CurrentBlockHash:   syncBlockHash,
+			CurrentBlockHeight: syncBlockHeight,
+		}, err
+	}
+
 	err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
 		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
 		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
@@ -2769,10 +4243,16 @@ func (w *Wallet) Accounts(scope waddrmgr.KeyScope) (*AccountsResult, error) {
 	}, err
 }
 
-// AccountBalanceResult is a single result for the Wallet.AccountBalances method.
+// AccountBalanceResult is a single result for the Wallet.AccountBalances
+// method.
 type AccountBalanceResult struct {
-	AccountNumber  uint32
-	AccountName    string
+	// AccountNumber is the account's internal identifier.
+	AccountNumber uint32
+
+	// AccountName is the account's user-facing name.
+	AccountName string
+
+	// AccountBalance is the account's confirmed balance.
 	AccountBalance btcutil.Amount
 }
 
@@ -2788,6 +4268,71 @@ func (w *Wallet) AccountBalances(scope waddrmgr.KeyScope,
 	}
 
 	var results []AccountBalanceResult
+	if w.db == nil {
+		err = w.store.View(
+			context.Background(), func(tx walletstore.ReadTx) error {
+				syncBlock := w.Manager.SyncedTo()
+				accounts, err := tx.Addr().Accounts(scope)
+				if err != nil {
+					return err
+				}
+
+				results = make([]AccountBalanceResult, len(accounts))
+				resultIndex := make(map[uint32]int, len(accounts))
+				for i, account := range accounts {
+					results[i].AccountNumber = account.Account
+					results[i].AccountName = account.Name
+					resultIndex[account.Account] = i
+				}
+
+				outputs, err := tx.Tx().UnspentOutputs()
+				if err != nil {
+					return err
+				}
+				for i := range outputs {
+					output := &outputs[i]
+					if !hasMinConfs(
+						requiredConfs, output.Height, syncBlock.Height,
+					) {
+
+						continue
+					}
+					if output.FromCoinBase && !hasMinConfs(
+						int32(w.ChainParams().CoinbaseMaturity),
+						output.Height, syncBlock.Height,
+					) {
+
+						continue
+					}
+
+					_, addrs, _, err := txscript.ExtractPkScriptAddrs(
+						output.PkScript, w.chainParams,
+					)
+					if err != nil || len(addrs) == 0 {
+						continue
+					}
+					account, err := manager.AddrAccountFromStore(
+						tx.Addr(), addrs[0],
+					)
+					if err != nil {
+						continue
+					}
+
+					index, ok := resultIndex[account]
+					if !ok {
+						return errors.New("address account is not registered")
+					}
+					results[index].AccountBalance += output.Amount
+				}
+
+				return nil
+			}, func() {
+				results = nil
+			},
+		)
+		return results, err
+	}
+
 	err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
 		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
 		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
@@ -2867,10 +4412,12 @@ func (w *Wallet) AccountBalances(scope waddrmgr.KeyScope,
 // output index.
 type creditSlice []wtxmgr.Credit
 
+// Len returns the number of credits in the slice.
 func (s creditSlice) Len() int {
 	return len(s)
 }
 
+// Less reports whether one credit should sort before another.
 func (s creditSlice) Less(i, j int) bool {
 	switch {
 	// If both credits are from the same tx, sort by output index.
@@ -2893,6 +4440,7 @@ func (s creditSlice) Less(i, j int) bool {
 	}
 }
 
+// Swap exchanges two credits in the slice.
 func (s creditSlice) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
@@ -2906,139 +4454,149 @@ func (w *Wallet) ListUnspent(minconf, maxconf int32,
 	accountName string) ([]*btcjson.ListUnspentResult, error) {
 
 	var results []*btcjson.ListUnspentResult
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
+	err := w.store.View(
+		context.Background(), func(tx walletstore.ReadTx) error {
+			syncBlock := w.Manager.SyncedTo()
 
-		syncBlock := w.Manager.SyncedTo()
-
-		filter := accountName != ""
-		unspent, err := w.TxStore.UnspentOutputs(txmgrNs)
-		if err != nil {
-			return err
-		}
-		sort.Sort(sort.Reverse(creditSlice(unspent)))
-
-		defaultAccountName := "default"
-
-		results = make([]*btcjson.ListUnspentResult, 0, len(unspent))
-		for i := range unspent {
-			output := unspent[i]
-
-			// Outputs with fewer confirmations than the minimum or
-			// more confs than the maximum are excluded.
-			confs := calcConf(output.Height, syncBlock.Height)
-			if confs < minconf || confs > maxconf {
-				continue
+			filter := accountName != ""
+			unspent, err := tx.Tx().UnspentOutputs()
+			if err != nil {
+				return err
 			}
+			sort.Sort(sort.Reverse(creditSlice(unspent)))
 
-			// Only mature coinbase outputs are included.
-			if output.FromCoinBase {
-				target := int32(w.ChainParams().CoinbaseMaturity)
-				if !hasMinConfs(
-					target, output.Height, syncBlock.Height,
-				) {
+			defaultAccountName := "default"
 
+			results = make([]*btcjson.ListUnspentResult, 0, len(unspent))
+			for i := range unspent {
+				output := unspent[i]
+
+				// Outputs with fewer confirmations than the minimum or
+				// more confs than the maximum are excluded.
+				confs := calcConf(output.Height, syncBlock.Height)
+				if confs < minconf || confs > maxconf {
 					continue
 				}
-			}
 
-			// Exclude locked outputs from the result set.
-			if w.LockedOutpoint(output.OutPoint) {
-				continue
-			}
+				// Only mature coinbase outputs are included.
+				if output.FromCoinBase {
+					target := int32(w.ChainParams().CoinbaseMaturity)
+					if !hasMinConfs(
+						target, output.Height, syncBlock.Height,
+					) {
 
-			// Lookup the associated account for the output.  Use the
-			// default account name in case there is no associated account
-			// for some reason, although this should never happen.
-			//
-			// This will be unnecessary once transactions and outputs are
-			// grouped under the associated account in the db.
-			outputAcctName := defaultAccountName
-			sc, addrs, _, err := txscript.ExtractPkScriptAddrs(
-				output.PkScript, w.chainParams)
-			if err != nil {
-				continue
-			}
-			if len(addrs) > 0 {
-				smgr, acct, err := w.Manager.AddrAccount(addrmgrNs, addrs[0])
-				if err == nil {
-					s, err := smgr.AccountName(addrmgrNs, acct)
-					if err == nil {
-						outputAcctName = s
-					}
-				}
-			}
-
-			if filter && outputAcctName != accountName {
-				continue
-			}
-
-			// At the moment watch-only addresses are not supported, so all
-			// recorded outputs that are not multisig are "spendable".
-			// Multisig outputs are only "spendable" if all keys are
-			// controlled by this wallet.
-			//
-			// TODO: Each case will need updates when watch-only addrs
-			// is added.  For P2PK, P2PKH, and P2SH, the address must be
-			// looked up and not be watching-only.  For multisig, all
-			// pubkeys must belong to the manager with the associated
-			// private key (currently it only checks whether the pubkey
-			// exists, since the private key is required at the moment).
-			var spendable bool
-		scSwitch:
-			switch sc {
-			case txscript.PubKeyHashTy:
-				spendable = true
-			case txscript.PubKeyTy:
-				spendable = true
-			case txscript.WitnessV0ScriptHashTy:
-				spendable = true
-			case txscript.WitnessV0PubKeyHashTy:
-				spendable = true
-			case txscript.MultiSigTy:
-				for _, a := range addrs {
-					_, err := w.Manager.Address(addrmgrNs, a)
-					if err == nil {
 						continue
 					}
-					if waddrmgr.IsError(err, waddrmgr.ErrAddressNotFound) {
-						break scSwitch
-					}
-					return err
 				}
-				spendable = true
-			}
 
-			result := &btcjson.ListUnspentResult{
-				TxID:          output.OutPoint.Hash.String(),
-				Vout:          output.OutPoint.Index,
-				Account:       outputAcctName,
-				ScriptPubKey:  hex.EncodeToString(output.PkScript),
-				Amount:        output.Amount.ToBTC(),
-				Confirmations: int64(confs),
-				Spendable:     spendable,
-			}
+				// Exclude locked outputs from the result set.
+				if w.LockedOutpoint(output.OutPoint) {
+					continue
+				}
 
-			// BUG: this should be a JSON array so that all
-			// addresses can be included, or removed (and the
-			// caller extracts addresses from the pkScript).
-			if len(addrs) > 0 {
-				result.Address = addrs[0].EncodeAddress()
-			}
+				// Lookup the associated account for the output.  Use the
+				// default account name in case there is no associated account
+				// for some reason, although this should never happen.
+				//
+				// This will be unnecessary once transactions and outputs are
+				// grouped under the associated account in the db.
+				outputAcctName := defaultAccountName
+				sc, addrs, _, err := txscript.ExtractPkScriptAddrs(
+					output.PkScript, w.chainParams)
+				if err != nil {
+					continue
+				}
+				if len(addrs) > 0 {
+					smgr, acct, err := w.Manager.AddrAccountFromStore(
+						tx.Addr(), addrs[0],
+					)
+					if err == nil {
+						s, err := smgr.AccountNameFromStore(
+							tx.Addr(), acct,
+						)
+						if err == nil {
+							outputAcctName = s
+						}
+					}
+				}
 
-			results = append(results, result)
-		}
-		return nil
-	})
+				if filter && outputAcctName != accountName {
+					continue
+				}
+
+				// At the moment watch-only addresses are not supported, so all
+				// recorded outputs that are not multisig are "spendable".
+				// Multisig outputs are only "spendable" if all keys are
+				// controlled by this wallet.
+				//
+				// TODO: Each case will need updates when watch-only addrs
+				// is added.  For P2PK, P2PKH, and P2SH, the address must be
+				// looked up and not be watching-only.  For multisig, all
+				// pubkeys must belong to the manager with the associated
+				// private key (currently it only checks whether the pubkey
+				// exists, since the private key is required at the moment).
+				var spendable bool
+			scSwitch:
+				switch sc {
+				case txscript.PubKeyHashTy:
+					spendable = true
+				case txscript.PubKeyTy:
+					spendable = true
+				case txscript.WitnessV0ScriptHashTy:
+					spendable = true
+				case txscript.WitnessV0PubKeyHashTy:
+					spendable = true
+				case txscript.MultiSigTy:
+					for _, a := range addrs {
+						_, err := w.Manager.AddressFromStore(tx.Addr(), a)
+						if err == nil {
+							continue
+						}
+						if waddrmgr.IsError(err, waddrmgr.ErrAddressNotFound) {
+							break scSwitch
+						}
+						return err
+					}
+					spendable = true
+				}
+
+				result := &btcjson.ListUnspentResult{
+					TxID:          output.OutPoint.Hash.String(),
+					Vout:          output.OutPoint.Index,
+					Account:       outputAcctName,
+					ScriptPubKey:  hex.EncodeToString(output.PkScript),
+					Amount:        output.Amount.ToBTC(),
+					Confirmations: int64(confs),
+					Spendable:     spendable,
+				}
+
+				// BUG: this should be a JSON array so that all
+				// addresses can be included, or removed (and the
+				// caller extracts addresses from the pkScript).
+				if len(addrs) > 0 {
+					result.Address = addrs[0].EncodeAddress()
+				}
+
+				results = append(results, result)
+			}
+			return nil
+		}, func() {
+			results = nil
+		})
+
 	return results, err
 }
 
 // ListLeasedOutputResult is a single result for the Wallet.ListLeasedOutputs
 // method. See that method for more details.
 type ListLeasedOutputResult struct {
+	// LockedOutput identifies the output lease and its owner.
 	*wtxmgr.LockedOutput
-	Value    int64
+
+	// Value is the leased output amount in satoshis.
+	Value int64
+
+	// PkScript is the leased output's public-key script.
 	PkScript []byte
 }
 
@@ -3046,39 +4604,42 @@ type ListLeasedOutputResult struct {
 // utxos.
 func (w *Wallet) ListLeasedOutputs() ([]*ListLeasedOutputResult, error) {
 	var results []*ListLeasedOutputResult
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		ns := tx.ReadBucket(wtxmgrNamespaceKey)
-		outputs, err := w.TxStore.ListLockedOutputs(ns)
-		if err != nil {
-			return err
-		}
-
-		for _, output := range outputs {
-			details, err := w.TxStore.TxDetails(ns, &output.Outpoint.Hash)
+	err := w.store.View(
+		context.Background(), func(tx walletstore.ReadTx) error {
+			outputs, err := tx.Tx().ListLockedOutputs()
 			if err != nil {
 				return err
 			}
 
-			if details == nil {
-				log.Infof("unable to find tx details for "+
-					"%v:%v", output.Outpoint.Hash,
-					output.Outpoint.Index)
-				continue
+			for _, output := range outputs {
+				details, err := tx.Tx().TxDetails(&output.Outpoint.Hash)
+				if err != nil {
+					return err
+				}
+
+				if details == nil {
+					log.Infof("unable to find tx details for "+
+						"%v:%v", output.Outpoint.Hash,
+						output.Outpoint.Index)
+					continue
+				}
+
+				txOut := details.MsgTx.TxOut[output.Outpoint.Index]
+
+				result := &ListLeasedOutputResult{
+					LockedOutput: output,
+					Value:        txOut.Value,
+					PkScript:     txOut.PkScript,
+				}
+
+				results = append(results, result)
 			}
 
-			txOut := details.MsgTx.TxOut[output.Outpoint.Index]
+			return nil
+		}, func() {
+			results = nil
+		})
 
-			result := &ListLeasedOutputResult{
-				LockedOutput: output,
-				Value:        txOut.Value,
-				PkScript:     txOut.PkScript,
-			}
-
-			results = append(results, result)
-		}
-
-		return nil
-	})
 	return results, err
 }
 
@@ -3086,37 +4647,57 @@ func (w *Wallet) ListLeasedOutputs() ([]*ListLeasedOutputResult, error) {
 // private keys in a wallet.
 func (w *Wallet) DumpPrivKeys() ([]string, error) {
 	var privkeys []string
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-		// Iterate over each active address, appending the private key to
-		// privkeys.
-		return w.Manager.ForEachActiveAddress(
-			addrmgrNs, func(addr address.Address) error {
-				ma, err := w.Manager.Address(addrmgrNs, addr)
-				if err != nil {
-					return err
-				}
+	appendKey := func(ma waddrmgr.ManagedAddress) error {
+		// Only those addresses with keys needed.
+		pka, ok := ma.(waddrmgr.ManagedPubKeyAddress)
+		if !ok {
+			return nil
+		}
 
-				// Only those addresses with keys needed.
-				pka, ok := ma.(waddrmgr.ManagedPubKeyAddress)
-				if !ok {
-					return nil
-				}
+		wif, err := pka.ExportPrivKey()
+		if err != nil {
+			return err
+		}
+		privkeys = append(privkeys, wif.String())
 
-				wif, err := pka.ExportPrivKey()
-				if err != nil {
-					// It would be nice to zero out the array here. However,
-					// since strings in go are immutable, and we have no
-					// control over the caller I don't think we can. :(
-					return err
-				}
+		return nil
+	}
 
-				privkeys = append(privkeys, wif.String())
+	var err error
+	if w.db != nil {
+		err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+			addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+			return w.Manager.ForEachActiveAddress(
+				addrmgrNs, func(addr address.Address) error {
+					ma, err := w.Manager.Address(addrmgrNs, addr)
+					if err != nil {
+						return err
+					}
 
-				return nil
+					return appendKey(ma)
+				},
+			)
+		})
+	} else {
+		err = w.store.View(
+			context.Background(), func(tx walletstore.ReadTx) error {
+				return w.Manager.ForEachActiveAddressFromStore(
+					tx.Addr(), func(addr address.Address) error {
+						ma, err := w.Manager.AddressFromStore(
+							tx.Addr(), addr,
+						)
+						if err != nil {
+							return err
+						}
+
+						return appendKey(ma)
+					},
+				)
+			}, func() {
+				privkeys = nil
 			},
 		)
-	})
+	}
 	return privkeys, err
 }
 
@@ -3124,13 +4705,25 @@ func (w *Wallet) DumpPrivKeys() ([]string, error) {
 // single wallet address.
 func (w *Wallet) DumpWIFPrivateKey(addr address.Address) (string, error) {
 	var maddr waddrmgr.ManagedAddress
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		waddrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-		// Get private key from wallet if it exists.
-		var err error
-		maddr, err = w.Manager.Address(waddrmgrNs, addr)
-		return err
-	})
+	var err error
+	if w.db != nil {
+		err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+			waddrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+			var err error
+			maddr, err = w.Manager.Address(waddrmgrNs, addr)
+			return err
+		})
+	} else {
+		err = w.store.View(
+			context.Background(), func(tx walletstore.ReadTx) error {
+				var err error
+				maddr, err = w.Manager.AddressFromStore(tx.Addr(), addr)
+				return err
+			}, func() {
+				maddr = nil
+			},
+		)
+	}
 	if err != nil {
 		return "", err
 	}
@@ -3222,12 +4815,16 @@ func (w *Wallet) LeaseOutput(id wtxmgr.LockID, op wire.OutPoint,
 	duration time.Duration) (time.Time, error) {
 
 	var expiry time.Time
-	err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-		ns := tx.ReadWriteBucket(wtxmgrNamespaceKey)
-		var err error
-		expiry, err = w.TxStore.LockOutput(ns, id, op, duration)
-		return err
-	})
+	err := w.store.UpdateOnce(
+		context.Background(), func(tx walletstore.ReadWriteTx) error {
+			var err error
+			expiry, err = tx.Tx().LockOutput(id, op, duration)
+			return err
+		}, func() {
+			expiry = time.Time{}
+		},
+	)
+
 	return expiry, err
 }
 
@@ -3235,10 +4832,11 @@ func (w *Wallet) LeaseOutput(id wtxmgr.LockID, op wire.OutPoint,
 // selection if it remains unspent. The ID should match the one used to
 // originally lock the output.
 func (w *Wallet) ReleaseOutput(id wtxmgr.LockID, op wire.OutPoint) error {
-	return walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-		ns := tx.ReadWriteBucket(wtxmgrNamespaceKey)
-		return w.TxStore.UnlockOutput(ns, id, op)
-	})
+	return w.store.UpdateOnce(
+		context.Background(), func(tx walletstore.ReadWriteTx) error {
+			return tx.Tx().UnlockOutput(id, op)
+		}, nil,
+	)
 }
 
 // resendUnminedTxs iterates through all transactions that spend from wallet
@@ -3246,12 +4844,25 @@ func (w *Wallet) ReleaseOutput(id wtxmgr.LockID, op wire.OutPoint) error {
 // to send each to the chain server for relay.
 func (w *Wallet) resendUnminedTxs() {
 	var txs []*wire.MsgTx
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
-		var err error
-		txs, err = w.TxStore.UnminedTxs(txmgrNs)
-		return err
-	})
+	var err error
+	if w.db != nil {
+		err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+			txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
+			var err error
+			txs, err = w.TxStore.UnminedTxs(txmgrNs)
+			return err
+		})
+	} else {
+		err = w.store.View(
+			context.Background(), func(tx walletstore.ReadTx) error {
+				var err error
+				txs, err = tx.Tx().UnminedTxs()
+				return err
+			}, func() {
+				txs = nil
+			},
+		)
+	}
 	if err != nil {
 		log.Errorf("Unable to retrieve unconfirmed transactions to "+
 			"resend: %v", err)
@@ -3275,16 +4886,30 @@ func (w *Wallet) resendUnminedTxs() {
 // addresses in a wallet.
 func (w *Wallet) SortedActivePaymentAddresses() ([]string, error) {
 	var addrStrs []string
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+	appendAddress := func(addr address.Address) error {
+		addrStrs = append(addrStrs, addr.EncodeAddress())
+		return nil
+	}
 
-		return w.Manager.ForEachActiveAddress(
-			addrmgrNs, func(addr address.Address) error {
-				addrStrs = append(addrStrs, addr.EncodeAddress())
-				return nil
+	var err error
+	if w.db != nil {
+		err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+			addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+			return w.Manager.ForEachActiveAddress(
+				addrmgrNs, appendAddress,
+			)
+		})
+	} else {
+		err = w.store.View(
+			context.Background(), func(tx walletstore.ReadTx) error {
+				return w.Manager.ForEachActiveAddressFromStore(
+					tx.Addr(), appendAddress,
+				)
+			}, func() {
+				addrStrs = nil
 			},
 		)
-	})
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -3315,13 +4940,47 @@ func (w *Wallet) NewAddress(account uint32,
 		addr  address.Address
 		props *waddrmgr.AccountProperties
 	)
-	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		var err error
-		addr, props, err = w.newAddress(addrmgrNs, account, scope)
-		return err
-	})
+	if w.db != nil {
+		err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+			addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+			var err error
+			addr, props, err = w.newAddress(
+				addrmgrNs, account, scope,
+			)
+			return err
+		})
+	} else {
+		err = w.store.UpdateOnce(
+			context.Background(), func(tx walletstore.ReadWriteTx) error {
+				manager, err := w.Manager.FetchScopedKeyManager(scope)
+				if err != nil {
+					return err
+				}
+
+				managed, accountProps, err :=
+					manager.NextExternalAddressFromStore(
+						tx.Addr(), account,
+					)
+				if err != nil {
+					return err
+				}
+
+				addr = managed.Address()
+				props = accountProps
+
+				return nil
+			}, func() {
+				addr = nil
+				props = nil
+			},
+		)
+	}
 	if err != nil {
+		var ambiguous *walletstore.AmbiguousCommitError
+		if errors.As(err, &ambiguous) {
+			w.Manager.MarkAccountCacheStale(scope, account)
+		}
+
 		return nil, err
 	}
 
@@ -3336,6 +4995,8 @@ func (w *Wallet) NewAddress(account uint32,
 	return addr, nil
 }
 
+// newAddress derives the next KV-backed external address and its updated
+// account properties.
 func (w *Wallet) newAddress(addrmgrNs walletdb.ReadWriteBucket, account uint32,
 	scope waddrmgr.KeyScope) (address.Address, *waddrmgr.AccountProperties,
 	error) {
@@ -3380,13 +5041,42 @@ func (w *Wallet) NewChangeAddress(account uint32,
 	defer w.newAddrMtx.Unlock()
 
 	var addr address.Address
-	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		var err error
-		addr, err = w.newChangeAddress(addrmgrNs, account, scope)
-		return err
-	})
+	if w.db != nil {
+		err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+			addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+			var err error
+			addr, err = w.newChangeAddress(addrmgrNs, account, scope)
+			return err
+		})
+	} else {
+		err = w.store.UpdateOnce(
+			context.Background(),
+			func(tx walletstore.ReadWriteTx) error {
+				manager, err := w.Manager.FetchScopedKeyManager(scope)
+				if err != nil {
+					return err
+				}
+
+				managed, _, err := manager.NextInternalAddressFromStore(
+					tx.Addr(), account,
+				)
+				if err != nil {
+					return err
+				}
+				addr = managed.Address()
+
+				return nil
+			}, func() {
+				addr = nil
+			},
+		)
+	}
 	if err != nil {
+		var ambiguous *walletstore.AmbiguousCommitError
+		if errors.As(err, &ambiguous) {
+			w.Manager.MarkAccountCacheStale(scope, account)
+		}
+
 		return nil, err
 	}
 
@@ -3450,9 +5140,16 @@ func calcConf(txHeight, curHeight int32) int32 {
 // AccountTotalReceivedResult is a single result for the
 // Wallet.TotalReceivedForAccounts method.
 type AccountTotalReceivedResult struct {
-	AccountNumber    uint32
-	AccountName      string
-	TotalReceived    btcutil.Amount
+	// AccountNumber is the account's internal identifier.
+	AccountNumber uint32
+
+	// AccountName is the account's user-facing name.
+	AccountName string
+
+	// TotalReceived is the amount received by the account.
+	TotalReceived btcutil.Amount
+
+	// LastConfirmation is the confirmation count of the latest credit.
 	LastConfirmation int32
 }
 
@@ -3467,70 +5164,77 @@ func (w *Wallet) TotalReceivedForAccounts(scope waddrmgr.KeyScope,
 	}
 
 	var results []AccountTotalReceivedResult
-	err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
+	err = w.store.View(
+		context.Background(), func(tx walletstore.ReadTx) error {
+			syncBlock := w.Manager.SyncedTo()
 
-		syncBlock := w.Manager.SyncedTo()
-
-		err := manager.ForEachAccount(addrmgrNs, func(account uint32) error {
-			accountName, err := manager.AccountName(addrmgrNs, account)
+			err := manager.ForEachAccountFromStore(
+				tx.Addr(), func(account uint32) error {
+					accountName, err := manager.AccountNameFromStore(
+						tx.Addr(), account,
+					)
+					if err != nil {
+						return err
+					}
+					results = append(results, AccountTotalReceivedResult{
+						AccountNumber: account,
+						AccountName:   accountName,
+					})
+					return nil
+				})
 			if err != nil {
 				return err
 			}
-			results = append(results, AccountTotalReceivedResult{
-				AccountNumber: account,
-				AccountName:   accountName,
-			})
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+			resultIndex := make(map[uint32]int, len(results))
+			for i := range results {
+				resultIndex[results[i].AccountNumber] = i
+			}
 
-		var stopHeight int32
+			var stopHeight int32
 
-		if minConf > 0 {
-			stopHeight = syncBlock.Height - minConf + 1
-		} else {
-			stopHeight = -1
-		}
+			if minConf > 0 {
+				stopHeight = syncBlock.Height - minConf + 1
+			} else {
+				stopHeight = -1
+			}
 
-		rangeFn := func(details []wtxmgr.TxDetails) (bool, error) {
-			for i := range details {
-				detail := &details[i]
-				for _, cred := range detail.Credits {
-					pkScript := detail.MsgTx.TxOut[cred.Index].PkScript
-					var outputAcct uint32
-
-					_, addrs, _, err := txscript.ExtractPkScriptAddrs(
-						pkScript, w.chainParams,
-					)
-					if err == nil && len(addrs) > 0 {
-						_, outputAcct, err = w.Manager.AddrAccount(
-							addrmgrNs, addrs[0],
+			rangeFn := func(details []wtxmgr.TxDetails) (bool, error) {
+				for i := range details {
+					detail := &details[i]
+					for _, cred := range detail.Credits {
+						pkScript := detail.MsgTx.TxOut[cred.Index].PkScript
+						_, addrs, _, err := txscript.ExtractPkScriptAddrs(
+							pkScript, w.chainParams,
 						)
-					}
-					if err == nil {
-						acctIndex := int(outputAcct)
-						if outputAcct == waddrmgr.ImportedAddrAccount {
-							acctIndex = len(results) - 1
+						if err != nil || len(addrs) == 0 {
+							continue
 						}
-						res := &results[acctIndex]
-						res.TotalReceived += cred.Amount
 
-						confs := calcConf(
-							detail.Block.Height,
-							syncBlock.Height,
+						outputAccount, err := manager.AddrAccountFromStore(
+							tx.Addr(), addrs[0],
 						)
-						res.LastConfirmation = confs
+						if err != nil {
+							continue
+						}
+						index, ok := resultIndex[outputAccount]
+						if !ok {
+							continue
+						}
+
+						res := &results[index]
+						res.TotalReceived += cred.Amount
+						res.LastConfirmation = calcConf(
+							detail.Block.Height, syncBlock.Height,
+						)
 					}
 				}
+				return false, nil
 			}
-			return false, nil
-		}
-		return w.TxStore.RangeTransactions(txmgrNs, 0, stopHeight, rangeFn)
-	})
+			return tx.Tx().RangeTransactions(0, stopHeight, rangeFn)
+		}, func() {
+			results = nil
+		})
+
 	return results, err
 }
 
@@ -3541,45 +5245,49 @@ func (w *Wallet) TotalReceivedForAddr(addr address.Address,
 	minConf int32) (btcutil.Amount, error) {
 
 	var amount btcutil.Amount
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
+	err := w.store.View(
+		context.Background(), func(tx walletstore.ReadTx) error {
+			syncBlock := w.Manager.SyncedTo()
 
-		syncBlock := w.Manager.SyncedTo()
+			var (
+				addrStr    = addr.EncodeAddress()
+				stopHeight int32
+			)
 
-		var (
-			addrStr    = addr.EncodeAddress()
-			stopHeight int32
-		)
-
-		if minConf > 0 {
-			stopHeight = syncBlock.Height - minConf + 1
-		} else {
-			stopHeight = -1
-		}
-		rangeFn := func(details []wtxmgr.TxDetails) (bool, error) {
-			for i := range details {
-				detail := &details[i]
-				for _, cred := range detail.Credits {
-					pkScript := detail.MsgTx.TxOut[cred.Index].PkScript
-					_, addrs, _, err := txscript.ExtractPkScriptAddrs(pkScript,
-						w.chainParams)
-					// An error creating addresses from the output script only
-					// indicates a non-standard script, so ignore this credit.
-					if err != nil {
-						continue
-					}
-					for _, a := range addrs {
-						if addrStr == a.EncodeAddress() {
-							amount += cred.Amount
-							break
+			if minConf > 0 {
+				stopHeight = syncBlock.Height - minConf + 1
+			} else {
+				stopHeight = -1
+			}
+			rangeFn := func(details []wtxmgr.TxDetails) (bool, error) {
+				for i := range details {
+					detail := &details[i]
+					for _, cred := range detail.Credits {
+						pkScript := detail.MsgTx.TxOut[cred.Index].PkScript
+						_, addrs, _, err :=
+							txscript.ExtractPkScriptAddrs(
+								pkScript, w.chainParams,
+							)
+						// An address error only indicates a non-standard
+						// script, so ignore this credit.
+						if err != nil {
+							continue
+						}
+						for _, a := range addrs {
+							if addrStr == a.EncodeAddress() {
+								amount += cred.Amount
+								break
+							}
 						}
 					}
 				}
+				return false, nil
 			}
-			return false, nil
-		}
-		return w.TxStore.RangeTransactions(txmgrNs, 0, stopHeight, rangeFn)
-	})
+			return tx.Tx().RangeTransactions(0, stopHeight, rangeFn)
+		}, func() {
+			amount = 0
+		})
+
 	return amount, err
 }
 
@@ -3668,8 +5376,11 @@ func (w *Wallet) sendOutputs(outputs []*wire.TxOut, keyScope *waddrmgr.KeyScope,
 // SignatureError records the underlying error when validating a transaction
 // input signature.
 type SignatureError struct {
+	// InputIndex identifies the transaction input with an invalid signature.
 	InputIndex uint32
-	Error      error
+
+	// Error is the underlying signature validation failure.
+	Error error
 }
 
 // SignTransaction uses secrets of the wallet, as well as additional secrets
@@ -3685,6 +5396,13 @@ func (w *Wallet) SignTransaction(tx *wire.MsgTx, hashType txscript.SigHashType,
 	additionalPrevScripts map[wire.OutPoint][]byte,
 	additionalKeysByAddress map[string]*btcutil.WIF,
 	p2shRedeemScriptsByAddress map[string][]byte) ([]SignatureError, error) {
+
+	if w.db == nil {
+		return w.signTransactionFromStore(
+			tx, hashType, additionalPrevScripts,
+			additionalKeysByAddress, p2shRedeemScriptsByAddress,
+		)
+	}
 
 	var signErrors []SignatureError
 	err := walletdb.View(w.db, func(dbtx walletdb.ReadTx) error {
@@ -3922,49 +5640,89 @@ func (w *Wallet) reliablyPublishTransaction(tx *wire.MsgTx,
 	// Along the way, we'll extract our relevant destination addresses from
 	// the transaction.
 	var ourAddrs []address.Address
-	err = walletdb.Update(w.db, func(dbTx walletdb.ReadWriteTx) error {
-		addrmgrNs := dbTx.ReadWriteBucket(waddrmgrNamespaceKey)
-		for _, txOut := range tx.TxOut {
-			_, addrs, _, err := txscript.ExtractPkScriptAddrs(
-				txOut.PkScript, w.chainParams,
-			)
-			if err != nil {
-				// Non-standard outputs can safely be skipped
-				// because they're not supported by the wallet.
-				log.Warnf("Non-standard pkScript=%x in tx=%v",
-					txOut.PkScript, tx.TxHash())
-
-				continue
-			}
-			for _, addr := range addrs {
-				// Skip any addresses which are not relevant to
-				// us.
-				_, err := w.Manager.Address(addrmgrNs, addr)
-				if waddrmgr.IsError(err, waddrmgr.ErrAddressNotFound) {
+	if w.db != nil {
+		err = walletdb.Update(w.db, func(dbTx walletdb.ReadWriteTx) error {
+			addrmgrNs := dbTx.ReadWriteBucket(waddrmgrNamespaceKey)
+			for _, txOut := range tx.TxOut {
+				_, addrs, _, err := txscript.ExtractPkScriptAddrs(
+					txOut.PkScript, w.chainParams,
+				)
+				if err != nil {
+					log.Warnf("Non-standard pkScript=%x in tx=%v",
+						txOut.PkScript, tx.TxHash())
 					continue
 				}
+				for _, addr := range addrs {
+					_, err := w.Manager.Address(addrmgrNs, addr)
+					if waddrmgr.IsError(
+						err, waddrmgr.ErrAddressNotFound,
+					) {
+
+						continue
+					}
+					if err != nil {
+						return err
+					}
+					ourAddrs = append(ourAddrs, addr)
+				}
+			}
+
+			if len(label) != 0 {
+				txmgrNs := dbTx.ReadWriteBucket(wtxmgrNamespaceKey)
+				err = w.TxStore.PutTxLabel(
+					txmgrNs, tx.TxHash(), label,
+				)
 				if err != nil {
 					return err
 				}
-				ourAddrs = append(ourAddrs, addr)
 			}
-		}
 
-		// If there is a label we should write, get the namespace key
-		// and record it in the tx store.
-		if len(label) != 0 {
-			txmgrNs := dbTx.ReadWriteBucket(wtxmgrNamespaceKey)
+			return w.addRelevantTx(dbTx, txRec, nil)
+		})
+	} else {
+		err = w.store.UpdateOnce(
+			context.Background(), func(dbTx walletstore.ReadWriteTx) error {
+				for _, txOut := range tx.TxOut {
+					_, addrs, _, err := txscript.ExtractPkScriptAddrs(
+						txOut.PkScript, w.chainParams,
+					)
+					if err != nil {
+						log.Warnf("Non-standard pkScript=%x in tx=%v",
+							txOut.PkScript, tx.TxHash())
+						continue
+					}
+					for _, addr := range addrs {
+						_, err := w.Manager.AddressFromStore(
+							dbTx.Addr(), addr,
+						)
+						if waddrmgr.IsError(
+							err, waddrmgr.ErrAddressNotFound,
+						) {
 
-			err = w.TxStore.PutTxLabel(
-				txmgrNs, tx.TxHash(), label,
-			)
-			if err != nil {
-				return err
-			}
-		}
+							continue
+						}
+						if err != nil {
+							return err
+						}
+						ourAddrs = append(ourAddrs, addr)
+					}
+				}
 
-		return w.addRelevantTx(dbTx, txRec, nil)
-	})
+				if len(label) != 0 {
+					if err := dbTx.Tx().PutTxLabel(
+						tx.TxHash(), label,
+					); err != nil {
+
+						return err
+					}
+				}
+
+				return w.addRelevantTxFromStore(dbTx, txRec, nil)
+			}, func() {
+				ourAddrs = nil
+			},
+		)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -3977,6 +5735,28 @@ func (w *Wallet) reliablyPublishTransaction(tx *wire.MsgTx,
 	}
 
 	return w.publishTransaction(tx)
+}
+
+// removeUnminedTransaction removes a transaction from the active manager
+// backend after the chain backend reports that it should not be rebroadcast.
+func (w *Wallet) removeUnminedTransaction(tx *wire.MsgTx) error {
+	txRecord, err := wtxmgr.NewTxRecordFromMsgTx(tx, time.Now())
+	if err != nil {
+		return err
+	}
+
+	if w.db != nil {
+		return walletdb.Update(w.db, func(dbTx walletdb.ReadWriteTx) error {
+			txmgrNs := dbTx.ReadWriteBucket(wtxmgrNamespaceKey)
+			return w.TxStore.RemoveUnminedTx(txmgrNs, txRecord)
+		})
+	}
+
+	return w.store.UpdateOnce(
+		context.Background(), func(dbTx walletstore.ReadWriteTx) error {
+			return dbTx.Tx().RemoveUnminedTx(txRecord)
+		}, nil,
+	)
 }
 
 // publishTransaction attempts to send an unconfirmed transaction to the
@@ -4003,14 +5783,7 @@ func (w *Wallet) publishTransaction(tx *wire.MsgTx) (*chainhash.Hash, error) {
 	case errors.Is(rpcErr, chain.ErrTxAlreadyKnown),
 		errors.Is(rpcErr, chain.ErrTxAlreadyConfirmed):
 
-		dbErr := walletdb.Update(w.db, func(dbTx walletdb.ReadWriteTx) error {
-			txmgrNs := dbTx.ReadWriteBucket(wtxmgrNamespaceKey)
-			txRec, err := wtxmgr.NewTxRecordFromMsgTx(tx, time.Now())
-			if err != nil {
-				return err
-			}
-			return w.TxStore.RemoveUnminedTx(txmgrNs, txRec)
-		})
+		dbErr := w.removeUnminedTransaction(tx)
 		if dbErr != nil {
 			log.Warnf("Unable to remove confirmed transaction %v "+
 				"from unconfirmed store: %v", tx.TxHash(), dbErr)
@@ -4029,14 +5802,7 @@ func (w *Wallet) publishTransaction(tx *wire.MsgTx) (*chainhash.Hash, error) {
 	// we'll remove it from the transaction store, as otherwise, we'll
 	// attempt to continually re-broadcast it, and the UTXO state of the
 	// wallet won't be accurate.
-	dbErr := walletdb.Update(w.db, func(dbTx walletdb.ReadWriteTx) error {
-		txmgrNs := dbTx.ReadWriteBucket(wtxmgrNamespaceKey)
-		txRec, err := wtxmgr.NewTxRecordFromMsgTx(tx, time.Now())
-		if err != nil {
-			return err
-		}
-		return w.TxStore.RemoveUnminedTx(txmgrNs, txRec)
-	})
+	dbErr := w.removeUnminedTransaction(tx)
 	if dbErr != nil {
 		log.Warnf("Unable to remove invalid transaction %v: %v",
 			tx.TxHash(), dbErr)
@@ -4071,7 +5837,7 @@ func (w *Wallet) ChainParams() *chaincfg.Params {
 
 // Database returns the underlying walletdb database. This method is provided
 // in order to allow applications wrapping btcwallet to store app-specific data
-// with the wallet's database.
+// with the wallet's database. It returns nil for a Store-backed wallet.
 func (w *Wallet) Database() walletdb.DB {
 	return w.db
 }
@@ -4086,11 +5852,11 @@ func (w *Wallet) RemoveDescendants(tx *wire.MsgTx) error {
 		return err
 	}
 
-	return walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-		wtxmgrNs := tx.ReadWriteBucket(wtxmgrNamespaceKey)
-
-		return w.TxStore.RemoveUnminedTx(wtxmgrNs, txRecord)
-	})
+	return w.store.UpdateOnce(
+		context.Background(), func(tx walletstore.ReadWriteTx) error {
+			return tx.Tx().RemoveUnminedTx(txRecord)
+		}, nil,
+	)
 }
 
 // BirthdayBlock returns the birthday block of the wallet.
@@ -4100,15 +5866,29 @@ func (w *Wallet) RemoveDescendants(tx *wire.MsgTx) error {
 func (w *Wallet) BirthdayBlock() (*waddrmgr.BlockStamp, error) {
 	var birthdayBlock waddrmgr.BlockStamp
 
-	// Query the wallet's birthday block height from db.
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
+	var err error
+	if w.db != nil {
+		err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+			addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
 
-		bb, _, err := w.Manager.BirthdayBlock(addrmgrNs)
-		birthdayBlock = bb
+			bb, _, err := w.Manager.BirthdayBlock(addrmgrNs)
+			birthdayBlock = bb
 
-		return err
-	})
+			return err
+		})
+	} else {
+		err = w.store.View(
+			context.Background(), func(tx walletstore.ReadTx) error {
+				bb, _, err := w.Manager.BirthdayBlockFromStore(
+					tx.Addr(),
+				)
+				birthdayBlock = bb
+				return err
+			}, func() {
+				birthdayBlock = waddrmgr.BlockStamp{}
+			},
+		)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -4123,44 +5903,173 @@ func (w *Wallet) AddScopeManager(scope waddrmgr.KeyScope,
 
 	var scopedManager *waddrmgr.ScopedKeyManager
 
-	err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+	var err error
+	if w.db != nil {
+		err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+			addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
 
-		manager, err := w.Manager.NewScopedKeyManager(
-			addrmgrNs, scope, addrSchema,
+			manager, err := w.Manager.NewScopedKeyManager(
+				addrmgrNs, scope, addrSchema,
+			)
+			scopedManager = manager
+
+			return err
+		})
+	} else {
+		err = w.store.UpdateOnce(
+			context.Background(),
+			func(tx walletstore.ReadWriteTx) error {
+				var err error
+				scopedManager, err =
+					w.Manager.NewScopedKeyManagerFromStore(
+						tx.Addr(), scope, addrSchema,
+					)
+				return err
+			}, func() {
+				scopedManager = nil
+			},
 		)
-		scopedManager = manager
-
-		return err
-	})
+	}
 	if err != nil {
+		manager, attached := w.attachStoreScopeAfterAmbiguous(err, scope)
+		if attached && manager.AddrSchema() == addrSchema {
+			return manager, nil
+		}
+
 		return nil, err
 	}
 
 	return scopedManager, nil
 }
 
-// InitAccounts creates a number of accounts specified by `num`, with account
-// number ranges from 1 to `num`.
-func (w *Wallet) InitAccounts(scope *waddrmgr.ScopedKeyManager,
-	watchOnly bool, num uint32) error {
+// InitializeKeyScope ensures that a key scope and the exact requested accounts
+// exist. Private key material is removed only after all accounts are durable
+// when convertToWatchOnly is true.
+func (w *Wallet) InitializeKeyScope(scope waddrmgr.KeyScope,
+	addrSchema waddrmgr.ScopeAddrSchema, accounts []uint32,
+	convertToWatchOnly bool) error {
+
+	scopedManager, err := w.Manager.FetchScopedKeyManager(scope)
+	if waddrmgr.IsError(err, waddrmgr.ErrScopeNotFound) {
+		scopedManager, err = w.AddScopeManager(scope, addrSchema)
+	}
+	if err != nil {
+		return err
+	}
+
+	return w.initAccounts(
+		scopedManager, convertToWatchOnly, accounts,
+	)
+}
+
+// attachStoreScopeAfterAmbiguous reconstructs a scope that became durable even
+// though its creation transaction returned an ambiguous commit error.
+func (w *Wallet) attachStoreScopeAfterAmbiguous(err error,
+	scope waddrmgr.KeyScope) (*waddrmgr.ScopedKeyManager, bool) {
+
+	if w.db != nil {
+		return nil, false
+	}
+	var ambiguous *walletstore.AmbiguousCommitError
+	if !errors.As(err, &ambiguous) {
+		return nil, false
+	}
+
+	var manager *waddrmgr.ScopedKeyManager
+	attachErr := w.store.View(
+		context.Background(), func(tx walletstore.ReadTx) error {
+			var err error
+			manager, err = w.Manager.AttachScopedKeyManagerFromStore(
+				tx.Addr(), scope,
+			)
+			return err
+		}, func() {
+			manager = nil
+		},
+	)
+	if attachErr != nil {
+		return nil, false
+	}
+
+	return manager, true
+}
+
+// refreshStartBlockAfterAmbiguous reloads the durable import start block when
+// a Store cannot determine whether an import transaction committed.
+func (w *Wallet) refreshStartBlockAfterAmbiguous(err error) {
+	if w.db != nil {
+		return
+	}
+	var ambiguous *walletstore.AmbiguousCommitError
+	if !errors.As(err, &ambiguous) {
+		return
+	}
+
+	refreshErr := w.store.View(
+		context.Background(), func(tx walletstore.ReadTx) error {
+			return w.Manager.RefreshStartBlockFromStore(tx.Addr())
+		}, nil,
+	)
+	if refreshErr != nil {
+		log.Warnf("Unable to refresh ambiguous import start block: %v",
+			refreshErr)
+	}
+}
+
+// initAccounts ensures that the requested accounts exist in one backend
+// transaction and optionally converts the wallet to watch-only afterward.
+func (w *Wallet) initAccounts(scope *waddrmgr.ScopedKeyManager,
+	watchOnly bool, accounts []uint32) error {
+
+	if w.db == nil {
+		return w.store.UpdateOnce(
+			context.Background(),
+			func(tx walletstore.ReadWriteTx) error {
+				for _, account := range accounts {
+					_, err := tx.Addr().Account(
+						scope.Scope(), account,
+					)
+					if err == nil {
+						continue
+					}
+					if !waddrmgr.IsError(
+						err, waddrmgr.ErrAccountNotFound,
+					) {
+
+						return err
+					}
+
+					if err := scope.NewRawAccountFromStore(
+						tx.Addr(), account,
+					); err != nil {
+
+						return err
+					}
+				}
+
+				if watchOnly {
+					return w.Manager.ConvertToWatchingOnlyFromStore(
+						tx.Addr(),
+					)
+				}
+
+				return nil
+			}, nil,
+		)
+	}
 
 	return walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
 		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
 
-		// Generate all accounts that we could ever need. This includes
-		// all key families.
-		for account := uint32(1); account <= num; account++ {
-			// Otherwise, we'll check if the account already exists,
-			// if so, we can once again bail early.
+		for _, account := range accounts {
 			_, err := scope.AccountName(addrmgrNs, account)
 			if err == nil {
 				continue
 			}
+			if !waddrmgr.IsError(err, waddrmgr.ErrAccountNotFound) {
+				return err
+			}
 
-			// If we reach this point, then the account hasn't yet
-			// been created, so we'll need to create it before we
-			// can proceed.
 			err = scope.NewRawAccount(addrmgrNs, account)
 			if err != nil {
 				return err
@@ -4184,6 +6093,185 @@ func (w *Wallet) InitAccounts(scope *waddrmgr.ScopedKeyManager,
 	})
 }
 
+// InitAccounts creates accounts numbered from one through num. This legacy
+// range-based API is retained for callers that do not know their exact account
+// set.
+func (w *Wallet) InitAccounts(scope *waddrmgr.ScopedKeyManager,
+	watchOnly bool, num uint32) error {
+
+	accounts := make([]uint32, 0, num)
+	for account := uint32(1); account <= num && account != 0; account++ {
+		accounts = append(accounts, account)
+	}
+
+	return w.initAccounts(scope, watchOnly, accounts)
+}
+
+// NextExternalKey derives and persists the next external public key for an
+// account, returning the allocated child index. Missing private accounts are
+// created in the same transaction as the allocation.
+func (w *Wallet) NextExternalKey(scope waddrmgr.KeyScope,
+	account uint32) (*btcec.PublicKey, uint32, error) {
+
+	scopedManager, err := w.Manager.FetchScopedKeyManager(scope)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	w.newAddrMtx.Lock()
+	defer w.newAddrMtx.Unlock()
+
+	var managedAddress waddrmgr.ManagedAddress
+	if w.db != nil {
+		err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+			addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+			_, err := scopedManager.AccountName(addrmgrNs, account)
+			if waddrmgr.IsError(err, waddrmgr.ErrAccountNotFound) &&
+				!w.WatchOnly() {
+
+				err = scopedManager.NewRawAccount(addrmgrNs, account)
+			}
+			if err != nil {
+				return err
+			}
+
+			addresses, err := scopedManager.NextExternalAddresses(
+				addrmgrNs, account, 1,
+			)
+			if err != nil {
+				return err
+			}
+			managedAddress = addresses[0]
+
+			return nil
+		})
+	} else {
+		err = w.store.UpdateOnce(
+			context.Background(),
+			func(tx walletstore.ReadWriteTx) error {
+				_, err := tx.Addr().Account(scope, account)
+				if waddrmgr.IsError(
+					err, waddrmgr.ErrAccountNotFound,
+				) && !w.WatchOnly() {
+
+					err = scopedManager.NewRawAccountFromStore(
+						tx.Addr(), account,
+					)
+				}
+				if err != nil {
+					return err
+				}
+
+				managedAddress, _, err =
+					scopedManager.NextExternalAddressFromStore(
+						tx.Addr(), account,
+					)
+
+				return err
+			}, func() {
+				managedAddress = nil
+			},
+		)
+	}
+	if err != nil {
+		var ambiguous *walletstore.AmbiguousCommitError
+		if errors.As(err, &ambiguous) {
+			w.Manager.MarkAccountCacheStale(scope, account)
+		}
+
+		return nil, 0, err
+	}
+
+	pubKeyAddress, ok := managedAddress.(waddrmgr.ManagedPubKeyAddress)
+	if !ok {
+		return nil, 0, fmt.Errorf("managed address %T has no public key",
+			managedAddress)
+	}
+	_, path, _ := pubKeyAddress.DerivationInfo()
+
+	return pubKeyAddress.PubKey(), path.Index, nil
+}
+
+// DeriveManagedPubKey derives an arbitrary managed public key. A missing
+// account is created for a wallet with private key material, while watch-only
+// callers must initialize or import the account first.
+func (w *Wallet) DeriveManagedPubKey(scope waddrmgr.KeyScope,
+	path waddrmgr.DerivationPath) (*btcec.PublicKey, error) {
+
+	scopedManager, err := w.Manager.FetchScopedKeyManager(scope)
+	if err != nil {
+		return nil, err
+	}
+
+	var managedAddress waddrmgr.ManagedAddress
+	if w.db != nil {
+		err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+			addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+			managedAddress, err = scopedManager.DeriveFromKeyPath(
+				addrmgrNs, path,
+			)
+			if !waddrmgr.IsError(err, waddrmgr.ErrAccountNotFound) ||
+				w.WatchOnly() {
+
+				return err
+			}
+
+			if err := scopedManager.NewRawAccount(
+				addrmgrNs, path.InternalAccount,
+			); err != nil {
+
+				return err
+			}
+
+			managedAddress, err = scopedManager.DeriveFromKeyPath(
+				addrmgrNs, path,
+			)
+
+			return err
+		})
+	} else {
+		err = w.store.UpdateOnce(
+			context.Background(),
+			func(tx walletstore.ReadWriteTx) error {
+				_, err := tx.Addr().Account(
+					scope, path.InternalAccount,
+				)
+				if waddrmgr.IsError(
+					err, waddrmgr.ErrAccountNotFound,
+				) && !w.WatchOnly() {
+
+					err = scopedManager.NewRawAccountFromStore(
+						tx.Addr(), path.InternalAccount,
+					)
+				}
+				if err != nil {
+					return err
+				}
+
+				managedAddress, err =
+					scopedManager.DeriveFromKeyPathFromStore(
+						tx.Addr(), path,
+					)
+
+				return err
+			}, func() {
+				managedAddress = nil
+			},
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	pubKeyAddress, ok := managedAddress.(waddrmgr.ManagedPubKeyAddress)
+	if !ok {
+		return nil, fmt.Errorf("managed address %T has no public key",
+			managedAddress)
+	}
+
+	return pubKeyAddress.PubKey(), nil
+}
+
 // DeriveFromKeyPath derives a private key using the given derivation path.
 func (w *Wallet) DeriveFromKeyPath(scope waddrmgr.KeyScope,
 	path waddrmgr.DerivationPath) (*btcec.PrivateKey, error) {
@@ -4201,9 +6289,7 @@ func (w *Wallet) DeriveFromKeyPath(scope waddrmgr.KeyScope,
 	}
 
 	// The key wasn't in the cache, let's fully derive it now.
-	err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-
+	derive := func(addrmgrNs walletdb.ReadBucket) error {
 		addr, err := scopedMgr.DeriveFromKeyPath(addrmgrNs, path)
 		if err != nil {
 			return fmt.Errorf("error deriving private key: %w", err)
@@ -4220,7 +6306,37 @@ func (w *Wallet) DeriveFromKeyPath(scope waddrmgr.KeyScope,
 		privKey, err = mpka.PrivKey()
 
 		return err
-	})
+	}
+	if w.db != nil {
+		err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+			return derive(tx.ReadBucket(waddrmgrNamespaceKey))
+		})
+	} else {
+		err = w.store.View(
+			context.Background(), func(tx walletstore.ReadTx) error {
+				addr, err := scopedMgr.DeriveFromKeyPathFromStore(
+					tx.Addr(), path,
+				)
+				if err != nil {
+					return fmt.Errorf(
+						"error deriving private key: %w", err,
+					)
+				}
+				mpka, ok := addr.(waddrmgr.ManagedPubKeyAddress)
+				if !ok {
+					return fmt.Errorf(
+						"managed address type for %v is `%T` but want "+
+							"waddrmgr.ManagedPubKeyAddress", addr, addr,
+					)
+				}
+				privKey, err = mpka.PrivKey()
+
+				return err
+			}, func() {
+				privKey = nil
+			},
+		)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -4252,7 +6368,9 @@ func (w *Wallet) DeriveFromKeyPathAddAccount(scope waddrmgr.KeyScope,
 		if err == nil {
 			key, ok := addr.(waddrmgr.ManagedPubKeyAddress)
 			if !ok {
-				return nil
+				return fmt.Errorf(
+					"managed address %T has no private key", addr,
+				)
 			}
 
 			// Overwrite the returned private key variable.
@@ -4265,6 +6383,51 @@ func (w *Wallet) DeriveFromKeyPathAddAccount(scope waddrmgr.KeyScope,
 	}
 
 	// The key wasn't in the cache, let's fully derive it now.
+	if w.db == nil {
+		err = w.store.UpdateOnce(
+			context.Background(),
+			func(tx walletstore.ReadWriteTx) error {
+				_, err := scopedMgr.AccountPropertiesFromStore(
+					tx.Addr(), path.InternalAccount,
+				)
+				if err != nil && !waddrmgr.IsError(
+					err, waddrmgr.ErrAccountNotFound,
+				) {
+
+					return err
+				}
+				if waddrmgr.IsError(err, waddrmgr.ErrAccountNotFound) {
+					if err := scopedMgr.NewRawAccountFromStore(
+						tx.Addr(), path.InternalAccount,
+					); err != nil {
+
+						return err
+					}
+				}
+
+				addr, err := scopedMgr.DeriveFromKeyPathFromStore(
+					tx.Addr(), path,
+				)
+				if err != nil {
+					return fmt.Errorf(
+						"error deriving private key: %w", err,
+					)
+				}
+				key, ok := addr.(waddrmgr.ManagedPubKeyAddress)
+				if !ok {
+					return fmt.Errorf(
+						"managed address %T has no private key", addr,
+					)
+				}
+				privKey, err = key.PrivKey()
+				return err
+			}, func() {
+				privKey = nil
+			},
+		)
+		return privKey, err
+	}
+
 	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
 		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
 
@@ -4282,7 +6445,9 @@ func (w *Wallet) DeriveFromKeyPathAddAccount(scope waddrmgr.KeyScope,
 
 		// If we've reached this point, then the account doesn't yet
 		// exist, so we'll create it now to ensure we can sign.
-		err = scopedMgr.NewRawAccount(addrmgrNs, path.Account)
+		err = scopedMgr.NewRawAccount(
+			addrmgrNs, path.InternalAccount,
+		)
 		if err != nil {
 			return err
 		}
@@ -4364,6 +6529,7 @@ func CreateWatchingOnly(db walletdb.DB, pubPass []byte,
 	)
 }
 
+// create initializes the wallet namespaces in an existing walletdb database.
 func create(db walletdb.DB, pubPass, privPass []byte,
 	rootKey *hdkeychain.ExtendedKey, params *chaincfg.Params,
 	birthday time.Time, isWatchingOnly bool,
@@ -4484,10 +6650,58 @@ func OpenWithRetry(db walletdb.DB, pubPass []byte, cbs *waddrmgr.OpenCallbacks,
 
 	log.Infof("Opened wallet") // TODO: log balance? last sync height?
 
+	w := newWallet(
+		db, walletkvdb.NewStore(db, addrMgr, txMgr), addrMgr, txMgr,
+		pubPass, params, recoveryWindow, syncRetryInterval,
+	)
+
+	return w, nil
+}
+
+// OpenFromStore loads an existing wallet around the real address manager and a
+// backend-neutral Store without constructing a walletdb database.
+func OpenFromStore(store walletstore.Store, pubPass []byte,
+	params *chaincfg.Params, recoveryWindow uint32,
+	syncRetryInterval time.Duration) (*Wallet, error) {
+
+	var snapshot *waddrmgr.ManagerSnapshot
+	err := store.View(
+		context.Background(), func(tx walletstore.ReadTx) error {
+			var err error
+			snapshot, err = waddrmgr.ReadManagerSnapshot(tx.Addr())
+			return err
+		}, func() {
+			snapshot = nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	addrMgr, err := waddrmgr.OpenFromSnapshot(snapshot, pubPass, params)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Infof("Opened wallet")
+
+	return newWallet(
+		nil, store, addrMgr, nil, pubPass, params, recoveryWindow,
+		syncRetryInterval,
+	), nil
+}
+
+// newWallet initializes the existing Wallet state machine around the supplied
+// manager stores.
+func newWallet(db walletdb.DB, store walletstore.Store,
+	addrMgr *waddrmgr.Manager, txMgr *wtxmgr.Store, pubPass []byte,
+	params *chaincfg.Params, recoveryWindow uint32,
+	syncRetryInterval time.Duration) *Wallet {
+
 	w := &Wallet{
 		publicPassphrase:    pubPass,
 		db:                  db,
-		store:               walletkvdb.NewStore(db, addrMgr, txMgr),
+		store:               store,
 		Manager:             addrMgr,
 		TxStore:             txMgr,
 		lockedOutpoints:     map[wire.OutPoint]struct{}{},
@@ -4510,9 +6724,6 @@ func OpenWithRetry(db walletdb.DB, pubPass []byte, cbs *waddrmgr.OpenCallbacks,
 	}
 
 	w.NtfnServer = newNotificationServer(w)
-	w.TxStore.NotifyUnspent = func(hash *chainhash.Hash, index uint32) {
-		w.NtfnServer.notifyUnspentOutput(0, hash, index)
-	}
 
-	return w, nil
+	return w
 }


### PR DESCRIPTION
## Change Description

This draft PR is stacked on #1296 and evaluates whether btcwallet's existing
wallet facade can operate directly over the backend-neutral SQL Stores.

It follows the compatibility-first approach:

- It retains the existing `wallet.Wallet`, `wallet.Loader`, and `waddrmgr`
  runtime.
- It does not use or introduce PR #1297's `SQLWallet`.
- It does not add a parallel coordinator, syncer, or journal.
- Existing KV wallets continue using their legacy path.
- Populated-wallet migration is outside this experiment.

## Scope

The prototype covers:

- Wallet creation, opening, locking, and passphrase lifecycle.
- Accounts, scopes, address derivation, imports, and watch-only wallets.
- Transaction ingestion, balances, UTXOs, leases, labels, and notifications.
- Recovery, rescans, restart behavior, and reorg handling.
- Transaction creation, signing, publishing, and PSBT operations.
- SQLite and PostgreSQL manager and transaction Stores.
- lnd-facing scope, account, key derivation, private-key, and ECDH operations.
- SQLite contention, failure-injection, and synchronization benchmarks.

The prototype splits several long-running operations into read, compute, and
write phases:

- Wallet-open KDF and address reconstruction occur after the Store view closes.
- Chain hash, header, and filter RPCs occur outside Store transactions.
- Coin selection, signing, script validation, and watcher registration occur
  outside Store transactions.
- Final writes revalidate sync tips, UTXOs, and address indexes.

This materially improves SQLite lock behavior:

- The wallet-open Store view at 1,000 keys falls from approximately 145.9 ms to
  3.0 ms.
- Blocked RPC, strategy, signing, and watcher operations allow unrelated writes
  to finish in approximately 4.2-4.5 ms.
- A mixed key-allocation/funding workload measures 9.1 ms p50, 20.4 ms p95,
  and 22.3 ms p99.
- No SQLite busy errors or writer retries occur in the measured workload.

The branch contains 96 files with approximately 21,437 additions and 1,717
deletions.

## Issues Found

The experiment demonstrates that adapting the existing wallet requires more
than replacing its storage operations.

An independent Store-callback audit found these remaining issues:

- Recovery performs derivation inside replayable write callbacks.
- Funding plan conflicts can replay caller policy, coin selection, signing,
  and script validation.
- Funding does not revalidate the chain tip used for confirmation and coinbase
  maturity decisions.
- Several ambiguous-commit checks verify the terminal sync tip without proving
  the complete atomic write set.
- Passphrase changes and watch-only conversion can commit durably without
  publishing the corresponding live secret or cache state.
- Retryable reads can mutate address and account caches before the transaction
  succeeds.
- Forty-six Store callbacks retain derivation, decryption, cache mutation,
  logging, dynamic callback dispatch, or unbounded work.

Correcting these issues requires systematic prepare, commit, and reconcile
semantics across wallet lifecycle, recovery, imports, keys, transactions, and
notifications.

This removes the expected implementation-size and schedule advantage of the
compatibility-first approach.

## Conclusion

The prototype proves that the existing wallet can operate over native SQL
storage without using `SQLWallet` or emulating walletdb buckets.

It also shows that making this architecture safe requires introducing
role-style transaction ownership throughout the legacy wallet. Continuing the
adapter would effectively rebuild the role-based persistence model behind the
existing facade while retaining duplicated KV and Store paths.

The role-based native SQL wallet is therefore the preferred production
direction. This branch is preserved as a decision PoC and as a source of
behavioral, contention, failure-injection, and synchronization acceptance tests.
It is not proposed as the production implementation.
