### PR TITLE
wallet: translate load not-found errors

### DIFF
--- a/itest/manager_test.go
+++ b/itest/manager_test.go
@@ -214,11 +214,19 @@ func testManagerLoadReload(h *bwtest.HarnessTest) {
 // testManagerLoadMissing verifies that loading a wallet that was never created
 // fails rather than silently returning an empty wallet.
 func testManagerLoadMissing(h *bwtest.HarnessTest) {
+	// Arrange a manager whose durable store has never contained the named
+	// wallet from the standard test configuration.
 	cfg, _ := h.TestWalletConfig()
-
 	manager := h.NewWalletManager()
-	_, err := manager.Load(cfg)
-	require.Error(h, err, "load of never-created wallet should fail")
+
+	// Act by asking the manager to load the never-created wallet.
+	w, err := manager.Load(cfg)
+
+	// Assert that the public missing-wallet contract is returned without a
+	// partially assembled wallet.
+	require.ErrorIs(h, err, wallet.ErrWalletNotFound,
+		"load of never-created wallet should report wallet not found")
+	require.Nil(h, w, "load of never-created wallet should return no wallet")
 }
 
 // testManagerCreateWatchOnly verifies that a watch-only wallet is created,

--- a/wallet/internal/db/kvdb/driver_test.go
+++ b/wallet/internal/db/kvdb/driver_test.go
@@ -5,31 +5,69 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/stretchr/testify/require"
 )
 
-// TestOpenStoreUninitializedDB verifies that opening a database with no
-// waddrmgr namespace fails without closing it: the Manager owns the physical
+// TestOpenStoreUninitializedDB verifies that opening a pristine database
+// reports a missing wallet without closing it: the Manager owns the physical
 // handle, so a failed open must leave it usable for the caller to close.
 func TestOpenStoreUninitializedDB(t *testing.T) {
 	t.Parallel()
 
+	// Arrange a pristine caller-owned database with neither wallet
+	// namespace initialized.
 	dbConn, cleanup := newTestDB(t)
 	t.Cleanup(cleanup)
 
-	_, _, err := OpenStore(Config{
+	// Act by opening the same pristine database twice. The second call
+	// distinguishes a caller-owned handle from one closed by the first
+	// failed open.
+	_, _, firstErr := OpenStore(Config{
 		DB:          dbConn,
 		ChainParams: &chaincfg.MainNetParams,
 	})
-	require.ErrorIs(t, err, errMissingAddrmgrNamespace)
+	_, _, secondErr := OpenStore(Config{
+		DB:          dbConn,
+		ChainParams: &chaincfg.MainNetParams,
+	})
 
-	// The handle is still ours: a second attempt reaches the same failure
-	// rather than a closed-database error.
+	// Assert that both opens report an absent wallet, proving the first
+	// failure left the caller-owned database usable.
+	require.ErrorIs(t, firstErr, db.ErrWalletNotFound)
+	require.ErrorIs(t, secondErr, db.ErrWalletNotFound)
+}
+
+// TestOpenStoreIncompleteWallet verifies that a partially initialized wallet
+// remains a backend error instead of being classified as an absent wallet.
+func TestOpenStoreIncompleteWallet(t *testing.T) {
+	t.Parallel()
+
+	// Arrange a database containing only the address-manager namespace. This
+	// lone namespace models partial or corrupt wallet state rather than a
+	// wallet that was never created.
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	err := walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		_, err := tx.CreateTopLevelBucket(waddrmgr.NamespaceKey)
+
+		return err
+	})
+	require.NoError(t, err, "failed to construct incomplete wallet state")
+
+	// Act by asking the kvdb adapter to open the incomplete wallet state.
 	_, _, err = OpenStore(Config{
 		DB:          dbConn,
 		ChainParams: &chaincfg.MainNetParams,
 	})
-	require.ErrorIs(t, err, errMissingAddrmgrNamespace)
+
+	// Assert that the missing transaction-manager namespace remains a
+	// backend error and is not collapsed into the absent-wallet sentinel.
+	require.ErrorIs(t, err, errMissingTxmgrNamespace)
+	require.NotErrorIs(t, err, db.ErrWalletNotFound)
 }
 
 // TestCreateWalletThenOpenStore verifies the create/open round trip on one

