### PR TITLE
wallet: enforce synchronization test boundary

### DIFF
--- a/bwtest/harness_assertions.go
+++ b/bwtest/harness_assertions.go
@@ -15,7 +15,8 @@ var (
 )
 
 // AssertWalletSynced polls until the wallet reports it is synced to the
-// miner's best known height.
+// miner's exact best block. Once this returns, wallet reads for that block may
+// be asserted without another retry.
 func (h *HarnessTest) AssertWalletSynced(w *wallet.Wallet) {
 	h.Helper()
 
@@ -24,16 +25,23 @@ func (h *HarnessTest) AssertWalletSynced(w *wallet.Wallet) {
 	}
 
 	err := wait.NoError(func() error {
-		syncedTo := w.SyncedTo()
+		info, err := w.Info(h.Context())
+		if err != nil {
+			return fmt.Errorf("get wallet info: %w", err)
+		}
 
-		_, bestHeight, err := h.miner.Client.GetBestBlock()
+		bestHash, bestHeight, err := h.miner.Client.GetBestBlock()
 		if err != nil {
 			return fmt.Errorf("get best block: %w", err)
 		}
 
-		if syncedTo.Height != bestHeight {
-			return fmt.Errorf("%w: wallet=%d chain=%d", ErrWalletNotSynced,
-				syncedTo.Height, bestHeight)
+		if !info.Synced || info.SyncedTo.Height != bestHeight ||
+			!info.SyncedTo.Hash.IsEqual(bestHash) {
+
+			return fmt.Errorf("%w: synced=%v wallet=%v:%d "+
+				"chain=%v:%d", ErrWalletNotSynced, info.Synced,
+				info.SyncedTo.Hash, info.SyncedTo.Height, bestHash,
+				bestHeight)
 		}
 
 		return nil

--- a/bwtest/harness_wallet.go
+++ b/bwtest/harness_wallet.go
@@ -2,7 +2,6 @@ package bwtest
 
 import (
 	"bytes"
-	"fmt"
 	"strings"
 	"time"
 
@@ -10,7 +9,6 @@ import (
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
-	"github.com/btcsuite/btcwallet/bwtest/wait"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet"
 	"github.com/stretchr/testify/require"
@@ -203,53 +201,7 @@ func (h *HarnessTest) FundWallet(w *wallet.Wallet,
 		})
 	}
 
-	h.AssertUtxosVisible(w, outpoints...)
-
 	return outpoints
-}
-
-// AssertUtxosVisible polls until the wallet's GetUtxo query can observe every
-// outpoint.
-func (h *HarnessTest) AssertUtxosVisible(w *wallet.Wallet,
-	outpoints ...wire.OutPoint) {
-
-	h.Helper()
-
-	err := wait.NoError(func() error {
-		for _, op := range outpoints {
-			_, err := w.GetUtxo(h.Context(), op)
-			if err != nil {
-				return fmt.Errorf("utxo %v not visible: %w",
-					op, err)
-			}
-		}
-
-		return nil
-	}, defaultTestTimeout)
-	require.NoError(h, err, "timeout waiting for utxos to be visible")
-}
-
-// AssertUtxoConfirmations polls until the wallet reports the outpoint with the
-// expected number of confirmations.
-func (h *HarnessTest) AssertUtxoConfirmations(w *wallet.Wallet,
-	op wire.OutPoint, confs int32) {
-
-	h.Helper()
-
-	err := wait.NoError(func() error {
-		utxo, err := w.GetUtxo(h.Context(), op)
-		if err != nil {
-			return fmt.Errorf("utxo %v not visible: %w", op, err)
-		}
-
-		if utxo.Confirmations != confs {
-			return fmt.Errorf("utxo %v: want %d confirmations, "+
-				"got %d", op, confs, utxo.Confirmations)
-		}
-
-		return nil
-	}, defaultTestTimeout)
-	require.NoError(h, err, "timeout waiting for utxo confirmations")
 }
 
 // ensureAccount makes sure an account exists for the given key scope, creating

--- a/itest/utxo_manager_test.go
+++ b/itest/utxo_manager_test.go
@@ -97,26 +97,14 @@ func testListUnspent(h *bwtest.HarnessTest) {
 		funded[op] = amounts[i]
 	}
 
-	// The funding transaction is confirmed, so every output reports one
-	// confirmation. FundWallet waits on GetUtxo, but ListUnspent is a
-	// separate query whose confirmation filter tracks the synced height, so
-	// poll until it reports the full set.
-	err = wait.NoError(func() error {
-		utxos, err = w.ListUnspent(h.Context(), wallet.UtxoQuery{
-			MinConfs: 0,
-			MaxConfs: maxConfsLimit,
-		})
-		if err != nil {
-			return fmt.Errorf("list unspent: %w", err)
-		}
-
-		if len(utxos) != 3 {
-			return fmt.Errorf("want 3 utxos, got %d", len(utxos))
-		}
-
-		return nil
-	}, pollTimeout)
-	require.NoError(h, err, "unexpected UTXO count")
+	// FundWallet waits for the block's exact committed wallet tip, so the
+	// confirmed outputs are ready for one direct ListUnspent assertion.
+	utxos, err = w.ListUnspent(h.Context(), wallet.UtxoQuery{
+		MinConfs: 0,
+		MaxConfs: maxConfsLimit,
+	})
+	require.NoError(h, err, "failed to list funded outputs")
+	require.Len(h, utxos, 3, "unexpected UTXO count")
 
 	// Results are sorted by amount in ascending order.
 	require.Equal(h, btcutil.Amount(oneBTC), utxos[0].Amount)
@@ -161,12 +149,9 @@ func testListUnspent(h *bwtest.HarnessTest) {
 	require.NoError(h, err, "failed to list unspent by unknown account")
 	require.Empty(h, utxos, "unknown account filter returned UTXOs")
 
-	// Advance the chain so every funded output reaches two confirmations
-	// and the confirmation bounds become selective. Mining only waits for
-	// the wallet's synced height, so wait for the confirmation count the
-	// bounds below depend on.
+	// Advance the chain so every funded output reaches two confirmations and
+	// the confirmation bounds become selective.
 	h.MineBlocks(1)
-	h.AssertUtxoConfirmations(w, outpoints[0], 2)
 
 	utxos, err = w.ListUnspent(h.Context(), wallet.UtxoQuery{
 		MinConfs: 3,
@@ -210,28 +195,14 @@ func testListUnspentImmatureCoinbase(h *bwtest.HarnessTest) {
 	funded := h.FundWallet(w, oneBTC)
 	require.Len(h, funded, 1, "unexpected funded outpoint count")
 
-	// Mining only waits for the wallet's synced height, which does not imply
-	// the coinbase has been committed to the wallet's UTXO store yet.
-	var utxos []*wallet.Utxo
-
-	err := wait.NoError(func() error {
-		listed, err := w.ListUnspent(h.Context(), wallet.UtxoQuery{
-			MinConfs: 0,
-			MaxConfs: maxConfsLimit,
-		})
-		if err != nil {
-			return fmt.Errorf("list unspent: %w", err)
-		}
-
-		if len(listed) != 2 {
-			return fmt.Errorf("want 2 utxos, got %d", len(listed))
-		}
-
-		utxos = listed
-
-		return nil
-	}, pollTimeout)
-	require.NoError(h, err, "coinbase and funded outputs not listed")
+	// Both mining helpers wait for the exact committed wallet tip, so the
+	// coinbase and ordinary output are ready for one direct read.
+	utxos, err := w.ListUnspent(h.Context(), wallet.UtxoQuery{
+		MinConfs: 0,
+		MaxConfs: maxConfsLimit,
+	})
+	require.NoError(h, err, "failed to list coinbase and funded outputs")
+	require.Len(h, utxos, 2, "coinbase and funded outputs not listed")
 
 	var coinbase, control *wallet.Utxo
 

--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -470,10 +470,20 @@ func (w *Wallet) ChangePassphrase(ctx context.Context,
 // and dynamic synchronization state.
 //
 // This is part of the Controller interface.
-func (w *Wallet) Info(_ context.Context) (*Info, error) {
+func (w *Wallet) Info(ctx context.Context) (*Info, error) {
 	err := w.state.validateStarted()
 	if err != nil {
 		return nil, err
+	}
+
+	walletInfo, err := w.store.GetWallet(ctx, w.cfg.Name)
+	if err != nil {
+		return nil, fmt.Errorf("get wallet info: %w", err)
+	}
+
+	syncedTo, err := db.OptionalBlockStampFromBlock(walletInfo.SyncedTo)
+	if err != nil {
+		return nil, fmt.Errorf("decode wallet sync tip: %w", err)
 	}
 
 	info := &Info{
@@ -482,7 +492,7 @@ func (w *Wallet) Info(_ context.Context) (*Info, error) {
 		ChainParams:      w.cfg.ChainParams,
 		Locked:           !w.state.isUnlocked(),
 		Synced:           w.state.isSynced(),
-		SyncedTo:         w.SyncedTo(), //nolint:contextcheck // Legacy API.
+		SyncedTo:         syncedTo,
 		IsRecoveryMode:   w.state.isRecoveryMode(),
 		RecoveryProgress: 0,
 	}

--- a/wallet/controller_test.go
+++ b/wallet/controller_test.go
@@ -1202,7 +1202,10 @@ func TestControllerInfo(t *testing.T) {
 	// Arrange: Create and start a test wallet with mocked subsystems.
 	w, deps := createTestWalletWithMocks(t)
 
-	bs := waddrmgr.BlockStamp{Height: 100}
+	syncedTo := &db.Block{
+		Hash:   chainhash.Hash{100},
+		Height: 100,
+	}
 	deps.store.On("GetWallet", mock.Anything, mock.Anything).Return(
 		&db.WalletInfo{
 			BirthdayBlock: &db.Block{Height: 100},
@@ -1217,9 +1220,6 @@ func TestControllerInfo(t *testing.T) {
 	// Mock the chain backend to return a specific name.
 	deps.chain.On("BackEnd").Return("mock")
 
-	// Mock SyncedTo to return a known block stamp.
-	deps.addrStore.On("SyncedTo").Return(bs)
-
 	// Mock syncState to indicate the wallet is fully synced.
 	deps.syncer.On("syncState").Return(syncStateSynced)
 
@@ -1227,6 +1227,10 @@ func TestControllerInfo(t *testing.T) {
 	expectStopTeardown(deps)
 
 	require.NoError(t, w.Start(t.Context()))
+
+	deps.store.On("GetWallet", mock.Anything, mock.Anything).Return(
+		&db.WalletInfo{SyncedTo: syncedTo}, nil,
+	).Once()
 
 	// Act: Call the Info method.
 	info, err := w.Info(t.Context())
@@ -1237,12 +1241,52 @@ func TestControllerInfo(t *testing.T) {
 	require.Equal(t, "mock", info.Backend)
 	require.Equal(t, int32(100), info.BirthdayBlock.Height)
 	require.True(t, info.Synced)
+	require.Equal(t, int32(syncedTo.Height), info.SyncedTo.Height)
+	require.Equal(t, syncedTo.Hash, info.SyncedTo.Hash)
 	require.True(t, info.Locked)
 
 	// Cleanup: Stop the wallet to release resources.
 	err = w.Stop(t.Context())
 	require.NoError(t, err)
 	w.wg.Wait()
+}
+
+// TestControllerInfoSyncTipErrors verifies Info preserves Store errors and
+// represents a wallet without a committed sync tip using the legacy unknown
+// height.
+func TestControllerInfoSyncTipErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Store error", func(t *testing.T) {
+		t.Parallel()
+
+		w, deps := createTestWalletWithMocks(t)
+		startLoadedWalletForTest(t, w)
+
+		deps.store.On("GetWallet", mock.Anything, "").Return(
+			nil, errDBMock,
+		).Once()
+
+		_, err := w.Info(t.Context())
+		require.ErrorIs(t, err, errDBMock)
+	})
+
+	t.Run("No synced tip", func(t *testing.T) {
+		t.Parallel()
+
+		w, deps := createTestWalletWithMocks(t)
+		startLoadedWalletForTest(t, w)
+
+		deps.store.On("GetWallet", mock.Anything, "").Return(
+			&db.WalletInfo{}, nil,
+		).Once()
+		deps.syncer.On("syncState").Return(syncStateSynced)
+		deps.chain.On("BackEnd").Return("mock")
+
+		info, err := w.Info(t.Context())
+		require.NoError(t, err)
+		require.Equal(t, int32(-1), info.SyncedTo.Height)
+	})
 }
 
 // TestControllerResync verifies the Resync method.

--- a/wallet/internal/db/block_common.go
+++ b/wallet/internal/db/block_common.go
@@ -40,6 +40,16 @@ func BlockStampFromBlock(block *Block) (waddrmgr.BlockStamp, error) {
 	}, nil
 }
 
+// OptionalBlockStampFromBlock converts optional database block metadata into
+// the legacy block-stamp shape, returning height -1 for missing metadata.
+func OptionalBlockStampFromBlock(block *Block) (waddrmgr.BlockStamp, error) {
+	if block == nil {
+		return waddrmgr.BlockStamp{Height: -1}, nil
+	}
+
+	return BlockStampFromBlock(block)
+}
+
 // BlockFromBlockStamp converts a legacy block-stamp into the database store
 // block shape. The timestamp is normalized to UTC.
 func BlockFromBlockStamp(block waddrmgr.BlockStamp) (*Block, error) {

--- a/wallet/internal/db/block_common_test.go
+++ b/wallet/internal/db/block_common_test.go
@@ -37,6 +37,16 @@ func TestBlockStampFromBlock(t *testing.T) {
 	require.ErrorIs(t, err, ErrInvalidParam)
 }
 
+// TestOptionalBlockStampFromBlock verifies that missing Store block metadata
+// maps to the legacy unknown height.
+func TestOptionalBlockStampFromBlock(t *testing.T) {
+	t.Parallel()
+
+	stamp, err := OptionalBlockStampFromBlock(nil)
+	require.NoError(t, err)
+	require.Equal(t, int32(-1), stamp.Height)
+}
+
 // TestBlockFromBlockStamp verifies that legacy block-stamps convert to the
 // store block shape with UTC timestamps.
 func TestBlockFromBlockStamp(t *testing.T) {

--- a/wallet/internal/db/kvdb/txstore_test.go
+++ b/wallet/internal/db/kvdb/txstore_test.go
@@ -2427,6 +2427,85 @@ func TestApplyTxBatchSkipsStaleSyncedToRestore(t *testing.T) {
 	require.Equal(t, newerTip, mgr.SyncedTo())
 }
 
+// TestGetWalletWaitsForFailedSyncTipRestore verifies that GetWallet cannot
+// expose the in-memory sync tip written by a walletdb transaction that later
+// fails.
+func TestGetWalletWaitsForFailedSyncTipRestore(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	mgr := newSpendableAddrMgr(t, dbConn)
+	t.Cleanup(mgr.Close)
+
+	previousTip := waddrmgr.BlockStamp{
+		Height:    100,
+		Hash:      chainhash.Hash{87},
+		Timestamp: time.Unix(1710004900, 0),
+	}
+	writeSyncedTo(t, dbConn, mgr, previousTip)
+
+	type walletRead struct {
+		info *db.WalletInfo
+		err  error
+	}
+
+	readStarted := make(chan struct{})
+	readResult := make(chan walletRead, 1)
+
+	var store *Store
+
+	addrStore := &succeedThenFailSyncedAddrStore{
+		Manager: mgr,
+		beforeRestore: func() {
+			go func() {
+				close(readStarted)
+
+				info, err := store.GetWallet(
+					t.Context(), "default",
+				)
+				readResult <- walletRead{info: info, err: err}
+			}()
+
+			<-readStarted
+
+			select {
+			case <-readResult:
+				t.Fatal("GetWallet returned before sync tip restore")
+
+			case <-time.After(100 * time.Millisecond):
+			}
+		},
+	}
+	store = NewStore(dbConn, nil, addrStore)
+
+	attemptedTip := &db.Block{
+		Hash:      chainhash.Hash{88},
+		Height:    101,
+		Timestamp: time.Unix(1710005000, 0),
+	}
+	err := store.ApplyTxBatch(t.Context(), db.TxBatchParams{
+		WalletID: 0,
+		SyncedTo: attemptedTip,
+	})
+	require.ErrorIs(t, err, errInducedFailure)
+
+	var result walletRead
+	select {
+	case result = <-readResult:
+
+	case <-time.After(time.Second):
+		t.Fatal("GetWallet remained blocked after sync tip restore")
+	}
+
+	require.NoError(t, result.err)
+	require.NotNil(t, result.info.SyncedTo)
+	require.Equal(t, uint32(previousTip.Height),
+		result.info.SyncedTo.Height)
+	require.Equal(t, previousTip.Hash, result.info.SyncedTo.Hash)
+}
+
 // TestApplyTxBatchEmptyNoAddrStore verifies that a batch with no transactions
 // and no sync-tip update returns nil without an address manager and without
 // opening a write transaction. The store is built with a nil addrStore and the

--- a/wallet/internal/db/kvdb/walletstore.go
+++ b/wallet/internal/db/kvdb/walletstore.go
@@ -72,6 +72,13 @@ func (s *Store) GetWallet(_ context.Context,
 			errMissingAddrStore)
 	}
 
+	// SetSyncedTo updates the legacy manager's in-memory tip before its
+	// walletdb transaction commits. Serialize this read with Store writes so
+	// only a committed tip, or the restored tip after a failed write, is
+	// observable.
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	addrStore := s.addrStore
 
 	var (

--- a/wallet/syncer.go
+++ b/wallet/syncer.go
@@ -794,28 +794,6 @@ func (s *syncer) unminedTxns(ctx context.Context) ([]*wire.MsgTx, error) {
 	return wtxmgr.DependencySort(txSet), nil
 }
 
-// updateSyncTip records the latest synced block through the store.
-func (s *syncer) updateSyncTip(ctx context.Context,
-	block wtxmgr.BlockMeta) error {
-
-	storeBlock, err := storeBlockFromBlockMeta(block)
-	if err != nil {
-		return err
-	}
-
-	err = s.store.UpdateWallet(
-		ctx, db.UpdateWalletParams{
-			WalletID: s.walletID,
-			SyncedTo: storeBlock,
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("update sync tip: %w", err)
-	}
-
-	return nil
-}
-
 // putTxNotifications records relevant transaction notifications through the
 // store.
 func (s *syncer) putTxNotifications(ctx context.Context,
@@ -841,6 +819,18 @@ func (s *syncer) putBlockNotifications(ctx context.Context,
 	if blockMeta == nil {
 		return fmt.Errorf("filtered block is missing metadata: %w",
 			db.ErrInvalidParam)
+	}
+
+	current, err := s.syncedTo(ctx)
+	if err != nil {
+		return err
+	}
+
+	// A filtered notification may remain queued after advanceChainSync has
+	// already scanned past it. Only the exact next block may move the tip
+	// forward; the sync loop handles gaps and rollback handles rewinds.
+	if blockMeta.Height != current.Height+1 {
+		return nil
 	}
 
 	block, err := storeBlockFromBlockMeta(*blockMeta)
@@ -1765,7 +1755,7 @@ func (s *syncer) handleChainUpdate(ctx context.Context, n any) error {
 func (s *syncer) processChainUpdate(ctx context.Context, update any) error {
 	switch n := update.(type) {
 	case chain.BlockConnected:
-		return s.updateSyncTip(ctx, wtxmgr.BlockMeta(n))
+		return nil
 
 	// A block was disconnected. We use checkRollback to safely verify our
 	// chain state against the backend and rewind if necessary. This

--- a/wallet/syncer.go
+++ b/wallet/syncer.go
@@ -640,12 +640,7 @@ func (s *syncer) syncedTo(ctx context.Context) (waddrmgr.BlockStamp, error) {
 			err)
 	}
 
-	// A nil SyncedTo means the wallet has not been synced to any block yet.
-	if walletInfo.SyncedTo == nil {
-		return waddrmgr.BlockStamp{Height: -1}, nil
-	}
-
-	syncedTo, err := db.BlockStampFromBlock(walletInfo.SyncedTo)
+	syncedTo, err := db.OptionalBlockStampFromBlock(walletInfo.SyncedTo)
 	if err != nil {
 		return waddrmgr.BlockStamp{}, fmt.Errorf("decode wallet sync tip: %w",
 			err)

--- a/wallet/syncer_test.go
+++ b/wallet/syncer_test.go
@@ -923,12 +923,9 @@ func TestHandleChainUpdate(t *testing.T) {
 		store, walletID,
 	)
 
-	// Case 1: Test handling of a BlockConnected notification, which
-	// advances the synced tip through the store.
+	// Case 1: Test handling of a BlockConnected notification. The filtered
+	// block notification owns the later Store update.
 	meta := wtxmgr.BlockMeta{Block: wtxmgr.Block{Height: 100}}
-
-	store.On("UpdateWallet", mock.Anything, mock.Anything).Return(
-		nil).Once()
 
 	// Act & Assert: Verify that a BlockConnected notification is
 	// correctly processed.
@@ -1506,6 +1503,7 @@ func TestProcessFilteredBlockBareMultisigCandidate(t *testing.T) {
 		Time: blockTime,
 	}
 
+	expectSyncedTip(store, waddrmgr.BlockStamp{Height: 101})
 	store.On("ApplyTxBatch", mock.Anything,
 		matchMultisigCandidateBatch(walletID, tx, members, block),
 	).Return(nil).Once()
@@ -1627,6 +1625,8 @@ func TestProcessFilteredBlockPassesCreditCandidates(t *testing.T) {
 		Time: time.Unix(789, 0).UTC(),
 	}
 
+	expectSyncedTip(store, waddrmgr.BlockStamp{Height: 102})
+
 	wantCandidates := map[uint32]address.Address{
 		0: firstAddr,
 		1: secondAddr,
@@ -1687,6 +1687,7 @@ func TestProcessFilteredBlockUsesStore(t *testing.T) {
 		Time: blockTime,
 	}
 
+	expectSyncedTip(store, waddrmgr.BlockStamp{Height: 100})
 	store.On("ApplyTxBatch", mock.Anything,
 		matchBlockTxBatch(walletID, tx, addr, received, block),
 	).Return(nil).Once()
@@ -1700,6 +1701,44 @@ func TestProcessFilteredBlockUsesStore(t *testing.T) {
 	// Assert: The block transaction and sync tip were written together.
 	require.NoError(t, err)
 	store.AssertExpectations(t)
+}
+
+// TestProcessFilteredBlockOrder verifies that stale, duplicate, and
+// skipped-height notifications are left for the normal sync loop to reconcile.
+func TestProcessFilteredBlockOrder(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		current      int32
+		notification int32
+	}{
+		{name: "stale", current: 102, notification: 101},
+		{name: "duplicate", current: 102, notification: 102},
+		{name: "gap", current: 100, notification: 102},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := &walletmock.Store{}
+			expectSyncedTip(store, waddrmgr.BlockStamp{
+				Height: test.current,
+			})
+
+			s := newSyncer(Config{}, nil, nil, nil, store, 0)
+			err := s.processChainUpdate(
+				t.Context(), chain.FilteredBlockConnected{
+					Block: &wtxmgr.BlockMeta{Block: wtxmgr.Block{
+						Height: test.notification,
+					}},
+				},
+			)
+			require.NoError(t, err)
+			store.AssertExpectations(t)
+		})
+	}
 }
 
 // storeScanBatchFixture contains expected values for store scan batch tests.
@@ -3272,12 +3311,8 @@ func TestWaitForEvent(t *testing.T) {
 	notificationChan := make(chan any, 1)
 	mockChain.On("Notifications").Return((<-chan any)(notificationChan))
 
-	// Case 1: Test event handling when a chain notification arrives, which
-	// advances the synced tip through the store.
+	// Case 1: Test event handling when a chain notification arrives.
 	notificationChan <- chain.BlockConnected{}
-
-	store.On("UpdateWallet", mock.Anything, mock.Anything).Return(
-		nil).Once()
 
 	// Act & Assert: Call waitForEvent and verify it correctly processes
 	// the arriving notification.
@@ -4853,13 +4888,7 @@ func TestProcessChainUpdate(t *testing.T) {
 			update: chain.BlockConnected{
 				Block: wtxmgr.Block{Height: 100},
 			},
-			setup: func(store *walletmock.Store, c *bwmock.Chain) {
-				store.On("UpdateWallet", mock.Anything, mock.MatchedBy(
-					func(params db.UpdateWalletParams) bool {
-						return params.SyncedTo != nil &&
-							params.SyncedTo.Height == 100
-					})).Return(nil).Once()
-			},
+			setup: func(*walletmock.Store, *bwmock.Chain) {},
 		},
 		{
 			name: "RelevantTx",
@@ -4882,6 +4911,9 @@ func TestProcessChainUpdate(t *testing.T) {
 				},
 			},
 			setup: func(store *walletmock.Store, c *bwmock.Chain) {
+				expectSyncedTip(
+					store, waddrmgr.BlockStamp{Height: 101},
+				)
 				store.On("ApplyTxBatch", mock.Anything, mock.MatchedBy(
 					func(params db.TxBatchParams) bool {
 						return params.SyncedTo != nil &&
@@ -4926,40 +4958,9 @@ func TestProcessChainUpdate(t *testing.T) {
 
 			// Assert
 			require.NoError(t, err)
+			store.AssertExpectations(t)
 		})
 	}
-}
-
-// TestProcessChainUpdateRoutesSyncTip verifies connected block notifications
-// update the runtime store sync tip when the store is available.
-func TestProcessChainUpdateRoutesSyncTip(t *testing.T) {
-	t.Parallel()
-
-	store := &walletmock.Store{}
-	s := newSyncer(Config{}, nil, nil, nil, &walletmock.Store{}, 0)
-	s.store = store
-	s.walletID = 77
-
-	block := wtxmgr.BlockMeta{
-		Block: wtxmgr.Block{
-			Hash:   chainhash.Hash{77},
-			Height: 144,
-		},
-		Time: time.Unix(1710003800, 0),
-	}
-	store.On("UpdateWallet", mock.Anything, mock.MatchedBy(
-		func(params db.UpdateWalletParams) bool {
-			return params.WalletID == s.walletID &&
-				params.SyncedTo != nil &&
-				params.SyncedTo.Hash == block.Hash &&
-				params.SyncedTo.Height == uint32(block.Height) &&
-				params.SyncedTo.Timestamp.Equal(block.Time)
-		},
-	)).Return(nil).Once()
-
-	err := s.processChainUpdate(t.Context(), chain.BlockConnected(block))
-	require.NoError(t, err)
-	store.AssertExpectations(t)
 }
 
 // TestAdvanceChainSyncUsesStoreSyncedTo verifies Store-backed synchronization
@@ -5479,11 +5480,6 @@ func TestRunSyncStep_Success(t *testing.T) {
 	mockChain.On("Notifications").Return((<-chan any)(notifChan)).Maybe()
 
 	notifChan <- chain.BlockConnected{Block: wtxmgr.Block{Height: 101}}
-
-	// The queued BlockConnected notification advances the synced tip
-	// through the store.
-	store.On("UpdateWallet", mock.Anything, mock.Anything).Return(
-		nil).Once()
 
 	// Act: Execute a sync step.
 	err := s.runSyncStep(t.Context())

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -457,11 +457,11 @@ func (w *Wallet) ID() uint32 {
 func (w *Wallet) SyncedTo() waddrmgr.BlockStamp {
 	if w.addrStore == nil {
 		info, err := w.store.GetWallet(context.Background(), w.cfg.Name)
-		if err != nil || info.SyncedTo == nil {
+		if err != nil {
 			return waddrmgr.BlockStamp{Height: -1}
 		}
 
-		stamp, err := db.BlockStampFromBlock(info.SyncedTo)
+		stamp, err := db.OptionalBlockStampFromBlock(info.SyncedTo)
 		if err != nil {
 			return waddrmgr.BlockStamp{Height: -1}
 		}


### PR DESCRIPTION
## Summary

Implements roadmap Task 433 by making `Wallet.Info().Synced` a reliable boundary for block-derived wallet assertions.

## Change Description

Report the committed wallet sync tip, publish connected-block progress only after the filtered update commits, and make the harness wait for both `Synced` and the miner’s exact tip. UTXO integration checks now perform one-shot reads after that boundary instead of retrying wallet results.