### PR TITLE
build: preserve semantic version separators

### DIFF
--- a/build/version.go
+++ b/build/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // semanticAlphabet
-const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
+const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-."
 
 // These constants define the application version and follow the semantic
 // versioning 2.0.0 spec (http://semver.org/).
@@ -21,13 +21,19 @@ const (
 	appPatch uint = 1
 
 	// appPreRelease MUST only contain characters from semanticAlphabet
-	// per the semantic versioning spec.
+	// per the semantic versioning spec.  That is necessary but not
+	// sufficient: semanticAlphabet is a per-character filter and cannot
+	// reject a malformed arrangement of valid characters, such as a
+	// trailing or doubled '.', so the value must also be a well-formed
+	// dot-separated list of non-empty identifiers.
 	appPreRelease = "alpha"
 )
 
 // appBuild is defined as a variable so it can be overridden during the build
 // process with '-ldflags "-X main.appBuild foo' if needed.  It MUST only
-// contain characters from semanticAlphabet per the semantic versioning spec.
+// contain characters from semanticAlphabet per the semantic versioning spec,
+// and like appPreRelease must also be a well-formed dot-separated list of
+// non-empty identifiers, which the per-character filter cannot enforce.
 var appBuild string
 
 // Version returns the application version as a properly formed string per the

--- a/build/version_test.go
+++ b/build/version_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package build
+
+import "testing"
+
+// TestNormalizeVerString ensures semantic version separators are preserved
+// while characters outside the alphabet are still stripped.
+func TestNormalizeVerString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "dotted pre-release identifier",
+			in:   "beta.rc1",
+			want: "beta.rc1",
+		},
+		{
+			// appBuild may be set to a dotted value via -ldflags at
+			// build time.
+			name: "dotted build metadata",
+			in:   "exp.sha.5114f85",
+			want: "exp.sha.5114f85",
+		},
+		{
+			// Guards against the filter being dropped entirely: an
+			// identity function satisfies the cases above.
+			name: "character outside the alphabet",
+			in:   "beta!rc1",
+			want: "betarc1",
+		},
+	}
+
+	for _, test := range tests {
+		if got := normalizeVerString(test.in); got != test.want {
+			t.Fatalf("%s: normalizeVerString(%q) = %q, want %q",
+				test.name, test.in, got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
btcd hit this in its own copy of `version.go` and fixed it in [65db493](https://github.com/btcsuite/btcd/commit/65db49397a59fb10fd5a954df19bda33ce4e5e5d) ("version: preserve semantic version separators", btcsuite/btcd#2578): SemVer separates pre-release identifiers and build metadata with periods, but `semanticAlphabet` omitted the period, so `normalizeVerString` silently collapsed `beta.rc1` into `betarc1`.

`btcwallet/build/version.go` carries the same code and still has the old alphabet:

```
btcd/version.go:14           ...uvwxyz-."
btcwallet/build/version.go:14 ...uvwxyz-"
```

btcd's test, run unchanged against this copy, fails:

```
--- FAIL: TestNormalizeVerString
    version_test.go:25: unexpected normalized version: got "betarc1", want "beta.rc1"
```

This is reachable rather than latent. `normalizeVerString` is applied to `appBuild`, which the comment above it documents as settable at build time:

```go
// appBuild is defined as a variable so it can be overridden during the build
// process with '-ldflags "-X main.appBuild foo' if needed.
```

SemVer build metadata is dot-separated — `exp.sha.5114f85` is an example from the spec itself — so a btcwallet built with that stamp reports `0.15.1-alpha+expsha5114f85`, with the separators dropped and the metadata no longer round-tripping.

The change is the one-character fix from 65db493 plus that commit's test, with a build metadata case added for the `appBuild` path.

`go build ./...`, `go test ./build/`, `gofmt` and `go vet` are clean.

Two things I noticed but left alone to keep the diff to the fix:

- That doc comment says `-X main.appBuild`, but this copy lives in package `build`, so the flag is really `-X github.com/btcsuite/btcwallet/build.appBuild`. It was accurate before the code moved out of `main`.
- btcsuite/btcd#2596 applies the same fix to `btcd/cmd/btcctl/version.go`, which is a third copy of this file that was also missed.

---

*Disclosure: written with AI assistance; the analysis, fix and test were verified locally.*
