### PR TITLE
docs: separate live watches from recovery

### DIFF
--- a/docs/developer/adr/0004-targeted-rescan-vs-rewind.md
+++ b/docs/developer/adr/0004-targeted-rescan-vs-rewind.md
@@ -1,5 +1,13 @@
 # ADR 0004: Targeted Rescan vs. Global Rewind
 
+> **Superseded in part:** ADR 0005 supersedes Section 2.2's automatic import
+> trigger. Imports may register a live watch after persistence, but they do not
+> start historical recovery; callers invoke `Rescan(...)` explicitly. Section
+> 2.2's account-exclusive target description is also superseded: requested
+> accounts limit derivation horizons, while recovery-relevant addresses and
+> UTXOs are loaded wallet-wide. A targeted rescan still does not rewind the
+> global `SyncedTo` watermark.
+
 ## 1. Context
 
 In `btcwallet`, discovering missing transactions has historically required a "Rescan." The legacy implementation treated all rescans as a "Rewind":

--- a/docs/developer/adr/0005-no-auto-rescan-on-import.md
+++ b/docs/developer/adr/0005-no-auto-rescan-on-import.md
@@ -2,19 +2,28 @@
 
 ## 1. Context
 
-When importing new keys, addresses, or accounts into a wallet (e.g., via `ImportPrivateKey` or `ImportAccount`), the wallet needs to scan the blockchain history to discover any existing funds associated with these new credentials.
+When importing new keys, addresses, or accounts into a wallet, the wallet needs
+to scan the blockchain history to discover any existing funds associated with
+these new credentials.
 
 A common pattern in some wallet implementations is to automatically trigger a rescan immediately upon import. However, this approach introduces several issues:
+
 *   **Performance Storms:** If a user or application imports a batch of 100 keys sequentially, an automatic trigger would launch 100 overlapping, redundant rescan jobs.
 *   **Blocking Behavior:** If the import method waits for the scan, a simple database insertion becomes a potentially hour-long operation.
-*   **API Ambiguity:** It blurs the line between "State Management" (adding a key) and "Network Operation" (scanning the chain).
+*   **API Ambiguity:** It blurs the line between importing wallet state and
+    explicitly requesting historical recovery.
 
 ## 2. Decision
 
 `btcwallet` will **not** automatically trigger a blockchain rescan when keys, addresses, or accounts are imported.
 
-*   **Import Methods are Purely Database Operations:** Methods like `ImportPrivateKey`, `ImportAccount`, and `ImportScript` will only persist the data to the wallet database and return immediately.
-*   **Rescans Must Be Explicit:** The caller is responsible for explicitly requesting a rescan (via `Rescan(...)`) after the import is complete.
+*   **Imports Do Not Start Historical Recovery:** Maintained controller import
+    methods persist wallet data and, for watchable addresses, synchronously
+    request live notifications from the chain backend. Live registration does
+    not scan historical blocks.
+*   **Historical Rescans Must Be Explicit:** The caller is responsible for
+    explicitly requesting a rescan (via `Rescan(...)`) after the import is
+    complete.
 
 ## 3. Rationale
 
@@ -22,9 +31,11 @@ A common pattern in some wallet implementations is to automatically trigger a re
 This design allows downstream applications (like `lnd` or custom scripts) to batch imports efficiently. An application can import 1,000 keys in a loop and then trigger a **single** targeted rescan for the aggregate birthday of those keys. This is orders of magnitude more efficient than 1,000 individual scans.
 
 ### 3.2 API Clarity
-Separating the concerns of "Storage" and "Synchronization" makes the API predictable.
-*   `ImportXXX`: "I want to save this key." (Fast, Atomic, Synchronous)
-*   `Rescan`: "I want to look for money." (Slow, Asynchronous, Cancellable)
+Separating live registration from historical recovery makes the API
+predictable.
+
+*   `ImportXXX`: "I want to save this key and watch new activity."
+*   `Rescan`: "I want to search historical blocks."
 
 ### 3.3 User Control
 The user (or calling software) retains control over system resources. They may choose to import keys now but defer the heavy scanning operation until a maintenance window or when bandwidth is available.

--- a/docs/developer/scanning_sync_architecture.md
+++ b/docs/developer/scanning_sync_architecture.md
@@ -65,12 +65,17 @@ This is the default background process that ensures the wallet maintains consens
 *   **Mechanism**: Sequential forward scanning of block batches.
 *   **Persistence**: Upon successful completion of a batch, the wallet updates its global "sync tip" in the database.
 
-### 3.2 Targeted Rescan (Import Scanning)
-Triggered by user actions like importing a new account, a private key, or an XPUB.
+### 3.2 Targeted Rescan
+Targeted rescans start only from an explicit caller request. Imports do not
+start them, as decided by ADR 0005.
 
-*   **Goal**: Discover historical transactions for the *newly added* keys without affecting the synchronization status of existing keys.
-*   **Mechanism**: Ad-hoc scanning of a specific block range (typically from the birthday of the imported key to the current tip).
-*   **Persistence**: Found transactions are inserted into the database, but the global `SyncedTo` watermark is **not** altered. This allows the wallet to remain "Synced" for the rest of its keys while processing the import in the background.
+*   **Goal**: Scan a requested historical range without rewinding the global
+    `SyncedTo` watermark.
+*   **Targets**: Requested account scopes limit derivation horizons and
+    lookahead expansion. Recovery-relevant active addresses and watched UTXOs
+    are currently loaded wallet-wide, so matching is not account-exclusive.
+*   **Persistence**: Found transactions are inserted while `SyncedTo` remains
+    unchanged.
 
 ---
 
@@ -88,10 +93,11 @@ When performing the standard chain sync, the wallet loads **all** active data fr
 The `RecoveryState` is initialized with this data and immediately derives `N` new lookahead addresses (based on the `RecoveryWindow`) for every account branch.
 
 ### 4.2 Loading for Targeted Rescan
-When performing a targeted rescan (e.g., after `ImportAccount`), the caller provides specific targets. The wallet constructs a **Partial Recovery State**:
-1.  **Targets**: Only the specific accounts or addresses requested by the caller are loaded.
-2.  **Isolation**: Existing, fully-synced accounts are **excluded** from this state.
-3.  **Efficiency**: This ensures the scanner only spends CPU cycles matching the new keys, ignoring the thousands of keys that are already up-to-date.
+For an explicit targeted request, the Syncer filters derivation horizons to
+the requested account scopes, then loads recovery-relevant active addresses
+and watched UTXOs wallet-wide. This includes accountless raw imports. The scan
+does not rewind `SyncedTo`, but it can match wallet state outside the requested
+account scopes.
 
 ---
 


### PR DESCRIPTION
## Summary

- Separate live-tip watch registration from explicit historical recovery.
- Clarify targeted rescan state and current wallet-wide matching.

## Change Description

Implements roadmap Task 400

Imports may register addresses with the chain backend for new activity, but do
not start a historical scan. Historical recovery remains explicit. Targeted
`Rescan(...)` leaves global `SyncedTo` unchanged while requested accounts
limit derivation horizons rather than the wallet-wide match set.
