### PR TITLE
wallet: expose transaction status

### DIFF
--- a/wallet/internal/db/kvdb/txstore_test.go
+++ b/wallet/internal/db/kvdb/txstore_test.go
@@ -1274,6 +1274,7 @@ func TestGetTxDetailSuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, spend.Hash, detail.Hash)
 	require.Nil(t, detail.Block)
+	require.Equal(t, db.TxStatusPublished, detail.Status)
 	require.Len(t, detail.OwnedInputs, 1)
 	require.Len(t, detail.OwnedOutputs, 2)
 	require.Equal(t, funding.Hash, spend.MsgTx.TxIn[0].PreviousOutPoint.Hash)
@@ -1469,6 +1470,7 @@ func TestListTxDetailsCopiesMsgTx(t *testing.T) {
 	msgHashByDetailHash := make(map[chainhash.Hash]chainhash.Hash, len(details))
 	for _, detail := range details {
 		require.NotNil(t, detail.MsgTx)
+		require.Equal(t, db.TxStatusPublished, detail.Status)
 		msgHashByDetailHash[detail.Hash] = detail.MsgTx.TxHash()
 	}
 

--- a/wallet/tx_reader.go
+++ b/wallet/tx_reader.go
@@ -30,6 +30,11 @@ var (
 	// TxDetailInfo contract and omits the parsed transaction. Callers can
 	// match this error with errors.Is.
 	ErrNilTxDetailMsgTx = errors.New("tx detail MsgTx is nil")
+
+	// ErrInvalidTxStatus is returned when the store supplies a persisted
+	// transaction status that the public wallet API cannot represent. Callers
+	// can match this error with errors.Is.
+	ErrInvalidTxStatus = errors.New("invalid tx status")
 )
 
 // TxReader provides an interface for querying tx history.
@@ -300,12 +305,18 @@ func (w *Wallet) buildTxDetailFromStore(txDetails *db.TxDetailInfo,
 		return nil, ErrNilTxDetailMsgTx
 	}
 
+	status, err := txStatusFromDB(txDetails.Status)
+	if err != nil {
+		return nil, fmt.Errorf("convert tx status: %w", err)
+	}
+
 	msgTx := txDetails.MsgTx
 
 	details := buildBasicTxDetail(
 		txDetails.Hash, txDetails.SerializedTx, txDetails.Label,
 		txDetails.Received, msgTx,
 	)
+	details.Status = status
 
 	w.populateBlockDetails(details, txDetails.Block, currentHeight)
 	w.calculateValueAndFeeFromStore(details, txDetails, msgTx)
@@ -313,6 +324,32 @@ func (w *Wallet) buildTxDetailFromStore(txDetails *db.TxDetailInfo,
 	w.populatePrevOuts(details, msgTx, txDetails.OwnedInputs)
 
 	return details, nil
+}
+
+// txStatusFromDB converts the internal store status into the public wallet
+// status without coupling their enum values.
+func txStatusFromDB(status db.TxStatus) (TxStatus, error) {
+	switch status {
+	case db.TxStatusPending:
+		return TxStatusPending, nil
+
+	case db.TxStatusPublished:
+		return TxStatusPublished, nil
+
+	case db.TxStatusReplaced:
+		return TxStatusReplaced, nil
+
+	case db.TxStatusFailed:
+		return TxStatusFailed, nil
+
+	case db.TxStatusOrphaned:
+		return TxStatusOrphaned, nil
+
+	default:
+		return TxStatusUnknown, fmt.Errorf(
+			"%w: %d", ErrInvalidTxStatus, status,
+		)
+	}
 }
 
 // buildBasicTxDetail builds the common non-wallet-relative fields for one tx

--- a/wallet/tx_reader.go
+++ b/wallet/tx_reader.go
@@ -26,9 +26,10 @@ var (
 	// store.
 	ErrTxNotFound = errors.New("tx not found")
 
-	// errNilTxDetailMsgTx is returned when a store detail row violates the
-	// TxDetailInfo contract and omits the parsed transaction.
-	errNilTxDetailMsgTx = errors.New("tx detail MsgTx is nil")
+	// ErrNilTxDetailMsgTx is returned when a store detail row violates the
+	// TxDetailInfo contract and omits the parsed transaction. Callers can
+	// match this error with errors.Is.
+	ErrNilTxDetailMsgTx = errors.New("tx detail MsgTx is nil")
 )
 
 // TxReader provides an interface for querying tx history.
@@ -88,6 +89,71 @@ type BlockDetails struct {
 	Timestamp int64
 }
 
+// TxStatus describes the wallet-relative validity of a transaction.
+//
+// SQL-backed readers can return every persisted status because they retain
+// terminal transaction attempts for audit history. The kvdb backend only
+// returns TxStatusPending or TxStatusPublished because its legacy store does
+// not retain terminal attempts.
+type TxStatus uint8
+
+// txStatusUnknownString keeps unset and unsupported values on the same public
+// fallback representation.
+const txStatusUnknownString = "unknown"
+
+const (
+	// TxStatusUnknown identifies an unset or unrecognized public transaction
+	// status. Wallet readers do not return this status for a valid store row.
+	TxStatusUnknown TxStatus = iota
+
+	// TxStatusPending identifies a locally-authored transaction that the
+	// wallet has not published successfully.
+	TxStatusPending
+
+	// TxStatusPublished identifies a valid transaction observed by the
+	// wallet. Block distinguishes confirmed from unconfirmed transactions.
+	TxStatusPublished
+
+	// TxStatusReplaced identifies a transaction invalidated by an RBF
+	// replacement.
+	TxStatusReplaced
+
+	// TxStatusFailed identifies a transaction invalidated by a conflicting
+	// spend.
+	TxStatusFailed
+
+	// TxStatusOrphaned identifies a coinbase transaction disconnected from
+	// the best chain.
+	TxStatusOrphaned
+)
+
+// String returns the caller-facing name of the transaction status. Unmapped
+// values render as unknown instead of exposing an internal numeric code.
+func (s TxStatus) String() string {
+	switch s {
+	case TxStatusUnknown:
+		return txStatusUnknownString
+
+	case TxStatusPending:
+		return "pending"
+
+	case TxStatusPublished:
+		return "published"
+
+	case TxStatusReplaced:
+		return "replaced"
+
+	case TxStatusFailed:
+		return "failed"
+
+	case TxStatusOrphaned:
+		return "orphaned"
+
+	default:
+		return txStatusUnknownString
+	}
+}
+
 // TxDetail describes a tx relevant to a wallet. This is a flattened
 // and information-dense structure designed to be returned by the TxReader
 // interface.
@@ -127,6 +193,9 @@ type TxDetail struct {
 
 	// Block contains details of the block that includes this tx.
 	Block *BlockDetails
+
+	// Status is the wallet-relative validity state of the transaction.
+	Status TxStatus
 
 	// ReceivedTime is the time the tx was received by the wallet.
 	ReceivedTime time.Time
@@ -228,7 +297,7 @@ func (w *Wallet) buildTxDetailFromStore(txDetails *db.TxDetailInfo,
 	currentHeight int32) (*TxDetail, error) {
 
 	if txDetails.MsgTx == nil {
-		return nil, errNilTxDetailMsgTx
+		return nil, ErrNilTxDetailMsgTx
 	}
 
 	msgTx := txDetails.MsgTx

--- a/wallet/tx_reader_test.go
+++ b/wallet/tx_reader_test.go
@@ -19,6 +19,64 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestTxStatusString tests the caller-facing string form for every public
+// transaction status and for an unsupported numeric value.
+func TestTxStatusString(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name   string
+		status TxStatus
+		want   string
+	}{
+		{
+			name:   "unknown",
+			status: TxStatusUnknown,
+			want:   "unknown",
+		}, {
+			name:   "pending",
+			status: TxStatusPending,
+			want:   "pending",
+		}, {
+			name:   "published",
+			status: TxStatusPublished,
+			want:   "published",
+		}, {
+			name:   "replaced",
+			status: TxStatusReplaced,
+			want:   "replaced",
+		}, {
+			name:   "failed",
+			status: TxStatusFailed,
+			want:   "failed",
+		}, {
+			name:   "orphaned",
+			status: TxStatusOrphaned,
+			want:   "orphaned",
+		}, {
+			name:   "unsupported",
+			status: TxStatus(255),
+			want:   "unknown",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: Select the public status whose caller-facing form
+			// is under test.
+			status := tc.status
+
+			// Act: Render the status without exposing its numeric code.
+			result := status.String()
+
+			// Assert: Check the stable public status name.
+			require.Equal(t, tc.want, result)
+		})
+	}
+}
+
 // TestBuildTxDetailFromStore tests the detailed store-backed tx builder.
 func TestBuildTxDetailFromStore(t *testing.T) {
 	t.Parallel()
@@ -90,7 +148,7 @@ func TestBuildTxDetailFromStoreRequiresMsgTx(t *testing.T) {
 	_, err := w.buildTxDetailFromStore(txDetails, 1)
 
 	// Assert: Check that the contract violation is reported.
-	require.ErrorIs(t, err, errNilTxDetailMsgTx)
+	require.ErrorIs(t, err, ErrNilTxDetailMsgTx)
 }
 
 // TestGetTxPropagatesNilMsgTx tests that GetTx returns store detail contract
@@ -112,7 +170,7 @@ func TestGetTxPropagatesNilMsgTx(t *testing.T) {
 	_, err := w.GetTx(t.Context(), *TstTxHash)
 
 	// Assert: Check that the contract violation is propagated.
-	require.ErrorIs(t, err, errNilTxDetailMsgTx)
+	require.ErrorIs(t, err, ErrNilTxDetailMsgTx)
 }
 
 // TestListTxnsPropagatesNilMsgTx tests that ListTxns returns store detail
@@ -136,7 +194,7 @@ func TestListTxnsPropagatesNilMsgTx(t *testing.T) {
 	_, err := w.ListTxns(t.Context(), 0, 1000)
 
 	// Assert: Check that the contract violation is propagated.
-	require.ErrorIs(t, err, errNilTxDetailMsgTx)
+	require.ErrorIs(t, err, ErrNilTxDetailMsgTx)
 }
 
 // TestGetTxSuccess tests the GetTx method of the wallet for success scenarios.

--- a/wallet/tx_reader_test.go
+++ b/wallet/tx_reader_test.go
@@ -151,6 +151,24 @@ func TestBuildTxDetailFromStoreRequiresMsgTx(t *testing.T) {
 	require.ErrorIs(t, err, ErrNilTxDetailMsgTx)
 }
 
+// TestBuildTxDetailFromStoreRequiresValidStatus tests that unsupported store
+// statuses cannot silently convert to the public pending status.
+func TestBuildTxDetailFromStoreRequiresValidStatus(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a store detail row with an unsupported status.
+	minedDetails, _ := createMinedTxDetail(t)
+	txDetails := txDetailInfoFromLegacy(minedDetails)
+	txDetails.Status = db.TxStatus(255)
+	w, _ := createStartedWalletWithMocks(t)
+
+	// Act: Build the public detail from the malformed store row.
+	_, err := w.buildTxDetailFromStore(txDetails, 1)
+
+	// Assert: Check that the unsupported status fails closed.
+	require.ErrorIs(t, err, ErrInvalidTxStatus)
+}
+
 // TestGetTxPropagatesNilMsgTx tests that GetTx returns store detail contract
 // violations to callers.
 func TestGetTxPropagatesNilMsgTx(t *testing.T) {
@@ -243,6 +261,67 @@ func TestGetTxSuccess(t *testing.T) {
 	}
 }
 
+// TestGetTxStatus tests that GetTx preserves every persisted transaction
+// status through the wallet-owned public contract.
+func TestGetTxStatus(t *testing.T) {
+	t.Parallel()
+
+	// Keep the exhaustive store-to-wallet mapping in one test so a new
+	// database state cannot silently map to the public zero value.
+	testCases := []struct {
+		name       string
+		dbStatus   db.TxStatus
+		wantStatus TxStatus
+	}{
+		{
+			name:       "pending",
+			dbStatus:   db.TxStatusPending,
+			wantStatus: TxStatusPending,
+		}, {
+			name:       "published",
+			dbStatus:   db.TxStatusPublished,
+			wantStatus: TxStatusPublished,
+		}, {
+			name:       "replaced",
+			dbStatus:   db.TxStatusReplaced,
+			wantStatus: TxStatusReplaced,
+		}, {
+			name:       "failed",
+			dbStatus:   db.TxStatusFailed,
+			wantStatus: TxStatusFailed,
+		}, {
+			name:       "orphaned",
+			dbStatus:   db.TxStatusOrphaned,
+			wantStatus: TxStatusOrphaned,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: Mock one store detail with the selected status.
+			legacyDetails, _ := createUnminedTxDetail(t)
+			storeDetails := txDetailInfoFromLegacy(legacyDetails)
+			storeDetails.Status = tc.dbStatus
+			w, mocks := createStartedWalletWithMocks(t)
+			mocks.store.On(
+				"GetTxDetail", mock.Anything, db.GetTxDetailQuery{
+					WalletID: w.id,
+					Txid:     *TstTxHash,
+				},
+			).Return(storeDetails, nil).Once()
+
+			// Act: Get the transaction through the public wallet API.
+			details, err := w.GetTx(t.Context(), *TstTxHash)
+
+			// Assert: Check that the public status matches the store row.
+			require.NoError(t, err)
+			require.Equal(t, tc.wantStatus, details.Status)
+		})
+	}
+}
+
 // TestGetTxNotFound tests that GetTx returns the correct error when a
 // transaction is not found.
 func TestGetTxNotFound(t *testing.T) {
@@ -288,6 +367,64 @@ func TestListTxnsSuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, details, 1)
 	require.Equal(t, expectedTxDetail, details[0])
+}
+
+// TestListTxnsStatus tests that ListTxns preserves every persisted transaction
+// status through the wallet-owned public contract.
+func TestListTxnsStatus(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Build five listed store rows from one valid transaction
+	// fixture, assigning every persisted status once so one call exercises
+	// the complete list conversion path.
+	legacyDetails, _ := createUnminedTxDetail(t)
+	baseDetails := *txDetailInfoFromLegacy(legacyDetails)
+
+	pendingDetails := baseDetails
+	pendingDetails.Status = db.TxStatusPending
+
+	publishedDetails := baseDetails
+	publishedDetails.Status = db.TxStatusPublished
+
+	replacedDetails := baseDetails
+	replacedDetails.Status = db.TxStatusReplaced
+
+	failedDetails := baseDetails
+	failedDetails.Status = db.TxStatusFailed
+
+	orphanedDetails := baseDetails
+	orphanedDetails.Status = db.TxStatusOrphaned
+
+	storeDetails := []db.TxDetailInfo{
+		pendingDetails,
+		publishedDetails,
+		replacedDetails,
+		failedDetails,
+		orphanedDetails,
+	}
+
+	w, mocks := createStartedWalletWithMocks(t)
+	mocks.store.On(
+		"ListTxDetails", mock.Anything, db.ListTxDetailsQuery{
+			WalletID:    w.id,
+			StartHeight: 0,
+			EndHeight:   1000,
+		},
+	).Return(storeDetails, nil).Once()
+
+	// Act: List every transaction through one public wallet call.
+	details, err := w.ListTxns(t.Context(), 0, 1000)
+
+	// Assert: Check that every returned row preserves its corresponding
+	// persisted status in order.
+	require.NoError(t, err)
+	require.Len(t, details, len(storeDetails))
+
+	require.Equal(t, TxStatusPending, details[0].Status)
+	require.Equal(t, TxStatusPublished, details[1].Status)
+	require.Equal(t, TxStatusReplaced, details[2].Status)
+	require.Equal(t, TxStatusFailed, details[3].Status)
+	require.Equal(t, TxStatusOrphaned, details[4].Status)
 }
 
 // createUnminedTxDetail creates a test transaction that sends funds from the
