### PR TITLE
wallet: translate missing address errors

### DIFF
--- a/wallet/address_manager.go
+++ b/wallet/address_manager.go
@@ -46,6 +46,10 @@ var (
 	// script.
 	ErrDerivationPathNotFound = errors.New("derivation path not found")
 
+	// ErrAddressNotFound is returned when an address is not known to the
+	// wallet.
+	ErrAddressNotFound = errors.New("address not found")
+
 	// ErrUnknownAddrType is an error returned when a wallet function is
 	// called with an unknown address type.
 	ErrUnknownAddrType = errors.New("unknown address type")
@@ -186,7 +190,8 @@ type AddressManager interface {
 		address.Address, error)
 
 	// GetAddressInfo returns detailed information about a managed address. If
-	// the address is not known to the wallet, an error is returned.
+	// the address is not known to the wallet, the returned error wraps
+	// ErrAddressNotFound for errors.Is matching.
 	GetAddressInfo(ctx context.Context, a address.Address) (AddressInfo, error)
 
 	// ListAddresses lists all addresses for a given account, including
@@ -680,7 +685,9 @@ func nextUnusedStoreAddress(storeAddr db.AddressInfo,
 	return addr, true, nil
 }
 
-// GetAddressInfo returns detailed information regarding a wallet address.
+// GetAddressInfo returns detailed information regarding a wallet address. If
+// the address is not known to the wallet, the returned error wraps
+// ErrAddressNotFound for errors.Is matching.
 func (w *Wallet) GetAddressInfo(ctx context.Context, a address.Address) (
 	AddressInfo, error) {
 
@@ -701,6 +708,14 @@ func (w *Wallet) GetAddressInfo(ctx context.Context, a address.Address) (
 		},
 	)
 	if err != nil {
+		// Store implementations normalize backend-specific misses before
+		// this boundary. Translate only that normalized form so raw legacy
+		// manager errors remain unexpected errors.
+		if errors.Is(err, db.ErrAddressNotFound) {
+			return AddressInfo{}, fmt.Errorf("%w: addr=%v",
+				ErrAddressNotFound, a)
+		}
+
 		return AddressInfo{}, err
 	}
 

--- a/wallet/address_manager_test.go
+++ b/wallet/address_manager_test.go
@@ -707,6 +707,92 @@ func TestGetAddressInfo(t *testing.T) {
 	require.Equal(t, waddrmgr.WitnessPubKey, intInfo.AddrType)
 }
 
+// TestGetAddressInfoMapsNotFound verifies that a Store address miss exposes
+// only the wallet-owned public sentinel with address context.
+func TestGetAddressInfoMapsNotFound(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: configure the existing Store mock to return its normalized
+	// not-found sentinel for a valid address lookup.
+	w, deps := createStartedWalletWithMocks(t)
+	addr, err := address.NewAddressWitnessPubKeyHash(
+		make([]byte, 20), w.cfg.ChainParams,
+	)
+	require.NoError(t, err)
+
+	scriptPubKey, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	deps.store.On("GetAddress", mock.Anything, db.GetAddressQuery{
+		WalletID:     w.id,
+		ScriptPubKey: scriptPubKey,
+	}).Return((*db.AddressInfo)(nil), db.ErrAddressNotFound).Once()
+
+	// Act: look up the unknown address through the wallet-owned API
+	// boundary.
+	_, err = w.GetAddressInfo(t.Context(), addr)
+
+	// Assert: callers see the wallet sentinel and address context without
+	// inheriting the Store sentinel.
+	require.ErrorIs(t, err, ErrAddressNotFound)
+	require.ErrorContains(t, err, addr.String())
+	require.NotErrorIs(t, err, db.ErrAddressNotFound)
+}
+
+// TestGetAddressInfoPreservesStoreError verifies that an unexpected Store
+// failure retains its identity and is not promoted to the public not-found
+// contract.
+func TestGetAddressInfoPreservesStoreError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: configure the existing Store mock to return an unexpected
+	// error for an otherwise valid address query.
+	w, deps := createStartedWalletWithMocks(t)
+	addr, err := address.NewAddressWitnessPubKeyHash(
+		make([]byte, 20), w.cfg.ChainParams,
+	)
+	require.NoError(t, err)
+
+	scriptPubKey, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	deps.store.On("GetAddress", mock.Anything, db.GetAddressQuery{
+		WalletID:     w.id,
+		ScriptPubKey: scriptPubKey,
+	}).Return((*db.AddressInfo)(nil), errDBMock).Once()
+
+	// Act: pass the Store failure through the address lookup boundary.
+	_, err = w.GetAddressInfo(t.Context(), addr)
+
+	// Assert: the original error remains discoverable and is not
+	// reclassified as an address miss.
+	require.ErrorIs(t, err, errDBMock)
+	require.NotErrorIs(t, err, ErrAddressNotFound)
+}
+
+// TestGetAddressInfoRejectsInvalidAddress verifies that address-to-script
+// failures remain distinct from a wallet ownership miss and never reach the
+// Store.
+func TestGetAddressInfoRejectsInvalidAddress(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: use a typed nil address that cannot be converted to a
+	// script, together with the existing Store mock.
+	w, deps := createStartedWalletWithMocks(t)
+
+	var addr *address.AddressPubKeyHash
+
+	// Act: attempt the lookup before any Store query can be built.
+	_, err := w.GetAddressInfo(t.Context(), addr)
+
+	// Assert: the script-conversion error remains distinct from a wallet
+	// miss, and the Store was never queried.
+	require.Error(t, err)
+	require.ErrorContains(t, err, "pay to addr script")
+	require.NotErrorIs(t, err, ErrAddressNotFound)
+	deps.store.AssertNotCalled(t, "GetAddress", mock.Anything, mock.Anything)
+}
+
 // TestGetDerivationInfoExternalAddressSuccess tests that we can successfully
 // get the derivation info for an external address.
 func TestGetDerivationInfoExternalAddressSuccess(t *testing.T) {

--- a/wallet/internal/db/kvdb/addressstore_test.go
+++ b/wallet/internal/db/kvdb/addressstore_test.go
@@ -335,6 +335,48 @@ func TestGetAddressBareMultisigReturnsNotFound(t *testing.T) {
 	require.ErrorIs(t, err, db.ErrAddressNotFound)
 }
 
+// TestGetAddressUnknownStandardAddressReturnsNotFound verifies that a valid
+// standard script for an unowned address reaches the legacy manager lookup and
+// returns only the Store-owned address-miss sentinel.
+func TestGetAddressUnknownStandardAddressReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: build a real legacy-backed Store, then encode a standard
+	// witness address from a fresh key that was never imported into it. This
+	// keeps script extraction successful so the lookup reaches waddrmgr.
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	addrStore := newSpendableAddrMgr(t, dbConn)
+	store := NewStore(dbConn, nil, addrStore)
+
+	foreignKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	foreignAddr, err := address.NewAddressWitnessPubKeyHash(
+		address.Hash160(foreignKey.PubKey().SerializeCompressed()),
+		addrStore.ChainParams(),
+	)
+	require.NoError(t, err)
+
+	foreignScript, err := txscript.PayToAddrScript(foreignAddr)
+	require.NoError(t, err)
+
+	// Act: resolve the valid but unowned script through the modern kvdb Store
+	// boundary, which must normalize the legacy manager miss.
+	_, err = store.GetAddress(t.Context(), db.GetAddressQuery{
+		WalletID:     0,
+		ScriptPubKey: foreignScript,
+	})
+
+	// Assert: callers can classify the Store sentinel without inheriting the
+	// backend-specific waddrmgr.ManagerError in the error chain.
+	require.ErrorIs(t, err, db.ErrAddressNotFound)
+
+	var managerErr waddrmgr.ManagerError
+	require.NotErrorAs(t, err, &managerErr)
+}
+
 // TestAddressStoreResolveOwnedAddresses verifies that the batched resolver
 // returns only the wallet-owned subset of a mixed script set in a single
 // transaction, omits scripts that are not owned, and treats an empty input as

