### PR TITLE
wallet: expose AccountInfo

### DIFF
--- a/wallet/account_info.go
+++ b/wallet/account_info.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+)
+
+// AccountInfo describes the public, wallet-owned snapshot of an account. Its
+// pointer and byte-slice fields are owned by the result and may be mutated by
+// the caller without affecting Store state or another result.
+type AccountInfo struct {
+	// AccountNumber is the BIP44 account index used for a derived account. A
+	// nil pointer means the account has no BIP44 number, while a non-nil zero
+	// identifies account zero.
+	AccountNumber *AccountNumber
+
+	// AccountName is the human-readable name of the account.
+	AccountName string
+
+	// IsImported reports whether the account was imported rather than
+	// derived from the wallet seed.
+	IsImported bool
+
+	// ExternalKeyCount is the number of external keys derived for the
+	// account.
+	ExternalKeyCount uint32
+
+	// InternalKeyCount is the number of internal change keys derived for the
+	// account.
+	InternalKeyCount uint32
+
+	// ImportedKeyCount is the number of individually imported keys reported
+	// for legacy account stores.
+	ImportedKeyCount uint32
+
+	// ConfirmedBalance is the account balance from confirmed transactions.
+	ConfirmedBalance btcutil.Amount
+
+	// UnconfirmedBalance is the account balance from unconfirmed
+	// transactions.
+	UnconfirmedBalance btcutil.Amount
+
+	// IsWatchOnly reports the wallet-level watch-only state associated with
+	// the account snapshot.
+	IsWatchOnly bool
+
+	// CreatedAt is the time the account was created. A zero time means the
+	// backing Store does not know the creation time.
+	CreatedAt time.Time
+
+	// KeyScope identifies the account's BIP43 purpose and BIP44 coin type.
+	KeyScope waddrmgr.KeyScope
+
+	// AddrSchema is the effective external and internal address schema for
+	// the account.
+	AddrSchema waddrmgr.ScopeAddrSchema
+
+	// PublicKey is the serialized account-level extended public key when the
+	// wallet knows that public material.
+	PublicKey []byte
+
+	// MasterKeyFingerprint is the BIP32 root fingerprint associated with the
+	// account public key. A nil pointer means it is absent, while a non-nil
+	// zero is a present-zero fingerprint.
+	MasterKeyFingerprint *MasterFingerprint
+}