@@ -392,6 +529,7 @@ func createUnminedTxDetail(t *testing.T) (*wtxmgr.TxDetails, *TxDetail) {
 		Hash:          *TstTxHash,
 		RawTx:         TstSerializedTx,
 		Label:         testLabel,
+		Status:        TxStatusPublished,
 		Value:         totalCredits - debitAmt,
 		Fee:           fee,
 		FeeRate:       btcunit.CalcSatPerVByte(fee, weight.ToVB()),
@@ -457,6 +595,7 @@ func txDetailInfoFromLegacy(details *wtxmgr.TxDetails) *db.TxDetailInfo {
 		SerializedTx: details.SerializedTx,
 		Received:     details.Received,
 		Block:        block,
+		Status:       db.TxStatusPublished,
 		Label:        details.Label,
 		OwnedInputs:  ownedInputs,
 		OwnedOutputs: ownedOutputs,


### PR DESCRIPTION
## Summary

- Expose wallet-owned transaction validity through the public TxReader API.
- Preserve SQL terminal audit history while documenting the narrower kvdb result.

## Change Description

- Add TxStatus and populate TxDetail.Status through one centralized conversion.
- Table-test pending, published, failed, replaced, and orphaned SQL states.
- Verify kvdb reports only its retained pending and published facts.
- Implements roadmap Task 339