### PR TITLE
itest: add TxCreator integration tests

### DIFF
--- a/bwtest/README.md
+++ b/bwtest/README.md
@@ -34,28 +34,36 @@ The `bitcoind` backend uses ZMQ for block/tx notifications.
 
 ## Wallet Helpers
 
-`bwtest` includes convenience helpers for tests that do not want to directly
-exercise the wallet manager:
-
-- `(*HarnessTest).CreateEmptyWallet`
-- `(*HarnessTest).CreateFundedWallet`
-- `(*HarnessTest).FundWallet`
-
-Example usage:
+`bwtest` owns wallet creation, funding and lock policy so component tests do
+not each define their own. `(*HarnessTest).NewWallet` is the single
+parameterized entry point; it takes a `WalletFixture` describing what the case
+needs and returns the wallet with the outpoints funding produced:
 
 ```go
 func testFoo(t *bwtest.HarnessTest) {
-	t.CreateEmptyWallet()
+	w, outpoints := t.NewWallet(bwtest.WalletFixture{
+		AddrType: waddrmgr.WitnessPubKey,
+		Amounts:  []btcutil.Amount{oneBTC, twoBTC},
+		Unlocked: true,
+	})
 
-	// Now add tests that need a started wallet instance.
-}
-
-func testBar(t *bwtest.HarnessTest) {
-	t.CreateFundedWallet()
-
-	// Now add tests that need a wallet with spendable funds.
+	// Now add tests that need a wallet with two spendable coins.
 }
 ```
+
+`WalletFixture` carries the funding address type, the funding amounts, whether
+to unlock, and whether to leave the wallet unstarted. A case that selects the
+funded coins derives its key scope from the same `AddrType` with `KeyScope()`,
+so the funded scope has one authority.
+
+Two convenience wrappers remain for cases that need nothing else:
+
+- `(*HarnessTest).CreateEmptyWallet`
+- `(*HarnessTest).CreateFundedWallet`
+
+Funding is also available on its own through `(*HarnessTest).FundWallet` and
+`(*HarnessTest).FundWalletOfType`, and addresses through
+`(*HarnessTest).NewWalletAddress` and `(*HarnessTest).NewWalletAddressOfType`.
 
 Manager-focused tests should continue to create wallets through the manager API
 directly.

--- a/bwtest/harness_wallet.go
+++ b/bwtest/harness_wallet.go
@@ -131,35 +131,63 @@ func (h *HarnessTest) UnlockWallet(w *wallet.Wallet) {
 	require.NoError(h, err, "failed to unlock wallet")
 }
 
-// NewWalletAddress derives a fresh receive address from the wallet's default
-// account, ensuring the account exists first.
+// NewWalletAddress derives a fresh receive address of the default funding
+// type from the wallet's default account, ensuring the account exists first.
 func (h *HarnessTest) NewWalletAddress(w *wallet.Wallet) address.Address {
 	h.Helper()
 
-	scope, err := fundingAddrType.KeyScope()
-	require.NoError(h, err, "failed to resolve funding address scope")
+	return h.NewWalletAddressOfType(w, fundingAddrType)
+}
+
+// NewWalletAddressOfType derives a fresh receive address of the requested type
+// from the wallet's default account in that type's key scope, ensuring the
+// account exists first.
+//
+// Callers that need funds under a particular key scope must use this instead
+// of NewWalletAddress, because the wallet resolves accounts per scope: coins
+// held under one scope's default account are invisible to selection from
+// another.
+func (h *HarnessTest) NewWalletAddressOfType(w *wallet.Wallet,
+	addrType waddrmgr.AddressType) address.Address {
+
+	h.Helper()
+
+	scope, err := addrType.KeyScope()
+	require.NoError(h, err, "failed to resolve address scope")
 
 	h.ensureAccount(w, scope, waddrmgr.DefaultAccountName)
 
 	addr, err := w.NewAddress(
-		h.Context(), waddrmgr.DefaultAccountName, fundingAddrType, false,
+		h.Context(), waddrmgr.DefaultAccountName, addrType, false,
 	)
 	require.NoError(h, err, "failed to create address")
 
 	return addr
 }
 
