### PR TITLE
wallet: accept bounded recovery windows

### DIFF
--- a/wallet/manager_sqlite_test.go
+++ b/wallet/manager_sqlite_test.go
@@ -62,9 +62,8 @@ func TestManagerLoadSQLiteRequiresWalletRow(t *testing.T) {
 	t.Cleanup(func() { _ = m.Close() })
 
 	w, err := m.Load(Config{
-		Chain:          &bwmock.Chain{},
-		Name:           "no-such-wallet",
-		RecoveryWindow: MinRecoveryWindow,
+		Chain: &bwmock.Chain{},
+		Name:  "no-such-wallet",
 	})
 	require.ErrorIs(t, err, db.ErrWalletNotFound)
 	require.Nil(t, w)
@@ -80,10 +79,9 @@ func sqliteCreateConfig(t *testing.T) (Config, CreateWalletParams) {
 	require.NoError(t, err)
 
 	cfg := Config{
-		Chain:          &bwmock.Chain{},
-		ChainParams:    &chainParams,
-		Name:           testWalletName,
-		RecoveryWindow: MinRecoveryWindow,
+		Chain:       &bwmock.Chain{},
+		ChainParams: &chainParams,
+		Name:        testWalletName,
 	}
 	params := CreateWalletParams{
 		Mode:              ModeImportSeed,
@@ -242,10 +240,9 @@ func TestManagerSQLiteReopenDerivesAddress(t *testing.T) {
 
 	chain := &bwmock.Chain{}
 	cfg := Config{
-		Chain:          chain,
-		ChainParams:    &chainParams,
-		Name:           testWalletName,
-		RecoveryWindow: MinRecoveryWindow,
+		Chain:       chain,
+		ChainParams: &chainParams,
+		Name:        testWalletName,
 	}
 	privPass := []byte("private")
 

--- a/wallet/manager_test.go
+++ b/wallet/manager_test.go
@@ -109,11 +109,10 @@ func TestManagerCreateSuccess(t *testing.T) {
 
 			m := testKVDBManager(t)
 			cfg := Config{
-				Chain:          &bwmock.Chain{},
-				ChainParams:    &chainParams,
-				Name:           "test-wallet",
-				PubPassphrase:  []byte("public"),
-				RecoveryWindow: MinRecoveryWindow,
+				Chain:         &bwmock.Chain{},
+				ChainParams:   &chainParams,
+				Name:          "test-wallet",
+				PubPassphrase: []byte("public"),
 			}
 
 			// Attempt to create the wallet with the specified parameters.
@@ -324,7 +323,6 @@ func TestCreateWalletParamsPolicy(t *testing.T) {
 			}
 			cfg := Config{
 				Chain: &bwmock.Chain{}, Name: "test-wallet",
-				RecoveryWindow: MinRecoveryWindow,
 			}
 
 			wallet, err := m.Create(cfg, tc.params)
@@ -396,6 +394,37 @@ func TestManagerCreate_InvalidConfig(t *testing.T) {
 	require.Nil(t, w)
 }
 
+// TestManagerCreateExcessRecoveryWindow verifies that a recovery window above
+// the public maximum is rejected on the configuration's own merits, before
+// Create reaches the store or the chain backend that would serve it.
+func TestManagerCreateExcessRecoveryWindow(t *testing.T) {
+	t.Parallel()
+
+	// A chain mock with no registered calls fails the test if the request
+	// reaches the chain backend.
+	chainMock := &bwmock.Chain{}
+	defer chainMock.AssertExpectations(t)
+
+	backend := &recordingManagerBackend{}
+	m := &Manager{
+		wallets:     make(map[string]*Wallet),
+		backend:     backend,
+		chainParams: &chainParams,
+	}
+	cfg := Config{
+		Chain:          chainMock,
+		Name:           "test-wallet",
+		RecoveryWindow: MaxRecoveryWindow + 1,
+	}
+
+	w, err := m.Create(cfg, CreateWalletParams{Mode: ModeGenSeed})
+
+	require.Nil(t, w)
+	require.ErrorIs(t, err, ErrInvalidParam)
+	require.ErrorContains(t, err, "RecoveryWindow")
+	require.False(t, backend.createCalled)
+}
+
 // TestManagerLoadSuccess verifies that an existing wallet can be successfully
 // loaded from the database. This tests the persistence and restoration flow.
 func TestManagerLoadSuccess(t *testing.T) {
@@ -405,11 +434,10 @@ func TestManagerLoadSuccess(t *testing.T) {
 
 	m := testKVDBManagerAt(t, dbPath)
 	cfg := Config{
-		Chain:          &bwmock.Chain{},
-		ChainParams:    &chainParams,
-		Name:           "test-wallet",
-		PubPassphrase:  []byte("public"),
-		RecoveryWindow: MinRecoveryWindow,
+		Chain:         &bwmock.Chain{},
+		ChainParams:   &chainParams,
+		Name:          "test-wallet",
+		PubPassphrase: []byte("public"),
 	}
 	params := CreateWalletParams{
 		Mode:              ModeGenSeed,
@@ -459,11 +487,10 @@ func TestManagerLoad_ExistingWallet(t *testing.T) {
 
 	m := testKVDBManagerAt(t, dbPath)
 	cfg := Config{
-		Chain:          &bwmock.Chain{},
-		ChainParams:    &chainParams,
-		Name:           "test-wallet",
-		PubPassphrase:  []byte("public"),
-		RecoveryWindow: MinRecoveryWindow,
+		Chain:         &bwmock.Chain{},
+		ChainParams:   &chainParams,
+		Name:          "test-wallet",
+		PubPassphrase: []byte("public"),
 	}
 	params := CreateWalletParams{
 		Mode:              ModeGenSeed,
@@ -677,11 +704,10 @@ func TestManagerKVDBCreateWatchOnlyShell(t *testing.T) {
 // Manager tests.
 func testWatchOnlyConfig() Config {
 	return Config{
-		Chain:          &bwmock.Chain{},
-		ChainParams:    &chainParams,
-		Name:           "watch-only",
-		PubPassphrase:  []byte("public"),
-		RecoveryWindow: MinRecoveryWindow,
+		Chain:         &bwmock.Chain{},
+		ChainParams:   &chainParams,
+		Name:          "watch-only",
+		PubPassphrase: []byte("public"),
 	}
 }
 
@@ -696,11 +722,10 @@ func TestManagerKVDBRejectsSecondName(t *testing.T) {
 
 	m := testKVDBManager(t)
 	cfg := Config{
-		Chain:          &bwmock.Chain{},
-		ChainParams:    &chainParams,
-		Name:           "first",
-		PubPassphrase:  []byte("public"),
-		RecoveryWindow: MinRecoveryWindow,
+		Chain:         &bwmock.Chain{},
+		ChainParams:   &chainParams,
+		Name:          "first",
+		PubPassphrase: []byte("public"),
 	}
 	params := CreateWalletParams{
 		Mode:              ModeGenSeed,
@@ -762,11 +787,10 @@ func TestManagerCreateFailureLeavesManagerReusable(t *testing.T) {
 
 			m := tc.manager(t)
 			cfg := Config{
-				Chain:          &bwmock.Chain{},
-				ChainParams:    &chainParams,
-				Name:           testWalletName,
-				PubPassphrase:  tc.pubPass,
-				RecoveryWindow: MinRecoveryWindow,
+				Chain:         &bwmock.Chain{},
+				ChainParams:   &chainParams,
+				Name:          testWalletName,
+				PubPassphrase: tc.pubPass,
 			}
 
 			// Arrange + Act: a seed too short for BIP32 fails root
@@ -857,12 +881,11 @@ func TestManagerIgnoresPerWalletDBAndChainParams(t *testing.T) {
 			// Arrange: no DB and no network at all — the Manager
 			// must supply both.
 			cfg := Config{
-				Chain:          &bwmock.Chain{},
-				ChainParams:    nil,
-				DB:             nil,
-				Name:           testWalletName,
-				PubPassphrase:  tc.pubPass,
-				RecoveryWindow: MinRecoveryWindow,
+				Chain:         &bwmock.Chain{},
+				ChainParams:   nil,
+				DB:            nil,
+				Name:          testWalletName,
+				PubPassphrase: tc.pubPass,
 			}
 
 			w, err := m.Create(cfg, CreateWalletParams{
@@ -910,11 +933,10 @@ func TestManagerCreateHonoursCreatePubPassphrase(t *testing.T) {
 	// Arrange + Act: create under createPub while the Config names configPub.
 	m := testKVDBManagerAt(t, dbPath)
 	cfg := Config{
-		Chain:          &bwmock.Chain{},
-		ChainParams:    &chainParams,
-		Name:           testWalletName,
-		PubPassphrase:  configPub,
-		RecoveryWindow: MinRecoveryWindow,
+		Chain:         &bwmock.Chain{},
+		ChainParams:   &chainParams,
+		Name:          testWalletName,
+		PubPassphrase: configPub,
 	}
 	w, err := m.Create(cfg, CreateWalletParams{
 		Mode:              ModeImportSeed,

--- a/wallet/syncer_test.go
+++ b/wallet/syncer_test.go
@@ -31,6 +31,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// testScanRecoveryWindow is a small non-zero look-ahead used by the scan tests
+// that need a recovery horizon beyond the addresses already on record.
+const testScanRecoveryWindow = 20
+
 // TestSyncerInitialization verifies that a new syncer is created with the
 // correct default state.
 func TestSyncerInitialization(t *testing.T) {
@@ -2107,7 +2111,7 @@ func TestFullScanRecoverySeparatesStoreIDAndAccountNumber(t *testing.T) {
 	props := scanAccountProps(scanAccounts)
 	require.Len(t, props, 2)
 
-	rs := NewRecoveryState(MinRecoveryWindow, &chaincfg.SimNetParams, nil)
+	rs := NewRecoveryState(testScanRecoveryWindow, &chaincfg.SimNetParams, nil)
 	initStoreScanState(t, rs, scanAccounts)
 
 	// Assert: each account keeps its own identity under its distinct store
@@ -3247,7 +3251,7 @@ func TestHandleScanReq(t *testing.T) {
 
 	mockChain = &bwmock.Chain{}
 	sTargeted.cfg.Chain = mockChain
-	sTargeted.cfg.RecoveryWindow = MinRecoveryWindow
+	sTargeted.cfg.RecoveryWindow = testScanRecoveryWindow
 
 	// Target the auto-created default derived account at number 0.
 	req = &scanReq{
@@ -4497,7 +4501,7 @@ func TestScanWithTargets_Empty(t *testing.T) {
 	s.cfg.Chain = mockChain
 	s.cfg.SyncMethod = SyncMethodAuto
 	s.cfg.MaxCFilterItems = 100
-	s.cfg.RecoveryWindow = MinRecoveryWindow
+	s.cfg.RecoveryWindow = testScanRecoveryWindow
 
 	// Target the auto-created default derived account at number 0. It
 	// resolves to its durable name and seeds the recovery state with a
@@ -4763,7 +4767,7 @@ func TestScanWithTargets_Errors(t *testing.T) {
 
 		mockChain := &bwmock.Chain{}
 		s.cfg.Chain = mockChain
-		s.cfg.RecoveryWindow = MinRecoveryWindow
+		s.cfg.RecoveryWindow = testScanRecoveryWindow
 
 		req := &scanReq{
 			startBlock: waddrmgr.BlockStamp{Height: 100},
@@ -4792,7 +4796,7 @@ func TestScanWithTargets_Errors(t *testing.T) {
 
 		mockChain := &bwmock.Chain{}
 		s.cfg.Chain = mockChain
-		s.cfg.RecoveryWindow = MinRecoveryWindow
+		s.cfg.RecoveryWindow = testScanRecoveryWindow
 
 		req := &scanReq{
 			startBlock: waddrmgr.BlockStamp{Height: 100},

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -60,11 +60,11 @@ const (
 	// locking.
 	defaultLockDuration = 10 * time.Minute
 
-	// MinRecoveryWindow is the minimum allowed value for the RecoveryWindow
-	// configuration parameter. This value ensures that a sufficient number
-	// of addresses are scanned during wallet recovery to avoid missing
-	// funds due to gaps in the address chain.
-	MinRecoveryWindow = 20
+	// MaxRecoveryWindow is the largest accepted value for the
+	// RecoveryWindow configuration parameter. The bound is public so a
+	// caller can reject an expensive request on its own, before the wallet
+	// reaches its Store or the chain backend to serve it.
+	MaxRecoveryWindow = 100_000
 )
 
 var (
@@ -187,7 +187,19 @@ type Config struct {
 	// ChainParams defines the network parameters (e.g. mainnet, testnet).
 	ChainParams *chaincfg.Params
 
-	// RecoveryWindow specifies the address lookahead for recovery.
+	// RecoveryWindow specifies the address lookahead used when this wallet
+	// scans for its own history. Any value from zero through
+	// MaxRecoveryWindow is accepted.
+	//
+	// The value is used exactly as supplied: the wallet applies no default
+	// and rounds nothing up, so an unset field means a window of zero
+	// rather than an unspecified one. A caller that wants a default — for
+	// example the twenty this field once required — passes it here.
+	//
+	// A zero window derives no lookahead addresses at all. The scan itself
+	// still runs: the addresses and unspent outputs already persisted for
+	// this wallet are watched and synchronized as they always are, so only
+	// the discovery of unused gaps is given up.
 	RecoveryWindow uint32
 
 	// WalletSyncRetryInterval is the interval at which the wallet should
@@ -237,9 +249,9 @@ func (c *Config) validate() error {
 		return fmt.Errorf("%w: Name", ErrMissingParam)
 	}
 
-	if c.RecoveryWindow < MinRecoveryWindow {
-		return fmt.Errorf("%w: RecoveryWindow must be at least %d",
-			ErrInvalidParam, MinRecoveryWindow)
+	if c.RecoveryWindow > MaxRecoveryWindow {
+		return fmt.Errorf("%w: RecoveryWindow must not exceed %d",
+			ErrInvalidParam, MaxRecoveryWindow)
 	}
 
 	return nil

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -57,46 +57,32 @@ func TestConfigValidate(t *testing.T) {
 		{
 			name: "valid config",
 			config: Config{
-				Chain:          &bwmock.Chain{},
-				ChainParams:    &chainParams,
-				Name:           "test-wallet",
-				RecoveryWindow: MinRecoveryWindow,
+				Chain:       &bwmock.Chain{},
+				ChainParams: &chainParams,
+				Name:        "test-wallet",
 			},
-		},
-		{
-			name: "invalid RecoveryWindow",
-			config: Config{
-				Chain:          &bwmock.Chain{},
-				ChainParams:    &chainParams,
-				Name:           "test-wallet",
-				RecoveryWindow: MinRecoveryWindow - 1,
-			},
-			expectedErr: "RecoveryWindow",
 		},
 		{
 			name: "missing Chain",
 			config: Config{
-				ChainParams:    &chainParams,
-				Name:           "test-wallet",
-				RecoveryWindow: MinRecoveryWindow,
+				ChainParams: &chainParams,
+				Name:        "test-wallet",
 			},
 			expectedErr: "Chain",
 		},
 		{
 			name: "missing ChainParams",
 			config: Config{
-				Chain:          &bwmock.Chain{},
-				Name:           "test-wallet",
-				RecoveryWindow: MinRecoveryWindow,
+				Chain: &bwmock.Chain{},
+				Name:  "test-wallet",
 			},
 			expectedErr: "ChainParams",
 		},
 		{
 			name: "missing Name",
 			config: Config{
-				Chain:          &bwmock.Chain{},
-				ChainParams:    &chainParams,
-				RecoveryWindow: MinRecoveryWindow,
+				Chain:       &bwmock.Chain{},
+				ChainParams: &chainParams,
 			},
 			expectedErr: "Name",
 		},
@@ -114,6 +100,48 @@ func TestConfigValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestConfigValidateRecoveryWindow ensures the configuration accepts every
+// recovery window from zero through the public maximum and rejects the first
+// value above it.
+func TestConfigValidateRecoveryWindow(t *testing.T) {
+	t.Parallel()
+
+	// A zero window asks for no look-ahead at all, and recovery already
+	// runs with windows far below the twenty this configuration used to
+	// demand, so every one of these is a request the wallet serves as
+	// written.
+	accepted := []uint32{0, 1, 2, 19, 20, MaxRecoveryWindow}
+	for _, window := range accepted {
+		t.Run(fmt.Sprintf("accepts %d", window), func(t *testing.T) {
+			t.Parallel()
+
+			cfg := Config{
+				Chain:          &bwmock.Chain{},
+				ChainParams:    &chainParams,
+				Name:           "test-wallet",
+				RecoveryWindow: window,
+			}
+
+			require.NoError(t, cfg.validate())
+		})
+	}
+
+	t.Run("rejects the first excess window", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := Config{
+			Chain:          &bwmock.Chain{},
+			ChainParams:    &chainParams,
+			Name:           "test-wallet",
+			RecoveryWindow: MaxRecoveryWindow + 1,
+		}
+
+		err := cfg.validate()
+		require.ErrorIs(t, err, ErrInvalidParam)
+		require.ErrorContains(t, err, "RecoveryWindow")
+	})
 }
 
 // TestWalletSyncedToUsesStore verifies that a wallet without a legacy address


### PR DESCRIPTION
Implements Task 342 — accept bounded recovery windows.

`Config.validate` rejected every `RecoveryWindow` below 20 and bounded it from
above not at all. The floor was artificial: `RecoveryWindow` has exactly one
non-test consumer, `syncer.go`'s `NewRecoveryState`, and recovery already
operates with windows far smaller than 20. Nothing between the configuration
and the scan reads the field, so a caller asking for a window of one — or for
none — was refused a request the syncer would have served unchanged.

## What changed

`wallet/wallet.go` only:

- `MinRecoveryWindow = 20` is replaced by `MaxRecoveryWindow = 100_000`.
- `Config.validate` rejects `> MaxRecoveryWindow` with the existing
  wallet-owned `ErrInvalidParam` contract, and accepts everything below it.
- The `RecoveryWindow` field comment states the accepted range.

The check keeps its position in `validate`, which `Manager.Create` and
`Manager.Load` call before `deriveRootKey` and `backend.create` — so the
rejection lands before any Store or chain access rather than depending on one.

## Task 342 acceptance criteria mapped to tests

| Criterion | Test |
| --- | --- |
| Accepts 0, 1, 2, 19, 20, `MaxRecoveryWindow` unchanged | `TestConfigValidateRecoveryWindow` (subtest per value) |
| Maximum-plus-one returns the wallet-owned invalid-parameter error | `TestConfigValidateRecoveryWindow/rejects_the_first_excess_window` — `ErrorIs(ErrInvalidParam)` |
| ...without Store or chain access | `TestManagerCreate_ExcessRecoveryWindow` — `recordingManagerBackend.createCalled` is false, and a `bwmock.Chain` with no registered calls passes `AssertExpectations` |
| Existing small-window recovery fixtures remain valid | Full `wallet` package suite passes; `bwtest`'s window of 20 is untouched |
| RPC retains its separate negative-value check | No RPC file is touched. `RecoveryWindow` stays `uint32`, so the unsigned configuration never sees a negative value |


## Verification

- `go test ./wallet/...` — all packages pass.
- `golangci-lint run ./wallet/...` — 0 issues.
