### PR TITLE
wallet: filter recovery blocks outside database transaction

### DIFF
--- a/wallet/mock.go
+++ b/wallet/mock.go
@@ -16,6 +16,9 @@ type mockChainClient struct {
 	getBestBlockHeight int32
 	getBlockHashFunc   func() (*chainhash.Hash, error)
 	getBlockHeader     *wire.BlockHeader
+	filterBlocksFunc   func(*chain.FilterBlocksRequest) (
+		*chain.FilterBlocksResponse, error)
+	notifyReceivedFunc func([]address.Address) error
 }
 
 var _ chain.Interface = (*mockChainClient)(nil)
@@ -53,8 +56,12 @@ func (m *mockChainClient) IsCurrent() bool {
 	return false
 }
 
-func (m *mockChainClient) FilterBlocks(*chain.FilterBlocksRequest) (
+func (m *mockChainClient) FilterBlocks(req *chain.FilterBlocksRequest) (
 	*chain.FilterBlocksResponse, error) {
+	if m.filterBlocksFunc != nil {
+		return m.filterBlocksFunc(req)
+	}
+
 	return nil, nil
 }
 
@@ -77,7 +84,11 @@ func (m *mockChainClient) Rescan(*chainhash.Hash, []address.Address,
 	return nil
 }
 
-func (m *mockChainClient) NotifyReceived([]address.Address) error {
+func (m *mockChainClient) NotifyReceived(addrs []address.Address) error {
+	if m.notifyReceivedFunc != nil {
+		return m.notifyReceivedFunc(addrs)
+	}
+
 	return nil
 }
 

--- a/wallet/recovery_internal_test.go
+++ b/wallet/recovery_internal_test.go
@@ -1,0 +1,474 @@
+package wallet
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btcwallet/chain"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/walletdb"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+	"github.com/stretchr/testify/require"
+)
+
+// newRecoveryTestState creates the recovery state and scoped-manager map used
+// by a production recovery run, including state already persisted in walletdb.
+func newRecoveryTestState(t *testing.T, w *Wallet) (*RecoveryManager,
+	map[waddrmgr.KeyScope]*waddrmgr.ScopedKeyManager) {
+
+	t.Helper()
+
+	recoveryMgr := NewRecoveryManager(
+		w.recoveryWindow, recoveryBatchSize, w.chainParams,
+	)
+
+	scopedMgrs := make(
+		map[waddrmgr.KeyScope]*waddrmgr.ScopedKeyManager,
+	)
+	for _, scopedMgr := range w.Manager.ActiveScopedKeyManagers() {
+		scopedMgrs[scopedMgr.Scope()] = scopedMgr
+	}
+
+	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+		txMgrNS := tx.ReadBucket(wtxmgrNamespaceKey)
+
+		credits, err := w.TxStore.UnspentOutputs(txMgrNS)
+		if err != nil {
+			return err
+		}
+
+		addrMgrNS := tx.ReadBucket(waddrmgrNamespaceKey)
+
+		return recoveryMgr.Resurrect(addrMgrNS, scopedMgrs, credits)
+	})
+	require.NoError(t, err)
+
+	return recoveryMgr, scopedMgrs
+}
+
+// newRecoveryTestBlock returns matching filter and sync records for a block.
+func newRecoveryTestBlock(height int32) (wtxmgr.BlockMeta,
+	*waddrmgr.BlockStamp) {
+
+	var hash chainhash.Hash
+
+	hash[0] = byte(height)
+
+	timestamp := time.Unix(int64(height), 0)
+	blockMeta := wtxmgr.BlockMeta{
+		Block: wtxmgr.Block{
+			Hash:   hash,
+			Height: height,
+		},
+		Time: timestamp,
+	}
+	blockStamp := &waddrmgr.BlockStamp{
+		Hash:      hash,
+		Height:    height,
+		Timestamp: timestamp,
+	}
+
+	return blockMeta, blockStamp
+}
+
+// newRecoveryTestResponse builds a filter response for the highest external
+// address in a scope and a transaction that pays to that address.
+//
+//nolint:ireturn
+func newRecoveryTestResponse(req *chain.FilterBlocksRequest,
+	scope waddrmgr.KeyScope, value int64) (*chain.FilterBlocksResponse,
+	address.Address, uint32, *wire.MsgTx, error) {
+
+	var (
+		recoveredAddr  address.Address
+		recoveredIndex uint32
+	)
+	for scopedIndex, candidate := range req.ExternalAddrs {
+		if scopedIndex.Scope != scope {
+			continue
+		}
+
+		if recoveredAddr != nil && scopedIndex.Index < recoveredIndex {
+			continue
+		}
+
+		recoveredAddr = candidate
+		recoveredIndex = scopedIndex.Index
+	}
+
+	if recoveredAddr == nil {
+		return nil, nil, 0, nil, errors.New("missing recovery address")
+	}
+
+	pkScript, err := txscript.PayToAddrScript(recoveredAddr)
+	if err != nil {
+		return nil, nil, 0, nil, err
+	}
+
+	relevantTx := &wire.MsgTx{
+		TxIn:  []*wire.TxIn{{}},
+		TxOut: []*wire.TxOut{wire.NewTxOut(value, pkScript)},
+	}
+	response := &chain.FilterBlocksResponse{
+		BatchIndex: 0,
+		BlockMeta:  req.Blocks[0],
+		FoundExternalAddrs: map[waddrmgr.KeyScope]map[uint32]struct{}{
+			scope: {recoveredIndex: {}},
+		},
+		RelevantTxns: []*wire.MsgTx{relevantTx},
+	}
+
+	return response, recoveredAddr, recoveredIndex, relevantTx, nil
+}
+
+// TestRecoveryFilterBlocksDoesNotHoldWriter verifies that a chain backend can
+// obtain a wallet database write transaction while FilterBlocks is running.
+// A network-backed backend may block for an unbounded amount of time, so
+// holding the writer across this call would also block every unrelated wallet
+// operation that needs to persist state.
+func TestRecoveryFilterBlocksDoesNotHoldWriter(t *testing.T) {
+	t.Parallel()
+
+	w, cleanup := testWallet(t)
+	defer cleanup()
+
+	recoveryMgr, scopedMgrs := newRecoveryTestState(t, w)
+
+	height := w.Manager.SyncedTo().Height + 1
+	blockMeta, blockStamp := newRecoveryTestBlock(height)
+	batch := []wtxmgr.BlockMeta{blockMeta}
+	blocks := []*waddrmgr.BlockStamp{blockStamp}
+
+	errWriterHeld := errors.New("wallet writer held during FilterBlocks")
+	filterCalls := 0
+	chainClient := &mockChainClient{}
+	chainClient.filterBlocksFunc = func(*chain.FilterBlocksRequest) (
+		*chain.FilterBlocksResponse, error) {
+
+		filterCalls++
+
+		writerDone := make(chan error, 1)
+		go func() {
+			writerDone <- walletdb.Update(
+				w.db, func(walletdb.ReadWriteTx) error {
+					return nil
+				},
+			)
+		}()
+
+		select {
+		case err := <-writerDone:
+			return nil, err
+
+		case <-time.After(time.Second):
+			return nil, errWriterHeld
+		}
+	}
+
+	err := w.recoverBatch(
+		chainClient, batch, blocks, recoveryMgr.State(), scopedMgrs,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, filterCalls)
+}
+
+// TestRecoveryFilterBlocksSerializesAddressCreation verifies that a recovery
+// request's address horizon stays fixed until the batch is committed. Address
+// creation may continue as soon as the backend call returns.
+func TestRecoveryFilterBlocksSerializesAddressCreation(t *testing.T) {
+	t.Parallel()
+
+	w, cleanup := testWallet(t)
+	defer cleanup()
+
+	recoveryMgr, scopedMgrs := newRecoveryTestState(t, w)
+
+	height := w.Manager.SyncedTo().Height + 1
+	blockMeta, blockStamp := newRecoveryTestBlock(height)
+	batch := []wtxmgr.BlockMeta{blockMeta}
+	blocks := []*waddrmgr.BlockStamp{blockStamp}
+
+	errAddressNotSerialized := errors.New(
+		"address creation completed before recovery commit",
+	)
+	addressDone := make(chan error, 1)
+	filterCalls := 0
+	expectedSync := *blockStamp
+
+	chainClient := &mockChainClient{}
+	chainClient.notifyReceivedFunc = func([]address.Address) error {
+		if w.Manager.SyncedTo() != expectedSync {
+			return errAddressNotSerialized
+		}
+
+		return nil
+	}
+	chainClient.filterBlocksFunc = func(*chain.FilterBlocksRequest) (
+		*chain.FilterBlocksResponse, error) {
+
+		filterCalls++
+
+		addressGoroutineStarted := make(chan struct{})
+		go func() {
+			close(addressGoroutineStarted)
+
+			_, err := w.NewAddress(
+				waddrmgr.DefaultAccountNum,
+				waddrmgr.KeyScopeBIP0084,
+			)
+			addressDone <- err
+		}()
+
+		<-addressGoroutineStarted
+
+		select {
+		case err := <-addressDone:
+			if err != nil {
+				return nil, err
+			}
+
+			return nil, errAddressNotSerialized
+
+		case <-time.After(100 * time.Millisecond):
+		}
+
+		return nil, nil //nolint:nilnil
+	}
+	w.chainClient = chainClient
+
+	err := w.recoverBatch(
+		chainClient, batch, blocks, recoveryMgr.State(), scopedMgrs,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, filterCalls)
+	require.Equal(t, expectedSync, w.Manager.SyncedTo())
+
+	select {
+	case err := <-addressDone:
+		require.NoError(t, err)
+
+	case <-time.After(time.Second):
+		t.Fatal("address creation remained blocked after recovery commit")
+	}
+}
+
+// TestRecoveryBatchCommitsResults verifies that discoveries from multiple
+// backend calls and the synced-to marker are committed together after the
+// backend finishes filtering.
+func TestRecoveryBatchCommitsResults(t *testing.T) {
+	t.Parallel()
+
+	w, cleanup := testWallet(t)
+	defer cleanup()
+
+	recoveryMgr, scopedMgrs := newRecoveryTestState(t, w)
+
+	height := w.Manager.SyncedTo().Height + 1
+	firstMeta, firstStamp := newRecoveryTestBlock(height)
+	secondMeta, secondStamp := newRecoveryTestBlock(height + 1)
+	thirdMeta, thirdStamp := newRecoveryTestBlock(height + 2)
+	batch := []wtxmgr.BlockMeta{firstMeta, secondMeta, thirdMeta}
+	blocks := []*waddrmgr.BlockStamp{firstStamp, secondStamp, thirdStamp}
+
+	scope := waddrmgr.KeyScopeBIP0084
+
+	var (
+		filterCalls      int
+		recoveredAddrs   []address.Address
+		recoveredIndexes []uint32
+		relevantTxns     []*wire.MsgTx
+	)
+
+	chainClient := &mockChainClient{}
+	chainClient.filterBlocksFunc = func(req *chain.FilterBlocksRequest) (
+		*chain.FilterBlocksResponse, error) {
+
+		filterCalls++
+		if filterCalls == 3 {
+			// A nil response means the backend scanned the rest of the
+			// batch without another match.
+			return nil, nil //nolint:nilnil
+		}
+
+		response, recoveredAddr, recoveredIndex, relevantTx, err :=
+			newRecoveryTestResponse(
+				req, scope, int64(1000+filterCalls),
+			)
+		if err != nil {
+			return nil, err
+		}
+
+		recoveredAddrs = append(
+			recoveredAddrs, recoveredAddr,
+		)
+		recoveredIndexes = append(
+			recoveredIndexes, recoveredIndex,
+		)
+		relevantTxns = append(relevantTxns, relevantTx)
+
+		return response, nil
+	}
+
+	err := w.recoverBatch(
+		chainClient, batch, blocks, recoveryMgr.State(), scopedMgrs,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 3, filterCalls)
+	require.Equal(t, *thirdStamp, w.Manager.SyncedTo())
+
+	var (
+		accountProps *waddrmgr.AccountProperties
+
+		addressesUsed []bool
+		txDetails     []*wtxmgr.TxDetails
+	)
+
+	err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+		addrMgrNS := tx.ReadBucket(waddrmgrNamespaceKey)
+		scopedMgr := scopedMgrs[scope]
+
+		var err error
+
+		accountProps, err = scopedMgr.AccountProperties(
+			addrMgrNS, waddrmgr.DefaultAccountNum,
+		)
+		if err != nil {
+			return err
+		}
+
+		for _, recoveredAddr := range recoveredAddrs {
+			managedAddr, err := scopedMgr.Address(
+				addrMgrNS, recoveredAddr,
+			)
+			if err != nil {
+				return err
+			}
+
+			addressesUsed = append(
+				addressesUsed, managedAddr.Used(addrMgrNS),
+			)
+		}
+
+		txMgrNS := tx.ReadBucket(wtxmgrNamespaceKey)
+		for _, relevantTx := range relevantTxns {
+			txHash := relevantTx.TxHash()
+
+			details, err := w.TxStore.TxDetails(txMgrNS, &txHash)
+			if err != nil {
+				return err
+			}
+
+			txDetails = append(txDetails, details)
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, recoveredIndexes[len(recoveredIndexes)-1]+1,
+		accountProps.ExternalKeyCount)
+	require.Equal(t, []bool{true, true}, addressesUsed)
+	require.Len(t, txDetails, 2)
+	require.NotNil(t, txDetails[0])
+	require.NotNil(t, txDetails[1])
+}
+
+// TestRecoveryBatchFilterErrorRollsBack verifies that an error from a later
+// backend request cannot leave earlier discoveries or a newer synced-to marker
+// in walletdb.
+func TestRecoveryBatchFilterErrorRollsBack(t *testing.T) {
+	t.Parallel()
+
+	w, cleanup := testWallet(t)
+	defer cleanup()
+
+	recoveryMgr, scopedMgrs := newRecoveryTestState(t, w)
+
+	initialSync := w.Manager.SyncedTo()
+	firstMeta, firstStamp := newRecoveryTestBlock(initialSync.Height + 1)
+	secondMeta, secondStamp := newRecoveryTestBlock(initialSync.Height + 2)
+	batch := []wtxmgr.BlockMeta{firstMeta, secondMeta}
+	blocks := []*waddrmgr.BlockStamp{firstStamp, secondStamp}
+
+	scope := waddrmgr.KeyScopeBIP0084
+
+	var (
+		filterCalls  int
+		relevantTx   *wire.MsgTx
+		initialProps *waddrmgr.AccountProperties
+	)
+
+	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+		addrMgrNS := tx.ReadBucket(waddrmgrNamespaceKey)
+
+		var err error
+
+		initialProps, err = scopedMgrs[scope].AccountProperties(
+			addrMgrNS, waddrmgr.DefaultAccountNum,
+		)
+
+		return err
+	})
+	require.NoError(t, err)
+
+	errLaterFilter := errors.New("later FilterBlocks call failed")
+	chainClient := &mockChainClient{}
+	chainClient.filterBlocksFunc = func(req *chain.FilterBlocksRequest) (
+		*chain.FilterBlocksResponse, error) {
+
+		filterCalls++
+		if filterCalls > 1 {
+			return nil, errLaterFilter
+		}
+
+		response, _, _, transaction, err := newRecoveryTestResponse(
+			req, scope, 1000,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		relevantTx = transaction
+
+		return response, nil
+	}
+
+	err = w.recoverBatch(
+		chainClient, batch, blocks, recoveryMgr.State(), scopedMgrs,
+	)
+	require.ErrorIs(t, err, errLaterFilter)
+	require.Equal(t, 2, filterCalls)
+	require.Equal(t, initialSync, w.Manager.SyncedTo())
+
+	var (
+		finalProps *waddrmgr.AccountProperties
+		txDetails  *wtxmgr.TxDetails
+	)
+
+	err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+		addrMgrNS := tx.ReadBucket(waddrmgrNamespaceKey)
+
+		var err error
+
+		finalProps, err = scopedMgrs[scope].AccountProperties(
+			addrMgrNS, waddrmgr.DefaultAccountNum,
+		)
+		if err != nil {
+			return err
+		}
+
+		txMgrNS := tx.ReadBucket(wtxmgrNamespaceKey)
+		txHash := relevantTx.TxHash()
+		txDetails, err = w.TxStore.TxDetails(txMgrNS, &txHash)
+
+		return err
+	})
+	require.NoError(t, err)
+	require.Equal(t, initialProps.ExternalKeyCount,
+		finalProps.ExternalKeyCount)
+	require.Nil(t, txDetails)
+}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -134,6 +134,11 @@ type Wallet struct {
 	chainClientSynced  bool
 	chainClientSyncMtx sync.Mutex
 
+	// newAddrMtx serializes complete operations that can advance address
+	// indexes, including transaction construction or funding that may create
+	// a change address. Seed recovery holds it across each filter batch to
+	// keep the recovery horizon fixed. It must remain held through transaction
+	// commit callbacks that update the address manager's in-memory state.
 	newAddrMtx sync.Mutex
 
 	lockedOutpoints    map[wire.OutPoint]struct{}
@@ -791,28 +796,10 @@ func (w *Wallet) recovery(chainClient chain.Interface,
 		// state to disk.
 		recoveryBatch := recoveryMgr.BlockBatch()
 		if len(recoveryBatch) == recoveryBatchSize || height == bestHeight {
-			err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-				ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-				if err := w.recoverScopedAddresses(
-					chainClient, tx, ns, recoveryBatch,
-					recoveryMgr.State(), scopedMgrs,
-				); err != nil {
-					return err
-				}
-
-				// TODO: Any error here will roll back this
-				// entire tx. This may cause the in memory sync
-				// point to become desyncronized. Refactor so
-				// that this cannot happen.
-				for _, block := range blocks {
-					err := w.Manager.SetSyncedTo(ns, block)
-					if err != nil {
-						return err
-					}
-				}
-
-				return nil
-			})
+			err := w.recoverBatch(
+				chainClient, recoveryBatch, blocks,
+				recoveryMgr.State(), scopedMgrs,
+			)
 			if err != nil {
 				return err
 			}
@@ -833,6 +820,50 @@ func (w *Wallet) recovery(chainClient chain.Interface,
 	return nil
 }
 
+// recoverBatch scans and commits one recovery batch. Operations that can
+// advance address indexes, including transaction construction and funding, are
+// serialized across the backend scan and final commit. This keeps the recovery
+// horizon fixed while leaving the wallet database available to unrelated
+// writers during backend I/O.
+func (w *Wallet) recoverBatch(chainClient chain.Interface,
+	recoveryBatch []wtxmgr.BlockMeta, blocks []*waddrmgr.BlockStamp,
+	recoveryState *RecoveryState,
+	scopedMgrs map[waddrmgr.KeyScope]*waddrmgr.ScopedKeyManager) error {
+
+	w.newAddrMtx.Lock()
+	defer w.newAddrMtx.Unlock()
+
+	filterResponses, err := w.recoverScopedAddresses(
+		chainClient, recoveryBatch, recoveryState, scopedMgrs,
+	)
+	if err != nil {
+		return err
+	}
+
+	return walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+		err := w.applyRecoveryResponses(
+			tx, filterResponses, scopedMgrs, recoveryState,
+		)
+		if err != nil {
+			return err
+		}
+
+		// TODO: Any error here will roll back this entire tx. This may
+		// cause the in memory sync point to become desyncronized.
+		// Refactor so that this cannot happen.
+		for _, block := range blocks {
+			err := w.Manager.SetSyncedTo(ns, block)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
 // recoverScopedAddresses scans a range of blocks in attempts to recover any
 // previously used addresses for a particular account derivation path. At a high
 // level, the algorithm works as follows:
@@ -848,39 +879,56 @@ func (w *Wallet) recovery(chainClient chain.Interface,
 // TODO(conner): parallelize/pipeline/cache intermediate network requests
 func (w *Wallet) recoverScopedAddresses(
 	chainClient chain.Interface,
-	tx walletdb.ReadWriteTx,
-	ns walletdb.ReadWriteBucket,
 	batch []wtxmgr.BlockMeta,
 	recoveryState *RecoveryState,
-	scopedMgrs map[waddrmgr.KeyScope]*waddrmgr.ScopedKeyManager) error {
+	scopedMgrs map[waddrmgr.KeyScope]*waddrmgr.ScopedKeyManager) (
+	[]*chain.FilterBlocksResponse, error) {
 
 	// If there are no blocks in the batch, we are done.
 	if len(batch) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	log.Infof("Scanning %d blocks for recoverable addresses", len(batch))
 
+	var filterResponses []*chain.FilterBlocksResponse
+
 expandHorizons:
-	for scope, scopedMgr := range scopedMgrs {
-		scopeState := recoveryState.StateForScope(scope)
-		err := expandScopeHorizons(ns, scopedMgr, scopeState)
-		if err != nil {
-			return err
+	var filterReq *chain.FilterBlocksRequest
+
+	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+
+		for scope, scopedMgr := range scopedMgrs {
+			scopeState := recoveryState.StateForScope(scope)
+
+			err := expandScopeHorizons(ns, scopedMgr, scopeState)
+			if err != nil {
+				return err
+			}
 		}
+
+		// With the internal and external horizons properly expanded, we
+		// now construct the filter blocks request. The request includes
+		// the range of blocks we intend to scan, in addition to the
+		// scope-index -> addr map for all internal and external branches.
+		filterReq = newFilterBlocksRequest(
+			batch, scopedMgrs, recoveryState,
+		)
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
-	// With the internal and external horizons properly expanded, we now
-	// construct the filter blocks request. The request includes the range
-	// of blocks we intend to scan, in addition to the scope-index -> addr
-	// map for all internal and external branches.
-	filterReq := newFilterBlocksRequest(batch, scopedMgrs, recoveryState)
-
 	// Initiate the filter blocks request using our chain backend. If an
-	// error occurs, we are unable to proceed with the recovery.
+	// error occurs, we are unable to proceed with the recovery. This call
+	// can perform remote I/O, so it must not run while a database write
+	// transaction is held.
 	filterResp, err := chainClient.FilterBlocks(filterReq)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// If the filter response is empty, this signals that the rest of the
@@ -888,8 +936,10 @@ expandHorizons:
 	// result, no further modifications to our recovery state are required
 	// and we can proceed to the next batch.
 	if filterResp == nil {
-		return nil
+		return filterResponses, nil
 	}
+
+	filterResponses = append(filterResponses, filterResp)
 
 	// Otherwise, retrieve the block info for the block that detected a
 	// non-zero number of address matches.
@@ -898,38 +948,19 @@ expandHorizons:
 	// Log any non-trivial findings of addresses or outpoints.
 	logFilterBlocksResp(block, filterResp)
 
-	// Report any external or internal addresses found as a result of the
-	// appropriate branch recovery state. Adding indexes above the
-	// last-found index of either will result in the horizons being expanded
-	// upon the next iteration. Any found addresses are also marked used
-	// using the scoped key manager.
-	err = extendFoundAddresses(ns, filterResp, scopedMgrs, recoveryState)
-	if err != nil {
-		return err
-	}
+	// Advance the in-memory branch horizons before filtering the remainder
+	// of the batch. This is the only place that reports found indexes to the
+	// recovery state. The corresponding persistent changes are committed
+	// atomically with the batch's synced-to update after all remote work is
+	// complete.
+	reportFoundAddresses(filterResp, recoveryState)
 
-	// Update the global set of watched outpoints with any that were found
-	// in the block.
+	// Update the in-memory watched-outpoint set before filtering the
+	// remainder of the batch. Relevant transactions and wallet sync state
+	// are persisted together after all remote work is complete.
 	for outPoint, addr := range filterResp.FoundOutPoints {
 		outPoint := outPoint
 		recoveryState.AddWatchedOutPoint(&outPoint, addr)
-	}
-
-	// Finally, record all of the relevant transactions that were returned
-	// in the filter blocks response. This ensures that these transactions
-	// and their outputs are tracked when the final rescan is performed.
-	for _, txn := range filterResp.RelevantTxns {
-		txRecord, err := wtxmgr.NewTxRecordFromMsgTx(
-			txn, filterResp.BlockMeta.Time,
-		)
-		if err != nil {
-			return err
-		}
-
-		err = w.addRelevantTx(tx, txRecord, &filterResp.BlockMeta)
-		if err != nil {
-			return err
-		}
 	}
 
 	// Update the batch to indicate that we've processed all block through
@@ -942,6 +973,66 @@ expandHorizons:
 		goto expandHorizons
 	}
 
+	return filterResponses, nil
+}
+
+// reportFoundAddresses advances the in-memory recovery horizons for the next
+// filter request. The corresponding address-manager writes are deferred until
+// all remote filtering for the batch has completed.
+func reportFoundAddresses(filterResp *chain.FilterBlocksResponse,
+	recoveryState *RecoveryState) {
+
+	for scope, indexes := range filterResp.FoundExternalAddrs {
+		scopeState := recoveryState.StateForScope(scope)
+		for index := range indexes {
+			scopeState.ExternalBranch.ReportFound(index)
+		}
+	}
+
+	for scope, indexes := range filterResp.FoundInternalAddrs {
+		scopeState := recoveryState.StateForScope(scope)
+		for index := range indexes {
+			scopeState.InternalBranch.ReportFound(index)
+		}
+	}
+}
+
+// applyRecoveryResponses persists all address and transaction discoveries for
+// one recovery batch. The caller invokes this in the same transaction that
+// advances the wallet's synced-to marker, preserving the original atomic
+// commit boundary.
+func (w *Wallet) applyRecoveryResponses(tx walletdb.ReadWriteTx,
+	filterResponses []*chain.FilterBlocksResponse,
+	scopedMgrs map[waddrmgr.KeyScope]*waddrmgr.ScopedKeyManager,
+	recoveryState *RecoveryState) error {
+
+	ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+	for _, filterResp := range filterResponses {
+		err := extendFoundAddresses(
+			ns, filterResp, scopedMgrs, recoveryState,
+		)
+		if err != nil {
+			return err
+		}
+
+		for _, txn := range filterResp.RelevantTxns {
+			txRecord, err := wtxmgr.NewTxRecordFromMsgTx(
+				txn, filterResp.BlockMeta.Time,
+			)
+			if err != nil {
+				return err
+			}
+
+			err = w.addRelevantTx(
+				tx, txRecord, &filterResp.BlockMeta,
+			)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -951,7 +1042,7 @@ expandHorizons:
 // persistent state of the wallet. If any invalid child keys are detected, the
 // horizon will be properly extended such that our lookahead always includes the
 // proper number of valid child keys.
-func expandScopeHorizons(ns walletdb.ReadWriteBucket,
+func expandScopeHorizons(ns walletdb.ReadBucket,
 	scopedMgr *waddrmgr.ScopedKeyManager,
 	scopeState *ScopeRecoveryState) error {
 
@@ -1075,8 +1166,8 @@ func newFilterBlocksRequest(batch []wtxmgr.BlockMeta,
 }
 
 // extendFoundAddresses accepts a filter blocks response that contains addresses
-// found on chain, and advances the state of all relevant derivation paths to
-// match the highest found child index for each branch.
+// found on chain and persists the derivation paths already advanced during the
+// scan phase.
 func extendFoundAddresses(ns walletdb.ReadWriteBucket,
 	filterResp *chain.FilterBlocksResponse,
 	scopedMgrs map[waddrmgr.KeyScope]*waddrmgr.ScopedKeyManager,
@@ -1086,19 +1177,11 @@ func extendFoundAddresses(ns walletdb.ReadWriteBucket,
 	// for scopes that reported a non-zero number of external addresses in
 	// this block.
 	for scope, indexes := range filterResp.FoundExternalAddrs {
-		// First, report all external child indexes found for this
-		// scope. This ensures that the external last-found index will
-		// be updated to include the maximum child index seen thus far.
 		scopeState := recoveryState.StateForScope(scope)
-		for index := range indexes {
-			scopeState.ExternalBranch.ReportFound(index)
-		}
-
 		scopedMgr := scopedMgrs[scope]
 
-		// Now, with all found addresses reported, derive and extend all
-		// external addresses up to and including the current last found
-		// index for this scope.
+		// Derive and extend all external addresses up to and including
+		// the current last found index for this scope.
 		exNextUnfound := scopeState.ExternalBranch.NextUnfound()
 
 		exLastFound := exNextUnfound
@@ -1129,19 +1212,11 @@ func extendFoundAddresses(ns walletdb.ReadWriteBucket,
 	// for scopes that reported a non-zero number of internal addresses in
 	// this block.
 	for scope, indexes := range filterResp.FoundInternalAddrs {
-		// First, report all internal child indexes found for this
-		// scope. This ensures that the internal last-found index will
-		// be updated to include the maximum child index seen thus far.
 		scopeState := recoveryState.StateForScope(scope)
-		for index := range indexes {
-			scopeState.InternalBranch.ReportFound(index)
-		}
-
 		scopedMgr := scopedMgrs[scope]
 
-		// Now, with all found addresses reported, derive and extend all
-		// internal addresses up to and including the current last found
-		// index for this scope.
+		// Derive and extend all internal addresses up to and including
+		// the current last found index for this scope.
 		inNextUnfound := scopeState.InternalBranch.NextUnfound()
 
 		inLastFound := inNextUnfound


### PR DESCRIPTION
## The problem

During seed recovery, the wallet scans old blocks in batches. It used to keep a wallet database write transaction open while the chain backend ran `FilterBlocks`.

`FilterBlocks` can wait on the network. If it is slow, the open transaction blocks every other wallet database writer. On a physical iPhone this blocked invoice authentication key work long enough for invoice creation to time out.

## The fix

This PR splits each recovery batch into three steps:

1. Read the wallet's address state in a short read transaction and build a complete filter request.
2. Close that transaction, then ask the chain backend to scan the blocks.
3. After every backend call for the batch succeeds, save all recovered addresses, transactions, and sync markers in one write transaction.

Operations that can advance address indexes, including address creation and transaction funding, are held for the duration of a recovery batch. This keeps the address range in the request stable while the backend scans it. Other database writers, including key operations unrelated to address indexes, remain available.

## Safety rule

Recovery still has one all-or-nothing database update per batch:

- If a backend call fails, the wallet does not save any discovery from that batch and does not move its sync marker forward.
- If the final database update fails, walletdb rolls back the recovered addresses, transactions, and sync marker together.
- If the process stops before that update, the stored sync marker is unchanged, so recovery scans the batch again after restart.

Filter responses remain in memory until the batch commits, so peak recovery memory grows with matching blocks and transactions within one batch. This bounded trade-off preserves the single atomic commit boundary.

The old database transaction never locked the chain backend or froze its view of the chain. Moving backend I/O outside that transaction therefore does not weaken reorg handling. Requests still name the exact blocks to scan, and the existing rollback and rescan paths are unchanged.

## What does not change

- The recovery window, block batches, address derivation, and watched outpoints are unchanged.
- The `chain.Interface` API and its request and response types are unchanged.
- The wallet database schema is unchanged.
- A failed scan is still an error; it is never treated as an empty result.
- Address-index operations could already wait behind the old wallet-wide database writer. They now wait on a narrow address-index lock, while unrelated writers can continue.

## Backend safety

This change is not specific to lwwallet or Esplora.

The built-in btcd, bitcoind, and Neutrino backends all receive a self-contained `FilterBlocksRequest` containing the block list, address maps, and watched outpoints. They return a self-contained response and do not receive or use a wallet database transaction. The implementations differ only in how they query the chain: Neutrino and btcd use compact-filter-based paths, while bitcoind fetches blocks through Bitcoin Core. Bitcoin Core notification mode—RPC polling or ZMQ—does not change this recovery call.

An external `chain.Interface` implementation, such as an Esplora-backed wallet, has the same contract. The PR changes when btcwallet holds its own locks; it does not change what any backend must do.

## Tests

New backend-neutral tests verify that:

- an unrelated wallet database writer can complete while `FilterBlocks` is running;
- real address creation is serialized until the batch is committed, then completes normally;
- the locking tests cannot pass without invoking `FilterBlocks`;
- discoveries returned by multiple backend calls are committed with the final sync marker;
- an error from a later backend call leaves earlier discoveries and the sync marker uncommitted.

Local checks:

- `golangci-lint run ./wallet`
- `go test ./wallet -run 'TestRecovery(FilterBlocks|Batch)' -count=10`
- focused recovery tests with the race detector, repeated five times
- the complete wallet unit suite

The original failure was also retested on an Esplora-backed Wavelength build on a physical iPhone. Two consecutive invoice requests completed in under one second instead of timing out at 20 seconds.

## Compatibility and rollout

There are no API, database, protocol, configuration, or backend changes. Existing wallets and all current chain backends use the same recovery data and commit boundary. The visible behavior change is that unrelated wallet writes no longer wait for recovery network I/O.

Fixes #1317.

Related downstream report: https://github.com/lightninglabs/wavelength/issues/1134
