### PR TITLE
itest: add AccountManager mutation integration tests

### DIFF
--- a/bwtest/README.md
+++ b/bwtest/README.md
@@ -35,9 +35,9 @@ The `bitcoind` backend uses ZMQ for block/tx notifications.
 ## Wallet Helpers
 
 `bwtest` owns wallet creation, funding and lock policy so component tests do
-not each define their own. `(*HarnessTest).NewWallet` is the single
-parameterized entry point; it takes a `WalletFixture` describing what the case
-needs and returns the wallet with the outpoints funding produced:
+not each define their own. `(*HarnessTest).NewWallet` takes a `WalletFixture`
+describing what the case needs and returns the wallet with the outpoints funding
+produced:
 
 ```go
 func testFoo(t *bwtest.HarnessTest) {
@@ -51,10 +51,20 @@ func testFoo(t *bwtest.HarnessTest) {
 }
 ```
 
-`WalletFixture` carries the funding address type, the funding amounts, whether
-to unlock, and whether to leave the wallet unstarted. A case that selects the
-funded coins derives its key scope from the same `AddrType` with `KeyScope()`,
-so the funded scope has one authority.
+`WalletFixture` carries the funding address type, funding amounts, whether to
+unlock, and whether to leave the wallet unstarted. Its zero value returns a
+started, locked wallet. `WatchOnly` creates a rootless `ModeShell` watch-only
+wallet.
+`InitialAccounts` seeds a watch-only shell wallet; a non-empty slice implies
+watch-only even when `WatchOnly` is false, and nil and empty slices are
+equivalent. A case that selects funded coins derives its key scope from the
+same `AddrType` with `KeyScope()`, so the funded scope has one authority.
+
+`NewWallet` privately records the configuration needed to reload its wallet.
+Pass that wallet to `(*HarnessTest).ReloadWallet(w)` when a component test needs
+to reopen it. A successful reload consumes the old generation and returns a
+fresh, registered, started, but locked replacement pointer from the same
+persistent store. Use the returned pointer for a later reload.
 
 Two convenience wrappers remain for cases that need nothing else:
 
@@ -65,8 +75,13 @@ Funding is also available on its own through `(*HarnessTest).FundWallet` and
 `(*HarnessTest).FundWalletOfType`, and addresses through
 `(*HarnessTest).NewWalletAddress` and `(*HarnessTest).NewWalletAddressOfType`.
 
-Manager-focused tests should continue to create wallets through the manager API
-directly.
+Manager-focused tests should continue to create wallets through the Manager API
+directly and register each one with `(*HarnessTest).RegisterWallet(manager, w)`
+before starting it. They may register multiple wallets under one manager. At
+teardown, the harness stops all registered wallets before closing each manager
+once. Raw `RegisterWallet` entries are not reloadable. `ReloadWallet` is limited
+to a wallet created by `NewWallet` that is the only registered wallet on its
+manager, because reloading closes and replaces that manager.
 
 ## Signed Transactions
 

--- a/bwtest/harness.go
+++ b/bwtest/harness.go
@@ -38,6 +38,11 @@ const (
 	defaultChainReconnectAttempts = 5
 )
 