-// FundWallet pays one output per amount to fresh wallet addresses in a single
-// miner transaction, confirms it, and returns the wallet outpoints in the
-// order of the amounts argument.
+// FundWallet pays one output per amount to fresh wallet addresses of the
+// default funding type in a single miner transaction, confirms it, and returns
+// the wallet outpoints in the order of the amounts argument.
 func (h *HarnessTest) FundWallet(w *wallet.Wallet,
+	amounts ...btcutil.Amount) []wire.OutPoint {
+
+	h.Helper()
+
+	return h.FundWalletOfType(w, fundingAddrType, amounts...)
+}
+
+// FundWalletOfType pays one output per amount to fresh wallet addresses of the
+// requested address type in a single miner transaction, confirms it, and
+// returns the wallet outpoints in the order of the amounts argument.
+func (h *HarnessTest) FundWalletOfType(w *wallet.Wallet,
+	addrType waddrmgr.AddressType,
 	amounts ...btcutil.Amount) []wire.OutPoint {
 
 	h.Helper()
 
 	outputs := make([]*wire.TxOut, 0, len(amounts))
 	for _, amount := range amounts {
-		addr := h.NewWalletAddress(w)
+		addr := h.NewWalletAddressOfType(w, addrType)
 
 		pkScript, err := txscript.PayToAddrScript(addr)
 		require.NoError(h, err, "failed to create pkscript")

--- a/bwtest/harness_wallet.go
+++ b/bwtest/harness_wallet.go
@@ -291,6 +291,42 @@ func (h *HarnessTest) FundWalletOfType(w *wallet.Wallet,
 	return outpoints
 }
 
+// ForeignOutpoint returns an outpoint of the funding transaction that the
+// funded wallet does not own.
+//
+// Funding pays one output per requested amount plus a single change output
+// back to the miner, so exactly one index in the transaction's first
+// len(funded)+1 outputs is not wallet-owned. That output exists on chain and is
+// spendable by the miner, which makes it the fixture's foreign coin.
+func (h *HarnessTest) ForeignOutpoint(funded []wire.OutPoint) wire.OutPoint {
+	h.Helper()
+
+	require.NotEmpty(h, funded, "no funded outpoints")
+
+	owned := make(map[uint32]struct{}, len(funded))
+	for _, outpoint := range funded {
+		owned[outpoint.Index] = struct{}{}
+	}
+
+	for index := range len(funded) + 1 {
+		//nolint:gosec // A funding transaction's output count is small.
+		outputIndex := uint32(index)
+
+		if _, ok := owned[outputIndex]; ok {
+			continue
+		}
+
+		return wire.OutPoint{
+			Hash:  funded[0].Hash,
+			Index: outputIndex,
+		}
+	}
+
+	h.Fatalf("funding transaction has no foreign output")
+
+	return wire.OutPoint{}
+}
+
 // ensureAccount makes sure an account exists for the given key scope, creating
 // it when the backend did not seed it at wallet creation.
 func (h *HarnessTest) ensureAccount(w *wallet.Wallet,

--- a/bwtest/harness_wallet.go
+++ b/bwtest/harness_wallet.go
@@ -92,15 +92,14 @@ type WalletFixture struct {
 }
 
 // NewWallet creates, registers and prepares a wallet as the fixture describes,
-// returning it alongside the outpoints funding produced, in the order of the
-// requested amounts.
+// returning it alongside what its funding transaction created.
 //
 // A funded fixture returns after the funding block's synchronization check,
 // which mining performs for every registered wallet, so its coins are readable
 // without a further check; deriving an address afterwards does not need one
 // either. An unfunded fixture mines nothing and so provides no such boundary.
 func (h *HarnessTest) NewWallet(fixture WalletFixture) (*wallet.Wallet,
-	[]wire.OutPoint) {
+	WalletFunding) {
 
 	h.Helper()
 
@@ -121,7 +120,7 @@ func (h *HarnessTest) NewWallet(fixture WalletFixture) (*wallet.Wallet,
 			h, fixture.Amounts, "funding needs a started wallet",
 		)
 
-		return w, nil
+		return w, WalletFunding{}
 	}
 
 	err = w.Start(h.Context())
@@ -132,7 +131,7 @@ func (h *HarnessTest) NewWallet(fixture WalletFixture) (*wallet.Wallet,
 	}
 
 	if len(fixture.Amounts) == 0 {
-		return w, nil
+		return w, WalletFunding{}
 	}
 
 	return w, h.FundWalletOfType(w, fixture.AddrType, fixture.Amounts...)
@@ -224,11 +223,23 @@ func (h *HarnessTest) NewWalletAddressOfType(w *wallet.Wallet,
 	return addr
 }
 
+// WalletFunding describes the outputs a funding transaction created.
+type WalletFunding struct {
+	// WalletOutpoints are the outputs the funded wallet owns, in the order
+	// of the amounts that were requested.
+	WalletOutpoints []wire.OutPoint
+
+	// ForeignOutpoints are the transaction's remaining outputs, which
+	// exist on chain but belong to the miner rather than to the funded
+	// wallet. Funding pays its own change here, so there is normally one.
+	ForeignOutpoints []wire.OutPoint
+}
+
 // FundWallet pays one output per amount to fresh wallet addresses of the
 // default funding type in a single miner transaction, confirms it, and returns
-// the wallet outpoints in the order of the amounts argument.
+// what the funding transaction created.
 func (h *HarnessTest) FundWallet(w *wallet.Wallet,
-	amounts ...btcutil.Amount) []wire.OutPoint {
+	amounts ...btcutil.Amount) WalletFunding {
 
 	h.Helper()
 
@@ -237,10 +248,13 @@ func (h *HarnessTest) FundWallet(w *wallet.Wallet,
 
 // FundWalletOfType pays one output per amount to fresh wallet addresses of the
 // requested address type in a single miner transaction, confirms it, and
-// returns the wallet outpoints in the order of the amounts argument.
+// returns what the funding transaction created.
+//
+// The transaction's outputs are classified here, where the transaction itself
+// is known, so no caller has to infer which of them the wallet owns.
 func (h *HarnessTest) FundWalletOfType(w *wallet.Wallet,
 	addrType waddrmgr.AddressType,
-	amounts ...btcutil.Amount) []wire.OutPoint {
+	amounts ...btcutil.Amount) WalletFunding {
 
 	h.Helper()
 
@@ -267,7 +281,11 @@ func (h *HarnessTest) FundWalletOfType(w *wallet.Wallet,
 	// Locate each wallet output's index within the funding transaction so
 	// callers receive ready-to-use outpoints in the order of the amounts
 	// argument.
-	outpoints := make([]wire.OutPoint, 0, len(outputs))
+	owned := make(map[uint32]struct{}, len(outputs))
+	funding := WalletFunding{
+		WalletOutpoints: make([]wire.OutPoint, 0, len(outputs)),
+	}
+
 	for _, output := range outputs {
 		index := -1
 
@@ -282,49 +300,34 @@ func (h *HarnessTest) FundWalletOfType(w *wallet.Wallet,
 		require.NotEqual(h, -1, index,
 			"funding output missing from transaction")
 
-		outpoints = append(outpoints, wire.OutPoint{
-			Hash:  *txid,
-			Index: uint32(index), //nolint:gosec
-		})
+		outputIndex := uint32(index) //nolint:gosec
+		owned[outputIndex] = struct{}{}
+
+		funding.WalletOutpoints = append(
+			funding.WalletOutpoints, wire.OutPoint{
+				Hash:  *txid,
+				Index: outputIndex,
+			},
+		)
 	}
 
-	return outpoints
-}
-
-// ForeignOutpoint returns an outpoint of the funding transaction that the
-// funded wallet does not own.
-//
-// Funding pays one output per requested amount plus a single change output
-// back to the miner, so exactly one index in the transaction's first
-// len(funded)+1 outputs is not wallet-owned. That output exists on chain and is
-// spendable by the miner, which makes it the fixture's foreign coin.
-func (h *HarnessTest) ForeignOutpoint(funded []wire.OutPoint) wire.OutPoint {
-	h.Helper()
-
-	require.NotEmpty(h, funded, "no funded outpoints")
-
-	owned := make(map[uint32]struct{}, len(funded))
-	for _, outpoint := range funded {
-		owned[outpoint.Index] = struct{}{}
-	}
-
-	for index := range len(funded) + 1 {
-		//nolint:gosec // A funding transaction's output count is small.
-		outputIndex := uint32(index)
-
+	// Whatever the transaction pays elsewhere belongs to the miner, and is
+	// reported as it stands rather than assumed to exist.
+	for i := range tx.TxOut {
+		outputIndex := uint32(i) //nolint:gosec
 		if _, ok := owned[outputIndex]; ok {
 			continue
 		}
 
-		return wire.OutPoint{
-			Hash:  funded[0].Hash,
-			Index: outputIndex,
-		}
+		funding.ForeignOutpoints = append(
+			funding.ForeignOutpoints, wire.OutPoint{
+				Hash:  *txid,
+				Index: outputIndex,
+			},
+		)
 	}
 
-	h.Fatalf("funding transaction has no foreign output")
-
-	return wire.OutPoint{}
+	return funding
 }
 
 // ensureAccount makes sure an account exists for the given key scope, creating

--- a/bwtest/harness_wallet.go
+++ b/bwtest/harness_wallet.go
@@ -95,10 +95,10 @@ type WalletFixture struct {
 // returning it alongside the outpoints funding produced, in the order of the
 // requested amounts.
 //
-// The returned wallet is not a synchronization boundary. Funding and address
-// derivation are both wallet side effects, so a case that reads wallet state
-// must cross AssertWalletSynced after its own last funding or derivation, not
-// merely after this call.
+// A funded fixture returns after the funding block's synchronization check,
+// which mining performs for every registered wallet, so its coins are readable
+// without a further check; deriving an address afterwards does not need one
+// either. An unfunded fixture mines nothing and so provides no such boundary.
 func (h *HarnessTest) NewWallet(fixture WalletFixture) (*wallet.Wallet,
 	[]wire.OutPoint) {
 

--- a/bwtest/harness_wallet.go
+++ b/bwtest/harness_wallet.go
@@ -67,11 +67,41 @@ func (h *HarnessTest) TestWalletConfig() (wallet.Config,
 	return cfg, params
 }
 
-// CreateEmptyWallet creates, starts, and registers a new wallet instance.
+// WalletFixture describes the wallet a test case needs. It is the harness's
+// parameterized wallet preparation request, so a component test states what it
+// needs instead of growing its own creation, funding and lock policy.
+type WalletFixture struct {
+	// AddrType is the address type funding is paid to. A test that selects
+	// those coins derives its key scope from this same value with
+	// KeyScope(), so the funded scope has a single authority.
+	//
+	// This field is always honored, including its zero value, PubKeyHash.
+	AddrType waddrmgr.AddressType
+
+	// Amounts funds the wallet with one confirmed output per amount, in
+	// the order given. Funding needs a running wallet, so it cannot be
+	// combined with Unstarted.
+	Amounts []btcutil.Amount
+
+	// Unlocked unlocks the wallet once it has started.
+	Unlocked bool
+
+	// Unstarted returns the wallet before Start, for cases asserting
+	// behavior that is only observable while the wallet is not running.
+	Unstarted bool
+}
+
+// NewWallet creates, registers and prepares a wallet as the fixture describes,
+// returning it alongside the outpoints funding produced, in the order of the
+// requested amounts.
 //
-// This is intended for non-manager integration tests that want a ready-to-use
-// wallet without repeating boilerplate.
-func (h *HarnessTest) CreateEmptyWallet() *wallet.Wallet {
+// The returned wallet is not a synchronization boundary. Funding and address
+// derivation are both wallet side effects, so a case that reads wallet state
+// must cross AssertWalletSynced after its own last funding or derivation, not
+// merely after this call.
+func (h *HarnessTest) NewWallet(fixture WalletFixture) (*wallet.Wallet,
+	[]wire.OutPoint) {
+
 	h.Helper()
 
 	cfg, params := h.TestWalletConfig()
@@ -86,8 +116,36 @@ func (h *HarnessTest) CreateEmptyWallet() *wallet.Wallet {
 	// successful one twice, out of order with the Manager close.
 	h.RegisterWallet(w)
 
+	if fixture.Unstarted {
+		require.Empty(
+			h, fixture.Amounts, "funding needs a started wallet",
+		)
+
+		return w, nil
+	}
+
 	err = w.Start(h.Context())
 	require.NoError(h, err, "failed to start wallet")
+
+	if fixture.Unlocked {
+		h.UnlockWallet(w)
+	}
+
+	if len(fixture.Amounts) == 0 {
+		return w, nil
+	}
+
+	return w, h.FundWalletOfType(w, fixture.AddrType, fixture.Amounts...)
+}
+
+// CreateEmptyWallet creates, starts, and registers a new wallet instance.
+//
+// This is intended for non-manager integration tests that want a ready-to-use
+// wallet without repeating boilerplate.
+func (h *HarnessTest) CreateEmptyWallet() *wallet.Wallet {
+	h.Helper()
+
+	w, _ := h.NewWallet(WalletFixture{AddrType: fundingAddrType})
 
 	return w
 }
@@ -96,11 +154,12 @@ func (h *HarnessTest) CreateEmptyWallet() *wallet.Wallet {
 func (h *HarnessTest) CreateFundedWallet() *wallet.Wallet {
 	h.Helper()
 
-	w := h.CreateEmptyWallet()
-
 	const tenBTC = 10 * btcutil.SatoshiPerBitcoin
 
-	h.FundWallet(w, tenBTC)
+	w, _ := h.NewWallet(WalletFixture{
+		AddrType: fundingAddrType,
+		Amounts:  []btcutil.Amount{tenBTC},
+	})
 
 	return w
 }

--- a/itest/fixtures_test.go
+++ b/itest/fixtures_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btcwallet/pkg/btcunit"
+	"github.com/btcsuite/btcwallet/wallet/txrules"
 )
 
 // Fixture values shared by more than one component's integration tests. They
@@ -23,11 +25,17 @@ const (
 	// enough that the lease never expires mid-test.
 	leaseDuration = 10 * time.Minute
 
-	// The funding amounts shared by the component test cases.
+	// The funding and payment amounts shared by the component test cases.
+	halfBTC  = btcutil.SatoshiPerBitcoin / 2
 	oneBTC   = 1 * btcutil.SatoshiPerBitcoin
 	twoBTC   = 2 * btcutil.SatoshiPerBitcoin
 	threeBTC = 3 * btcutil.SatoshiPerBitcoin
 )
+
+// relayFeeRate is the default relay fee, one satoshi per virtual byte. Any
+// case that authors a transaction pays it, and it keeps the fee negligible
+// against the funding amounts above.
+var relayFeeRate = btcunit.NewSatPerKVByte(txrules.DefaultRelayFeePerKb)
 
 // unknownOutpoint returns an outpoint that was never mined and is therefore
 // unknown to any wallet.

--- a/itest/fixtures_test.go
+++ b/itest/fixtures_test.go
@@ -1,0 +1,36 @@
+//go:build itest
+
+package itest
+
+import (
+	"math"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+)
+
+// Fixture values shared by more than one component's integration tests. They
+// live here rather than in one component's test file so that no component owns
+// the values another component depends on.
+const (
+	// maxConfsLimit is used as the MaxConfs bound when a test does not want
+	// to constrain the upper confirmation range.
+	maxConfsLimit = math.MaxInt32
+
+	// leaseDuration is the standard lease length for tests. It is long
+	// enough that the lease never expires mid-test.
+	leaseDuration = 10 * time.Minute
+
+	// The funding amounts shared by the component test cases.
+	oneBTC   = 1 * btcutil.SatoshiPerBitcoin
+	twoBTC   = 2 * btcutil.SatoshiPerBitcoin
+	threeBTC = 3 * btcutil.SatoshiPerBitcoin
+)
+
+// unknownOutpoint returns an outpoint that was never mined and is therefore
+// unknown to any wallet.
+func unknownOutpoint() wire.OutPoint {
+	return wire.OutPoint{Hash: chainhash.Hash{0xaa}, Index: 0}
+}

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -111,4 +111,8 @@ var allTestCases = []*testCase{
 		Name:     "txcreator reject inputs",
 		TestFunc: testCreateTransactionRejectInputs,
 	},
+	{
+		Name:     "txcreator wallet state",
+		TestFunc: testCreateTransactionWalletState,
+	},
 }

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -79,4 +79,8 @@ var allTestCases = []*testCase{
 		Name:     "utxomanager list leased outputs",
 		TestFunc: testListLeasedOutputs,
 	},
+	{
+		Name:     "txcreator select coins",
+		TestFunc: testCreateTransactionSelectCoins,
+	},
 }

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -91,4 +91,8 @@ var allTestCases = []*testCase{
 		Name:     "txcreator manual inputs",
 		TestFunc: testCreateTransactionManualInputs,
 	},
+	{
+		Name:     "txcreator default account",
+		TestFunc: testCreateTransactionDefaultAccount,
+	},
 }

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -95,4 +95,8 @@ var allTestCases = []*testCase{
 		Name:     "txcreator default account",
 		TestFunc: testCreateTransactionDefaultAccount,
 	},
+	{
+		Name:     "txcreator coin source",
+		TestFunc: testCreateTransactionCoinSource,
+	},
 }

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -107,4 +107,8 @@ var allTestCases = []*testCase{
 		Name:     "txcreator reject intent",
 		TestFunc: testCreateTransactionRejectIntent,
 	},
+	{
+		Name:     "txcreator reject inputs",
+		TestFunc: testCreateTransactionRejectInputs,
+	},
 }

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -103,4 +103,8 @@ var allTestCases = []*testCase{
 		Name:     "txcreator omit change",
 		TestFunc: testCreateTransactionOmitChange,
 	},
+	{
+		Name:     "txcreator reject intent",
+		TestFunc: testCreateTransactionRejectIntent,
+	},
 }

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -108,6 +108,10 @@ var allTestCases = []*testCase{
 		TestFunc: testCreateTransactionRejectIntent,
 	},
 	{
+		Name:     "txcreator output boundaries",
+		TestFunc: testCreateTransactionOutputBoundaries,
+	},
+	{
 		Name:     "txcreator reject inputs",
 		TestFunc: testCreateTransactionRejectInputs,
 	},

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -83,4 +83,8 @@ var allTestCases = []*testCase{
 		Name:     "txcreator select coins",
 		TestFunc: testCreateTransactionSelectCoins,
 	},
+	{
+		Name:     "txcreator multiple outputs",
+		TestFunc: testCreateTransactionMultipleOutputs,
+	},
 }

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -99,4 +99,8 @@ var allTestCases = []*testCase{
 		Name:     "txcreator coin source",
 		TestFunc: testCreateTransactionCoinSource,
 	},
+	{
+		Name:     "txcreator omit change",
+		TestFunc: testCreateTransactionOmitChange,
+	},
 }

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -87,4 +87,8 @@ var allTestCases = []*testCase{
 		Name:     "txcreator multiple outputs",
 		TestFunc: testCreateTransactionMultipleOutputs,
 	},
+	{
+		Name:     "txcreator manual inputs",
+		TestFunc: testCreateTransactionManualInputs,
+	},
 }

--- a/itest/tx_creator_test.go
+++ b/itest/tx_creator_test.go
@@ -158,3 +158,71 @@ func testCreateTransactionSelectCoins(h *bwtest.HarnessTest) {
 	require.Empty(h, leases, "creating a transaction reserved a coin")
 }
 
+// testCreateTransactionMultipleOutputs verifies that every requested output
+// reaches the authored transaction intact when an intent asks for more than
+// one, alongside the change output.
+func testCreateTransactionMultipleOutputs(h *bwtest.HarnessTest) {
+	// quarterBTC is the second payment amount. It differs from the first so
+	// the two payments are distinguishable by value as well as by script.
+	const quarterBTC = btcutil.SatoshiPerBitcoin / 4
+
+	scope, err := txCreatorFundingType.KeyScope()
+	require.NoError(h, err, "failed to resolve funding scope")
+
+	w, _ := h.NewWallet(bwtest.WalletFixture{
+		AddrType: txCreatorFundingType,
+		Amounts:  []btcutil.Amount{oneBTC, twoBTC},
+		Unlocked: true,
+	})
+
+	// Each payment is derived separately, so an authored transaction that
+	// collapsed its outputs onto one recipient fails the assertions below.
+	first := deriveWalletPayment(h, w, txCreatorFundingType, halfBTC)
+	second := deriveWalletPayment(h, w, txCreatorFundingType, quarterBTC)
+	require.NotEqual(
+		h, first.PkScript, second.PkScript, "payments share a script",
+	)
+
+	h.AssertWalletSynced(w)
+
+	account := &wallet.ScopedAccount{
+		AccountName: waddrmgr.DefaultAccountName,
+		KeyScope:    scope,
+	}
+
+	authored, err := w.CreateTransaction(h.Context(), &wallet.TxIntent{
+		Outputs: []wire.TxOut{first, second},
+		Inputs: &wallet.InputsPolicy{
+			Strategy: wallet.CoinSelectionLargest,
+			MinConfs: 1,
+			Source:   account,
+		},
+		ChangeSource: account,
+		FeeRate:      relayFeeRate,
+	})
+	require.NoError(h, err, "failed to create transaction")
+
+	// Both payments and one change output are present. The change position
+	// is randomized, so the payments are located by content.
+	require.Len(h, authored.Tx.TxOut, 3, "unexpected output count")
+	require.GreaterOrEqual(h, authored.ChangeIndex, 0, "no change output")
+
+	paid := make(map[string]int64, len(authored.Tx.TxOut))
+	for i, output := range authored.Tx.TxOut {
+		if i == authored.ChangeIndex {
+			continue
+		}
+
+		paid[string(output.PkScript)] = output.Value
+	}
+
+	require.Equal(
+		h, first.Value, paid[string(first.PkScript)],
+		"first payment missing or altered",
+	)
+	require.Equal(
+		h, second.Value, paid[string(second.PkScript)],
+		"second payment missing or altered",
+	)
+}
+

--- a/itest/tx_creator_test.go
+++ b/itest/tx_creator_test.go
@@ -325,3 +325,52 @@ func testCreateTransactionManualInputs(h *bwtest.HarnessTest) {
 	)
 }
 
+// testCreateTransactionDefaultAccount verifies that an intent naming neither
+// an input source nor a change source funds itself from the default account,
+// which the wallet resolves under the Taproot key scope.
+func testCreateTransactionDefaultAccount(h *bwtest.HarnessTest) {
+	w, outpoints := h.NewWallet(bwtest.WalletFixture{
+		AddrType: waddrmgr.TaprootPubKey,
+		Amounts:  []btcutil.Amount{oneBTC},
+		Unlocked: true,
+	})
+
+	payment := deriveWalletPayment(h, w, waddrmgr.TaprootPubKey, halfBTC)
+
+	h.AssertWalletSynced(w)
+
+	authored, err := w.CreateTransaction(h.Context(), &wallet.TxIntent{
+		Outputs: []wire.TxOut{payment},
+		FeeRate: relayFeeRate,
+	})
+	require.NoError(h, err, "failed to create transaction")
+
+	// The implicit source is the default account of the Taproot scope, the
+	// only account holding coins here.
+	require.Len(h, authored.Tx.TxIn, 1, "unexpected input count")
+	require.Equal(
+		h, outpoints[0], authored.Tx.TxIn[0].PreviousOutPoint,
+		"unexpected selected input",
+	)
+
+	// The implicit change source is that same account, so the change output
+	// is an internal Taproot address of the wallet.
+	require.Len(h, authored.Tx.TxOut, 2, "unexpected output count")
+	require.GreaterOrEqual(h, authored.ChangeIndex, 0, "no change output")
+
+	change := authored.Tx.TxOut[authored.ChangeIndex]
+	_, changeAddrs, _, err := txscript.ExtractPkScriptAddrs(
+		change.PkScript, h.NetParams(),
+	)
+	require.NoError(h, err, "failed to extract change address")
+	require.Len(h, changeAddrs, 1, "unexpected change address count")
+
+	changeInfo, err := w.GetAddressInfo(h.Context(), changeAddrs[0])
+	require.NoError(h, err, "change address is unknown to the wallet")
+	require.True(h, changeInfo.Internal, "change address is not internal")
+	require.Equal(
+		h, waddrmgr.TaprootPubKey, changeInfo.AddrType,
+		"unexpected change address type",
+	)
+}
+

--- a/itest/tx_creator_test.go
+++ b/itest/tx_creator_test.go
@@ -443,3 +443,59 @@ func testCreateTransactionCoinSource(h *bwtest.HarnessTest) {
 	)
 }
 
+// testCreateTransactionOmitChange verifies that a transaction whose remainder
+// would be dust is authored without a change output.
+func testCreateTransactionOmitChange(h *bwtest.HarnessTest) {
+	// smallCoin is the only coin the wallet holds, so the payment below is
+	// funded by it alone.
+	const smallCoin = 100_000
+
+	// changeLeftover is what remains of the coin after the payment. The fee
+	// for this single input, single output shape at the default relay rate
+	// takes most of it, and what is left is below the dust limit for a
+	// witness pubkey change output, so the wallet must drop the change.
+	// Only that omission is asserted here; the fee itself is not.
+	const changeLeftover = 300
+
+	scope, err := txCreatorFundingType.KeyScope()
+	require.NoError(h, err, "failed to resolve funding scope")
+
+	w, outpoints := h.NewWallet(bwtest.WalletFixture{
+		AddrType: txCreatorFundingType,
+		Amounts:  []btcutil.Amount{smallCoin},
+		Unlocked: true,
+	})
+
+	payment := deriveWalletPayment(
+		h, w, txCreatorFundingType, smallCoin-changeLeftover,
+	)
+
+	h.AssertWalletSynced(w)
+
+	authored, err := w.CreateTransaction(h.Context(), &wallet.TxIntent{
+		Outputs: []wire.TxOut{payment},
+		Inputs: &wallet.InputsManual{
+			UTXOs: []wire.OutPoint{outpoints[0]},
+		},
+		ChangeSource: &wallet.ScopedAccount{
+			AccountName: waddrmgr.DefaultAccountName,
+			KeyScope:    scope,
+		},
+		FeeRate: relayFeeRate,
+	})
+	require.NoError(h, err, "failed to create transaction")
+
+	require.Equal(
+		h, -1, authored.ChangeIndex, "dust change output not omitted",
+	)
+	require.Len(h, authored.Tx.TxOut, 1, "unexpected output count")
+	require.Equal(
+		h, payment.PkScript, authored.Tx.TxOut[0].PkScript,
+		"payment script changed",
+	)
+	require.Equal(
+		h, payment.Value, authored.Tx.TxOut[0].Value,
+		"payment value changed",
+	)
+}
+

--- a/itest/tx_creator_test.go
+++ b/itest/tx_creator_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcwallet/pkg/btcunit"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet"
+	"github.com/btcsuite/btcwallet/wallet/txauthor"
 	"github.com/btcsuite/btcwallet/wallet/txrules"
 	"github.com/stretchr/testify/require"
 )
