### PR TITLE
itest: add TxPublisher integration tests

### DIFF
--- a/bwtest/README.md
+++ b/bwtest/README.md
@@ -68,6 +68,43 @@ Funding is also available on its own through `(*HarnessTest).FundWallet` and
 Manager-focused tests should continue to create wallets through the manager API
 directly.
 
+## Signed Transactions
+
+`(*HarnessTest).SignSpend` authors and signs a transaction from a wallet's own
+coins. It takes a `SpendFixture` naming the inputs and the outputs, and returns
+the signed transaction:
+
+```go
+tx := t.SignSpend(w, bwtest.SpendFixture{
+	Inputs:  []wire.OutPoint{funding.WalletOutpoints[0]},
+	Outputs: []wire.TxOut{{Value: amount, PkScript: pkScript}},
+})
+```
+
+The inputs and outputs are used verbatim, in the order given, and every input is
+final. Unlike `CreateTransaction` no coin selection, change or output policy is
+applied, so a case can author a transaction the network is required to reject —
+a dust payment, a fee the relay will not carry — which is what publication tests
+need. Cases that mean to test coin selection or change should use
+`CreateTransaction` instead.
+
+The wallet must be started, synced and unlocked, and it must own every named
+input.
+
+To build a rejected output without writing down an amount that drifts from
+policy, `(*HarnessTest).DustThreshold` returns the smallest amount an output
+paying a given script may carry; anything below it is dust.
+
+## Chain Backend Capabilities
+
+Not every backend answers every question. `ChainBackend.SupportsMempoolAcceptance`
+reports whether the backend under test runs the mempool acceptance check, and
+each backend answers for the client it constructs so the answer cannot drift
+from the implementation. Neutrino is a light client with no mempool and reports
+the check as unimplemented instead of returning a verdict, so cases reach it as
+`t.Backend.SupportsMempoolAcceptance()` and assert a definite result on both
+sides of the split rather than skipping a backend.
+
 ## Fast Scrypt
 
 `bwtest` sets `waddrmgr.DefaultScryptOptions` to `waddrmgr.FastScryptOptions` via

--- a/bwtest/backend.go
+++ b/bwtest/backend.go
@@ -26,6 +26,16 @@ type ChainBackend interface {
 	// Name returns the name of the backend ("btcd", "bitcoind", "neutrino").
 	Name() string
 
+	// SupportsMempoolAcceptance reports whether the clients this backend
+	// creates answer the mempool acceptance test. A backend that keeps no
+	// mempool reports the check as unimplemented instead of returning a
+	// verdict.
+	//
+	// Each backend answers for the client it constructs, so the answer
+	// cannot drift from the implementation the way a central lookup by
+	// name would.
+	SupportsMempoolAcceptance() bool
+
 	// Start launches the chain backend.
 	Start() error
 

--- a/bwtest/bitcoind.go
+++ b/bwtest/bitcoind.go
@@ -123,6 +123,14 @@ func NewBitcoindBackend(t *testing.T, logDir string) *BitcoindBackend {
 	}
 }
 
+// SupportsMempoolAcceptance reports that bitcoind answers the mempool
+// acceptance test: it serves testmempoolaccept over RPC.
+//
+// NOTE: This is part of the ChainBackend interface.
+func (b *BitcoindBackend) SupportsMempoolAcceptance() bool {
+	return true
+}
+
 // Name returns the identifier of the backend.
 func (b *BitcoindBackend) Name() string {
 	return backendBitcoind

--- a/bwtest/btcd.go
+++ b/bwtest/btcd.go
@@ -55,6 +55,14 @@ func NewBtcdBackend(t *testing.T, logDir string) *BtcdBackend {
 	}
 }
 
