### PR TITLE
itest+wallet: make WatchOnly the sole authority at create time

### DIFF
--- a/itest/controller_test.go
+++ b/itest/controller_test.go
@@ -12,8 +12,6 @@ import (
 // stops cleanly, Stop is idempotent, a stopped instance restarts cleanly, and
 // a fresh Load yields a working instance.
 func testControllerStartStop(h *bwtest.HarnessTest) {
-	h.Helper()
-
 	cfg, params := h.TestWalletConfig()
 
 	manager := h.NewWalletManager()
@@ -51,8 +49,6 @@ func testControllerStartStop(h *bwtest.HarnessTest) {
 // they are forbidden before Start, a failed unlock leaves the wallet locked,
 // and Lock is idempotent after an explicit lock.
 func testControllerUnlockLock(h *bwtest.HarnessTest) {
-	h.Helper()
-
 	const wrongPassphrase = "wrong-private-passphrase"
 
 	cfg, params := h.TestWalletConfig()
@@ -125,8 +121,6 @@ func testControllerUnlockLock(h *bwtest.HarnessTest) {
 // reports the configured backend and chain params, and tracks synchronization
 // as a block is mined.
 func testControllerInfo(h *bwtest.HarnessTest) {
-	h.Helper()
-
 	cfg, params := h.TestWalletConfig()
 
 	manager := h.NewWalletManager()

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -32,6 +32,14 @@ var allTestCases = []*testCase{
 		TestFunc: testManagerLoadMissing,
 	},
 	{
+		Name:     "manager create watchonly",
+		TestFunc: testManagerCreateWatchOnly,
+	},
+	{
+		Name:     "manager reject invalid watchonly params",
+		TestFunc: testManagerRejectInvalidWatchOnlyParams,
+	},
+	{
 		Name:     "controller start stop",
 		TestFunc: testControllerStartStop,
 	},

--- a/itest/manager_test.go
+++ b/itest/manager_test.go
@@ -15,8 +15,6 @@ import (
 
 // testCreateWallet verifies a wallet can be created, started, and synced.
 func testCreateWallet(h *bwtest.HarnessTest) {
-	h.Helper()
-
 	// This is a manager-focused test, so drive the Manager API directly
 	// rather than the harness's CreateEmptyWallet convenience helper.
 	cfg, params := h.TestWalletConfig()
@@ -45,8 +43,6 @@ func testCreateWallet(h *bwtest.HarnessTest) {
 // testManagerCreateDuplicate verifies that both a live wallet cache entry and
 // a completed wallet in the durable store reject a duplicate creation.
 func testManagerCreateDuplicate(h *bwtest.HarnessTest) {
-	h.Helper()
-
 	cfg, params := h.TestWalletConfig()
 
 	manager := h.NewWalletManager()
@@ -80,8 +76,6 @@ func testManagerCreateDuplicate(h *bwtest.HarnessTest) {
 // testManagerLoadReload verifies Manager cache identity, durable reload, and
 // birthday metadata while preserving lifecycle ownership.
 func testManagerLoadReload(h *bwtest.HarnessTest) {
-	h.Helper()
-
 	cfg, params := h.TestWalletConfig()
 
 	// Keep the effective birthday five days ahead of the chain after the
@@ -153,8 +147,6 @@ func testManagerLoadReload(h *bwtest.HarnessTest) {
 // testManagerLoadMissing verifies that loading a wallet that was never created
 // fails rather than silently returning an empty wallet.
 func testManagerLoadMissing(h *bwtest.HarnessTest) {
-	h.Helper()
-
 	cfg, _ := h.TestWalletConfig()
 
 	manager := h.NewWalletManager()

--- a/itest/manager_test.go
+++ b/itest/manager_test.go
@@ -3,10 +3,13 @@
 package itest
 
 import (
+	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
 	"github.com/btcsuite/btcwallet/bwtest"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet"
 	"github.com/stretchr/testify/require"
 )
 
@@ -157,4 +160,167 @@ func testManagerLoadMissing(h *bwtest.HarnessTest) {
 	manager := h.NewWalletManager()
 	_, err := manager.Load(cfg)
 	require.Error(h, err, "load of never-created wallet should fail")
+}
+
+// testManagerCreateWatchOnly verifies that a watch-only wallet is created,
+// starts, syncs like a spendable wallet, and stays watch-only across a reload
+// from the durable store.
+//
+// The wallet is rootless: that is the one watch-only shape every backend can
+// represent, and its keyspace arrives later as account-level xpub imports. An
+// XPub root is a SQL-only variant, covered by the Manager unit tests.
+func testManagerCreateWatchOnly(h *bwtest.HarnessTest) {
+	cfg, params := h.TestWalletConfig()
+	params.Mode = wallet.ModeShell
+	params.WatchOnly = true
+
+	manager := h.NewWalletManager()
+	w, err := manager.Create(cfg, params)
+	require.NoError(h, err, "failed to create watch-only wallet")
+	h.RegisterWallet(w)
+
+	require.NoError(h, w.Start(h.Context()), "failed to start wallet")
+	h.AssertWalletSynced(w)
+
+	require.True(h, w.IsWatchOnly(), "created wallet is not watch-only")
+
+	// A watch-only wallet tracks the chain like any other wallet.
+	h.MineBlocks(1)
+
+	// Keep both resources registered until shutdown succeeds, then reload from
+	// the durable store with a fresh Manager.
+	require.NoError(h, w.Stop(h.Context()), "failed to stop wallet")
+	require.True(h, h.DeregisterWallet(w), "failed to deregister wallet")
+	require.NoError(h, manager.Close(), "failed to close wallet manager")
+	require.True(h, h.ReleaseManager(manager), "failed to release manager")
+
+	manager = h.NewWalletManager()
+	reloaded, err := manager.Load(cfg)
+	require.NoError(h, err, "failed to reload watch-only wallet")
+	h.RegisterWallet(reloaded)
+
+	require.NoError(
+		h, reloaded.Start(h.Context()), "failed to start reloaded wallet",
+	)
+	require.True(
+		h, reloaded.IsWatchOnly(),
+		"reloaded wallet lost its watch-only state",
+	)
+}
+
+// testManagerRejectInvalidWatchOnlyParams verifies that invalid create
+// parameters are rejected before a wallet can be created.
+func testManagerRejectInvalidWatchOnlyParams(h *bwtest.HarnessTest) {
+	// The entries are never imported: every request below is rejected on its
+	// parameters alone, so a named placeholder account is enough.
+	initialAccounts := []wallet.WatchOnlyAccount{{Name: "watchonly"}}
+
+	neuteredRootKey := rootPubKey(h)
+	privateRootKey := masterKey(h)
+
+	manager := h.NewWalletManager()
+
+	testCases := []struct {
+		name       string
+		update     func(*wallet.CreateWalletParams)
+		wantErrMsg string
+	}{
+		{
+			name: "xpub spendable",
+			update: func(params *wallet.CreateWalletParams) {
+				params.Mode = wallet.ModeImportExtKey
+				params.RootKey = neuteredRootKey
+				params.WatchOnly = false
+			},
+			wantErrMsg: "private key required for non-watch-only wallet",
+		},
+		{
+			name: "initial accounts spendable",
+			update: func(params *wallet.CreateWalletParams) {
+				params.Mode = wallet.ModeShell
+				params.WatchOnly = false
+				params.InitialAccounts = initialAccounts
+			},
+			wantErrMsg: "cannot create a non-watch-only wallet with " +
+				"InitialAccounts; xpub-only imports require WatchOnly=true",
+		},
+		{
+			name: "initial accounts outside shell mode",
+			update: func(params *wallet.CreateWalletParams) {
+				params.WatchOnly = true
+				params.InitialAccounts = initialAccounts
+			},
+			wantErrMsg: "initial accounts should only be set for ModeShell",
+		},
+		{
+			name: "rootless spendable",
+			update: func(params *wallet.CreateWalletParams) {
+				params.Mode = wallet.ModeShell
+				params.WatchOnly = false
+			},
+			wantErrMsg: "a rootless wallet holds no signing material; it " +
+				"requires WatchOnly",
+		},
+		{
+			name: "seed watch-only",
+			update: func(params *wallet.CreateWalletParams) {
+				params.WatchOnly = true
+			},
+			wantErrMsg: "a seed derives a private root key, which a " +
+				"watch-only wallet cannot hold; use ModeImportExtKey with an " +
+				"XPub or ModeShell",
+		},
+		{
+			name: "private root watch-only",
+			update: func(params *wallet.CreateWalletParams) {
+				params.Mode = wallet.ModeImportExtKey
+				params.RootKey = privateRootKey
+				params.WatchOnly = true
+			},
+			wantErrMsg: "watch-only wallet cannot be created from a private " +
+				"root key; neuter it first",
+		},
+	}
+
+	for _, tc := range testCases {
+		h.Run(tc.name, func(t *testing.T) {
+			cfg, params := h.TestWalletConfig()
+			tc.update(&params)
+
+			w, err := manager.Create(cfg, params)
+			require.ErrorIs(
+				t, err, wallet.ErrWalletParams,
+				"rejected create returned a different error",
+			)
+			require.ErrorContains(t, err, tc.wantErrMsg)
+			require.Nil(t, w, "rejected create returned a wallet")
+		})
+	}
+}
+
+// rootPubKey returns a neutered master extended key for the harness network.
+func rootPubKey(h *bwtest.HarnessTest) *hdkeychain.ExtendedKey {
+	h.Helper()
+
+	rootPub, err := masterKey(h).Neuter()
+	require.NoError(h, err, "failed to neuter the master key")
+
+	return rootPub
+}
+
+// masterKey derives the master extended private key for the harness network
+// from a fixed seed. Every wallet keyed by it is rejected before creation, so
+// nothing persists it and a failure reproduces with the same key material.
+func masterKey(h *bwtest.HarnessTest) *hdkeychain.ExtendedKey {
+	h.Helper()
+
+	seed := make([]byte, hdkeychain.RecommendedSeedLen)
+	for i := range seed {
+		seed[i] = byte(i + 1)
+	}
+
+	root, err := hdkeychain.NewMaster(seed, h.NetParams())
+	require.NoError(h, err, "failed to derive the master key")
+
+	return root
 }

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -35,12 +35,7 @@ type stubAccountDeriveFn struct {
 func newStubAccountDeriveFn(t *testing.T) stubAccountDeriveFn {
 	t.Helper()
 
-	seed := make([]byte, hdkeychain.RecommendedSeedLen)
-	for i := range seed {
-		seed[i] = byte(i + 1)
-	}
-
-	masterKey, err := hdkeychain.NewMaster(seed, &chainParams)
+	masterKey, err := hdkeychain.NewMaster(fixedTestSeed(), &chainParams)
 	require.NoError(t, err)
 
 	fingerprint, err := masterKeyFingerprint(masterKey)

--- a/wallet/common_test.go
+++ b/wallet/common_test.go
@@ -24,8 +24,14 @@ import (
 // testWalletName is the wallet name shared by Store-backed wallet tests.
 const testWalletName = "test-wallet"
 
+// fixedTestSeedFingerprint is the BIP32 master-key fingerprint of the root
+// derived from fixedTestSeed over chainParams. Zero is a legal fingerprint, so
+// tests assert this exact value rather than merely a non-zero one.
+const fixedTestSeedFingerprint uint32 = 0x5bf9f809
+
 // fixedTestSeed returns a deterministic HD seed, so tests that assert on
-// derived key material can pin exact expected values.
+// derived key material can pin exact expected values such as
+// fixedTestSeedFingerprint.
 func fixedTestSeed() []byte {
 	seed := make([]byte, hdkeychain.RecommendedSeedLen)
 	for i := range seed {

--- a/wallet/common_test.go
+++ b/wallet/common_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	bwmock "github.com/btcsuite/btcwallet/bwtest/mock"
 	"github.com/btcsuite/btcwallet/waddrmgr"
@@ -22,6 +23,17 @@ import (
 
 // testWalletName is the wallet name shared by Store-backed wallet tests.
 const testWalletName = "test-wallet"
+
+// fixedTestSeed returns a deterministic HD seed, so tests that assert on
+// derived key material can pin exact expected values.
+func fixedTestSeed() []byte {
+	seed := make([]byte, hdkeychain.RecommendedSeedLen)
+	for i := range seed {
+		seed[i] = byte(i + 1)
+	}
+
+	return seed
+}
 
 var (
 	errDBMock         = errors.New("db error")

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -71,8 +71,10 @@ type CreateWalletParams struct {
 	// Seed is required for ModeImportSeed. Ignored for others.
 	Seed []byte
 
-	// RootKey is required for ModeImportExtKey. Ignored for others. Can be XPrv
-	// or XPub.
+	// RootKey is required for ModeImportExtKey and must be nil for every
+	// other mode, which reject a key they would not use. It must agree with
+	// WatchOnly: an XPrv for a spendable wallet, an XPub for a watch-only
+	// one.
 	RootKey *hdkeychain.ExtendedKey
 
 	// InitialAccounts is optional and names watch-only accounts to import
@@ -80,8 +82,11 @@ type CreateWalletParams struct {
 	// honored for ModeShell.
 	InitialAccounts []WatchOnlyAccount
 
-	// WatchOnly requests a watch-only wallet. It is honored for an XPub root
-	// (ModeImportExtKey) and a rootless shell (ModeShell).
+	// WatchOnly requests a watch-only wallet, and is the sole authority on
+	// whether the created wallet is watch-only. The root key must agree with
+	// it: a watch-only wallet takes an XPub root (ModeImportExtKey) or no
+	// root at all (ModeShell), while a spendable wallet requires a private
+	// root key.
 	WatchOnly bool
 
 	// Birthday is the wallet's birthday.
@@ -221,17 +226,17 @@ func (m *Manager) Create(cfg Config,
 		return nil, err
 	}
 
-	rootKey, err := m.prepareWalletCreation(cfg, params)
-	if err != nil {
-		return nil, err
-	}
-
 	// Per ADR 0012 a wallet is uniformly watch-only or uniformly
 	// spendable. Validate the params.InitialAccounts list upfront so a
 	// mismatched-mode create fails before any backend create runs
 	// (otherwise the wallet row exists on disk while importInitialAccounts
 	// later rejects an entry, leaving a half-created wallet).
 	err = validateInitialAccountsMode(params)
+	if err != nil {
+		return nil, err
+	}
+
+	rootKey, err := m.prepareWalletCreation(cfg, params)
 	if err != nil {
 		return nil, err
 	}
@@ -297,6 +302,16 @@ func (p *CreateWalletParams) validate() error {
 	if p.Mode != ModeShell && len(p.InitialAccounts) > 0 {
 		return fmt.Errorf("%w: initial accounts should only be set "+
 			"for ModeShell", ErrWalletParams)
+	}
+
+	// A seed is private material: both seed modes produce a private root
+	// key that a watch-only wallet cannot hold. Reject the contradiction
+	// here, before the key is generated or derived, so no signing material
+	// is ever created only to be thrown away.
+	if p.WatchOnly && (p.Mode == ModeGenSeed || p.Mode == ModeImportSeed) {
+		return fmt.Errorf("%w: a seed derives a private root key, which "+
+			"a watch-only wallet cannot hold; use ModeImportExtKey "+
+			"with an XPub or ModeShell", ErrWalletParams)
 	}
 
 	if p.Mode == ModeGenSeed {
@@ -390,8 +405,9 @@ func (m *Manager) Load(cfg Config) (*Wallet, error) {
 	return w, nil
 }
 
-// prepareWalletCreation derives the root key for wallet creation. The caller
-// has already validated cfg and params.
+// prepareWalletCreation derives the root key for wallet creation and checks it
+// against the requested watch-only state. The caller has already validated cfg
+// and params.
 func (m *Manager) prepareWalletCreation(cfg Config,
 	params CreateWalletParams) (*hdkeychain.ExtendedKey, error) {
 
@@ -400,14 +416,50 @@ func (m *Manager) prepareWalletCreation(cfg Config,
 		return nil, err
 	}
 
-	// If the wallet is NOT watch-only, we require a private root key to be able
-	// to sign transactions and derive child private keys.
-	if !params.WatchOnly && rootKey != nil && !rootKey.IsPrivate() {
-		return nil, fmt.Errorf("%w: private key required for "+
-			"non-watch-only wallet", ErrWalletParams)
+	err = validateWatchOnlyRootKey(params, rootKey)
+	if err != nil {
+		return nil, err
 	}
 
 	return rootKey, nil
+}
+
+// validateWatchOnlyRootKey checks the derived root key against the requested
+// watch-only state.
+//
+// params.WatchOnly is the single source of truth: every backend persists that
+// flag verbatim, so a request whose key material contradicts it is rejected
+// here rather than silently reinterpreted.
+func validateWatchOnlyRootKey(params CreateWalletParams,
+	rootKey *hdkeychain.ExtendedKey) error {
+
+	hasPrivateKey := rootKey != nil && rootKey.IsPrivate()
+
+	switch {
+	// A watch-only wallet must not be handed signing material, because
+	// nothing persists it: kvdb drops the root key outright and a SQL
+	// wallet keeps only its neutered form. Accepting an extended private
+	// key here would silently discard the caller's key material, leaving a
+	// wallet that cannot sign and a seed it has no record of.
+	case params.WatchOnly && hasPrivateKey:
+		return fmt.Errorf("%w: watch-only wallet cannot be created "+
+			"from a private root key; neuter it first", ErrWalletParams)
+
+	// A spendable wallet needs a root key at all. A rootless wallet holds
+	// its accounts as imported extended public keys, which is watch-only by
+	// construction.
+	case !params.WatchOnly && rootKey == nil:
+		return fmt.Errorf("%w: a rootless wallet holds no signing "+
+			"material; it requires WatchOnly", ErrWalletParams)
+
+	// That root key must be private, so the wallet can sign transactions
+	// and derive child private keys.
+	case !params.WatchOnly && !hasPrivateKey:
+		return fmt.Errorf("%w: private key required for "+
+			"non-watch-only wallet", ErrWalletParams)
+	}
+
+	return nil
 }
 
 // deriveRootKey resolves the master extended key based on the creation mode.

--- a/wallet/manager_kvdb.go
+++ b/wallet/manager_kvdb.go
@@ -84,6 +84,23 @@ func (b *kvdbManagerBackend) create(ctx context.Context, cfg Config,
 		PubPassphrase: params.PubPassphrase,
 	}
 
+	// waddrmgr recognizes exactly one watch-only shape: a manager created
+	// without a root key. It has nowhere to persist a neutered root and treats
+	// every key it is handed as spendable, so it would fail deriving the
+	// hardened cointype key from an xpub anyway.
+	//
+	// Reject a supplied root key rather than dropping it. Discarding it would
+	// lose caller key material without a word, and make one request mean two
+	// different things: a SQL wallet records that key on the wallet row. This
+	// leaves the same watch-only shape the legacy constructor offered -- "No
+	// root key can be provided as this wallet will be watching only" -- whose
+	// keyspace is built from account-level xpub imports, one account at a time.
+	if params.WatchOnly && rootKey != nil {
+		return nil, fmt.Errorf("%w: kvdb cannot persist a watch-only "+
+			"root key; create a rootless wallet (ModeShell) and "+
+			"import account xpubs instead", ErrInvalidParam)
+	}
+
 	err := kvdb.CreateWallet(adapterCfg, kvdb.CreateWalletRequest{
 		RootKey:           rootKey,
 		PrivatePassphrase: params.PrivatePassphrase,

--- a/wallet/manager_sql.go
+++ b/wallet/manager_sql.go
@@ -95,9 +95,13 @@ func sqlCreateWalletParams(cfg Config, params CreateWalletParams,
 		Birthday:       birthday,
 	}
 
+	// A rootless wallet persists no master public key. Every other wallet
+	// persists its root neutered: a spendable wallet's private root is
+	// neutered here, and a watch-only wallet's root is already public. The
+	// caller has validated the key against params.WatchOnly, so a private
+	// root key implies a spendable wallet.
 	switch {
 	case rootKey == nil:
-		createParams.IsWatchOnly = true
 
 	case rootKey.IsPrivate():
 		masterPubKey, err := rootKey.Neuter()
@@ -108,7 +112,6 @@ func sqlCreateWalletParams(cfg Config, params CreateWalletParams,
 		createParams.MasterPubKey = []byte(masterPubKey.String())
 
 	default:
-		createParams.IsWatchOnly = true
 		createParams.MasterPubKey = []byte(rootKey.String())
 	}
 

--- a/wallet/manager_test.go
+++ b/wallet/manager_test.go
@@ -251,6 +251,16 @@ func TestCreateWalletParams_Validate(t *testing.T) {
 		expectedErr string
 	}{
 		{
+			name: "ModeGenSeed with WatchOnly",
+			params: CreateWalletParams{
+				Mode:      ModeGenSeed,
+				WatchOnly: true,
+			},
+			expectedErr: "a seed derives a private root key, which a " +
+				"watch-only wallet cannot hold; use ModeImportExtKey " +
+				"with an XPub or ModeShell",
+		},
+		{
 			name: "ModeGenSeed with Seed",
 			params: CreateWalletParams{
 				Mode: ModeGenSeed,
@@ -265,6 +275,17 @@ func TestCreateWalletParams_Validate(t *testing.T) {
 				RootKey: rootKey,
 			},
 			expectedErr: "root key should not be set for ModeGenSeed",
+		},
+		{
+			name: "ModeImportSeed with WatchOnly",
+			params: CreateWalletParams{
+				Mode:      ModeImportSeed,
+				Seed:      seed,
+				WatchOnly: true,
+			},
+			expectedErr: "a seed derives a private root key, which a " +
+				"watch-only wallet cannot hold; use ModeImportExtKey " +
+				"with an XPub or ModeShell",
 		},
 		{
 			name: "ModeImportSeed with RootKey",
@@ -645,6 +666,76 @@ func TestValidateInitialAccountsModeUpfront(t *testing.T) {
 			err := validateInitialAccountsMode(tc.params)
 			if tc.wantErr {
 				require.ErrorIs(t, err, ErrWalletParams)
+
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestValidateWatchOnlyRootKey verifies that the requested watch-only state is
+// checked against the derived root key. params.WatchOnly is what every backend
+// persists, so a contradicting key must be rejected rather than reinterpreted.
+func TestValidateWatchOnlyRootKey(t *testing.T) {
+	t.Parallel()
+
+	rootKey, err := hdkeychain.NewMaster(fixedTestSeed(), &chainParams)
+	require.NoError(t, err)
+
+	rootPubKey, err := rootKey.Neuter()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		watchOnly  bool
+		rootKey    *hdkeychain.ExtendedKey
+		wantErrMsg string
+	}{
+		{
+			name:    "spendable wallet with a private root key",
+			rootKey: rootKey,
+		},
+		{
+			name:      "watch-only wallet with a neutered root key",
+			watchOnly: true,
+			rootKey:   rootPubKey,
+		},
+		{
+			name:      "watch-only wallet with no root key",
+			watchOnly: true,
+		},
+		{
+			// Nothing would persist the private half, so the seed
+			// would vanish without a word.
+			name:       "watch-only wallet with a private root key",
+			watchOnly:  true,
+			rootKey:    rootKey,
+			wantErrMsg: "neuter it first",
+		},
+		{
+			name:       "spendable wallet with a neutered root key",
+			rootKey:    rootPubKey,
+			wantErrMsg: "private key required",
+		},
+		{
+			name:       "spendable wallet with no root key",
+			wantErrMsg: "requires WatchOnly",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateWatchOnlyRootKey(
+				CreateWalletParams{WatchOnly: tc.watchOnly},
+				tc.rootKey,
+			)
+			if tc.wantErrMsg != "" {
+				require.ErrorIs(t, err, ErrWalletParams)
+				require.ErrorContains(t, err, tc.wantErrMsg)
 
 				return
 			}

--- a/wallet/manager_test.go
+++ b/wallet/manager_test.go
@@ -745,6 +745,88 @@ func TestValidateWatchOnlyRootKey(t *testing.T) {
 	}
 }
 
+// TestManagerKVDBWatchOnlyRejectsRootKey verifies that the legacy kvdb backend
+// refuses a watch-only wallet carrying a root key, rather than dropping the key
+// it cannot persist.
+//
+// waddrmgr has nowhere to keep a neutered root and treats every key it is
+// handed as spendable, so it cannot represent this wallet. A SQL wallet does
+// record the key, so accepting the request on kvdb would silently discard
+// caller key material and make one request mean two different things.
+func TestManagerKVDBWatchOnlyRejectsRootKey(t *testing.T) {
+	t.Parallel()
+
+	// Derive the root from a fixed seed so the SQL fingerprint below is an
+	// exact constant. Zero is a legal BIP32 fingerprint, so a "not zero"
+	// assertion would be both theoretically flaky and satisfied by the wrong
+	// key; this pins the one correct value instead.
+	rootKey, err := hdkeychain.NewMaster(fixedTestSeed(), &chainParams)
+	require.NoError(t, err)
+
+	rootPubKey, err := rootKey.Neuter()
+	require.NoError(t, err)
+
+	cfg := testWatchOnlyConfig()
+	params := CreateWalletParams{
+		Mode:              ModeImportExtKey,
+		RootKey:           rootPubKey,
+		WatchOnly:         true,
+		PubPassphrase:     []byte("public"),
+		PrivatePassphrase: []byte("private"),
+		Birthday:          time.Now(),
+	}
+
+	w, err := testKVDBManager(t).Create(cfg, params)
+	require.ErrorIs(t, err, ErrInvalidParam)
+	require.ErrorContains(t, err, "cannot persist a watch-only root key")
+	require.Nil(t, w)
+
+	// A SQL wallet accepts the very same request, records the key and parses
+	// the fingerprint of exactly that key. That asymmetry is why kvdb rejects
+	// rather than drops.
+	sqlWallet, err := testSQLiteManager(t).Create(cfg, params)
+	require.NoError(t, err)
+	require.True(t, sqlWallet.IsWatchOnly())
+	require.Equal(t, fixedTestSeedFingerprint, sqlWallet.masterFingerprint)
+}
+
+// TestManagerKVDBCreateWatchOnlyShell verifies that the legacy kvdb backend
+// creates a rootless watch-only wallet, which is the one watch-only shape its
+// format can represent and what the legacy watch-only constructor built.
+func TestManagerKVDBCreateWatchOnlyShell(t *testing.T) {
+	t.Parallel()
+
+	params := CreateWalletParams{
+		Mode:              ModeShell,
+		WatchOnly:         true,
+		PubPassphrase:     []byte("public"),
+		PrivatePassphrase: []byte("private"),
+		Birthday:          time.Now(),
+	}
+
+	w, err := testKVDBManager(t).Create(testWatchOnlyConfig(), params)
+	require.NoError(t, err)
+	require.NotNil(t, w)
+	require.True(t, w.IsWatchOnly())
+
+	// No root key was supplied, so no master fingerprint is cached. The value
+	// is unobservable on a watch-only wallet regardless: it is reported only
+	// for derived accounts, which such a wallet cannot have.
+	require.Zero(t, w.masterFingerprint)
+}
+
+// testWatchOnlyConfig returns the wallet Config shared by the watch-only
+// Manager tests.
+func testWatchOnlyConfig() Config {
+	return Config{
+		Chain:          &bwmock.Chain{},
+		ChainParams:    &chainParams,
+		Name:           "watch-only",
+		PubPassphrase:  []byte("public"),
+		RecoveryWindow: MinRecoveryWindow,
+	}
+}
+
 // TestManagerKVDBRejectsSecondName verifies that a kvdb Manager serves one
 // wallet per database.
 //


### PR DESCRIPTION
`CreateWalletParams.WatchOnly` is what every backend persists, so a create
request whose key material contradicts it is now rejected instead of being
silently reinterpreted:

- A watch-only wallet may not carry a private root key (nothing persists it)
  nor use a seed mode; a spendable wallet requires a private root key.
- The kvdb backend refuses any root key on a watch-only wallet: waddrmgr can
  only represent the rootless shape, and dropping the key would make the same
  request mean two different things across backends.
- SQLite takes `IsWatchOnly` from the params instead of inferring it from the
  key.