### PR TITLE
wallet+bwtest: add PostgreSQL harness

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
   # Format, compileation and lint check
   ########################
   lint-check:
-    name: Format, compilation and lint check
+    name: Static checks (format, compile, lint)
     runs-on: ubuntu-latest
     steps:
       - name: git checkout
@@ -85,7 +85,7 @@ jobs:
 
   check-commits:
     if: github.event_name == 'pull_request'
-    name: Check commits
+    name: Commit checks
     runs-on: ubuntu-latest
     steps:
       - name: git checkout
@@ -114,7 +114,7 @@ jobs:
   # run unit tests
   ########################
   unit-test:
-    name: run unit tests
+    name: Unit tests (${{ matrix.unit_type }})
     runs-on: ubuntu-latest
     strategy:
       # Allow other tests in the matrix to continue if one fails.
@@ -171,7 +171,7 @@ jobs:
   # run integration tests (SQLite + Postgres)
   ########################
   itest-db:
-    name: ${{ matrix.db }} itest (${{ matrix.race && 'race' || 'cover' }})
+    name: Database itest (${{ matrix.db }}, ${{ matrix.race && 'race' || 'cover' }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -211,10 +211,12 @@ jobs:
   ########################
   # Run bwtest integration tests against each supported chain backend.
   #
-  # Each job runs over both wallet database backends (kvdb and sqlite).
+  # btcd and neutrino run with kvdb and sqlite. The bitcoind matrix crosses
+  # every supported bitcoind version with kvdb, sqlite, and postgres so it
+  # catches compatibility bugs specific to a node version and wallet database.
   ########################
   itest-btcd:
-    name: itest btcd (${{ matrix.db }})
+    name: Wallet itest (btcd, ${{ matrix.db }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -264,7 +266,7 @@ jobs:
   #   in-process neutrino backend while blocks/peers come from btcd.
   ########################
   itest-neutrino:
-    name: itest neutrino (${{ matrix.db }})
+    name: Wallet itest (neutrino, ${{ matrix.db }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -309,18 +311,19 @@ jobs:
   #
   # Job flow:
   # - Install btcd `${{ env.BTCD_VERSION_LATEST }}` as the shared miner.
-  # - Run a matrix over bitcoind versions `30` (latest) and `28` (older).
+  # - Cross bitcoind versions `30` (latest) and `28` (older) with every wallet
+  #   database so each version/database combination is tested independently.
   # - Extract each matrix binary from the docker image and run
   #   `make itest chain=bitcoind db=${{ matrix.db }}`.
   ########################
   itest-bitcoind:
-    name: itest bitcoind (v${{ matrix.bitcoind_version }}, ${{ matrix.db }})
+    name: Wallet itest (bitcoind v${{ matrix.bitcoind_version }}, ${{ matrix.db }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         bitcoind_version: ['30', '28']
-        db: [kvdb, sqlite]
+        db: [kvdb, sqlite, postgres]
     steps:
       - name: git checkout
         uses: actions/checkout@v5
@@ -378,7 +381,7 @@ jobs:
   # Complete parallel coverage uploads
   ########################
   finish:
-    name: Finish coverage upload
+    name: Coverage upload
     if: ${{ !cancelled() }}
     needs: [unit-test, itest-db]
     runs-on: ubuntu-latest

--- a/bwtest/database.go
+++ b/bwtest/database.go
@@ -21,6 +21,9 @@ const (
 	// dbNameSQLite is the identifier used for the SQLite wallet backend.
 	dbNameSQLite = "sqlite"
 
+	// dbNamePostgres is the identifier used for the PostgreSQL wallet backend.
+	dbNamePostgres = "postgres"
+
 	// kvdbDriver is the walletdb driver name used for kvdb.
 	kvdbDriver = "bdb"
 

--- a/bwtest/harness.go
+++ b/bwtest/harness.go
@@ -57,12 +57,16 @@ type HarnessTest struct {
 	// passed to wallets under test.
 	ChainClient chain.Interface
 
-	// WalletDBPath is the wallet database path created for the current
+	// WalletDBSource is the database path or DSN created for the current
 	// subtest.
-	WalletDBPath string
+	WalletDBSource string
 
 	// dbType is the configured wallet database backend.
 	dbType string
+
+	// postgresServer is the process-scoped PostgreSQL server shared by the
+	// parent harness and its subtests.
+	postgresServer *postgresTestServer
 
 	// managers holds the wallet managers created for this subtest. They are
 	// closed after every registered wallet has stopped.
@@ -117,8 +121,16 @@ func SetupHarness(t *testing.T, chainBackendType, dbType string) *HarnessTest {
 		dbType:  dbType,
 	}
 
-	// Ensure the harness is cleaned up when the test finishes.
+	// Ensure the harness is cleaned up if PostgreSQL startup fails and when
+	// the test finishes normally.
 	t.Cleanup(ht.Stop)
+
+	if dbType == dbNamePostgres {
+		server, err := newPostgresTestServer(t.Context())
+		require.NoError(t, err, "failed to start postgres test server")
+
+		ht.postgresServer = server
+	}
 
 	return ht
 }
@@ -132,11 +144,12 @@ func (h *HarnessTest) Subtest(t *testing.T) *HarnessTest {
 	h.Helper()
 
 	st := &HarnessTest{
-		T:       t,
-		logDir:  h.logDir,
-		miner:   h.miner,
-		Backend: h.Backend,
-		dbType:  h.dbType,
+		T:              t,
+		logDir:         h.logDir,
+		miner:          h.miner,
+		Backend:        h.Backend,
+		dbType:         h.dbType,
+		postgresServer: h.postgresServer,
 	}
 
 	// Use the subtest's testing context for miner assertions.
@@ -200,9 +213,7 @@ func (h *HarnessTest) Subtest(t *testing.T) *HarnessTest {
 func (h *HarnessTest) NewWalletManager() *wallet.Manager {
 	h.Helper()
 
-	// Switch explicitly: mapping every unknown -db value onto kvdb would let
-	// `db=postgres` pass while exercising kvdb, and the PostgreSQL Manager is
-	// not part of this milestone.
+	// Switch explicitly so every -db value exercises the selected Manager.
 	var backend wallet.DBBackend
 
 	switch h.dbType {
@@ -213,14 +224,17 @@ func (h *HarnessTest) NewWalletManager() *wallet.Manager {
 	case dbNameSQLite:
 		backend = wallet.DBBackendSQLite
 
+	case dbNamePostgres:
+		backend = wallet.DBBackendPostgres
+
 	default:
 		h.Fatalf("unsupported -db value %q: the wallet Manager serves "+
-			"kvdb and sqlite", h.dbType)
+			"kvdb, sqlite, and postgres", h.dbType)
 	}
 
 	manager, err := wallet.NewManager(h.Context(), wallet.ManagerConfig{
 		Backend:     backend,
-		DataSource:  h.WalletDBPath,
+		DataSource:  h.WalletDBSource,
 		ChainParams: h.NetParams(),
 	})
 	require.NoError(h, err, "failed to create wallet manager")
@@ -251,20 +265,28 @@ func (h *HarnessTest) teardownWallets(ctx context.Context) error {
 func (h *HarnessTest) assertBackendArtifact() {
 	h.Helper()
 
-	err := validateBackendArtifact(h.dbType, h.WalletDBPath)
+	err := validateBackendArtifact(h.dbType, h.WalletDBSource)
 	require.NoError(h, err)
 }
 
-// validateBackendArtifact verifies that a database file has the requested
-// backend's header.
-func validateBackendArtifact(dbType, dbPath string) error {
+// validateBackendArtifact verifies that the data source uses the requested
+// backend and has an initialized wallet schema.
+func validateBackendArtifact(dbType, dbSource string) error {
 	switch dbType {
 	case dbNameKvdb, dbNameSQLite:
+		return validateFileBackendArtifact(dbType, dbSource)
+
+	case dbNamePostgres:
+		return validatePostgresSchema(dbSource)
 
 	default:
 		return fmt.Errorf("%w: %s", ErrUnknownDBBackend, dbType)
 	}
+}
 
+// validateFileBackendArtifact verifies that a database file has the requested
+// backend's header.
+func validateFileBackendArtifact(dbType, dbPath string) error {
 	// The path is created and owned by the test harness.
 	f, err := os.Open(dbPath) //nolint:gosec
 	if err != nil {
@@ -435,14 +457,33 @@ func (h *HarnessTest) Stop() {
 	h.mu.Unlock()
 
 	// Stop the chain backend first to avoid it attempting to reconnect while
-	// the miner is being torn down.
-	require.NoError(h, h.Backend.Stop(), "failed to stop chain backend")
+	// the miner is being torn down. Collect shutdown errors so every shared
+	// process is still released.
+	var shutdownErr error
 
-	// Finally, stop the miner.
+	err := h.Backend.Stop()
+	if err != nil {
+		shutdownErr = fmt.Errorf("stop chain backend: %w", err)
+	}
+
+	// Stop PostgreSQL before the miner because miner teardown reports failures
+	// with FailNow and could otherwise skip container termination.
+	if h.postgresServer != nil {
+		err := h.postgresServer.close(context.Background())
+		if err != nil {
+			shutdownErr = errors.Join(shutdownErr, fmt.Errorf(
+				"stop postgres test server: %w", err,
+			))
+		}
+	}
+
+	// Stop the miner after its chain backend.
 	h.miner.Stop()
 
 	// Flatten logs into the per-run log dir.
 	h.finalizeLogs()
+
+	require.NoError(h, shutdownErr, "failed to stop harness")
 }
 
 // stopActiveWallets stops all wallets registered with the harness.
@@ -490,11 +531,33 @@ func (h *HarnessTest) setUpChainClient() {
 	h.ChainClient = chainClient
 }
 
-// setUpWalletDB prepares a wallet database path for the configured test
-// backend.
+// setUpWalletDB prepares an isolated wallet data source for the configured
+// test backend.
 func (h *HarnessTest) setUpWalletDB() {
 	h.Helper()
 
-	dbDir := h.TempDir()
-	h.WalletDBPath = filepath.Join(dbDir, wallet.WalletDBName)
+	switch h.dbType {
+	case dbNameKvdb, dbNameSQLite:
+		dbDir := h.TempDir()
+		h.WalletDBSource = filepath.Join(dbDir, wallet.WalletDBName)
+
+	case dbNamePostgres:
+		require.NotNil(h, h.postgresServer, "postgres server not started")
+
+		database, err := h.postgresServer.newDatabase(
+			h.Context(), h.Name(),
+		)
+		require.NoError(h, err, "failed to create postgres test database")
+
+		h.WalletDBSource = database.dsn
+		h.Cleanup(func() {
+			require.NoError(
+				h, database.close(context.Background()),
+				"failed to drop postgres test database",
+			)
+		})
+
+	default:
+		h.Fatalf("unsupported -db value %q", h.dbType)
+	}
 }

--- a/bwtest/harness_test.go
+++ b/bwtest/harness_test.go
@@ -71,9 +71,9 @@ func TestReleaseManagerTransfersTeardownOwnership(t *testing.T) {
 
 	// Arrange: a Manager owned by a harness.
 	h := &HarnessTest{
-		T:            t,
-		dbType:       "kvdb",
-		WalletDBPath: filepath.Join(t.TempDir(), "wallet.db"),
+		T:              t,
+		dbType:         "kvdb",
+		WalletDBSource: filepath.Join(t.TempDir(), "wallet.db"),
 	}
 	manager := h.NewWalletManager()
 
@@ -87,7 +87,7 @@ func TestReleaseManagerTransfersTeardownOwnership(t *testing.T) {
 	reopened, err := wallet.NewManager(t.Context(), wallet.ManagerConfig{
 		//nolint:staticcheck // This test intentionally reopens legacy kvdb.
 		Backend:     wallet.DBBackendKVDB,
-		DataSource:  h.WalletDBPath,
+		DataSource:  h.WalletDBSource,
 		ChainParams: h.NetParams(),
 	})
 	require.NoError(
@@ -138,9 +138,9 @@ func testManagerTeardownAfterFailedCreate(t *testing.T, dbType string,
 	t.Helper()
 
 	h := &HarnessTest{
-		T:            t,
-		dbType:       dbType,
-		WalletDBPath: filepath.Join(t.TempDir(), "wallet.db"),
+		T:              t,
+		dbType:         dbType,
+		WalletDBSource: filepath.Join(t.TempDir(), "wallet.db"),
 	}
 
 	manager := h.NewWalletManager()
@@ -178,11 +178,20 @@ func testManagerTeardownAfterFailedCreate(t *testing.T, dbType string,
 	// A fresh Manager proves the database was released.
 	reopened, err := wallet.NewManager(t.Context(), wallet.ManagerConfig{
 		Backend:     backend,
-		DataSource:  h.WalletDBPath,
+		DataSource:  h.WalletDBSource,
 		ChainParams: h.NetParams(),
 	})
 	require.NoError(t, err, "teardown must release the database")
 	require.NoError(t, reopened.Close())
+}
+
+// TestBackendArtifactPostgresRejectsInvalidDSN verifies that PostgreSQL
+// validation uses a connection probe instead of treating the DSN as a file.
+func TestBackendArtifactPostgresRejectsInvalidDSN(t *testing.T) {
+	t.Parallel()
+
+	err := validateBackendArtifact(dbNamePostgres, "://invalid")
+	require.ErrorContains(t, err, "postgres")
 }
 
 // teardownWaitLimit bounds teardown so a leaked Manager fails the test.

--- a/bwtest/postgres.go
+++ b/bwtest/postgres.go
@@ -2,13 +2,16 @@ package bwtest
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"errors"
 	"fmt"
 	"net"
+	"net/url"
 	"time"
 
 	"github.com/docker/go-connections/nat"
+	"github.com/jackc/pgx/v5"
 	_ "github.com/jackc/pgx/v5/stdlib" // Register the pgx SQL driver.
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
@@ -19,9 +22,9 @@ const (
 	// postgresTestImage is the PostgreSQL image used by the harness.
 	postgresTestImage = "postgres:18-alpine"
 
-	// postgresTestDatabase is the administrative database used by the
+	// postgresAdminDatabase is the administrative database used by the
 	// harness.
-	postgresTestDatabase = "postgres"
+	postgresAdminDatabase = "postgres"
 
 	// postgresTestUsername and postgresTestPassword are credentials scoped
 	// to the disposable PostgreSQL container.
@@ -35,6 +38,10 @@ const (
 	// postgresShutdownTimeout bounds container teardown after the test
 	// context has been canceled.
 	postgresShutdownTimeout = time.Minute
+
+	// postgresDatabaseHashBytes keeps database identifiers short while
+	// retaining enough entropy to isolate test names.
+	postgresDatabaseHashBytes = 12
 )
 
 // postgresTestServer owns the process-scoped PostgreSQL test container and
@@ -43,6 +50,14 @@ type postgresTestServer struct {
 	container *postgres.PostgresContainer
 	adminDB   *sql.DB
 	adminDSN  string
+}
+
+// postgresTestDatabase is one per-subtest database in the shared PostgreSQL
+// server.
+type postgresTestDatabase struct {
+	server *postgresTestServer
+	name   string
+	dsn    string
 }
 
 // newPostgresTestServer starts PostgreSQL and opens its administrative
@@ -57,14 +72,14 @@ func newPostgresTestServer(ctx context.Context) (*postgresTestServer, error) {
 			return fmt.Sprintf(
 				"postgres://%s:%s@%s/%s?sslmode=disable",
 				postgresTestUsername, postgresTestPassword, hostPort,
-				postgresTestDatabase,
+				postgresAdminDatabase,
 			)
 		},
 	).WithStartupTimeout(postgresStartupTimeout)
 
 	container, err := postgres.Run(
 		ctx, postgresTestImage,
-		postgres.WithDatabase(postgresTestDatabase),
+		postgres.WithDatabase(postgresAdminDatabase),
 		postgres.WithUsername(postgresTestUsername),
 		postgres.WithPassword(postgresTestPassword),
 		testcontainers.WithWaitStrategyAndDeadline(
@@ -117,6 +132,80 @@ func newPostgresTestServer(ctx context.Context) (*postgresTestServer, error) {
 	}
 
 	return server, nil
+}
+
+// newDatabase creates an isolated database and returns its rewritten DSN.
+func (s *postgresTestServer) newDatabase(ctx context.Context,
+	testName string) (*postgresTestDatabase, error) {
+
+	database := &postgresTestDatabase{
+		server: s,
+		name:   postgresDatabaseName(testName),
+	}
+	identifier := pgx.Identifier{database.name}.Sanitize()
+
+	createCtx, cancel := context.WithTimeout(ctx, defaultTestTimeout)
+	defer cancel()
+
+	_, err := s.adminDB.ExecContext(
+		createCtx, "CREATE DATABASE "+identifier,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create postgres database %q: %w",
+			database.name, err)
+	}
+
+	database.dsn, err = postgresDatabaseDSN(s.adminDSN, database.name)
+	if err != nil {
+		return nil, errors.Join(err, database.close(ctx))
+	}
+
+	return database, nil
+}
+
+// close drops the isolated database after its Managers have closed.
+func (d *postgresTestDatabase) close(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(
+		ctx, defaultTestTimeout,
+	)
+	defer cancel()
+
+	identifier := pgx.Identifier{d.name}.Sanitize()
+	_, err := d.server.adminDB.ExecContext(
+		ctx, "DROP DATABASE IF EXISTS "+identifier,
+	)
+	if err != nil {
+		return fmt.Errorf("drop postgres database %q: %w", d.name, err)
+	}
+
+	return nil
+}
+
+// postgresDatabaseName returns a short, deterministic SQL identifier for a
+// subtest name.
+func postgresDatabaseName(testName string) string {
+	hash := sha256.Sum256([]byte(testName))
+
+	return fmt.Sprintf(
+		"bwtest_%x", hash[:postgresDatabaseHashBytes],
+	)
+}
+
+// postgresDatabaseDSN rewrites an administrative DSN to select database.
+func postgresDatabaseDSN(adminDSN, database string) (string, error) {
+	dsn, err := url.Parse(adminDSN)
+	if err != nil {
+		return "", fmt.Errorf("parse postgres admin DSN: %w", err)
+	}
+
+	if dsn.Scheme == "" || dsn.Host == "" {
+		return "", errors.New("parse postgres admin DSN: missing endpoint")
+	}
+
+	dsn.Path = "/" + database
+	dsn.RawPath = ""
+
+	return dsn.String(), nil
 }
 
 // close releases the administrative connection and immediately terminates

--- a/bwtest/postgres.go
+++ b/bwtest/postgres.go
@@ -1,0 +1,142 @@
+package bwtest
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/docker/go-connections/nat"
+	_ "github.com/jackc/pgx/v5/stdlib" // Register the pgx SQL driver.
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const (
+	// postgresTestImage is the PostgreSQL image used by the harness.
+	postgresTestImage = "postgres:18-alpine"
+
+	// postgresTestDatabase is the administrative database used by the
+	// harness.
+	postgresTestDatabase = "postgres"
+
+	// postgresTestUsername and postgresTestPassword are credentials scoped
+	// to the disposable PostgreSQL container.
+	postgresTestUsername = "postgres"
+	postgresTestPassword = "postgres"
+
+	// postgresStartupTimeout includes the time needed to pull and start the
+	// PostgreSQL image.
+	postgresStartupTimeout = 2 * time.Minute
+
+	// postgresShutdownTimeout bounds container teardown after the test
+	// context has been canceled.
+	postgresShutdownTimeout = time.Minute
+)
+
+// postgresTestServer owns the process-scoped PostgreSQL test container and
+// its administrative connection.
+type postgresTestServer struct {
+	container *postgres.PostgresContainer
+	adminDB   *sql.DB
+	adminDSN  string
+}
+
+// newPostgresTestServer starts PostgreSQL and opens its administrative
+// connection after a successful SQL readiness probe.
+func newPostgresTestServer(ctx context.Context) (*postgresTestServer, error) {
+	cleanupCtx := context.WithoutCancel(ctx)
+
+	waitForSQL := wait.ForSQL(
+		"5432/tcp", "pgx", func(host string, port nat.Port) string {
+			hostPort := net.JoinHostPort(host, port.Port())
+
+			return fmt.Sprintf(
+				"postgres://%s:%s@%s/%s?sslmode=disable",
+				postgresTestUsername, postgresTestPassword, hostPort,
+				postgresTestDatabase,
+			)
+		},
+	).WithStartupTimeout(postgresStartupTimeout)
+
+	container, err := postgres.Run(
+		ctx, postgresTestImage,
+		postgres.WithDatabase(postgresTestDatabase),
+		postgres.WithUsername(postgresTestUsername),
+		postgres.WithPassword(postgresTestPassword),
+		testcontainers.WithWaitStrategyAndDeadline(
+			postgresStartupTimeout, waitForSQL,
+		),
+	)
+	if err != nil {
+		var cleanupErr error
+		if container != nil {
+			cleanupErr = (&postgresTestServer{
+				container: container,
+			}).close(cleanupCtx)
+		}
+
+		return nil, errors.Join(
+			fmt.Errorf("start postgres test server: %w", err),
+			cleanupErr,
+		)
+	}
+
+	server := &postgresTestServer{container: container}
+
+	server.adminDSN, err = container.ConnectionString(
+		ctx, "sslmode=disable",
+	)
+	if err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("get postgres admin DSN: %w", err),
+			server.close(cleanupCtx),
+		)
+	}
+
+	server.adminDB, err = sql.Open("pgx", server.adminDSN)
+	if err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("open postgres admin connection: %w", err),
+			server.close(cleanupCtx),
+		)
+	}
+
+	pingCtx, cancel := context.WithTimeout(ctx, defaultTestTimeout)
+	defer cancel()
+
+	err = server.adminDB.PingContext(pingCtx)
+	if err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("ping postgres admin connection: %w", err),
+			server.close(cleanupCtx),
+		)
+	}
+
+	return server, nil
+}
+
+// close releases the administrative connection and immediately terminates
+// the disposable PostgreSQL container.
+func (s *postgresTestServer) close(ctx context.Context) error {
+	var err error
+	if s.adminDB != nil {
+		err = s.adminDB.Close()
+	}
+
+	if s.container == nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, postgresShutdownTimeout)
+	defer cancel()
+
+	terminateErr := s.container.Terminate(
+		ctx, testcontainers.StopTimeout(0),
+	)
+
+	return errors.Join(err, terminateErr)
+}

--- a/bwtest/postgres.go
+++ b/bwtest/postgres.go
@@ -171,8 +171,11 @@ func (d *postgresTestDatabase) close(ctx context.Context) error {
 	defer cancel()
 
 	identifier := pgx.Identifier{d.name}.Sanitize()
+
+	// Managers close before this cleanup. WITH (FORCE) also releases the
+	// auxiliary advisory-lock session retained by the migration driver.
 	_, err := d.server.adminDB.ExecContext(
-		ctx, "DROP DATABASE IF EXISTS "+identifier,
+		ctx, "DROP DATABASE IF EXISTS "+identifier+" WITH (FORCE)",
 	)
 	if err != nil {
 		return fmt.Errorf("drop postgres database %q: %w", d.name, err)
@@ -206,6 +209,43 @@ func postgresDatabaseDSN(adminDSN, database string) (string, error) {
 	dsn.RawPath = ""
 
 	return dsn.String(), nil
+}
+
+// validatePostgresSchema verifies that the PostgreSQL data source is reachable
+// and contains the migrated wallet schema.
+func validatePostgresSchema(dsn string) (err error) {
+	dbConn, err := sql.Open("pgx", dsn)
+	if err != nil {
+		return fmt.Errorf("open postgres schema probe: %w", err)
+	}
+
+	defer func() {
+		err = errors.Join(err, dbConn.Close())
+	}()
+
+	ctx, cancel := context.WithTimeout(
+		context.Background(), defaultTestTimeout,
+	)
+	defer cancel()
+
+	var exists bool
+
+	err = dbConn.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.tables
+			WHERE table_schema = 'public' AND table_name = 'wallets'
+		)
+	`).Scan(&exists)
+	if err != nil {
+		return fmt.Errorf("query postgres wallet schema: %w", err)
+	}
+
+	if !exists {
+		return errors.New("postgres wallet schema is missing")
+	}
+
+	return nil
 }
 
 // close releases the administrative connection and immediately terminates

--- a/bwtest/postgres_test.go
+++ b/bwtest/postgres_test.go
@@ -1,0 +1,80 @@
+package bwtest
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPostgresDatabaseNameSafe verifies that arbitrary subtest names become
+// short identifiers containing only a fixed prefix and lowercase hex.
+func TestPostgresDatabaseNameSafe(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "punctuation",
+			input: `TestManager/reopen; DROP DATABASE postgres`,
+		},
+		{
+			name: "long name",
+			input: "TestManager/this name is deliberately much longer " +
+				"than a PostgreSQL identifier",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			name := postgresDatabaseName(test.input)
+
+			require.Regexp(t, `^bwtest_[0-9a-f]{24}$`, name)
+			require.Equal(t, name, postgresDatabaseName(test.input))
+		})
+	}
+}
+
+// TestPostgresDatabaseNameDistinct verifies that different subtests do not
+// select the same isolated database.
+func TestPostgresDatabaseNameDistinct(t *testing.T) {
+	t.Parallel()
+
+	require.NotEqual(
+		t, postgresDatabaseName("TestManager/create"),
+		postgresDatabaseName("TestManager/load"),
+	)
+}
+
+// TestPostgresDatabaseDSNSelectsDatabase verifies that rewriting retains the
+// administrative endpoint and selects only the isolated database.
+func TestPostgresDatabaseDSNSelectsDatabase(t *testing.T) {
+	t.Parallel()
+
+	const adminDSN = "postgres://user:pass@localhost:5432/postgres?" +
+		"sslmode=disable"
+
+	dsn, err := postgresDatabaseDSN(adminDSN, "bwtest_deadbeef")
+	require.NoError(t, err)
+
+	cfg, err := pgx.ParseConfig(dsn)
+	require.NoError(t, err)
+	require.Equal(t, "bwtest_deadbeef", cfg.Database)
+	require.Equal(t, "localhost", cfg.Host)
+	require.Equal(t, uint16(5432), cfg.Port)
+	require.Equal(t, "user", cfg.User)
+}
+
+// TestPostgresDatabaseDSNRejectsInvalid verifies that malformed administrative
+// configuration is reported before a database can be selected.
+func TestPostgresDatabaseDSNRejectsInvalid(t *testing.T) {
+	t.Parallel()
+
+	dsn, err := postgresDatabaseDSN("://invalid", "bwtest_deadbeef")
+	require.ErrorContains(t, err, "parse postgres admin DSN")
+	require.Empty(t, dsn)
+}

--- a/wallet/common_test.go
+++ b/wallet/common_test.go
@@ -131,8 +131,9 @@ func testSQLManager(tb testing.TB, store db.Store) *Manager {
 
 	return &Manager{
 		wallets: make(map[string]*Wallet),
-		backend: &sqliteManagerBackend{
-			store: store,
+		backend: &sqlManagerBackend{
+			store:   store,
+			closeFn: func() error { return nil },
 		},
 		chainParams: &chainParams,
 	}

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -158,6 +158,9 @@ func NewManager(ctx context.Context, cfg ManagerConfig) (*Manager, error) {
 
 	case DBBackendSQLite:
 		backend, err = newSQLiteManagerBackend(ctx, cfg)
+
+	case DBBackendPostgres:
+		backend, err = newPostgresManagerBackend(ctx, cfg)
 	}
 
 	if err != nil {

--- a/wallet/manager_config.go
+++ b/wallet/manager_config.go
@@ -26,6 +26,9 @@ const (
 
 	// DBBackendSQLite selects the SQLite store.
 	DBBackendSQLite DBBackend = "sqlite"
+
+	// DBBackendPostgres selects the PostgreSQL store.
+	DBBackendPostgres DBBackend = "postgres"
 )
 
 // errUnsupportedBackend reports a Backend this build does not serve.
@@ -39,19 +42,19 @@ var errUnsupportedBackend = errors.New("unsupported database backend")
 //
 // The struct is flat on purpose: there are no per-backend sub-structs to
 // populate at once, so it cannot describe a backend it is not set to. Some
-// fields apply to only one backend, which is documented here rather than
+// fields apply to only certain backends, which is documented here rather than
 // prevented by a second validation layer:
 //
-//	field                      kvdb    sqlite
-//	DataSource, ChainParams    both backends
-//	MaxConnections             sqlite only
+//	field                      kvdb    sqlite    postgres
+//	DataSource, ChainParams    all backends
+//	MaxConnections             SQL backends
 //	NoFreelistSync, Timeout    kvdb only
 type ManagerConfig struct {
 	// Backend selects the database implementation. Required.
 	Backend DBBackend
 
 	// DataSource locates the database: a filesystem path for kvdb and
-	// SQLite, and a DSN once a networked backend is added. Required.
+	// SQLite, and a DSN for PostgreSQL. Required.
 	DataSource string
 
 	// MaxConnections bounds the SQL connection pool. Zero uses the store
@@ -80,7 +83,7 @@ type ManagerConfig struct {
 // so a wallet is never opened somewhere the caller did not name.
 func (c ManagerConfig) validate() error {
 	switch c.Backend {
-	case DBBackendKVDB, DBBackendSQLite:
+	case DBBackendKVDB, DBBackendSQLite, DBBackendPostgres:
 
 	case "":
 		return fmt.Errorf("%w: Backend", ErrMissingParam)
@@ -99,7 +102,7 @@ func (c ManagerConfig) validate() error {
 
 	// MaxConnections is a SQL pool bound; kvdb ignores it, so only the SQL
 	// backends validate it.
-	if c.Backend == DBBackendSQLite && c.MaxConnections < 0 {
+	if c.Backend != DBBackendKVDB && c.MaxConnections < 0 {
 		return fmt.Errorf("%w: MaxConnections must not be negative",
 			ErrInvalidParam)
 	}

--- a/wallet/manager_config_test.go
+++ b/wallet/manager_config_test.go
@@ -41,6 +41,14 @@ func TestManagerConfigValidate(t *testing.T) {
 			},
 		},
 		{
+			name: "postgres",
+			cfg: ManagerConfig{
+				Backend:     DBBackendPostgres,
+				DataSource:  "postgres://user:pass@localhost/wallet",
+				ChainParams: &chaincfg.SimNetParams,
+			},
+		},
+		{
 			// kvdb reads these; sqlite ignores them. Neither is an
 			// error, which is what makes the flat shape workable.
 			name: "kvdb knobs on sqlite are ignored",
@@ -91,6 +99,17 @@ func TestManagerConfigValidate(t *testing.T) {
 			cfg: ManagerConfig{
 				Backend:        DBBackendSQLite,
 				DataSource:     testSQLiteDBName,
+				ChainParams:    &chaincfg.SimNetParams,
+				MaxConnections: -1,
+			},
+			wantIs:  ErrInvalidParam,
+			wantMsg: "MaxConnections",
+		},
+		{
+			name: "postgres negative max connections",
+			cfg: ManagerConfig{
+				Backend:        DBBackendPostgres,
+				DataSource:     "postgres://localhost/wallet",
 				ChainParams:    &chaincfg.SimNetParams,
 				MaxConnections: -1,
 			},

--- a/wallet/manager_postgres.go
+++ b/wallet/manager_postgres.go
@@ -1,0 +1,27 @@
+package wallet
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcwallet/wallet/internal/db/pg"
+)
+
+// newPostgresManagerBackend opens the PostgreSQL Store owned by a Manager.
+func newPostgresManagerBackend(ctx context.Context,
+	cfg ManagerConfig) (*sqlManagerBackend, error) {
+
+	store, err := pg.NewStore(ctx, pg.Config{
+		Dsn:            cfg.DataSource,
+		MaxConnections: cfg.MaxConnections,
+		DeriveAddress:  newSQLAddressDeriver(cfg.ChainParams),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("open postgres store: %w", err)
+	}
+
+	return &sqlManagerBackend{
+		store:   store,
+		closeFn: store.Close,
+	}, nil
+}

--- a/wallet/manager_postgres_test.go
+++ b/wallet/manager_postgres_test.go
@@ -1,0 +1,24 @@
+package wallet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestManagerPostgresRejectsInvalidDSN verifies that NewManager passes a
+// PostgreSQL data source to the Store and preserves its validation context.
+func TestManagerPostgresRejectsInvalidDSN(t *testing.T) {
+	t.Parallel()
+
+	m, err := NewManager(t.Context(), ManagerConfig{
+		Backend:     DBBackendPostgres,
+		DataSource:  "://invalid",
+		ChainParams: &chainParams,
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "open postgres store")
+	require.ErrorContains(t, err, "invalid config")
+	require.ErrorContains(t, err, "invalid DSN")
+	require.Nil(t, m)
+}

--- a/wallet/manager_sql.go
+++ b/wallet/manager_sql.go
@@ -3,8 +3,11 @@ package wallet
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
+	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	vault "github.com/btcsuite/btcwallet/wallet/internal/keyvault"
 )
@@ -22,8 +25,7 @@ func (b *sqlManagerBackend) create(ctx context.Context, cfg Config,
 	params CreateWalletParams, rootKey *hdkeychain.ExtendedKey) (
 	*walletData, error) {
 
-	createParams, err := sqliteCreateWalletParams(
-		cfg, params, rootKey,
+	createParams, err := sqlCreateWalletParams(cfg, params, rootKey,
 		birthdayWithSafetyMargin(params.Birthday),
 	)
 	if err != nil {
@@ -75,4 +77,72 @@ func (b *sqlManagerBackend) close() error {
 	}
 
 	return b.closeFn()
+}
+
+// sqlCreateWalletParams converts wallet creation inputs into SQL rows.
+func sqlCreateWalletParams(cfg Config, params CreateWalletParams,
+	rootKey *hdkeychain.ExtendedKey, birthday time.Time) (
+	db.CreateWalletParams, error) {
+
+	createParams := db.CreateWalletParams{
+		Name: cfg.Name,
+		IsImported: params.Mode == ModeImportSeed ||
+			params.Mode == ModeImportExtKey,
+		// LatestMgrVersion is a small constant that fits int32.
+		//nolint:gosec
+		ManagerVersion: int32(waddrmgr.LatestMgrVersion),
+		IsWatchOnly:    params.WatchOnly,
+		Birthday:       birthday,
+	}
+
+	switch {
+	case rootKey == nil:
+		createParams.IsWatchOnly = true
+
+	case rootKey.IsPrivate():
+		masterPubKey, err := rootKey.Neuter()
+		if err != nil {
+			return db.CreateWalletParams{}, fmt.Errorf("derive pubkey: %w", err)
+		}
+
+		createParams.MasterPubKey = []byte(masterPubKey.String())
+
+	default:
+		createParams.IsWatchOnly = true
+		createParams.MasterPubKey = []byte(rootKey.String())
+	}
+
+	secrets, err := vault.CreateWalletSecrets(
+		params.PrivatePassphrase, rootKey, createParams.IsWatchOnly)
+	if err != nil {
+		return db.CreateWalletParams{}, fmt.Errorf(
+			"create wallet secrets: %w", err)
+	}
+
+	createParams.MasterKeyPrivParams = secrets.MasterPrivParams
+	createParams.EncryptedCryptoPrivKey = secrets.EncryptedCryptoPrivKey
+	createParams.EncryptedCryptoScriptKey = secrets.EncryptedCryptoScriptKey
+	createParams.EncryptedMasterPrivKey = secrets.EncryptedMasterHdPrivKey
+
+	return createParams, nil
+}
+
+// birthdayWithSafetyMargin applies the legacy margin to a non-zero birthday.
+func birthdayWithSafetyMargin(birthday time.Time) time.Time {
+	if birthday.IsZero() {
+		return birthday
+	}
+
+	return birthday.Add(-waddrmgr.BirthdaySafetyMargin)
+}
+
+// newSQLAddressDeriver returns an address derivation callback for a network.
+func newSQLAddressDeriver(
+	chainParams *chaincfg.Params) db.AddressDerivationFunc {
+
+	return func(_ context.Context, params db.AddressDerivationParams) (
+		*db.DerivedAddressData, error) {
+
+		return deriveAddressData(chainParams, params)
+	}
 }

--- a/wallet/manager_sql.go
+++ b/wallet/manager_sql.go
@@ -1,0 +1,78 @@
+package wallet
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	vault "github.com/btcsuite/btcwallet/wallet/internal/keyvault"
+)
+
+// sqlManagerBackend owns the SQL Store shared by a Manager's wallets.
+type sqlManagerBackend struct {
+	store   db.Store
+	closeFn func() error
+}
+
+var _ managerBackend = (*sqlManagerBackend)(nil)
+
+// create atomically creates a SQL wallet and returns its committed data.
+func (b *sqlManagerBackend) create(ctx context.Context, cfg Config,
+	params CreateWalletParams, rootKey *hdkeychain.ExtendedKey) (
+	*walletData, error) {
+
+	createParams, err := sqliteCreateWalletParams(
+		cfg, params, rootKey,
+		birthdayWithSafetyMargin(params.Birthday),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := b.store.CreateWallet(ctx, createParams)
+	if err != nil {
+		return nil, fmt.Errorf("create runtime wallet: %w", err)
+	}
+
+	return b.walletData(info)
+}
+
+// load reads an existing SQL wallet and resolves its runtime dependencies.
+func (b *sqlManagerBackend) load(ctx context.Context,
+	cfg Config) (*walletData, error) {
+
+	info, err := b.store.GetWallet(ctx, cfg.Name)
+	if err != nil {
+		return nil, fmt.Errorf("get runtime wallet: %w", err)
+	}
+
+	return b.walletData(info)
+}
+
+// walletData resolves the runtime dependencies for one committed wallet row.
+func (b *sqlManagerBackend) walletData(
+	w *db.WalletInfo) (*walletData, error) {
+
+	fingerprint, err := masterFingerprint(w)
+	if err != nil {
+		return nil, fmt.Errorf("cache master fingerprint: %w", err)
+	}
+
+	return &walletData{
+		id:                w.ID,
+		store:             b.store,
+		vault:             vault.NewWalletVault(b.store, w.ID, w.IsWatchOnly),
+		masterFingerprint: fingerprint,
+		isWatchOnly:       w.IsWatchOnly,
+	}, nil
+}
+
+// close releases the SQL Store when this backend owns it.
+func (b *sqlManagerBackend) close() error {
+	if b.closeFn == nil {
+		return nil
+	}
+
+	return b.closeFn()
+}

--- a/wallet/manager_sqlite.go
+++ b/wallet/manager_sqlite.go
@@ -5,14 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 
-	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
-	"github.com/btcsuite/btcd/chaincfg/v2"
-	"github.com/btcsuite/btcwallet/waddrmgr"
-	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wallet/internal/db/sqlite"
-	"github.com/btcsuite/btcwallet/wallet/internal/keyvault"
 )
 
 // newSQLiteManagerBackend opens the SQLite Store owned by a Manager.
@@ -27,7 +21,7 @@ func newSQLiteManagerBackend(ctx context.Context,
 	store, err := sqlite.NewStore(ctx, sqlite.Config{
 		DBPath:         cfg.DataSource,
 		MaxConnections: cfg.MaxConnections,
-		DeriveAddress:  newSQLiteAddressDeriver(cfg.ChainParams),
+		DeriveAddress:  newSQLAddressDeriver(cfg.ChainParams),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite store: %w", err)
@@ -37,79 +31,4 @@ func newSQLiteManagerBackend(ctx context.Context,
 		store:   store,
 		closeFn: store.Close,
 	}, nil
-}
-
-// sqliteCreateWalletParams converts wallet creation inputs into the SQL
-// wallet metadata and secret rows.
-func sqliteCreateWalletParams(cfg Config, params CreateWalletParams,
-	rootKey *hdkeychain.ExtendedKey, birthday time.Time) (
-	db.CreateWalletParams, error) {
-
-	createParams := db.CreateWalletParams{
-		Name: cfg.Name,
-		IsImported: params.Mode == ModeImportSeed ||
-			params.Mode == ModeImportExtKey,
-		// LatestMgrVersion is a small constant that fits int32.
-		//nolint:gosec
-		ManagerVersion: int32(waddrmgr.LatestMgrVersion),
-		IsWatchOnly:    params.WatchOnly,
-		Birthday:       birthday,
-	}
-
-	switch {
-	case rootKey == nil:
-		createParams.IsWatchOnly = true
-
-	case rootKey.IsPrivate():
-		masterPubKey, err := rootKey.Neuter()
-		if err != nil {
-			return db.CreateWalletParams{}, fmt.Errorf(
-				"derive master HD pubkey: %w", err,
-			)
-		}
-
-		createParams.MasterPubKey = []byte(masterPubKey.String())
-
-	default:
-		createParams.IsWatchOnly = true
-		createParams.MasterPubKey = []byte(rootKey.String())
-	}
-
-	secrets, err := keyvault.CreateWalletSecrets(
-		params.PrivatePassphrase, rootKey, createParams.IsWatchOnly,
-	)
-	if err != nil {
-		return db.CreateWalletParams{}, fmt.Errorf(
-			"create wallet secrets: %w", err,
-		)
-	}
-
-	createParams.MasterKeyPrivParams = secrets.MasterPrivParams
-	createParams.EncryptedCryptoPrivKey = secrets.EncryptedCryptoPrivKey
-	createParams.EncryptedCryptoScriptKey = secrets.EncryptedCryptoScriptKey
-	createParams.EncryptedMasterPrivKey = secrets.EncryptedMasterHdPrivKey
-
-	return createParams, nil
-}
-
-// birthdayWithSafetyMargin applies the legacy birthday safety margin to a
-// non-zero birthday.
-func birthdayWithSafetyMargin(birthday time.Time) time.Time {
-	if birthday.IsZero() {
-		return birthday
-	}
-
-	return birthday.Add(-waddrmgr.BirthdaySafetyMargin)
-}
-
-// newSQLiteAddressDeriver returns the SQLite address derivation callback for
-// the configured network.
-func newSQLiteAddressDeriver(
-	chainParams *chaincfg.Params) db.AddressDerivationFunc {
-
-	return func(_ context.Context, params db.AddressDerivationParams) (
-		*db.DerivedAddressData, error) {
-
-		return deriveAddressData(chainParams, params)
-	}
 }

--- a/wallet/manager_sqlite.go
+++ b/wallet/manager_sqlite.go
@@ -15,18 +15,9 @@ import (
 	"github.com/btcsuite/btcwallet/wallet/internal/keyvault"
 )
 
-// sqliteManagerBackend owns the SQLite Store shared by a Manager's wallets.
-type sqliteManagerBackend struct {
-	store   db.Store
-	closeFn func() error
-}
-
-// Compile-time assertion that sqliteManagerBackend implements managerBackend.
-var _ managerBackend = (*sqliteManagerBackend)(nil)
-
 // newSQLiteManagerBackend opens the SQLite Store owned by a Manager.
 func newSQLiteManagerBackend(ctx context.Context,
-	cfg ManagerConfig) (*sqliteManagerBackend, error) {
+	cfg ManagerConfig) (*sqlManagerBackend, error) {
 
 	err := os.MkdirAll(filepath.Dir(cfg.DataSource), defaultWalletDBDirPerm)
 	if err != nil {
@@ -42,78 +33,10 @@ func newSQLiteManagerBackend(ctx context.Context,
 		return nil, fmt.Errorf("open sqlite store: %w", err)
 	}
 
-	return &sqliteManagerBackend{
+	return &sqlManagerBackend{
 		store:   store,
 		closeFn: store.Close,
 	}, nil
-}
-
-// create atomically creates a SQLite wallet and returns its committed data.
-func (b *sqliteManagerBackend) create(ctx context.Context, cfg Config,
-	params CreateWalletParams, rootKey *hdkeychain.ExtendedKey) (
-	*walletData, error) {
-
-	createParams, err := sqliteCreateWalletParams(
-		cfg, params, rootKey,
-		birthdayWithSafetyMargin(params.Birthday),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	info, err := b.store.CreateWallet(ctx, createParams)
-	if err != nil {
-		return nil, fmt.Errorf("create runtime wallet: %w", err)
-	}
-
-	fingerprint, err := masterFingerprint(info)
-	if err != nil {
-		return nil, fmt.Errorf("cache master fingerprint: %w", err)
-	}
-
-	return &walletData{
-		id:    info.ID,
-		store: b.store,
-		vault: keyvault.NewWalletVault(
-			b.store, info.ID, info.IsWatchOnly,
-		),
-		masterFingerprint: fingerprint,
-		isWatchOnly:       info.IsWatchOnly,
-	}, nil
-}
-
-// load reads an existing SQLite wallet and resolves its runtime dependencies.
-func (b *sqliteManagerBackend) load(ctx context.Context,
-	cfg Config) (*walletData, error) {
-
-	info, err := b.store.GetWallet(ctx, cfg.Name)
-	if err != nil {
-		return nil, fmt.Errorf("get runtime wallet: %w", err)
-	}
-
-	fingerprint, err := masterFingerprint(info)
-	if err != nil {
-		return nil, fmt.Errorf("cache master fingerprint: %w", err)
-	}
-
-	return &walletData{
-		id:    info.ID,
-		store: b.store,
-		vault: keyvault.NewWalletVault(
-			b.store, info.ID, info.IsWatchOnly,
-		),
-		masterFingerprint: fingerprint,
-		isWatchOnly:       info.IsWatchOnly,
-	}, nil
-}
-
-// close releases the SQLite Store when this backend owns it.
-func (b *sqliteManagerBackend) close() error {
-	if b.closeFn == nil {
-		return nil
-	}
-
-	return b.closeFn()
 }
 
 // sqliteCreateWalletParams converts wallet creation inputs into the SQL

--- a/wallet/manager_sqlite_test.go
+++ b/wallet/manager_sqlite_test.go
@@ -106,7 +106,7 @@ func TestSQLiteCreateWalletParamsCreatesSpendableSecrets(t *testing.T) {
 	rootKey, err := hdkeychain.NewMaster(params.Seed, &chainParams)
 	require.NoError(t, err)
 
-	got, err := sqliteCreateWalletParams(
+	got, err := sqlCreateWalletParams(
 		cfg, params, rootKey, birthdayWithSafetyMargin(params.Birthday),
 	)
 	require.NoError(t, err)
@@ -190,7 +190,7 @@ func TestSQLiteCreateWalletParamsBirthdayVerbatim(t *testing.T) {
 
 			// Act: build the SQL runtime create params with the
 			// already-resolved birthday.
-			got, err := sqliteCreateWalletParams(
+			got, err := sqlCreateWalletParams(
 				cfg, params, rootKey, tc.birthday,
 			)
 			require.NoError(t, err)


### PR DESCRIPTION
## Change Description

Draft stacked on #1300 (`itests/very-first-itests`).

This change adds PostgreSQL as a first-class `wallet.Manager` backend while
sharing the existing SQL create/load implementation with SQLite. The test
harness starts one PostgreSQL 18 server for the suite, provisions an isolated
database for each subtest, validates the migrated schema, and closes wallets
and Managers before dropping databases and terminating the container.

The four Manager and three Controller integration cases introduced by #1300
run unchanged with `db=postgres`; this PR does not modify `itest/*` or expand
the default CI matrix.

## Steps to Test

```bash
make fmt
/opt/homebrew/bin/go test ./wallet ./bwtest
make itest chain=btcd db=kvdb
make itest chain=btcd db=sqlite
make itest chain=btcd db=postgres
make lint-check
```

## Pull Request Checklist

### Testing

- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation

- [x] The change is not [insubstantial](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#ideal-git-commit-structure).
- [x] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md) for further guidance.