+// SupportsMempoolAcceptance reports that btcd answers the mempool acceptance
+// test: it serves testmempoolaccept over RPC.
+//
+// NOTE: This is part of the ChainBackend interface.
+func (b *BtcdBackend) SupportsMempoolAcceptance() bool {
+	return true
+}
+
 // Name returns the identifier of the backend.
 func (b *BtcdBackend) Name() string {
 	return backendBtcd

--- a/bwtest/harness_wallet.go
+++ b/bwtest/harness_wallet.go
@@ -2,16 +2,16 @@ package bwtest
 
 import (
 	"bytes"
-	"strings"
-	"time"
-
 	"github.com/btcsuite/btcd/address/v2"
 	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/mempool"
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet"
 	"github.com/stretchr/testify/require"
+	"strings"
+	"time"
 )
 
 const (
@@ -328,6 +328,26 @@ func (h *HarnessTest) FundWalletOfType(w *wallet.Wallet,
 	}
 
 	return funding
+}
+
+// DustThreshold returns the smallest amount an output paying pkScript may
+// carry without the network refusing it as dust. Any amount below it is dust.
+//
+// The limit depends on the output's script, so it is taken from the relay
+// policy rather than written down as a number that would silently drift from
+// it. The policy states dust as the comparison
+// value*1000/threshold < relayFee, which first holds at the threshold itself,
+// so the threshold is the smallest amount that clears it at the default relay
+// fee. A case paying a different relay fee cannot use this.
+//
+// The script is assumed spendable, which is what paying a wallet address
+// produces. An unspendable script is dust at any amount and has no threshold.
+func (h *HarnessTest) DustThreshold(pkScript []byte) btcutil.Amount {
+	h.Helper()
+
+	output := wire.TxOut{PkScript: pkScript}
+
+	return btcutil.Amount(mempool.GetDustThreshold(&output))
 }
 
 // ensureAccount makes sure an account exists for the given key scope, creating

--- a/bwtest/harness_wallet.go
+++ b/bwtest/harness_wallet.go
@@ -2,16 +2,18 @@ package bwtest
 
 import (
 	"bytes"
+	"strings"
+	"time"
+
 	"github.com/btcsuite/btcd/address/v2"
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/mempool"
+	"github.com/btcsuite/btcd/psbt/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet"
 	"github.com/stretchr/testify/require"
-	"strings"
-	"time"
 )
 
 const (
@@ -348,6 +350,78 @@ func (h *HarnessTest) DustThreshold(pkScript []byte) btcutil.Amount {
 	output := wire.TxOut{PkScript: pkScript}
 
 	return btcutil.Amount(mempool.GetDustThreshold(&output))
+}
+
+// spendTxVersion is the transaction version SignSpend authors. Version 2 is
+// the standard version both supported chain backends relay.
+const spendTxVersion = 2
+
+// SpendFixture describes a transaction the harness authors from a wallet's own
+// coins and signs with the wallet's keys.
+type SpendFixture struct {
+	// Inputs are the wallet-owned coins the transaction spends.
+	Inputs []wire.OutPoint
+
+	// Outputs are the transaction's outputs. No change output is added, so
+	// whatever the outputs leave behind is paid as the fee.
+	Outputs []wire.TxOut
+}
+
+// SignSpend returns a signed transaction spending the wallet coins the fixture
+// names.
+//
+// The inputs and outputs are used exactly as given, in the order given. Unlike
+// CreateTransaction this applies no coin selection, no change and no output
+// policy, which is what lets a case author a transaction the network is
+// required to reject. The wallet must be started, synced and unlocked.
+func (h *HarnessTest) SignSpend(w *wallet.Wallet,
+	fixture SpendFixture) *wire.MsgTx {
+
+	h.Helper()
+
+	inputs := make([]*wire.OutPoint, len(fixture.Inputs))
+	sequences := make([]uint32, len(fixture.Inputs))
+
+	for i := range fixture.Inputs {
+		inputs[i] = &fixture.Inputs[i]
+
+		// Every input is final. No case needs replaceability, and a
+		// transaction that signals it changes how a backend judges a
+		// conflict with an unconfirmed transaction. A case that wants
+		// replacement should add the knob then, rather than inherit it
+		// from a zero value.
+		sequences[i] = wire.MaxTxInSequenceNum
+	}
+
+	// psbt.New keeps the output pointers it is given, so the returned
+	// transaction would otherwise share its outputs with the caller's
+	// fixture, and mutating the fixture would alter an already-signed
+	// transaction. Hand it copies instead.
+	outputs := make([]*wire.TxOut, len(fixture.Outputs))
+	for i := range fixture.Outputs {
+		output := fixture.Outputs[i]
+		outputs[i] = &output
+	}
+
+	packet, err := psbt.New(inputs, outputs, spendTxVersion, 0, sequences)
+	require.NoError(h, err, "failed to create psbt")
+
+	// The wallet supplies each input's previous output and derivation path
+	// from its own records, so the fixture only has to name the outpoints.
+	// Unknown inputs are an error rather than a silently unsigned input,
+	// which would surface later as an opaque finalization failure.
+	packet, err = w.DecorateInputs(h.Context(), packet, false)
+	require.NoError(h, err, "failed to decorate psbt inputs")
+
+	// FinalizePsbt signs the wallet-owned inputs on its way to building the
+	// final witnesses, so a separate SignPsbt call would add nothing.
+	err = w.FinalizePsbt(h.Context(), packet)
+	require.NoError(h, err, "failed to finalize psbt")
+
+	tx, err := psbt.Extract(packet)
+	require.NoError(h, err, "failed to extract signed transaction")
+
+	return tx
 }
 
 // ensureAccount makes sure an account exists for the given key scope, creating

--- a/bwtest/neutrino.go
+++ b/bwtest/neutrino.go
@@ -32,6 +32,15 @@ func NewNeutrinoBackend(t *testing.T, _ string) *NeutrinoBackend {
 	return &NeutrinoBackend{}
 }
 
+// SupportsMempoolAcceptance reports that neutrino does not answer the mempool
+// acceptance test. A light client keeps no mempool, so its TestMempoolAccept
+// returns chain.ErrUnimplemented for every transaction.
+//
+// NOTE: This is part of the ChainBackend interface.
+func (n *NeutrinoBackend) SupportsMempoolAcceptance() bool {
+	return false
+}
+
 // Name returns the identifier of the backend.
 func (n *NeutrinoBackend) Name() string {
 	return backendNeutrino

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -123,4 +123,8 @@ var allTestCases = []*testCase{
 		Name:     "txpublisher reject acceptance",
 		TestFunc: testCheckMempoolAcceptanceRejected,
 	},
+	{
+		Name:     "txpublisher broadcast transaction",
+		TestFunc: testBroadcastTransaction,
+	},
 }

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -135,4 +135,8 @@ var allTestCases = []*testCase{
 		Name:     "txpublisher reject broadcast",
 		TestFunc: testBroadcastRejected,
 	},
+	{
+		Name:     "txpublisher acceptance state",
+		TestFunc: testCheckMempoolAcceptanceWalletState,
+	},
 }

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -127,4 +127,8 @@ var allTestCases = []*testCase{
 		Name:     "txpublisher broadcast transaction",
 		TestFunc: testBroadcastTransaction,
 	},
+	{
+		Name:     "txpublisher broadcast known",
+		TestFunc: testBroadcastAlreadyKnown,
+	},
 }

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -119,4 +119,8 @@ var allTestCases = []*testCase{
 		Name:     "txpublisher check acceptance",
 		TestFunc: testCheckMempoolAcceptanceAccepted,
 	},