--- a/wallet/internal/db/kvdb/lifecycle.go
+++ b/wallet/internal/db/kvdb/lifecycle.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/walletdb/migration"
 	"github.com/btcsuite/btcwallet/wtxmgr"
@@ -79,11 +80,16 @@ func OpenStore(cfg Config) (*Store, *waddrmgr.Manager, error) {
 
 	err := walletdb.Update(cfg.DB, func(tx walletdb.ReadWriteTx) error {
 		addrMgrBucket := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+		txMgrBucket := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+
+		if addrMgrBucket == nil && txMgrBucket == nil {
+			return db.ErrWalletNotFound
+		}
+
 		if addrMgrBucket == nil {
 			return errMissingAddrmgrNamespace
 		}
 
-		txMgrBucket := tx.ReadWriteBucket(wtxmgrNamespaceKey)
 		if txMgrBucket == nil {
 			return errMissingTxmgrNamespace
 		}

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -11,9 +11,12 @@ import (
 	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 )
 
 var (
+	// ErrWalletNotFound is returned when a wallet is not found by Manager.Load.
+	ErrWalletNotFound = errors.New("wallet not found")
 
 	// ErrWalletParams is returned when the creation parameters are invalid.
 	ErrWalletParams = errors.New("invalid wallet params")
@@ -368,7 +371,8 @@ func validateInitialAccountKeys(accounts []WatchOnlyAccount) error {
 
 // Load loads an existing wallet from the provided configuration. It opens the
 // database, initializes the wallet structure, and registers it with the manager
-// for tracking.
+// for tracking. If the named wallet does not exist, Load returns
+// ErrWalletNotFound.
 func (m *Manager) Load(cfg Config) (*Wallet, error) {
 	// The Manager owns the network for every wallet it serves; see Create.
 	cfg.ChainParams = m.chainParams
@@ -390,6 +394,14 @@ func (m *Manager) Load(cfg Config) (*Wallet, error) {
 
 	data, err := m.backend.load(context.Background(), cfg)
 	if err != nil {
+		// Hide the database sentinel at the public Manager boundary while
+		// retaining the requested wallet name for caller diagnostics.
+		if errors.Is(err, db.ErrWalletNotFound) {
+			return nil, fmt.Errorf(
+				"wallet %q: %w", cfg.Name, ErrWalletNotFound,
+			)
+		}
+
 		return nil, err
 	}
 

--- a/wallet/manager_sqlite_test.go
+++ b/wallet/manager_sqlite_test.go
@@ -47,25 +47,27 @@ func TestManagerCreateUsesCommittedWalletRow(t *testing.T) {
 	require.Equal(t, uint32(7), w.ID())
 }
 
-// TestManagerLoadSQLiteRequiresWalletRow verifies that loading a name with no
-// SQLite wallet row surfaces the not-found error through the public Manager
-// API rather than assembling a Wallet over an absent row.
-func TestManagerLoadSQLiteRequiresWalletRow(t *testing.T) {
+// TestManagerLoadPreservesBackendFailure verifies that a non-not-found SQL
+// backend failure is not reclassified as a missing wallet.
+func TestManagerLoadPreservesBackendFailure(t *testing.T) {
 	t.Parallel()
 
-	m, err := NewManager(t.Context(), ManagerConfig{
-		Backend:     DBBackendSQLite,
-		DataSource:  filepath.Join(t.TempDir(), "runtime.sqlite"),
-		ChainParams: &chainParams,
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = m.Close() })
+	// Arrange a SQL manager whose wallet lookup returns an unrelated
+	// backend sentinel instead of the database not-found classification.
+	cfg, _ := sqliteCreateConfig(t)
+	store := &walletmock.Store{}
+	t.Cleanup(func() { store.AssertExpectations(t) })
 
-	w, err := m.Load(Config{
-		Chain: &bwmock.Chain{},
-		Name:  "no-such-wallet",
-	})
-	require.ErrorIs(t, err, db.ErrWalletNotFound)
+	store.On("GetWallet", mock.Anything, cfg.Name).
+		Return(nil, errDBMock).Once()
+
+	// Act by loading the wallet through the public Manager boundary.
+	w, err := testSQLManager(t, store).Load(cfg)
+
+	// Assert that the original backend failure remains discoverable and is
+	// not replaced with the public missing-wallet sentinel.
+	require.ErrorIs(t, err, errDBMock)
+	require.NotErrorIs(t, err, ErrWalletNotFound)
 	require.Nil(t, w)
 }
 

--- a/wallet/manager_test.go
+++ b/wallet/manager_test.go
@@ -528,9 +528,12 @@ func TestManagerLoadError(t *testing.T) {
 		require.Nil(t, w)
 	})
 
-	t.Run("Uninitialized DB", func(t *testing.T) {
+	t.Run("Missing Wallet", func(t *testing.T) {
 		t.Parallel()
 
+		// Arrange a fresh kvdb-backed Manager whose database has never
+		// contained wallet state. This distinguishes absence from a
+		// partially initialized or corrupt wallet.
 		m := testKVDBManager(t)
 		cfg := Config{
 			Chain:       &bwmock.Chain{},
@@ -538,16 +541,42 @@ func TestManagerLoadError(t *testing.T) {
 			Name:        "test",
 		}
 
-		// Attempt to load from a database that has valid buckets but no
-		// wallet data (waddrmgr is not initialized). This should fail
-		// at the database loading step.
+		// Act by loading the never-created wallet through the public
+		// Manager boundary.
 		w, err := m.Load(cfg)
 
-		// We expect an error from waddrmgr.Open indicating the address
-		// manager namespace is missing or invalid.
-		require.Error(t, err)
+		// Assert that the Manager replaces the internal database sentinel
+		// with its public missing-wallet contract and returns no partial
+		// Wallet.
+		require.ErrorIs(t, err, ErrWalletNotFound)
+		require.NotErrorIs(t, err, db.ErrWalletNotFound)
 		require.Nil(t, w)
 	})
+}
+
+// TestManagerLoadMissingSQLite verifies that a real SQLite wallet miss obeys
+// the public Manager contract without exposing its internal database sentinel.
+func TestManagerLoadMissingSQLite(t *testing.T) {
+	t.Parallel()
+
+	// Arrange a Manager over a fresh real SQLite database with a wallet name
+	// that has never been created.
+	m := testSQLiteManager(t)
+
+	const walletName = "no-such-wallet"
+
+	// Act by loading the absent wallet through the public Manager method.
+	w, err := m.Load(Config{
+		Chain: &bwmock.Chain{},
+		Name:  walletName,
+	})
+
+	// Assert that callers receive only the wallet-owned sentinel, retain the
+	// requested name for context, and never receive a partial Wallet.
+	require.ErrorIs(t, err, ErrWalletNotFound)
+	require.NotErrorIs(t, err, db.ErrWalletNotFound)
+	require.ErrorContains(t, err, walletName)
+	require.Nil(t, w)
 }
 
 // TestManagerString verifies that the String representation of the Manager


### PR DESCRIPTION
## Summary

Implements roadmap Task 379

## Change Description

- Expose wallet-owned `ErrWalletNotFound` from `Manager.Load`.
- Translate SQLite and pristine-kvdb misses without leaking the database
  sentinel.
- Preserve other backend errors and add public-boundary regression coverage.
