### PR TITLE
itest: fix case filtering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ itest:
 	@$(call print, "Running integration tests.")
 	@$(GOTEST) -v ./itest \
 		-tags="itest $(DEV_TAGS) nolog" \
-		$(if $(icase),-test.run="TestBtcWallet$$|$(icase)",) \
+		$(if $(icase),-test.run="^TestBtcWallet/[^/]+/$(icase)",) \
 		$(filter-out -test.run=%,$(TEST_FLAGS)) \
 		-args \
 		-chain="$(if $(backend),$(backend),$(if $(chain),$(chain),btcd))" \


### PR DESCRIPTION
## Summary

- match integration-test cases through their hierarchical subtest path
- stop the parent TestBtcWallet match from selecting every case

## Testing

- `make itest chain=btcd db=sqlite icase=manager_load_missing nocache=1`
- `make itest chain=btcd db=sqlite icase=manager nocache=1`