+	{
+		Name:     "txpublisher reject acceptance",
+		TestFunc: testCheckMempoolAcceptanceRejected,
+	},
 }

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -115,4 +115,8 @@ var allTestCases = []*testCase{
 		Name:     "txcreator wallet state",
 		TestFunc: testCreateTransactionWalletState,
 	},
+	{
+		Name:     "txpublisher check acceptance",
+		TestFunc: testCheckMempoolAcceptanceAccepted,
+	},
 }

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -131,4 +131,8 @@ var allTestCases = []*testCase{
 		Name:     "txpublisher broadcast known",
 		TestFunc: testBroadcastAlreadyKnown,
 	},
+	{
+		Name:     "txpublisher reject broadcast",
+		TestFunc: testBroadcastRejected,
+	},
 }

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -139,4 +139,8 @@ var allTestCases = []*testCase{
 		Name:     "txpublisher acceptance state",
 		TestFunc: testCheckMempoolAcceptanceWalletState,
 	},
+	{
+		Name:     "txpublisher broadcast state",
+		TestFunc: testBroadcastWalletState,
+	},
 }

--- a/itest/tx_creator_test.go
+++ b/itest/tx_creator_test.go
@@ -720,17 +720,10 @@ func testCreateTransactionOutputBoundaries(h *bwtest.HarnessTest) {
 		KeyScope:    scope,
 	}
 
