### PR TITLE
wallet: define semantic account identity

### DIFF
--- a/wallet/account_identity.go
+++ b/wallet/account_identity.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"errors"
+
+	"github.com/btcsuite/btcwallet/waddrmgr"
+)
+
+var errInvalidAccountSelector = errors.New(
+	"exactly one of account name or account number must be provided",
+)
+
+// AccountNumber is the BIP44 account index within a key scope. A nil pointer
+// means the account has no BIP44 number, while a non-nil zero identifies
+// account zero.
+type AccountNumber uint32
+
+// MasterFingerprint is the BIP32 master key fingerprint. A nil pointer means
+// the fingerprint is absent, while a non-nil zero is a present-zero
+// fingerprint.
+type MasterFingerprint uint32
+
+// AccountSelector identifies an account by its portable wallet semantics.
+// Callers construct selectors with NewAccountSelectorByName or
+// NewAccountSelectorByNumber.
+type AccountSelector struct {
+	keyScope      waddrmgr.KeyScope
+	accountName   *string
+	accountNumber *AccountNumber
+}
+
+// NewAccountSelectorByName identifies an account by its key scope and name.
+func NewAccountSelectorByName(keyScope waddrmgr.KeyScope,
+	accountName string) AccountSelector {
+
+	return AccountSelector{
+		keyScope:    keyScope,
+		accountName: &accountName,
+	}
+}
+
+// NewAccountSelectorByNumber identifies a wallet-derived account by its key
+// scope and BIP44 account number.
+func NewAccountSelectorByNumber(keyScope waddrmgr.KeyScope,
+	accountNumber AccountNumber) AccountSelector {
+
+	return AccountSelector{
+		keyScope:      keyScope,
+		accountNumber: &accountNumber,
+	}
+}
+
+// validate verifies that exactly one account identity is set. Scope support
+// and account existence are resolved by the consuming operation.
+func (s AccountSelector) validate() error {
+	if (s.accountName == nil) == (s.accountNumber == nil) {
+		return errInvalidAccountSelector
+	}
+
+	return nil
+}

--- a/wallet/account_identity_test.go
+++ b/wallet/account_identity_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/stretchr/testify/require"
+)
+
+const accountIdentityTestName = "imported-xpub"
+
+// TestAccountIdentitySelectorConstructors verifies that the public
+// constructors preserve the supplied semantic identity.
+func TestAccountIdentitySelectorConstructors(t *testing.T) {
+	t.Parallel()
+
+	keyScope := waddrmgr.KeyScopeBIP0084
+	accountName := accountIdentityTestName
+	accountNumber := AccountNumber(0)
+
+	byName := NewAccountSelectorByName(keyScope, accountName)
+
+	require.Equal(t, keyScope, byName.keyScope)
+	require.NotNil(t, byName.accountName)
+	require.Equal(t, accountName, *byName.accountName)
+	require.Nil(t, byName.accountNumber)
+
+	byNumber := NewAccountSelectorByNumber(keyScope, accountNumber)
+
+	require.Equal(t, keyScope, byNumber.keyScope)
+	require.Nil(t, byNumber.accountName)
+	require.NotNil(t, byNumber.accountNumber)
+	require.Equal(t, accountNumber, *byNumber.accountNumber)
+}
+
+// TestAccountIdentitySelectorValidate verifies that semantic account selectors
+// accept exactly one portable identity and reject ambiguous or empty shapes.
+func TestAccountIdentitySelectorValidate(t *testing.T) {
+	t.Parallel()
+
+	accountName := accountIdentityTestName
+	accountNumber := AccountNumber(0)
+
+	tests := []struct {
+		name      string
+		selector  AccountSelector
+		wantError bool
+	}{
+		{
+			name: "accepts name constructor",
+			selector: NewAccountSelectorByName(
+				waddrmgr.KeyScopeBIP0084, accountName,
+			),
+		},
+		{
+			name: "accepts present zero number constructor",
+			selector: NewAccountSelectorByNumber(
+				waddrmgr.KeyScopeBIP0084, accountNumber,
+			),
+		},
+		{
+			name: "rejects neither",
+			selector: AccountSelector{
+				keyScope: waddrmgr.KeyScopeBIP0084,
+			},
+			wantError: true,
+		},
+		{
+			name: "rejects both",
+			selector: AccountSelector{
+				keyScope:      waddrmgr.KeyScopeBIP0084,
+				accountName:   &accountName,
+				accountNumber: &accountNumber,
+			},
+			wantError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := test.selector.validate()
+
+			if test.wantError {
+				require.ErrorIs(t, err, errInvalidAccountSelector)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestAccountIdentityOptionalValues verifies that callers can distinguish
+// absent identity values from present-zero values using pointers.
+func TestAccountIdentityOptionalValues(t *testing.T) {
+	t.Parallel()
+
+	var absentAccountNumber *AccountNumber
+
+	accountNumber := AccountNumber(0)
+	presentAccountNumber := &accountNumber
+
+	var absentFingerprint *MasterFingerprint
+
+	fingerprint := MasterFingerprint(0)
+	presentFingerprint := &fingerprint
+
+	require.Nil(t, absentAccountNumber)
+	require.NotNil(t, presentAccountNumber)
+	require.Equal(t, AccountNumber(0), *presentAccountNumber)
+	require.Nil(t, absentFingerprint)
+	require.NotNil(t, presentFingerprint)
+	require.Equal(t, MasterFingerprint(0), *presentFingerprint)
+}


### PR DESCRIPTION
## Summary

Implements Task 341 — define semantic account identity.

## Change Description

Add wallet-owned `AccountNumber` and `MasterFingerprint` types plus an opaque
`AccountSelector` with constructors for name and number selection. Keep shape
validation package-private and leave key-scope support and account existence
checks to consuming operations and the Store.
