### PR TITLE
docs: add ADR authoring template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,9 +50,10 @@ Welcome to the `btcwallet` knowledge base. This file defines the global project
 - **Test Locations:** Unit tests live alongside code. DB integration tests live
   in `wallet/internal/db/itest`. E2E integration tests are orchestrated from
   `itest/`.
-- **ADR** Before changing architecture-sensitive areas, review
-  `docs/developer/adr/README.md` for recorded design decisions, context,
-  tradeoffs, and consequences.
+- **ADR:** Before changing architecture-sensitive areas, review
+  `docs/developer/adr/README.md` for recorded decisions, context, tradeoffs,
+  and consequences. For design tasks, read that guide and follow
+  `docs/developer/adr/template.md`.
 
 ## VERIFICATION STRATEGY
 - Start by running the narrowest relevant test.

--- a/docs/developer/adr/README.md
+++ b/docs/developer/adr/README.md
@@ -4,6 +4,34 @@ This directory contains [Architecture Decision Records (ADRs)](https://github.co
 
 ADRs serve as a historical log of important design choices, providing context for future development and helping new contributors understand the rationale behind the system's architecture.
 
+## Authoring ADRs
+
+Copy [the ADR template](./template.md) to a file named
+`NNNN-short-title.md`, using the next available four-digit number and a concise
+kebab-case title. Replace every instructional comment, complete every section,
+wrap Markdown near 80 columns, and add the ADR to the index below.
+
+Each ADR has exactly one decision status:
+
+- `Proposed`: under discussion and not authoritative.
+- `Accepted`: approved and authoritative for the current architecture.
+- `Rejected`: considered but not approved.
+- `Deprecated`: no longer authoritative and not replaced by one specific ADR.
+- `Superseded`: fully replaced by the ADR named in `Superseded by`.
+
+Implementation progress is not a decision status. Record it in the
+implementation overview or references instead. ADRs written before this
+template that omit a status are treated as `Accepted` unless a relationship
+link says otherwise. The legacy `Accepted and Implemented` wording is also
+equivalent to `Accepted`.
+
+Use `Amends` for a compatible, partial change. The earlier ADR remains
+`Accepted` and links back with `Amended by`. Use `Supersedes` when a new ADR
+fully replaces an earlier decision. The earlier ADR then becomes `Superseded`
+and links back with `Superseded by`. Add both sides of either relationship in
+the same change. When relating a legacy ADR, add its normalized status and
+relationship metadata, but do not rewrite its historical decision body.
+
 ## Existing ADRs
 
 - [ADR 0001: Multi-Wallet Architecture](./0001-multi-wallet-architecture.md) - Decides on the architecture for managing multiple distinct wallets and networks within a single daemon instance.

--- a/docs/developer/adr/template.md
+++ b/docs/developer/adr/template.md
@@ -1,0 +1,92 @@
+# ADR NNNN: Title
+
+## Status
+
+- **Status:** Proposed
+- **Date:** YYYY-MM-DD
+
+## Relationships
+
+- **Amends:** None.
+- **Supersedes:** None.
+- **Amended by:** None.
+- **Superseded by:** None.
+
+<!--
+Replace None with relative links to related ADRs. Follow the lifecycle and
+reciprocal-link rules in this directory's README.
+-->
+
+## 1. Problem
+
+<!--
+Describe the problem in detail. State the decision that must be made, its
+scope, who or what it affects, and the risks of leaving it unresolved.
+-->
+
+## 2. Context
+
+<!--
+Describe the relevant system behavior and architecture in detail. Include the
+forces that shape the decision, prior ADRs, known evidence, and assumptions a
+future reader needs to understand why this decision arose.
+-->
+
+### Constraints
+
+<!--
+List the technical, compatibility, security, performance, operational, and
+project constraints that bound the decision. Distinguish hard requirements
+from preferences where that difference matters.
+-->
+
+## 3. Decision
+
+<!--
+State the chosen architecture or design precisely. Define its boundaries,
+responsibilities, invariants, and important interactions without turning this
+section into an implementation plan.
+-->
+
+## 4. Rationale
+
+<!--
+Explain why the decision best satisfies the problem and constraints. Describe
+the evidence, tradeoffs, and assumptions that make it preferable.
+-->
+
+## 5. Alternatives Considered
+
+### Alternative: Name
+
+<!--
+Describe each credible alternative and why it was rejected. Relate the
+rejection to concrete constraints, risks, or tradeoffs instead of merely
+stating that the chosen decision is better. Repeat this subsection as needed.
+-->
+
+## 6. Consequences
+
+### Positive
+
+<!-- Describe the expected benefits and capabilities. -->
+
+### Negative and Risks
+
+<!--
+Describe costs, limitations, follow-up risks, and any decisions deliberately
+left open.
+-->
+
+## 7. Implementation Overview
+
+<!--
+Give only the high-level implementation shape: affected components,
+interfaces, data flow, migrations, compatibility boundaries, and validation
+approach where relevant. Do not include task breakdowns, file-by-file edits,
+commit sequences, timelines, or code walkthroughs.
+-->
+
+## 8. References
+
+<!-- Link related ADRs, design documents, issues, or supporting evidence. -->


### PR DESCRIPTION
## Summary

Add a reusable ADR authoring template and repository guidance.

## Change Description

Document decision context, lifecycle statuses, amendments, and supersession while keeping implementation guidance high-level. Route design tasks through the ADR template without weakening existing architecture review requirements.