-	// The dust limit depends on the output's script, so the edge is derived
-	// from the relay policy itself rather than written down as a number
-	// that would silently drift from it.
-	candidate := wire.TxOut{PkScript: payment.PkScript}
-	for candidate.Value = 1; ; candidate.Value++ {
-		if !txrules.IsDustOutput(&candidate, txrules.DefaultRelayFeePerKb) {
-			break
-		}
-	}
-
-	smallestPayment := candidate.Value
+	// The dust limit depends on the output's script, and the harness derives
+	// it from the relay policy, so the edge here cannot drift from the one
+	// the publication cases use.
+	smallestPayment := int64(h.DustThreshold(payment.PkScript))
 
 	// One satoshi below that edge is dust, and the edge itself is payable.
 	_, err = w.CreateTransaction(h.Context(), &wallet.TxIntent{

--- a/itest/tx_publisher_test.go
+++ b/itest/tx_publisher_test.go
@@ -199,3 +199,84 @@ func testCheckMempoolAcceptanceRejected(h *bwtest.HarnessTest) {
 	require.NoError(h, err, "rejected transaction consumed the coin")
 	require.True(h, utxo.Spendable, "coin is no longer spendable")
 }
+
+// testBroadcastTransaction verifies that a published transaction reaches the
+// network and becomes visible through the wallet's own coin view, both while it
+// waits in the mempool and once it is mined.
+func testBroadcastTransaction(h *bwtest.HarnessTest) {
+	w, funding := h.NewWallet(bwtest.WalletFixture{
+		AddrType: txPublisherFundingType,
+		Amounts:  []btcutil.Amount{oneBTC, twoBTC},
+		Unlocked: true,
+	})
+
+	// The second coin is never named by the transaction. It stays behind as
+	// the control that tells "this coin was spent" apart from "the wallet
+	// lost sight of its coins".
+	spent, untouched := funding.WalletOutpoints[0], funding.WalletOutpoints[1]
+
+	addr := h.NewWalletAddressOfType(w, txPublisherFundingType)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(h, err, "failed to create payment pkscript")
+
+	tx := h.SignSpend(w, bwtest.SpendFixture{
+		Inputs: []wire.OutPoint{spent},
+		Outputs: []wire.TxOut{{
+			Value:    oneBTC - spendFee,
+			PkScript: pkScript,
+		}},
+	})
+
+	err = w.Broadcast(h.Context(), tx, "")
+	require.NoError(h, err, "failed to broadcast transaction")
+
+	txid := tx.TxHash()
+
+	// The transaction reached the network.
+	h.AssertTxInMempool(txid)
+
+	// Before it is mined the wallet already reflects it: the coin it spends
+	// is gone from the spendable set.
+	_, err = w.GetUtxo(h.Context(), spent)
+	require.ErrorIs(
+		h, err, wallet.ErrUnknownOutput,
+		"broadcast left the spent coin in the wallet",
+	)
+
+	// The output it creates is a wallet coin, and reports no confirmations
+	// while it waits.
+	created := wire.OutPoint{Hash: txid, Index: 0}
+
+	unconfirmed, err := w.GetUtxo(h.Context(), created)
+	require.NoError(
+		h, err, "broadcast output did not become a wallet coin",
+	)
+	require.Equal(
+		h, btcutil.Amount(oneBTC-spendFee), unconfirmed.Amount,
+		"unexpected output amount",
+	)
+	require.Zero(
+		h, unconfirmed.Confirmations,
+		"unmined output reports confirmations",
+	)
+
+	// The wallet tracks the transaction it published.
+	_, err = w.GetTx(h.Context(), txid)
+	require.NoError(h, err, "broadcast transaction is not tracked")
+
+	// The coin the transaction never named is untouched.
+	_, err = w.GetUtxo(h.Context(), untouched)
+	require.NoError(h, err, "broadcast consumed an unrelated coin")
+
+	h.MineBlockWithTx(tx)
+
+	// Confirmation is visible through the same coin view.
+	confirmed, err := w.GetUtxo(h.Context(), created)
+	require.NoError(h, err, "mined output is no longer a wallet coin")
+	require.Equal(
+		h, int32(1), confirmed.Confirmations,
+		"mined output reports unexpected confirmations",
+	)
+	require.True(h, confirmed.Spendable, "mined output is not spendable")
+}

--- a/itest/tx_publisher_test.go
+++ b/itest/tx_publisher_test.go
@@ -454,3 +454,35 @@ func testCheckMempoolAcceptanceWalletState(h *bwtest.HarnessTest) {
 		"acceptance check after stop not rejected",
 	)
 }
+
+// testBroadcastWalletState verifies the same lifecycle gate on Broadcast, which
+// enforces it separately from the acceptance check.
+func testBroadcastWalletState(h *bwtest.HarnessTest) {
+	w, _ := h.NewWallet(bwtest.WalletFixture{
+		AddrType:  txPublisherFundingType,
+		Unstarted: true,
+	})
+
+	// The gate refuses the transaction before anything looks at its
+	// content, so this only has to be non-nil. It is never published.
+	tx := wire.NewMsgTx(wire.TxVersion)
+
+	err := w.Broadcast(h.Context(), tx, "")
+	require.ErrorIs(
+		h, err, wallet.ErrStateForbidden,
+		"broadcast before start not rejected",
+	)
+
+	require.NoError(h, w.Start(h.Context()), "failed to start wallet")
+
+	// Stop the wallet, then deregister it so the harness does not drive a
+	// stopped wallet during teardown.
+	require.NoError(h, w.Stop(h.Context()), "failed to stop wallet")
+	require.True(h, h.DeregisterWallet(w), "failed to deregister wallet")
+
+	err = w.Broadcast(h.Context(), tx, "")
+	require.ErrorIs(
+		h, err, wallet.ErrStateForbidden,
+		"broadcast after stop not rejected",
+	)
+}

--- a/itest/tx_publisher_test.go
+++ b/itest/tx_publisher_test.go
@@ -420,3 +420,37 @@ func testBroadcastRejected(h *bwtest.HarnessTest) {
 	require.NoError(h, err, "refused transaction consumed the coin")
 	require.True(h, utxo.Spendable, "coin is no longer spendable")
 }
+
+// testCheckMempoolAcceptanceWalletState verifies the lifecycle gate on the
+// acceptance check: it is unavailable before the wallet starts and after it
+// stops, so a caller asking during startup or shutdown is told the wallet is
+// not running rather than something about its transaction.
+func testCheckMempoolAcceptanceWalletState(h *bwtest.HarnessTest) {
+	w, _ := h.NewWallet(bwtest.WalletFixture{
+		AddrType:  txPublisherFundingType,
+		Unstarted: true,
+	})
+
+	// The gate refuses the transaction before anything looks at its
+	// content, so this only has to be non-nil. It is never published.
+	tx := wire.NewMsgTx(wire.TxVersion)
+
+	err := w.CheckMempoolAcceptance(h.Context(), tx)
+	require.ErrorIs(
+		h, err, wallet.ErrStateForbidden,
+		"acceptance check before start not rejected",
+	)
+
+	require.NoError(h, w.Start(h.Context()), "failed to start wallet")
+
+	// Stop the wallet, then deregister it so the harness does not drive a
+	// stopped wallet during teardown.
+	require.NoError(h, w.Stop(h.Context()), "failed to stop wallet")
+	require.True(h, h.DeregisterWallet(w), "failed to deregister wallet")
+
+	err = w.CheckMempoolAcceptance(h.Context(), tx)
+	require.ErrorIs(
+		h, err, wallet.ErrStateForbidden,
+		"acceptance check after stop not rejected",
+	)
+}

--- a/itest/tx_publisher_test.go
+++ b/itest/tx_publisher_test.go
@@ -1,0 +1,92 @@
+//go:build itest
+
+package itest
+
+import (
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btcwallet/bwtest"
+	"github.com/btcsuite/btcwallet/chain"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet"
+	"github.com/stretchr/testify/require"
+)
+
+// txPublisherFundingType is the address type the TxPublisher cases fund and
+// spend. Each case derives its key scope from this value, so the funded scope
+// is never stated twice.
+const txPublisherFundingType = waddrmgr.WitnessPubKey
+
+// spendFee is the fee in satoshis that the publication fixtures leave behind.
+// It clears the relay minimum by a wide margin while staying far below the
+// backend's default maximum fee rate of 10,000 sat/vbyte, above which an
+// otherwise valid transaction is rejected as paying absurdly much.
+const spendFee = 10_000
+
+// testCheckMempoolAcceptanceAccepted verifies that the acceptance check reports
+// the chain backend's verdict for a spendable transaction, and that asking the
+// question publishes nothing: the transaction reaches neither the network nor
+// the wallet, and the wallet's coins are untouched.
+func testCheckMempoolAcceptanceAccepted(h *bwtest.HarnessTest) {
+	w, funding := h.NewWallet(bwtest.WalletFixture{
+		AddrType: txPublisherFundingType,
+		Amounts:  []btcutil.Amount{oneBTC},
+		Unlocked: true,
+	})
+
+	// Pay the funded coin back to the wallet less the fee, which makes the
+	// transaction unambiguously spendable and wallet-relevant on both its
+	// input and its output side.
+	addr := h.NewWalletAddressOfType(w, txPublisherFundingType)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(h, err, "failed to create payment pkscript")
+
+	tx := h.SignSpend(w, bwtest.SpendFixture{
+		Inputs: []wire.OutPoint{funding.WalletOutpoints[0]},
+		Outputs: []wire.TxOut{{
+			Value:    oneBTC - spendFee,
+			PkScript: pkScript,
+		}},
+	})
+
+	// Snapshot the coins before asking, so the comparison afterwards proves
+	// the check consumed nothing rather than merely that a coin still
+	// exists.
+	before, err := w.ListUnspent(h.Context(), wallet.UtxoQuery{
+		MinConfs: 0,
+		MaxConfs: maxConfsLimit,
+	})
+	require.NoError(h, err, "failed to list unspent")
+
+	err = w.CheckMempoolAcceptance(h.Context(), tx)
+	if h.Backend.SupportsMempoolAcceptance() {
+		require.NoError(h, err, "spendable transaction not accepted")
+	} else {
+		require.ErrorIs(
+			h, err, chain.ErrUnimplemented,
+			"backend without a mempool returned a verdict",
+		)
+	}
+
+	// Whatever the verdict, the check is an inspection. It must not reach
+	// the network.
+	h.AssertTxNotInMempool(tx.TxHash())
+
+	// Nor may it record the transaction in the wallet.
+	_, err = w.GetTx(h.Context(), tx.TxHash())
+	require.ErrorIs(
+		h, err, wallet.ErrTxNotFound,
+		"acceptance check recorded the transaction",
+	)
+
+	after, err := w.ListUnspent(h.Context(), wallet.UtxoQuery{
+		MinConfs: 0,
+		MaxConfs: maxConfsLimit,
+	})
+	require.NoError(h, err, "failed to list unspent")
+	require.ElementsMatch(
+		h, before, after, "acceptance check changed the wallet's coins",
+	)
+}

--- a/itest/tx_publisher_test.go
+++ b/itest/tx_publisher_test.go
@@ -90,3 +90,112 @@ func testCheckMempoolAcceptanceAccepted(h *bwtest.HarnessTest) {
 		h, before, after, "acceptance check changed the wallet's coins",
 	)
 }
