### PR TITLE
wallet: separate transaction authoring

### DIFF
--- a/wallet/psbt_manager.go
+++ b/wallet/psbt_manager.go
@@ -580,11 +580,15 @@ func validatePsbtParentOutput(outPoint wire.OutPoint,
 //
 // It executes the funding logic by:
 //  1. Validation: Checking the `FundIntent` for consistency.
-//  2. Creation: Converting the intent into a `TxIntent` and delegating to the
-//     `CreateTransaction` method (which handles the underlying coin selection
-//     and change calculation algorithms).
+//  2. Creation: Converting the intent into a `TxIntent`, preparing its input
+//     and change sources, and invoking the shared transaction authoring method.
 //  3. Population: Calling `populatePsbtPacket` to apply the selected inputs and
 //     change output to the PSBT structure and sort it according to BIP 69.
+//
+// FundPsbt deliberately invokes the neutral authoring boundary instead of the
+// public CreateTransaction wrapper. Their construction flow is identical
+// today, but keeping the wrappers independent prevents direct-transaction watch
+// delivery from leaking into PSBT-specific lease, cleanup, and publication.
 func (w *Wallet) FundPsbt(ctx context.Context, intent *FundIntent) (
 	*psbt.Packet, int32, error) {
 
@@ -602,8 +606,20 @@ func (w *Wallet) FundPsbt(ctx context.Context, intent *FundIntent) (
 	// Create a TxIntent from the FundIntent.
 	txIntent := w.createTxIntent(intent)
 
-	// Create the transaction.
-	authoredTx, err := w.CreateTransaction(ctx, txIntent)
+	err = normalizeAndValidateTxIntent(txIntent)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	inputSource, changeSource, err := w.prepareTxAuthSources(ctx, txIntent)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// Create the transaction through the shared authoring boundary.
+	authoredTx, err := w.authorTransaction(
+		txIntent.Outputs, txIntent.FeeRate, inputSource, changeSource,
+	)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/wallet/psbt_manager_test.go
+++ b/wallet/psbt_manager_test.go
@@ -869,6 +869,101 @@ func TestDecorateInputsErrDecorationFailed(t *testing.T) {
 	require.ErrorIs(t, err, errDb)
 }
 
+// TestFundPsbtExplicitPolicy verifies the public PSBT wrapper prepares sources,
+// authors the transaction, and publishes the funded packet itself.
+func TestFundPsbtExplicitPolicy(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Prepare a synced wallet whose default BIP0086 account has
+	// one mature 100,000-sat UTXO, then build a packet requesting the
+	// fixture's 99,700-sat payment. Register the store metadata needed to
+	// decorate that selected P2WPKH input in the funded PSBT.
+	w, mocks := createStartedWalletWithMocks(t)
+	mocks.syncer.On("syncState").Return(syncStateSynced).Once()
+
+	fixture := expectDefaultAuthoringSources(t, w, mocks)
+	tx := wire.NewMsgTx(wire.TxVersion)
+	tx.AddTxOut(&fixture.payment)
+	packet, err := psbt.NewFromUnsignedTx(tx)
+	require.NoError(t, err)
+
+	mocks.store.On("GetUtxo", mock.Anything, db.GetUtxoQuery{
+		WalletID: w.id, OutPoint: fixture.utxo.OutPoint,
+	}).Return(&fixture.utxo, nil).Once()
+	mocks.store.On("GetTxDetail", mock.Anything, db.GetTxDetailQuery{
+		WalletID: w.id, Txid: fixture.utxo.OutPoint.Hash,
+	}).Return(testStoreTxDetail(
+		fixture.utxo.OutPoint.Hash, wire.NewTxOut(
+			int64(fixture.utxo.Amount), fixture.utxo.PkScript,
+		),
+	), nil).Once()
+
+	expectSignerDerivedAddressInfo(
+		t, w, mocks, fixture.inputAddr, db.WitnessPubKey,
+		fixture.inputKey.PubKey(),
+	)
+
+	// Act: Fund the packet through FundPsbt with an explicit automatic
+	// selection policy and the fixture's fee rate.
+	funded, changeIndex, err := w.FundPsbt(t.Context(), &FundIntent{
+		Packet:  packet,
+		Policy:  &InputsPolicy{},
+		FeeRate: defaultFeeRate,
+	})
+
+	// Assert: FundPsbt must mutate and return the caller's packet, select
+	// exactly the fixture UTXO, preserve the 99,700-sat payment, decorate
+	// the input with that UTXO, and report -1 because no change survived.
+	require.NoError(t, err)
+	require.Same(t, packet, funded)
+	require.Equal(t, int32(-1), changeIndex)
+	require.Len(t, funded.UnsignedTx.TxIn, 1)
+	require.Equal(t, fixture.utxo.OutPoint,
+		funded.UnsignedTx.TxIn[0].PreviousOutPoint)
+	require.Len(t, funded.UnsignedTx.TxOut, 1)
+	require.Equal(t, fixture.payment, *funded.UnsignedTx.TxOut[0])
+	require.NotNil(t, funded.Inputs[0].WitnessUtxo)
+	require.Equal(t, int64(fixture.utxo.Amount),
+		funded.Inputs[0].WitnessUtxo.Value)
+	require.Equal(t, fixture.utxo.PkScript,
+		funded.Inputs[0].WitnessUtxo.PkScript)
+}
+
+// TestFundPsbtInvalidTxIntent verifies wrapper rewiring preserves transaction
+// validation errors without mutating the caller's packet.
+func TestFundPsbtInvalidTxIntent(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Prepare a packet with one 10,000-sat output and retain its
+	// unsigned transaction pointer. A zero fee rate must fail TxIntent
+	// validation before source preparation or packet population can run.
+	w, mocks := createStartedWalletWithMocks(t)
+	mocks.syncer.On("syncState").Return(syncStateSynced).Once()
+
+	script := append([]byte{0x00, 0x14}, make([]byte, 20)...)
+	tx := wire.NewMsgTx(wire.TxVersion)
+	tx.AddTxOut(&wire.TxOut{Value: 10_000, PkScript: script})
+	packet, err := psbt.NewFromUnsignedTx(tx)
+	require.NoError(t, err)
+
+	originalTx := packet.UnsignedTx
+
+	// Act: Attempt to fund the packet with the invalid zero fee rate.
+	funded, changeIndex, err := w.FundPsbt(t.Context(), &FundIntent{
+		Packet: packet, Policy: &InputsPolicy{},
+		FeeRate: btcunit.ZeroSatPerKVByte,
+	})
+
+	// Assert: FundPsbt must return ErrMissingFeeRate, no funded packet, and
+	// the error-path change index. The original transaction object and its
+	// sole 10,000-sat output must remain untouched.
+	require.ErrorIs(t, err, ErrMissingFeeRate)
+	require.Nil(t, funded)
+	require.Zero(t, changeIndex)
+	require.Same(t, originalTx, packet.UnsignedTx)
+	require.Equal(t, int64(10_000), packet.UnsignedTx.TxOut[0].Value)
+}
+
 // TestValidateFundIntentSuccess tests that validateFundIntent returns no error
 // for valid funding intents.
 func TestValidateFundIntentSuccess(t *testing.T) {

--- a/wallet/tx_creator.go
+++ b/wallet/tx_creator.go
@@ -600,21 +600,11 @@ func (w *Wallet) createChangeSource(ctx context.Context,
 	}, nil
 }
 
-// CreateTransaction creates a new unsigned transaction spending unspent outputs
-// to the given outputs. It is the main implementation of the TxCreator
-// interface. The method will produce a valid, unsigned transaction, which can
-// then be passed to the Signer interface to be signed.
-func (w *Wallet) CreateTransaction(ctx context.Context, intent *TxIntent) (
-	*txauthor.AuthoredTx, error) {
-
-	err := w.state.validateSynced()
-	if err != nil {
-		return nil, err
-	}
-
-	// Check that the intent is not nil.
+// normalizeAndValidateTxIntent applies the default input policy and validates
+// a transaction intent before source preparation.
+func normalizeAndValidateTxIntent(intent *TxIntent) error {
 	if intent == nil {
-		return nil, ErrNilTxIntent
+		return ErrNilTxIntent
 	}
 
 	// If no input source is specified, an auto coin selection with the
@@ -626,7 +616,24 @@ func (w *Wallet) CreateTransaction(ctx context.Context, intent *TxIntent) (
 		intent.Inputs = &InputsPolicy{}
 	}
 
-	err = validateTxIntent(intent)
+	return validateTxIntent(intent)
+}
+
+// CreateTransaction creates a new unsigned transaction spending unspent outputs
+// to the given outputs. It is the direct-transaction wrapper around the neutral
+// authoring boundary and the main implementation of the TxCreator interface.
+// Direct-transaction watch delivery belongs to this wrapper; PSBT funding calls
+// the neutral boundary independently so its lease, cleanup, and publication
+// obligations remain in FundPsbt.
+func (w *Wallet) CreateTransaction(ctx context.Context, intent *TxIntent) (
+	*txauthor.AuthoredTx, error) {
+
+	err := w.state.validateSynced()
+	if err != nil {
+		return nil, err
+	}
+
+	err = normalizeAndValidateTxIntent(intent)
 	if err != nil {
 		return nil, err
 	}
@@ -636,24 +643,38 @@ func (w *Wallet) CreateTransaction(ctx context.Context, intent *TxIntent) (
 		return nil, err
 	}
 
+	return w.authorTransaction(
+		intent.Outputs, intent.FeeRate, inputSource, changeSource,
+	)
+}
+
+// authorTransaction creates an unsigned transaction from the outputs, fee rate,
+// and precomputed input and change sources shared by both public wrappers. Its
+// narrow request keeps wrapper-owned input policies, change accounts, labels,
+// and lifecycle effects outside the neutral boundary.
+func (w *Wallet) authorTransaction(outputs []wire.TxOut,
+	feeRate btcunit.SatPerKVByte,
+	inputSource txauthor.InputSource,
+	changeSource *txauthor.ChangeSource) (*txauthor.AuthoredTx, error) {
+
 	// The txauthor.NewUnsignedTransaction function expects a slice of
 	// *wire.TxOut, but our intent has a slice of wire.TxOut. We perform
 	// the conversion here.
 	//
 	// TODO(yy): change the signature of `NewUnsignedTransaction` to take a
 	// list of `wire.TxOut`.
-	outputs := make([]*wire.TxOut, 0, len(intent.Outputs))
-	for _, output := range intent.Outputs {
-		outputs = append(outputs, &output)
+	txOutputs := make([]*wire.TxOut, 0, len(outputs))
+	for _, output := range outputs {
+		txOutputs = append(txOutputs, &output)
 	}
 
 	// With the input source and change source prepared, we can now call the
 	// txauthor package to perform the actual coin selection and create the
 	// unsigned transaction.
-	feeSatPerKb := intent.FeeRate.Val()
+	feeSatPerKb := feeRate.Val()
 
 	tx, err := txauthor.NewUnsignedTransaction(
-		outputs, feeSatPerKb, inputSource, changeSource,
+		txOutputs, feeSatPerKb, inputSource, changeSource,
 	)
 	if err != nil {
 		return nil, err

--- a/wallet/tx_creator_test.go
+++ b/wallet/tx_creator_test.go
@@ -1,6 +1,7 @@
 package wallet
 
 import (
+	"context"
 	"testing"
 
 	"github.com/btcsuite/btcd/address/v2"
@@ -11,7 +12,9 @@ import (
 	"github.com/btcsuite/btcwallet/pkg/btcunit"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/txauthor"
 	"github.com/btcsuite/btcwallet/wallet/txrules"
+	"github.com/btcsuite/btcwallet/wallet/txsizes"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -34,6 +37,89 @@ var (
 
 	defaultFeeRate = btcunit.NewSatPerKVByte(1000)
 )
+
+// defaultAuthoringFixture describes the input, payment, and signing metadata
+// returned by expectDefaultAuthoringSources. The fixture spends one mature
+// 100,000-sat default-account UTXO on a 99,700-sat payment, leaving no change
+// output after fees.
+type defaultAuthoringFixture struct {
+	// payment is the single 99,700-sat recipient output requested by the
+	// transaction intent.
+	payment wire.TxOut
+
+	// utxo is the mature 100,000-sat default-account input selected to fund
+	// payment.
+	utxo db.UtxoInfo
+
+	// inputKey is the private key backing utxo and supplies its public key
+	// during PSBT input decoration.
+	inputKey *btcec.PrivateKey
+
+	// inputAddr is the P2WPKH address backing utxo and identifies its wallet
+	// derivation metadata during PSBT input decoration.
+	inputAddr address.Address
+}
+
+// expectDefaultAuthoringSources configures automatic selection from the default
+// BIP0086 account. It registers the account-by-name and account-by-number
+// lookups, a chain tip at height 100, one 100,000-sat P2WPKH UTXO mined at
+// height 1, and one P2TR-sized derived change script. The requested payment is
+// 99,700 sat, so the remainder after fees is below the change threshold: the
+// authoring result must contain one input, the payment output, and no change.
+func expectDefaultAuthoringSources(t *testing.T, w *Wallet,
+	mocks *mockWalletDeps) defaultAuthoringFixture {
+
+	t.Helper()
+
+	inputKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	inputAddr, err := address.NewAddressWitnessPubKeyHash(
+		address.Hash160(inputKey.PubKey().SerializeCompressed()),
+		&chainParams,
+	)
+	require.NoError(t, err)
+	inputScript, err := txscript.PayToAddrScript(inputAddr)
+	require.NoError(t, err)
+
+	payment := wire.TxOut{Value: 99_700, PkScript: inputScript}
+	inputAmount := btcutil.Amount(100_000)
+	defaultAccountNum := uint32(waddrmgr.DefaultAccountNum)
+	scope := db.KeyScope(waddrmgr.KeyScopeBIP0086)
+	accountInfo := &db.AccountInfo{
+		AccountNumber: &defaultAccountNum,
+		AccountName:   waddrmgr.DefaultAccountName,
+		AddrSchema:    db.ScopeAddrMap[scope],
+	}
+	mocks.store.On("GetAccount", mock.Anything, db.GetAccountQuery{
+		WalletID: w.id, Scope: scope, Name: &defaultAccountName,
+	}).Return(accountInfo, nil).Once()
+	mocks.store.On("GetAccount", mock.Anything, db.GetAccountQuery{
+		WalletID: w.id, Scope: scope, AccountNumber: &defaultAccountNum,
+	}).Return(accountInfo, nil).Once()
+	mocks.chain.On("BlockStamp").Return(
+		&waddrmgr.BlockStamp{Height: 100}, nil,
+	).Once()
+	utxo := db.UtxoInfo{
+		OutPoint: validUTXO, Amount: inputAmount, PkScript: inputScript,
+		Height: 1,
+	}
+	mocks.store.On("ListUTXOs", mock.Anything, db.ListUtxosQuery{
+		WalletID: w.id, Scope: &scope, AccountName: &defaultAccountName,
+	}).Return([]db.UtxoInfo{utxo}, nil).Once()
+	mocks.store.On("NewDerivedAddress", mock.Anything,
+		db.NewDerivedAddressParams{
+			WalletID: w.id, AccountName: defaultAccountName,
+			Scope: scope, Change: true,
+		},
+	).Return(&db.AddressInfo{
+		ScriptPubKey: make([]byte, txsizes.P2TRPkScriptSize),
+	}, nil).Once()
+
+	return defaultAuthoringFixture{
+		payment: payment, utxo: utxo, inputKey: inputKey,
+		inputAddr: inputAddr,
+	}
+}
 
 // txIntentTestCases enumerates the TxIntent validation scenarios exercised by
 // TestValidateTxIntent.
@@ -501,6 +587,178 @@ func TestDetermineChangeSource(t *testing.T) {
 			require.Equal(t, tc.expectedSource, source)
 		})
 	}
+}
+
+// TestAuthorTransaction verifies the shared authoring boundary preserves
+// transaction results, callback timing, and source errors without wrapper
+// effects.
+func TestAuthorTransaction(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Use a 50,000-sat payment and distinct input and change
+	// scripts. Each table row controls the surplus returned by the input
+	// source or injects the exact callback error authoring must propagate.
+	inputScript := append([]byte{0x00, 0x14}, make([]byte, 20)...)
+	changeScript := append([]byte(nil), inputScript...)
+	changeScript[len(changeScript)-1] = 1
+	output := wire.TxOut{Value: 50_000, PkScript: inputScript}
+
+	testCases := []struct {
+		name         string
+		changeAmount btcutil.Amount
+		inputErr     error
+		changeErr    error
+	}{
+		{
+			name: "direct no change",
+		},
+		{
+			name:         "psbt viable change",
+			changeAmount: 10_000,
+		},
+		{
+			name:     "input source failure",
+			inputErr: errDBMock,
+		},
+		{
+			name:      "change source failure",
+			changeErr: errChainMock,
+		},
+		{
+			name:     "cancellation",
+			inputErr: context.Canceled,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: Build counting callbacks so the test records the
+			// input target requested by txauthor and whether change-script
+			// allocation is attempted. A successful input callback returns
+			// exactly the requested target plus the case's change amount.
+			w, _ := createTestWalletWithMocks(t)
+
+			var (
+				inputCalls, changeCalls int
+				inputTarget             btcutil.Amount
+			)
+
+			inputSource := func(target btcutil.Amount) (btcutil.Amount,
+				[]*wire.TxIn, []btcutil.Amount, [][]byte, error) {
+
+				inputCalls++
+				inputTarget = target
+
+				if tc.inputErr != nil {
+					return 0, nil, nil, nil, tc.inputErr
+				}
+
+				total := target + tc.changeAmount
+
+				return total, []*wire.TxIn{{}},
+					[]btcutil.Amount{total}, [][]byte{inputScript}, nil
+			}
+			changeSource := &txauthor.ChangeSource{
+				ScriptSize: len(changeScript),
+				NewScript: func() ([]byte, error) {
+					changeCalls++
+					return changeScript, tc.changeErr
+				},
+			}
+
+			wantErr := tc.inputErr
+			if wantErr == nil {
+				wantErr = tc.changeErr
+			}
+
+			// Act: Invoke the neutral authoring boundary directly, without
+			// either public wallet wrapper.
+			authored, err := w.authorTransaction(
+				[]wire.TxOut{output}, defaultFeeRate, inputSource,
+				changeSource,
+			)
+
+			// Assert: The input source is queried exactly once and an
+			// injected callback error is returned unchanged without
+			// publishing a partially authored transaction.
+			require.ErrorIs(t, err, wantErr)
+			require.Equal(t, 1, inputCalls)
+
+			if wantErr != nil {
+				require.Nil(t, authored)
+
+				if tc.inputErr != nil {
+					require.Zero(t, changeCalls)
+				} else {
+					require.Equal(t, 1, changeCalls)
+				}
+
+				return
+			}
+
+			// A successful result must allocate the change script once,
+			// spend one input, preserve its previous script and total
+			// amount, and charge the target amount above the payment as
+			// its fee.
+			require.Equal(t, 1, changeCalls)
+			require.Len(t, authored.Tx.TxIn, 1)
+			require.Equal(t, inputScript, authored.PrevScripts[0])
+			require.Equal(t, inputTarget+tc.changeAmount,
+				authored.TotalInput)
+			fee := authored.TotalInput - txauthor.SumOutputValues(
+				authored.Tx.TxOut,
+			)
+			require.Equal(t, inputTarget-btcutil.Amount(output.Value), fee)
+
+			if tc.changeAmount == 0 {
+				// With no surplus, the result contains only the exact
+				// 50,000-sat payment and reports no change index.
+				require.Equal(t, -1, authored.ChangeIndex)
+				require.Len(t, authored.Tx.TxOut, 1)
+				require.Equal(t, output, *authored.Tx.TxOut[0])
+			} else {
+				// With a 10,000-sat surplus, the randomized change
+				// position must identify an output with that exact value
+				// and the change callback's script.
+				require.GreaterOrEqual(t, authored.ChangeIndex, 0)
+				require.Len(t, authored.Tx.TxOut, 2)
+				change := authored.Tx.TxOut[authored.ChangeIndex]
+				require.Equal(t, int64(tc.changeAmount), change.Value)
+				require.Equal(t, changeScript, change.PkScript)
+			}
+		})
+	}
+}
+
+// TestCreateTransactionDefaultPolicy verifies nil inputs still select from the
+// default account through the direct wrapper.
+func TestCreateTransactionDefaultPolicy(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Prepare a synced wallet whose default BIP0086 account has
+	// one mature 100,000-sat UTXO. The 99,700-sat payment leaves only a
+	// sub-dust remainder after fees, so no change output should be created.
+	w, mocks := createStartedWalletWithMocks(t)
+	mocks.syncer.On("syncState").Return(syncStateSynced).Once()
+	fixture := expectDefaultAuthoringSources(t, w, mocks)
+
+	// Act: Omit Inputs so CreateTransaction must install the default
+	// automatic-selection policy before preparing its sources.
+	authored, err := w.CreateTransaction(t.Context(), &TxIntent{
+		Outputs: []wire.TxOut{fixture.payment}, FeeRate: defaultFeeRate,
+	})
+
+	// Assert: The wrapper must select the fixture's sole UTXO, publish the
+	// exact 99,700-sat payment, and report -1 because no change survived.
+	require.NoError(t, err)
+	require.Equal(t, -1, authored.ChangeIndex)
+	require.Len(t, authored.Tx.TxIn, 1)
+	require.Equal(t, fixture.utxo.OutPoint,
+		authored.Tx.TxIn[0].PreviousOutPoint)
+	require.Len(t, authored.Tx.TxOut, 1)
+	require.Equal(t, fixture.payment, *authored.Tx.TxOut[0])
 }
 
 // TestCreateTransactionInvalidIntent tests that an error is returned when an


### PR DESCRIPTION
## Summary

Separate shared transaction construction from the direct-transaction and PSBT
public wrapper contracts.

`CreateTransaction` and `FundPsbt` use the same normalization, source
preparation, and authoring flow today. They deliberately invoke a private,
effect-neutral authoring boundary independently because their public contracts
will diverge: direct transaction creation owns direct change-watch delivery,
while PSBT funding owns PSBT decoration and publication together with its own
watched-change, lease, and cleanup obligations. If `FundPsbt` continued calling
the public `CreateTransaction` wrapper, direct-only effects added there would
leak into PSBT funding.

## Change Description

- Add one private authoring routine shared by the two public wrappers.
- Keep input and change source preparation at each wrapper boundary.
- Keep watch, lease, cleanup, finalization, and result publication out of the
  shared routine.
- Cover no-change, viable-change, source-error, cancellation, and callback
  behavior, plus direct and PSBT wrapper source preparation.
- Document the exact input, payment, change, and PSBT metadata expected by the
  wrapper tests.

Implements roadmap Task 425