@@ -371,6 +372,74 @@ func testCreateTransactionDefaultAccount(h *bwtest.HarnessTest) {
 	require.Equal(
 		h, waddrmgr.TaprootPubKey, changeInfo.AddrType,
 		"unexpected change address type",
+	)
+}
+
+// testCreateTransactionCoinSource verifies that a policy restricted to a
+// candidate list selects only from that list and honors its confirmation
+// bound.
+func testCreateTransactionCoinSource(h *bwtest.HarnessTest) {
+	// unreachableConfs is a confirmation floor no candidate in this case
+	// can meet: the funding block is the chain tip, so every coin the
+	// wallet holds has exactly one confirmation.
+	const unreachableConfs = 2
+
+	scope, err := txCreatorFundingType.KeyScope()
+	require.NoError(h, err, "failed to resolve funding scope")
+
+	w, outpoints := h.NewWallet(bwtest.WalletFixture{
+		AddrType: txCreatorFundingType,
+		Amounts:  []btcutil.Amount{oneBTC, twoBTC, threeBTC},
+		Unlocked: true,
+	})
+
+	payment := deriveWalletPayment(h, w, txCreatorFundingType, halfBTC)
+
+	h.AssertWalletSynced(w)
+
+	account := &wallet.ScopedAccount{
+		AccountName: waddrmgr.DefaultAccountName,
+		KeyScope:    scope,
+	}
+
+	// Only the candidate coin is spendable here, even though the wallet
+	// holds larger coins outside the list.
+	authored, err := w.CreateTransaction(h.Context(), &wallet.TxIntent{
+		Outputs: []wire.TxOut{payment},
+		Inputs: &wallet.InputsPolicy{
+			MinConfs: 1,
+			Source: &wallet.CoinSourceUTXOs{
+				UTXOs: []wire.OutPoint{outpoints[0]},
+			},
+		},
+		ChangeSource: account,
+		FeeRate:      relayFeeRate,
+	})
+	require.NoError(h, err, "failed to create transaction")
+
+	require.Len(h, authored.Tx.TxIn, 1, "unexpected input count")
+	require.Equal(
+		h, outpoints[0], authored.Tx.TxIn[0].PreviousOutPoint,
+		"unexpected candidate selected",
+	)
+
+	// A confirmation bound the candidate cannot meet leaves the policy with
+	// nothing to select.
+	_, err = w.CreateTransaction(h.Context(), &wallet.TxIntent{
+		Outputs: []wire.TxOut{payment},
+		Inputs: &wallet.InputsPolicy{
+			MinConfs: unreachableConfs,
+			Source: &wallet.CoinSourceUTXOs{
+				UTXOs: []wire.OutPoint{outpoints[0]},
+			},
+		},
+		ChangeSource: account,
+		FeeRate:      relayFeeRate,
+	})
+
+	var sourceErr txauthor.InputSourceError
+	require.ErrorAs(
+		h, err, &sourceErr, "under-confirmed candidate not skipped",
 	)
 }
 

--- a/itest/tx_creator_test.go
+++ b/itest/tx_creator_test.go
@@ -17,21 +17,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	// halfBTC is the payment amount the TxCreator cases use. It is small
-	// enough that any single funded coin covers it.
-	halfBTC = btcutil.SatoshiPerBitcoin / 2
-
-	// txCreatorFundingType is the address type the TxCreator cases fund and
-	// select from. Each case derives its key scope from this value, so the
-	// funded scope is never stated twice.
-	txCreatorFundingType = waddrmgr.WitnessPubKey
-)
-
-// relayFeeRate is the fee rate the TxCreator cases author at. It is the
-// default relay fee, one satoshi per virtual byte, which keeps the fee
-// negligible against the funded amounts.
-var relayFeeRate = btcunit.NewSatPerKVByte(txrules.DefaultRelayFeePerKb)
+// txCreatorFundingType is the address type the TxCreator cases fund and select
+// from. Each case derives its key scope from this value, so the funded scope is
+// never stated twice.
+const txCreatorFundingType = waddrmgr.WitnessPubKey
 
 // deriveWalletPayment derives a fresh external address of the requested type
 // from the wallet and returns a payment of amount to it.