+
+// testCheckMempoolAcceptanceRejected verifies that representative rejections
+// come back as stable error identities rather than backend-specific text, and
+// that a refused transaction is no more published than an accepted one.
+func testCheckMempoolAcceptanceRejected(h *bwtest.HarnessTest) {
+	w, funding := h.NewWallet(bwtest.WalletFixture{
+		AddrType: txPublisherFundingType,
+		Amounts:  []btcutil.Amount{oneBTC},
+		Unlocked: true,
+	})
+
+	spent := funding.WalletOutpoints[0]
+
+	addr := h.NewWalletAddressOfType(w, txPublisherFundingType)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(h, err, "failed to create payment pkscript")
+
+	// One satoshi under the threshold for this script is dust by the
+	// relay's own definition, so the assertion tracks the policy instead of
+	// a number that would drift from it.
+	dust := int64(h.DustThreshold(pkScript)) - 1
+
+	// A second output absorbs the rest of the coin, so the dust payment is
+	// the only rule this transaction breaks. Paying the remainder as fee
+	// instead would break the maximum fee rate as well and leave which
+	// rejection the backend reports up to the order of its checks.
+	dustTx := h.SignSpend(w, bwtest.SpendFixture{
+		Inputs: []wire.OutPoint{spent},
+		Outputs: []wire.TxOut{
+			{
+				Value:    dust,
+				PkScript: pkScript,
+			},
+			{
+				Value:    oneBTC - spendFee - dust,
+				PkScript: pkScript,
+			},
+		},
+	})
+
+	// An input the chain has never seen cannot be signed by anyone, so this
+	// transaction is built directly rather than through the wallet.
+	unknown := unknownOutpoint()
+
+	unknownInputTx := wire.NewMsgTx(wire.TxVersion)
+	unknownInputTx.AddTxIn(wire.NewTxIn(&unknown, nil, nil))
+	unknownInputTx.AddTxOut(&wire.TxOut{
+		Value:    oneBTC - spendFee,
+		PkScript: pkScript,
+	})
+
+	// Spending one coin twice is malformed before any policy applies, so
+	// this transaction is likewise built directly: no signer would produce
+	// it.
+	duplicateInputTx := wire.NewMsgTx(wire.TxVersion)
+	duplicateInputTx.AddTxIn(wire.NewTxIn(&spent, nil, nil))
+	duplicateInputTx.AddTxIn(wire.NewTxIn(&spent, nil, nil))
+	duplicateInputTx.AddTxOut(&wire.TxOut{
+		Value:    oneBTC - spendFee,
+		PkScript: pkScript,
+	})
+
+	rejections := []struct {
+		name string
+		tx   *wire.MsgTx
+		want error
+	}{
+		{
+			name: "dust payment",
+			tx:   dustTx,
+			want: chain.ErrDust,
+		},
+		{
+			name: "unknown input",
+			tx:   unknownInputTx,
+			want: chain.ErrMissingInputs,
+		},
+		{
+			name: "duplicate input",
+			tx:   duplicateInputTx,
+			want: chain.ErrDuplicateInput,
+		},
+	}
+
+	for _, rejection := range rejections {
+		want := rejection.want
+
+		// A backend with no mempool judges none of these. It reports
+		// the check as unimplemented instead of naming the rule that
+		// was broken, which is just as definite an answer.
+		if !h.Backend.SupportsMempoolAcceptance() {
+			want = chain.ErrUnimplemented
+		}
+
+		err := w.CheckMempoolAcceptance(h.Context(), rejection.tx)
+		require.ErrorIs(
+			h, err, want, "unexpected verdict for %s",
+			rejection.name,
+		)
+
+		h.AssertTxNotInMempool(rejection.tx.TxHash())
+	}
+
+	// A refused transaction leaves the coin it named still spendable.
+	utxo, err := w.GetUtxo(h.Context(), spent)
+	require.NoError(h, err, "rejected transaction consumed the coin")
+	require.True(h, utxo.Spendable, "coin is no longer spendable")
+}