--- a/wallet/account_info.go
+++ b/wallet/account_info.go
@@ -5,10 +5,13 @@
 package wallet
 
 import (
+	"slices"
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/addresstype"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 )
 
 // AccountInfo describes the public, wallet-owned snapshot of an account. Its
@@ -69,4 +72,86 @@ type AccountInfo struct {
 	// account public key. A nil pointer means it is absent, while a non-nil
 	// zero is a present-zero fingerprint.
 	MasterKeyFingerprint *MasterFingerprint
+}
+
+// accountInfoFromDB converts a store account snapshot into a caller-owned
+// public account snapshot.
+func accountInfoFromDB(info db.AccountInfo) (AccountInfo, error) {
+	addrSchema, err := scopeAddrSchemaFromDB(info.AddrSchema)
+	if err != nil {
+		return AccountInfo{}, err
+	}
+
+	result := AccountInfo{
+		AccountName:        info.AccountName,
+		IsImported:         info.IsImported,
+		ExternalKeyCount:   info.ExternalKeyCount,
+		InternalKeyCount:   info.InternalKeyCount,
+		ImportedKeyCount:   info.ImportedKeyCount,
+		ConfirmedBalance:   info.ConfirmedBalance,
+		UnconfirmedBalance: info.UnconfirmedBalance,
+		IsWatchOnly:        info.IsWatchOnly,
+		CreatedAt:          info.CreatedAt,
+		KeyScope: waddrmgr.KeyScope{
+			Purpose: info.KeyScope.Purpose,
+			Coin:    info.KeyScope.Coin,
+		},
+		AddrSchema: addrSchema,
+		PublicKey:  slices.Clone(info.PublicKey),
+	}
+
+	if info.AccountNumber != nil {
+		accountNumber := AccountNumber(*info.AccountNumber)
+		result.AccountNumber = &accountNumber
+	}
+
+	fingerprint := MasterFingerprint(info.MasterKeyFingerprint)
+	result.MasterKeyFingerprint = &fingerprint
+
+	return result, nil
+}
+
+// accountInfosFromDB converts store account snapshots while preserving a nil
+// source slice.
+func accountInfosFromDB(infos []db.AccountInfo) ([]AccountInfo, error) {
+	if infos == nil {
+		return nil, nil
+	}
+
+	results := make([]AccountInfo, len(infos))
+	for i := range infos {
+		info, err := accountInfoFromDB(infos[i])
+		if err != nil {
+			return nil, err
+		}
+
+		results[i] = info
+	}
+
+	return results, nil
+}
+
+// scopeAddrSchemaFromDB converts store address types to their wallet-facing
+// representations.
+func scopeAddrSchemaFromDB(
+	schema db.ScopeAddrSchema) (waddrmgr.ScopeAddrSchema, error) {
+
+	externalAddrType, err := addresstype.ToWallet(
+		schema.ExternalAddrType, false,
+	)
+	if err != nil {
+		return waddrmgr.ScopeAddrSchema{}, err
+	}
+
+	internalAddrType, err := addresstype.ToWallet(
+		schema.InternalAddrType, false,
+	)
+	if err != nil {
+		return waddrmgr.ScopeAddrSchema{}, err
+	}
+
+	return waddrmgr.ScopeAddrSchema{
+		ExternalAddrType: externalAddrType,
+		InternalAddrType: internalAddrType,
+	}, nil
 }

--- a/wallet/account_info_test.go
+++ b/wallet/account_info_test.go
@@ -1,0 +1,243 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/addresstype"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAccountInfoFromDBConvertsFields verifies every store field exposed by
+// the public account snapshot is converted without losing its value.
+func TestAccountInfoFromDBConvertsFields(t *testing.T) {
+	t.Parallel()
+
+	accountNumber := uint32(7)
+	createdAt := time.Date(2026, time.August, 20, 12, 30, 0, 0, time.UTC)
+	stored := db.AccountInfo{
+		AccountNumber:      &accountNumber,
+		AccountName:        "derived account",
+		ExternalKeyCount:   11,
+		InternalKeyCount:   13,
+		ImportedKeyCount:   17,
+		ConfirmedBalance:   btcutil.Amount(19),
+		UnconfirmedBalance: btcutil.Amount(23),
+		IsWatchOnly:        true,
+		CreatedAt:          createdAt,
+		KeyScope:           db.KeyScope{Purpose: 49, Coin: 1},
+		AddrSchema: db.ScopeAddrSchema{
+			ExternalAddrType: db.NestedWitnessPubKey,
+			InternalAddrType: db.WitnessPubKey,
+		},
+		PublicKey:            []byte("xpub"),
+		MasterKeyFingerprint: 0x01020304,
+	}
+	wantAccountNumber := AccountNumber(7)
+	wantFingerprint := MasterFingerprint(0x01020304)
+	want := AccountInfo{
+		AccountNumber:      &wantAccountNumber,
+		AccountName:        "derived account",
+		ExternalKeyCount:   11,
+		InternalKeyCount:   13,
+		ImportedKeyCount:   17,
+		ConfirmedBalance:   btcutil.Amount(19),
+		UnconfirmedBalance: btcutil.Amount(23),
+		IsWatchOnly:        true,
+		CreatedAt:          createdAt,
+		KeyScope:           waddrmgr.KeyScope{Purpose: 49, Coin: 1},
+		AddrSchema: waddrmgr.ScopeAddrSchema{
+			ExternalAddrType: waddrmgr.NestedWitnessPubKey,
+			InternalAddrType: waddrmgr.WitnessPubKey,
+		},
+		PublicKey:            []byte("xpub"),
+		MasterKeyFingerprint: &wantFingerprint,
+	}
+
+	got, err := accountInfoFromDB(stored)
+
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+// TestAccountInfoFromDBPreservesOptionalValues verifies account-number absence
+// and present-zero values survive conversion without ambiguous test controls.
+func TestAccountInfoFromDBPreservesOptionalValues(t *testing.T) {
+	t.Parallel()
+
+	zeroAccountNumber := uint32(0)
+	wantZeroAccountNumber := AccountNumber(0)
+	tests := []struct {
+		name                  string
+		accountNumber         *uint32
+		isImported            bool
+		masterFingerprint     uint32
+		wantAccountNumber     *AccountNumber
+		wantMasterFingerprint MasterFingerprint
+	}{
+		{
+			name: "absent account number and " +
+				"zero fingerprint",
+			masterFingerprint:     0,
+			wantAccountNumber:     nil,
+			wantMasterFingerprint: MasterFingerprint(0),
+		},
+		{
+			name: "present zero account and " +
+				"nonzero fingerprint",
+			accountNumber:         &zeroAccountNumber,
+			isImported:            true,
+			masterFingerprint:     123,
+			wantAccountNumber:     &wantZeroAccountNumber,
+			wantMasterFingerprint: MasterFingerprint(123),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := accountInfoFromDB(db.AccountInfo{
+				AccountNumber: test.accountNumber,
+				IsImported:    test.isImported,
+				AddrSchema: db.ScopeAddrSchema{
+					ExternalAddrType: db.WitnessPubKey,
+					InternalAddrType: db.WitnessPubKey,
+				},
+				MasterKeyFingerprint: test.masterFingerprint,
+			})
+
+			require.NoError(t, err)
+			require.Equal(
+				t, test.wantAccountNumber, got.AccountNumber,
+			)
+			require.Equal(t, test.isImported, got.IsImported)
+			wantFingerprint := test.wantMasterFingerprint
+			require.Equal(
+				t, wantFingerprint, *got.MasterKeyFingerprint,
+			)
+		})
+	}
+}
+
+// TestAccountInfoFromDBCopiesMutableFields verifies independently converted
+// results do not share pointers or byte slices with the store or each other.
+func TestAccountInfoFromDBCopiesMutableFields(t *testing.T) {
+	t.Parallel()
+
+	accountNumber := uint32(7)
+	stored := db.AccountInfo{
+		AccountNumber: &accountNumber,
+		AddrSchema: db.ScopeAddrSchema{
+			ExternalAddrType: db.WitnessPubKey,
+			InternalAddrType: db.WitnessPubKey,
+		},
+		PublicKey:            []byte("xpub"),
+		MasterKeyFingerprint: 42,
+	}
+
+	first, err := accountInfoFromDB(stored)
+	require.NoError(t, err)
+	second, err := accountInfoFromDB(stored)
+	require.NoError(t, err)
+
+	*first.AccountNumber = 8
+	first.PublicKey[0] = 'X'
+	*first.MasterKeyFingerprint = 99
+
+	require.Equal(t, uint32(7), *stored.AccountNumber)
+	require.Equal(t, []byte("xpub"), stored.PublicKey)
+	require.Equal(t, uint32(42), stored.MasterKeyFingerprint)
+	require.Equal(t, AccountNumber(7), *second.AccountNumber)
+	require.Equal(t, []byte("xpub"), second.PublicKey)
+	require.Equal(t, MasterFingerprint(42), *second.MasterKeyFingerprint)
+}
+
+// TestAccountInfoFromDBRejectsUnsupportedAddrSchema verifies unsupported
+// address types prevent a partial public result.
+func TestAccountInfoFromDBRejectsUnsupportedAddrSchema(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		schema db.ScopeAddrSchema
+	}{
+		{
+			name: "unsupported external type",
+			schema: db.ScopeAddrSchema{
+				ExternalAddrType: db.Anchor,
+				InternalAddrType: db.WitnessPubKey,
+			},
+		},
+		{
+			name: "unsupported internal type",
+			schema: db.ScopeAddrSchema{
+				ExternalAddrType: db.WitnessPubKey,
+				InternalAddrType: db.Anchor,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := accountInfoFromDB(db.AccountInfo{
+				AddrSchema: test.schema,
+			})
+
+			require.ErrorIs(t, err, addresstype.ErrUnknown)
+			require.Equal(t, AccountInfo{}, got)
+		})
+	}
+}
+
+// TestAccountInfosFromDBPreservesSliceShape verifies nil and non-nil empty
+// store results retain their distinct slice shapes.
+func TestAccountInfosFromDBPreservesSliceShape(t *testing.T) {
+	t.Parallel()
+
+	var nilStored []db.AccountInfo
+
+	got, err := accountInfosFromDB(nilStored)
+	require.NoError(t, err)
+	require.Nil(t, got)
+
+	emptyStored := []db.AccountInfo{}
+	got, err = accountInfosFromDB(emptyStored)
+	require.NoError(t, err)
+	require.Equal(t, []AccountInfo{}, got)
+}
+
+// TestAccountInfosFromDBReturnsConversionError verifies list conversion does
+// not return a partial result when one account has an unsupported address type.
+func TestAccountInfosFromDBReturnsConversionError(t *testing.T) {
+	t.Parallel()
+
+	got, err := accountInfosFromDB([]db.AccountInfo{
+		{
+			AddrSchema: db.ScopeAddrSchema{
+				ExternalAddrType: db.WitnessPubKey,
+				InternalAddrType: db.WitnessPubKey,
+			},
+		},
+		// Anchor has no wallet-facing address type, so this row must
+		// fail conversion.
+		{
+			AddrSchema: db.ScopeAddrSchema{
+				ExternalAddrType: db.Anchor,
+				InternalAddrType: db.WitnessPubKey,
+			},
+		},
+	})
+
+	require.ErrorIs(t, err, addresstype.ErrUnknown)
+	require.Nil(t, got)
+}

