### PR TITLE
wallet+db: define account creation identity

### DIFF
--- a/docs/developer/adr/0012-wallet-level-watch-only-uniformity.md
+++ b/docs/developer/adr/0012-wallet-level-watch-only-uniformity.md
@@ -70,6 +70,34 @@ The legacy JSON-RPC contract (`getbalance`, `listaccounts`,
 external consumers do not break. Wallet-internal callers migrate to the
 single-bucket shape.
 
+### Supplied account XPub custody
+
+The public account-creation operations in ADR 0013 supply no matching private
+account material. SQL therefore accepts their unnumbered and numbered
+caller-supplied XPub shapes only in a uniformly watch-only wallet. This
+does not change the Store-level rule that a spendable wallet may contain
+externally sourced account material only when matching encrypted private
+account material is supplied.
+
+These public-only caller-supplied account shapes cannot coexist in one SQL
+wallet with wallet-root-derived accounts. The supplied shapes require a
+uniformly watch-only wallet, while wallet-root account derivation uses the
+spendable wallet's private root. The immutable wallet custody mode prevents
+those paths from being combined.
+
+Importing a private wallet root is different from supplying an account XPub.
+Accounts derived from that root remain wallet-root-derived and may be
+spendable.
+
+An account's immutable `NoChainSync` value is independent of this custody
+rule. Spendable and uniformly watch-only wallets may each contain accounts
+with either value; excluding an account from automatic chain synchronization
+neither adds nor removes signing capability.
+
+The legacy kvdb mixed-mode exception remains limited to arbitrary, unnumbered,
+watch-chain account imports; it does not provide path-bound identity or SQL
+parity. ADR 0013 owns the account identity and chain-sync decisions.
+
 ### Imported addresses land in a reserved wallet-level bucket
 
 An imported address — with or without private-key material — is never
@@ -193,6 +221,9 @@ model.
 - [ADR 0011](0011-no-addresses-used-column.md): addresses table omits the
   `used` column (related — also a "compute, don't persist" choice; this ADR
   makes the opposite call by persisting wallet-level watch-only).
+- [ADR 0013](0013-normalized-account-address-identity.md): defines account
+  provenance, optional number and fingerprint, scope, schema, and chain-sync
+  policy independently of wallet custody.
 - [Bitcoin Core v23.0 release notes][btc-core-v23-release]: documents
   descriptor wallets becoming the default wallet type for new wallets.
 - [Bitcoin Core `createwallet` documentation][btc-core-createwallet]:

--- a/docs/developer/adr/0013-normalized-account-address-identity.md
+++ b/docs/developer/adr/0013-normalized-account-address-identity.md
@@ -20,26 +20,28 @@ looked like members of an account solely because SQL needed a non-null
 
 The recovery follow-up needs immutable SQL identity for imported xpub scan
 horizons. Account names and nullable account numbers are not suitable for that
-purpose: names can be renamed, and imported xpubs do not have BIP44 account
-numbers.
+purpose: names can be renamed, and unnumbered caller-supplied XPub accounts do
+not have account numbers.
 
 The word "imported" is overloaded across wallet layers. A wallet may be
 imported from a seed while its accounts remain derivable from that seed. An
-account xpub may be imported while its child addresses remain derivable from the
-xpub. A raw script or public-key address import is not derivable at all. The SQL
-schema therefore models whether a row has derivation identity, not where the
-user originally obtained the material.
+account XPub may be imported while its child addresses remain derivable from
+the XPub. A raw script or public-key address import is not derivable at all.
+The SQL schema therefore keeps account-key provenance separate from whether an
+address row has derivation identity.
 
 ## 2. Decision
 
 Normalize account and address identity around real persisted identity only:
 
-| Case | Parent | Number | Path |
+| Case | Parent | Number | Child path |
 | --- | --- | --- | --- |
-| Wallet-derived account | `accounts` row | BIP44 number | N/A |
-| Imported xpub account | `accounts` row | none | N/A |
-| Wallet-derived child address | derived account | has number | branch/index |
-| Imported-xpub child address | imported xpub account | none | branch/index |
+| Wallet-root-derived account | `accounts` row | required | N/A |
+| Caller-supplied XPub, unnumbered | `accounts` row | none | N/A |
+| Caller-supplied XPub, numbered | `accounts` row | required | N/A |
+| Root-derived child address | root account | required | branch/index |
+| Unnumbered-XPub child address | caller-supplied account | none | branch/index |
+| Numbered-XPub child address | caller-supplied account | required | branch/index |
 | Raw imported address | none | none | none; no scope |
 
 The SQL primitive is `is_derived` rather than `is_imported`. An imported-xpub
@@ -47,27 +49,146 @@ child address is imported from a user perspective, but it is still derived from
 an account xpub and has branch/index path facts. A raw imported address is not
 derived from an account and has no scope or path facts.
 
-The structural booleans describe row shape only. They are not provenance or
-audit fields. If provenance becomes necessary later, it should be modeled
-separately.
+The address `is_derived` boolean describes row shape only. Account
+`is_derived` has the narrower meaning "the account XPub was derived from this
+wallet's private root." It is an immutable custody/provenance fact and does not
+say whether child addresses can be derived: all three account shapes derive
+branch and address children from an account XPub.
 
 ### Accounts
 
 `accounts` is the stable account identity table. It holds wallet, scope, name,
 account-level public key, master fingerprint, next external/internal derivation
-indexes, a structural `is_derived` bit, and a nullable `account_number`.
+indexes, an `is_derived` provenance bit, and a nullable `account_number`.
 
-Wallet-derived accounts set `is_derived` and have a non-null BIP44 account
-number. Imported xpub accounts clear `is_derived` and leave `account_number`
-NULL because they do not have wallet-derived BIP44 identity.
+Wallet-root-derived accounts set `is_derived` and have a non-null account
+number. Unnumbered caller-supplied XPub accounts clear `is_derived` and leave
+`account_number` NULL. Numbered caller-supplied XPub accounts also clear
+`is_derived`, because the wallet did not derive their account key, but retain
+the real non-null hardened account component declared by the caller and
+validated against the supplied depth-three XPub.
 
-There is no `derived_accounts` table. The account ID is the immutable identity
-for both wallet-derived accounts and imported xpub accounts. Account number is
-an optional identity attribute of wallet-derived accounts only.
+There is no `derived_accounts` table. The account ID remains an internal Store
+identity for all account shapes. It is not a portable public identifier.
+Numbered public lookup uses `(scope, account_number)` for either root-derived
+or numbered caller-supplied provenance. An unnumbered caller-supplied account
+has no number and is selected by its mutable name within its scope.
 
-Account identity fields, including `id`, `wallet_id`, `scope_id`,
-`is_derived`, and `account_number`, are immutable after creation. Account-name
-uniqueness stays centralized on `accounts`.
+All numbered accounts in one wallet scope share the same account-number
+namespace regardless of provenance. A numbered caller-supplied account
+occupies its `(scope, account_number)` slot, and another account that declares
+the same pair is rejected. Public-only caller-supplied and wallet-root-derived
+accounts cannot coexist under the SQL custody rule, but the numbered namespace
+does not acquire a separate caller-supplied domain.
+
+Account provenance, account-number presence and value, master-fingerprint
+presence and value, scope, effective address schema, `NoChainSync`, and XPub
+are immutable after creation. Account names remain mutable, scope-unique
+display and lookup metadata. SQL row IDs and kvdb adapter account numbers never
+cross the Store boundary as semantic identity.
+
+#### Account Creation Identity
+
+Wallet-root provenance and account-number presence are orthogonal. The
+accepted account shapes are:
+
+| Source | SQL custody | Provenance | Number | Fingerprint |
+| --- | --- | --- | --- | --- |
+| Generated seed | spendable | wallet-root | required | computed |
+| Imported private root | spendable | wallet-root | required | computed |
+| Caller-supplied XPub, unnumbered | watch-only | caller-supplied | absent | required |
+| Caller-supplied XPub, numbered | watch-only | caller-supplied | required | optional |
+
+The persisted `is_derived` fact and the public `IsImported` projection encode
+wallet-root versus caller-supplied provenance. The optional account number
+distinguishes unnumbered from numbered caller-supplied identity, so no second
+provenance enum is needed. Accounts derived from an imported private wallet
+root remain wallet-root-derived; a supplied account XPub remains
+caller-supplied even when it has a known account number.
+
+For a numbered caller-supplied XPub, the full key origin is the caller-declared
+tuple `(master fingerprint?, purpose', coin_type', account')`. The wallet
+validates the public key's network, depth, and hardened account child against
+the requested account number. It cannot authenticate the hardened purpose or
+coin ancestors or optional fingerprint, which remain caller-declared
+provenance. Fingerprint presence, including present-zero, is preserved.
+Root-derived accounts use the wallet-computed fingerprint.
+
+#### Account Creation Requests
+
+`NewAccountParams` is the one extensible wallet-owned account-creation request.
+It starts with the existing name and scope inputs plus `NoChainSync`. Optional
+exact account selection, custom scope schema selection, a supplied account
+XPub, and its optional fingerprint enter the request only with their owning
+behavior; the initial request does not publish dormant fields. No separate
+exact-account, lnd-specific, or key-family operation is introduced.
+
+`AccountInfo` exposes the immutable `NoChainSync` fact alongside the account's
+identity facts. This result does not make chain synchronization a custody or
+signing signal.
+
+The retained ordinary unnumbered-import signature is
+`ImportAccount(context.Context, string, *hdkeychain.ExtendedKey, uint32,
+waddrmgr.AddressType, bool) (*AccountInfo, error)`.
+Its fingerprint is required, including zero. The XPub version and address type
+retain their existing scope and schema selection. The operation has no exact
+account number, schema override, or `NoChainSync` input, always creates and
+reports `NoChainSync=false`, and does not gain an `ImportAccountParams`
+wrapper.
+
+Caller-declared scope is authoritative only for a numbered caller-supplied
+XPub request through `NewAccountParams`. Its extended-key version is checked for
+the configured Bitcoin network but does not infer scope or schema. Ordinary
+`ImportAccount` retains the distinct version-and-address-type selection above.
+
+#### Chain Synchronization
+
+`NoChainSync` is an immutable boolean independent of wallet-level signing
+custody:
+
+| Wallet custody | `NoChainSync=false` | `NoChainSync=true` |
+| --- | --- | --- |
+| Spendable | automatic chain sync | excluded from automatic chain sync |
+| Uniformly watch-only | automatic chain sync | excluded from automatic chain sync |
+
+When false, the account participates in automatic chain discovery and live
+script registration. When true, its derived scripts are excluded from both.
+Neither value changes address ownership, public child derivation, or signing
+capability, and neither causes an owned transaction learned through another
+ingestion path to be discarded. Signing continues to follow the wallet's
+existing custody model.
+
+#### Scope And Branch Schema
+
+An omitted address schema reuses an existing scope's persisted schema or the
+canonical schema for a standard scope. Creating a new custom scope requires an
+explicit schema. Supplying a schema for an existing scope is an equality
+assertion; any external/internal branch mismatch is a conflict and the request
+fails before mutation.
+
+Each branch must be derivable from a single account key. The supported forms
+are P2PKH (`PubKeyHash`), P2SH-P2WPKH (`NestedWitnessPubKey`), P2WPKH
+(`WitnessPubKey`), and key-path P2TR (`TaprootPubKey`); other forms are not
+account schemas.
+
+For collision comparison within one wallet, an account XPub's normalized
+payload is its public key and chain code. Version bytes, depth, parent
+fingerprint, child number, name, optional account number, provenance, and
+declared master fingerprint do not distinguish that payload.
+
+Accounts with equal normalized payloads conflict when their corresponding
+external branch schemas or corresponding internal branch schemas can derive
+the same scripts. External and internal branches are not cross-compared because
+their `/0/` and `/1/` derivation paths are disjoint. Admission is allowed only
+when both corresponding branch-schema pairs are disjoint. Equal normalized
+payloads in one scope always conflict because accounts in that scope share its
+effective schema.
+
+Existing schema fields, including `coin_pub_key`, `key_scope_secrets`, and all
+other columns, remain. Account-shape constraints and affected validation and
+read paths must admit a caller-supplied numbered account with
+`is_derived=false` and a non-null `account_number` while preserving the
+root-derived numbered and caller-supplied unnumbered shapes.
 
 #### Store Adapter Identity
 
@@ -82,18 +203,18 @@ kvdb account numbers restart in every key scope, so an `AccountID` can recur
 within one wallet. SQL row IDs happen to have wider uniqueness, but shared code
 must not depend on that backend-specific property.
 
-kvdb populates the adapter identity for wallet-derived accounts, imported-xpub
+kvdb populates the adapter identity for wallet-derived accounts, imported-XPub
 accounts, and its imported-address pseudo-account. An imported account has no
-wallet-derived BIP44 `AccountNumber`, but waddrmgr still persists an unmasked
-internal account number for scoped lookup. Recovery also uses the adapter
-identity to key per-account state and stamp scan horizons. Returning no kvdb
-adapter identity would therefore make imported-account recovery and numeric
-kvdb lookup ambiguous or unusable.
+public `AccountNumber` under the legacy ordinary-import contract, but waddrmgr
+still persists an unmasked internal account number for scoped lookup. Recovery
+also uses the adapter identity to key per-account state and stamp scan
+horizons. Returning no kvdb adapter identity would therefore make imported-
+account recovery and numeric kvdb lookup ambiguous or unusable.
 
-`AccountNumber` remains an optional BIP44 derivation attribute, and
+`AccountNumber` remains an optional known hardened account component, and
 `AccountName` remains mutable display and lookup metadata. A wallet-derived
-kvdb account's adapter ID may numerically equal its BIP44 account number, but
-that coincidence does not give the two fields the same meaning.
+kvdb account's adapter ID may numerically equal its account number, but that
+coincidence does not give the two fields the same meaning or prove provenance.
 
 The adapter identity is stable only for an account within its backing Store
 and backend-defined domain. SQL row IDs and kvdb account numbers are not
@@ -105,36 +226,41 @@ backend's adapter value, an SQL row ID, or the current
 
 #### Account Alternatives
 
-The first rejected alternative was to keep mapping imported xpub accounts to
-account number `0`. That preserves compatibility with BIP44-shaped callers, but
-it makes imported xpubs collide with the default wallet-derived account and
-forces runtime code to distinguish fake `0` from real `0`.
+The first rejected alternative was to keep mapping unnumbered caller-supplied
+XPub accounts to account number `0`. That preserves compatibility with
+BIP44-shaped callers, but it makes unnumbered imports collide with the default
+wallet-derived account and forces runtime code to distinguish fake `0` from
+real `0`.
 
 The second rejected alternative was to split BIP44 account numbers into a
 `derived_accounts` table. That matched the subtype model, but it mostly moved
 one nullable field out of `accounts` while adding another join and a
 parent/child shape invariant. A row-local check on `accounts` is simpler and
-still prevents imported xpub accounts from being mistaken for BIP44 account
-`0`.
+still prevents unnumbered caller-supplied XPub accounts from being mistaken
+for account `0`.
 
-The accepted tradeoff is a nullable `account_number` with `is_derived` enforcing
-the row shape. This keeps the account invariant local to the account row, avoids
-parent/child drift for one optional field, and still removes fake identity.
+The accepted tradeoff is a nullable `account_number` interpreted together with
+immutable account provenance. This keeps the invariant local to the account
+row, admits a truthful numbered caller-supplied path, and still removes fake
+identity.
 
 #### Account Consequences
 
 Pros:
 
-- Imported xpub accounts can no longer be mistaken for BIP44 account `0`.
-- `GetAccountByNumber` is derived-account-only by construction.
-- SQL recovery can later key imported-xpub scan horizons by immutable
-  `account_id`.
+- Unnumbered caller-supplied XPub accounts can no longer be mistaken for
+  account `0`.
+- Numbered lookup can represent both root-derived and numbered
+  caller-supplied accounts without accepting a backend ID.
+- SQL recovery can key unnumbered-XPub scan horizons by immutable internal
+  `account_id` while public code uses semantic selectors.
 - Account lists remain low-cardinality reads over one identity table.
 
 Cons:
 
 - Go callers must treat account numbers as optional.
-- Imported account code must not collapse SQL NULL to Go zero.
+- Code handling unnumbered caller-supplied accounts must not collapse SQL NULL
+  to Go zero.
 - Read paths must consistently reject impossible account shapes.
 
 ### Addresses
@@ -189,8 +315,8 @@ Pros:
 
 - Raw imported addresses no longer require a fake account row.
 - Raw imports no longer carry fake scope or derivation-path identity.
-- Imported-xpub child addresses and wallet-derived child addresses share the
-  same derived-address path model.
+- Unnumbered-XPub, numbered-XPub, and wallet-root-derived child addresses share
+  the same derived-address path model.
 - Derived address queries can start from account/path facts, while raw import
   queries can start from wallet-local script identity.
 - Account-scoped address creation and address-index checks can use
@@ -215,16 +341,20 @@ Cons:
   types.
 - `db.AccountInfo` exposes an internal adapter `AccountID` and makes
   `AccountNumber` optional. SQL maps `AccountID` from `accounts.id`; kvdb maps
-  it from waddrmgr's per-scope internal account number. Shared code pairs it
+  it from waddrmgr's per-scope internal account number. SQL account numbers are
+  present for root-derived and numbered caller-supplied accounts and absent
+  for unnumbered caller-supplied accounts. Shared code pairs adapter identity
   with `KeyScope` and must not expose it as a portable public account ID.
 - `db.AddressInfo` makes `AccountID` and `AccountNumber` optional. SQL raw
   imports have neither, use an empty account name and zero key scope, and are
-  listed with an accountless query. Imported-xpub child addresses have an
-  account ID and scope inherited from their account but no BIP44 account
-  number.
-- `AddressDerivationParams` carries an optional derived account number. Imported
-  xpub child addresses must not synthesize `0` and accidentally derive wallet
-  seed keys.
+  listed with an accountless query. Unnumbered-XPub child addresses have an
+  account ID and scope inherited from their account but no account number;
+  numbered-XPub children retain their real number.
+- `AddressDerivationParams` carries an optional account number. Unnumbered-XPub
+  child addresses must not synthesize `0` and accidentally claim a full public
+  origin or derive wallet-seed keys. A numbered caller-supplied child may
+  report its caller-declared origin without claiming the wallet authenticated
+  its hardened ancestors.
 - `ListAddressesQuery` uses pointer selectors: both `Scope` and `AccountName`
   set means account-scoped derived children; both nil means raw imported
   addresses; one set without the other is invalid.


### PR DESCRIPTION
## Summary

Implements roadmap Task 387.

## Change Description

Define root-derived, arbitrary external, and path-bound external account
identity across ADR 0012 and ADR 0013. Record staged request ownership,
the retained ordinary-import boundary, and the NoChainSync policy
independently from wallet custody.