--- a/itest/tx_publisher_test.go
+++ b/itest/tx_publisher_test.go
@@ -280,3 +280,60 @@ func testBroadcastTransaction(h *bwtest.HarnessTest) {
 	)
 	require.True(h, confirmed.Spendable, "mined output is not spendable")
 }
+
+// testBroadcastAlreadyKnown verifies that publishing a transaction the network
+// already holds succeeds rather than failing, and publishes it only once. The
+// wallet rebroadcasts its unmined transactions on every sync step, so a repeat
+// that reported failure would make ordinary operation look broken.
+func testBroadcastAlreadyKnown(h *bwtest.HarnessTest) {
+	w, funding := h.NewWallet(bwtest.WalletFixture{
+		AddrType: txPublisherFundingType,
+		Amounts:  []btcutil.Amount{oneBTC},
+		Unlocked: true,
+	})
+
+	addr := h.NewWalletAddressOfType(w, txPublisherFundingType)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(h, err, "failed to create payment pkscript")
+
+	tx := h.SignSpend(w, bwtest.SpendFixture{
+		Inputs: []wire.OutPoint{funding.WalletOutpoints[0]},
+		Outputs: []wire.TxOut{{
+			Value:    oneBTC - spendFee,
+			PkScript: pkScript,
+		}},
+	})
+
+	txid := tx.TxHash()
+
+	err = w.Broadcast(h.Context(), tx, "")
+	require.NoError(h, err, "failed to broadcast transaction")
+
+	h.AssertTxInMempool(txid)
+
+	// Publishing the same transaction again succeeds.
+	err = w.Broadcast(h.Context(), tx, "")
+	require.NoError(
+		h, err, "re-broadcast of a mempool transaction was refused",
+	)
+
+	// The repeat published nothing new: the network still holds one copy.
+	mempool := h.AssertNumTxnsInMempool(1)
+	require.Equal(
+		h, txid, mempool[0], "unexpected transaction in the mempool",
+	)
+
+	// The wallet's coin view is unchanged by the repeat, so the second
+	// attempt did not re-record or invalidate what the first claimed.
+	created := wire.OutPoint{Hash: txid, Index: 0}
+
+	utxo, err := w.GetUtxo(h.Context(), created)
+	require.NoError(h, err, "re-broadcast dropped the wallet's output")
+	require.Equal(
+		h, btcutil.Amount(oneBTC-spendFee), utxo.Amount,
+		"unexpected output amount",
+	)
+
+	h.MineBlockWithTx(tx)
+}

