### PR TITLE
wallet: serialize Manager wallet assembly

### DIFF
--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -28,6 +28,10 @@ var allTestCases = []*testCase{
 		TestFunc: testManagerLoadReload,
 	},
 	{
+		Name:     "manager load concurrent",
+		TestFunc: testManagerLoadConcurrent,
+	},
+	{
 		Name:     "manager load missing",
 		TestFunc: testManagerLoadMissing,
 	},

--- a/itest/manager_test.go
+++ b/itest/manager_test.go
@@ -3,6 +3,7 @@
 package itest
 
 import (
+	"sync"
 	"time"
 
 	"github.com/btcsuite/btcwallet/bwtest"
@@ -10,6 +11,74 @@ import (
 	"github.com/btcsuite/btcwallet/wallet"
 	"github.com/stretchr/testify/require"
 )
+
+// testManagerLoadConcurrent verifies that every supported Manager backend gives
+// concurrent cold Loads one exact runtime Wallet pointer.
+func testManagerLoadConcurrent(h *bwtest.HarnessTest) {
+	// Arrange. The setup Manager creates durable state, then closes so the
+	// test Manager opens the same backend with an empty runtime cache. Using
+	// two Managers is required to exercise a true cold Load on kvdb as well
+	// as SQL.
+	cfg, params := h.TestWalletConfig()
+	setupManager := h.NewWalletManager()
+
+	created, err := setupManager.Create(cfg, params)
+	require.NoError(h, err, "failed to create wallet")
+	require.NoError(h, created.Stop(h.Context()), "failed to stop wallet")
+	require.NoError(h, setupManager.Close(), "failed to close setup manager")
+	require.True(
+		h, h.ReleaseManager(setupManager),
+		"failed to release setup manager",
+	)
+
+	manager := h.NewWalletManager()
+
+	// Multiple callers contend for cold assembly. The exact number is not
+	// significant as long as it is greater than one.
+	const numCallers = 8
+
+	type result struct {
+		// wallet is the exact runtime returned to one caller.
+		wallet *wallet.Wallet
+
+		// err is the Load result returned with wallet.
+		err error
+	}
+
+	results := make(chan result, numCallers)
+	start := make(chan struct{})
+
+	var ready sync.WaitGroup
+
+	ready.Add(numCallers)
+
+	for range numCallers {
+		go func() {
+			ready.Done()
+			<-start
+
+			w, err := manager.Load(cfg)
+			results <- result{wallet: w, err: err}
+		}()
+	}
+
+	// Act. Release every caller into the empty Manager cache together.
+	ready.Wait()
+	close(start)
+
+	// Assert. One caller assembles the runtime and every other caller returns
+	// that exact installed pointer.
+	first := <-results
+	require.NoError(h, first.err, "failed to load wallet")
+	installed := first.wallet
+	h.RegisterWallet(installed)
+
+	for range numCallers - 1 {
+		result := <-results
+		require.NoError(h, result.err, "failed to load wallet")
+		require.Same(h, installed, result.wallet, "load rebuilt wallet")
+	}
+}
 
 // testCreateWallet verifies a wallet can be created, started, and synced.
 func testCreateWallet(h *bwtest.HarnessTest) {

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -107,10 +107,11 @@ type CreateWalletParams struct {
 type Manager struct {
 	sync.RWMutex
 
-	// wallets holds the active wallets keyed by their unique name, published
-	// as soon as they are assembled. A ModeShell Create imports its initial
-	// accounts after publishing, so a wallet can be observed here before
-	// that import finishes.
+	// wallets holds the active wallets keyed by their unique name. The
+	// Manager lock serializes Create and Load through assembly and cache
+	// installation. A ModeShell Create imports its initial accounts after
+	// installation, so a wallet can be observed here before that import
+	// finishes.
 	wallets map[string]*Wallet
 
 	// backend owns the database and resolves the storage dependencies for
@@ -209,16 +210,18 @@ func (m *Manager) Create(cfg Config,
 		return nil, err
 	}
 
+	m.Lock()
+
 	data, err := m.backend.create(
 		context.Background(), cfg, params, rootKey,
 	)
 	if err != nil {
+		m.Unlock()
+
 		return nil, err
 	}
 
 	w := newManagedWallet(cfg, data)
-
-	m.Lock()
 	m.wallets[cfg.Name] = w
 	m.Unlock()
 
@@ -366,10 +369,6 @@ func validateInitialAccountKeys(accounts []WatchOnlyAccount) error {
 // Load loads an existing wallet from the provided configuration. It opens the
 // database, initializes the wallet structure, and registers it with the manager
 // for tracking.
-//
-// TODO(yy): concurrent Load calls for the same name are not serialized, so two
-// callers racing on one wallet can both open a store. Call it from one
-// goroutine per wallet until that is fixed.
 func (m *Manager) Load(cfg Config) (*Wallet, error) {
 	// The Manager owns the network for every wallet it serves; see Create.
 	cfg.ChainParams = m.chainParams
@@ -379,12 +378,12 @@ func (m *Manager) Load(cfg Config) (*Wallet, error) {
 		return nil, err
 	}
 
-	// A wallet already published under this name is returned as is; callers
-	// serialize Create and Load, so a miss means this call builds it.
-	m.RLock()
-	existingW, ok := m.wallets[cfg.Name]
-	m.RUnlock()
+	m.Lock()
+	defer m.Unlock()
 
+	// A wallet already installed under this name is returned as is. The
+	// Manager lock makes a miss the sole assembly owner until installation.
+	existingW, ok := m.wallets[cfg.Name]
 	if ok {
 		return existingW, nil
 	}
@@ -395,10 +394,7 @@ func (m *Manager) Load(cfg Config) (*Wallet, error) {
 	}
 
 	w := newManagedWallet(cfg, data)
-
-	m.Lock()
 	m.wallets[cfg.Name] = w
-	m.Unlock()
 
 	return w, nil
 }


### PR DESCRIPTION
## Change Description

Implements roadmap Task 453.

Serialize every Manager `Create` and cold `Load` operation through one
Manager-wide lock. The lock spans durable creation, or the Load cache
decision, through backend assembly and cache installation. Concurrent
same-name Loads therefore return one exact Wallet pointer, and Create cannot
be overtaken between durable commit and runtime installation.

The cache remains `map[string]*Wallet` and contains only fully assembled
Wallets. Different wallet names intentionally assemble sequentially; there
are no per-name entries, channels, transient nil values, or result latches.

## Steps to Test

1. Run: `make unit pkg=wallet`
2. Run the concurrent Manager Load integration test for each backend:
   - `make itest chain=btcd db=kvdb icase="manager load concurrent"`
   - `make itest chain=btcd db=sqlite icase="manager load concurrent"`
   - `make itest chain=btcd db=postgres icase="manager load concurrent"`
3. Run: `make lint-check`

## Pull Request Checklist

### Testing

- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation

- [x] The change is not [insubstantial](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#ideal-git-commit-structure).
- [x] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md) for further guidance.