### PR TITLE
wallet: make account results wallet-owned

### DIFF
--- a/wallet/account_derive.go
+++ b/wallet/account_derive.go
@@ -6,11 +6,9 @@ package wallet
 
 import (
 	"context"
-	"encoding/binary"
 	"errors"
 	"fmt"
 
-	"github.com/btcsuite/btcd/address/v2"
 	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
@@ -192,7 +190,5 @@ func masterKeyFingerprint(masterKey *hdkeychain.ExtendedKey) (uint32, error) {
 		return 0, fmt.Errorf("master pubkey: %w", err)
 	}
 
-	hash := address.Hash160(pubKey.SerializeCompressed())
-
-	return binary.BigEndian.Uint32(hash[:4]), nil
+	return db.MasterKeyFingerprint(pubKey), nil
 }

--- a/wallet/account_info.go
+++ b/wallet/account_info.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+)
+
+// AccountInfo describes the public, wallet-owned snapshot of an account. Its
+// pointer and byte-slice fields are owned by the result and may be mutated by
+// the caller without affecting Store state or another result.
+type AccountInfo struct {
+	// AccountNumber is the BIP44 account index used for a derived account. A
+	// nil pointer means the account has no BIP44 number, while a non-nil zero
+	// identifies account zero.
+	AccountNumber *AccountNumber
+
+	// AccountName is the human-readable name of the account.
+	AccountName string
+
+	// IsImported reports whether the account was imported rather than
+	// derived from the wallet seed.
+	IsImported bool
+
+	// ExternalKeyCount is the number of external keys derived for the
+	// account.
+	ExternalKeyCount uint32
+
+	// InternalKeyCount is the number of internal change keys derived for the
+	// account.
+	InternalKeyCount uint32
+
+	// ImportedKeyCount is the number of individually imported keys reported
+	// for legacy account stores.
+	ImportedKeyCount uint32
+
+	// ConfirmedBalance is the account balance from confirmed transactions.
+	ConfirmedBalance btcutil.Amount
+
+	// UnconfirmedBalance is the account balance from unconfirmed
+	// transactions.
+	UnconfirmedBalance btcutil.Amount
+
+	// IsWatchOnly reports the wallet-level watch-only state associated with
+	// the account snapshot.
+	IsWatchOnly bool
+
+	// CreatedAt is the time the account was created. A zero time means the
+	// backing Store does not know the creation time.
+	CreatedAt time.Time
+
+	// KeyScope identifies the account's BIP43 purpose and BIP44 coin type.
+	KeyScope waddrmgr.KeyScope
+
+	// AddrSchema is the effective external and internal address schema for
+	// the account.
+	AddrSchema waddrmgr.ScopeAddrSchema
+
+	// PublicKey is the serialized account-level extended public key when the
+	// wallet knows that public material.
+	PublicKey []byte
+
+	// MasterKeyFingerprint is the BIP32 root fingerprint associated with the
+	// account public key. A nil pointer means it is absent, while a non-nil
+	// zero is a present-zero fingerprint.
+	MasterKeyFingerprint *MasterFingerprint
+}

--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -10,6 +10,7 @@
 package wallet
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -24,6 +25,7 @@ import (
 	"github.com/btcsuite/btcwallet/internal/zero"
 	"github.com/btcsuite/btcwallet/netparams"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/addresstype"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 )
 
@@ -115,26 +117,26 @@ type AccountManager interface {
 	// NewAccount creates a new account for a given key scope and name. The
 	// provided name must be unique within that key scope.
 	NewAccount(ctx context.Context, scope waddrmgr.KeyScope, name string) (
-		*db.AccountInfo, error)
+		*AccountInfo, error)
 
 	// ListAccounts returns a list of all accounts managed by the wallet.
-	ListAccounts(ctx context.Context) ([]db.AccountInfo, error)
+	ListAccounts(ctx context.Context) ([]AccountInfo, error)
 
 	// ListAccountsByScope returns a list of all accounts for a given key
 	// scope.
 	ListAccountsByScope(ctx context.Context, scope waddrmgr.KeyScope) (
-		[]db.AccountInfo, error)
+		[]AccountInfo, error)
 
 	// ListAccountsByName searches for accounts with the given name across
 	// all key scopes. Because names are not globally unique, this may
 	// return multiple results.
 	ListAccountsByName(ctx context.Context, name string) (
-		[]db.AccountInfo, error)
+		[]AccountInfo, error)
 
 	// GetAccount returns the snapshot for a specific account, looked up
 	// by its key scope and unique name within that scope.
 	GetAccount(ctx context.Context, scope waddrmgr.KeyScope, name string) (
-		*db.AccountInfo, error)
+		*AccountInfo, error)
 
 	// RenameAccount renames an existing account. To uniquely identify the
 	// account, the key scope must be provided. The new name must be unique
@@ -154,7 +156,7 @@ type AccountManager interface {
 	ImportAccount(ctx context.Context, name string,
 		accountKey *hdkeychain.ExtendedKey,
 		masterKeyFingerprint uint32, addrType waddrmgr.AddressType,
-		dryRun bool) (*db.AccountInfo, error)
+		dryRun bool) (*AccountInfo, error)
 }
 
 // A compile time check to ensure that Wallet implements the interface.
@@ -177,13 +179,74 @@ func (w *Wallet) canonicalStoreAccountInfo(
 	return storeInfo
 }
 