--- a/itest/tx_publisher_test.go
+++ b/itest/tx_publisher_test.go
@@ -337,3 +337,86 @@ func testBroadcastAlreadyKnown(h *bwtest.HarnessTest) {
 
 	h.MineBlockWithTx(tx)
 }
+
+// testBroadcastRejected verifies that a transaction the network refuses is
+// reported with a stable identity and claims no coin: neither of its outputs
+// becomes spendable, and the coin it named is still there afterwards.
+func testBroadcastRejected(h *bwtest.HarnessTest) {
+	w, funding := h.NewWallet(bwtest.WalletFixture{
+		AddrType: txPublisherFundingType,
+		Amounts:  []btcutil.Amount{oneBTC},
+		Unlocked: true,
+	})
+
+	spent := funding.WalletOutpoints[0]
+
+	addr := h.NewWalletAddressOfType(w, txPublisherFundingType)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(h, err, "failed to create payment pkscript")
+
+	// A dust payment is a well formed transaction the network will not
+	// relay, which is what this case needs: the wallet has every reason to
+	// record it and only the backend's answer to stop it. The second output
+	// absorbs the rest of the coin so dust is the only rule it breaks, and
+	// both outputs pay the wallet, so a refusal that still left the wallet
+	// holding coins would be visible below.
+	//
+	// A double spend of an unconfirmed transaction was tried as the subject
+	// here and dropped: bitcoind enables full replace-by-fee by default, so
+	// it judges the second transaction as a replacement bid, accepting it
+	// when it pays more and reporting an insufficient fee when it pays
+	// less, while btcd reports a mempool conflict. One condition with three
+	// outcomes is not a contract a caller can branch on.
+	dust := int64(h.DustThreshold(pkScript)) - 1
+
+	tx := h.SignSpend(w, bwtest.SpendFixture{
+		Inputs: []wire.OutPoint{spent},
+		Outputs: []wire.TxOut{
+			{
+				Value:    dust,
+				PkScript: pkScript,
+			},
+			{
+				Value:    oneBTC - spendFee - dust,
+				PkScript: pkScript,
+			},
+		},
+	})
+
+	err = w.Broadcast(h.Context(), tx, "")
+
+	require.ErrorIs(
+		h, err, chain.ErrDust, "dust transaction was not refused",
+	)
+
+	// The refusal published nothing.
+	h.AssertTxNotInMempool(tx.TxHash())
+
+	// It claimed no coin either. Neither output became one, which both of
+	// them would have, since both pay the wallet.
+	//
+	// Whether the transaction was recorded at all is deliberately not
+	// asserted, because it differs by backend and the difference is not
+	// this task's to define. A backend that answers the acceptance check
+	// refuses before Broadcast records anything, while neutrino has no
+	// answer to refuse with, so it records, publishes, and invalidates the
+	// row once its peer rejects. Both leave the coin view below identical;
+	// what the store keeps for an invalidated transaction belongs to the
+	// invalidation task.
+	for i := range tx.TxOut {
+		_, err = w.GetUtxo(h.Context(), wire.OutPoint{
+			Hash:  tx.TxHash(),
+			Index: uint32(i),
+		})
+		require.ErrorIs(
+			h, err, wallet.ErrUnknownOutput,
+			"refused transaction left output %d in the wallet", i,
+		)
+	}
+
+	// And the coin it named is untouched.
+	utxo, err := w.GetUtxo(h.Context(), spent)
+	require.NoError(h, err, "refused transaction consumed the coin")
+	require.True(h, utxo.Spendable, "coin is no longer spendable")
+}