--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -115,26 +115,26 @@ type AccountManager interface {
 	// NewAccount creates a new account for a given key scope and name. The
 	// provided name must be unique within that key scope.
 	NewAccount(ctx context.Context, scope waddrmgr.KeyScope, name string) (
-		*db.AccountInfo, error)
+		*AccountInfo, error)
 
 	// ListAccounts returns a list of all accounts managed by the wallet.
-	ListAccounts(ctx context.Context) ([]db.AccountInfo, error)
+	ListAccounts(ctx context.Context) ([]AccountInfo, error)
 
 	// ListAccountsByScope returns a list of all accounts for a given key
 	// scope.
 	ListAccountsByScope(ctx context.Context, scope waddrmgr.KeyScope) (
-		[]db.AccountInfo, error)
+		[]AccountInfo, error)
 
 	// ListAccountsByName searches for accounts with the given name across
 	// all key scopes. Because names are not globally unique, this may
 	// return multiple results.
 	ListAccountsByName(ctx context.Context, name string) (
-		[]db.AccountInfo, error)
+		[]AccountInfo, error)
 
 	// GetAccount returns the snapshot for a specific account, looked up
 	// by its key scope and unique name within that scope.
 	GetAccount(ctx context.Context, scope waddrmgr.KeyScope, name string) (
-		*db.AccountInfo, error)
+		*AccountInfo, error)
 
 	// RenameAccount renames an existing account. To uniquely identify the
 	// account, the key scope must be provided. The new name must be unique