+// accountInfoFromStore converts one Store account snapshot into the public
+// wallet-owned result. Every pointer and byte slice in the result is copied so
+// callers cannot mutate Store-owned data or another independently converted
+// result.
+func (w *Wallet) accountInfoFromStore(
+	storeInfo *db.AccountInfo) (*AccountInfo, error) {
+
+	if storeInfo == nil {
+		return nil, errors.New("store account info is nil")
+	}
+
+	canonicalStoreInfo := w.canonicalStoreAccountInfo(*storeInfo)
+	storeInfo = &canonicalStoreInfo
+
+	externalAddrType, err := addresstype.ToWallet(
+		storeInfo.AddrSchema.ExternalAddrType, false,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("external account address schema: %w", err)
+	}
+
+	internalAddrType, err := addresstype.ToWallet(
+		storeInfo.AddrSchema.InternalAddrType, false,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("internal account address schema: %w", err)
+	}
+
+	var accountNumber *AccountNumber
+	if storeInfo.AccountNumber != nil {
+		number := AccountNumber(*storeInfo.AccountNumber)
+		accountNumber = &number
+	}
+
+	var masterFingerprint *MasterFingerprint
+	if storeInfo.MasterKeyFingerprint != nil {
+		fingerprint := MasterFingerprint(*storeInfo.MasterKeyFingerprint)
+		masterFingerprint = &fingerprint
+	}
+
+	return &AccountInfo{
+		AccountNumber:      accountNumber,
+		AccountName:        storeInfo.AccountName,
+		IsImported:         storeInfo.IsImported,
+		ExternalKeyCount:   storeInfo.ExternalKeyCount,
+		InternalKeyCount:   storeInfo.InternalKeyCount,
+		ImportedKeyCount:   storeInfo.ImportedKeyCount,
+		ConfirmedBalance:   storeInfo.ConfirmedBalance,
+		UnconfirmedBalance: storeInfo.UnconfirmedBalance,
+		IsWatchOnly:        storeInfo.IsWatchOnly,
+		CreatedAt:          storeInfo.CreatedAt,
+		KeyScope:           waddrmgr.KeyScope(storeInfo.KeyScope),
+		AddrSchema: waddrmgr.ScopeAddrSchema{
+			ExternalAddrType: externalAddrType,
+			InternalAddrType: internalAddrType,
+		},
+		PublicKey:            bytes.Clone(storeInfo.PublicKey),
+		MasterKeyFingerprint: masterFingerprint,
+	}, nil
+}
+
 // NewAccount creates the next account and returns its account info. The name
 // must be unique under the key scope. In order to support automatic seed
 // restoring, new accounts may not be created when all of the previous 100
 // accounts have no transaction history (this is a deviation from the BIP0044
 // spec, which allows no unused account gaps).
 func (w *Wallet) NewAccount(ctx context.Context, scope waddrmgr.KeyScope,
-	name string) (*db.AccountInfo, error) {
+	name string) (*AccountInfo, error) {
 
 	err := w.state.validateStarted()
 	if err != nil {
@@ -214,18 +277,16 @@ func (w *Wallet) NewAccount(ctx context.Context, scope waddrmgr.KeyScope,
 		return nil, err
 	}
 
-	canonicalInfo := w.canonicalStoreAccountInfo(*info)
-
-	return &canonicalInfo, nil
+	return w.accountInfoFromStore(info)
 }
 
-// propertiesToAccountInfo wraps a waddrmgr.AccountProperties + total
-// balance into the canonical db.AccountInfo shape the public wallet
-// API now exposes. The legacy waddrmgr path does not separate
-// confirmed/unconfirmed balances, so the supplied total is reported
-// on ConfirmedBalance; UnconfirmedBalance stays zero. For derived accounts,
-// wallet-level watch-only and master-fingerprint state takes precedence over
-// lock-state-dependent waddrmgr account properties.
+// propertiesToAccountInfo wraps a waddrmgr.AccountProperties + total balance
+// into the internal Store snapshot shape converted at the Wallet boundary.
+// The legacy waddrmgr path does not separate confirmed/unconfirmed balances,
+// so the supplied total is reported on ConfirmedBalance; UnconfirmedBalance
+// stays zero. For derived accounts, wallet-level watch-only and
+// master-fingerprint state takes precedence over lock-state-dependent
+// waddrmgr account properties.
 func propertiesToAccountInfo(props *waddrmgr.AccountProperties,
 	total btcutil.Amount, isImported bool, walletWatchOnly bool,
 	masterFingerprint uint32) db.AccountInfo {
@@ -293,7 +354,7 @@ func propertiesToAccountInfo(props *waddrmgr.AccountProperties,
 }
 
 // ListAccounts returns every account across all key scopes with its balance.
-func (w *Wallet) ListAccounts(ctx context.Context) ([]db.AccountInfo, error) {
+func (w *Wallet) ListAccounts(ctx context.Context) ([]AccountInfo, error) {
 	err := w.state.validateStarted()
 	if err != nil {
 		return nil, err
@@ -304,26 +365,36 @@ func (w *Wallet) ListAccounts(ctx context.Context) ([]db.AccountInfo, error) {
 	})
 }
 
-// listAccountInfos returns cache.ListAccounts snapshots with wallet-cached
-// master fingerprints injected for derived account rows.
+// listAccountInfos converts cache.ListAccounts snapshots into wallet-owned
+// results while preserving a nil Store slice.
 func (w *Wallet) listAccountInfos(ctx context.Context,
-	query db.ListAccountsQuery) ([]db.AccountInfo, error) {
+	query db.ListAccountsQuery) ([]AccountInfo, error) {
 
 	infos, err := w.cache.ListAccounts(ctx, query)
 	if err != nil {
 		return nil, err
 	}
 
-	for i := range infos {
-		infos[i] = w.canonicalStoreAccountInfo(infos[i])
+	if infos == nil {
+		return nil, nil
 	}
 
-	return infos, nil
+	results := make([]AccountInfo, len(infos))
+	for i := range infos {
+		result, err := w.accountInfoFromStore(&infos[i])
+		if err != nil {
+			return nil, err
+		}
+
+		results[i] = *result
+	}
+
+	return results, nil
 }
 
 // ListAccountsByScope returns all accounts for the given key scope.
 func (w *Wallet) ListAccountsByScope(ctx context.Context,
-	scope waddrmgr.KeyScope) ([]db.AccountInfo, error) {
+	scope waddrmgr.KeyScope) ([]AccountInfo, error) {
 
 	err := w.state.validateStarted()
 	if err != nil {
@@ -340,7 +411,7 @@ func (w *Wallet) ListAccountsByScope(ctx context.Context,
 
 // ListAccountsByName returns every account matching name across all scopes.
 func (w *Wallet) ListAccountsByName(ctx context.Context,
-	name string) ([]db.AccountInfo, error) {
+	name string) ([]AccountInfo, error) {
 
 	err := w.state.validateStarted()
 	if err != nil {
@@ -357,7 +428,7 @@ func (w *Wallet) ListAccountsByName(ctx context.Context,
 // The account snapshot, including the running balance, is fetched in a
 // single Store read.
 func (w *Wallet) GetAccount(ctx context.Context, scope waddrmgr.KeyScope,
-	name string) (*db.AccountInfo, error) {
+	name string) (*AccountInfo, error) {
 
 	err := w.state.validateStarted()
 	if err != nil {
@@ -381,9 +452,7 @@ func (w *Wallet) GetAccount(ctx context.Context, scope waddrmgr.KeyScope,
 		return nil, err
 	}
 
-	canonicalInfo := w.canonicalStoreAccountInfo(*info)
-
-	return &canonicalInfo, nil
+	return w.accountInfoFromStore(info)
 }
 
 // RenameAccount renames an existing account. The new name must be unique within
@@ -440,7 +509,7 @@ func (w *Wallet) RenameAccount(ctx context.Context,
 func (w *Wallet) ImportAccount(ctx context.Context,
 	name string, accountKey *hdkeychain.ExtendedKey,
 	masterKeyFingerprint uint32, addrType waddrmgr.AddressType,
-	dryRun bool) (*db.AccountInfo, error) {
+	dryRun bool) (*AccountInfo, error) {
 
 	err := w.state.validateStarted()
 	if err != nil {
@@ -457,7 +526,7 @@ func (w *Wallet) ImportAccount(ctx context.Context,
 func (w *Wallet) importAccountInternal(ctx context.Context,
 	name string, accountKey *hdkeychain.ExtendedKey,
 	masterKeyFingerprint uint32, addrType waddrmgr.AddressType,
-	dryRun bool) (*db.AccountInfo, error) {
+	dryRun bool) (*AccountInfo, error) {
 
 	err := validateExtendedPubKey(
 		accountKey, true, w.cfg.ChainParams,
@@ -501,7 +570,7 @@ func (w *Wallet) importAccountInternal(ctx context.Context,
 		return nil, err
 	}
 
-	return info, nil
+	return w.accountInfoFromStore(info)
 }
 
 // dbScopeAddrSchema converts a waddrmgr per-account address schema override

--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -160,6 +160,23 @@ type AccountManager interface {
 // A compile time check to ensure that Wallet implements the interface.
 var _ AccountManager = (*Wallet)(nil)
 
+// canonicalStoreAccountInfo returns an internal Store snapshot whose derived
+// account fingerprint comes from the Wallet cache. Legacy Store snapshots can
+// contain an absent, zero, or stale fingerprint, while w.masterFingerprint is
+// loaded from the wallet's master HD public key and is canonical.
+func (w *Wallet) canonicalStoreAccountInfo(
+	storeInfo db.AccountInfo) db.AccountInfo {
+
+	if storeInfo.IsImported {
+		return storeInfo
+	}
+
+	fingerprint := w.masterFingerprint
+	storeInfo.MasterKeyFingerprint = &fingerprint
+
+	return storeInfo
+}
+
 // NewAccount creates the next account and returns its account info. The name
 // must be unique under the key scope. In order to support automatic seed
 // restoring, new accounts may not be created when all of the previous 100
@@ -197,11 +214,9 @@ func (w *Wallet) NewAccount(ctx context.Context, scope waddrmgr.KeyScope,
 		return nil, err
 	}
 
-	if !info.IsImported {
-		info.MasterKeyFingerprint = w.masterFingerprint
-	}
+	canonicalInfo := w.canonicalStoreAccountInfo(*info)
 
-	return info, nil
+	return &canonicalInfo, nil
 }
 
 // propertiesToAccountInfo wraps a waddrmgr.AccountProperties + total
@@ -234,7 +249,17 @@ func propertiesToAccountInfo(props *waddrmgr.AccountProperties,
 
 	if isImported {
 		isWatchOnly = walletWatchOnly || props.IsWatchOnly
+
+		// Imported accounts are not derived from the wallet seed, so their
+		// waddrmgr fingerprint takes precedence over the cached seed value.
 		fingerprint = props.MasterKeyFingerprint
+	}
+
+	var fingerprintResult *uint32
+	// AccountPubKey distinguishes an imported XPub, whose fingerprint is
+	// present, from the keyless imported-address pseudo-account.
+	if !isImported || props.AccountPubKey != nil {
+		fingerprintResult = &fingerprint
 	}
 
 	scope := db.KeyScope(props.KeyScope)
@@ -262,7 +287,7 @@ func propertiesToAccountInfo(props *waddrmgr.AccountProperties,
 		KeyScope:             scope,
 		AddrSchema:           addrSchema,
 		PublicKey:            pubKey,
-		MasterKeyFingerprint: fingerprint,
+		MasterKeyFingerprint: fingerprintResult,
 		ConfirmedBalance:     total,
 	}
 }
@@ -290,9 +315,7 @@ func (w *Wallet) listAccountInfos(ctx context.Context,
 	}
 
 	for i := range infos {
-		if !infos[i].IsImported {
-			infos[i].MasterKeyFingerprint = w.masterFingerprint
-		}
+		infos[i] = w.canonicalStoreAccountInfo(infos[i])
 	}
 
 	return infos, nil
@@ -358,16 +381,9 @@ func (w *Wallet) GetAccount(ctx context.Context, scope waddrmgr.KeyScope,
 		return nil, err
 	}
 
-	// The kvdb store's default-account row carries fingerprint=0 for
-	// derived accounts because waddrmgr persists no per-account
-	// fingerprint there. Inject the wallet-cached value (parsed from
-	// the master HD pubkey at Manager.Load time) so external consumers
-	// see the canonical BIP32 root fingerprint.
-	if !info.IsImported {
-		info.MasterKeyFingerprint = w.masterFingerprint
-	}
+	canonicalInfo := w.canonicalStoreAccountInfo(*info)
 
-	return info, nil
+	return &canonicalInfo, nil
 }
 
 // RenameAccount renames an existing account. The new name must be unique within

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/address/v2"
 	"github.com/btcsuite/btcd/btcutil/v2"
@@ -20,6 +21,214 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+// TestAccountInfoFromStore verifies SQL and modern kvdb snapshots map every
+// public semantic field without exposing Store identity. The fixtures cover
+// absent, present-zero, and present-nonzero optional values, including a stale
+// derived fingerprint that must be replaced by the Wallet-cached value.
+func TestAccountInfoFromStore(t *testing.T) {
+	t.Parallel()
+
+	var (
+		storeAccountID        = uint32(91)
+		storeAccountZero      = uint32(0)
+		storeAccountSeven     = uint32(7)
+		storeFingerprintZero  = uint32(0)
+		storeFingerprintStale = uint32(0xfedcba98)
+		publicAccountZero     = AccountNumber(0)
+		publicAccountSeven    = AccountNumber(7)
+		publicFingerprintZero = MasterFingerprint(0)
+		publicFingerprintSet  = MasterFingerprint(0x01020304)
+	)
+
+	createdAt := time.Date(
+		2026, time.August, 15, 9, 30, 0, 0, time.UTC,
+	)
+	tests := []struct {
+		name              string
+		walletFingerprint uint32
+		store             db.AccountInfo
+		want              AccountInfo
+	}{
+		{
+			name: "sql present zero optionals",
+			store: db.AccountInfo{
+				AccountID:          &storeAccountID,
+				AccountNumber:      &storeAccountZero,
+				AccountName:        "sql derived",
+				ExternalKeyCount:   2,
+				InternalKeyCount:   3,
+				ImportedKeyCount:   4,
+				ConfirmedBalance:   btcutil.Amount(5),
+				UnconfirmedBalance: btcutil.Amount(6),
+				IsWatchOnly:        true,
+				CreatedAt:          createdAt,
+				KeyScope:           db.KeyScope{Purpose: 49, Coin: 0},
+				AddrSchema: db.ScopeAddrSchema{
+					ExternalAddrType: db.NestedWitnessPubKey,
+					InternalAddrType: db.WitnessPubKey,
+				},
+				PublicKey:            []byte{7, 8, 9},
+				MasterKeyFingerprint: &storeFingerprintZero,
+			},
+			want: AccountInfo{
+				AccountNumber:      &publicAccountZero,
+				AccountName:        "sql derived",
+				ExternalKeyCount:   2,
+				InternalKeyCount:   3,
+				ImportedKeyCount:   4,
+				ConfirmedBalance:   btcutil.Amount(5),
+				UnconfirmedBalance: btcutil.Amount(6),
+				IsWatchOnly:        true,
+				CreatedAt:          createdAt,
+				KeyScope:           waddrmgr.KeyScope{Purpose: 49, Coin: 0},
+				AddrSchema: waddrmgr.ScopeAddrSchema{
+					ExternalAddrType: waddrmgr.NestedWitnessPubKey,
+					InternalAddrType: waddrmgr.WitnessPubKey,
+				},
+				PublicKey:            []byte{7, 8, 9},
+				MasterKeyFingerprint: &publicFingerprintZero,
+			},
+		},
+		{
+			name: "modern kvdb absent optionals",
+			store: db.AccountInfo{
+				AccountID:          &storeAccountID,
+				AccountName:        "imported",
+				IsImported:         true,
+				ExternalKeyCount:   10,
+				InternalKeyCount:   11,
+				ImportedKeyCount:   12,
+				ConfirmedBalance:   btcutil.Amount(13),
+				UnconfirmedBalance: btcutil.Amount(14),
+				CreatedAt:          createdAt.Add(time.Hour),
+				KeyScope:           db.KeyScope{Purpose: 84, Coin: 1},
+				AddrSchema: db.ScopeAddrSchema{
+					ExternalAddrType: db.WitnessPubKey,
+					InternalAddrType: db.WitnessPubKey,
+				},
+			},
+			want: AccountInfo{
+				AccountName:        "imported",
+				IsImported:         true,
+				ExternalKeyCount:   10,
+				InternalKeyCount:   11,
+				ImportedKeyCount:   12,
+				ConfirmedBalance:   btcutil.Amount(13),
+				UnconfirmedBalance: btcutil.Amount(14),
+				CreatedAt:          createdAt.Add(time.Hour),
+				KeyScope:           waddrmgr.KeyScope{Purpose: 84, Coin: 1},
+				AddrSchema: waddrmgr.ScopeAddrSchema{
+					ExternalAddrType: waddrmgr.WitnessPubKey,
+					InternalAddrType: waddrmgr.WitnessPubKey,
+				},
+			},
+		},
+		{
+			name:              "modern kvdb ignores stale fingerprint",
+			walletFingerprint: uint32(publicFingerprintSet),
+			store: db.AccountInfo{
+				AccountID:          &storeAccountID,
+				AccountNumber:      &storeAccountSeven,
+				AccountName:        "kvdb derived",
+				ExternalKeyCount:   15,
+				InternalKeyCount:   16,
+				ImportedKeyCount:   17,
+				ConfirmedBalance:   btcutil.Amount(18),
+				UnconfirmedBalance: btcutil.Amount(19),
+				IsWatchOnly:        true,
+				CreatedAt:          createdAt.Add(2 * time.Hour),
+				KeyScope:           db.KeyScope{Purpose: 86, Coin: 1},
+				AddrSchema: db.ScopeAddrSchema{
+					ExternalAddrType: db.TaprootPubKey,
+					InternalAddrType: db.TaprootPubKey,
+				},
+				PublicKey:            []byte{20, 21, 22},
+				MasterKeyFingerprint: &storeFingerprintStale,
+			},
+			want: AccountInfo{
+				AccountNumber:      &publicAccountSeven,
+				AccountName:        "kvdb derived",
+				ExternalKeyCount:   15,
+				InternalKeyCount:   16,
+				ImportedKeyCount:   17,
+				ConfirmedBalance:   btcutil.Amount(18),
+				UnconfirmedBalance: btcutil.Amount(19),
+				IsWatchOnly:        true,
+				CreatedAt:          createdAt.Add(2 * time.Hour),
+				KeyScope:           waddrmgr.KeyScope{Purpose: 86, Coin: 1},
+				AddrSchema: waddrmgr.ScopeAddrSchema{
+					ExternalAddrType: waddrmgr.TaprootPubKey,
+					InternalAddrType: waddrmgr.TaprootPubKey,
+				},
+				PublicKey:            []byte{20, 21, 22},
+				MasterKeyFingerprint: &publicFingerprintSet,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			w := &Wallet{masterFingerprint: test.walletFingerprint}
+			got, err := w.accountInfoFromStore(&test.store)
+			require.NoError(t, err)
+			require.Equal(t, test.want, *got)
+		})
+	}
+}
+
+// TestAccountInfoFromStoreCopiesMutableFields verifies independently converted
+// results do not alias Store-owned optionals or public-key bytes.
+func TestAccountInfoFromStoreCopiesMutableFields(t *testing.T) {
+	t.Parallel()
+
+	accountNumber := uint32(2)
+	fingerprint := uint32(3)
+	store := db.AccountInfo{
+		AccountNumber: &accountNumber,
+		IsImported:    true,
+		AddrSchema: db.ScopeAddrSchema{
+			ExternalAddrType: db.WitnessPubKey,
+			InternalAddrType: db.WitnessPubKey,
+		},
+		PublicKey:            []byte{4, 5, 6},
+		MasterKeyFingerprint: &fingerprint,
+	}
+	w := &Wallet{}
+
+	first, err := w.accountInfoFromStore(&store)
+	require.NoError(t, err)
+	second, err := w.accountInfoFromStore(&store)
+	require.NoError(t, err)
+
+	*first.AccountNumber = AccountNumber(20)
+	*first.MasterKeyFingerprint = MasterFingerprint(30)
+	first.PublicKey[0] = 40
+
+	require.Equal(t, uint32(2), *store.AccountNumber)
+	require.Equal(t, uint32(3), *store.MasterKeyFingerprint)
+	require.Equal(t, []byte{4, 5, 6}, store.PublicKey)
+	require.Equal(t, AccountNumber(2), *second.AccountNumber)
+	require.Equal(t, MasterFingerprint(3), *second.MasterKeyFingerprint)
+	require.Equal(t, []byte{4, 5, 6}, second.PublicKey)
+}
+
+// TestAccountInfoFromStoreRejectsInvalidSchema verifies a malformed Store
+// schema fails conversion instead of producing a partial public result.
+func TestAccountInfoFromStoreRejectsInvalidSchema(t *testing.T) {
+	t.Parallel()
+
+	store := db.AccountInfo{AddrSchema: db.ScopeAddrSchema{
+		ExternalAddrType: db.Anchor,
+		InternalAddrType: db.WitnessPubKey,
+	}}
+
+	got, err := (&Wallet{}).accountInfoFromStore(&store)
+	require.ErrorContains(t, err, "external account address schema")
+	require.Nil(t, got)
+}
 
 // stubAccountDeriveFn holds the master-key material the test wallet's
 // buildAccountDeriveFn path consumes.

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -147,7 +147,8 @@ func TestPropertiesToAccountInfoLockedDerivedNotMisclassified(t *testing.T) {
 	require.Equal(t, uint32(7), *info.AccountNumber)
 	require.False(t, info.IsImported)
 	require.False(t, info.IsWatchOnly)
-	require.Equal(t, masterFingerprint, info.MasterKeyFingerprint)
+	require.NotNil(t, info.MasterKeyFingerprint)
+	require.Equal(t, masterFingerprint, *info.MasterKeyFingerprint)
 }
 
 // TestValidateExtendedPubKeyNil verifies that a nil account key is rejected
@@ -176,7 +177,7 @@ func TestPropertiesToAccountInfoImportedClassifiedAndMasked(t *testing.T) {
 	require.Nil(t, info.AccountNumber)
 	require.True(t, info.IsImported)
 	require.True(t, info.IsWatchOnly)
-	require.Equal(t, importedFingerprint, info.MasterKeyFingerprint)
+	require.Nil(t, info.MasterKeyFingerprint)
 }
 
 // TestListAccounts verifies ListAccounts returns account snapshots with the
@@ -203,10 +204,9 @@ func TestListAccounts(t *testing.T) {
 		WalletID: 0,
 	}).Return([]db.AccountInfo{
 		{
-			AccountNumber:        &accountNumber,
-			AccountName:          "default",
-			KeyScope:             bip84,
-			MasterKeyFingerprint: 0,
+			AccountNumber: &accountNumber,
+			AccountName:   "default",
+			KeyScope:      bip84,
 		},
 	}, nil).Once()
 
@@ -215,7 +215,8 @@ func TestListAccounts(t *testing.T) {
 
 	require.Len(t, accounts, 1)
 	require.Equal(t, "default", accounts[0].AccountName)
-	require.Equal(t, masterFP, accounts[0].MasterKeyFingerprint)
+	require.NotNil(t, accounts[0].MasterKeyFingerprint)
+	require.Equal(t, masterFP, *accounts[0].MasterKeyFingerprint)
 }
 
 // TestListAccountsByScope verifies the scope filter narrows the query.
@@ -358,10 +359,9 @@ func TestGetAccount(t *testing.T) {
 
 	// Seed a non-zero cached master fingerprint so the
 	// derived-account override path produces an observable value.
-	// The mocked store deliberately returns MasterKeyFingerprint: 0
-	// (matching what waddrmgr's default-account row carries for
-	// legacy derived rows) so the wallet-level override is what
-	// surfaces the value to the caller.
+	// The mocked store deliberately returns an absent fingerprint,
+	// matching a legacy derived row with no kvdb side-bucket entry,
+	// so the wallet-level fallback surfaces the value to the caller.
 	const masterFP uint32 = 0xDEADBEEF
 
 	w.masterFingerprint = masterFP
@@ -379,12 +379,11 @@ func TestGetAccount(t *testing.T) {
 		Scope:    dbScope,
 		Name:     &name,
 	}).Return(&db.AccountInfo{
-		AccountNumber:        &accountNumber,
-		AccountName:          name,
-		KeyScope:             dbScope,
-		ConfirmedBalance:     100,
-		UnconfirmedBalance:   23,
-		MasterKeyFingerprint: 0,
+		AccountNumber:      &accountNumber,
+		AccountName:        name,
+		KeyScope:           dbScope,
+		ConfirmedBalance:   100,
+		UnconfirmedBalance: 23,
 	}, nil).Once()
 
 	info, err := w.GetAccount(t.Context(), scope, name)
@@ -394,7 +393,8 @@ func TestGetAccount(t *testing.T) {
 	require.Equal(t, name, info.AccountName)
 	require.Equal(t, btcutil.Amount(100), info.ConfirmedBalance)
 	require.Equal(t, btcutil.Amount(23), info.UnconfirmedBalance)
-	require.Equal(t, masterFP, info.MasterKeyFingerprint)
+	require.NotNil(t, info.MasterKeyFingerprint)
+	require.Equal(t, masterFP, *info.MasterKeyFingerprint)
 }
 
 // TestGetAccountIncludesImportedPseudoAccount verifies that the AccountInfo
@@ -468,7 +468,9 @@ func TestNewAccount(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, account.AccountNumber)
 	require.Equal(t, uint32(1), *account.AccountNumber)
-	require.Equal(t, stub.masterKeyFingerprint, account.MasterKeyFingerprint)
+	require.NotNil(t, account.MasterKeyFingerprint)
+	require.Equal(t, stub.masterKeyFingerprint,
+		*account.MasterKeyFingerprint)
 
 	// Duplicate-name path.
 	expectAccountDeriveSetup(t, deps, stub)

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -216,7 +216,8 @@ func TestListAccounts(t *testing.T) {
 	require.Len(t, accounts, 1)
 	require.Equal(t, "default", accounts[0].AccountName)
 	require.NotNil(t, accounts[0].MasterKeyFingerprint)
-	require.Equal(t, masterFP, *accounts[0].MasterKeyFingerprint)
+	require.Equal(t, MasterFingerprint(masterFP),
+		*accounts[0].MasterKeyFingerprint)
 }
 
 // TestListAccountsByScope verifies the scope filter narrows the query.
@@ -389,12 +390,13 @@ func TestGetAccount(t *testing.T) {
 	info, err := w.GetAccount(t.Context(), scope, name)
 	require.NoError(t, err)
 	require.NotNil(t, info.AccountNumber)
-	require.Equal(t, uint32(1), *info.AccountNumber)
+	require.Equal(t, AccountNumber(1), *info.AccountNumber)
 	require.Equal(t, name, info.AccountName)
 	require.Equal(t, btcutil.Amount(100), info.ConfirmedBalance)
 	require.Equal(t, btcutil.Amount(23), info.UnconfirmedBalance)
 	require.NotNil(t, info.MasterKeyFingerprint)
-	require.Equal(t, masterFP, *info.MasterKeyFingerprint)
+	require.Equal(t, MasterFingerprint(masterFP),
+		*info.MasterKeyFingerprint)
 }
 
 // TestGetAccountIncludesImportedPseudoAccount verifies that the AccountInfo
@@ -467,9 +469,9 @@ func TestNewAccount(t *testing.T) {
 	account, err := w.NewAccount(t.Context(), scope, testAccountName)
 	require.NoError(t, err)
 	require.NotNil(t, account.AccountNumber)
-	require.Equal(t, uint32(1), *account.AccountNumber)
+	require.Equal(t, AccountNumber(1), *account.AccountNumber)
 	require.NotNil(t, account.MasterKeyFingerprint)
-	require.Equal(t, stub.masterKeyFingerprint,
+	require.Equal(t, MasterFingerprint(stub.masterKeyFingerprint),
 		*account.MasterKeyFingerprint)
 
 	// Duplicate-name path.
@@ -525,7 +527,7 @@ func TestNewAccountMissingHDSeedDefersToStore(t *testing.T) {
 	account, err := w.NewAccount(t.Context(), scope, testAccountName)
 	require.NoError(t, err)
 	require.NotNil(t, account.AccountNumber)
-	require.Equal(t, uint32(1), *account.AccountNumber)
+	require.Equal(t, AccountNumber(1), *account.AccountNumber)
 }
 
 // TestRenameAccount verifies RenameAccount routes through

--- a/wallet/internal/db/accountstore_accountinfo.go
+++ b/wallet/internal/db/accountstore_accountinfo.go
@@ -124,6 +124,24 @@ func optionalAccountNumber(accountNumber sql.NullInt64) (*uint32, error) {
 	return result, nil
 }
 
+// optionalMasterFingerprint converts a nullable SQL master fingerprint to a
+// pointer without collapsing an absent value into a present zero.
+func optionalMasterFingerprint(
+	masterFingerprint sql.NullInt64) (*uint32, error) {
+
+	var result *uint32
+	if masterFingerprint.Valid {
+		converted, err := Int64ToUint32(masterFingerprint.Int64)
+		if err != nil {
+			return nil, fmt.Errorf("master fingerprint: %w", err)
+		}
+
+		result = &converted
+	}
+
+	return result, nil
+}
+
 // getKeyCounts converts external, internal, and imported key counts from
 // int64 to uint32 and handles errors.
 func getKeyCounts(external, internal, imported int64) (uint32, uint32,
@@ -230,12 +248,9 @@ func AccountPropsRowToInfo[AddrTypeId ~int16 | ~int64](
 		return nil, fmt.Errorf("coin type: %w", err)
 	}
 
-	var fingerprint uint32
-	if row.MasterFingerprint.Valid {
-		fingerprint, err = Int64ToUint32(row.MasterFingerprint.Int64)
-		if err != nil {
-			return nil, fmt.Errorf("master fingerprint: %w", err)
-		}
+	fingerprint, err := optionalMasterFingerprint(row.MasterFingerprint)
+	if err != nil {
+		return nil, err
 	}
 
 	// Normalized SQL account rows track HD branch counters only. Individually
@@ -346,7 +361,7 @@ func BuildAccountInfo(accountID *uint32, accountNum *uint32,
 	isImported bool, externalKeyCount, internalKeyCount,
 	importedKeyCount uint32, isWatchOnly bool, createdAt time.Time,
 	scope KeyScope, addrSchema ScopeAddrSchema, publicKey []byte,
-	masterKeyFingerprint uint32,
+	masterKeyFingerprint *uint32,
 	confirmedBalance, unconfirmedBalance btcutil.Amount) *AccountInfo {
 
 	return &AccountInfo{
@@ -459,12 +474,9 @@ func AccountRowToInfo[AccOriginId ~int16 | ~int64](
 		return nil, err
 	}
 
-	var fingerprint uint32
-	if row.MasterFingerprint.Valid {
-		fingerprint, err = Int64ToUint32(row.MasterFingerprint.Int64)
-		if err != nil {
-			return nil, fmt.Errorf("master fingerprint: %w", err)
-		}
+	fingerprint, err := optionalMasterFingerprint(row.MasterFingerprint)
+	if err != nil {
+		return nil, err
 	}
 
 	addrSchema, err := DerivedAddressAccountSchema(

--- a/wallet/internal/db/accountstore_accountinfo_test.go
+++ b/wallet/internal/db/accountstore_accountinfo_test.go
@@ -38,6 +38,46 @@ func TestAccountRowToInfoPopulatesAddrSchema(t *testing.T) {
 	require.Equal(t, int64(42), info.rowID)
 }
 
+// TestOptionalMasterFingerprintPreservesPresence verifies SQL NULL and valid
+// values remain distinguishable, including a valid zero fingerprint.
+func TestOptionalMasterFingerprintPreservesPresence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value sql.NullInt64
+		want  *uint32
+	}{
+		{
+			name: "absent",
+		},
+		{
+			name:  "present zero",
+			value: sql.NullInt64{Valid: true},
+			want:  ptrUint32(0),
+		},
+		{
+			name: "present nonzero",
+			value: sql.NullInt64{
+				Int64: 42,
+				Valid: true,
+			},
+			want: ptrUint32(42),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := optionalMasterFingerprint(test.value)
+
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+		})
+	}
+}
+
 // TestScopeAddrSchemaFromWaddrmgr verifies legacy address-manager schemas are
 // converted into the database account schema shape.
 func TestScopeAddrSchemaFromWaddrmgr(t *testing.T) {

--- a/wallet/internal/db/accountstore_common.go
+++ b/wallet/internal/db/accountstore_common.go
@@ -2,9 +2,22 @@ package db
 
 import (
 	"database/sql"
+	"encoding/binary"
 	"errors"
 	"fmt"
+
+	"github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/btcec/v2"
 )
+
+// MasterKeyFingerprint returns the BIP32 fingerprint for a master public key.
+// The fingerprint is the first four bytes of the HASH160 of the compressed
+// public key, interpreted in big-endian byte order.
+func MasterKeyFingerprint(pubKey *btcec.PublicKey) uint32 {
+	hash := address.Hash160(pubKey.SerializeCompressed())
+
+	return binary.BigEndian.Uint32(hash[:4])
+}
 
 // MapGetAccountSecretErr returns the typed ErrAccountNotFound when err is
 // sql.ErrNoRows, describing the selector the caller queried by, and falls back

--- a/wallet/internal/db/accountstore_createderived.go
+++ b/wallet/internal/db/accountstore_createderived.go
@@ -257,10 +257,12 @@ func CreateDerivedAccountWithOps(ctx context.Context,
 		return nil, err
 	}
 
+	masterFingerprint := derived.MasterKeyFingerprint
+
 	return BuildAccountInfo(
 		accountID, &accNumber, params.Name, false, 0, 0, 0,
 		walletIsWatchOnly, row.CreatedAt, params.Scope, addrSchema,
-		derived.PublicKey, derived.MasterKeyFingerprint,
+		derived.PublicKey, &masterFingerprint,
 		0, 0,
 	), nil
 }

--- a/wallet/internal/db/accountstore_createimported_test.go
+++ b/wallet/internal/db/accountstore_createimported_test.go
@@ -58,7 +58,7 @@ func TestCreateImportedAccountWithOps(t *testing.T) {
 		KeyScope:             params.Scope,
 		AddrSchema:           ScopeAddrMap[params.Scope],
 		PublicKey:            params.PublicKey,
-		MasterKeyFingerprint: params.MasterFingerprint,
+		MasterKeyFingerprint: ptrUint32(params.MasterFingerprint),
 	}
 
 	ops := &mockCreateImportedAccountOps{}
@@ -101,7 +101,9 @@ func TestCreateImportedAccountWithOps(t *testing.T) {
 	require.Equal(t, createdAt, info.CreatedAt)
 	require.Equal(t, ScopeAddrMap[params.Scope], info.AddrSchema)
 	require.Equal(t, params.PublicKey, info.PublicKey)
-	require.Equal(t, params.MasterFingerprint, info.MasterKeyFingerprint)
+	require.NotNil(t, info.MasterKeyFingerprint)
+	require.Equal(t, params.MasterFingerprint,
+		*info.MasterKeyFingerprint)
 }
 
 // TestCreateImportedAccountWithOpsRejectsInvalidParams verifies the shared
@@ -175,7 +177,7 @@ func TestCreateImportedAccountWithOpsSkipsSecretInsertion(t *testing.T) {
 		KeyScope:             params.Scope,
 		AddrSchema:           ScopeAddrMap[params.Scope],
 		PublicKey:            params.PublicKey,
-		MasterKeyFingerprint: params.MasterFingerprint,
+		MasterKeyFingerprint: ptrUint32(params.MasterFingerprint),
 	}
 
 	ops := &mockCreateImportedAccountOps{}

--- a/wallet/internal/db/addressstore_common.go
+++ b/wallet/internal/db/addressstore_common.go
@@ -258,8 +258,13 @@ func convertAddressAccountMetadata[TypeID any](
 	KeyScope, error) {
 
 	if row.AccountProps != nil {
+		var masterFingerprint uint32
+		if row.AccountProps.MasterKeyFingerprint != nil {
+			masterFingerprint = *row.AccountProps.MasterKeyFingerprint
+		}
+
 		return row.AccountProps.AccountNumber, row.AccountProps.AccountName,
-			row.AccountProps.MasterKeyFingerprint,
+			masterFingerprint,
 			row.AccountProps.KeyScope, nil
 	}
 

--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -457,9 +457,10 @@ type AccountInfo struct {
 	PublicKey []byte
 
 	// MasterKeyFingerprint is the fingerprint of the root master key
-	// (BIP32 m/) corresponding to this account's public key. Used by
-	// some hardware wallets for proper identification and signing.
-	MasterKeyFingerprint uint32
+	// (BIP32 m/) corresponding to this account's public key. A nil pointer
+	// means the fingerprint is absent, while a non-nil zero is a
+	// present-zero fingerprint.
+	MasterKeyFingerprint *uint32
 
 	// rowID is the SQL backend's per-account row ID. Populated by
 	// ProcessAccountRows so AttachBalances can pair AccountBalancesByIDs

--- a/wallet/internal/db/itest/accountstore_getaccount_test.go
+++ b/wallet/internal/db/itest/accountstore_getaccount_test.go
@@ -118,7 +118,8 @@ func TestGetAccountReturnsPublicKeyAndFingerprint(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NotEmpty(t, derived.PublicKey)
-	require.NotZero(t, derived.MasterKeyFingerprint)
+	require.NotNil(t, derived.MasterKeyFingerprint)
+	require.NotZero(t, *derived.MasterKeyFingerprint)
 
 	derivedRead, err := store.GetAccount(
 		t.Context(), getAccountQueryByName(walletID, scope, "derived"),

--- a/wallet/internal/db/itest/addressstore_test.go
+++ b/wallet/internal/db/itest/addressstore_test.go
@@ -1980,8 +1980,9 @@ func TestNewDerivedAddress(t *testing.T) {
 			require.Equal(t, account.AccountNumber, info.AccountNumber)
 			require.Equal(t, account.AccountName, info.AccountName)
 			require.Equal(t, account.KeyScope, info.KeyScope)
+			require.NotNil(t, account.MasterKeyFingerprint)
 			require.Equal(
-				t, account.MasterKeyFingerprint,
+				t, *account.MasterKeyFingerprint,
 				info.MasterKeyFingerprint,
 			)
 		})

--- a/wallet/internal/db/kvdb/accountstore_createderived.go
+++ b/wallet/internal/db/kvdb/accountstore_createderived.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
@@ -236,8 +237,29 @@ func (o *createDerivedAccountOps) deriveAccountFromScopedKey(
 		return nil, fmt.Errorf("derive scoped account: %w", err)
 	}
 
+	masterPubKey, err := readMasterPubKey(o.mgr, o.ns)
+	if err != nil {
+		return nil, err
+	}
+
+	var fingerprint uint32
+	if len(masterPubKey) > 0 {
+		rootKey, err := hdkeychain.NewKeyFromString(string(masterPubKey))
+		if err != nil {
+			return nil, fmt.Errorf("parse master HD pubkey: %w", err)
+		}
+
+		rootPubKey, err := rootKey.ECPubKey()
+		if err != nil {
+			return nil, fmt.Errorf("master pubkey: %w", err)
+		}
+
+		fingerprint = db.MasterKeyFingerprint(rootPubKey)
+	}
+
 	return &db.DerivedAccountData{
-		PublicKey:           pubKey,
-		EncryptedPrivateKey: encPrivKey,
+		PublicKey:            pubKey,
+		EncryptedPrivateKey:  encPrivKey,
+		MasterKeyFingerprint: fingerprint,
 	}, nil
 }

--- a/wallet/internal/db/kvdb/accountstore_fingerprints_test.go
+++ b/wallet/internal/db/kvdb/accountstore_fingerprints_test.go
@@ -106,7 +106,8 @@ func TestCreateDerivedAccountPersistsMasterKeyFingerprint(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NotNil(t, info.AccountNumber)
-	require.Equal(t, testFingerprintValue, info.MasterKeyFingerprint)
+	require.NotNil(t, info.MasterKeyFingerprint)
+	require.Equal(t, testFingerprintValue, *info.MasterKeyFingerprint)
 
 	// Round-trip via Store.GetAccount — the value must come back
 	// from the side bucket, not from waddrmgr's row.
@@ -116,15 +117,14 @@ func TestCreateDerivedAccountPersistsMasterKeyFingerprint(t *testing.T) {
 		Name:  &name,
 	})
 	require.NoError(t, err)
-	require.Equal(t, testFingerprintValue, got.MasterKeyFingerprint)
+	require.NotNil(t, got.MasterKeyFingerprint)
+	require.Equal(t, testFingerprintValue, *got.MasterKeyFingerprint)
 }
 
 // TestLoadAccountInfoFallsBackOnMissingFingerprintRow verifies the
-// legacy-compatibility path: a derived account whose side-bucket entry
-// is missing reads back props.MasterKeyFingerprint (which is 0 for
-// waddrmgr default-account rows). The wallet-layer override is the
-// canonical compatibility fallback at the public boundary; this test
-// pins the store-layer behavior (returns 0 honestly).
+// legacy-compatibility path: a derived account whose side-bucket entry is
+// missing reports an absent fingerprint. The wallet-layer override is the
+// canonical compatibility fallback at the public boundary.
 func TestLoadAccountInfoFallsBackOnMissingFingerprintRow(t *testing.T) {
 	t.Parallel()
 
@@ -149,7 +149,8 @@ func TestLoadAccountInfoFallsBackOnMissingFingerprintRow(t *testing.T) {
 		deriveFn,
 	)
 	require.NoError(t, err)
-	require.Equal(t, testFingerprintValue, info.MasterKeyFingerprint)
+	require.NotNil(t, info.MasterKeyFingerprint)
+	require.Equal(t, testFingerprintValue, *info.MasterKeyFingerprint)
 
 	// Manually delete the side-bucket entry to simulate a legacy
 	// derived account that pre-dates the side bucket.
@@ -168,17 +169,14 @@ func TestLoadAccountInfoFallsBackOnMissingFingerprintRow(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Read back — store now returns 0 (waddrmgr's default-account
-	// row has no fingerprint). The wallet-layer override outside
-	// of kvdb backfills the cached master fingerprint at the
-	// public boundary.
+	// Read back. The Store preserves the missing side-bucket entry as an
+	// absent value so the Wallet boundary can apply its cached fallback
+	// without confusing absence with a present-zero fingerprint.
 	name := "fp-derived-fallback"
 	got, err := store.GetAccount(t.Context(), db.GetAccountQuery{
 		Scope: scope,
 		Name:  &name,
 	})
 	require.NoError(t, err)
-	require.Equal(t, uint32(0), got.MasterKeyFingerprint,
-		"missing side-bucket entry must fall back to waddrmgr's 0",
-	)
+	require.Nil(t, got.MasterKeyFingerprint)
 }

--- a/wallet/internal/db/kvdb/accountstore_getaccount.go
+++ b/wallet/internal/db/kvdb/accountstore_getaccount.go
@@ -207,20 +207,30 @@ func effectiveAddrSchema(scopeSchema waddrmgr.ScopeAddrSchema,
 // at the public boundary.
 func resolveMasterFingerprintForAccount(ns walletdb.ReadBucket,
 	scope waddrmgr.KeyScope,
-	props *waddrmgr.AccountProperties) (uint32, error) {
+	props *waddrmgr.AccountProperties,
+	accountIsImported bool) (*uint32, error) {
 
 	persisted, ok, err := getAccountMasterFingerprint(
 		ns, scope, props.AccountNumber,
 	)
 	if err != nil {
-		return 0, fmt.Errorf("read master fingerprint: %w", err)
+		return nil, fmt.Errorf("read master fingerprint: %w", err)
 	}
 
 	if ok {
-		return persisted, nil
+		return &persisted, nil
 	}
 
-	return props.MasterKeyFingerprint, nil
+	// Imported XPub accounts persist the importer-supplied fingerprint on
+	// their waddrmgr row. The keyless imported-address pseudo-account has no
+	// fingerprint, so keep it absent.
+	if accountIsImported && props.AccountPubKey != nil {
+		fingerprint := props.MasterKeyFingerprint
+
+		return &fingerprint, nil
+	}
+
+	return nil, nil //nolint:nilnil // Absence triggers the wallet fallback.
 }
 
 // loadAccountInfo materializes a db.AccountInfo from waddrmgr's
@@ -258,7 +268,7 @@ func loadAccountInfo(ns walletdb.ReadBucket,
 	}
 
 	fingerprint, err := resolveMasterFingerprintForAccount(
-		ns, scope, props,
+		ns, scope, props, accountIsImported,
 	)
 	if err != nil {
 		return nil, err

--- a/wallet/internal/db/kvdb/accountstore_test.go
+++ b/wallet/internal/db/kvdb/accountstore_test.go
@@ -433,7 +433,10 @@ func TestCreateDerivedAccount(t *testing.T) {
 	require.Equal(t, savingsAccountName, info.AccountName)
 	require.False(t, info.IsImported)
 	require.NotEmpty(t, info.PublicKey)
-	require.Equal(t, uint32(0xC0DEC0DE), info.MasterKeyFingerprint)
+	require.NotNil(t, info.MasterKeyFingerprint)
+	require.NotZero(t, *info.MasterKeyFingerprint)
+	require.NotNil(t, info.MasterKeyFingerprint)
+	require.Equal(t, uint32(0xC0DEC0DE), *info.MasterKeyFingerprint)
 
 	// A subsequent GetAccount must observe the new row.
 	name := savingsAccountName
@@ -561,6 +564,7 @@ func TestCreateDerivedAccountFallsBackToScopedKey(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, info.AccountNumber, read.AccountNumber)
+	require.Equal(t, info.MasterKeyFingerprint, read.MasterKeyFingerprint)
 }
 
 var errTestBoom = errors.New("kvdb test boom")
@@ -597,7 +601,8 @@ func TestCreateImportedAccount(t *testing.T) {
 	require.Equal(t, "imported-xpub", info.AccountName)
 	require.True(t, info.IsImported)
 	require.True(t, info.IsWatchOnly)
-	require.Equal(t, uint32(0xDEADBEEF), info.MasterKeyFingerprint)
+	require.NotNil(t, info.MasterKeyFingerprint)
+	require.Equal(t, uint32(0xDEADBEEF), *info.MasterKeyFingerprint)
 
 	// The imported xpub has no BIP44 number, but kvdb still populates the
 	// durable store AccountID from its internal waddrmgr account number, which
@@ -1330,5 +1335,6 @@ func TestCreateImportedAccountAllowsMultipleInScope(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, "bob-import", got.AccountName)
-	require.Equal(t, uint32(0xFEEDFACE), got.MasterKeyFingerprint)
+	require.NotNil(t, got.MasterKeyFingerprint)
+	require.Equal(t, uint32(0xFEEDFACE), *got.MasterKeyFingerprint)
 }

--- a/wallet/syncer.go
+++ b/wallet/syncer.go
@@ -2109,6 +2109,11 @@ func (s *syncer) storeScanAccount(info db.AccountInfo,
 		return storeScanAccount{}, err
 	}
 
+	var masterFingerprint uint32
+	if info.MasterKeyFingerprint != nil {
+		masterFingerprint = *info.MasterKeyFingerprint
+	}
+
 	return storeScanAccount{
 		props: &waddrmgr.AccountProperties{
 			AccountNumber:        recoveryKey,
@@ -2116,7 +2121,7 @@ func (s *syncer) storeScanAccount(info db.AccountInfo,
 			ExternalKeyCount:     info.ExternalKeyCount,
 			InternalKeyCount:     info.InternalKeyCount,
 			ImportedKeyCount:     info.ImportedKeyCount,
-			MasterKeyFingerprint: info.MasterKeyFingerprint,
+			MasterKeyFingerprint: masterFingerprint,
 			KeyScope:             waddrmgr.KeyScope(info.KeyScope),
 			IsWatchOnly:          info.IsWatchOnly,
 			AccountPubKey:        accountPubKey,

--- a/wallet/syncer_test.go
+++ b/wallet/syncer_test.go
@@ -2168,6 +2168,7 @@ func TestStoreScanHorizonsListAccounts(t *testing.T) {
 	)
 	accountNumber2 := uint32(2)
 	accountID := uint32(41)
+	masterFingerprint := uint32(9)
 
 	accounts := []db.AccountInfo{{
 		AccountID:            &accountID,
@@ -2176,7 +2177,7 @@ func TestStoreScanHorizonsListAccounts(t *testing.T) {
 		ExternalKeyCount:     5,
 		InternalKeyCount:     3,
 		ImportedKeyCount:     1,
-		MasterKeyFingerprint: 9,
+		MasterKeyFingerprint: &masterFingerprint,
 		KeyScope:             db.KeyScopeBIP0084,
 		IsWatchOnly:          true,
 	}}


### PR DESCRIPTION
## Summary

Make AccountManager results wallet-owned and publicly implementable.

## Change Description

Add wallet.AccountInfo, preserve optional account and fingerprint presence across SQL and kvdb, copy mutable result fields, and cover backend conversion behavior.

Implements roadmap Task 377