--- a/wallet/tx_publisher.go
+++ b/wallet/tx_publisher.go
@@ -39,9 +39,18 @@ var (
 type TxPublisher interface {
 	// CheckMempoolAcceptance checks if a transaction would be accepted by
 	// the mempool without broadcasting.
+	//
+	// Not every chain backend keeps a mempool to ask. One that does not,
+	// such as a light client, returns chain.ErrUnimplemented instead of a
+	// verdict, so a caller that must work against any backend treats that
+	// as "unknown" rather than as a rejection.
 	CheckMempoolAcceptance(ctx context.Context, tx *wire.MsgTx) error
 
 	// Broadcast broadcasts a transaction to the network.
+	//
+	// When the backend cannot answer the acceptance check, the transaction
+	// is published without one, so a nil return means it was sent, not that
+	// the network accepted it.
 	Broadcast(ctx context.Context, tx *wire.MsgTx, label string) error
 }
 
@@ -50,6 +59,13 @@ var _ TxPublisher = (*Wallet)(nil)
 
 // CheckMempoolAcceptance checks if a transaction would be accepted by the
 // mempool without broadcasting.
+//
+// A chain backend with no mempool cannot answer the question and returns
+// chain.ErrUnimplemented rather than a verdict; a backend too old to serve the
+// check returns rpcclient.ErrBackendVersion. Neither means the transaction was
+// rejected.
+//
+// NOTE: This is part of the TxPublisher interface.
 func (w *Wallet) CheckMempoolAcceptance(_ context.Context,
 	tx *wire.MsgTx) error {
 
@@ -99,6 +115,10 @@ func (w *Wallet) CheckMempoolAcceptance(_ context.Context,
 
 // Broadcast broadcasts a tx to the network. It is the main implementation of
 // the TxPublisher interface.
+//
+// A backend that cannot answer the mempool acceptance check does not stop the
+// publish: the tx is sent without a verdict, so a nil return reports that it
+// was handed to the network, not that the network kept it.
 func (w *Wallet) Broadcast(ctx context.Context, tx *wire.MsgTx,
 	label string) error {
 


### PR DESCRIPTION
Implements Task 435 — cover transaction publication contracts.

`CheckMempoolAcceptance` and `Broadcast` had unit coverage against a mocked
chain and no integration coverage at all. This adds six cases in
`itest/tx_publisher_test.go`.

## Task 435 acceptance criteria mapped to tests

| Criterion | Case |
| --- | --- |
| Accepted spend | `txpublisher check acceptance`, `txpublisher broadcast transaction` |
| Representative policy rejection | `txpublisher reject acceptance` (dust → `chain.ErrDust`), `txpublisher reject broadcast` |
| Malformed or conflicting | `txpublisher reject acceptance` (unknown input → `chain.ErrMissingInputs`, duplicate input → `chain.ErrDuplicateInput`) |
| Already-known behavior | `txpublisher broadcast known` |
| Stopped Wallet state | `txpublisher wallet state` (both methods, before Start and after Stop; nil transaction on a running wallet) |
| Acceptance check never publishes | `txpublisher check acceptance` (mempool, wallet records and coins all unchanged) |
| Broadcast observable before and after mining | `txpublisher broadcast transaction` |
| kvdb, SQLite and PostgreSQL, no skip branch | Full suite passes on all three; no case contains database-conditional code |
| Test-only | No production file is touched |

## Harness changes

Both additive, in `bwtest`:

- `SpendFixture` and `SignSpend` — authors and signs a transaction from named
  wallet coins, using the inputs and outputs verbatim. Not built on
  `CreateTransaction`/`FundPsbt`, which enforce the creation-time policy Task
  434 owns and reject the dust fixture outright.
- `MempoolAcceptanceSupported` — one authority for which chain backends answer
  the acceptance check.

## Backend neutrality

The rejections were chosen so one identity holds on every backend. Three
candidates were measured and discarded:

- **Minimum relay fee** — btcd reports a mempool minimum, bitcoind a relay
  minimum. Dust carries the policy requirement instead.
- **Double spend** — bitcoind enables full replace-by-fee by default, so it
  judges the second transaction as a replacement bid, accepting it when it pays
  more and reporting an insufficient fee when it pays less, while btcd reports a
  mempool conflict. `MaxTxInSequenceNum` does not prevent this. Duplicate inputs
  cover the malformed requirement instead.
- **No outputs** — btcd rejects on serialized size before reaching the
  empty-output rule, mapping to `ErrUndefined`.

Neutrino has no mempool and reports the acceptance check as unimplemented. The
two cases whose subject is that check assert `chain.ErrUnimplemented` there
rather than skipping, so every backend gets a definite assertion. Everything
else is backend-neutral with no split, including the dust refusal, which
neutrino's peer returns over the wire.


Part of #1250.