@@ -154,7 +154,7 @@ type AccountManager interface {
 	ImportAccount(ctx context.Context, name string,
 		accountKey *hdkeychain.ExtendedKey,
 		masterKeyFingerprint uint32, addrType waddrmgr.AddressType,
-		dryRun bool) (*db.AccountInfo, error)
+		dryRun bool) (*AccountInfo, error)
 }
 
 // A compile time check to ensure that Wallet implements the interface.
@@ -166,7 +166,7 @@ var _ AccountManager = (*Wallet)(nil)
 // accounts have no transaction history (this is a deviation from the BIP0044
 // spec, which allows no unused account gaps).
 func (w *Wallet) NewAccount(ctx context.Context, scope waddrmgr.KeyScope,
-	name string) (*db.AccountInfo, error) {
+	name string) (*AccountInfo, error) {
 
 	err := w.state.validateStarted()
 	if err != nil {
@@ -201,11 +201,16 @@ func (w *Wallet) NewAccount(ctx context.Context, scope waddrmgr.KeyScope,
 		info.MasterKeyFingerprint = w.masterFingerprint
 	}
 
-	return info, nil
+	accountInfo, err := accountInfoFromDB(*info)
+	if err != nil {
+		return nil, err
+	}
+
+	return &accountInfo, nil
 }
 
 // propertiesToAccountInfo wraps a waddrmgr.AccountProperties + total
-// balance into the canonical db.AccountInfo shape the public wallet
+// balance into the canonical AccountInfo shape the public wallet
 // API now exposes. The legacy waddrmgr path does not separate
 // confirmed/unconfirmed balances, so the supplied total is reported
 // on ConfirmedBalance; UnconfirmedBalance stays zero. For derived accounts,
@@ -213,16 +218,17 @@ func (w *Wallet) NewAccount(ctx context.Context, scope waddrmgr.KeyScope,
 // lock-state-dependent waddrmgr account properties.
 func propertiesToAccountInfo(props *waddrmgr.AccountProperties,
 	total btcutil.Amount, isImported bool, walletWatchOnly bool,
-	masterFingerprint uint32) db.AccountInfo {
+	masterFingerprint uint32) AccountInfo {
 
 	var pubKey []byte
 	if props.AccountPubKey != nil {
 		pubKey = []byte(props.AccountPubKey.String())
 	}
 
-	var accountNumber *uint32
+	var accountNumber *AccountNumber
 	if !isImported {
-		accountNumber = &props.AccountNumber
+		accountNum := AccountNumber(props.AccountNumber)
+		accountNumber = &accountNum
 	}
 
 	isWatchOnly := walletWatchOnly
@@ -237,38 +243,34 @@ func propertiesToAccountInfo(props *waddrmgr.AccountProperties,
 		fingerprint = props.MasterKeyFingerprint
 	}
 
-	scope := db.KeyScope(props.KeyScope)
-	addrSchema := db.ScopeAddrMap[scope]
+	addrSchema := waddrmgr.ScopeAddrMap[props.KeyScope]
 
 	if props.AddrSchema != nil {
-		override, err := db.ScopeAddrSchemaFromWaddrmgr(*props.AddrSchema)
-		if err != nil {
-			log.Errorf("propertiesToAccountInfo: skipping invalid "+
-				"AddrSchema override (%v); falling back to scope "+
-				"default", err)
-		} else {
-			addrSchema = override
-		}
+		addrSchema = *props.AddrSchema
 	}
 
-	return db.AccountInfo{
-		AccountNumber:        accountNumber,
-		AccountName:          props.AccountName,
-		IsImported:           isImported,
-		ExternalKeyCount:     props.ExternalKeyCount,
-		InternalKeyCount:     props.InternalKeyCount,
-		ImportedKeyCount:     props.ImportedKeyCount,
-		IsWatchOnly:          isWatchOnly,
-		KeyScope:             scope,
-		AddrSchema:           addrSchema,
-		PublicKey:            pubKey,
-		MasterKeyFingerprint: fingerprint,
-		ConfirmedBalance:     total,
+	result := AccountInfo{
+		AccountNumber:    accountNumber,
+		AccountName:      props.AccountName,
+		IsImported:       isImported,
+		ExternalKeyCount: props.ExternalKeyCount,
+		InternalKeyCount: props.InternalKeyCount,
+		ImportedKeyCount: props.ImportedKeyCount,
+		IsWatchOnly:      isWatchOnly,
+		KeyScope:         props.KeyScope,
+		AddrSchema:       addrSchema,
+		PublicKey:        pubKey,
+		ConfirmedBalance: total,
 	}
+
+	masterKeyFingerprint := MasterFingerprint(fingerprint)
+	result.MasterKeyFingerprint = &masterKeyFingerprint
+
+	return result
 }
 
 // ListAccounts returns every account across all key scopes with its balance.
-func (w *Wallet) ListAccounts(ctx context.Context) ([]db.AccountInfo, error) {
+func (w *Wallet) ListAccounts(ctx context.Context) ([]AccountInfo, error) {
 	err := w.state.validateStarted()
 	if err != nil {
 		return nil, err
@@ -282,7 +284,7 @@ func (w *Wallet) ListAccounts(ctx context.Context) ([]db.AccountInfo, error) {
 // listAccountInfos returns cache.ListAccounts snapshots with wallet-cached
 // master fingerprints injected for derived account rows.
 func (w *Wallet) listAccountInfos(ctx context.Context,
-	query db.ListAccountsQuery) ([]db.AccountInfo, error) {
+	query db.ListAccountsQuery) ([]AccountInfo, error) {
 
 	infos, err := w.cache.ListAccounts(ctx, query)
 	if err != nil {
@@ -295,12 +297,12 @@ func (w *Wallet) listAccountInfos(ctx context.Context,
 		}
 	}
 
-	return infos, nil
+	return accountInfosFromDB(infos)
 }
 
 // ListAccountsByScope returns all accounts for the given key scope.
 func (w *Wallet) ListAccountsByScope(ctx context.Context,
-	scope waddrmgr.KeyScope) ([]db.AccountInfo, error) {
+	scope waddrmgr.KeyScope) ([]AccountInfo, error) {
 
 	err := w.state.validateStarted()
 	if err != nil {
@@ -317,7 +319,7 @@ func (w *Wallet) ListAccountsByScope(ctx context.Context,
 
 // ListAccountsByName returns every account matching name across all scopes.
 func (w *Wallet) ListAccountsByName(ctx context.Context,
-	name string) ([]db.AccountInfo, error) {
+	name string) ([]AccountInfo, error) {
 
 	err := w.state.validateStarted()
 	if err != nil {
@@ -334,7 +336,7 @@ func (w *Wallet) ListAccountsByName(ctx context.Context,
 // The account snapshot, including the running balance, is fetched in a
 // single Store read.
 func (w *Wallet) GetAccount(ctx context.Context, scope waddrmgr.KeyScope,
-	name string) (*db.AccountInfo, error) {
+	name string) (*AccountInfo, error) {
 
 	err := w.state.validateStarted()
 	if err != nil {
@@ -367,7 +369,12 @@ func (w *Wallet) GetAccount(ctx context.Context, scope waddrmgr.KeyScope,
 		info.MasterKeyFingerprint = w.masterFingerprint
 	}
 
-	return info, nil
+	accountInfo, err := accountInfoFromDB(*info)
+	if err != nil {
+		return nil, err
+	}
+
+	return &accountInfo, nil
 }
 
 // RenameAccount renames an existing account. The new name must be unique within
@@ -424,16 +431,26 @@ func (w *Wallet) RenameAccount(ctx context.Context,
 func (w *Wallet) ImportAccount(ctx context.Context,
 	name string, accountKey *hdkeychain.ExtendedKey,
 	masterKeyFingerprint uint32, addrType waddrmgr.AddressType,
-	dryRun bool) (*db.AccountInfo, error) {
+	dryRun bool) (*AccountInfo, error) {
 
 	err := w.state.validateStarted()
 	if err != nil {
 		return nil, err
 	}
 
-	return w.importAccountInternal(
+	info, err := w.importAccountInternal(
 		ctx, name, accountKey, masterKeyFingerprint, addrType, dryRun,
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	accountInfo, err := accountInfoFromDB(*info)
+	if err != nil {
+		return nil, err
+	}
+
+	return &accountInfo, nil
 }
 
 // importAccountInternal is the internal implementation of ImportAccount,

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -144,10 +144,12 @@ func TestPropertiesToAccountInfoLockedDerivedNotMisclassified(t *testing.T) {
 	}, 123, false, false, masterFingerprint)
 
 	require.NotNil(t, info.AccountNumber)
-	require.Equal(t, uint32(7), *info.AccountNumber)
+	require.Equal(t, AccountNumber(7), *info.AccountNumber)
 	require.False(t, info.IsImported)
 	require.False(t, info.IsWatchOnly)
-	require.Equal(t, masterFingerprint, info.MasterKeyFingerprint)
+	require.Equal(
+		t, MasterFingerprint(masterFingerprint), *info.MasterKeyFingerprint,
+	)
 }
 
 // TestValidateExtendedPubKeyNil verifies that a nil account key is rejected
@@ -176,7 +178,11 @@ func TestPropertiesToAccountInfoImportedClassifiedAndMasked(t *testing.T) {
 	require.Nil(t, info.AccountNumber)
 	require.True(t, info.IsImported)
 	require.True(t, info.IsWatchOnly)
-	require.Equal(t, importedFingerprint, info.MasterKeyFingerprint)
+
+	expectedFingerprint := MasterFingerprint(importedFingerprint)
+	require.Equal(
+		t, expectedFingerprint, *info.MasterKeyFingerprint,
+	)
 }
 
 // TestListAccounts verifies ListAccounts returns account snapshots with the
@@ -215,7 +221,9 @@ func TestListAccounts(t *testing.T) {
 
 	require.Len(t, accounts, 1)
 	require.Equal(t, "default", accounts[0].AccountName)
-	require.Equal(t, masterFP, accounts[0].MasterKeyFingerprint)
+	require.Equal(
+		t, MasterFingerprint(masterFP), *accounts[0].MasterKeyFingerprint,
+	)
 }
 
 // TestListAccountsByScope verifies the scope filter narrows the query.
@@ -390,11 +398,13 @@ func TestGetAccount(t *testing.T) {
 	info, err := w.GetAccount(t.Context(), scope, name)
 	require.NoError(t, err)
 	require.NotNil(t, info.AccountNumber)
-	require.Equal(t, uint32(1), *info.AccountNumber)
+	require.Equal(t, AccountNumber(1), *info.AccountNumber)
 	require.Equal(t, name, info.AccountName)
 	require.Equal(t, btcutil.Amount(100), info.ConfirmedBalance)
 	require.Equal(t, btcutil.Amount(23), info.UnconfirmedBalance)
-	require.Equal(t, masterFP, info.MasterKeyFingerprint)
+	require.Equal(
+		t, MasterFingerprint(masterFP), *info.MasterKeyFingerprint,
+	)
 }
 
 // TestGetAccountIncludesImportedPseudoAccount verifies that the AccountInfo
@@ -467,8 +477,12 @@ func TestNewAccount(t *testing.T) {
 	account, err := w.NewAccount(t.Context(), scope, testAccountName)
 	require.NoError(t, err)
 	require.NotNil(t, account.AccountNumber)
-	require.Equal(t, uint32(1), *account.AccountNumber)
-	require.Equal(t, stub.masterKeyFingerprint, account.MasterKeyFingerprint)
+	require.Equal(t, AccountNumber(1), *account.AccountNumber)
+
+	expectedFingerprint := MasterFingerprint(stub.masterKeyFingerprint)
+	require.Equal(
+		t, expectedFingerprint, *account.MasterKeyFingerprint,
+	)
 
 	// Duplicate-name path.
 	expectAccountDeriveSetup(t, deps, stub)
@@ -523,7 +537,7 @@ func TestNewAccountMissingHDSeedDefersToStore(t *testing.T) {
 	account, err := w.NewAccount(t.Context(), scope, testAccountName)
 	require.NoError(t, err)
 	require.NotNil(t, account.AccountNumber)
-	require.Equal(t, uint32(1), *account.AccountNumber)
+	require.Equal(t, AccountNumber(1), *account.AccountNumber)
 }
 
 // TestRenameAccount verifies RenameAccount routes through
@@ -587,11 +601,12 @@ func TestImportAccount(t *testing.T) {
 			MasterFingerprint: masterFP,
 			PublicKey:         []byte(acctPubKey.String()),
 		}).Return(&db.AccountInfo{
-		AccountName: testAccountName,
-		IsImported:  true,
-		IsWatchOnly: true,
-		KeyScope:    dbScope,
-		PublicKey:   []byte(acctPubKey.String()),
+		AccountName:          testAccountName,
+		IsImported:           true,
+		IsWatchOnly:          true,
+		KeyScope:             dbScope,
+		PublicKey:            []byte(acctPubKey.String()),
+		MasterKeyFingerprint: masterFP,
 	}, nil).Once()
 
 	props, err := w.ImportAccount(
@@ -600,6 +615,9 @@ func TestImportAccount(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, testAccountName, props.AccountName)
+	require.Equal(
+		t, MasterFingerprint(masterFP), *props.MasterKeyFingerprint,
+	)
 }
 
 // TestImportAccountDryRun verifies that dry-run imports still route through

--- a/wallet/benchmark_helpers_test.go
+++ b/wallet/benchmark_helpers_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
-	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/stretchr/testify/require"
@@ -937,9 +936,9 @@ func signMultipleInputsWithTweaker(tb testing.TB, w *Wallet, tx *wire.MsgTx,
 // listAccountsDeprecated wraps the deprecated Accounts API to satisfy the same
 // contract as ListAccounts by calling Accounts across all active key scopes
 // and aggregating the results.
-func listAccountsDeprecated(w *Wallet) ([]db.AccountInfo, error) {
+func listAccountsDeprecated(w *Wallet) ([]AccountInfo, error) {
 	var (
-		allAccounts   []db.AccountInfo
+		allAccounts   []AccountInfo
 		scopeManagers = w.addrStore.ActiveScopedKeyManagers()
 	)
 
@@ -965,10 +964,10 @@ func listAccountsDeprecated(w *Wallet) ([]db.AccountInfo, error) {
 // same contract as ListAccountsByName by calling Accounts API across all active
 // key scopes, filtering by account name, and aggregating the results.
 func listAccountsByNameDeprecated(w *Wallet,
-	name string) ([]db.AccountInfo, error) {
+	name string) ([]AccountInfo, error) {
 
 	var (
-		matchingAccounts []db.AccountInfo
+		matchingAccounts []AccountInfo
 		scopeManagers    = w.addrStore.ActiveScopedKeyManagers()
 	)
 
@@ -998,7 +997,7 @@ func listAccountsByNameDeprecated(w *Wallet,
 // contract as GetAccount by calling Accounts API across all active key scopes
 // and filtering by account name.
 func getAccountDeprecated(w *Wallet, scope waddrmgr.KeyScope,
-	accountName string) (*db.AccountInfo, error) {
+	accountName string) (*AccountInfo, error) {
 
 	result, err := w.Accounts(scope)
 	if err != nil {
@@ -1018,7 +1017,7 @@ func getAccountDeprecated(w *Wallet, scope waddrmgr.KeyScope,
 
 // accountResultToInfo converts the deprecated account result shape into the
 // account-info shape used by the replacement read APIs.
-func accountResultToInfo(w *Wallet, account AccountResult) db.AccountInfo {
+func accountResultToInfo(w *Wallet, account AccountResult) AccountInfo {
 	isImported := account.AccountNumber == waddrmgr.ImportedAddrAccount
 
 	return propertiesToAccountInfo(


### PR DESCRIPTION
## Change Description

Expose a wallet-owned `AccountInfo` result type and return it from the public `AccountManager` APIs instead of leaking `wallet/internal/db.AccountInfo`.

The wallet boundary converts store snapshots into public scope and schema types, copies mutable pointer and byte-slice fields, preserves account-number and fingerprint values, and keeps store and cache contracts internal. Tests cover complete field conversion, result ownership, unsupported schemas, and list conversion behavior.

Implements [roadmap Task 377](https://github.com/yyforyongyu/btcwallet-sql-roadmap/blob/main/tasks/377-account-manager-wallet-dto.md).

This is a prelude to https://github.com/btcsuite/btcwallet/pull/1326. Isolating the public account-result boundary here keeps that AccountManager mutation integration PR focused and makes its review easier.

## Steps to Test

1. Run: `go test ./... -count=1`

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions. (N/A; this is an API boundary change.)

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#ideal-git-commit-structure).
- [x] Any new logging statements use an appropriate subsystem and logging level. (N/A; no logging changes.)

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md) for further guidance.