+// walletRegistration tracks every wallet owned by one Manager. Each map value
+// is a copied reload configuration, or nil for wallets registered through
+// RegisterWallet.
+type walletRegistration map[*wallet.Wallet]*wallet.Config
+
 // HarnessTest is the integration test harness.
 type HarnessTest struct {
 	*testing.T
@@ -68,16 +73,12 @@ type HarnessTest struct {
 	// parent harness and its subtests.
 	postgresServer *postgresTestServer
 
-	// managers holds the wallet managers created for this subtest. They are
-	// closed after every registered wallet has stopped.
-	managers []*wallet.Manager
+	// wallets owns the wallet registrations for each Manager.
+	wallets map[*wallet.Manager]walletRegistration
 
 	// mu protects harness state that can be accessed across the main test and
 	// subtests. This includes the wallet registry and idempotent shutdown.
 	mu sync.Mutex
-
-	// wallets is the set of wallets created by a test case.
-	wallets []*wallet.Wallet
 
 	// stopped prevents stopping shared infrastructure more than once.
 	stopped bool
@@ -239,7 +240,14 @@ func (h *HarnessTest) NewWalletManager() *wallet.Manager {
 	})
 	require.NoError(h, err, "failed to create wallet manager")
 
-	h.managers = append(h.managers, manager)
+	h.mu.Lock()
+
+	if h.wallets == nil {
+		h.wallets = make(map[*wallet.Manager]walletRegistration)
+	}
+
+	h.wallets[manager] = make(walletRegistration)
+	h.mu.Unlock()
 
 	// Verify the Manager opened the backend requested by the -db flag without
 	// adding a production accessor solely for the test.
@@ -252,11 +260,22 @@ func (h *HarnessTest) NewWalletManager() *wallet.Manager {
 func (h *HarnessTest) teardownWallets(ctx context.Context) error {
 	err := h.stopActiveWallets(ctx)
 
-	for _, manager := range h.managers {
+	h.mu.Lock()
+
+	managers := make([]*wallet.Manager, 0, len(h.wallets))
+	for manager := range h.wallets {
+		managers = append(managers, manager)
+	}
+
+	h.mu.Unlock()
+
+	for _, manager := range managers {
 		err = errors.Join(err, manager.Close())
 	}
 
-	h.managers = nil
+	h.mu.Lock()
+	h.wallets = nil
+	h.mu.Unlock()
 
 	return err
 }
@@ -330,26 +349,52 @@ func validateFileBackendArtifact(dbType, dbPath string) error {
 	return nil
 }
 
-// RegisterWallet registers a wallet with the harness.
+// RegisterWallet registers a wallet with its harness-owned manager.
 //
 // Registered wallets are automatically included in harness-level assertions,
 // such as MineBlocks.
-func (h *HarnessTest) RegisterWallet(w *wallet.Wallet) {
+func (h *HarnessTest) RegisterWallet(manager *wallet.Manager,
+	w *wallet.Wallet) {
+
 	h.Helper()
 
-	if w == nil {
-		h.Fatalf("cannot register nil wallet")
-	}
+	h.registerWallet(manager, w, nil)
+}
+
+// registerWallet records a wallet under manager and copies reloadConfig when
+// provided.
+func (h *HarnessTest) registerWallet(manager *wallet.Manager, w *wallet.Wallet,
+	reloadConfig *wallet.Config) {
+
+	h.Helper()
 
 	h.mu.Lock()
-	h.wallets = append(h.wallets, w)
-	h.mu.Unlock()
+	defer h.mu.Unlock()
+
+	registration, ok := h.wallets[manager]
+	require.True(h, ok, "manager is not owned by this harness")
+	require.NotNil(h, w, "cannot register nil wallet")
+
+	for _, registered := range h.wallets {
+		_, exists := registered[w]
+		require.False(
+			h, exists,
+			"wallet is already registered with this harness",
+		)
+	}
+
+	var config *wallet.Config
+	if reloadConfig != nil {
+		copiedConfig := *reloadConfig
+		config = &copiedConfig
+	}
+
+	registration[w] = config
 }
 
 // DeregisterWallet releases a wallet from harness ownership.
 //
-// It returns false when the wallet is nil or was not registered. The remaining
-// registrations retain their original order.
+// It returns false when the wallet is nil or was not registered.
 func (h *HarnessTest) DeregisterWallet(w *wallet.Wallet) bool {
 	h.Helper()
 
@@ -360,12 +405,12 @@ func (h *HarnessTest) DeregisterWallet(w *wallet.Wallet) bool {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	for i, registered := range h.wallets {
-		if registered != w {
+	for _, registration := range h.wallets {
+		if _, ok := registration[w]; !ok {
 			continue
 		}
 
-		h.wallets = append(h.wallets[:i], h.wallets[i+1:]...)
+		delete(registration, w)
 
 		return true
 	}
@@ -375,8 +420,8 @@ func (h *HarnessTest) DeregisterWallet(w *wallet.Wallet) bool {
 
 // ReleaseManager releases a Manager from harness teardown ownership.
 //
-// It returns false when the Manager is nil or was not registered. The remaining
-// registrations retain their original order.
+// It returns false when the Manager is nil, was not registered, or has any
+// registered wallets.
 func (h *HarnessTest) ReleaseManager(manager *wallet.Manager) bool {
 	h.Helper()
 
@@ -384,25 +429,33 @@ func (h *HarnessTest) ReleaseManager(manager *wallet.Manager) bool {
 		return false
 	}
 
-	for i, registered := range h.managers {
-		if registered != manager {
-			continue
-		}
+	h.mu.Lock()
+	defer h.mu.Unlock()
 
-		h.managers = append(h.managers[:i], h.managers[i+1:]...)
-
-		return true
+	registration, ok := h.wallets[manager]
+	if !ok || len(registration) != 0 {
+		return false
 	}
 
-	return false
+	delete(h.wallets, manager)
+
+	return true
 }
 
 // ActiveWallets returns a snapshot of wallets registered with this harness.
+// The order is unspecified.
 func (h *HarnessTest) ActiveWallets() []*wallet.Wallet {
 	h.Helper()
 
 	h.mu.Lock()
-	wallets := append([]*wallet.Wallet(nil), h.wallets...)
+
+	var wallets []*wallet.Wallet
+	for _, registration := range h.wallets {
+		for w := range registration {
+			wallets = append(wallets, w)
+		}
+	}
+
 	h.mu.Unlock()
 
 	return wallets
@@ -495,14 +548,7 @@ func (h *HarnessTest) stopActiveWallets(ctx context.Context) error {
 
 	var stopErr error
 
-	for i, w := range h.ActiveWallets() {
-		if w == nil {
-			// Keep cleanup robust against partially initialized test state. A
-			// caller could register a wallet reference and fail before the
-			// assignment completes.
-			continue
-		}
-
+	for _, w := range h.ActiveWallets() {
 		// The modern Wallet controller's Stop method is idempotent.
 		//
 		// NOTE: We intentionally don't call the deprecated WaitForShutdown/
@@ -510,9 +556,9 @@ func (h *HarnessTest) stopActiveWallets(ctx context.Context) error {
 		// legacy fields initialized.
 		err := w.Stop(ctx)
 		if err != nil {
-			stopErr = errors.Join(stopErr, fmt.Errorf(
-				"stop wallet %d: %w", i, err,
-			))
+			stopErr = errors.Join(
+				stopErr, fmt.Errorf("stop wallet: %w", err),
+			)
 		}
 	}
 

--- a/bwtest/harness_test.go
+++ b/bwtest/harness_test.go
@@ -12,54 +12,117 @@ import (
 )
 
 // TestDeregisterWalletRemovesRegisteredWallet verifies that deregistration
-// removes exactly the requested wallet, preserves the order of the remaining
-// registrations, and reports absent wallets without failing.
+// removes only the requested wallet and leaves its sibling registered.
 func TestDeregisterWalletRemovesRegisteredWallet(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: a harness with three registered wallet identities.
-	h := &HarnessTest{T: t}
-	first := &wallet.Wallet{}
+	// Arrange: two wallets registered under one Manager.
+	manager := &wallet.Manager{}
 	removed := &wallet.Wallet{}
-	last := &wallet.Wallet{}
+	sibling := &wallet.Wallet{}
+	h := &HarnessTest{
+		T: t,
+		wallets: map[*wallet.Manager]walletRegistration{
+			manager: {
+				removed: nil,
+				sibling: nil,
+			},
+		}}
 
-	h.RegisterWallet(first)
-	h.RegisterWallet(removed)
-	h.RegisterWallet(last)
+	// Act: the wallet is deregistered, then queried again as absent and
+	// nil.
+	removedWallet := h.DeregisterWallet(removed)
+	removedAgain := h.DeregisterWallet(removed)
+	removedNil := h.DeregisterWallet(nil)
 
-	// Act: the middle wallet is deregistered.
-	require.True(t, h.DeregisterWallet(removed))
-
-	// Assert: only it is removed, ordering is retained, and absence is safe.
-	active := h.ActiveWallets()
-	require.Len(t, active, 2)
-	require.Same(t, first, active[0])
-	require.Same(t, last, active[1])
-	require.False(t, h.DeregisterWallet(removed))
-	require.False(t, h.DeregisterWallet(nil))
+	// Assert: the sibling remains and absent wallets are reported safely.
+	require.True(t, removedWallet)
+	require.False(t, removedAgain)
+	require.False(t, removedNil)
+	require.ElementsMatch(t, []*wallet.Wallet{sibling}, h.ActiveWallets())
 }
 
-// TestReleaseManagerRemovesRegisteredManager verifies that releasing a Manager
-// preserves the remaining teardown order and reports an absent Manager.
+// TestRegisterWalletSupportsMultipleWalletsPerManager verifies that one
+// Manager can own multiple registered wallets.
+func TestRegisterWalletSupportsMultipleWalletsPerManager(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: one manager with two wallet pointers.
+	manager := &wallet.Manager{}
+	first := &wallet.Wallet{}
+	second := &wallet.Wallet{}
+	h := &HarnessTest{
+		T: t,
+		wallets: map[*wallet.Manager]walletRegistration{
+			manager: {},
+		},
+	}
+
+	// Act: register both wallets under the same manager.
+	h.RegisterWallet(manager, first)
+	h.RegisterWallet(manager, second)
+
+	// Assert: both wallets are active regardless of map order.
+	active := h.ActiveWallets()
+	require.ElementsMatch(t, []*wallet.Wallet{first, second}, active)
+	require.Len(t, h.wallets[manager], 2)
+	require.Nil(t, h.wallets[manager][first])
+	require.Nil(t, h.wallets[manager][second])
+}
+
+// TestReleaseManagerRejectsRegisteredWallet verifies that Manager ownership
+// cannot be released while any wallet remains registered.
+func TestReleaseManagerRejectsRegisteredWallet(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: a Manager with one registered wallet.
+	manager := &wallet.Manager{}
+	w := &wallet.Wallet{}
+	h := &HarnessTest{
+		T: t,
+		wallets: map[*wallet.Manager]walletRegistration{
+			manager: {
+				w: nil,
+			},
+		},
+	}
+
+	// Act: release is attempted while the registration is non-empty.
+	released := h.ReleaseManager(manager)
+
+	// Assert: release is rejected and the Manager remains owned.
+	require.False(t, released)
+	require.Contains(t, h.wallets, manager)
+}
+
+// TestReleaseManagerRemovesRegisteredManager verifies that releasing an empty
+// Manager retains unrelated registrations and reports an absent Manager.
 func TestReleaseManagerRemovesRegisteredManager(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: a harness with three Manager registrations.
+	// Arrange: a harness with three empty Manager registrations.
 	first := &wallet.Manager{}
 	released := &wallet.Manager{}
 	last := &wallet.Manager{}
 	h := &HarnessTest{
-		T:        t,
-		managers: []*wallet.Manager{first, released, last},
+		T: t,
+		wallets: map[*wallet.Manager]walletRegistration{
+			first:    {},
+			released: {},
+			last:     {},
+		},
 	}
 
 	// Act: the middle Manager is released from teardown ownership.
 	require.True(t, h.ReleaseManager(released))
 
-	// Assert: only it is removed, ordering is retained, and absence is safe.
-	require.Len(t, h.managers, 2)
-	require.Same(t, first, h.managers[0])
-	require.Same(t, last, h.managers[1])
+	// Assert: only it is removed and absence is safe.
+	require.Len(t, h.wallets, 2)
+	_, firstRegistered := h.wallets[first]
+	_, lastRegistered := h.wallets[last]
+
+	require.True(t, firstRegistered)
+	require.True(t, lastRegistered)
 	require.False(t, h.ReleaseManager(released))
 	require.False(t, h.ReleaseManager(nil))
 }
@@ -76,6 +139,7 @@ func TestReleaseManagerTransfersTeardownOwnership(t *testing.T) {
 		WalletDBSource: filepath.Join(t.TempDir(), "wallet.db"),
 	}
 	manager := h.NewWalletManager()
+	require.NotNil(t, h.wallets[manager])
 
 	// Act: the test closes the Manager before releasing teardown ownership.
 	require.NoError(t, manager.Close())

--- a/bwtest/harness_wallet.go
+++ b/bwtest/harness_wallet.go
@@ -85,6 +85,15 @@ type WalletFixture struct {
 	// combined with Unstarted.
 	Amounts []btcutil.Amount
 
+	// WatchOnly creates a rootless watch-only shell wallet when
+	// InitialAccounts is empty.
+	WatchOnly bool
+
+	// InitialAccounts seeds a watch-only shell wallet with the provided
+	// accounts. A nil or empty slice creates no accounts, and a non-empty
+	// slice implies WatchOnly.
+	InitialAccounts []wallet.WatchOnlyAccount
+
 	// Unlocked unlocks the wallet once it has started.
 	Unlocked bool
 
@@ -106,6 +115,10 @@ func (h *HarnessTest) NewWallet(fixture WalletFixture) (*wallet.Wallet,
 	h.Helper()
 
 	cfg, params := h.TestWalletConfig()
+	if fixture.WatchOnly || len(fixture.InitialAccounts) != 0 {
+		params.Mode, params.WatchOnly = wallet.ModeShell, true
+		params.InitialAccounts = fixture.InitialAccounts
+	}
 
 	manager := h.NewWalletManager()
 	w, err := manager.Create(cfg, params)
@@ -115,7 +128,7 @@ func (h *HarnessTest) NewWallet(fixture WalletFixture) (*wallet.Wallet,
 	// cleanup owner. Registering after Start would leave a wallet whose Start
 	// failed unregistered, and a second direct Stop callback here would stop a
 	// successful one twice, out of order with the Manager close.
-	h.RegisterWallet(w)
+	h.registerWallet(manager, w, &cfg)
 
 	if fixture.Unstarted {
 		require.Empty(
@@ -137,6 +150,73 @@ func (h *HarnessTest) NewWallet(fixture WalletFixture) (*wallet.Wallet,
 	}
 
 	return w, h.FundWalletOfType(w, fixture.AddrType, fixture.Amounts...)
+}
+
+// ReloadWallet consumes current after shutting it down and returns a fresh
+// registered, started, and locked replacement loaded from the same store.
+// The current wallet must be the Manager's only registered wallet because
+// reload closes and replaces that Manager. Callers must use the returned wallet
+// for any later reload.
+func (h *HarnessTest) ReloadWallet(current *wallet.Wallet) *wallet.Wallet {
+	h.Helper()
+
+	require.NotNil(h, current, "cannot reload nil wallet")
+
+	h.mu.Lock()
+
+	var (
+		manager           *wallet.Manager
+		reloadConfig      *wallet.Config
+		registeredWallets int
+	)
+
+	for candidate, registration := range h.wallets {
+		config, ok := registration[current]
+		if !ok {
+			continue
+		}
+
+		manager = candidate
+		reloadConfig = config
+		registeredWallets = len(registration)
+
+		break
+	}
+
+	h.mu.Unlock()
+
+	require.NotNil(h, manager, "wallet is not registered with this harness")
+	require.NotNil(h, reloadConfig, "wallet is not reloadable")
+	require.Equal(
+		h, 1, registeredWallets,
+		"wallet manager has sibling registered wallets",
+	)
+
+	cfg := *reloadConfig
+
+	ctx := h.Context()
+	require.NoError(
+		h, current.Stop(ctx), "failed to stop wallet before reload",
+	)
+	require.True(
+		h, h.DeregisterWallet(current), "failed to deregister wallet",
+	)
+	require.NoError(
+		h, manager.Close(), "failed to close wallet manager",
+	)
+	require.True(
+		h, h.ReleaseManager(manager), "failed to release wallet manager",
+	)
+
+	manager = h.NewWalletManager()
+	w, err := manager.Load(cfg)
+	require.NoError(h, err, "failed to reload wallet")
+	require.NotSame(h, current, w, "reload returned the original wallet")
+
+	h.registerWallet(manager, w, &cfg)
+	require.NoError(h, w.Start(ctx), "failed to start reloaded wallet")
+
+	return w
 }
 
 // CreateEmptyWallet creates, starts, and registers a new wallet instance.

--- a/itest/account_manager_test.go
+++ b/itest/account_manager_test.go
@@ -1,0 +1,358 @@
+//go:build itest
+
+package itest
+
+import (
+	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
+	"github.com/btcsuite/btcwallet/bwtest"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet"
+	"github.com/stretchr/testify/require"
+)
+
+// importedAccountKeys holds deterministic public and private account material
+// used to exercise imported-account contracts without sharing wallet state.
+// accountPrivateKey is present only so a case can assert private keys are
+// refused.
+type importedAccountKeys struct {
+	scope                waddrmgr.KeyScope
+	addrType             waddrmgr.AddressType
+	accountKey           *hdkeychain.ExtendedKey
+	otherAccountKey      *hdkeychain.ExtendedKey
+	accountPrivateKey    *hdkeychain.ExtendedKey
+	masterKeyFingerprint uint32
+}
+
+// canonicalAccountKey returns a derived account key under the network default
+// public version so backend-specific serialized versions compare consistently.
+func canonicalAccountKey(h *bwtest.HarnessTest, key []byte) []byte {
+	h.Helper()
+
+	parsed, err := hdkeychain.NewKeyFromString(string(key))
+	require.NoError(h, err, "failed to decode account public key")
+	normalized, err := parsed.CloneWithVersion(
+		h.NetParams().HDPublicKeyID[:],
+	)
+	require.NoError(
+		h, err, "failed to normalize account public key version",
+	)
+
+	return []byte(normalized.String())
+}
+
+// deterministicImportedAccountKeys derives distinct BIP84 account XPubs from a
+// fixed root so imported-account cases are reproducible.
+func deterministicImportedAccountKeys(
+	h *bwtest.HarnessTest) importedAccountKeys {
+
+	h.Helper()
+
+	scope := waddrmgr.KeyScopeBIP0084
+	root, err := hdkeychain.NewMaster(
+		[]byte{
+			0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+			0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+		},
+		h.NetParams(),
+	)
+	require.NoError(h, err, "failed to derive deterministic root key")
+
+	defer root.Zero()
+
+	purpose, err := root.Derive(hdkeychain.HardenedKeyStart + scope.Purpose)
+	require.NoError(h, err, "failed to derive BIP84 purpose key")
+
+	defer purpose.Zero()
+
+	coinType, err := purpose.Derive(
+		hdkeychain.HardenedKeyStart + h.NetParams().HDCoinType,
+	)
+	require.NoError(h, err, "failed to derive BIP84 coin type key")
+
+	defer coinType.Zero()
+
+	// Neuter hands the public key the same chain code and parent
+	// fingerprint slices the private key holds, so the two account private
+	// keys below must outlive this call. Zeroing either one rewrites the
+	// XPub being returned.
+	accountPrivateKey, err := coinType.Derive(hdkeychain.HardenedKeyStart)
+	require.NoError(h, err, "failed to derive imported account private key")
+	accountKey, err := accountPrivateKey.Neuter()
+	require.NoError(h, err, "failed to derive imported account public key")
+
+	otherPrivateKey, err := coinType.Derive(hdkeychain.HardenedKeyStart + 1)
+	require.NoError(h, err, "failed to derive second imported private key")
+	otherAccountKey, err := otherPrivateKey.Neuter()
+	require.NoError(h, err, "failed to derive second imported public key")
+
+	return importedAccountKeys{
+		scope:                scope,
+		addrType:             waddrmgr.WitnessPubKey,
+		accountKey:           accountKey,
+		otherAccountKey:      otherAccountKey,
+		accountPrivateKey:    accountPrivateKey,
+		masterKeyFingerprint: purpose.ParentFingerprint(),
+	}
+}
+
+// testAccountManagerCreateAccount verifies that a new derived account's
+// returned view matches an immediate read and survives a wallet reload.
+func testAccountManagerCreateAccount(h *bwtest.HarnessTest) {
+	const accountName = "account manager created"
+
+	scope := waddrmgr.KeyScopeBIP0084
+	ctx := h.Context()
+	w, _ := h.NewWallet(bwtest.WalletFixture{Unlocked: true})
+
+	created, err := w.NewAccount(ctx, scope, accountName)
+
+	require.NoError(h, err, "failed to create derived account")
+	require.Equal(h, accountName, created.AccountName)
+	require.NotNil(
+		h, created.AccountNumber, "derived account has no number",
+	)
+	require.Zero(h, created.ExternalKeyCount)
+	require.Zero(h, created.InternalKeyCount)
+	require.Zero(h, created.ImportedKeyCount)
+	require.Zero(h, created.ConfirmedBalance)
+	require.Zero(h, created.UnconfirmedBalance)
+	require.False(h, created.IsImported, "derived account is imported")
+	require.False(h, created.IsWatchOnly, "derived account is watch-only")
+	require.NotZero(
+		h, created.CreatedAt, "derived account has no creation time",
+	)
+	require.Equal(h, scope, created.KeyScope)
+	require.Equal(
+		h, waddrmgr.WitnessPubKey, created.AddrSchema.ExternalAddrType,
+	)
+	require.Equal(
+		h, waddrmgr.WitnessPubKey, created.AddrSchema.InternalAddrType,
+	)
+	normalizedPublicKey := canonicalAccountKey(h, created.PublicKey)
+	require.NotEmpty(
+		h, normalizedPublicKey, "derived account has no public key",
+	)
+	require.NotNil(
+		h, created.MasterKeyFingerprint,
+		"derived account has no master key fingerprint",
+	)
+	require.NotZero(
+		h, *created.MasterKeyFingerprint,
+		"derived account has no master key fingerprint",
+	)
+	want := *created
+	want.PublicKey = normalizedPublicKey
+	got, err := w.GetAccount(ctx, scope, accountName)
+	require.NoError(h, err, "failed to read created account")
+
+	gotInfo := *got
+	gotInfo.PublicKey = canonicalAccountKey(h, gotInfo.PublicKey)
+	require.Equal(h, want, gotInfo)
+
+	w = h.ReloadWallet(w)
+	durable, err := w.GetAccount(ctx, scope, accountName)
+	require.NoError(h, err, "failed to read account after reload")
+
+	durableInfo := *durable
+	durableInfo.PublicKey = canonicalAccountKey(h, durableInfo.PublicKey)
+	require.Equal(h, want, durableInfo)
+}
+
+// testAccountManagerCreateAccountSequence verifies that derived account numbers
+// are allocated contiguously within a key scope, that each scope allocates from
+// its own counter, and that the counter survives a wallet reload.
+func testAccountManagerCreateAccountSequence(h *bwtest.HarnessTest) {
+	const (
+		otherScopeName = "account manager sequence other"
+		resumedName    = "account manager sequence next"
+	)
+
+	names := []string{
+		"account manager sequence one",
+		"account manager sequence two",
+		"account manager sequence three",
+	}
+
+	ctx := h.Context()
+	scope := waddrmgr.KeyScopeBIP0084
+	w, _ := h.NewWallet(bwtest.WalletFixture{Unlocked: true})
+
+	numbers := make([]wallet.AccountNumber, 0, len(names))
+	for _, name := range names {
+		created, err := w.NewAccount(ctx, scope, name)
+		require.NoError(h, err, "failed to create %q", name)
+		require.NotNil(h, created.AccountNumber, "%q has no number", name)
+
+		numbers = append(numbers, *created.AccountNumber)
+	}
+
+	for i := 1; i < len(numbers); i++ {
+		require.Equal(
+			h, numbers[i-1]+1, numbers[i],
+			"%q did not take the next account number", names[i],
+		)
+	}
+
+	// A second scope allocates from its own counter, so its first
+	// user-created account repeats the first scope's starting number.
+	other, err := w.NewAccount(ctx, waddrmgr.KeyScopeBIP0044, otherScopeName)
+	require.NoError(h, err, "failed to create other scope account")
+	require.NotNil(h, other.AccountNumber, "other scope has no number")
+
+	require.Equal(
+		h, numbers[0], *other.AccountNumber,
+		"second scope did not allocate from its own counter",
+	)
+
+	// The counter is persistent, so the next account continues the sequence
+	// rather than reusing a number.
+	w = h.ReloadWallet(w)
+	h.UnlockWallet(w)
+
+	resumed, err := w.NewAccount(ctx, scope, resumedName)
+	require.NoError(h, err, "failed to create account after reload")
+	require.NotNil(
+		h, resumed.AccountNumber, "resumed account has no number",
+	)
+	require.Equal(
+		h, numbers[len(numbers)-1]+1, *resumed.AccountNumber,
+		"account number did not resume the sequence after reload",
+	)
+}
+
+// testAccountManagerRejectAccountCreation verifies rejected names cannot alter
+// an existing account or its scope's account count.
+func testAccountManagerRejectAccountCreation(h *bwtest.HarnessTest) {
+	const (
+		sourceName         = "account manager rejection source"
+		afterRejectionName = "account manager after rejection"
+	)
+
+	scope := waddrmgr.KeyScopeBIP0084
+	ctx := h.Context()
+	w, _ := h.NewWallet(bwtest.WalletFixture{Unlocked: true})
+
+	_, err := w.NewAccount(ctx, scope, sourceName)
+	require.NoError(h, err, "failed to create rejection source")
+
+	existing, err := w.GetAccount(ctx, scope, sourceName)
+	require.NoError(h, err, "failed to read rejection source")
+
+	wantExisting := *existing
+	wantExisting.PublicKey = canonicalAccountKey(h, wantExisting.PublicKey)
+	accounts, err := w.ListAccountsByScope(ctx, scope)
+	require.NoError(h, err, "failed to list source scope accounts")
+
+	wantCount := len(accounts)
+
+	// These rejections have no stable public error identity yet, so the
+	// rows assert rejection and unchanged state only.
+	testCases := []struct {
+		name        string
+		accountName string
+	}{
+		{
+			name:        "duplicate source name",
+			accountName: sourceName,
+		},
+		{
+			name:        "empty name",
+			accountName: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		_, err := w.NewAccount(ctx, scope, tc.accountName)
+
+		require.Error(h, err, "%s was accepted", tc.name)
+
+		current, err := w.GetAccount(ctx, scope, sourceName)
+		require.NoError(
+			h, err, "failed to read source account after rejection",
+		)
+
+		currentInfo := *current
+		currentInfo.PublicKey = canonicalAccountKey(
+			h, currentInfo.PublicKey,
+		)
+		require.Equal(h, wantExisting, currentInfo)
+
+		accounts, err = w.ListAccountsByScope(ctx, scope)
+		require.NoError(
+			h, err, "failed to list accounts after rejection",
+		)
+		require.Len(
+			h, accounts, wantCount, "rejection changed account count",
+		)
+	}
+
+	// The account number is allocated before the insert, so only the
+	// rolled-back transaction keeps a rejected call from consuming one.
+	next, err := w.NewAccount(ctx, scope, afterRejectionName)
+	require.NoError(h, err, "failed to create account after rejections")
+	require.NotNil(
+		h, next.AccountNumber, "account after rejections has no number",
+	)
+	require.Equal(
+		h, *wantExisting.AccountNumber+1, *next.AccountNumber,
+		"rejected creation consumed an account number",
+	)
+}
+
+// testAccountManagerEnforceAccountCreationLifecycle verifies NewAccount admits
+// neither locked nor stopped wallets.
+func testAccountManagerEnforceAccountCreationLifecycle(h *bwtest.HarnessTest) {
+	const (
+		lockedName  = "account manager locked"
+		stoppedName = "account manager stopped"
+	)
+
+	scope := waddrmgr.KeyScopeBIP0084
+	ctx := h.Context()
+	w, _ := h.NewWallet(bwtest.WalletFixture{Unlocked: true})
+
+	accounts, err := w.ListAccounts(ctx)
+	require.NoError(h, err, "failed to list accounts before rejections")
+
+	wantCount := len(accounts)
+
+	require.NoError(h, w.Lock(ctx), "failed to lock wallet")
+
+	_, err = w.NewAccount(ctx, scope, lockedName)
+
+	require.Error(h, err, "locked wallet created an account")
+	require.NoError(h, w.Stop(ctx), "failed to stop wallet")
+
+	_, err = w.NewAccount(ctx, scope, stoppedName)
+
+	require.ErrorIs(h, err, wallet.ErrStateForbidden)
+
+	// An admission rejected before or after the wallet stops must leave no
+	// partial account, so neither name resolves across a reopen and the
+	// account set is unchanged.
+	w = h.ReloadWallet(w)
+	_, err = w.GetAccount(ctx, scope, lockedName)
+	require.Error(h, err, "locked rejection created an account")
+	_, err = w.GetAccount(ctx, scope, stoppedName)
+	require.Error(h, err, "stopped rejection created an account")
+
+	accounts, err = w.ListAccounts(ctx)
+	require.NoError(h, err, "failed to list accounts after rejections")
+	require.Len(h, accounts, wantCount, "rejection changed account count")
+}
+
+// testAccountManagerRejectWatchOnlyAccountCreation verifies a rootless wallet
+// cannot derive account key material.
+func testAccountManagerRejectWatchOnlyAccountCreation(h *bwtest.HarnessTest) {
+	const accountName = "watch-only"
+
+	ctx := h.Context()
+	w, _ := h.NewWallet(bwtest.WalletFixture{WatchOnly: true})
+	require.True(h, w.IsWatchOnly(), "watch-only fixture is not watch-only")
+
+	_, err := w.NewAccount(ctx, waddrmgr.KeyScopeBIP0084, accountName)
+
+	require.Error(h, err, "watch-only wallet created an account")
+	_, err = w.GetAccount(ctx, waddrmgr.KeyScopeBIP0084, accountName)
+	require.Error(h, err, "rejected watch-only account name resolves")
+}

--- a/itest/account_manager_test.go
+++ b/itest/account_manager_test.go
@@ -3,12 +3,18 @@
 package itest
 
 import (
+	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
 	"github.com/btcsuite/btcwallet/bwtest"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet"
 	"github.com/stretchr/testify/require"
 )
+
+// accountManagerFundingType is the address type whose key scope the
+// default-account case operates in. Funding it materializes that scope on
+// every backend.
+const accountManagerFundingType = waddrmgr.WitnessPubKey
 
 // importedAccountKeys holds deterministic public and private account material
 // used to exercise imported-account contracts without sharing wallet state.
@@ -355,4 +361,302 @@ func testAccountManagerRejectWatchOnlyAccountCreation(h *bwtest.HarnessTest) {
 	require.Error(h, err, "watch-only wallet created an account")
 	_, err = w.GetAccount(ctx, waddrmgr.KeyScopeBIP0084, accountName)
 	require.Error(h, err, "rejected watch-only account name resolves")
+}
+
+// testAccountManagerRenameDerivedAccount verifies that renaming a derived
+// account changes only its name and survives a wallet reload.
+func testAccountManagerRenameDerivedAccount(h *bwtest.HarnessTest) {
+	const (
+		sourceName  = "account manager derived source"
+		renamedName = "account manager derived renamed"
+	)
+
+	scope := waddrmgr.KeyScopeBIP0084
+	ctx := h.Context()
+	w, _ := h.NewWallet(bwtest.WalletFixture{Unlocked: true})
+	_, err := w.NewAccount(ctx, scope, sourceName)
+	require.NoError(h, err, "failed to create derived rename source")
+
+	source, err := w.GetAccount(ctx, scope, sourceName)
+	require.NoError(h, err, "failed to read derived rename source")
+
+	wantRenamed := *source
+	wantRenamed.AccountName = renamedName
+	wantRenamed.PublicKey = canonicalAccountKey(h, wantRenamed.PublicKey)
+
+	err = w.RenameAccount(ctx, scope, sourceName, renamedName)
+
+	require.NoError(h, err, "failed to rename derived account")
+	_, err = w.GetAccount(ctx, scope, sourceName)
+	require.Error(h, err, "old derived account name still resolves")
+	renamed, err := w.GetAccount(ctx, scope, renamedName)
+	require.NoError(h, err, "failed to read renamed derived account")
+
+	renamedInfo := *renamed
+	renamedInfo.PublicKey = canonicalAccountKey(h, renamedInfo.PublicKey)
+	require.Equal(h, wantRenamed, renamedInfo)
+
+	w = h.ReloadWallet(w)
+	_, err = w.GetAccount(ctx, scope, sourceName)
+	require.Error(h, err, "old derived account name resolves after reload")
+	durable, err := w.GetAccount(ctx, scope, renamedName)
+	require.NoError(h, err, "failed to read renamed account after reload")
+
+	durableInfo := *durable
+	durableInfo.PublicKey = canonicalAccountKey(h, durableInfo.PublicKey)
+	require.Equal(h, wantRenamed, durableInfo)
+}
+
+// testAccountManagerRenameDefaultAccount verifies the default account keeps a
+// present-zero account number across a rename and a wallet reload, rather than
+// collapsing the zero value to an absent identity.
+//
+// The scope is derived from the funding address type because that is the only
+// scope every backend is guaranteed to hold a default account in: kvdb seeds
+// one per scope at genesis, while SQL creates it lazily on first use.
+func testAccountManagerRenameDefaultAccount(h *bwtest.HarnessTest) {
+	const renamedName = "account manager renamed default"
+
+	scope, err := accountManagerFundingType.KeyScope()
+	require.NoError(h, err, "failed to resolve funding scope")
+
+	ctx := h.Context()
+	w, _ := h.NewWallet(
+		bwtest.WalletFixture{
+			AddrType: accountManagerFundingType,
+			Amounts:  []btcutil.Amount{oneBTC},
+			Unlocked: true,
+		},
+	)
+
+	source, err := w.GetAccount(ctx, scope, waddrmgr.DefaultAccountName)
+	require.NoError(h, err, "failed to read default account")
+	require.NotNil(h, source.AccountNumber, "default account has no number")
+	require.Zero(
+		h, *source.AccountNumber, "default account number is not zero",
+	)
+
+	wantRenamed := *source
+	wantRenamed.AccountName = renamedName
+	wantRenamed.PublicKey = canonicalAccountKey(h, wantRenamed.PublicKey)
+
+	err = w.RenameAccount(
+		ctx, scope, waddrmgr.DefaultAccountName, renamedName,
+	)
+
+	require.NoError(h, err, "failed to rename default account")
+	renamed, err := w.GetAccount(ctx, scope, renamedName)
+	require.NoError(h, err, "failed to read renamed default account")
+	require.NotNil(
+		h, renamed.AccountNumber, "renamed default account has no number",
+	)
+	require.Zero(
+		h, *renamed.AccountNumber,
+		"renamed default account number is not zero",
+	)
+
+	renamedInfo := *renamed
+	renamedInfo.PublicKey = canonicalAccountKey(h, renamedInfo.PublicKey)
+	require.Equal(h, wantRenamed, renamedInfo)
+
+	w = h.ReloadWallet(w)
+	durable, err := w.GetAccount(ctx, scope, renamedName)
+	require.NoError(
+		h, err, "failed to read renamed default account after reload",
+	)
+	require.NotNil(
+		h, durable.AccountNumber,
+		"default account number is absent after reload",
+	)
+	require.Zero(
+		h, *durable.AccountNumber,
+		"default account number is not zero after reload",
+	)
+
+	durableInfo := *durable
+	durableInfo.PublicKey = canonicalAccountKey(h, durableInfo.PublicKey)
+	require.Equal(h, wantRenamed, durableInfo)
+}
+
+// testAccountManagerRenameImportedAccount verifies an InitialAccounts XPub
+// keeps its caller-supplied serialization when renamed and reloaded.
+func testAccountManagerRenameImportedAccount(h *bwtest.HarnessTest) {
+	const (
+		sourceName  = "account manager imported source"
+		renamedName = "account manager imported renamed"
+	)
+
+	keys := deterministicImportedAccountKeys(h)
+	ctx := h.Context()
+	w, _ := h.NewWallet(
+		bwtest.WalletFixture{
+			InitialAccounts: []wallet.WatchOnlyAccount{{
+				Scope:                keys.scope,
+				XPub:                 keys.accountKey,
+				MasterKeyFingerprint: keys.masterKeyFingerprint,
+				Name:                 sourceName,
+				AddrType:             keys.addrType,
+			}},
+		},
+	)
+	source, err := w.GetAccount(ctx, keys.scope, sourceName)
+	require.NoError(h, err, "failed to read imported account")
+
+	wantRenamed := *source
+	wantRenamed.AccountName = renamedName
+	wantRenamed.PublicKey = []byte(keys.accountKey.String())
+
+	err = w.RenameAccount(ctx, keys.scope, sourceName, renamedName)
+
+	require.NoError(h, err, "failed to rename imported account")
+	_, err = w.GetAccount(ctx, keys.scope, sourceName)
+	require.Error(h, err, "old imported account name still resolves")
+	renamed, err := w.GetAccount(ctx, keys.scope, renamedName)
+	require.NoError(h, err, "failed to read renamed imported account")
+	require.Equal(h, wantRenamed, *renamed)
+
+	w = h.ReloadWallet(w)
+	_, err = w.GetAccount(ctx, keys.scope, sourceName)
+	require.Error(h, err, "old imported account name resolves after reload")
+	durable, err := w.GetAccount(ctx, keys.scope, renamedName)
+	require.NoError(h, err, "failed to read renamed import after reload")
+	require.Equal(h, wantRenamed, *durable)
+}
+
+// testAccountManagerRejectAccountRename verifies rejected rename requests leave
+// the established source and duplicate target unchanged.
+func testAccountManagerRejectAccountRename(h *bwtest.HarnessTest) {
+	const (
+		sourceName      = "account manager rename source"
+		duplicateTarget = "account manager occupied target"
+	)
+
+	scope := waddrmgr.KeyScopeBIP0084
+	ctx := h.Context()
+	w, _ := h.NewWallet(bwtest.WalletFixture{Unlocked: true})
+
+	_, err := w.NewAccount(ctx, scope, sourceName)
+	require.NoError(h, err, "failed to create rename source")
+	_, err = w.NewAccount(ctx, scope, duplicateTarget)
+	require.NoError(h, err, "failed to create duplicate rename target")
+
+	wantAccounts, err := w.ListAccounts(ctx)
+	require.NoError(h, err, "failed to list accounts before rejection")
+
+	// These rejections have no stable public error identity yet, so the
+	// rows assert rejection and unchanged state only.
+	testCases := []struct {
+		name    string
+		oldName string
+		newName string
+	}{
+		{
+			name:    "duplicate target",
+			oldName: sourceName,
+			newName: duplicateTarget,
+		},
+		{
+			name:    "empty target",
+			oldName: sourceName,
+			newName: "",
+		},
+		{
+			name:    "reserved target",
+			oldName: sourceName,
+			newName: waddrmgr.ImportedAddrAccountName,
+		},
+		{
+			name:    "unknown source",
+			oldName: "account manager unknown source",
+			newName: "account manager unknown target",
+		},
+		{
+			name:    "reserved source",
+			oldName: waddrmgr.ImportedAddrAccountName,
+			newName: "account manager reserved source target",
+		},
+	}
+
+	for _, tc := range testCases {
+		err := w.RenameAccount(
+			ctx, scope, tc.oldName, tc.newName,
+		)
+
+		require.Error(h, err, "%s was accepted", tc.name)
+
+		gotAccounts, err := w.ListAccounts(ctx)
+		require.NoError(h, err, "failed to list accounts after rejection")
+		require.ElementsMatch(
+			h, wantAccounts, gotAccounts, "%s changed the account set", tc.name,
+		)
+	}
+}
+
+// testAccountManagerEnforceAccountRenameLifecycle verifies metadata rename is
+// admitted while locked but rejected after the wallet stops.
+func testAccountManagerEnforceAccountRenameLifecycle(h *bwtest.HarnessTest) {
+	const (
+		sourceName  = "account manager lifecycle source"
+		lockedName  = "account manager locked rename"
+		stoppedName = "account manager stopped rename"
+	)
+
+	scope := waddrmgr.KeyScopeBIP0084
+	ctx := h.Context()
+	w, _ := h.NewWallet(bwtest.WalletFixture{Unlocked: true})
+	_, err := w.NewAccount(ctx, scope, sourceName)
+	require.NoError(h, err, "failed to create lifecycle source")
+
+	// Reload to reach the started but locked state this rename must be
+	// admitted in, not to re-check that the source persisted.
+	w = h.ReloadWallet(w)
+	source, err := w.GetAccount(ctx, scope, sourceName)
+	require.NoError(h, err, "failed to read lifecycle source")
+
+	wantLockedRename := *source
+	wantLockedRename.AccountName = lockedName
+	wantLockedRename.PublicKey = canonicalAccountKey(
+		h, wantLockedRename.PublicKey,
+	)
+
+	err = w.RenameAccount(ctx, scope, sourceName, lockedName)
+
+	require.NoError(h, err, "locked wallet rejected metadata rename")
+	_, err = w.GetAccount(ctx, scope, sourceName)
+	require.Error(h, err, "old locked rename name still resolves")
+	locked, err := w.GetAccount(ctx, scope, lockedName)
+	require.NoError(h, err, "failed to read locked rename")
+
+	lockedInfo := *locked
+	lockedInfo.PublicKey = canonicalAccountKey(h, lockedInfo.PublicKey)
+	require.Equal(h, wantLockedRename, lockedInfo)
+
+	w = h.ReloadWallet(w)
+	_, err = w.GetAccount(ctx, scope, sourceName)
+	require.Error(h, err, "old locked rename name resolves after reload")
+	durable, err := w.GetAccount(ctx, scope, lockedName)
+	require.NoError(h, err, "failed to read locked rename after reload")
+
+	durableInfo := *durable
+	durableInfo.PublicKey = canonicalAccountKey(h, durableInfo.PublicKey)
+	require.Equal(h, wantLockedRename, durableInfo)
+	require.NoError(h, w.Stop(ctx), "failed to stop wallet")
+
+	err = w.RenameAccount(ctx, scope, lockedName, stoppedName)
+
+	require.ErrorIs(h, err, wallet.ErrStateForbidden)
+
+	// The rejected rename must not move the account, so the source keeps
+	// its complete result and the target stays absent across a reopen.
+	w = h.ReloadWallet(w)
+	_, err = w.GetAccount(ctx, scope, stoppedName)
+	require.Error(h, err, "stopped rename created a target account")
+	unchanged, err := w.GetAccount(ctx, scope, lockedName)
+	require.NoError(h, err, "failed to read source after stopped rename")
+
+	unchangedInfo := *unchanged
+	unchangedInfo.PublicKey = canonicalAccountKey(
+		h, unchangedInfo.PublicKey,
+	)
+	require.Equal(h, wantLockedRename, unchangedInfo)
 }

--- a/itest/account_manager_test.go
+++ b/itest/account_manager_test.go
@@ -660,3 +660,348 @@ func testAccountManagerEnforceAccountRenameLifecycle(h *bwtest.HarnessTest) {
 	)
 	require.Equal(h, wantLockedRename, unchangedInfo)
 }
+
+// testAccountManagerImportAccount verifies that one XPub import's returned
+// view matches an immediate read and survives a wallet reload.
+func testAccountManagerImportAccount(h *bwtest.HarnessTest) {
+	const (
+		existingName = "account manager import existing"
+		accountName  = "account manager imported"
+	)
+
+	keys := deterministicImportedAccountKeys(h)
+	ctx := h.Context()
+	w, _ := h.NewWallet(
+		bwtest.WalletFixture{
+			InitialAccounts: []wallet.WatchOnlyAccount{{
+				Scope:                keys.scope,
+				XPub:                 keys.otherAccountKey,
+				MasterKeyFingerprint: keys.masterKeyFingerprint,
+				Name:                 existingName,
+				AddrType:             keys.addrType,
+			}},
+		},
+	)
+
+	imported, err := w.ImportAccount(
+		ctx, accountName, keys.accountKey, keys.masterKeyFingerprint,
+		keys.addrType, false,
+	)
+
+	require.NoError(h, err, "failed to import account")
+	require.Nil(h, imported.AccountNumber, "imported account has a number")
+	require.Equal(h, accountName, imported.AccountName)
+	require.True(h, imported.IsImported, "account is not imported")
+	require.True(
+		h, imported.IsWatchOnly, "imported account is not watch-only",
+	)
+	require.Zero(h, imported.ExternalKeyCount)
+	require.Zero(h, imported.InternalKeyCount)
+	require.Zero(h, imported.ImportedKeyCount)
+	require.Zero(h, imported.ConfirmedBalance)
+	require.Zero(h, imported.UnconfirmedBalance)
+	require.NotZero(
+		h, imported.CreatedAt, "imported account has no creation time",
+	)
+	require.Equal(h, keys.scope, imported.KeyScope)
+	require.Equal(h, keys.addrType, imported.AddrSchema.ExternalAddrType)
+	require.Equal(h, keys.addrType, imported.AddrSchema.InternalAddrType)
+	require.Equal(h, []byte(keys.accountKey.String()), imported.PublicKey)
+	require.NotNil(
+		h, imported.MasterKeyFingerprint,
+		"imported account has no master key fingerprint",
+	)
+	require.Equal(
+		h, wallet.MasterFingerprint(keys.masterKeyFingerprint),
+		*imported.MasterKeyFingerprint,
+	)
+	want := *imported
+	got, err := w.GetAccount(ctx, keys.scope, accountName)
+	require.NoError(h, err, "failed to read imported account")
+	require.Equal(h, want, *got)
+
+	w = h.ReloadWallet(w)
+	durable, err := w.GetAccount(ctx, keys.scope, accountName)
+	require.NoError(h, err, "failed to read imported account after reload")
+	require.Equal(h, want, *durable)
+}
+
+// testAccountManagerImportAccountZeroFingerprint verifies an import declaring
+// a zero master key fingerprint keeps a present-zero identity across the
+// mutation result, its lookup, and a wallet reload, rather than collapsing the
+// zero value to an absent identity.
+func testAccountManagerImportAccountZeroFingerprint(h *bwtest.HarnessTest) {
+	const (
+		existingName = "account manager zero fingerprint existing"
+		accountName  = "account manager zero fingerprint"
+	)
+
+	keys := deterministicImportedAccountKeys(h)
+	ctx := h.Context()
+	w, _ := h.NewWallet(
+		bwtest.WalletFixture{
+			InitialAccounts: []wallet.WatchOnlyAccount{{
+				Scope:                keys.scope,
+				XPub:                 keys.otherAccountKey,
+				MasterKeyFingerprint: keys.masterKeyFingerprint,
+				Name:                 existingName,
+				AddrType:             keys.addrType,
+			}},
+		},
+	)
+
+	imported, err := w.ImportAccount(
+		ctx, accountName, keys.accountKey, 0, keys.addrType, false,
+	)
+
+	require.NoError(h, err, "failed to import zero fingerprint account")
+	require.NotNil(
+		h, imported.MasterKeyFingerprint,
+		"zero fingerprint collapsed to absent on import",
+	)
+	require.Zero(
+		h, *imported.MasterKeyFingerprint,
+		"imported fingerprint is not zero",
+	)
+
+	want := *imported
+	got, err := w.GetAccount(ctx, keys.scope, accountName)
+	require.NoError(h, err, "failed to read zero fingerprint account")
+	require.NotNil(
+		h, got.MasterKeyFingerprint,
+		"zero fingerprint collapsed to absent on lookup",
+	)
+	require.Zero(
+		h, *got.MasterKeyFingerprint, "read fingerprint is not zero",
+	)
+	require.Equal(h, want, *got)
+
+	// The seeded account keeps its non-zero fingerprint, so a present-zero
+	// identity is distinguishable from a present-nonzero one in the same
+	// wallet rather than from a backend-wide default.
+	existing, err := w.GetAccount(ctx, keys.scope, existingName)
+	require.NoError(h, err, "failed to read seeded imported account")
+	require.NotNil(
+		h, existing.MasterKeyFingerprint,
+		"seeded account has no master key fingerprint",
+	)
+	require.Equal(
+		h, wallet.MasterFingerprint(keys.masterKeyFingerprint),
+		*existing.MasterKeyFingerprint,
+	)
+
+	w = h.ReloadWallet(w)
+	durable, err := w.GetAccount(ctx, keys.scope, accountName)
+	require.NoError(
+		h, err, "failed to read zero fingerprint account after reload",
+	)
+	require.NotNil(
+		h, durable.MasterKeyFingerprint,
+		"zero fingerprint collapsed to absent after reload",
+	)
+	require.Zero(
+		h, *durable.MasterKeyFingerprint,
+		"fingerprint is not zero after reload",
+	)
+	require.Equal(h, want, *durable)
+}
+
+// testAccountManagerPreviewAccountImport verifies a dry run returns portable
+// identity fields without materializing an account.
+func testAccountManagerPreviewAccountImport(h *bwtest.HarnessTest) {
+	const (
+		existingName = "account manager preview existing"
+		accountName  = "account manager import preview"
+	)
+
+	keys := deterministicImportedAccountKeys(h)
+	ctx := h.Context()
+	w, _ := h.NewWallet(
+		bwtest.WalletFixture{
+			InitialAccounts: []wallet.WatchOnlyAccount{{
+				Scope:                keys.scope,
+				XPub:                 keys.otherAccountKey,
+				MasterKeyFingerprint: keys.masterKeyFingerprint,
+				Name:                 existingName,
+				AddrType:             keys.addrType,
+			}},
+		},
+	)
+
+	preview, err := w.ImportAccount(
+		ctx, accountName, keys.accountKey, keys.masterKeyFingerprint,
+		keys.addrType, true,
+	)
+
+	require.NoError(h, err, "failed to preview account import")
+	require.Equal(h, accountName, preview.AccountName)
+	require.True(h, preview.IsImported, "preview is not imported")
+	require.True(h, preview.IsWatchOnly, "preview is not watch-only")
+	require.Nil(h, preview.AccountNumber, "preview has an account number")
+	require.Equal(h, keys.scope, preview.KeyScope)
+	require.Equal(h, []byte(keys.accountKey.String()), preview.PublicKey)
+	require.NotNil(
+		h, preview.MasterKeyFingerprint,
+		"preview account has no master key fingerprint",
+	)
+	require.Equal(
+		h, wallet.MasterFingerprint(keys.masterKeyFingerprint),
+		*preview.MasterKeyFingerprint,
+	)
+	_, err = w.GetAccount(ctx, keys.scope, accountName)
+	require.Error(h, err, "preview materialized an account")
+}
+
+// testAccountManagerRejectAccountImport verifies rejected imports preserve the
+// existing imported account and its scope's account count.
+func testAccountManagerRejectAccountImport(h *bwtest.HarnessTest) {
+	const existingName = "account manager existing import"
+
+	keys := deterministicImportedAccountKeys(h)
+	ctx := h.Context()
+	w, _ := h.NewWallet(
+		bwtest.WalletFixture{
+			InitialAccounts: []wallet.WatchOnlyAccount{{
+				Scope:                keys.scope,
+				XPub:                 keys.accountKey,
+				MasterKeyFingerprint: keys.masterKeyFingerprint,
+				Name:                 existingName,
+				AddrType:             keys.addrType,
+			}},
+		},
+	)
+
+	wantAccounts, err := w.ListAccounts(ctx)
+	require.NoError(h, err, "failed to list accounts before rejection")
+
+	testCases := []struct {
+		name        string
+		accountName string
+		accountKey  *hdkeychain.ExtendedKey
+	}{
+		// Both rows collide on name only. Rejecting a colliding XPub
+		// under a fresh name is a separate contract the wallet does
+		// not implement yet.
+		{
+			name:        "duplicate name, same key",
+			accountName: existingName,
+			accountKey:  keys.accountKey,
+		},
+		{
+			name:        "duplicate name, other key",
+			accountName: existingName,
+			accountKey:  keys.otherAccountKey,
+		},
+		{
+			name:        "empty name",
+			accountName: "",
+			accountKey:  keys.otherAccountKey,
+		},
+	}
+
+	for _, tc := range testCases {
+		_, err := w.ImportAccount(
+			ctx, tc.accountName, tc.accountKey, keys.masterKeyFingerprint,
+			keys.addrType, false,
+		)
+
+		require.Error(h, err, "%s was accepted", tc.name)
+
+		gotAccounts, err := w.ListAccounts(ctx)
+		require.NoError(h, err, "failed to list accounts after rejection")
+		require.ElementsMatch(
+			h, wantAccounts, gotAccounts, "%s changed the account set", tc.name,
+		)
+	}
+}
+
+// testAccountManagerRejectInvalidImportKey verifies invalid import keys are
+// rejected without changing the account set.
+func testAccountManagerRejectInvalidImportKey(h *bwtest.HarnessTest) {
+	const existingName = "account manager existing import"
+
+	keys := deterministicImportedAccountKeys(h)
+	ctx := h.Context()
+	w, _ := h.NewWallet(
+		bwtest.WalletFixture{
+			InitialAccounts: []wallet.WatchOnlyAccount{{
+				Scope:                keys.scope,
+				XPub:                 keys.accountKey,
+				MasterKeyFingerprint: keys.masterKeyFingerprint,
+				Name:                 existingName,
+				AddrType:             keys.addrType,
+			}},
+		},
+	)
+
+	wantAccounts, err := w.ListAccounts(ctx)
+	require.NoError(h, err, "failed to list accounts before rejection")
+
+	testCases := []struct {
+		name        string
+		accountName string
+		accountKey  *hdkeychain.ExtendedKey
+	}{
+		{
+			name:        "nil key",
+			accountName: "account manager nil key",
+			accountKey:  nil,
+		},
+		{
+			name:        "private key",
+			accountName: "account manager private key",
+			accountKey:  keys.accountPrivateKey,
+		},
+	}
+
+	for _, tc := range testCases {
+		_, err := w.ImportAccount(
+			ctx, tc.accountName, tc.accountKey, keys.masterKeyFingerprint,
+			keys.addrType, false,
+		)
+
+		require.ErrorIs(h, err, wallet.ErrInvalidAccountKey)
+
+		gotAccounts, err := w.ListAccounts(ctx)
+		require.NoError(
+			h, err, "failed to list accounts after rejection",
+		)
+		require.ElementsMatch(
+			h, wantAccounts, gotAccounts, "%s changed the account set", tc.name,
+		)
+	}
+}
+
+// testAccountManagerEnforceAccountImportLifecycle verifies that a stopped
+// watch-only wallet rejects an otherwise valid account import.
+func testAccountManagerEnforceAccountImportLifecycle(h *bwtest.HarnessTest) {
+	const accountName = "account manager stopped import"
+
+	keys := deterministicImportedAccountKeys(h)
+	ctx := h.Context()
+	w, _ := h.NewWallet(bwtest.WalletFixture{WatchOnly: true})
+
+	accounts, err := w.ListAccounts(ctx)
+	require.NoError(h, err, "failed to list accounts before rejection")
+
+	wantCount := len(accounts)
+
+	require.NoError(h, w.Stop(ctx), "failed to stop wallet")
+
+	_, err = w.ImportAccount(
+		ctx, accountName, keys.accountKey, keys.masterKeyFingerprint,
+		keys.addrType, false,
+	)
+
+	require.ErrorIs(h, err, wallet.ErrStateForbidden)
+
+	// A rejected import must leave no partial account, so the target stays
+	// absent across a reopen and the account set is unchanged.
+	w = h.ReloadWallet(w)
+	_, err = w.GetAccount(ctx, keys.scope, accountName)
+	require.Error(h, err, "stopped import created an account")
+
+	accounts, err = w.ListAccounts(ctx)
+	require.NoError(h, err, "failed to list accounts after rejection")
+	require.Len(h, accounts, wantCount, "rejection changed account count")
+}

--- a/itest/controller_test.go
+++ b/itest/controller_test.go
@@ -17,7 +17,7 @@ func testControllerStartStop(h *bwtest.HarnessTest) {
 	manager := h.NewWalletManager()
 	w, err := manager.Create(cfg, params)
 	require.NoError(h, err, "failed to create wallet")
-	h.RegisterWallet(w)
+	h.RegisterWallet(manager, w)
 
 	require.NoError(h, w.Start(h.Context()), "failed to start wallet")
 
@@ -39,7 +39,7 @@ func testControllerStartStop(h *bwtest.HarnessTest) {
 	manager = h.NewWalletManager()
 	reloaded, err := manager.Load(cfg)
 	require.NoError(h, err, "failed to reload wallet")
-	h.RegisterWallet(reloaded)
+	h.RegisterWallet(manager, reloaded)
 	require.NoError(
 		h, reloaded.Start(h.Context()), "failed to start reloaded wallet",
 	)
@@ -56,7 +56,7 @@ func testControllerUnlockLock(h *bwtest.HarnessTest) {
 	manager := h.NewWalletManager()
 	w, err := manager.Create(cfg, params)
 	require.NoError(h, err, "failed to create wallet")
-	h.RegisterWallet(w)
+	h.RegisterWallet(manager, w)
 
 	// Before Start, unlock and lock are forbidden.
 	err = w.Unlock(h.Context(), wallet.UnlockRequest{
@@ -126,7 +126,7 @@ func testControllerInfo(h *bwtest.HarnessTest) {
 	manager := h.NewWalletManager()
 	w, err := manager.Create(cfg, params)
 	require.NoError(h, err, "failed to create wallet")
-	h.RegisterWallet(w)
+	h.RegisterWallet(manager, w)
 
 	// Info is forbidden before Start.
 	_, err = w.Info(h.Context())

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -60,6 +60,26 @@ var allTestCases = []*testCase{
 		TestFunc: testAccountManagerRejectWatchOnlyAccountCreation,
 	},
 	{
+		Name:     "account manager rename derived account",
+		TestFunc: testAccountManagerRenameDerivedAccount,
+	},
+	{
+		Name:     "account manager rename default account",
+		TestFunc: testAccountManagerRenameDefaultAccount,
+	},
+	{
+		Name:     "account manager rename imported account",
+		TestFunc: testAccountManagerRenameImportedAccount,
+	},
+	{
+		Name:     "account manager reject account rename",
+		TestFunc: testAccountManagerRejectAccountRename,
+	},
+	{
+		Name:     "account manager enforce account rename lifecycle",
+		TestFunc: testAccountManagerEnforceAccountRenameLifecycle,
+	},
+	{
 		Name:     "controller start stop",
 		TestFunc: testControllerStartStop,
 	},

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -80,6 +80,30 @@ var allTestCases = []*testCase{
 		TestFunc: testAccountManagerEnforceAccountRenameLifecycle,
 	},
 	{
+		Name:     "account manager import account",
+		TestFunc: testAccountManagerImportAccount,
+	},
+	{
+		Name:     "account manager import account zero fingerprint",
+		TestFunc: testAccountManagerImportAccountZeroFingerprint,
+	},
+	{
+		Name:     "account manager preview account import",
+		TestFunc: testAccountManagerPreviewAccountImport,
+	},
+	{
+		Name:     "account manager reject account import",
+		TestFunc: testAccountManagerRejectAccountImport,
+	},
+	{
+		Name:     "account manager reject invalid import key",
+		TestFunc: testAccountManagerRejectInvalidImportKey,
+	},
+	{
+		Name:     "account manager enforce account import lifecycle",
+		TestFunc: testAccountManagerEnforceAccountImportLifecycle,
+	},
+	{
 		Name:     "controller start stop",
 		TestFunc: testControllerStartStop,
 	},

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -40,6 +40,26 @@ var allTestCases = []*testCase{
 		TestFunc: testManagerCreateWatchOnly,
 	},
 	{
+		Name:     "account manager create account",
+		TestFunc: testAccountManagerCreateAccount,
+	},
+	{
+		Name:     "account manager create account sequence",
+		TestFunc: testAccountManagerCreateAccountSequence,
+	},
+	{
+		Name:     "account manager reject account creation",
+		TestFunc: testAccountManagerRejectAccountCreation,
+	},
+	{
+		Name:     "account manager enforce account creation lifecycle",
+		TestFunc: testAccountManagerEnforceAccountCreationLifecycle,
+	},
+	{
+		Name:     "account manager reject watchonly account creation",
+		TestFunc: testAccountManagerRejectWatchOnlyAccountCreation,
+	},
+	{
 		Name:     "controller start stop",
 		TestFunc: testControllerStartStop,
 	},

--- a/itest/manager_test.go
+++ b/itest/manager_test.go
@@ -71,7 +71,7 @@ func testManagerLoadConcurrent(h *bwtest.HarnessTest) {
 	first := <-results
 	require.NoError(h, first.err, "failed to load wallet")
 	installed := first.wallet
-	h.RegisterWallet(installed)
+	h.RegisterWallet(manager, installed)
 
 	for range numCallers - 1 {
 		result := <-results
@@ -94,7 +94,7 @@ func testCreateWallet(h *bwtest.HarnessTest) {
 	// The harness stops every registered wallet and then closes every
 	// Manager. Do not add another Stop cleanup here; it would only stop the
 	// wallet early and duplicate the harness-owned teardown.
-	h.RegisterWallet(w)
+	h.RegisterWallet(manager, w)
 
 	err = w.Start(h.Context())
 	require.NoError(h, err, "failed to start wallet")
@@ -115,7 +115,7 @@ func testManagerCreateDuplicate(h *bwtest.HarnessTest) {
 	manager := h.NewWalletManager()
 	w, err := manager.Create(cfg, params)
 	require.NoError(h, err, "failed to create wallet")
-	h.RegisterWallet(w)
+	h.RegisterWallet(manager, w)
 
 	err = w.Start(h.Context())
 	require.NoError(h, err, "failed to start wallet")
@@ -153,7 +153,7 @@ func testManagerLoadReload(h *bwtest.HarnessTest) {
 	manager := h.NewWalletManager()
 	w, err := manager.Create(cfg, params)
 	require.NoError(h, err, "failed to create wallet")
-	h.RegisterWallet(w)
+	h.RegisterWallet(manager, w)
 
 	err = w.Start(h.Context())
 	require.NoError(h, err, "failed to start wallet")
@@ -188,7 +188,7 @@ func testManagerLoadReload(h *bwtest.HarnessTest) {
 	// Reload a fresh instance from the same durable store.
 	reloaded, err := manager.Load(cfg)
 	require.NoError(h, err, "failed to reload wallet")
-	h.RegisterWallet(reloaded)
+	h.RegisterWallet(manager, reloaded)
 	require.NotSame(h, w, reloaded, "reload returned the torn-down instance")
 
 	err = reloaded.Start(h.Context())
@@ -243,7 +243,7 @@ func testManagerCreateWatchOnly(h *bwtest.HarnessTest) {
 	manager := h.NewWalletManager()
 	w, err := manager.Create(cfg, params)
 	require.NoError(h, err, "failed to create watch-only wallet")
-	h.RegisterWallet(w)
+	h.RegisterWallet(manager, w)
 
 	require.NoError(h, w.Start(h.Context()), "failed to start wallet")
 	h.AssertWalletSynced(w)
@@ -263,7 +263,7 @@ func testManagerCreateWatchOnly(h *bwtest.HarnessTest) {
 	manager = h.NewWalletManager()
 	reloaded, err := manager.Load(cfg)
 	require.NoError(h, err, "failed to reload watch-only wallet")
-	h.RegisterWallet(reloaded)
+	h.RegisterWallet(manager, reloaded)
 
 	require.NoError(
 		h, reloaded.Start(h.Context()), "failed to start reloaded wallet",

--- a/wallet/internal/db/accountstore_accountinfo.go
+++ b/wallet/internal/db/accountstore_accountinfo.go
@@ -289,6 +289,42 @@ func AccountPropsRowToInfo[AddrTypeId ~int16 | ~int64](
 	}, nil
 }
 
+// addrTypeToWaddrmgr maps a database AddressType to its legacy waddrmgr
+// representation. The two enums share names but not ordinal values, so a
+// direct cast would corrupt the schema.
+func addrTypeToWaddrmgr(t AddressType) (waddrmgr.AddressType, error) {
+	switch t {
+	case RawPubKey:
+		return waddrmgr.RawPubKey, nil
+
+	case PubKeyHash:
+		return waddrmgr.PubKeyHash, nil
+
+	case ScriptHash:
+		return waddrmgr.Script, nil
+
+	case NestedWitnessPubKey:
+		return waddrmgr.NestedWitnessPubKey, nil
+
+	case WitnessPubKey:
+		return waddrmgr.WitnessPubKey, nil
+
+	case WitnessScript:
+		return waddrmgr.WitnessScript, nil
+
+	case TaprootPubKey:
+		return waddrmgr.TaprootPubKey, nil
+
+	case Anchor:
+		return 0, fmt.Errorf("%w: database address type %d",
+			ErrInvalidParam, t)
+
+	default:
+		return 0, fmt.Errorf("%w: database address type %d",
+			ErrInvalidParam, t)
+	}
+}
+
 // addrTypeFromWaddrmgr maps a legacy waddrmgr.AddressType to the database
 // AddressType. The two enums share names but not ordinal values, so a direct
 // cast would corrupt the schema (e.g. waddrmgr.PubKeyHash=0 collides with
@@ -346,6 +382,30 @@ func ScopeAddrSchemaFromWaddrmgr(
 	}
 
 	return ScopeAddrSchema{
+		ExternalAddrType: external,
+		InternalAddrType: internal,
+	}, nil
+}
+
+// ScopeAddrSchemaToWaddrmgr converts a database account schema into the
+// legacy address-manager schema shape. An unrepresentable address type is
+// surfaced as ErrInvalidParam rather than coerced to a different enum value.
+func ScopeAddrSchemaToWaddrmgr(
+	schema ScopeAddrSchema) (waddrmgr.ScopeAddrSchema, error) {
+
+	external, err := addrTypeToWaddrmgr(schema.ExternalAddrType)
+	if err != nil {
+		return waddrmgr.ScopeAddrSchema{},
+			fmt.Errorf("external: %w", err)
+	}
+
+	internal, err := addrTypeToWaddrmgr(schema.InternalAddrType)
+	if err != nil {
+		return waddrmgr.ScopeAddrSchema{},
+			fmt.Errorf("internal: %w", err)
+	}
+
+	return waddrmgr.ScopeAddrSchema{
 		ExternalAddrType: external,
 		InternalAddrType: internal,
 	}, nil

--- a/wallet/internal/db/accountstore_accountinfo_test.go
+++ b/wallet/internal/db/accountstore_accountinfo_test.go
@@ -105,3 +105,121 @@ func TestScopeAddrSchemaFromWaddrmgr(t *testing.T) {
 		InternalAddrType: PubKeyHash,
 	}, schema)
 }
+
+// TestAddrTypeToWaddrmgr verifies every database address type with a
+// legacy waddrmgr representation maps explicitly rather than by ordinal.
+func TestAddrTypeToWaddrmgr(t *testing.T) {
+	t.Parallel()
+
+	// The three legacy values below have different ordinals in the database
+	// and waddrmgr enums, which is why this conversion cannot use a cast.
+	require.NotEqual(t, uint8(RawPubKey), uint8(waddrmgr.RawPubKey))
+	require.NotEqual(t, uint8(PubKeyHash), uint8(waddrmgr.PubKeyHash))
+	require.NotEqual(t, uint8(ScriptHash), uint8(waddrmgr.Script))
+
+	testCases := []struct {
+		name  string
+		input AddressType
+		want  waddrmgr.AddressType
+	}{
+		{
+			name:  "raw pubkey",
+			input: RawPubKey,
+			want:  waddrmgr.RawPubKey,
+		},
+		{
+			name:  "pubkey hash",
+			input: PubKeyHash,
+			want:  waddrmgr.PubKeyHash,
+		},
+		{
+			name:  "script hash",
+			input: ScriptHash,
+			want:  waddrmgr.Script,
+		},
+		{
+			name:  "nested witness pubkey",
+			input: NestedWitnessPubKey,
+			want:  waddrmgr.NestedWitnessPubKey,
+		},
+		{
+			name:  "witness pubkey",
+			input: WitnessPubKey,
+			want:  waddrmgr.WitnessPubKey,
+		},
+		{
+			name:  "witness script",
+			input: WitnessScript,
+			want:  waddrmgr.WitnessScript,
+		},
+		{
+			name:  "taproot pubkey",
+			input: TaprootPubKey,
+			want:  waddrmgr.TaprootPubKey,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := addrTypeToWaddrmgr(testCase.input)
+
+			require.NoError(t, err)
+			require.Equal(t, testCase.want, got)
+		})
+	}
+}
+
+// TestAddrTypeToWaddrmgrRejectsUnrepresentable verifies address types that
+// have no legacy waddrmgr representation return ErrInvalidParam.
+func TestAddrTypeToWaddrmgrRejectsUnrepresentable(t *testing.T) {
+	t.Parallel()
+
+	testCases := []AddressType{
+		Anchor,
+		AddressType(255),
+	}
+	for _, testCase := range testCases {
+		_, err := addrTypeToWaddrmgr(testCase)
+
+		require.ErrorIs(t, err, ErrInvalidParam)
+	}
+}
+
+// TestScopeAddrSchemaToWaddrmgr verifies database schemas are converted into
+// the legacy address-manager shape with branch-specific conversion errors.
+func TestScopeAddrSchemaToWaddrmgr(t *testing.T) {
+	t.Parallel()
+
+	schema, err := ScopeAddrSchemaToWaddrmgr(
+		ScopeAddrSchema{
+			ExternalAddrType: PubKeyHash,
+			InternalAddrType: PubKeyHash,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t, waddrmgr.ScopeAddrSchema{
+			ExternalAddrType: waddrmgr.PubKeyHash,
+			InternalAddrType: waddrmgr.PubKeyHash,
+		}, schema,
+	)
+
+	_, err = ScopeAddrSchemaToWaddrmgr(
+		ScopeAddrSchema{
+			ExternalAddrType: Anchor,
+			InternalAddrType: WitnessPubKey,
+		},
+	)
+	require.ErrorIs(t, err, ErrInvalidParam)
+	require.ErrorContains(t, err, "external:")
+
+	_, err = ScopeAddrSchemaToWaddrmgr(
+		ScopeAddrSchema{
+			ExternalAddrType: WitnessPubKey,
+			InternalAddrType: Anchor,
+		},
+	)
+	require.ErrorIs(t, err, ErrInvalidParam)
+	require.ErrorContains(t, err, "internal:")
+}

--- a/wallet/internal/db/kvdb/accountstore_createimported.go
+++ b/wallet/internal/db/kvdb/accountstore_createimported.go
@@ -105,7 +105,17 @@ func (s *Store) putImportedAccount(ns walletdb.ReadWriteBucket,
 	pubKey *hdkeychain.ExtendedKey,
 	walletIsWatchOnly bool) (*db.AccountInfo, error) {
 
-	addrSchema := waddrmgrScopeAddrSchema(params.AddrSchema)
+	var addrSchema *waddrmgr.ScopeAddrSchema
+	if params.AddrSchema != nil {
+		converted, err := db.ScopeAddrSchemaToWaddrmgr(
+			*params.AddrSchema,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("address schema: %w", err)
+		}
+
+		addrSchema = &converted
+	}
 
 	scopedMgr, err := s.scopedManagerOrCreate(
 		ns, scope, addrSchema, params.DryRun,
@@ -204,19 +214,4 @@ func dryRunImportedAccount(ns walletdb.ReadWriteBucket,
 	return loadAccountInfo(
 		ns, scopedMgr, accountNumber, walletIsWatchOnly,
 	)
-}
-
-// waddrmgrScopeAddrSchema converts the account-store schema type into the
-// waddrmgr per-account address schema type.
-func waddrmgrScopeAddrSchema(
-	schema *db.ScopeAddrSchema) *waddrmgr.ScopeAddrSchema {
-
-	if schema == nil {
-		return nil
-	}
-
-	return &waddrmgr.ScopeAddrSchema{
-		ExternalAddrType: waddrmgr.AddressType(schema.ExternalAddrType),
-		InternalAddrType: waddrmgr.AddressType(schema.InternalAddrType),
-	}
 }

--- a/wallet/internal/db/kvdb/accountstore_renameaccount.go
+++ b/wallet/internal/db/kvdb/accountstore_renameaccount.go
@@ -42,9 +42,18 @@ func (s *Store) RenameAccount(_ context.Context,
 			return err
 		}
 
-		err = assertRenameableAccount(ns, scopedMgr, acctNum)
-		if err != nil {
-			return err
+		// AccountNumber is the public BIP44 identifier, so reject
+		// waddrmgr-internal numbers assigned to imported accounts.
+		if params.AccountNumber != nil {
+			err = assertRenameableAccount(ns, scopedMgr, acctNum)
+			if err != nil {
+				return err
+			}
+		} else if acctNum == waddrmgr.ImportedAddrAccount {
+			// Name lookups may select imported xpub accounts.
+			// Only the reserved raw-import pseudo-account remains
+			// unrenameable.
+			return db.ErrAccountNotFound
 		}
 
 		err = scopedMgr.RenameAccount(ns, acctNum, params.NewName)
@@ -74,9 +83,8 @@ func resolveRenameAccountNumber(ns walletdb.ReadBucket,
 	return acctNum, nil
 }
 
-// assertRenameableAccount rejects imported accounts before calling
-// waddrmgr.RenameAccount, which only knows about the legacy imported-address
-// pseudo-account slot.
+// assertRenameableAccount rejects account rows without a public BIP44 account
+// number.
 func assertRenameableAccount(ns walletdb.ReadBucket,
 	scopedMgr waddrmgr.AccountStore, acctNum uint32) error {
 

--- a/wallet/internal/db/kvdb/accountstore_test.go
+++ b/wallet/internal/db/kvdb/accountstore_test.go
@@ -279,9 +279,9 @@ func TestRenameAccountNotFound(t *testing.T) {
 	require.ErrorIs(t, err, db.ErrAccountNotFound)
 }
 
-// TestRenameAccountRejectsImported verifies that kvdb rejects imported account
-// renames both by name and by waddrmgr's internal account number.
-func TestRenameAccountRejectsImported(t *testing.T) {
+// TestRenameAccountImported verifies imported xpubs can be renamed by name,
+// while internal-number selection and the raw-import pseudo-account reject.
+func TestRenameAccountImported(t *testing.T) {
 	t.Parallel()
 
 	store, _, cleanup := newAccountStoreFixture(t)
@@ -314,7 +314,27 @@ func TestRenameAccountRejectsImported(t *testing.T) {
 		OldName: name,
 		NewName: "renamed-imported",
 	})
+	require.NoError(t, err)
+
+	_, err = store.GetAccount(
+		t.Context(), db.GetAccountQuery{
+			Scope: scope,
+			Name:  &name,
+		},
+	)
 	require.ErrorIs(t, err, db.ErrAccountNotFound)
+
+	renamedName := "renamed-imported"
+	info, err := store.GetAccount(
+		t.Context(), db.GetAccountQuery{
+			Scope: scope,
+			Name:  &renamedName,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, renamedName, info.AccountName)
+	require.True(t, info.IsImported)
+	require.Nil(t, info.AccountNumber)
 
 	mgrScope := waddrmgr.KeyScope(scope)
 	scopedMgr, err := store.addrStore.FetchScopedKeyManager(mgrScope)
@@ -327,27 +347,38 @@ func TestRenameAccountRejectsImported(t *testing.T) {
 
 		var err error
 
-		internalNumber, err = scopedMgr.LookupAccount(ns, name)
+		internalNumber, err = scopedMgr.LookupAccount(ns, renamedName)
 
 		return err
 	})
 	require.NoError(t, err)
 
-	err = store.RenameAccount(t.Context(), db.RenameAccountParams{
-		Scope:         scope,
-		AccountNumber: &internalNumber,
-		NewName:       "renamed-imported",
-	})
+	err = store.RenameAccount(
+		t.Context(), db.RenameAccountParams{
+			Scope:         scope,
+			AccountNumber: &internalNumber,
+			NewName:       "renamed-imported-number",
+		},
+	)
 	require.ErrorIs(t, err, db.ErrAccountNotFound)
 
-	info, err := store.GetAccount(
+	err = store.RenameAccount(
+		t.Context(), db.RenameAccountParams{
+			Scope:   scope,
+			OldName: waddrmgr.ImportedAddrAccountName,
+			NewName: "renamed-raw-import",
+		},
+	)
+	require.ErrorIs(t, err, db.ErrAccountNotFound)
+
+	info, err = store.GetAccount(
 		t.Context(), db.GetAccountQuery{
 			Scope: scope,
-			Name:  &name,
+			Name:  &renamedName,
 		},
 	)
 	require.NoError(t, err)
-	require.Equal(t, name, info.AccountName)
+	require.Equal(t, renamedName, info.AccountName)
 }
 
 // kvdbDeriveFnFixture returns an AccountDerivationFunc that derives an

--- a/wallet/internal/db/kvdb/accountstore_test.go
+++ b/wallet/internal/db/kvdb/accountstore_test.go
@@ -829,6 +829,74 @@ func TestCreateImportedAccountUsesAddrSchema(t *testing.T) {
 		return nil
 	})
 	require.NoError(t, err)
+
+	// BIP44 uses db.PubKeyHash=1 while waddrmgr.PubKeyHash=0. This case
+	// guards against the old raw cast by asserting the persisted legacy
+	// schema for both the external and internal branches.
+	bip44Scope := db.KeyScope{
+		Purpose: waddrmgr.KeyScopeBIP0044.Purpose,
+		Coin:    waddrmgr.KeyScopeBIP0044.Coin,
+	}
+	bip44Schema := db.ScopeAddrSchema{
+		ExternalAddrType: db.PubKeyHash,
+		InternalAddrType: db.PubKeyHash,
+	}
+	bip44Name := "imported-bip44-schema"
+
+	info, err = store.CreateImportedAccount(
+		t.Context(), db.CreateImportedAccountParams{
+			Scope:             bip44Scope,
+			Name:              bip44Name,
+			MasterFingerprint: 0xDEADBEEF,
+			PublicKey:         []byte(masterPub.String()),
+			AddrSchema:        &bip44Schema,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, bip44Schema, info.AddrSchema)
+
+	info, err = store.GetAccount(
+		t.Context(), db.GetAccountQuery{
+			Scope: bip44Scope,
+			Name:  &bip44Name,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, bip44Schema, info.AddrSchema)
+
+	bip44ScopedMgr, err := store.addrStore.FetchScopedKeyManager(
+		waddrmgr.KeyScope(bip44Scope),
+	)
+	require.NoError(t, err)
+
+	err = walletdb.View(store.db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgr.NamespaceKey)
+
+		accountNumber, err := bip44ScopedMgr.LookupAccount(
+			ns, bip44Name,
+		)
+		if err != nil {
+			return err
+		}
+
+		props, err := bip44ScopedMgr.AccountProperties(
+			ns, accountNumber,
+		)
+		if err != nil {
+			return err
+		}
+
+		require.NotNil(t, props.AddrSchema)
+		require.Equal(
+			t, waddrmgr.ScopeAddrSchema{
+				ExternalAddrType: waddrmgr.PubKeyHash,
+				InternalAddrType: waddrmgr.PubKeyHash,
+			}, *props.AddrSchema,
+		)
+
+		return nil
+	})
+	require.NoError(t, err)
 }
 
 // newCreditedFixture builds an account store backed by a spendable wallet


### PR DESCRIPTION
Implements roadmap Task 429 by adding daemon-level integration coverage for the
public AccountManager mutation APIs:

- `NewAccount`
- `RenameAccount`
- `ImportAccount`

## Test structure

The account-manager suite has 15 independently registered cases in
`itest/account_manager_test.go`: five creation, five rename, and five import
cases. Successful mutations, rejection and rollback checks, and lifecycle gates
are isolated instead of sharing one long scenario. Rejection tables contain
only inputs and expected results.

Every case runs unchanged against kvdb, SQLite, and PostgreSQL. There is no
backend branch anywhere in the suite; backend-specific code is confined to
harness setup and teardown.

## Coverage

The scenarios cover:

- complete public `AccountInfo` results from mutation, lookup, and wallet
  reload;
- the absent, present-zero, and present-nonzero forms of both optional
  identities — a present-zero `AccountNumber` via the default account and a
  present-zero `MasterKeyFingerprint` via a zero-fingerprint import — so a
  backend cannot collapse a present zero into an absent value;
- rejection of duplicate, invalid-name, invalid-key, reserved-name, and
  missing-source requests, with the public account set left unchanged;
- locked, stopped, and watch-only lifecycle gates, each reopening the wallet
  afterwards to prove the rejected call left no partial account behind;
- derived, default, and imported-XPub renames, including both reserved
  imported-name directions;
- persisted and dry-run imports; and
- complete serialized account-key comparisons after normalizing only the
  network version bytes.

## Scope

Stable public error identities for AccountManager rejections are owned by
Task 378 and are **not** established here. The duplicate-account and
rename-not-found mappings that an earlier revision of this PR carried have been
removed; the negative cases assert rejection and unchanged state only, and will
be tightened to `errors.Is`/`errors.As` in the dedicated Task 378 PR.

`AccountID` is intentionally outside this public mutation coverage. Account
query coverage remains scoped to Task 430.

## Supporting fixes

Two production fixes remain, both required for the shared contract to hold on
every backend:

- **Imported account address schemas** convert explicitly between the database
  and `waddrmgr` enums instead of casting ordinals. The two enums share names
  but not values, so the cast silently rewrote the schema of an imported BIP44
  account. This mismatch pre-exists the sql-wallet base and has no introducing
  commit; see the commit body for detail.
- **kvdb renames imported-XPub accounts by name**, while still refusing the
  reserved raw-import pseudo-account, so rename behaves identically on kvdb and
  SQL.

Carrying these here is a one-time exception, taken to avoid further churn in an
already-restacked branch. Production bugs discovered during future itest work
should be fixed in separate, focused PRs rather than folded into the test PR
that happened to surface them.

## Harness

The shared `bwtest` fixture supports rootless and seeded watch-only wallets and
keeps reload metadata private in one manager-keyed ownership registry. Wallets
are registered before start, reload replaces the sole wallet and manager it
consumes, and teardown stops wallets before closing managers.

## Testing

```bash
make lint-check
make unit
make itest chain=btcd db=kvdb icase="account manager"
make itest chain=btcd db=sqlite icase="account manager"
make itest chain=btcd db=postgres icase="account manager"
```
