### PR TITLE
wallet: define watch-only and script policy

### DIFF
--- a/itest/controller_test.go
+++ b/itest/controller_test.go
@@ -12,8 +12,6 @@ import (
 // stops cleanly, Stop is idempotent, a stopped instance restarts cleanly, and
 // a fresh Load yields a working instance.
 func testControllerStartStop(h *bwtest.HarnessTest) {
-	h.Helper()
-
 	cfg, params := h.TestWalletConfig()
 
 	manager := h.NewWalletManager()
@@ -51,8 +49,6 @@ func testControllerStartStop(h *bwtest.HarnessTest) {
 // they are forbidden before Start, a failed unlock leaves the wallet locked,
 // and Lock is idempotent after an explicit lock.
 func testControllerUnlockLock(h *bwtest.HarnessTest) {
-	h.Helper()
-
 	const wrongPassphrase = "wrong-private-passphrase"
 
 	cfg, params := h.TestWalletConfig()
@@ -125,8 +121,6 @@ func testControllerUnlockLock(h *bwtest.HarnessTest) {
 // reports the configured backend and chain params, and tracks synchronization
 // as a block is mined.
 func testControllerInfo(h *bwtest.HarnessTest) {
-	h.Helper()
-
 	cfg, params := h.TestWalletConfig()
 
 	manager := h.NewWalletManager()

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -32,6 +32,14 @@ var allTestCases = []*testCase{
 		TestFunc: testManagerLoadMissing,
 	},
 	{
+		Name:     "manager create watchonly",
+		TestFunc: testManagerCreateWatchOnly,
+	},
+	{
+		Name:     "manager reject invalid watchonly params",
+		TestFunc: testManagerRejectInvalidWatchOnlyParams,
+	},
+	{
 		Name:     "controller start stop",
 		TestFunc: testControllerStartStop,
 	},

--- a/itest/manager_test.go
+++ b/itest/manager_test.go
@@ -15,8 +15,6 @@ import (
 
 // testCreateWallet verifies a wallet can be created, started, and synced.
 func testCreateWallet(h *bwtest.HarnessTest) {
-	h.Helper()
-
 	// This is a manager-focused test, so drive the Manager API directly
 	// rather than the harness's CreateEmptyWallet convenience helper.
 	cfg, params := h.TestWalletConfig()
@@ -45,8 +43,6 @@ func testCreateWallet(h *bwtest.HarnessTest) {
 // testManagerCreateDuplicate verifies that both a live wallet cache entry and
 // a completed wallet in the durable store reject a duplicate creation.
 func testManagerCreateDuplicate(h *bwtest.HarnessTest) {
-	h.Helper()
-
 	cfg, params := h.TestWalletConfig()
 
 	manager := h.NewWalletManager()
@@ -80,8 +76,6 @@ func testManagerCreateDuplicate(h *bwtest.HarnessTest) {
 // testManagerLoadReload verifies Manager cache identity, durable reload, and
 // birthday metadata while preserving lifecycle ownership.
 func testManagerLoadReload(h *bwtest.HarnessTest) {
-	h.Helper()
-
 	cfg, params := h.TestWalletConfig()
 
 	// Keep the effective birthday five days ahead of the chain after the
@@ -153,8 +147,6 @@ func testManagerLoadReload(h *bwtest.HarnessTest) {
 // testManagerLoadMissing verifies that loading a wallet that was never created
 // fails rather than silently returning an empty wallet.
 func testManagerLoadMissing(h *bwtest.HarnessTest) {
-	h.Helper()
-
 	cfg, _ := h.TestWalletConfig()
 
 	manager := h.NewWalletManager()

--- a/itest/manager_test.go
+++ b/itest/manager_test.go
@@ -3,10 +3,13 @@
 package itest
 
 import (
+	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
 	"github.com/btcsuite/btcwallet/bwtest"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet"
 	"github.com/stretchr/testify/require"
 )
 
@@ -157,4 +160,154 @@ func testManagerLoadMissing(h *bwtest.HarnessTest) {
 	manager := h.NewWalletManager()
 	_, err := manager.Load(cfg)
 	require.Error(h, err, "load of never-created wallet should fail")
+}
+
+// testManagerCreateWatchOnly verifies that a watch-only wallet is created,
+// starts, syncs like a spendable wallet, and stays watch-only across a reload
+// from the durable store.
+//
+// The wallet is rootless: that is the one watch-only shape every backend can
+// represent, and its keyspace arrives later as account-level xpub imports. An
+// XPub root is a SQL-only variant, covered by the Manager unit tests.
+func testManagerCreateWatchOnly(h *bwtest.HarnessTest) {
+	cfg, params := h.TestWalletConfig()
+	params.Mode = wallet.ModeShell
+	params.WatchOnly = true
+
+	manager := h.NewWalletManager()
+	w, err := manager.Create(cfg, params)
+	require.NoError(h, err, "failed to create watch-only wallet")
+	h.RegisterWallet(w)
+
+	require.NoError(h, w.Start(h.Context()), "failed to start wallet")
+	h.AssertWalletSynced(w)
+
+	require.True(h, w.IsWatchOnly(), "created wallet is not watch-only")
+
+	// A watch-only wallet tracks the chain like any other wallet.
+	h.MineBlocks(1)
+
+	// Keep both resources registered until shutdown succeeds, then reload from
+	// the durable store with a fresh Manager.
+	require.NoError(h, w.Stop(h.Context()), "failed to stop wallet")
+	require.True(h, h.DeregisterWallet(w), "failed to deregister wallet")
+	require.NoError(h, manager.Close(), "failed to close wallet manager")
+	require.True(h, h.ReleaseManager(manager), "failed to release manager")
+
+	manager = h.NewWalletManager()
+	reloaded, err := manager.Load(cfg)
+	require.NoError(h, err, "failed to reload watch-only wallet")
+	h.RegisterWallet(reloaded)
+
+	require.NoError(
+		h, reloaded.Start(h.Context()), "failed to start reloaded wallet",
+	)
+	require.True(
+		h, reloaded.IsWatchOnly(),
+		"reloaded wallet lost its watch-only state",
+	)
+}
+
+// testManagerRejectInvalidWatchOnlyParams verifies that invalid create
+// parameters are rejected before a wallet can be created.
+func testManagerRejectInvalidWatchOnlyParams(h *bwtest.HarnessTest) {
+	// The entries are never imported: every request below is rejected on its
+	// parameters alone, so a named placeholder account is enough.
+	initialAccounts := []wallet.WatchOnlyAccount{{Name: "watchonly"}}
+
+	neuteredRootKey := rootPubKey(h)
+	privateRootKey := masterKey(h)
+
+	manager := h.NewWalletManager()
+
+	testCases := []struct {
+		name   string
+		update func(*wallet.CreateWalletParams)
+	}{
+		{
+			name: "xpub spendable",
+			update: func(params *wallet.CreateWalletParams) {
+				params.Mode = wallet.ModeImportExtKey
+				params.RootKey = neuteredRootKey
+				params.WatchOnly = false
+			},
+		},
+		{
+			name: "initial accounts spendable",
+			update: func(params *wallet.CreateWalletParams) {
+				params.Mode = wallet.ModeShell
+				params.WatchOnly = false
+				params.InitialAccounts = initialAccounts
+			},
+		},
+		{
+			name: "initial accounts outside shell mode",
+			update: func(params *wallet.CreateWalletParams) {
+				params.WatchOnly = true
+				params.InitialAccounts = initialAccounts
+			},
+		},
+		{
+			name: "rootless spendable",
+			update: func(params *wallet.CreateWalletParams) {
+				params.Mode = wallet.ModeShell
+				params.WatchOnly = false
+			},
+		},
+		{
+			name: "seed watch-only",
+			update: func(params *wallet.CreateWalletParams) {
+				params.WatchOnly = true
+			},
+		},
+		{
+			name: "private root watch-only",
+			update: func(params *wallet.CreateWalletParams) {
+				params.Mode = wallet.ModeImportExtKey
+				params.RootKey = privateRootKey
+				params.WatchOnly = true
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		h.Run(tc.name, func(t *testing.T) {
+			cfg, params := h.TestWalletConfig()
+			tc.update(&params)
+
+			w, err := manager.Create(cfg, params)
+			require.ErrorIs(
+				t, err, wallet.ErrWalletParams,
+				"rejected create returned a different error",
+			)
+			require.Nil(t, w, "rejected create returned a wallet")
+		})
+	}
+}
+
+// rootPubKey returns a neutered master extended key for the harness network.
+func rootPubKey(h *bwtest.HarnessTest) *hdkeychain.ExtendedKey {
+	h.Helper()
+
+	rootPub, err := masterKey(h).Neuter()
+	require.NoError(h, err, "failed to neuter the master key")
+
+	return rootPub
+}
+
+// masterKey derives the master extended private key for the harness network
+// from a fixed seed. Every wallet keyed by it is rejected before creation, so
+// nothing persists it and a failure reproduces with the same key material.
+func masterKey(h *bwtest.HarnessTest) *hdkeychain.ExtendedKey {
+	h.Helper()
+
+	seed := make([]byte, hdkeychain.RecommendedSeedLen)
+	for i := range seed {
+		seed[i] = byte(i + 1)
+	}
+
+	root, err := hdkeychain.NewMaster(seed, h.NetParams())
+	require.NoError(h, err, "failed to derive the master key")
+
+	return root
 }

--- a/itest/manager_test.go
+++ b/itest/manager_test.go
@@ -159,8 +159,7 @@ func testManagerLoadMissing(h *bwtest.HarnessTest) {
 // from the durable store.
 //
 // The wallet is rootless: that is the one watch-only shape every backend can
-// represent, and its keyspace arrives later as account-level xpub imports. An
-// XPub root is a SQL-only variant, covered by the Manager unit tests.
+// represent, and its keyspace arrives later as account-level xpub imports.
 func testManagerCreateWatchOnly(h *bwtest.HarnessTest) {
 	cfg, params := h.TestWalletConfig()
 	params.Mode = wallet.ModeShell

--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -147,7 +147,10 @@ type AccountManager interface {
 	// Private extended keys are rejected. The key scope is derived from
 	// the version bytes of the extended key. The account name must be
 	// unique within the derived scope. If dryRun is true, the import is
-	// validated but not persisted.
+	// validated but not persisted. SQL wallets accept this XPub-only
+	// material only when the wallet is watch-only under ADR 0012. The
+	// legacy kvdb backend retains its grandfathered mixed-mode import
+	// behavior until migration; neither path imports signing material.
 	ImportAccount(ctx context.Context, name string,
 		accountKey *hdkeychain.ExtendedKey,
 		masterKeyFingerprint uint32, addrType waddrmgr.AddressType,
@@ -407,6 +410,11 @@ func (w *Wallet) RenameAccount(ctx context.Context,
 // extended keys are rejected. The key scope is derived from the version
 // bytes of the extended key. The account name must be unique within the
 // derived scope.
+//
+// SQL wallets accept this XPub-only material only when the wallet is
+// watch-only under ADR 0012. The legacy kvdb backend retains its grandfathered
+// mixed-mode import behavior until migration; neither path imports signing
+// material.
 //
 // dryRun=true validates the import through the store and rolls the transaction
 // back; no account row is persisted.

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -35,12 +35,7 @@ type stubAccountDeriveFn struct {
 func newStubAccountDeriveFn(t *testing.T) stubAccountDeriveFn {
 	t.Helper()
 
-	seed := make([]byte, hdkeychain.RecommendedSeedLen)
-	for i := range seed {
-		seed[i] = byte(i + 1)
-	}
-
-	masterKey, err := hdkeychain.NewMaster(seed, &chainParams)
+	masterKey, err := hdkeychain.NewMaster(fixedTestSeed(), &chainParams)
 	require.NoError(t, err)
 
 	fingerprint, err := masterKeyFingerprint(masterKey)

--- a/wallet/address_manager.go
+++ b/wallet/address_manager.go
@@ -194,12 +194,18 @@ type AddressManager interface {
 	ListAddresses(ctx context.Context, accountName string,
 		addrType waddrmgr.AddressType) ([]AddressProperty, error)
 
-	// ImportPublicKey imports a single public key as a watch-only address.
+	// ImportPublicKey imports a single public key without private signing
+	// material. SQL wallets accept the import only when the wallet is
+	// watch-only under ADR 0012. The legacy kvdb backend retains its
+	// grandfathered mixed-mode behavior until migration.
 	ImportPublicKey(ctx context.Context, pubKey *btcec.PublicKey,
 		addrType waddrmgr.AddressType) error
 
-	// ImportTaprootScript imports a taproot script for tracking and
-	// spending.
+	// ImportTaprootScript imports a taproot script for tracking. Script
+	// presence describes a spending condition, not private signing authority.
+	// SQL wallets accept the script-only import only when the wallet is
+	// watch-only under ADR 0012. The legacy kvdb backend retains its
+	// grandfathered mixed-mode behavior until migration.
 	ImportTaprootScript(ctx context.Context,
 		tapscript waddrmgr.Tapscript) (AddressInfo, error)
 
@@ -804,7 +810,10 @@ func listAddressesQuery(walletID uint32, req page.Request[uint32],
 	return query, addresstype.StoreType{}, nil
 }
 
-// ImportPublicKey imports a single public key as a watch-only address.
+// ImportPublicKey imports a single public key without private signing material.
+// SQL wallets accept the import only when the wallet is watch-only under ADR
+// 0012. The legacy kvdb backend retains its grandfathered mixed-mode behavior
+// until migration.
 func (w *Wallet) ImportPublicKey(ctx context.Context, pubKey *btcec.PublicKey,
 	addrType waddrmgr.AddressType) error {
 
@@ -847,7 +856,11 @@ func (w *Wallet) ImportPublicKey(ctx context.Context, pubKey *btcec.PublicKey,
 	return w.cfg.Chain.NotifyReceived([]address.Address{addr})
 }
 
-// ImportTaprootScript imports a taproot script for tracking and spending.
+// ImportTaprootScript imports a taproot script for tracking. Script presence
+// describes a spending condition, not private signing authority. SQL wallets
+// accept the script-only import only when the wallet is watch-only under ADR
+// 0012. The legacy kvdb backend retains its grandfathered mixed-mode behavior
+// until migration.
 func (w *Wallet) ImportTaprootScript(ctx context.Context,
 	tapscript waddrmgr.Tapscript) (AddressInfo, error) {
 

--- a/wallet/common_test.go
+++ b/wallet/common_test.go
@@ -24,8 +24,14 @@ import (
 // testWalletName is the wallet name shared by Store-backed wallet tests.
 const testWalletName = "test-wallet"
 
+// fixedTestSeedFingerprint is the BIP32 master-key fingerprint of the root
+// derived from fixedTestSeed over chainParams. Zero is a legal fingerprint, so
+// tests assert this exact value rather than merely a non-zero one.
+const fixedTestSeedFingerprint uint32 = 0x5bf9f809
+
 // fixedTestSeed returns a deterministic HD seed, so tests that assert on
-// derived key material can pin exact expected values.
+// derived key material can pin exact expected values such as
+// fixedTestSeedFingerprint.
 func fixedTestSeed() []byte {
 	seed := make([]byte, hdkeychain.RecommendedSeedLen)
 	for i := range seed {

--- a/wallet/common_test.go
+++ b/wallet/common_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	bwmock "github.com/btcsuite/btcwallet/bwtest/mock"
 	"github.com/btcsuite/btcwallet/waddrmgr"
@@ -22,6 +23,17 @@ import (
 
 // testWalletName is the wallet name shared by Store-backed wallet tests.
 const testWalletName = "test-wallet"
+
+// fixedTestSeed returns a deterministic HD seed, so tests that assert on
+// derived key material can pin exact expected values.
+func fixedTestSeed() []byte {
+	seed := make([]byte, hdkeychain.RecommendedSeedLen)
+	for i := range seed {
+		seed[i] = byte(i + 1)
+	}
+
+	return seed
+}
 
 var (
 	errDBMock         = errors.New("db error")

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -34,12 +34,12 @@ const (
 	// (CreateWalletParams.Seed).
 	ModeImportSeed
 
-	// ModeImportExtKey indicates creating a wallet from an extended key
-	// (CreateWalletParams.RootKey).
+	// ModeImportExtKey indicates creating a spendable wallet from an extended
+	// private root key (CreateWalletParams.RootKey).
 	ModeImportExtKey
 
-	// ModeShell indicates creating an empty wallet shell (no root key).
-	// Intended for importing specific Account XPubs.
+	// ModeShell indicates creating a watch-only wallet shell without a root
+	// key. Its optional initial accounts contain account XPubs.
 	ModeShell
 )
 
@@ -71,10 +71,8 @@ type CreateWalletParams struct {
 	// Seed is required for ModeImportSeed. Ignored for others.
 	Seed []byte
 
-	// RootKey is required for ModeImportExtKey and must be nil for every
-	// other mode, which reject a key they would not use. It must agree with
-	// WatchOnly: an XPrv for a spendable wallet, an XPub for a watch-only
-	// one.
+	// RootKey is the required ModeImportExtKey XPrv. XPub-root creation is
+	// unsupported; use a ModeShell wallet and import account XPubs.
 	RootKey *hdkeychain.ExtendedKey
 
 	// InitialAccounts is optional and names watch-only accounts to import
@@ -82,11 +80,7 @@ type CreateWalletParams struct {
 	// honored for ModeShell.
 	InitialAccounts []WatchOnlyAccount
 
-	// WatchOnly requests a watch-only wallet, and is the sole authority on
-	// whether the created wallet is watch-only. The root key must agree with
-	// it: a watch-only wallet takes an XPub root (ModeImportExtKey) or no
-	// root at all (ModeShell), while a spendable wallet requires a private
-	// root key.
+	// WatchOnly requests a watch-only wallet and is valid only for ModeShell.
 	WatchOnly bool
 
 	// Birthday is the wallet's birthday.
@@ -101,22 +95,6 @@ type CreateWalletParams struct {
 
 	// PrivatePassphrase is the private passphrase for the wallet.
 	PrivatePassphrase []byte
-}
-
-// validateInitialAccountsMode enforces the ADR 0012 wallet-level watch-only
-// invariant against the params before any on-disk artifact is created. A
-// non-watch-only wallet cannot ship with watch-only InitialAccounts; the
-// import would later be rejected by requireAccountPrivKeyOnSpendable but
-// only after the wallet row had already been written. The check fires
-// once at create time so the failure is atomic.
-func validateInitialAccountsMode(params CreateWalletParams) error {
-	if params.WatchOnly || len(params.InitialAccounts) == 0 {
-		return nil
-	}
-
-	return fmt.Errorf("%w: cannot create a non-watch-only wallet with "+
-		"InitialAccounts; xpub-only imports require WatchOnly=true",
-		ErrWalletParams)
 }
 
 // Manager is a high-level manager that handles the lifecycle of multiple
@@ -226,16 +204,6 @@ func (m *Manager) Create(cfg Config,
 		return nil, err
 	}
 
-	// Per ADR 0012 a wallet is uniformly watch-only or uniformly
-	// spendable. Validate the params.InitialAccounts list upfront so a
-	// mismatched-mode create fails before any backend create runs
-	// (otherwise the wallet row exists on disk while importInitialAccounts
-	// later rejects an entry, leaving a half-created wallet).
-	err = validateInitialAccountsMode(params)
-	if err != nil {
-		return nil, err
-	}
-
 	rootKey, err := m.prepareWalletCreation(cfg, params)
 	if err != nil {
 		return nil, err
@@ -294,27 +262,17 @@ func (w *Wallet) importInitialAccounts(ctx context.Context,
 //
 //nolint:cyclop
 func (p *CreateWalletParams) validate() error {
-	if p.Mode == ModeUnknown {
-		return fmt.Errorf("%w: unknown mode", ErrWalletParams)
-	}
-
-	// InitialAccounts should only be set for ModeShell.
 	if p.Mode != ModeShell && len(p.InitialAccounts) > 0 {
 		return fmt.Errorf("%w: initial accounts should only be set "+
 			"for ModeShell", ErrWalletParams)
 	}
 
-	// A seed is private material: both seed modes produce a private root
-	// key that a watch-only wallet cannot hold. Reject the contradiction
-	// here, before the key is generated or derived, so no signing material
-	// is ever created only to be thrown away.
-	if p.WatchOnly && (p.Mode == ModeGenSeed || p.Mode == ModeImportSeed) {
-		return fmt.Errorf("%w: a seed derives a private root key, which "+
-			"a watch-only wallet cannot hold; use ModeImportExtKey "+
-			"with an XPub or ModeShell", ErrWalletParams)
-	}
+	switch p.Mode {
+	case ModeGenSeed:
+		if p.WatchOnly {
+			return fmt.Errorf("%w: ModeGenSeed is spendable", ErrWalletParams)
+		}
 
-	if p.Mode == ModeGenSeed {
 		if len(p.Seed) != 0 {
 			return fmt.Errorf("%w: seed should not be set for "+
 				"ModeGenSeed", ErrWalletParams)
@@ -324,9 +282,13 @@ func (p *CreateWalletParams) validate() error {
 			return fmt.Errorf("%w: root key should not be set for "+
 				"ModeGenSeed", ErrWalletParams)
 		}
-	}
 
-	if p.Mode == ModeImportSeed {
+	case ModeImportSeed:
+		if p.WatchOnly {
+			return fmt.Errorf("%w: ModeImportSeed must be spendable",
+				ErrWalletParams)
+		}
+
 		if len(p.Seed) == 0 {
 			return fmt.Errorf("%w: seed is required for "+
 				"ModeImportSeed", ErrWalletParams)
@@ -336,9 +298,8 @@ func (p *CreateWalletParams) validate() error {
 			return fmt.Errorf("%w: root key should not be set for "+
 				"ModeImportSeed", ErrWalletParams)
 		}
-	}
 
-	if p.Mode == ModeImportExtKey {
+	case ModeImportExtKey:
 		if p.RootKey == nil {
 			return fmt.Errorf("%w: root key is required for "+
 				"ModeImportExtKey", ErrWalletParams)
@@ -348,9 +309,23 @@ func (p *CreateWalletParams) validate() error {
 			return fmt.Errorf("%w: seed should not be set for "+
 				"ModeImportExtKey", ErrWalletParams)
 		}
-	}
 
-	if p.Mode == ModeShell {
+		if !p.RootKey.IsPrivate() {
+			return fmt.Errorf("%w: XPub-root wallet creation is "+
+				"unsupported; use ModeShell", ErrWalletParams)
+		}
+
+		if p.WatchOnly {
+			return fmt.Errorf("%w: ModeImportExtKey must be spendable",
+				ErrWalletParams)
+		}
+
+	case ModeShell:
+		if !p.WatchOnly {
+			return fmt.Errorf("%w: ModeShell must be watch-only",
+				ErrWalletParams)
+		}
+
 		if len(p.Seed) != 0 {
 			return fmt.Errorf("%w: seed should not be set for "+
 				"ModeShell", ErrWalletParams)
@@ -359,6 +334,28 @@ func (p *CreateWalletParams) validate() error {
 		if p.RootKey != nil {
 			return fmt.Errorf("%w: root key should not be set for "+
 				"ModeShell", ErrWalletParams)
+		}
+
+		return validateInitialAccountKeys(p.InitialAccounts)
+
+	case ModeUnknown:
+		fallthrough
+
+	default:
+		return fmt.Errorf("%w: unknown mode %v", ErrWalletParams, p.Mode)
+	}
+
+	return nil
+}
+
+// validateInitialAccountKeys requires public keys for shell account imports.
+func validateInitialAccountKeys(accounts []WatchOnlyAccount) error {
+	for i, account := range accounts {
+		switch {
+		case account.XPub == nil:
+			return fmt.Errorf("%w: account %d needs XPub", ErrWalletParams, i)
+		case account.XPub.IsPrivate():
+			return fmt.Errorf("%w: account %d needs XPub", ErrWalletParams, i)
 		}
 	}
 

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -71,8 +71,10 @@ type CreateWalletParams struct {
 	// Seed is required for ModeImportSeed. Ignored for others.
 	Seed []byte
 
-	// RootKey is required for ModeImportExtKey. Ignored for others. Can be XPrv
-	// or XPub.
+	// RootKey is required for ModeImportExtKey and must be nil for every
+	// other mode, which reject a key they would not use. It must agree with
+	// WatchOnly: an XPrv for a spendable wallet, an XPub for a watch-only
+	// one.
 	RootKey *hdkeychain.ExtendedKey
 
 	// InitialAccounts is optional and names watch-only accounts to import
@@ -80,8 +82,11 @@ type CreateWalletParams struct {
 	// honored for ModeShell.
 	InitialAccounts []WatchOnlyAccount
 
-	// WatchOnly requests a watch-only wallet. It is honored for an XPub root
-	// (ModeImportExtKey) and a rootless shell (ModeShell).
+	// WatchOnly requests a watch-only wallet, and is the sole authority on
+	// whether the created wallet is watch-only. The root key must agree with
+	// it: a watch-only wallet takes an XPub root (ModeImportExtKey) or no
+	// root at all (ModeShell), while a spendable wallet requires a private
+	// root key.
 	WatchOnly bool
 
 	// Birthday is the wallet's birthday.
@@ -221,17 +226,17 @@ func (m *Manager) Create(cfg Config,
 		return nil, err
 	}
 
-	rootKey, err := m.prepareWalletCreation(cfg, params)
-	if err != nil {
-		return nil, err
-	}
-
 	// Per ADR 0012 a wallet is uniformly watch-only or uniformly
 	// spendable. Validate the params.InitialAccounts list upfront so a
 	// mismatched-mode create fails before any backend create runs
 	// (otherwise the wallet row exists on disk while importInitialAccounts
 	// later rejects an entry, leaving a half-created wallet).
 	err = validateInitialAccountsMode(params)
+	if err != nil {
+		return nil, err
+	}
+
+	rootKey, err := m.prepareWalletCreation(cfg, params)
 	if err != nil {
 		return nil, err
 	}
@@ -297,6 +302,16 @@ func (p *CreateWalletParams) validate() error {
 	if p.Mode != ModeShell && len(p.InitialAccounts) > 0 {
 		return fmt.Errorf("%w: initial accounts should only be set "+
 			"for ModeShell", ErrWalletParams)
+	}
+
+	// A seed is private material: both seed modes produce a private root
+	// key that a watch-only wallet cannot hold. Reject the contradiction
+	// here, before the key is generated or derived, so no signing material
+	// is ever created only to be thrown away.
+	if p.WatchOnly && (p.Mode == ModeGenSeed || p.Mode == ModeImportSeed) {
+		return fmt.Errorf("%w: a seed derives a private root key, which "+
+			"a watch-only wallet cannot hold; use ModeImportExtKey "+
+			"with an XPub or ModeShell", ErrWalletParams)
 	}
 
 	if p.Mode == ModeGenSeed {
@@ -390,8 +405,9 @@ func (m *Manager) Load(cfg Config) (*Wallet, error) {
 	return w, nil
 }
 
-// prepareWalletCreation derives the root key for wallet creation. The caller
-// has already validated cfg and params.
+// prepareWalletCreation derives the root key for wallet creation and checks it
+// against the requested watch-only state. The caller has already validated cfg
+// and params.
 func (m *Manager) prepareWalletCreation(cfg Config,
 	params CreateWalletParams) (*hdkeychain.ExtendedKey, error) {
 
@@ -400,14 +416,50 @@ func (m *Manager) prepareWalletCreation(cfg Config,
 		return nil, err
 	}
 
-	// If the wallet is NOT watch-only, we require a private root key to be able
-	// to sign transactions and derive child private keys.
-	if !params.WatchOnly && rootKey != nil && !rootKey.IsPrivate() {
-		return nil, fmt.Errorf("%w: private key required for "+
-			"non-watch-only wallet", ErrWalletParams)
+	err = validateWatchOnlyRootKey(params, rootKey)
+	if err != nil {
+		return nil, err
 	}
 
 	return rootKey, nil
+}
+
+// validateWatchOnlyRootKey checks the derived root key against the requested
+// watch-only state.
+//
+// params.WatchOnly is the single source of truth: every backend persists that
+// flag verbatim, so a request whose key material contradicts it is rejected
+// here rather than silently reinterpreted.
+func validateWatchOnlyRootKey(params CreateWalletParams,
+	rootKey *hdkeychain.ExtendedKey) error {
+
+	hasPrivateKey := rootKey != nil && rootKey.IsPrivate()
+
+	switch {
+	// A watch-only wallet must not be handed signing material, because
+	// nothing persists it: kvdb drops the root key outright and a SQL
+	// wallet keeps only its neutered form. Accepting an extended private
+	// key here would silently discard the caller's key material, leaving a
+	// wallet that cannot sign and a seed it has no record of.
+	case params.WatchOnly && hasPrivateKey:
+		return fmt.Errorf("%w: watch-only wallet cannot be created "+
+			"from a private root key; neuter it first", ErrWalletParams)
+
+	// A spendable wallet needs a root key at all. A rootless wallet holds
+	// its accounts as imported extended public keys, which is watch-only by
+	// construction.
+	case !params.WatchOnly && rootKey == nil:
+		return fmt.Errorf("%w: a rootless wallet holds no signing "+
+			"material; it requires WatchOnly", ErrWalletParams)
+
+	// That root key must be private, so the wallet can sign transactions
+	// and derive child private keys.
+	case !params.WatchOnly && !hasPrivateKey:
+		return fmt.Errorf("%w: private key required for "+
+			"non-watch-only wallet", ErrWalletParams)
+	}
+
+	return nil
 }
 
 // deriveRootKey resolves the master extended key based on the creation mode.

--- a/wallet/manager_kvdb.go
+++ b/wallet/manager_kvdb.go
@@ -84,6 +84,23 @@ func (b *kvdbManagerBackend) create(ctx context.Context, cfg Config,
 		PubPassphrase: params.PubPassphrase,
 	}
 
+	// waddrmgr recognizes exactly one watch-only shape: a manager created
+	// without a root key. It has nowhere to persist a neutered root and treats
+	// every key it is handed as spendable, so it would fail deriving the
+	// hardened cointype key from an xpub anyway.
+	//
+	// Reject a supplied root key rather than dropping it. Discarding it would
+	// lose caller key material without a word, and make one request mean two
+	// different things: a SQL wallet records that key on the wallet row. This
+	// leaves the same watch-only shape the legacy constructor offered -- "No
+	// root key can be provided as this wallet will be watching only" -- whose
+	// keyspace is built from account-level xpub imports, one account at a time.
+	if params.WatchOnly && rootKey != nil {
+		return nil, fmt.Errorf("%w: kvdb cannot persist a watch-only "+
+			"root key; create a rootless wallet (ModeShell) and "+
+			"import account xpubs instead", ErrInvalidParam)
+	}
+
 	err := kvdb.CreateWallet(adapterCfg, kvdb.CreateWalletRequest{
 		RootKey:           rootKey,
 		PrivatePassphrase: params.PrivatePassphrase,

--- a/wallet/manager_sql.go
+++ b/wallet/manager_sql.go
@@ -95,9 +95,13 @@ func sqlCreateWalletParams(cfg Config, params CreateWalletParams,
 		Birthday:       birthday,
 	}
 
+	// A rootless wallet persists no master public key. Every other wallet
+	// persists its root neutered: a spendable wallet's private root is
+	// neutered here, and a watch-only wallet's root is already public. The
+	// caller has validated the key against params.WatchOnly, so a private
+	// root key implies a spendable wallet.
 	switch {
 	case rootKey == nil:
-		createParams.IsWatchOnly = true
 
 	case rootKey.IsPrivate():
 		masterPubKey, err := rootKey.Neuter()
@@ -108,7 +112,6 @@ func sqlCreateWalletParams(cfg Config, params CreateWalletParams,
 		createParams.MasterPubKey = []byte(masterPubKey.String())
 
 	default:
-		createParams.IsWatchOnly = true
 		createParams.MasterPubKey = []byte(rootKey.String())
 	}
 

--- a/wallet/manager_test.go
+++ b/wallet/manager_test.go
@@ -654,6 +654,76 @@ func TestValidateInitialAccountsModeUpfront(t *testing.T) {
 	}
 }
 
+// TestValidateWatchOnlyRootKey verifies that the requested watch-only state is
+// checked against the derived root key. params.WatchOnly is what every backend
+// persists, so a contradicting key must be rejected rather than reinterpreted.
+func TestValidateWatchOnlyRootKey(t *testing.T) {
+	t.Parallel()
+
+	rootKey, err := hdkeychain.NewMaster(fixedTestSeed(), &chainParams)
+	require.NoError(t, err)
+
+	rootPubKey, err := rootKey.Neuter()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		watchOnly  bool
+		rootKey    *hdkeychain.ExtendedKey
+		wantErrMsg string
+	}{
+		{
+			name:    "spendable wallet with a private root key",
+			rootKey: rootKey,
+		},
+		{
+			name:      "watch-only wallet with a neutered root key",
+			watchOnly: true,
+			rootKey:   rootPubKey,
+		},
+		{
+			name:      "watch-only wallet with no root key",
+			watchOnly: true,
+		},
+		{
+			// Nothing would persist the private half, so the seed
+			// would vanish without a word.
+			name:       "watch-only wallet with a private root key",
+			watchOnly:  true,
+			rootKey:    rootKey,
+			wantErrMsg: "neuter it first",
+		},
+		{
+			name:       "spendable wallet with a neutered root key",
+			rootKey:    rootPubKey,
+			wantErrMsg: "private key required",
+		},
+		{
+			name:       "spendable wallet with no root key",
+			wantErrMsg: "requires WatchOnly",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateWatchOnlyRootKey(
+				CreateWalletParams{WatchOnly: tc.watchOnly},
+				tc.rootKey,
+			)
+			if tc.wantErrMsg != "" {
+				require.ErrorIs(t, err, ErrWalletParams)
+				require.ErrorContains(t, err, tc.wantErrMsg)
+
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
 // TestManagerKVDBRejectsSecondName verifies that a kvdb Manager serves one
 // wallet per database.
 //

--- a/wallet/manager_test.go
+++ b/wallet/manager_test.go
@@ -724,6 +724,88 @@ func TestValidateWatchOnlyRootKey(t *testing.T) {
 	}
 }
 
+// TestManagerKVDBWatchOnlyRejectsRootKey verifies that the legacy kvdb backend
+// refuses a watch-only wallet carrying a root key, rather than dropping the key
+// it cannot persist.
+//
+// waddrmgr has nowhere to keep a neutered root and treats every key it is
+// handed as spendable, so it cannot represent this wallet. A SQL wallet does
+// record the key, so accepting the request on kvdb would silently discard
+// caller key material and make one request mean two different things.
+func TestManagerKVDBWatchOnlyRejectsRootKey(t *testing.T) {
+	t.Parallel()
+
+	// Derive the root from a fixed seed so the SQL fingerprint below is an
+	// exact constant. Zero is a legal BIP32 fingerprint, so a "not zero"
+	// assertion would be both theoretically flaky and satisfied by the wrong
+	// key; this pins the one correct value instead.
+	rootKey, err := hdkeychain.NewMaster(fixedTestSeed(), &chainParams)
+	require.NoError(t, err)
+
+	rootPubKey, err := rootKey.Neuter()
+	require.NoError(t, err)
+
+	cfg := testWatchOnlyConfig()
+	params := CreateWalletParams{
+		Mode:              ModeImportExtKey,
+		RootKey:           rootPubKey,
+		WatchOnly:         true,
+		PubPassphrase:     []byte("public"),
+		PrivatePassphrase: []byte("private"),
+		Birthday:          time.Now(),
+	}
+
+	w, err := testKVDBManager(t).Create(cfg, params)
+	require.ErrorIs(t, err, ErrInvalidParam)
+	require.ErrorContains(t, err, "cannot persist a watch-only root key")
+	require.Nil(t, w)
+
+	// A SQL wallet accepts the very same request, records the key and parses
+	// the fingerprint of exactly that key. That asymmetry is why kvdb rejects
+	// rather than drops.
+	sqlWallet, err := testSQLiteManager(t).Create(cfg, params)
+	require.NoError(t, err)
+	require.True(t, sqlWallet.IsWatchOnly())
+	require.Equal(t, fixedTestSeedFingerprint, sqlWallet.masterFingerprint)
+}
+
+// TestManagerKVDBCreateWatchOnlyShell verifies that the legacy kvdb backend
+// creates a rootless watch-only wallet, which is the one watch-only shape its
+// format can represent and what the legacy watch-only constructor built.
+func TestManagerKVDBCreateWatchOnlyShell(t *testing.T) {
+	t.Parallel()
+
+	params := CreateWalletParams{
+		Mode:              ModeShell,
+		WatchOnly:         true,
+		PubPassphrase:     []byte("public"),
+		PrivatePassphrase: []byte("private"),
+		Birthday:          time.Now(),
+	}
+
+	w, err := testKVDBManager(t).Create(testWatchOnlyConfig(), params)
+	require.NoError(t, err)
+	require.NotNil(t, w)
+	require.True(t, w.IsWatchOnly())
+
+	// No root key was supplied, so no master fingerprint is cached. The value
+	// is unobservable on a watch-only wallet regardless: it is reported only
+	// for derived accounts, which such a wallet cannot have.
+	require.Zero(t, w.masterFingerprint)
+}
+
+// testWatchOnlyConfig returns the wallet Config shared by the watch-only
+// Manager tests.
+func testWatchOnlyConfig() Config {
+	return Config{
+		Chain:          &bwmock.Chain{},
+		ChainParams:    &chainParams,
+		Name:           "watch-only",
+		PubPassphrase:  []byte("public"),
+		RecoveryWindow: MinRecoveryWindow,
+	}
+}
+
 // TestManagerKVDBRejectsSecondName verifies that a kvdb Manager serves one
 // wallet per database.
 //

--- a/wallet/manager_test.go
+++ b/wallet/manager_test.go
@@ -1,6 +1,7 @@
 package wallet
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 	"time"
@@ -192,13 +193,13 @@ func TestManagerCreateError(t *testing.T) {
 			expectedErr: "root key is required",
 		},
 		{
-			name: "Public Key for Non-WatchOnly",
+			name: "XPub root for spendable wallet",
 			params: CreateWalletParams{
 				Mode:      ModeImportExtKey,
 				RootKey:   pubKey,
 				WatchOnly: false,
 			},
-			expectedErr: "private key required",
+			expectedErr: "XPub-root wallet creation is unsupported",
 		},
 		{
 			name: "Unknown Mode",
@@ -232,94 +233,209 @@ func TestManagerCreateError(t *testing.T) {
 	}
 }
 
-// TestCreateWalletParams_Validate verifies that the validate method enforces
-// the correct constraints for each creation mode.
-func TestCreateWalletParams_Validate(t *testing.T) {
+// TestCreateWalletParamsPolicy verifies the complete creation-mode matrix and
+// proves every rejected combination fails before backend creation.
+func TestCreateWalletParamsPolicy(t *testing.T) {
 	t.Parallel()
 
-	// Pre-calculate cryptographic material to construct specific test
-	// scenarios.
 	seed, err := hdkeychain.GenerateSeed(hdkeychain.RecommendedSeedLen)
 	require.NoError(t, err)
 
 	rootKey, err := hdkeychain.NewMaster(seed, &chainParams)
 	require.NoError(t, err)
+	rootXPub, err := rootKey.Neuter()
+	require.NoError(t, err)
+
+	initialXPub := []WatchOnlyAccount{{XPub: rootXPub}}
+	initialXPrv := []WatchOnlyAccount{{XPub: rootKey}}
+	initialNil := []WatchOnlyAccount{{}}
 
 	tests := []struct {
-		name        string
-		params      CreateWalletParams
-		expectedErr string
+		name   string
+		params CreateWalletParams
+		valid  bool
 	}{
 		{
-			name: "ModeGenSeed with Seed",
-			params: CreateWalletParams{
-				Mode: ModeGenSeed,
-				Seed: seed,
-			},
-			expectedErr: "seed should not be set for ModeGenSeed",
+			name:   "generated seed spendable",
+			params: CreateWalletParams{Mode: ModeGenSeed},
+			valid:  true,
 		},
 		{
-			name: "ModeGenSeed with RootKey",
-			params: CreateWalletParams{
-				Mode:    ModeGenSeed,
-				RootKey: rootKey,
-			},
-			expectedErr: "root key should not be set for ModeGenSeed",
+			name:   "imported seed spendable",
+			params: CreateWalletParams{Mode: ModeImportSeed, Seed: seed},
+			valid:  true,
 		},
 		{
-			name: "ModeImportSeed with RootKey",
-			params: CreateWalletParams{
-				Mode:    ModeImportSeed,
-				Seed:    seed,
-				RootKey: rootKey,
-			},
-			expectedErr: "root key should not be set for ModeImportSeed",
+			name: "private root spendable",
+			params: CreateWalletParams{Mode: ModeImportExtKey,
+				RootKey: rootKey},
+			valid: true,
 		},
 		{
-			name: "ModeImportExtKey with Seed",
-			params: CreateWalletParams{
-				Mode:    ModeImportExtKey,
-				RootKey: rootKey,
-				Seed:    seed,
-			},
-			expectedErr: "seed should not be set for ModeImportExtKey",
+			name: "watch-only shell with XPub",
+			params: CreateWalletParams{Mode: ModeShell, WatchOnly: true,
+				InitialAccounts: initialXPub},
+			valid: true,
 		},
 		{
-			name: "ModeShell with Seed",
-			params: CreateWalletParams{
-				Mode: ModeShell,
-				Seed: seed,
-			},
-			expectedErr: "seed should not be set for ModeShell",
+			name:   "unknown mode",
+			params: CreateWalletParams{Mode: ModeUnknown},
 		},
 		{
-			name: "Unknown Mode",
-			params: CreateWalletParams{
-				Mode: ModeUnknown,
-			},
-			expectedErr: "unknown mode",
+			name:   "invalid mode",
+			params: CreateWalletParams{Mode: CreateMode(255)},
 		},
 		{
-			name: "InitialAccounts with ModeGenSeed",
-			params: CreateWalletParams{
-				Mode: ModeGenSeed,
-				InitialAccounts: []WatchOnlyAccount{{
-					Name: "test",
-				}},
+			name:   "generated seed watch-only",
+			params: CreateWalletParams{Mode: ModeGenSeed, WatchOnly: true},
+		},
+		{
+			name:   "generated seed with explicit seed",
+			params: CreateWalletParams{Mode: ModeGenSeed, Seed: seed},
+		},
+		{
+			name:   "generated seed with root key",
+			params: CreateWalletParams{Mode: ModeGenSeed, RootKey: rootKey},
+		},
+		{
+			name: "generated seed with initial account",
+			params: CreateWalletParams{Mode: ModeGenSeed,
+				InitialAccounts: initialXPub,
 			},
-			expectedErr: "initial accounts should only " +
-				"be set for ModeShell",
-		}}
+		},
+		{
+			name: "imported seed watch-only",
+			params: CreateWalletParams{Mode: ModeImportSeed, Seed: seed,
+				WatchOnly: true},
+		},
+		{
+			name:   "imported seed missing seed",
+			params: CreateWalletParams{Mode: ModeImportSeed},
+		},
+		{
+			name: "imported seed with root key",
+			params: CreateWalletParams{Mode: ModeImportSeed, Seed: seed,
+				RootKey: rootKey},
+		},
+		{
+			name: "imported seed with initial account",
+			params: CreateWalletParams{Mode: ModeImportSeed, Seed: seed,
+				InitialAccounts: initialXPub,
+			},
+		},
+		{
+			name: "private root watch-only",
+			params: CreateWalletParams{Mode: ModeImportExtKey,
+				RootKey: rootKey, WatchOnly: true},
+		},
+		{
+			name:   "extended root missing key",
+			params: CreateWalletParams{Mode: ModeImportExtKey},
+		},
+		{
+			name: "XPub root spendable",
+			params: CreateWalletParams{Mode: ModeImportExtKey,
+				RootKey: rootXPub},
+		},
+		{
+			name: "XPub root watch-only",
+			params: CreateWalletParams{Mode: ModeImportExtKey,
+				RootKey: rootXPub, WatchOnly: true},
+		},
+		{
+			name: "extended root with seed",
+			params: CreateWalletParams{Mode: ModeImportExtKey,
+				RootKey: rootKey, Seed: seed},
+		},
+		{
+			name: "extended root with initial account",
+			params: CreateWalletParams{Mode: ModeImportExtKey,
+				RootKey:         rootKey,
+				InitialAccounts: initialXPub,
+			},
+		},
+		{
+			name:   "spendable shell",
+			params: CreateWalletParams{Mode: ModeShell},
+		},
+		{
+			name: "shell with seed",
+			params: CreateWalletParams{Mode: ModeShell, Seed: seed,
+				WatchOnly: true},
+		},
+		{
+			name: "shell with root key",
+			params: CreateWalletParams{Mode: ModeShell, RootKey: rootKey,
+				WatchOnly: true},
+		},
+		{
+			name: "shell with nil account key",
+			params: CreateWalletParams{Mode: ModeShell, WatchOnly: true,
+				InitialAccounts: initialNil,
+			},
+		},
+		{
+			name: "shell with private account key",
+			params: CreateWalletParams{Mode: ModeShell, WatchOnly: true,
+				InitialAccounts: initialXPrv,
+			},
+		},
+	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := tc.params.validate()
-			require.Error(t, err)
-			require.ErrorContains(t, err, tc.expectedErr)
+			if tc.valid {
+				require.NoError(t, tc.params.validate())
+
+				return
+			}
+
+			backend := &recordingManagerBackend{}
+			m := &Manager{
+				wallets:     make(map[string]*Wallet),
+				backend:     backend,
+				chainParams: &chainParams,
+			}
+			cfg := Config{
+				Chain: &bwmock.Chain{}, Name: "test-wallet",
+				RecoveryWindow: MinRecoveryWindow,
+			}
+
+			_, err := m.Create(cfg, tc.params)
+			require.ErrorIs(t, err, ErrWalletParams)
+			require.False(t, backend.createCalled)
 		})
 	}
+}
+
+// recordingManagerBackend records whether Manager.Create reached backend
+// mutation during creation-policy tests.
+type recordingManagerBackend struct{ createCalled bool }
+
+// recordingManagerBackend implements managerBackend.
+var _ managerBackend = (*recordingManagerBackend)(nil)
+
+// create records an unexpected backend creation attempt.
+func (b *recordingManagerBackend) create(_ context.Context, _ Config,
+	_ CreateWalletParams, _ *hdkeychain.ExtendedKey) (*walletData, error) {
+
+	b.createCalled = true
+
+	return nil, ErrInvalidParam
+}
+
+// load is not used by creation-policy tests.
+func (*recordingManagerBackend) load(context.Context, Config) (*walletData,
+	error) {
+
+	return nil, ErrInvalidParam
+}
+
+// close is not used by creation-policy tests.
+func (*recordingManagerBackend) close() error {
+	return nil
 }
 
 // TestManagerCreate_InvalidConfig verifies that the Create method performs
@@ -599,61 +715,6 @@ func TestManager_deriveRootKey(t *testing.T) {
 	})
 }
 
-// TestValidateInitialAccountsModeUpfront verifies the ADR 0012 invariant:
-// a non-watch-only wallet cannot ship with InitialAccounts. The validator
-// runs before the kvdb wallet create so the failure is atomic and no
-// half-created wallet is left on disk.
-func TestValidateInitialAccountsModeUpfront(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name    string
-		params  CreateWalletParams
-		wantErr bool
-	}{
-		{
-			name: "watch-only with initial accounts is fine",
-			params: CreateWalletParams{
-				WatchOnly: true,
-				InitialAccounts: []WatchOnlyAccount{{
-					Name: "imported-xpub",
-				}},
-			},
-		},
-		{
-			name: "spendable with no initial accounts is fine",
-			params: CreateWalletParams{
-				WatchOnly: false,
-			},
-		},
-		{
-			name: "spendable with initial accounts is rejected",
-			params: CreateWalletParams{
-				WatchOnly: false,
-				InitialAccounts: []WatchOnlyAccount{{
-					Name: "imported-xpub",
-				}},
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			err := validateInitialAccountsMode(tc.params)
-			if tc.wantErr {
-				require.ErrorIs(t, err, ErrWalletParams)
-
-				return
-			}
-
-			require.NoError(t, err)
-		})
-	}
-}
-
 // TestValidateWatchOnlyRootKey verifies that the requested watch-only state is
 // checked against the derived root key. params.WatchOnly is what every backend
 // persists, so a contradicting key must be rejected rather than reinterpreted.
@@ -662,6 +723,9 @@ func TestValidateWatchOnlyRootKey(t *testing.T) {
 
 	rootKey, err := hdkeychain.NewMaster(fixedTestSeed(), &chainParams)
 	require.NoError(t, err)
+	fingerprint, err := masterKeyFingerprint(rootKey)
+	require.NoError(t, err)
+	require.Equal(t, fixedTestSeedFingerprint, fingerprint)
 
 	rootPubKey, err := rootKey.Neuter()
 	require.NoError(t, err)
@@ -724,21 +788,11 @@ func TestValidateWatchOnlyRootKey(t *testing.T) {
 	}
 }
 
-// TestManagerKVDBWatchOnlyRejectsRootKey verifies that the legacy kvdb backend
-// refuses a watch-only wallet carrying a root key, rather than dropping the key
-// it cannot persist.
-//
-// waddrmgr has nowhere to keep a neutered root and treats every key it is
-// handed as spendable, so it cannot represent this wallet. A SQL wallet does
-// record the key, so accepting the request on kvdb would silently discard
-// caller key material and make one request mean two different things.
+// TestManagerKVDBWatchOnlyRejectsRootKey verifies that XPub-root creation is
+// rejected before either backend can mutate wallet state.
 func TestManagerKVDBWatchOnlyRejectsRootKey(t *testing.T) {
 	t.Parallel()
 
-	// Derive the root from a fixed seed so the SQL fingerprint below is an
-	// exact constant. Zero is a legal BIP32 fingerprint, so a "not zero"
-	// assertion would be both theoretically flaky and satisfied by the wrong
-	// key; this pins the one correct value instead.
 	rootKey, err := hdkeychain.NewMaster(fixedTestSeed(), &chainParams)
 	require.NoError(t, err)
 
@@ -756,17 +810,14 @@ func TestManagerKVDBWatchOnlyRejectsRootKey(t *testing.T) {
 	}
 
 	w, err := testKVDBManager(t).Create(cfg, params)
-	require.ErrorIs(t, err, ErrInvalidParam)
-	require.ErrorContains(t, err, "cannot persist a watch-only root key")
+	require.ErrorIs(t, err, ErrWalletParams)
+	require.ErrorContains(t, err, "XPub-root wallet creation is unsupported")
 	require.Nil(t, w)
 
-	// A SQL wallet accepts the very same request, records the key and parses
-	// the fingerprint of exactly that key. That asymmetry is why kvdb rejects
-	// rather than drops.
-	sqlWallet, err := testSQLiteManager(t).Create(cfg, params)
-	require.NoError(t, err)
-	require.True(t, sqlWallet.IsWatchOnly())
-	require.Equal(t, fixedTestSeedFingerprint, sqlWallet.masterFingerprint)
+	w, err = testSQLiteManager(t).Create(cfg, params)
+	require.ErrorIs(t, err, ErrWalletParams)
+	require.ErrorContains(t, err, "XPub-root wallet creation is unsupported")
+	require.Nil(t, w)
 }
 
 // TestManagerKVDBCreateWatchOnlyShell verifies that the legacy kvdb backend


### PR DESCRIPTION
## Summary

Define explicit watch-only wallet creation and script-import policies.

## Change Description

- Validate every wallet creation mode before backend mutation.
- Restrict watch-only creation to shell mode with public initial accounts.
- Document SQL script-import limits and legacy kvdb behavior.