### PR TITLE
wallet+itest+bwtest: add Manager and Controller itests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -211,12 +211,15 @@ jobs:
   ########################
   # Run bwtest integration tests against each supported chain backend.
   #
-  # These jobs currently use kvdb only. Database expansion is planned via a
-  # separate matrix in a future change.
+  # Each job runs over both wallet database backends (kvdb and sqlite).
   ########################
   itest-btcd:
-    name: itest btcd
+    name: itest btcd (${{ matrix.db }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        db: [kvdb, sqlite]
     steps:
       - name: git checkout
         uses: actions/checkout@v5
@@ -240,14 +243,14 @@ jobs:
 
       # The btcd backend job runs btcd for both the shared miner and the chain
       # backend under test.
-      - name: run itest (btcd, kvdb)
-        run: make itest chain=btcd db=kvdb
+      - name: run itest (btcd, ${{ matrix.db }})
+        run: make itest chain=btcd db=${{ matrix.db }}
 
       - name: upload itest logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: itest-logs-btcd
+          name: itest-logs-btcd-${{ matrix.db }}
           path: itest/test-logs
           retention-days: 5
 
@@ -257,12 +260,16 @@ jobs:
   # Job flow:
   # - Install btcd `${{ env.BTCD_VERSION_LATEST }}`.
   # - Use btcd as the shared miner for the suite.
-  # - Run `make itest chain=neutrino db=kvdb` so wallets use the in-process
-  #   neutrino backend while blocks/peers come from btcd.
+  # - Run `make itest chain=neutrino db=${{ matrix.db }}` so wallets use the
+  #   in-process neutrino backend while blocks/peers come from btcd.
   ########################
   itest-neutrino:
-    name: itest neutrino
+    name: itest neutrino (${{ matrix.db }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        db: [kvdb, sqlite]
     steps:
       - name: git checkout
         uses: actions/checkout@v5
@@ -286,14 +293,14 @@ jobs:
 
       # Neutrino runs in-process, but it still relies on the shared btcd miner
       # for chain data and peer connectivity.
-      - name: run itest (neutrino, kvdb)
-        run: make itest chain=neutrino db=kvdb
+      - name: run itest (neutrino, ${{ matrix.db }})
+        run: make itest chain=neutrino db=${{ matrix.db }}
 
       - name: upload itest logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: itest-logs-neutrino
+          name: itest-logs-neutrino-${{ matrix.db }}
           path: itest/test-logs
           retention-days: 5
 
@@ -304,15 +311,16 @@ jobs:
   # - Install btcd `${{ env.BTCD_VERSION_LATEST }}` as the shared miner.
   # - Run a matrix over bitcoind versions `30` (latest) and `28` (older).
   # - Extract each matrix binary from the docker image and run
-  #   `make itest chain=bitcoind db=kvdb`.
+  #   `make itest chain=bitcoind db=${{ matrix.db }}`.
   ########################
   itest-bitcoind:
-    name: itest bitcoind (v${{ matrix.bitcoind_version }})
+    name: itest bitcoind (v${{ matrix.bitcoind_version }}, ${{ matrix.db }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         bitcoind_version: ['30', '28']
+        db: [kvdb, sqlite]
     steps:
       - name: git checkout
         uses: actions/checkout@v5
@@ -355,14 +363,14 @@ jobs:
           docker rm $CONTAINER_ID
           bitcoind --version
 
-      - name: run itest (bitcoind, kvdb)
-        run: make itest chain=bitcoind db=kvdb
+      - name: run itest (bitcoind, ${{ matrix.db }})
+        run: make itest chain=bitcoind db=${{ matrix.db }}
 
       - name: upload itest logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: itest-logs-bitcoind-${{ matrix.bitcoind_version }}
+          name: itest-logs-bitcoind-${{ matrix.bitcoind_version }}-${{ matrix.db }}
           path: itest/test-logs
           retention-days: 5
 

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ itest:
 		$(filter-out -test.run=%,$(TEST_FLAGS)) \
 		-args \
 		-chain="$(if $(backend),$(backend),$(if $(chain),$(chain),btcd))" \
-		-db="$(if $(db),$(db),kvdb)"
+		-db="$(if $(db),$(db),sqlite)"
 
 # =========
 # UTILITIES

--- a/bwtest/harness.go
+++ b/bwtest/harness.go
@@ -324,6 +324,57 @@ func (h *HarnessTest) RegisterWallet(w *wallet.Wallet) {
 	h.mu.Unlock()
 }
 
+// DeregisterWallet releases a wallet from harness ownership.
+//
+// It returns false when the wallet is nil or was not registered. The remaining
+// registrations retain their original order.
+func (h *HarnessTest) DeregisterWallet(w *wallet.Wallet) bool {
+	h.Helper()
+
+	if w == nil {
+		return false
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	for i, registered := range h.wallets {
+		if registered != w {
+			continue
+		}
+
+		h.wallets = append(h.wallets[:i], h.wallets[i+1:]...)
+
+		return true
+	}
+
+	return false
+}
+
+// ReleaseManager releases a Manager from harness teardown ownership.
+//
+// It returns false when the Manager is nil or was not registered. The remaining
+// registrations retain their original order.
+func (h *HarnessTest) ReleaseManager(manager *wallet.Manager) bool {
+	h.Helper()
+
+	if manager == nil {
+		return false
+	}
+
+	for i, registered := range h.managers {
+		if registered != manager {
+			continue
+		}
+
+		h.managers = append(h.managers[:i], h.managers[i+1:]...)
+
+		return true
+	}
+
+	return false
+}
+
 // ActiveWallets returns a snapshot of wallets registered with this harness.
 func (h *HarnessTest) ActiveWallets() []*wallet.Wallet {
 	h.Helper()

--- a/bwtest/harness_test.go
+++ b/bwtest/harness_test.go
@@ -11,6 +11,91 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestDeregisterWalletRemovesRegisteredWallet verifies that deregistration
+// removes exactly the requested wallet, preserves the order of the remaining
+// registrations, and reports absent wallets without failing.
+func TestDeregisterWalletRemovesRegisteredWallet(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: a harness with three registered wallet identities.
+	h := &HarnessTest{T: t}
+	first := &wallet.Wallet{}
+	removed := &wallet.Wallet{}
+	last := &wallet.Wallet{}
+
+	h.RegisterWallet(first)
+	h.RegisterWallet(removed)
+	h.RegisterWallet(last)
+
+	// Act: the middle wallet is deregistered.
+	require.True(t, h.DeregisterWallet(removed))
+
+	// Assert: only it is removed, ordering is retained, and absence is safe.
+	active := h.ActiveWallets()
+	require.Len(t, active, 2)
+	require.Same(t, first, active[0])
+	require.Same(t, last, active[1])
+	require.False(t, h.DeregisterWallet(removed))
+	require.False(t, h.DeregisterWallet(nil))
+}
+
+// TestReleaseManagerRemovesRegisteredManager verifies that releasing a Manager
+// preserves the remaining teardown order and reports an absent Manager.
+func TestReleaseManagerRemovesRegisteredManager(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: a harness with three Manager registrations.
+	first := &wallet.Manager{}
+	released := &wallet.Manager{}
+	last := &wallet.Manager{}
+	h := &HarnessTest{
+		T:        t,
+		managers: []*wallet.Manager{first, released, last},
+	}
+
+	// Act: the middle Manager is released from teardown ownership.
+	require.True(t, h.ReleaseManager(released))
+
+	// Assert: only it is removed, ordering is retained, and absence is safe.
+	require.Len(t, h.managers, 2)
+	require.Same(t, first, h.managers[0])
+	require.Same(t, last, h.managers[1])
+	require.False(t, h.ReleaseManager(released))
+	require.False(t, h.ReleaseManager(nil))
+}
+
+// TestReleaseManagerTransfersTeardownOwnership verifies that a successfully
+// closed Manager can be removed from teardown without a second close.
+func TestReleaseManagerTransfersTeardownOwnership(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: a Manager owned by a harness.
+	h := &HarnessTest{
+		T:            t,
+		dbType:       "kvdb",
+		WalletDBPath: filepath.Join(t.TempDir(), "wallet.db"),
+	}
+	manager := h.NewWalletManager()
+
+	// Act: the test closes the Manager before releasing teardown ownership.
+	require.NoError(t, manager.Close())
+	require.True(t, h.ReleaseManager(manager))
+
+	// Assert: teardown succeeds without a second close and the database
+	// reopened.
+	require.NoError(t, h.teardownWallets(t.Context()))
+	reopened, err := wallet.NewManager(t.Context(), wallet.ManagerConfig{
+		//nolint:staticcheck // This test intentionally reopens legacy kvdb.
+		Backend:     wallet.DBBackendKVDB,
+		DataSource:  h.WalletDBPath,
+		ChainParams: h.NetParams(),
+	})
+	require.NoError(
+		t, err, "released Manager must leave the database available",
+	)
+	require.NoError(t, reopened.Close())
+}
+
 // TestTeardownWalletsClosesManagerAfterFailedCreate verifies that centralized
 // teardown releases a Manager even when wallet creation fails.
 func TestTeardownWalletsClosesManagerAfterFailedCreate(t *testing.T) {

--- a/bwtest/harness_wallet.go
+++ b/bwtest/harness_wallet.go
@@ -16,8 +16,9 @@ const (
 	// defaultPubPass is the standard public passphrase used by test wallets.
 	defaultPubPass = "public"
 
-	// defaultPrivPass is the standard private passphrase used by test wallets.
-	defaultPrivPass = "private"
+	// TestWalletPrivatePassphrase is the standard private passphrase used by
+	// harness test wallets.
+	TestWalletPrivatePassphrase = "private"
 
 	// defaultWalletRecoveryWindow keeps enough look-ahead addresses for test
 	// cases that derive multiple addresses while scanning historical blocks.
@@ -28,27 +29,25 @@ const (
 	defaultWalletSyncRetryInterval = 500 * time.Millisecond
 )
 
-// CreateEmptyWallet creates, starts, and registers a new wallet instance.
-//
-// This is intended for non-manager integration tests that want a ready-to-use
-// wallet without repeating boilerplate.
-func (h *HarnessTest) CreateEmptyWallet() *wallet.Wallet {
-	h.Helper()
+// TestWalletConfig builds the standard Config and CreateWalletParams for a
+// harness test wallet. Callers retain ownership of the wallet lifecycle.
+func (h *HarnessTest) TestWalletConfig() (wallet.Config,
+	wallet.CreateWalletParams) {
 
-	name := "itest-" + strings.ReplaceAll(h.Name(), "/", "_")
+	h.Helper()
 
 	cfg := wallet.Config{
 		// The chain client is prepared by the harness; the database is
 		// owned by the Manager built below.
-		Chain: h.ChainClient,
+		Chain:       h.ChainClient,
+		ChainParams: h.NetParams(),
 
 		// Keep network and startup behavior deterministic across tests.
-		ChainParams:             h.NetParams(),
 		RecoveryWindow:          defaultWalletRecoveryWindow,
 		WalletSyncRetryInterval: defaultWalletSyncRetryInterval,
 
 		// Use a unique wallet name per test to avoid collisions in logs.
-		Name:          name,
+		Name:          "itest-" + strings.ReplaceAll(h.Name(), "/", "_"),
 		PubPassphrase: []byte(defaultPubPass),
 	}
 
@@ -56,12 +55,24 @@ func (h *HarnessTest) CreateEmptyWallet() *wallet.Wallet {
 		// Generate a fresh seed for each test wallet.
 		Mode:              wallet.ModeGenSeed,
 		PubPassphrase:     []byte(defaultPubPass),
-		PrivatePassphrase: []byte(defaultPrivPass),
+		PrivatePassphrase: []byte(TestWalletPrivatePassphrase),
 
 		// Use an old birthday to ensure the wallet can discover historical
 		// blocks when used in tests that pre-mine chain state.
 		Birthday: time.Now().Add(-1 * time.Hour),
 	}
+
+	return cfg, params
+}
+
+// CreateEmptyWallet creates, starts, and registers a new wallet instance.
+//
+// This is intended for non-manager integration tests that want a ready-to-use
+// wallet without repeating boilerplate.
+func (h *HarnessTest) CreateEmptyWallet() *wallet.Wallet {
+	h.Helper()
+
+	cfg, params := h.TestWalletConfig()
 
 	manager := h.NewWalletManager()
 	w, err := manager.Create(cfg, params)
@@ -88,7 +99,7 @@ func (h *HarnessTest) CreateFundedWallet() *wallet.Wallet {
 	w := h.CreateEmptyWallet()
 
 	err := w.Unlock(h.Context(), wallet.UnlockRequest{
-		Passphrase: []byte(defaultPrivPass),
+		Passphrase: []byte(TestWalletPrivatePassphrase),
 	})
 	require.NoError(h, err, "failed to unlock wallet")
 

--- a/itest/README.md
+++ b/itest/README.md
@@ -14,7 +14,8 @@ make itest
 make itest chain=btcd
 make itest chain=bitcoind
 
-# Select a wallet database backend.
+# Select a wallet database backend. Default: sqlite.
+make itest db=sqlite
 make itest db=kvdb
 
 # Filter cases by regex.

--- a/itest/controller_test.go
+++ b/itest/controller_test.go
@@ -1,0 +1,177 @@
+//go:build itest
+
+package itest
+
+import (
+	"github.com/btcsuite/btcwallet/bwtest"
+	"github.com/btcsuite/btcwallet/wallet"
+	"github.com/stretchr/testify/require"
+)
+
+// testControllerStartStop verifies the wallet lifecycle: a wallet starts and
+// stops cleanly, Stop is idempotent, a stopped instance restarts cleanly, and
+// a fresh Load yields a working instance.
+func testControllerStartStop(h *bwtest.HarnessTest) {
+	h.Helper()
+
+	cfg, params := h.TestWalletConfig()
+
+	manager := h.NewWalletManager()
+	w, err := manager.Create(cfg, params)
+	require.NoError(h, err, "failed to create wallet")
+	h.RegisterWallet(w)
+
+	require.NoError(h, w.Start(h.Context()), "failed to start wallet")
+
+	require.NoError(h, w.Stop(h.Context()), "failed to stop wallet")
+
+	// A second Stop is a no-op.
+	require.NoError(h, w.Stop(h.Context()), "second stop should be a no-op")
+
+	require.NoError(h, w.Start(h.Context()), "failed to restart stopped wallet")
+
+	// Keep the original wallet registered until Stop succeeds. Then remove it
+	// so MineBlocks cannot poll a stopped wallet during reload.
+	require.NoError(h, w.Stop(h.Context()), "failed to stop restarted wallet")
+	require.True(h, h.DeregisterWallet(w), "failed to deregister wallet")
+
+	// Keep the Manager registered until Close succeeds, then reload from disk.
+	require.NoError(h, manager.Close(), "failed to close wallet manager")
+	require.True(h, h.ReleaseManager(manager), "failed to release manager")
+	manager = h.NewWalletManager()
+	reloaded, err := manager.Load(cfg)
+	require.NoError(h, err, "failed to reload wallet")
+	h.RegisterWallet(reloaded)
+	require.NoError(
+		h, reloaded.Start(h.Context()), "failed to start reloaded wallet",
+	)
+}
+
+// testControllerUnlockLock verifies unlock/lock behavior and their state gates:
+// they are forbidden before Start, a failed unlock leaves the wallet locked,
+// and Lock is idempotent after an explicit lock.
+func testControllerUnlockLock(h *bwtest.HarnessTest) {
+	h.Helper()
+
+	const wrongPassphrase = "wrong-private-passphrase"
+
+	cfg, params := h.TestWalletConfig()
+
+	manager := h.NewWalletManager()
+	w, err := manager.Create(cfg, params)
+	require.NoError(h, err, "failed to create wallet")
+	h.RegisterWallet(w)
+
+	// Before Start, unlock and lock are forbidden.
+	err = w.Unlock(h.Context(), wallet.UnlockRequest{
+		Passphrase: []byte(bwtest.TestWalletPrivatePassphrase),
+	})
+	require.ErrorIs(
+		h, err, wallet.ErrStateForbidden, "unlock before start not rejected",
+	)
+	require.ErrorIs(
+		h, w.Lock(h.Context()), wallet.ErrStateForbidden,
+		"lock before start not rejected",
+	)
+
+	require.NoError(h, w.Start(h.Context()), "failed to start wallet")
+
+	// A freshly started wallet is locked.
+	requireLocked(h, w, true)
+
+	// Unlock with the correct passphrase. Timeout -1 keeps it unlocked until
+	// explicitly locked, so the assertion is not racy against auto-lock.
+	err = w.Unlock(h.Context(), wallet.UnlockRequest{
+		Passphrase: []byte(bwtest.TestWalletPrivatePassphrase),
+		Timeout:    -1,
+	})
+	require.NoError(h, err, "failed to unlock wallet")
+	requireLocked(h, w, false)
+
+	// Lock the wallet so the next Unlock validates the passphrase.
+	require.NoError(
+		h, w.Lock(h.Context()), "failed to lock wallet before wrong passphrase",
+	)
+	requireLocked(h, w, true)
+
+	// A wrong passphrase leaves the wallet locked after validation fails.
+	err = w.Unlock(h.Context(), wallet.UnlockRequest{
+		Passphrase: []byte(wrongPassphrase),
+		Timeout:    -1,
+	})
+	require.ErrorIs(
+		h, err, wallet.ErrInvalidPassphrase,
+		"wrong passphrase did not return invalid-passphrase error",
+	)
+	requireLocked(h, w, true)
+
+	// Restore the unlocked state so the explicit Lock transition is
+	// unambiguous.
+	err = w.Unlock(h.Context(), wallet.UnlockRequest{
+		Passphrase: []byte(bwtest.TestWalletPrivatePassphrase),
+		Timeout:    -1,
+	})
+	require.NoError(h, err, "failed to unlock wallet after failed unlock")
+	requireLocked(h, w, false)
+
+	// Lock transitions the wallet to locked state; a second Lock is a no-op.
+	require.NoError(h, w.Lock(h.Context()), "failed to lock wallet")
+	requireLocked(h, w, true)
+	require.NoError(h, w.Lock(h.Context()), "second lock should be a no-op")
+	requireLocked(h, w, true)
+}
+
+// testControllerInfo verifies the Info snapshot: it is forbidden before Start,
+// reports the configured backend and chain params, and tracks synchronization
+// as a block is mined.
+func testControllerInfo(h *bwtest.HarnessTest) {
+	h.Helper()
+
+	cfg, params := h.TestWalletConfig()
+
+	manager := h.NewWalletManager()
+	w, err := manager.Create(cfg, params)
+	require.NoError(h, err, "failed to create wallet")
+	h.RegisterWallet(w)
+
+	// Info is forbidden before Start.
+	_, err = w.Info(h.Context())
+	require.ErrorIs(
+		h, err, wallet.ErrStateForbidden, "info before start not rejected",
+	)
+
+	require.NoError(h, w.Start(h.Context()), "failed to start wallet")
+	h.AssertWalletSynced(w)
+
+	// Capture the baseline at the current chain tip so the next block measures
+	// only post-start mining, not startup catch-up.
+	before, err := w.Info(h.Context())
+	require.NoError(h, err, "failed to query wallet info")
+	require.Equal(
+		h, h.ChainClient.BackEnd(), before.Backend, "info backend mismatch",
+	)
+	require.Equal(
+		h, h.NetParams(), before.ChainParams, "info chain params mismatch",
+	)
+	require.True(h, before.Locked, "freshly started wallet should be locked")
+
+	// Mining advances the synced height.
+	h.MineBlocks(1)
+
+	after, err := w.Info(h.Context())
+	require.NoError(h, err, "failed to query wallet info after mining")
+	require.True(h, after.Synced, "wallet should be synced after mining")
+	require.Greater(
+		h, after.SyncedTo.Height, before.SyncedTo.Height,
+		"synced height did not advance after mining",
+	)
+}
+
+// requireLocked asserts the wallet's Info reports the expected locked state.
+func requireLocked(h *bwtest.HarnessTest, w *wallet.Wallet, locked bool) {
+	h.Helper()
+
+	info, err := w.Info(h.Context())
+	require.NoError(h, err, "failed to query wallet info")
+	require.Equal(h, locked, info.Locked, "unexpected locked state")
+}

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -27,4 +27,16 @@ var allTestCases = []*testCase{
 		Name:     "manager load missing",
 		TestFunc: testManagerLoadMissing,
 	},
+	{
+		Name:     "controller start stop",
+		TestFunc: testControllerStartStop,
+	},
+	{
+		Name:     "controller unlock lock",
+		TestFunc: testControllerUnlockLock,
+	},
+	{
+		Name:     "controller info",
+		TestFunc: testControllerInfo,
+	},
 }

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -19,4 +19,12 @@ var allTestCases = []*testCase{
 		Name:     "manager create wallet",
 		TestFunc: testCreateWallet,
 	},
+	{
+		Name:     "manager create duplicate",
+		TestFunc: testManagerCreateDuplicate,
+	},
+	{
+		Name:     "manager load missing",
+		TestFunc: testManagerLoadMissing,
+	},
 }

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -24,6 +24,10 @@ var allTestCases = []*testCase{
 		TestFunc: testManagerCreateDuplicate,
 	},
 	{
+		Name:     "manager load reload",
+		TestFunc: testManagerLoadReload,
+	},
+	{
 		Name:     "manager load missing",
 		TestFunc: testManagerLoadMissing,
 	},

--- a/itest/main_test.go
+++ b/itest/main_test.go
@@ -26,12 +26,12 @@ var (
 
 	// dbBackend defines the database backend to be used for the wallet
 	// storage.
-	// Options: "kvdb" (default), "sqlite", "postgres".
+	// Options: "sqlite" (default), "kvdb", "postgres".
 	//
 	// This flag allows verifying that the wallet functions correctly across all
 	// supported database drivers.
 	dbBackend = flag.String(
-		"db", "kvdb",
+		"db", "sqlite",
 		"database backend to use (kvdb, sqlite, postgres)",
 	)
 

--- a/itest/manager_test.go
+++ b/itest/manager_test.go
@@ -3,7 +3,10 @@
 package itest
 
 import (
+	"time"
+
 	"github.com/btcsuite/btcwallet/bwtest"
+	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/stretchr/testify/require"
 )
 
@@ -69,6 +72,79 @@ func testManagerCreateDuplicate(h *bwtest.HarnessTest) {
 	duplicate, err = manager.Create(cfg, params)
 	require.Error(h, err, "duplicate create not rejected against durable store")
 	require.Nil(h, duplicate, "duplicate create returned a wallet")
+}
+
+// testManagerLoadReload verifies Manager cache identity, durable reload, and
+// birthday metadata while preserving lifecycle ownership.
+func testManagerLoadReload(h *bwtest.HarnessTest) {
+	h.Helper()
+
+	cfg, params := h.TestWalletConfig()
+
+	// Keep the effective birthday five days ahead of the chain after the
+	// wallet's two-day safety margin. With every candidate too early, one real
+	// mined block guarantees birthday reconstruction selects a different block.
+	params.Birthday = time.Now().Add(7 * 24 * time.Hour)
+
+	manager := h.NewWalletManager()
+	w, err := manager.Create(cfg, params)
+	require.NoError(h, err, "failed to create wallet")
+	h.RegisterWallet(w)
+
+	err = w.Start(h.Context())
+	require.NoError(h, err, "failed to start wallet")
+
+	firstInfo, err := w.Info(h.Context())
+	require.NoError(h, err, "failed to query initial wallet info")
+
+	birthdayBlock := firstInfo.BirthdayBlock
+	require.NotEqual(
+		h, waddrmgr.BlockStamp{}, birthdayBlock,
+		"initial wallet did not initialize its birthday block",
+	)
+
+	// Mine through the real chain while the original wallet is active; the
+	// harness waits for the wallet to synchronize to the new tip.
+	h.MineBlocks(1)
+
+	// Loading an already-loaded wallet returns the same live instance
+	// without rebuilding.
+	wCached, err := manager.Load(cfg)
+	require.NoError(h, err, "failed to load cached wallet")
+	require.Same(h, w, wCached, "load of cached wallet rebuilt the instance")
+
+	// Keep both resources registered until shutdown succeeds, then reload from
+	// their durable state with a fresh Manager.
+	require.NoError(h, w.Stop(h.Context()), "failed to stop wallet")
+	require.True(h, h.DeregisterWallet(w), "failed to deregister wallet")
+	require.NoError(h, manager.Close(), "failed to close wallet manager")
+	require.True(h, h.ReleaseManager(manager), "failed to release manager")
+	manager = h.NewWalletManager()
+
+	// Reload a fresh instance from the same durable store.
+	reloaded, err := manager.Load(cfg)
+	require.NoError(h, err, "failed to reload wallet")
+	h.RegisterWallet(reloaded)
+	require.NotSame(h, w, reloaded, "reload returned the torn-down instance")
+
+	err = reloaded.Start(h.Context())
+	require.NoError(h, err, "failed to start reloaded wallet")
+
+	reloadedInfo, err := reloaded.Info(h.Context())
+	require.NoError(h, err, "failed to query reloaded wallet info")
+	require.Equal(
+		h, birthdayBlock.Height, reloadedInfo.BirthdayBlock.Height,
+		"reloaded wallet restored a different birthday block height",
+	)
+	require.Equal(
+		h, birthdayBlock.Hash, reloadedInfo.BirthdayBlock.Hash,
+		"reloaded wallet restored a different birthday block hash",
+	)
+	require.True(
+		h, birthdayBlock.Timestamp.Equal(reloadedInfo.BirthdayBlock.Timestamp),
+		"reloaded wallet restored the same birthday instant "+
+			"with different timestamp location metadata",
+	)
 }
 
 // testManagerLoadMissing verifies that loading a wallet that was never created

--- a/itest/manager_test.go
+++ b/itest/manager_test.go
@@ -3,10 +3,7 @@
 package itest
 
 import (
-	"time"
-
 	"github.com/btcsuite/btcwallet/bwtest"
-	"github.com/btcsuite/btcwallet/wallet"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,24 +11,10 @@ import (
 func testCreateWallet(h *bwtest.HarnessTest) {
 	h.Helper()
 
-	// Create a wallet using the Manager API. The Manager owns the database
-	// selected by the -db flag; the wallet config carries no backend.
-	cfg := wallet.Config{
-		Chain:                   h.ChainClient,
-		ChainParams:             h.NetParams(),
-		RecoveryWindow:          20,
-		WalletSyncRetryInterval: 500 * time.Millisecond,
-		Name:                    "testwallet",
-		PubPassphrase:           []byte("public"),
-	}
-
+	// This is a manager-focused test, so drive the Manager API directly
+	// rather than the harness's CreateEmptyWallet convenience helper.
+	cfg, params := h.TestWalletConfig()
 	manager := h.NewWalletManager()
-	params := wallet.CreateWalletParams{
-		Mode:              wallet.ModeGenSeed,
-		PubPassphrase:     []byte("public"),
-		PrivatePassphrase: []byte("private"),
-		Birthday:          time.Now().Add(-1 * time.Hour),
-	}
 
 	w, err := manager.Create(cfg, params)
 	require.NoError(h, err, "failed to create wallet")

--- a/itest/manager_test.go
+++ b/itest/manager_test.go
@@ -28,6 +28,57 @@ func testCreateWallet(h *bwtest.HarnessTest) {
 	err = w.Start(h.Context())
 	require.NoError(h, err, "failed to start wallet")
 
+	// Wait for the wallet to catch up to the existing tip before mining new
+	// blocks.
+	h.AssertWalletSynced(w)
+
 	// Mine a few blocks and require the wallet catches up.
 	h.MineBlocks(5)
+}
+
+// testManagerCreateDuplicate verifies that both a live wallet cache entry and
+// a completed wallet in the durable store reject a duplicate creation.
+func testManagerCreateDuplicate(h *bwtest.HarnessTest) {
+	h.Helper()
+
+	cfg, params := h.TestWalletConfig()
+
+	manager := h.NewWalletManager()
+	w, err := manager.Create(cfg, params)
+	require.NoError(h, err, "failed to create wallet")
+	h.RegisterWallet(w)
+
+	err = w.Start(h.Context())
+	require.NoError(h, err, "failed to start wallet")
+
+	// Creating a duplicate while the original is still cached must fail before
+	// the manager consults the durable store.
+	duplicate, err := manager.Create(cfg, params)
+	require.Error(h, err, "duplicate create not rejected by live wallet cache")
+	require.Nil(h, duplicate, "duplicate create returned a wallet")
+
+	// Keep both resources registered until shutdown succeeds, then open a new
+	// Manager over the durable store.
+	require.NoError(h, w.Stop(h.Context()), "failed to stop wallet")
+	require.True(h, h.DeregisterWallet(w), "failed to deregister wallet")
+	require.NoError(h, manager.Close(), "failed to close wallet manager")
+	require.True(h, h.ReleaseManager(manager), "failed to release manager")
+	manager = h.NewWalletManager()
+
+	// A fresh manager must reject creation over the completed durable wallet.
+	duplicate, err = manager.Create(cfg, params)
+	require.Error(h, err, "duplicate create not rejected against durable store")
+	require.Nil(h, duplicate, "duplicate create returned a wallet")
+}
+
+// testManagerLoadMissing verifies that loading a wallet that was never created
+// fails rather than silently returning an empty wallet.
+func testManagerLoadMissing(h *bwtest.HarnessTest) {
+	h.Helper()
+
+	cfg, _ := h.TestWalletConfig()
+
+	manager := h.NewWalletManager()
+	_, err := manager.Load(cfg)
+	require.Error(h, err, "load of never-created wallet should fail")
 }

--- a/wallet/internal/db/itest/walletstore_listsyncedblocks_test.go
+++ b/wallet/internal/db/itest/walletstore_listsyncedblocks_test.go
@@ -1,0 +1,54 @@
+//go:build itest
+
+package itest
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/stretchr/testify/require"
+)
+
+// TestListSyncedBlocksRejectsMissingRanges verifies missing block heights are
+// reported for both an interior gap and a missing range tail.
+func TestListSyncedBlocksRejectsMissingRanges(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		query db.ListSyncedBlocksQuery
+	}{
+		{
+			name: "gap",
+			query: db.ListSyncedBlocksQuery{
+				StartHeight: 144,
+				EndHeight:   146,
+			},
+		},
+		{
+			name: "short tail",
+			query: db.ListSyncedBlocksQuery{
+				StartHeight: 146,
+				EndHeight:   147,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: persist blocks on either side of the missing range.
+			store := NewTestStore(t)
+			queries := store.Queries()
+			CreateBlockFixture(t, queries, 144)
+			CreateBlockFixture(t, queries, 146)
+
+			// Act: request a range containing a missing height.
+			_, err := store.ListSyncedBlocks(t.Context(), test.query)
+
+			// Assert: missing ranges return the shared not-found error.
+			require.ErrorIs(t, err, db.ErrBlockNotFound)
+		})
+	}
+}

--- a/wallet/internal/db/pg/walletstore_listsyncedblocks.go
+++ b/wallet/internal/db/pg/walletstore_listsyncedblocks.go
@@ -88,7 +88,7 @@ func (s *Store) ListSyncedBlocks(ctx context.Context,
 
 			if block.Height != height {
 				return fmt.Errorf("get block %d: %w", height,
-					sql.ErrNoRows)
+					db.ErrBlockNotFound)
 			}
 
 			blocks = append(blocks, *block)
@@ -99,7 +99,7 @@ func (s *Store) ListSyncedBlocks(ctx context.Context,
 		// the tail of the range.
 		if len(blocks) != expected {
 			return fmt.Errorf("get block %d: %w", height,
-				sql.ErrNoRows)
+				db.ErrBlockNotFound)
 		}
 
 		return nil

--- a/wallet/internal/db/sqlite/walletstore_listsyncedblocks.go
+++ b/wallet/internal/db/sqlite/walletstore_listsyncedblocks.go
@@ -75,7 +75,7 @@ func (s *Store) ListSyncedBlocks(ctx context.Context,
 
 			if block.Height != height {
 				return fmt.Errorf("get block %d: %w", height,
-					sql.ErrNoRows)
+					db.ErrBlockNotFound)
 			}
 
 			blocks = append(blocks, *block)
@@ -86,7 +86,7 @@ func (s *Store) ListSyncedBlocks(ctx context.Context,
 		// the tail of the range.
 		if len(blocks) != int(expected) {
 			return fmt.Errorf("get block %d: %w", height,
-				sql.ErrNoRows)
+				db.ErrBlockNotFound)
 		}
 
 		return nil

--- a/wallet/syncer.go
+++ b/wallet/syncer.go
@@ -430,7 +430,7 @@ func (s *syncer) checkRollback(ctx context.Context) error {
 			ctx, startHeight, endHeight,
 		)
 		if err != nil {
-			return err
+			return s.resolveMissingHistoricalBlock(err, syncedTo)
 		}
 
 		// Fetch Remote Batch - Fetch corresponding hashes from the
@@ -489,6 +489,32 @@ func (s *syncer) checkRollback(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// resolveMissingHistoricalBlock accepts a missing historical block when the
+// persisted synced tip matches the chain backend.
+func (s *syncer) resolveMissingHistoricalBlock(listErr error,
+	syncedTo waddrmgr.BlockStamp) error {
+
+	if !errors.Is(listErr, db.ErrBlockNotFound) {
+		var managerErr waddrmgr.ManagerError
+		if !errors.As(listErr, &managerErr) ||
+			managerErr.ErrorCode != waddrmgr.ErrBlockNotFound {
+
+			return listErr
+		}
+	}
+
+	remoteHash, err := s.cfg.Chain.GetBlockHash(int64(syncedTo.Height))
+	if err != nil {
+		return fmt.Errorf("get synced block hash: %w", err)
+	}
+
+	if syncedTo.Hash.IsEqual(remoteHash) {
+		return nil
+	}
+
+	return listErr
 }
 
 // rewindToBlock rewinds wallet sync and transaction state to the given fork

--- a/wallet/syncer_test.go
+++ b/wallet/syncer_test.go
@@ -203,6 +203,106 @@ func TestCheckRollbackNoReorg(t *testing.T) {
 	store.AssertExpectations(t)
 }
 
+// TestCheckRollbackMissingHistoricalBlock verifies that a Store-backed wallet
+// accepts its persisted tip when its historical block range is unavailable.
+func TestCheckRollbackMissingHistoricalBlock(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: The Store has a valid synced tip but cannot provide the oldest
+	// block requested by the rollback scan.
+	mockChain := &bwmock.Chain{}
+	store := &walletmock.Store{}
+	s := newSyncer(Config{Chain: mockChain}, nil, nil, nil, store, 0)
+
+	tip := waddrmgr.BlockStamp{Height: 100, Hash: chainhash.Hash{0x01}}
+	expectSyncedTip(store, tip)
+	store.On("ListSyncedBlocks", mock.Anything, db.ListSyncedBlocksQuery{
+		StartHeight: 91,
+		EndHeight:   100,
+	}).Return(nil, db.ErrBlockNotFound).Once()
+	mockChain.On("GetBlockHash", int64(100)).Return(&tip.Hash, nil).Once()
+
+	// Act & Assert: The persisted tip proves the wallet remains on the main
+	// chain, so no rollback is necessary.
+	err := s.checkRollback(t.Context())
+	require.NoError(t, err)
+	store.AssertExpectations(t)
+	mockChain.AssertExpectations(t)
+}
+
+// TestResolveMissingHistoricalBlockTipMismatch verifies that a mismatched tip
+// returns the original missing historical block error.
+func TestResolveMissingHistoricalBlockTipMismatch(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: The SQL store cannot provide a historical block and the remote
+	// synced tip differs from the persisted tip.
+	mockChain := &bwmock.Chain{}
+	s := newSyncer(Config{Chain: mockChain}, nil, nil, nil, nil, 0)
+	tip := waddrmgr.BlockStamp{Height: 100, Hash: chainhash.Hash{0x01}}
+	remoteHash := chainhash.Hash{0x02}
+	listErr := db.ErrBlockNotFound
+
+	mockChain.On("GetBlockHash", int64(tip.Height)).Return(
+		&remoteHash, nil,
+	).Once()
+
+	// Act: Resolve the missing historical block against the mismatched tip.
+	err := s.resolveMissingHistoricalBlock(listErr, tip)
+
+	// Assert: The list error is returned without replacement.
+	require.Same(t, listErr, err)
+	require.ErrorIs(t, err, db.ErrBlockNotFound)
+	mockChain.AssertExpectations(t)
+}
+
+// TestResolveMissingHistoricalBlockChainLookupError verifies that a chain
+// lookup failure is wrapped while resolving a missing historical block.
+func TestResolveMissingHistoricalBlockChainLookupError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: The SQL store cannot provide a historical block and the chain
+	// backend cannot load the persisted synced tip.
+	mockChain := &bwmock.Chain{}
+	s := newSyncer(Config{Chain: mockChain}, nil, nil, nil, nil, 0)
+	tip := waddrmgr.BlockStamp{Height: 100, Hash: chainhash.Hash{0x01}}
+	mockChain.On("GetBlockHash", int64(tip.Height)).Return(
+		nil, errDBFail,
+	).Once()
+
+	// Act: Resolve the missing historical block.
+	err := s.resolveMissingHistoricalBlock(db.ErrBlockNotFound, tip)
+
+	// Assert: The chain error has context and remains available to callers.
+	require.ErrorContains(t, err, "get synced block hash")
+	require.ErrorIs(t, err, errDBFail)
+	mockChain.AssertExpectations(t)
+}
+
+// TestResolveMissingHistoricalBlockLegacyManagerError verifies that legacy
+// kvdb manager not-found errors remain compatible with rollback handling.
+func TestResolveMissingHistoricalBlockLegacyManagerError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: A legacy kvdb manager reports a missing historical block and the
+	// persisted synced tip matches the chain backend.
+	mockChain := &bwmock.Chain{}
+	s := newSyncer(Config{Chain: mockChain}, nil, nil, nil, nil, 0)
+	tip := waddrmgr.BlockStamp{Height: 100, Hash: chainhash.Hash{0x01}}
+	mockChain.On("GetBlockHash", int64(tip.Height)).Return(
+		&tip.Hash, nil,
+	).Once()
+
+	listErr := waddrmgr.ManagerError{ErrorCode: waddrmgr.ErrBlockNotFound}
+
+	// Act: Resolve the legacy missing historical block error.
+	err := s.resolveMissingHistoricalBlock(listErr, tip)
+
+	// Assert: The matching chain tip permits rollback initialization.
+	require.NoError(t, err)
+	mockChain.AssertExpectations(t)
+}
+
 // TestCheckRollbackDetected verifies checkRollback when reorg is detected.
 func TestCheckRollbackDetected(t *testing.T) {
 	t.Parallel()
@@ -3307,7 +3407,6 @@ func TestProcessChainUpdate_Disconnect(t *testing.T) {
 	)
 
 	expectSyncedTip(store, waddrmgr.BlockStamp{Height: 100})
-
 	// The store and the remote chain agree across the scanned batch, so the
 	// rollback check finds no reorg.
 	expectMatchingRollbackBatch(store, mockChain)
@@ -5353,6 +5452,7 @@ func TestHandleChainUpdate_Error(t *testing.T) {
 
 	// Assert: Verify failure.
 	require.ErrorContains(t, err, "failed to process chain update")
+	store.AssertExpectations(t)
 }
 
 // TestRunSyncStep_Success verifies the idle path in runSyncStep.


### PR DESCRIPTION
First slice of the public-API integration-test foundation (#1250): boots a
real SQL-backed wallet on the bwtest harness and exercises the two
lowest-level components end-to-end.

- Make SQLite the default integration-test wallet backend.
- Run integration tests against both SQLite and KVDB in CI.
- Add shared wallet configuration and backend lifecycle helpers.
- Add Manager tests for wallet creation, duplicate creation, loading, and
  missing wallets.
- Add Controller lifecycle tests.
- Normalize missing synced-block errors across SQLite and PostgreSQL.
- Handle missing historical rollback data during wallet reload.
- Add unit and integration regression coverage for rollback behavior.