--- a/wallet/signer.go
+++ b/wallet/signer.go
@@ -1246,7 +1246,7 @@ func (w *Wallet) privKeyForAddress(ctx context.Context,
 
 		return w.resolveImportedAddrPrivKey(ctx, scriptPubKey)
 
-	case errors.Is(err, db.ErrAddressNotFound):
+	case errors.Is(err, ErrAddressNotFound):
 		// The address is not owned by the wallet, so the wallet holds
 		// no private key for it.
 		return nil, ErrNoAssocPrivateKey

--- a/wallet/signer_test.go
+++ b/wallet/signer_test.go
@@ -2688,7 +2688,8 @@ func TestGetPrivKeyForAddressSuccess(t *testing.T) {
 func TestGetPrivKeyForAddressFail(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Set up the wallet and mocks.
+	// Arrange: create an unlocked wallet and one deterministic address query
+	// so each Store response exercises the same signer lookup path.
 	w, mocks := createUnlockedWalletWithMocks(t)
 	addr, err := address.NewAddressPubKeyHash(
 		make([]byte, 20), w.cfg.ChainParams,
@@ -2703,7 +2704,8 @@ func TestGetPrivKeyForAddressFail(t *testing.T) {
 		ScriptPubKey: pkScript,
 	}
 
-	// Case 1: An unexpected store error surfaces, not masked.
+	// Act and assert case 1: an unexpected Store error surfaces without
+	// being masked by a signing-specific sentinel.
 	mocks.store.On("GetAddress", mock.Anything, query).Return(
 		(*db.AddressInfo)(nil), errManagerNotFound,
 	).Once()
@@ -2711,14 +2713,38 @@ func TestGetPrivKeyForAddressFail(t *testing.T) {
 	_, err = w.GetPrivKeyForAddress(t.Context(), addr)
 	require.ErrorIs(t, err, errManagerNotFound)
 
-	// Case 2: The address is not owned by the wallet, so it has no
-	// associated private key.
+	// Act and assert case 2: a normalized Store miss reports that the wallet
+	// has no associated private key and hides the public lookup sentinel.
 	mocks.store.On("GetAddress", mock.Anything, query).Return(
 		(*db.AddressInfo)(nil), db.ErrAddressNotFound,
 	).Once()
 
 	_, err = w.GetPrivKeyForAddress(t.Context(), addr)
 	require.ErrorIs(t, err, ErrNoAssocPrivateKey)
+	require.NotErrorIs(t, err, ErrAddressNotFound)
+
+	// Arrange case 3: return a raw legacy manager miss. The kvdb Store
+	// translates real legacy misses before this boundary, so this synthetic
+	// response must remain an unexpected Store failure.
+	legacyErr := waddrmgr.ManagerError{
+		ErrorCode:   waddrmgr.ErrAddressNotFound,
+		Description: "address not found",
+	}
+	mocks.store.On("GetAddress", mock.Anything, query).Return(
+		(*db.AddressInfo)(nil), legacyErr,
+	).Once()
+
+	// Act: resolve the private key while the Store returns the raw manager
+	// error.
+	_, err = w.GetPrivKeyForAddress(t.Context(), addr)
+
+	// Assert: the typed legacy cause remains available and neither wallet
+	// sentinel replaces it.
+	var managerErr waddrmgr.ManagerError
+	require.ErrorAs(t, err, &managerErr)
+	require.Equal(t, waddrmgr.ErrAddressNotFound, managerErr.ErrorCode)
+	require.NotErrorIs(t, err, ErrNoAssocPrivateKey)
+	require.NotErrorIs(t, err, ErrAddressNotFound)
 }
 
 // TestGetPrivKeyForAddressImportedNoPrivKey verifies that requesting the


### PR DESCRIPTION
## Summary

Expose a wallet-owned not-found contract for address-manager lookups.

## Change Description

- Translate normalized Store address misses to `wallet.ErrAddressNotFound` while preserving address context.
- Preserve raw legacy manager errors and private-key lookup behavior.
- Cover translation and negative paths with the existing wallet test mocks.

Implements roadmap Task 380.