### PR TITLE
multi: match nested CI base branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
       - "master"
   pull_request:
     branches:
-      - "*"
+      - "**"
 concurrency:
   # Cancel any previous workflows if they are from a PR or push.
   group: ${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary

- run pull request CI for base branch names containing slashes

## Change Description

GitHub Actions treats the single-star branch glob as matching only branch
names without slashes. Use the recursive glob so stacked pull requests
targeting branches such as itests/very-first-itests trigger CI.