--- a/itest/tx_creator_test.go
+++ b/itest/tx_creator_test.go
@@ -55,11 +55,13 @@ func testCreateTransactionSelectCoins(h *bwtest.HarnessTest) {
 	scope, err := txCreatorFundingType.KeyScope()
 	require.NoError(h, err, "failed to resolve funding scope")
 
-	w, outpoints := h.NewWallet(bwtest.WalletFixture{
+	w, funding := h.NewWallet(bwtest.WalletFixture{
 		AddrType: txCreatorFundingType,
 		Amounts:  []btcutil.Amount{oneBTC, twoBTC},
 		Unlocked: true,
 	})
+
+	outpoints := funding.WalletOutpoints
 
 	payment := deriveWalletPayment(h, w, txCreatorFundingType, halfBTC)
 
@@ -219,11 +221,13 @@ func testCreateTransactionManualInputs(h *bwtest.HarnessTest) {
 	scope, err := txCreatorFundingType.KeyScope()
 	require.NoError(h, err, "failed to resolve funding scope")
 
-	w, outpoints := h.NewWallet(bwtest.WalletFixture{
+	w, funding := h.NewWallet(bwtest.WalletFixture{
 		AddrType: txCreatorFundingType,
 		Amounts:  []btcutil.Amount{oneBTC, twoBTC, threeBTC},
 		Unlocked: true,
 	})
+
+	outpoints := funding.WalletOutpoints
 
 	// The first payment needs two coins, the second needs one.
 	large := deriveWalletPayment(h, w, txCreatorFundingType, threeBTC+halfBTC)
@@ -314,11 +318,13 @@ func testCreateTransactionManualInputs(h *bwtest.HarnessTest) {
 // an input source nor a change source funds itself from the default account,
 // which the wallet resolves under the Taproot key scope.
 func testCreateTransactionDefaultAccount(h *bwtest.HarnessTest) {
-	w, outpoints := h.NewWallet(bwtest.WalletFixture{
+	w, funding := h.NewWallet(bwtest.WalletFixture{
 		AddrType: waddrmgr.TaprootPubKey,
 		Amounts:  []btcutil.Amount{oneBTC},
 		Unlocked: true,
 	})
+
+	outpoints := funding.WalletOutpoints
 
 	payment := deriveWalletPayment(h, w, waddrmgr.TaprootPubKey, halfBTC)
 
@@ -369,11 +375,13 @@ func testCreateTransactionCoinSource(h *bwtest.HarnessTest) {
 	scope, err := txCreatorFundingType.KeyScope()
 	require.NoError(h, err, "failed to resolve funding scope")
 
-	w, outpoints := h.NewWallet(bwtest.WalletFixture{
+	w, funding := h.NewWallet(bwtest.WalletFixture{
 		AddrType: txCreatorFundingType,
 		Amounts:  []btcutil.Amount{oneBTC, twoBTC, threeBTC},
 		Unlocked: true,
 	})
+
+	outpoints := funding.WalletOutpoints
 
 	payment := deriveWalletPayment(h, w, txCreatorFundingType, halfBTC)
 
@@ -440,11 +448,13 @@ func testCreateTransactionOmitChange(h *bwtest.HarnessTest) {
 	scope, err := txCreatorFundingType.KeyScope()
 	require.NoError(h, err, "failed to resolve funding scope")
 
-	w, outpoints := h.NewWallet(bwtest.WalletFixture{
+	w, funding := h.NewWallet(bwtest.WalletFixture{
 		AddrType: txCreatorFundingType,
 		Amounts:  []btcutil.Amount{smallCoin},
 		Unlocked: true,
 	})
+
+	outpoints := funding.WalletOutpoints
 
 	payment := deriveWalletPayment(
 		h, w, txCreatorFundingType, smallCoin-changeLeftover,
@@ -484,11 +494,13 @@ func testCreateTransactionRejectIntent(h *bwtest.HarnessTest) {
 	scope, err := txCreatorFundingType.KeyScope()
 	require.NoError(h, err, "failed to resolve funding scope")
 
-	w, outpoints := h.NewWallet(bwtest.WalletFixture{
+	w, funding := h.NewWallet(bwtest.WalletFixture{
 		AddrType: txCreatorFundingType,
 		Amounts:  []btcutil.Amount{oneBTC},
 		Unlocked: true,
 	})
+
+	outpoints := funding.WalletOutpoints
 
 	payment := deriveWalletPayment(h, w, txCreatorFundingType, halfBTC)
 
@@ -693,11 +705,13 @@ func testCreateTransactionOutputBoundaries(h *bwtest.HarnessTest) {
 	scope, err := txCreatorFundingType.KeyScope()
 	require.NoError(h, err, "failed to resolve funding scope")
 
-	w, outpoints := h.NewWallet(bwtest.WalletFixture{
+	w, funding := h.NewWallet(bwtest.WalletFixture{
 		AddrType: txCreatorFundingType,
 		Amounts:  []btcutil.Amount{oneBTC},
 		Unlocked: true,
 	})
+
+	outpoints := funding.WalletOutpoints
 
 	payment := deriveWalletPayment(h, w, txCreatorFundingType, halfBTC)
 
@@ -800,11 +814,13 @@ func testCreateTransactionRejectInputs(h *bwtest.HarnessTest) {
 	scope, err := txCreatorFundingType.KeyScope()
 	require.NoError(h, err, "failed to resolve funding scope")
 
-	w, outpoints := h.NewWallet(bwtest.WalletFixture{
+	w, funding := h.NewWallet(bwtest.WalletFixture{
 		AddrType: txCreatorFundingType,
 		Amounts:  []btcutil.Amount{oneBTC, twoBTC},
 		Unlocked: true,
 	})
+
+	outpoints := funding.WalletOutpoints
 
 	payment := deriveWalletPayment(h, w, txCreatorFundingType, halfBTC)
 
@@ -829,7 +845,12 @@ func testCreateTransactionRejectInputs(h *bwtest.HarnessTest) {
 		AccountName: waddrmgr.DefaultAccountName,
 		KeyScope:    scope,
 	}
-	foreign := h.ForeignOutpoint(outpoints)
+
+	require.Len(
+		h, funding.ForeignOutpoints, 1, "unexpected foreign output count",
+	)
+
+	foreign := funding.ForeignOutpoints[0]
 
 	ineligible := []struct {
 		name   string
@@ -982,7 +1003,8 @@ func testCreateTransactionWalletState(h *bwtest.HarnessTest) {
 
 	require.NoError(h, w.Start(h.Context()), "failed to start wallet")
 
-	outpoints := h.FundWalletOfType(w, txCreatorFundingType, oneBTC)
+	funding := h.FundWalletOfType(w, txCreatorFundingType, oneBTC)
+	outpoints := funding.WalletOutpoints
 
 	// Funding derives an address, which the harness unlocks for when the
 	// account is missing, but it restores the locked state afterwards.

--- a/itest/tx_creator_test.go
+++ b/itest/tx_creator_test.go
@@ -499,3 +499,214 @@ func testCreateTransactionOmitChange(h *bwtest.HarnessTest) {
 	)
 }
 
+// testCreateTransactionRejectIntent verifies the stable errors a malformed or
+// unresolvable intent produces, that the fee rate bound admits its own limit,
+// and that a rejection leaves the wallet's coins and leases untouched.
+func testCreateTransactionRejectIntent(h *bwtest.HarnessTest) {
+	scope, err := txCreatorFundingType.KeyScope()
+	require.NoError(h, err, "failed to resolve funding scope")
+
+	w, outpoints := h.NewWallet(bwtest.WalletFixture{
+		AddrType: txCreatorFundingType,
+		Amounts:  []btcutil.Amount{oneBTC},
+		Unlocked: true,
+	})
+
+	payment := deriveWalletPayment(h, w, txCreatorFundingType, halfBTC)
+
+	h.AssertWalletSynced(w)
+
+	account := &wallet.ScopedAccount{
+		AccountName: waddrmgr.DefaultAccountName,
+		KeyScope:    scope,
+	}
+	unknownAccount := &wallet.ScopedAccount{
+		AccountName: "no-such-account",
+		KeyScope:    scope,
+	}
+
+	testCases := []struct {
+		name        string
+		intent      *wallet.TxIntent
+		expectedErr error
+	}{{
+		name:        "nil intent",
+		intent:      nil,
+		expectedErr: wallet.ErrNilTxIntent,
+	}, {
+		name: "no outputs",
+		intent: &wallet.TxIntent{
+			Inputs:  &wallet.InputsPolicy{Source: account},
+			FeeRate: relayFeeRate,
+		},
+		expectedErr: wallet.ErrNoTxOutputs,
+	}, {
+		name: "negative output",
+		intent: &wallet.TxIntent{
+			Outputs: []wire.TxOut{{
+				Value:    -1,
+				PkScript: payment.PkScript,
+			}},
+			Inputs:  &wallet.InputsPolicy{Source: account},
+			FeeRate: relayFeeRate,
+		},
+		expectedErr: txrules.ErrAmountNegative,
+	}, {
+		name: "unnamed change account",
+		intent: &wallet.TxIntent{
+			Outputs:      []wire.TxOut{payment},
+			Inputs:       &wallet.InputsPolicy{Source: account},
+			ChangeSource: &wallet.ScopedAccount{KeyScope: scope},
+			FeeRate:      relayFeeRate,
+		},
+		expectedErr: wallet.ErrMissingAccountName,
+	}, {
+		name: "empty manual inputs",
+		intent: &wallet.TxIntent{
+			Outputs: []wire.TxOut{payment},
+			Inputs:  &wallet.InputsManual{},
+			FeeRate: relayFeeRate,
+		},
+		expectedErr: wallet.ErrManualInputsEmpty,
+	}, {
+		name: "duplicate manual inputs",
+		intent: &wallet.TxIntent{
+			Outputs: []wire.TxOut{payment},
+			Inputs: &wallet.InputsManual{
+				UTXOs: []wire.OutPoint{
+					outpoints[0], outpoints[0],
+				},
+			},
+			FeeRate: relayFeeRate,
+		},
+		expectedErr: wallet.ErrDuplicatedUtxo,
+	}, {
+		name: "empty coin source",
+		intent: &wallet.TxIntent{
+			Outputs: []wire.TxOut{payment},
+			Inputs: &wallet.InputsPolicy{
+				Source: &wallet.CoinSourceUTXOs{},
+			},
+			FeeRate: relayFeeRate,
+		},
+		expectedErr: wallet.ErrManualInputsEmpty,
+	}, {
+		name: "unnamed source account",
+		intent: &wallet.TxIntent{
+			Outputs: []wire.TxOut{payment},
+			Inputs: &wallet.InputsPolicy{
+				Source: &wallet.ScopedAccount{KeyScope: scope},
+			},
+			FeeRate: relayFeeRate,
+		},
+		expectedErr: wallet.ErrMissingAccountName,
+	}, {
+		name: "zero fee rate",
+		intent: &wallet.TxIntent{
+			Outputs: []wire.TxOut{payment},
+			Inputs:  &wallet.InputsPolicy{Source: account},
+			FeeRate: btcunit.NewSatPerKVByte(0),
+		},
+		expectedErr: wallet.ErrMissingFeeRate,
+	}, {
+		name: "excessive fee rate",
+		intent: &wallet.TxIntent{
+			Outputs: []wire.TxOut{payment},
+			Inputs:  &wallet.InputsPolicy{Source: account},
+			FeeRate: btcunit.NewSatPerKVByte(
+				wallet.DefaultMaxFeeRate.Val() + 1,
+			),
+		},
+		expectedErr: wallet.ErrFeeRateTooLarge,
+	}, {
+		name: "unknown source account",
+		intent: &wallet.TxIntent{
+			Outputs: []wire.TxOut{payment},
+			Inputs: &wallet.InputsPolicy{
+				MinConfs: 1,
+				Source:   unknownAccount,
+			},
+			ChangeSource: account,
+			FeeRate:      relayFeeRate,
+		},
+		expectedErr: wallet.ErrAccountNotFound,
+	}, {
+		name: "unknown change account",
+		intent: &wallet.TxIntent{
+			Outputs: []wire.TxOut{payment},
+			Inputs: &wallet.InputsPolicy{
+				MinConfs: 1,
+				Source:   account,
+			},
+			ChangeSource: unknownAccount,
+			FeeRate:      relayFeeRate,
+		},
+		expectedErr: wallet.ErrAccountNotFound,
+	}}
+
+	// A refused intent must leave the wallet's coins and leases as they
+	// were. Snapshot before the loop and compare straight after it, before
+	// anything succeeds.
+	utxosBefore, err := w.ListUnspent(h.Context(), wallet.UtxoQuery{
+		MinConfs: 0,
+		MaxConfs: maxConfsLimit,
+	})
+	require.NoError(h, err, "failed to list unspent")
+
+	leasesBefore, err := w.ListLeasedOutputs(h.Context())
+	require.NoError(h, err, "failed to list leased outputs")
+
+	for _, tc := range testCases {
+		_, err := w.CreateTransaction(h.Context(), tc.intent)
+		require.ErrorIs(
+			h, err, tc.expectedErr, "%s not rejected", tc.name,
+		)
+	}
+
+	utxosAfter, err := w.ListUnspent(h.Context(), wallet.UtxoQuery{
+		MinConfs: 0,
+		MaxConfs: maxConfsLimit,
+	})
+	require.NoError(h, err, "failed to list unspent")
+	require.Equal(
+		h, utxosBefore, utxosAfter, "a rejection changed the wallet's coins",
+	)
+
+	leasesAfter, err := w.ListLeasedOutputs(h.Context())
+	require.NoError(h, err, "failed to list leased outputs")
+	require.Equal(
+		h, leasesBefore, leasesAfter, "a rejection changed the wallet's leases",
+	)
+
+	// The maximum sane fee rate is itself allowed.
+	authored, err := w.CreateTransaction(h.Context(), &wallet.TxIntent{
+		Outputs: []wire.TxOut{payment},
+		Inputs: &wallet.InputsPolicy{
+			MinConfs: 1,
+			Source:   account,
+		},
+		ChangeSource: account,
+		FeeRate:      wallet.DefaultMaxFeeRate,
+	})
+	require.NoError(h, err, "maximum fee rate rejected")
+	require.NotEmpty(h, authored.Tx.TxIn, "authored transaction has no inputs")
+
+	// No rejection consumed a coin or reserved one.
+	utxos, err := w.ListUnspent(h.Context(), wallet.UtxoQuery{
+		MinConfs: 0,
+		MaxConfs: maxConfsLimit,
+	})
+	require.NoError(h, err, "failed to list unspent")
+
+	unspent := make([]wire.OutPoint, 0, len(utxos))
+	for _, utxo := range utxos {
+		unspent = append(unspent, utxo.OutPoint)
+	}
+
+	require.ElementsMatch(h, outpoints, unspent, "wallet utxo set changed")
+
+	leases, err := w.ListLeasedOutputs(h.Context())
+	require.NoError(h, err, "failed to list leased outputs")
+	require.Empty(h, leases, "a rejection reserved a coin")
+}
+

--- a/itest/tx_creator_test.go
+++ b/itest/tx_creator_test.go
@@ -226,3 +226,102 @@ func testCreateTransactionMultipleOutputs(h *bwtest.HarnessTest) {
 	)
 }
 
+// testCreateTransactionManualInputs verifies that caller-selected inputs are
+// used exactly as given, bypassing coin selection.
+func testCreateTransactionManualInputs(h *bwtest.HarnessTest) {
+	scope, err := txCreatorFundingType.KeyScope()
+	require.NoError(h, err, "failed to resolve funding scope")
+
+	w, outpoints := h.NewWallet(bwtest.WalletFixture{
+		AddrType: txCreatorFundingType,
+		Amounts:  []btcutil.Amount{oneBTC, twoBTC, threeBTC},
+		Unlocked: true,
+	})
+
+	// The first payment needs two coins, the second needs one.
+	large := deriveWalletPayment(h, w, txCreatorFundingType, threeBTC+halfBTC)
+	small := deriveWalletPayment(h, w, txCreatorFundingType, halfBTC)
+
+	h.AssertWalletSynced(w)
+
+	account := &wallet.ScopedAccount{
+		AccountName: waddrmgr.DefaultAccountName,
+		KeyScope:    scope,
+	}
+
+	// A payment no single coin covers is funded by exactly the two coins
+	// the caller named, and not by the pair selection would have reached
+	// for: largest first would have taken the three and two BTC coins.
+	authored, err := w.CreateTransaction(h.Context(), &wallet.TxIntent{
+		Outputs: []wire.TxOut{large},
+		Inputs: &wallet.InputsManual{
+			UTXOs: []wire.OutPoint{outpoints[0], outpoints[2]},
+		},
+		ChangeSource: account,
+		FeeRate:      relayFeeRate,
+	})
+	require.NoError(h, err, "failed to create transaction")
+
+	spent := make([]wire.OutPoint, 0, len(authored.Tx.TxIn))
+	for _, txIn := range authored.Tx.TxIn {
+		spent = append(spent, txIn.PreviousOutPoint)
+	}
+
+	require.ElementsMatch(
+		h, []wire.OutPoint{outpoints[0], outpoints[2]}, spent,
+		"unexpected manual inputs",
+	)
+	require.Equal(
+		h, btcutil.Amount(oneBTC+threeBTC), authored.TotalInput,
+		"unexpected total input",
+	)
+
+	// A signer reads the input metadata positionally, so entry i must
+	// describe the coin spent by input i, whatever order selection put
+	// them in.
+	require.Len(
+		h, authored.PrevScripts, len(authored.Tx.TxIn),
+		"unexpected prev script count",
+	)
+	require.Len(
+		h, authored.PrevInputValues, len(authored.Tx.TxIn),
+		"unexpected prev input value count",
+	)
+
+	for i, txIn := range authored.Tx.TxIn {
+		utxo, err := w.GetUtxo(h.Context(), txIn.PreviousOutPoint)
+		require.NoError(h, err, "input %d is not a wallet coin", i)
+
+		require.Equal(
+			h, utxo.Amount, authored.PrevInputValues[i],
+			"input %d value mismatch", i,
+		)
+		require.Equal(
+			h, utxo.PkScript, authored.PrevScripts[i],
+			"input %d script mismatch", i,
+		)
+	}
+
+	// A payment one named coin covers spends that coin alone, even though
+	// the wallet holds larger coins selection would have preferred.
+	authored, err = w.CreateTransaction(h.Context(), &wallet.TxIntent{
+		Outputs: []wire.TxOut{small},
+		Inputs: &wallet.InputsManual{
+			UTXOs: []wire.OutPoint{outpoints[0]},
+		},
+		ChangeSource: account,
+		FeeRate:      relayFeeRate,
+	})
+	require.NoError(h, err, "failed to create transaction")
+
+	require.Len(h, authored.Tx.TxIn, 1, "unexpected input count")
+	require.Equal(
+		h, outpoints[0], authored.Tx.TxIn[0].PreviousOutPoint,
+		"unexpected manual input",
+	)
+	require.Equal(
+		h, btcutil.Amount(oneBTC), authored.TotalInput,
+		"unexpected total input",
+	)
+}
+

--- a/itest/tx_creator_test.go
+++ b/itest/tx_creator_test.go
@@ -3,6 +3,7 @@
 package itest
 
 import (
+	"github.com/btcsuite/btcd/address/v2"
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
@@ -849,3 +850,87 @@ func testCreateTransactionRejectInputs(h *bwtest.HarnessTest) {
 	require.Equal(h, outpoints[0], leases[0].OutPoint, "unexpected lease")
 }
 
+// testCreateTransactionWalletState verifies the lifecycle gate on transaction
+// creation: it is forbidden before Start and after Stop, and a locked wallet
+// still authors, since an unsigned transaction needs no private key.
+func testCreateTransactionWalletState(h *bwtest.HarnessTest) {
+	// witnessProgramSize is the length of a witness pubkey hash program.
+	const witnessProgramSize = 20
+
+	scope, err := txCreatorFundingType.KeyScope()
+	require.NoError(h, err, "failed to resolve funding scope")
+
+	w, _ := h.NewWallet(bwtest.WalletFixture{
+		AddrType:  txCreatorFundingType,
+		Unstarted: true,
+	})
+
+	// A wallet that has not started cannot derive an address, so this
+	// payment goes to an arbitrary witness program. The intent is otherwise
+	// well formed, which keeps the assertion below about the state gate
+	// alone rather than about the order in which the gate and intent
+	// validation run.
+	addr, err := address.NewAddressWitnessPubKeyHash(
+		make([]byte, witnessProgramSize), h.NetParams(),
+	)
+	require.NoError(h, err, "failed to create witness address")
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(h, err, "failed to create payment pkscript")
+
+	account := &wallet.ScopedAccount{
+		AccountName: waddrmgr.DefaultAccountName,
+		KeyScope:    scope,
+	}
+	intent := &wallet.TxIntent{
+		Outputs: []wire.TxOut{{
+			Value:    halfBTC,
+			PkScript: pkScript,
+		}},
+		Inputs: &wallet.InputsPolicy{
+			MinConfs: 1,
+			Source:   account,
+		},
+		ChangeSource: account,
+		FeeRate:      relayFeeRate,
+	}
+
+	_, err = w.CreateTransaction(h.Context(), intent)
+	require.ErrorIs(
+		h, err, wallet.ErrStateForbidden,
+		"create transaction before start not rejected",
+	)
+
+	require.NoError(h, w.Start(h.Context()), "failed to start wallet")
+
+	outpoints := h.FundWalletOfType(w, txCreatorFundingType, oneBTC)
+
+	h.AssertWalletSynced(w)
+
+	// Funding derives an address, which the harness unlocks for when the
+	// account is missing, but it restores the locked state afterwards.
+	info, err := w.Info(h.Context())
+	require.NoError(h, err, "failed to query wallet info")
+	require.True(h, info.Locked, "wallet is not locked")
+
+	// Authoring an unsigned transaction does not require the private key.
+	authored, err := w.CreateTransaction(h.Context(), intent)
+	require.NoError(h, err, "locked wallet failed to create transaction")
+
+	require.Len(h, authored.Tx.TxIn, 1, "unexpected input count")
+	require.Equal(
+		h, outpoints[0], authored.Tx.TxIn[0].PreviousOutPoint,
+		"unexpected selected input",
+	)
+
+	// Stop the wallet, then deregister it so the harness does not drive a
+	// stopped wallet during teardown.
+	require.NoError(h, w.Stop(h.Context()), "failed to stop wallet")
+	require.True(h, h.DeregisterWallet(w), "failed to deregister wallet")
+
+	_, err = w.CreateTransaction(h.Context(), intent)
+	require.ErrorIs(
+		h, err, wallet.ErrStateForbidden,
+		"create transaction after stop not rejected",
+	)
+}

--- a/itest/tx_creator_test.go
+++ b/itest/tx_creator_test.go
@@ -40,8 +40,9 @@ var relayFeeRate = btcunit.NewSatPerKVByte(txrules.DefaultRelayFeePerKb)
 // external branch is what tells the payment apart from an internal change
 // output, which the cases rely on when they identify the change.
 //
-// Deriving the address changes the wallet, so a case must cross
-// AssertWalletSynced after its last call to this, not merely after funding.
+// Deriving the address changes the wallet but not its synchronization state,
+// which the harness has already asserted for every registered wallet while
+// mining the funding block.
 func deriveWalletPayment(h *bwtest.HarnessTest, w *wallet.Wallet,
 	addrType waddrmgr.AddressType, amount btcutil.Amount) wire.TxOut {
 
@@ -72,10 +73,6 @@ func testCreateTransactionSelectCoins(h *bwtest.HarnessTest) {
 	})
 
 	payment := deriveWalletPayment(h, w, txCreatorFundingType, halfBTC)
-
-	// Funding and the derivation above are both wallet side effects, so
-	// the synchronization boundary belongs here, after the last of them.
-	h.AssertWalletSynced(w)
 
 	account := &wallet.ScopedAccount{
 		AccountName: waddrmgr.DefaultAccountName,
@@ -186,8 +183,6 @@ func testCreateTransactionMultipleOutputs(h *bwtest.HarnessTest) {
 		h, first.PkScript, second.PkScript, "payments share a script",
 	)
 
-	h.AssertWalletSynced(w)
-
 	account := &wallet.ScopedAccount{
 		AccountName: waddrmgr.DefaultAccountName,
 		KeyScope:    scope,
@@ -244,8 +239,6 @@ func testCreateTransactionManualInputs(h *bwtest.HarnessTest) {
 	// The first payment needs two coins, the second needs one.
 	large := deriveWalletPayment(h, w, txCreatorFundingType, threeBTC+halfBTC)
 	small := deriveWalletPayment(h, w, txCreatorFundingType, halfBTC)
-
-	h.AssertWalletSynced(w)
 
 	account := &wallet.ScopedAccount{
 		AccountName: waddrmgr.DefaultAccountName,
@@ -340,8 +333,6 @@ func testCreateTransactionDefaultAccount(h *bwtest.HarnessTest) {
 
 	payment := deriveWalletPayment(h, w, waddrmgr.TaprootPubKey, halfBTC)
 
-	h.AssertWalletSynced(w)
-
 	authored, err := w.CreateTransaction(h.Context(), &wallet.TxIntent{
 		Outputs: []wire.TxOut{payment},
 		FeeRate: relayFeeRate,
@@ -396,8 +387,6 @@ func testCreateTransactionCoinSource(h *bwtest.HarnessTest) {
 	})
 
 	payment := deriveWalletPayment(h, w, txCreatorFundingType, halfBTC)
-
-	h.AssertWalletSynced(w)
 
 	account := &wallet.ScopedAccount{
 		AccountName: waddrmgr.DefaultAccountName,
@@ -472,8 +461,6 @@ func testCreateTransactionOmitChange(h *bwtest.HarnessTest) {
 		h, w, txCreatorFundingType, smallCoin-changeLeftover,
 	)
 
-	h.AssertWalletSynced(w)
-
 	authored, err := w.CreateTransaction(h.Context(), &wallet.TxIntent{
 		Outputs: []wire.TxOut{payment},
 		Inputs: &wallet.InputsManual{
@@ -515,8 +502,6 @@ func testCreateTransactionRejectIntent(h *bwtest.HarnessTest) {
 	})
 
 	payment := deriveWalletPayment(h, w, txCreatorFundingType, halfBTC)
-
-	h.AssertWalletSynced(w)
 
 	account := &wallet.ScopedAccount{
 		AccountName: waddrmgr.DefaultAccountName,
@@ -727,8 +712,6 @@ func testCreateTransactionOutputBoundaries(h *bwtest.HarnessTest) {
 
 	payment := deriveWalletPayment(h, w, txCreatorFundingType, halfBTC)
 
-	h.AssertWalletSynced(w)
-
 	account := &wallet.ScopedAccount{
 		AccountName: waddrmgr.DefaultAccountName,
 		KeyScope:    scope,
@@ -846,8 +829,6 @@ func testCreateTransactionRejectInputs(h *bwtest.HarnessTest) {
 	beyondBalance := deriveWalletPayment(
 		h, w, txCreatorFundingType, oneBTC+twoBTC+halfBTC,
 	)
-
-	h.AssertWalletSynced(w)
 
 	lockID := wtxmgr.LockID{1}
 	_, err = w.LeaseOutput(
@@ -1013,8 +994,6 @@ func testCreateTransactionWalletState(h *bwtest.HarnessTest) {
 	require.NoError(h, w.Start(h.Context()), "failed to start wallet")
 
 	outpoints := h.FundWalletOfType(w, txCreatorFundingType, oneBTC)
-
-	h.AssertWalletSynced(w)
 
 	// Funding derives an address, which the harness unlocks for when the
 	// account is missing, but it restores the locked state afterwards.

--- a/itest/tx_creator_test.go
+++ b/itest/tx_creator_test.go
@@ -1,0 +1,160 @@
+//go:build itest
+
+package itest
+
+import (
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btcwallet/bwtest"
+	"github.com/btcsuite/btcwallet/pkg/btcunit"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet"
+	"github.com/btcsuite/btcwallet/wallet/txrules"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// halfBTC is the payment amount the TxCreator cases use. It is small
+	// enough that any single funded coin covers it.
+	halfBTC = btcutil.SatoshiPerBitcoin / 2
+
+	// txCreatorFundingType is the address type the TxCreator cases fund and
+	// select from. Each case derives its key scope from this value, so the
+	// funded scope is never stated twice.
+	txCreatorFundingType = waddrmgr.WitnessPubKey
+)
+
+// relayFeeRate is the fee rate the TxCreator cases author at. It is the
+// default relay fee, one satoshi per virtual byte, which keeps the fee
+// negligible against the funded amounts.
+var relayFeeRate = btcunit.NewSatPerKVByte(txrules.DefaultRelayFeePerKb)
+
+// deriveWalletPayment derives a fresh external address of the requested type
+// from the wallet and returns a payment of amount to it.
+//
+// Paying the wallet itself keeps the destination wallet-visible, and the
+// external branch is what tells the payment apart from an internal change
+// output, which the cases rely on when they identify the change.
+//
+// Deriving the address changes the wallet, so a case must cross
+// AssertWalletSynced after its last call to this, not merely after funding.
+func deriveWalletPayment(h *bwtest.HarnessTest, w *wallet.Wallet,
+	addrType waddrmgr.AddressType, amount btcutil.Amount) wire.TxOut {
+
+	h.Helper()
+
+	addr := h.NewWalletAddressOfType(w, addrType)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(h, err, "failed to create payment pkscript")
+
+	return wire.TxOut{
+		Value:    int64(amount),
+		PkScript: pkScript,
+	}
+}
+
+// testCreateTransactionSelectCoins verifies that policy-based selection funds
+// a payment from the named account, returns the remainder to an internal
+// change address, and reserves nothing.
+func testCreateTransactionSelectCoins(h *bwtest.HarnessTest) {
+	scope, err := txCreatorFundingType.KeyScope()
+	require.NoError(h, err, "failed to resolve funding scope")
+
+	w, outpoints := h.NewWallet(bwtest.WalletFixture{
+		AddrType: txCreatorFundingType,
+		Amounts:  []btcutil.Amount{oneBTC, twoBTC},
+		Unlocked: true,
+	})
+
+	payment := deriveWalletPayment(h, w, txCreatorFundingType, halfBTC)
+
+	// Funding and the derivation above are both wallet side effects, so
+	// the synchronization boundary belongs here, after the last of them.
+	h.AssertWalletSynced(w)
+
+	account := &wallet.ScopedAccount{
+		AccountName: waddrmgr.DefaultAccountName,
+		KeyScope:    scope,
+	}
+
+	authored, err := w.CreateTransaction(h.Context(), &wallet.TxIntent{
+		Outputs: []wire.TxOut{payment},
+		Inputs: &wallet.InputsPolicy{
+			Strategy: wallet.CoinSelectionLargest,
+			MinConfs: 1,
+			Source:   account,
+		},
+		ChangeSource: account,
+		FeeRate:      relayFeeRate,
+	})
+	require.NoError(h, err, "failed to create transaction")
+
+	// Largest-first selection covers the payment with the two BTC coin on
+	// its own, and reports that coin as the spent input.
+	require.Len(h, authored.Tx.TxIn, 1, "unexpected input count")
+	require.Equal(
+		h, outpoints[1], authored.Tx.TxIn[0].PreviousOutPoint,
+		"unexpected selected input",
+	)
+	require.Equal(
+		h, btcutil.Amount(twoBTC), authored.TotalInput,
+		"unexpected total input",
+	)
+	require.Equal(
+		h, []btcutil.Amount{twoBTC}, authored.PrevInputValues,
+		"unexpected input values",
+	)
+
+	// The transaction pays the requested output and one change output.
+	require.Len(h, authored.Tx.TxOut, 2, "unexpected output count")
+	require.GreaterOrEqual(h, authored.ChangeIndex, 0, "no change output")
+
+	paid := authored.Tx.TxOut[1-authored.ChangeIndex]
+	require.Equal(h, payment.Value, paid.Value, "payment value changed")
+	require.Equal(h, payment.PkScript, paid.PkScript, "payment script changed")
+
+	// The remainder returns to the wallet on an internal address of the
+	// funded account.
+	change := authored.Tx.TxOut[authored.ChangeIndex]
+	_, changeAddrs, _, err := txscript.ExtractPkScriptAddrs(
+		change.PkScript, h.NetParams(),
+	)
+	require.NoError(h, err, "failed to extract change address")
+	require.Len(h, changeAddrs, 1, "unexpected change address count")
+
+	changeInfo, err := w.GetAddressInfo(h.Context(), changeAddrs[0])
+	require.NoError(h, err, "change address is unknown to the wallet")
+	require.True(h, changeInfo.Internal, "change address is not internal")
+	require.Equal(
+		h, txCreatorFundingType, changeInfo.AddrType,
+		"unexpected change address type",
+	)
+
+	// The inputs cover both outputs, leaving a fee behind.
+	require.Greater(
+		h, int64(authored.TotalInput), paid.Value+change.Value,
+		"authored transaction pays no fee",
+	)
+
+	// Creating a transaction neither spends nor reserves the coin it
+	// selected.
+	utxos, err := w.ListUnspent(h.Context(), wallet.UtxoQuery{
+		MinConfs: 0,
+		MaxConfs: maxConfsLimit,
+	})
+	require.NoError(h, err, "failed to list unspent")
+
+	unspent := make([]wire.OutPoint, 0, len(utxos))
+	for _, utxo := range utxos {
+		unspent = append(unspent, utxo.OutPoint)
+	}
+
+	require.ElementsMatch(h, outpoints, unspent, "wallet utxo set changed")
+
+	leases, err := w.ListLeasedOutputs(h.Context())
+	require.NoError(h, err, "failed to list leased outputs")
+	require.Empty(h, leases, "creating a transaction reserved a coin")
+}
+

--- a/itest/tx_creator_test.go
+++ b/itest/tx_creator_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/btcsuite/btcwallet/wallet"
 	"github.com/btcsuite/btcwallet/wallet/txauthor"
 	"github.com/btcsuite/btcwallet/wallet/txrules"
+	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/stretchr/testify/require"
 )
 
@@ -708,5 +709,143 @@ func testCreateTransactionRejectIntent(h *bwtest.HarnessTest) {
 	leases, err := w.ListLeasedOutputs(h.Context())
 	require.NoError(h, err, "failed to list leased outputs")
 	require.Empty(h, leases, "a rejection reserved a coin")
+}
+
+// testCreateTransactionRejectInputs verifies that inputs the wallet cannot
+// spend are refused, that selection skips a leased coin rather than spending
+// it, and that a refusal leaves the wallet's coins and leases untouched.
+func testCreateTransactionRejectInputs(h *bwtest.HarnessTest) {
+	scope, err := txCreatorFundingType.KeyScope()
+	require.NoError(h, err, "failed to resolve funding scope")
+
+	w, outpoints := h.NewWallet(bwtest.WalletFixture{
+		AddrType: txCreatorFundingType,
+		Amounts:  []btcutil.Amount{oneBTC, twoBTC},
+		Unlocked: true,
+	})
+
+	payment := deriveWalletPayment(h, w, txCreatorFundingType, halfBTC)
+
+	// The wallet holds three BTC in two coins. This payment needs both of
+	// them, so it is only fundable while neither is leased.
+	needsBothCoins := deriveWalletPayment(
+		h, w, txCreatorFundingType, twoBTC+halfBTC,
+	)
+
+	// This one exceeds everything the wallet holds.
+	beyondBalance := deriveWalletPayment(
+		h, w, txCreatorFundingType, oneBTC+twoBTC+halfBTC,
+	)
+
+	h.AssertWalletSynced(w)
+
+	lockID := wtxmgr.LockID{1}
+	_, err = w.LeaseOutput(
+		h.Context(), lockID, outpoints[0], leaseDuration,
+	)
+	require.NoError(h, err, "failed to lease output")
+
+	account := &wallet.ScopedAccount{
+		AccountName: waddrmgr.DefaultAccountName,
+		KeyScope:    scope,
+	}
+	foreign := h.ForeignOutpoint(outpoints)
+
+	ineligible := []struct {
+		name   string
+		inputs wallet.Inputs
+	}{{
+		name: "leased manual input",
+		inputs: &wallet.InputsManual{
+			UTXOs: []wire.OutPoint{outpoints[0]},
+		},
+	}, {
+		name: "unknown manual input",
+		inputs: &wallet.InputsManual{
+			UTXOs: []wire.OutPoint{unknownOutpoint()},
+		},
+	}, {
+		name: "foreign manual input",
+		inputs: &wallet.InputsManual{
+			UTXOs: []wire.OutPoint{foreign},
+		},
+	}, {
+		name: "leased candidate",
+		inputs: &wallet.InputsPolicy{
+			MinConfs: 1,
+			Source: &wallet.CoinSourceUTXOs{
+				UTXOs: []wire.OutPoint{outpoints[0]},
+			},
+		},
+	}, {
+		name: "foreign candidate",
+		inputs: &wallet.InputsPolicy{
+			MinConfs: 1,
+			Source: &wallet.CoinSourceUTXOs{
+				UTXOs: []wire.OutPoint{foreign},
+			},
+		},
+	}}
+
+	for _, tc := range ineligible {
+		_, err = w.CreateTransaction(h.Context(), &wallet.TxIntent{
+			Outputs:      []wire.TxOut{payment},
+			Inputs:       tc.inputs,
+			ChangeSource: account,
+			FeeRate:      relayFeeRate,
+		})
+		require.ErrorIs(
+			h, err, wallet.ErrUtxoNotEligible,
+			"%s not rejected", tc.name,
+		)
+	}
+
+	// Account selection skips the leased coin instead of spending it, so a
+	// payment that needs both coins can no longer be funded.
+	_, err = w.CreateTransaction(h.Context(), &wallet.TxIntent{
+		Outputs: []wire.TxOut{needsBothCoins},
+		Inputs: &wallet.InputsPolicy{
+			MinConfs: 1,
+			Source:   account,
+		},
+		ChangeSource: account,
+		FeeRate:      relayFeeRate,
+	})
+
+	var sourceErr txauthor.InputSourceError
+	require.ErrorAs(h, err, &sourceErr, "leased coin was selected")
+
+	// A payment beyond everything the wallet holds cannot be funded either.
+	_, err = w.CreateTransaction(h.Context(), &wallet.TxIntent{
+		Outputs: []wire.TxOut{beyondBalance},
+		Inputs: &wallet.InputsPolicy{
+			MinConfs: 1,
+			Source:   account,
+		},
+		ChangeSource: account,
+		FeeRate:      relayFeeRate,
+	})
+	require.ErrorAs(
+		h, err, &sourceErr, "payment beyond the balance was funded",
+	)
+
+	// Every refusal left the coins in place and the lease as it was.
+	utxos, err := w.ListUnspent(h.Context(), wallet.UtxoQuery{
+		MinConfs: 0,
+		MaxConfs: maxConfsLimit,
+	})
+	require.NoError(h, err, "failed to list unspent")
+
+	unspent := make([]wire.OutPoint, 0, len(utxos))
+	for _, utxo := range utxos {
+		unspent = append(unspent, utxo.OutPoint)
+	}
+
+	require.ElementsMatch(h, outpoints, unspent, "wallet utxo set changed")
+
+	leases, err := w.ListLeasedOutputs(h.Context())
+	require.NoError(h, err, "failed to list leased outputs")
+	require.Len(h, leases, 1, "wallet lease set changed")
+	require.Equal(h, outpoints[0], leases[0].OutPoint, "unexpected lease")
 }
 

--- a/itest/tx_creator_test.go
+++ b/itest/tx_creator_test.go
@@ -712,6 +712,115 @@ func testCreateTransactionRejectIntent(h *bwtest.HarnessTest) {
 	require.Empty(h, leases, "a rejection reserved a coin")
 }
 
+// testCreateTransactionOutputBoundaries verifies the output amount policy at
+// its edges: the largest dust amount and the smallest payable one, and the
+// largest amount a transaction output may carry.
+func testCreateTransactionOutputBoundaries(h *bwtest.HarnessTest) {
+	scope, err := txCreatorFundingType.KeyScope()
+	require.NoError(h, err, "failed to resolve funding scope")
+
+	w, outpoints := h.NewWallet(bwtest.WalletFixture{
+		AddrType: txCreatorFundingType,
+		Amounts:  []btcutil.Amount{oneBTC},
+		Unlocked: true,
+	})
+
+	payment := deriveWalletPayment(h, w, txCreatorFundingType, halfBTC)
+
+	h.AssertWalletSynced(w)
+
+	account := &wallet.ScopedAccount{
+		AccountName: waddrmgr.DefaultAccountName,
+		KeyScope:    scope,
+	}
+
+	// The dust limit depends on the output's script, so the edge is derived
+	// from the relay policy itself rather than written down as a number
+	// that would silently drift from it.
+	candidate := wire.TxOut{PkScript: payment.PkScript}
+	for candidate.Value = 1; ; candidate.Value++ {
+		if !txrules.IsDustOutput(&candidate, txrules.DefaultRelayFeePerKb) {
+			break
+		}
+	}
+
+	smallestPayment := candidate.Value
+
+	// One satoshi below that edge is dust, and the edge itself is payable.
+	_, err = w.CreateTransaction(h.Context(), &wallet.TxIntent{
+		Outputs: []wire.TxOut{{
+			Value:    smallestPayment - 1,
+			PkScript: payment.PkScript,
+		}},
+		Inputs: &wallet.InputsPolicy{
+			MinConfs: 1,
+			Source:   account,
+		},
+		ChangeSource: account,
+		FeeRate:      relayFeeRate,
+	})
+	require.ErrorIs(
+		h, err, txrules.ErrOutputIsDust, "dust output not rejected",
+	)
+
+	authored, err := w.CreateTransaction(h.Context(), &wallet.TxIntent{
+		Outputs: []wire.TxOut{{
+			Value:    smallestPayment,
+			PkScript: payment.PkScript,
+		}},
+		Inputs: &wallet.InputsPolicy{
+			MinConfs: 1,
+			Source:   account,
+		},
+		ChangeSource: account,
+		FeeRate:      relayFeeRate,
+	})
+	require.NoError(h, err, "smallest payable output rejected")
+	require.Equal(
+		h, outpoints[0], authored.Tx.TxIn[0].PreviousOutPoint,
+		"unexpected selected input",
+	)
+
+	// One satoshi above the maximum an output may carry is rejected on its
+	// value.
+	_, err = w.CreateTransaction(h.Context(), &wallet.TxIntent{
+		Outputs: []wire.TxOut{{
+			Value:    btcutil.MaxSatoshi + 1,
+			PkScript: payment.PkScript,
+		}},
+		Inputs: &wallet.InputsPolicy{
+			MinConfs: 1,
+			Source:   account,
+		},
+		ChangeSource: account,
+		FeeRate:      relayFeeRate,
+	})
+	require.ErrorIs(
+		h, err, txrules.ErrAmountExceedsMax,
+		"output above the maximum not rejected",
+	)
+
+	// The maximum itself passes the amount policy: this wallet simply
+	// cannot fund it, so it fails for want of coins instead.
+	_, err = w.CreateTransaction(h.Context(), &wallet.TxIntent{
+		Outputs: []wire.TxOut{{
+			Value:    btcutil.MaxSatoshi,
+			PkScript: payment.PkScript,
+		}},
+		Inputs: &wallet.InputsPolicy{
+			MinConfs: 1,
+			Source:   account,
+		},
+		ChangeSource: account,
+		FeeRate:      relayFeeRate,
+	})
+
+	var sourceErr txauthor.InputSourceError
+	require.ErrorAs(
+		h, err, &sourceErr, "maximum amount rejected on its value",
+	)
+}
+
 // testCreateTransactionRejectInputs verifies that inputs the wallet cannot
 // spend are refused, that selection skips a leased coin rather than spending
 // it, and that a refusal leaves the wallet's coins and leases untouched.

--- a/itest/utxo_manager_test.go
+++ b/itest/utxo_manager_test.go
@@ -4,11 +4,9 @@ package itest
 
 import (
 	"fmt"
-	"math"
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil/v2"
-	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/bwtest"
@@ -20,22 +18,9 @@ import (
 )
 
 const (
-	// maxConfsLimit is used as the MaxConfs bound when a test does not want
-	// to constrain the upper confirmation range.
-	maxConfsLimit = math.MaxInt32
-
-	// leaseDuration is the standard lease length for tests. It is long
-	// enough that the lease never expires mid-test.
-	leaseDuration = 10 * time.Minute
-
 	// pollTimeout bounds waits for asynchronous wallet state changes, such
 	// as unconfirmed transaction notifications and lease expiry.
 	pollTimeout = 30 * time.Second
-
-	// The funding amounts shared by the UtxoManager cases.
-	oneBTC   = 1 * btcutil.SatoshiPerBitcoin
-	twoBTC   = 2 * btcutil.SatoshiPerBitcoin
-	threeBTC = 3 * btcutil.SatoshiPerBitcoin
 )
 
 // createWallet creates and registers a wallet without starting it so tests can
@@ -53,12 +38,6 @@ func createWallet(h *bwtest.HarnessTest) *wallet.Wallet {
 	h.RegisterWallet(w)
 
 	return w
-}
-
-// unknownOutpoint returns an outpoint that was never mined and is therefore
-// unknown to any wallet.
-func unknownOutpoint() wire.OutPoint {
-	return wire.OutPoint{Hash: chainhash.Hash{0xaa}, Index: 0}
 }
 
 // testListUnspent verifies ListUnspent field enrichment, amount ordering,

--- a/itest/utxo_manager_test.go
+++ b/itest/utxo_manager_test.go
@@ -358,34 +358,10 @@ func testGetUtxo(h *bwtest.HarnessTest) {
 		"unknown outpoint not rejected",
 	)
 
-	// The funding transaction contains one change output back to the miner
-	// in addition to the wallet outputs, so exactly one index in
-	// [0, len(outpoints)] is not wallet-owned. That output exists on chain
-	// but belongs to the miner, so the wallet must reject it as unknown.
-	owned := make(map[uint32]bool, len(outpoints))
-	for _, op := range outpoints {
-		owned[op.Index] = true
-	}
-
-	changeIndex := -1
-	for i := range len(outpoints) + 1 {
-		if !owned[uint32(i)] {
-			changeIndex = i
-
-			break
-		}
-	}
-
-	require.NotEqual(
-		h, -1, changeIndex, "funding transaction has no change output",
-	)
-
-	foreign := wire.OutPoint{
-		Hash:  outpoints[0].Hash,
-		Index: uint32(changeIndex),
-	}
-
-	_, err = w.GetUtxo(h.Context(), foreign)
+	// The funding transaction also pays one change output back to the
+	// miner. That output exists on chain but belongs to the miner, so the
+	// wallet must reject it as unknown.
+	_, err = w.GetUtxo(h.Context(), h.ForeignOutpoint(outpoints))
 	require.ErrorIs(
 		h, err, wallet.ErrUnknownOutput,
 		"foreign outpoint not rejected",

--- a/itest/utxo_manager_test.go
+++ b/itest/utxo_manager_test.go
@@ -23,27 +23,10 @@ const (
 	pollTimeout = 30 * time.Second
 )
 
-// createWallet creates and registers a wallet without starting it so tests can
-// exercise the pre-start state gates before bringing the wallet up.
-func createWallet(h *bwtest.HarnessTest) *wallet.Wallet {
-	h.Helper()
-
-	cfg, params := h.TestWalletConfig()
-
-	manager := h.NewWalletManager()
-	w, err := manager.Create(cfg, params)
-	require.NoError(h, err, "failed to create wallet")
-
-	// Register before Start so teardown owns the wallet even if Start fails.
-	h.RegisterWallet(w)
-
-	return w
-}
-
 // testListUnspent verifies ListUnspent field enrichment, amount ordering,
 // account and confirmation filters, and the pre-start state gate.
 func testListUnspent(h *bwtest.HarnessTest) {
-	w := createWallet(h)
+	w, _ := h.NewWallet(bwtest.WalletFixture{Unstarted: true})
 
 	// ListUnspent is forbidden before Start.
 	_, err := w.ListUnspent(h.Context(), wallet.UtxoQuery{})
@@ -158,7 +141,7 @@ func testListUnspent(h *bwtest.HarnessTest) {
 // paying the wallet is reported as not spendable, because it has not reached
 // coinbase maturity.
 func testListUnspentImmatureCoinbase(h *bwtest.HarnessTest) {
-	w := createWallet(h)
+	w, _ := h.NewWallet(bwtest.WalletFixture{Unstarted: true})
 	require.NoError(h, w.Start(h.Context()), "failed to start wallet")
 
 	// The Spendable assertion below requires unlocking the wallet.
@@ -231,7 +214,7 @@ func testListUnspentUnconfirmed(h *bwtest.HarnessTest) {
 		h.Skip("neutrino cannot deliver unconfirmed transactions")
 	}
 
-	w := createWallet(h)
+	w, _ := h.NewWallet(bwtest.WalletFixture{Unstarted: true})
 	require.NoError(h, w.Start(h.Context()), "failed to start wallet")
 
 	h.FundWallet(w, oneBTC)
@@ -307,7 +290,7 @@ func testListUnspentUnconfirmed(h *bwtest.HarnessTest) {
 // outpoints, rejects unknown and foreign outpoints, and is forbidden before
 // Start.
 func testGetUtxo(h *bwtest.HarnessTest) {
-	w := createWallet(h)
+	w, _ := h.NewWallet(bwtest.WalletFixture{Unstarted: true})
 
 	// GetUtxo is forbidden before Start.
 	_, err := w.GetUtxo(h.Context(), unknownOutpoint())
@@ -373,7 +356,7 @@ func testGetUtxo(h *bwtest.HarnessTest) {
 // ID, unknown outpoints, and non-positive durations, and is forbidden before
 // Start.
 func testLeaseOutput(h *bwtest.HarnessTest) {
-	w := createWallet(h)
+	w, _ := h.NewWallet(bwtest.WalletFixture{Unstarted: true})
 
 	lockID1 := wtxmgr.LockID{1}
 	lockID2 := wtxmgr.LockID{2}
@@ -477,7 +460,7 @@ func testLeaseOutput(h *bwtest.HarnessTest) {
 // mismatched lock IDs and unknown outpoints, treats releasing an unleased
 // output as a no-op, and is forbidden before Start.
 func testReleaseOutput(h *bwtest.HarnessTest) {
-	w := createWallet(h)
+	w, _ := h.NewWallet(bwtest.WalletFixture{Unstarted: true})
 
 	lockID1 := wtxmgr.LockID{1}
 	lockID2 := wtxmgr.LockID{2}
@@ -548,7 +531,7 @@ func testReleaseOutput(h *bwtest.HarnessTest) {
 // their lock IDs and expirations, drops released leases, excludes expired
 // leases, and is forbidden before Start.
 func testListLeasedOutputs(h *bwtest.HarnessTest) {
-	w := createWallet(h)
+	w, _ := h.NewWallet(bwtest.WalletFixture{Unstarted: true})
 
 	// ListLeasedOutputs is forbidden before Start.
 	_, err := w.ListLeasedOutputs(h.Context())

--- a/itest/utxo_manager_test.go
+++ b/itest/utxo_manager_test.go
@@ -51,7 +51,7 @@ func testListUnspent(h *bwtest.HarnessTest) {
 	// Fund out of order so the ascending amount sort is observable.
 	amounts := []btcutil.Amount{threeBTC, oneBTC, twoBTC}
 
-	outpoints := h.FundWallet(w, amounts...)
+	outpoints := h.FundWallet(w, amounts...).WalletOutpoints
 	require.Len(h, outpoints, 3, "unexpected funded outpoint count")
 
 	funded := make(map[wire.OutPoint]btcutil.Amount, len(outpoints))
@@ -154,7 +154,7 @@ func testListUnspentImmatureCoinbase(h *bwtest.HarnessTest) {
 	h.MineBlockToAddress(addr)
 
 	// Fund an ordinary confirmed output as the spendable control.
-	funded := h.FundWallet(w, oneBTC)
+	funded := h.FundWallet(w, oneBTC).WalletOutpoints
 	require.Len(h, funded, 1, "unexpected funded outpoint count")
 
 	// Both mining helpers wait for the exact committed wallet tip, so the
@@ -304,7 +304,8 @@ func testGetUtxo(h *bwtest.HarnessTest) {
 	// The Spendable assertion below required unlocking the wallet.
 	h.UnlockWallet(w)
 
-	outpoints := h.FundWallet(w, oneBTC, twoBTC)
+	funding := h.FundWallet(w, oneBTC, twoBTC)
+	outpoints := funding.WalletOutpoints
 
 	// Iterate a slice rather than a map so the assertions run in a
 	// deterministic order and a duplicated outpoint can never collapse
@@ -344,7 +345,11 @@ func testGetUtxo(h *bwtest.HarnessTest) {
 	// The funding transaction also pays one change output back to the
 	// miner. That output exists on chain but belongs to the miner, so the
 	// wallet must reject it as unknown.
-	_, err = w.GetUtxo(h.Context(), h.ForeignOutpoint(outpoints))
+	require.Len(
+		h, funding.ForeignOutpoints, 1, "unexpected foreign output count",
+	)
+
+	_, err = w.GetUtxo(h.Context(), funding.ForeignOutpoints[0])
 	require.ErrorIs(
 		h, err, wallet.ErrUnknownOutput,
 		"foreign outpoint not rejected",
@@ -372,7 +377,7 @@ func testLeaseOutput(h *bwtest.HarnessTest) {
 
 	require.NoError(h, w.Start(h.Context()), "failed to start wallet")
 
-	outpoints := h.FundWallet(w, oneBTC, twoBTC)
+	outpoints := h.FundWallet(w, oneBTC, twoBTC).WalletOutpoints
 
 	// Lease the first output; the expiration tracks the requested duration.
 	expiration, err := w.LeaseOutput(
@@ -474,7 +479,7 @@ func testReleaseOutput(h *bwtest.HarnessTest) {
 
 	require.NoError(h, w.Start(h.Context()), "failed to start wallet")
 
-	outpoints := h.FundWallet(w, oneBTC)
+	outpoints := h.FundWallet(w, oneBTC).WalletOutpoints
 
 	// Releasing an output with no active lease is a no-op.
 	require.NoError(
@@ -542,7 +547,7 @@ func testListLeasedOutputs(h *bwtest.HarnessTest) {
 
 	require.NoError(h, w.Start(h.Context()), "failed to start wallet")
 
-	outpoints := h.FundWallet(w, oneBTC, twoBTC)
+	outpoints := h.FundWallet(w, oneBTC, twoBTC).WalletOutpoints
 
 	// A funded wallet starts with no leases.
 	leases, err := w.ListLeasedOutputs(h.Context())


### PR DESCRIPTION
Implements Task 434 — cover transaction creation contracts.

## Task 434 acceptance criteria mapped to tests

| Criterion | Case |
| --- | --- |
| Automatic coin selection | `txcreator select coins` (named account, largest-first), `txcreator default account` (no source named, resolved under BIP86) |
| Caller-selected inputs | `txcreator manual inputs` (selection bypassed), `txcreator coin source` (restricted candidate list) |
| Transactions with and without change | `txcreator select coins` (change to an internal address), `txcreator omit change` (dust remainder dropped) |
| Representative fee and output boundaries | `txcreator output boundaries` (dust edge derived from the relay policy, smallest payable amount, `MaxSatoshi` and one above it), `txcreator reject intent` (zero, maximum and above-maximum fee rates; negative output), `txcreator multiple outputs` |
| Insufficient funds | `txcreator reject inputs` (over balance, and a leased coin skipped by selection), `txcreator coin source` (confirmation bound) |
| Locked or foreign inputs | `txcreator reject inputs` (leased, unknown and on-chain foreign outputs, through both manual and candidate paths) |
| Invalid outputs | `txcreator reject intent` |
| Bad change source | `txcreator reject intent` (unnamed and unknown change accounts) |
| Stopped and locked wallet states | `txcreator wallet state` (forbidden before Start and after Stop; a locked wallet still authors) |
| Watch-only wallet state | Not covered — see below |
| Backend neutral for PostgreSQL | Full suite passes on SQLite, PostgreSQL and kvdb |
| Test-only, defines no future behavior | No production file is touched |

## Harness changes

All additive, in `bwtest`, with the existing entry points kept as wrappers:

- `WalletFixture` and `NewWallet` — one parameterized wallet preparation path (address type, funding amounts, unlock, unstarted), so component tests stop growing their own creation and funding policy.
- `FundWalletOfType` and `NewWalletAddressOfType` — funding under a chosen key scope, which the implicit default-account path needs, since the wallet resolves accounts per scope while the harness funded BIP84 only.
- `ForeignOutpoint` — the miner's change output as a property of the funding fixture; `testGetUtxo` now uses it instead of deriving it inline.
- Shared fixtures moved to `itest/fixtures_test.go` so no component's test file owns values another depends on.

Two existing-test changes follow from those, so each policy has one owner:
`testGetUtxo` uses `ForeignOutpoint` rather than its own inline copy, and the
seven UtxoManager cases drop their local `createWallet` for
`NewWallet(WalletFixture{Unstarted: true})`.

## Synchronization boundary

The final commit removes the explicit `AssertWalletSynced` calls from the
cases. Mining already asserts that every registered wallet is synced, which
funding does, so the calls asserted nothing further; over full-suite
PostgreSQL runs the known scan-completeness failure appeared at the same rate
either way, with the numbers recorded in that commit's body. Reverting that
one commit restores them.



## not covered

- **Watch-only state.** A funded watch-only wallet requires shell mode with public initial accounts, which #1320 currently restricts.


Part of #1250.

