### PR TITLE
chain: add live-tip-only watches

### DIFF
--- a/bwtest/mock/chain.go
+++ b/bwtest/mock/chain.go
@@ -162,6 +162,16 @@ func (m *Chain) NotifyReceived(addrs []address.Address) error {
 	return args.Error(0)
 }
 
+// WatchAddrsFromTip implements the chain.Interface interface and delegates the
+// full contextual call through mock.Mock so tests can assert the live-watch
+// delivery boundary explicitly.
+func (m *Chain) WatchAddrsFromTip(ctx context.Context,
+	addrs []address.Address) error {
+
+	args := m.Called(ctx, addrs)
+	return args.Error(0)
+}
+
 // NotifyBlocks implements the chain.Interface interface.
 func (m *Chain) NotifyBlocks() error {
 	args := m.Called()

--- a/bwtest/mock/mempool_chain.go
+++ b/bwtest/mock/mempool_chain.go
@@ -187,6 +187,14 @@ func (c *MempoolChain) Rescan(*chainhash.Hash, []address.Address,
 // NotifyReceived implements the chain.Interface interface.
 func (c *MempoolChain) NotifyReceived([]address.Address) error { return nil }
 
+// WatchAddrsFromTip implements chain.Interface for the deterministic mempool
+// fake. It has no notification filter, but still preserves caller cancellation.
+func (c *MempoolChain) WatchAddrsFromTip(ctx context.Context,
+	_ []address.Address) error {
+
+	return ctx.Err()
+}
+
 // NotifyBlocks implements the chain.Interface interface.
 func (c *MempoolChain) NotifyBlocks() error { return nil }
 

--- a/chain/bitcoind_client.go
+++ b/chain/bitcoind_client.go
@@ -367,6 +367,23 @@ func (c *BitcoindClient) NotifyReceived(addrs []address.Address) error {
 	return nil
 }
 
+// WatchAddrsFromTip adds addresses to bitcoind's existing in-memory
+// notification filter and starts block notifications without invoking either
+// historical rescan entry point. Reusing the filter maps also makes repeated
+// registrations idempotent.
+func (c *BitcoindClient) WatchAddrsFromTip(ctx context.Context,
+	addrs []address.Address) error {
+
+	err := ctx.Err()
+	if err != nil {
+		return err
+	}
+
+	c.updateWatchedFilters(addrs)
+
+	return c.NotifyBlocks()
+}
+
 // NotifySpent allows the chain backend to notify the caller whenever a
 // transaction spends any of the given outpoints.
 func (c *BitcoindClient) NotifySpent(outPoints []*wire.OutPoint) error {

--- a/chain/bitcoind_events_test.go
+++ b/chain/bitcoind_events_test.go
@@ -3,6 +3,7 @@ package chain
 import (
 	"fmt"
 	"os/exec"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -95,7 +96,6 @@ func runBitcoindEventsTests(t *testing.T, rpcPolling bool) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			// Initialize a fresh miner for the test case.
 			miner1 := setupMiner(t)
@@ -106,6 +106,77 @@ func runBitcoindEventsTests(t *testing.T, rpcPolling bool) {
 
 			test.testFn(t, miner1, btcClient)
 		})
+	}
+}
+
+// TestBitcoindEventsWatchAddrsFromTip applies the live-tip contract.
+//
+//nolint:paralleltest // Btcd's rpctest ports can collide across subtests.
+func TestBitcoindEventsWatchAddrsFromTip(t *testing.T) {
+	backends := []struct {
+		name       string
+		rpcPolling bool
+	}{
+		{
+			name:       "ZMQ",
+			rpcPolling: false,
+		},
+		{
+			name:       "RPC",
+			rpcPolling: true,
+		},
+	}
+
+	for _, backend := range backends {
+		t.Run(backend.name, func(t *testing.T) {
+			// Arrange: mine history before bitcoind starts and select its
+			// transport from data, excluding stale ZMQ transaction events.
+			miner := setupMiner(t)
+			addr := mineHistoricalWatchAddr(t, miner)
+			client := setupBitcoind(t, miner, backend.rpcPolling)
+
+			// Act: prove no hidden rescan with an isolated client, then run
+			// the production contract on the selected transport.
+			assertWatchAddrsFromTipDoesNotRescan(t, client, addr)
+			testWatchAddrsFromTipConformance(
+				t, miner, client, addr,
+			)
+
+			// Assert: one future notification drains through a later block.
+		})
+	}
+}
+
+// assertWatchAddrsFromTipDoesNotRescan uses a handler-free test client.
+func assertWatchAddrsFromTipDoesNotRescan(t *testing.T,
+	client *BitcoindClient, addr address.Address) {
+
+	t.Helper()
+
+	// Arrange: start only the sibling queue so registration owns the wait
+	// group and every tracked goroutine belongs to the operation under test.
+	probe, err := client.chainConn.NewBitcoindClient()
+	require.NoError(t, err)
+	probe.notificationQueue.Start()
+
+	atomic.StoreUint32(&probe.notifyBlocks, 1)
+	defer probe.Stop()
+
+	// Act: wait for registration work, then enqueue its FIFO marker.
+	err = probe.WatchAddrsFromTip(t.Context(), []address.Address{addr})
+	require.NoError(t, err)
+	probe.WaitForShutdown()
+
+	probe.notificationQueue.ChanIn() <- ClientConnected{}
+
+	// Assert: reach the marker without a historical rescan completion.
+	for ntfn := range probe.Notifications() {
+		if _, ok := ntfn.(ClientConnected); ok {
+			return
+		}
+
+		_, rescanned := ntfn.(*RescanFinished)
+		require.False(t, rescanned)
 	}
 }
 
@@ -704,6 +775,103 @@ func waitForClientConnected(t *testing.T, ntfns <-chan any) {
 		case <-timer.C:
 			require.FailNow(t, "timed out for ClientConnected "+
 				"notification")
+		}
+	}
+}
+
+// waitForExclusiveRelevantTx rejects every unexpected transaction.
+func waitForExclusiveRelevantTx(t *testing.T, ntfns <-chan any,
+	hash *chainhash.Hash) {
+
+	t.Helper()
+
+	timer := time.NewTimer(defaultTestTimeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case ntfn := <-ntfns:
+			switch value := ntfn.(type) {
+			case RelevantTx:
+				require.True(
+					t, value.TxRecord.Hash.IsEqual(hash),
+					"received unexpected relevant transaction %v",
+					value.TxRecord.Hash,
+				)
+
+				return
+
+			case FilteredBlockConnected:
+				// Bitcoind groups confirmed matches in block notifications,
+				// so inspect every record to expose a historical replay.
+				var found bool
+				for _, tx := range value.RelevantTxs {
+					require.True(
+						t, tx.Hash.IsEqual(hash),
+						"received unexpected relevant transaction %v",
+						tx.Hash,
+					)
+					require.False(
+						t, found,
+						"received duplicate relevant transaction %v",
+						tx.Hash,
+					)
+					found = true
+				}
+
+				if found {
+					return
+				}
+			}
+
+		case <-timer.C:
+			require.FailNow(t, "timed out waiting for RelevantTx "+
+				"notification")
+		}
+	}
+}
+
+// waitForNoRelevantTxUntilBlock drains notifications through an exact later
+// block, failing if a duplicate or delayed historical transaction appears.
+func waitForNoRelevantTxUntilBlock(t *testing.T, ntfns <-chan any,
+	hash *chainhash.Hash) {
+
+	t.Helper()
+
+	timer := time.NewTimer(defaultTestTimeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case ntfn := <-ntfns:
+			switch value := ntfn.(type) {
+			case RelevantTx:
+				require.FailNowf(
+					t, "unexpected relevant transaction",
+					"received transaction %v after the expected "+
+						"future delivery", value.TxRecord.Hash,
+				)
+
+			case FilteredBlockConnected:
+				// Every confirmed match after the expected delivery is a
+				// duplicate or delayed historical notification.
+				for _, tx := range value.RelevantTxs {
+					require.FailNowf(
+						t, "unexpected relevant transaction",
+						"received transaction %v after the "+
+							"expected future delivery", tx.Hash,
+					)
+				}
+
+			case BlockConnected:
+				if value.Hash.IsEqual(hash) {
+					return
+				}
+			}
+
+		case <-timer.C:
+			require.FailNow(t, "timed out waiting for post-delivery "+
+				"BlockConnected notification")
 		}
 	}
 }

--- a/chain/btcd.go
+++ b/chain/btcd.go
@@ -336,6 +336,24 @@ func (c *RPCClient) Rescan(startHash *chainhash.Hash, addrs []address.Address,
 	return c.Client.Rescan(startHash, addrs, flatOutpoints) // nolint:staticcheck
 }
 
+// WatchAddrsFromTip registers addresses with btcd's existing transaction
+// notification filter without issuing a rescan. The context is checked before
+// registration so a canceled delivery attempt cannot introduce new watches.
+func (c *RPCClient) WatchAddrsFromTip(ctx context.Context,
+	addrs []address.Address) error {
+
+	err := ctx.Err()
+	if err != nil {
+		return err
+	}
+
+	// Staticcheck recommends LoadTxFilter because NotifyReceived is
+	// deprecated. This adapter intentionally keeps NotifyReceived because
+	// its handlers consume OnRecvTx and OnRedeemingTx; LoadTxFilter delivers
+	// through the newer relevant-transaction notification path instead.
+	return c.Client.NotifyReceived(addrs) //nolint:staticcheck
+}
+
 // GetCFilter returns a compact filter for the given block hash and filter
 // type. It wraps the underlying rpcclient method and converts the result to a
 // *gcs.Filter.

--- a/chain/btcd_test.go
+++ b/chain/btcd_test.go
@@ -1,13 +1,17 @@
 package chain
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/integration/rpctest"
 	"github.com/btcsuite/btcd/rpcclient"
+	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/stretchr/testify/require"
 )
@@ -15,6 +19,17 @@ import (
 // setupBtcd starts up a btcd node with cfilters enabled and returns a client
 // wrapper of this connection.
 func setupBtcd(t *testing.T) (*rpctest.Harness, *RPCClient) {
+	t.Helper()
+
+	miner := setupBtcdMiner(t)
+	client := setupBtcdClient(t, miner)
+
+	return miner, client
+}
+
+// setupBtcdMiner starts a cfilter-enabled btcd harness independently from its
+// notification client so tests can establish chain history before subscribing.
+func setupBtcdMiner(t *testing.T) *rpctest.Harness {
 	t.Helper()
 
 	trickle := fmt.Sprintf("--trickleinterval=%v", 10*time.Millisecond)
@@ -30,6 +45,15 @@ func setupBtcd(t *testing.T) (*rpctest.Harness, *RPCClient) {
 	t.Cleanup(func() {
 		require.NoError(t, miner.TearDown())
 	})
+
+	return miner
+}
+
+// setupBtcdClient connects the production websocket adapter after any test
+// history exists, preventing pre-subscription transactions from entering its
+// notification stream.
+func setupBtcdClient(t *testing.T, miner *rpctest.Harness) *RPCClient {
+	t.Helper()
 
 	rpcConf := miner.RPCConfig()
 	client, err := NewRPCClientWithConfig(&RPCClientConfig{
@@ -56,7 +80,7 @@ func setupBtcd(t *testing.T) (*rpctest.Harness, *RPCClient) {
 		client.Stop()
 	})
 
-	return miner, client
+	return client
 }
 
 // TestValidateConfig checks the `validate` method on the RPCClientConfig
@@ -193,4 +217,110 @@ func TestRPCClientBatchMethods(t *testing.T) {
 
 	// Run batch method tests.
 	testInterfaceBatchMethods(t, miner, client)
+}
+
+// TestRPCClientWatchAddrsFromTip verifies btcd against the shared live-tip
+// registration contract.
+func TestRPCClientWatchAddrsFromTip(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: mine the historical payment before starting the production
+	// websocket client, ensuring no pre-registration event remains in flight.
+	miner := setupBtcdMiner(t)
+	addr := mineHistoricalWatchAddr(t, miner)
+	client := setupBtcdClient(t, miner)
+
+	// Act: run the backend-neutral sequence against the established history,
+	// repeat registration, and publish a distinct future payment.
+	testWatchAddrsFromTipConformance(t, miner, client, addr)
+
+	// Assert: the shared routine returns only after exactly one future payment
+	// and a later block barrier exclude historical or duplicate delivery.
+}
+
+// mineHistoricalWatchAddr confirms a payment before a notification client is
+// started, proving later registration does not initiate a backend history scan
+// without relying on ordering between independent transport event streams.
+func mineHistoricalWatchAddr(t *testing.T,
+	miner *rpctest.Harness) address.Address {
+
+	t.Helper()
+
+	addr, err := miner.NewAddress()
+	require.NoError(t, err)
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+	historicalTx, err := miner.CreateTransaction(
+		[]*wire.TxOut{{Value: 1000, PkScript: pkScript}}, 5, false,
+	)
+	require.NoError(t, err)
+	_, err = miner.GenerateAndSubmitBlock(
+		[]*btcutil.Tx{btcutil.NewTx(historicalTx)}, -1, time.Time{},
+	)
+	require.NoError(t, err)
+
+	return addr
+}
+
+// testWatchAddrsFromTipConformance proves the public no-history, idempotence,
+// and future-delivery contract through the production backend interface.
+func testWatchAddrsFromTipConformance(t *testing.T, miner *rpctest.Harness,
+	client Interface, addr address.Address) {
+
+	t.Helper()
+
+	// Arrange: enable block notifications and drain the connection marker. The
+	// supplied address was paid before this client started, so any delivery of
+	// that confirmed payment can only come from an unintended historical scan.
+	err := client.NotifyBlocks()
+	require.NoError(t, err)
+
+	ntfns := client.Notifications()
+	waitForClientConnected(t, ntfns)
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	// Act: register the same address twice, then create and publish a distinct
+	// transaction whose first possible delivery is after both calls return.
+	err = client.WatchAddrsFromTip(t.Context(), []address.Address{addr})
+	require.NoError(t, err)
+	err = client.WatchAddrsFromTip(t.Context(), []address.Address{addr})
+	require.NoError(t, err)
+
+	futureTx, err := miner.CreateTransaction(
+		[]*wire.TxOut{{Value: 2000, PkScript: pkScript}}, 5, false,
+	)
+	require.NoError(t, err)
+	_, err = client.SendRawTransaction(futureTx, true)
+	require.NoError(t, err)
+
+	// Assert: accept only the future transaction, then mine an empty block as a
+	// post-delivery synchronization barrier. Any historical or duplicate
+	// relevant transaction observed before that later block fails the contract.
+	futureHash := futureTx.TxHash()
+	waitForExclusiveRelevantTx(t, ntfns, &futureHash)
+
+	barrierBlock, err := miner.GenerateAndSubmitBlock(nil, -1, time.Time{})
+	require.NoError(t, err)
+	waitForNoRelevantTxUntilBlock(t, ntfns, barrierBlock.Hash())
+}
+
+// TestRPCClientWatchAddrsFromTipCanceled verifies that cancellation is checked
+// before the concrete btcd client is used or any registration can occur.
+func TestRPCClientWatchAddrsFromTipCanceled(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: create an intentionally uninitialized client and an already
+	// canceled context. The test would panic if registration reached btcd.
+	client := &RPCClient{}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	// Act: invoke the live-tip API with no addresses after cancellation.
+	err := client.WatchAddrsFromTip(ctx, nil)
+
+	// Assert: require the context error, proving cancellation was evaluated
+	// before dereferencing or mutating the backend client.
+	require.ErrorIs(t, err, context.Canceled)
 }

--- a/chain/interface.go
+++ b/chain/interface.go
@@ -53,6 +53,12 @@ type Interface interface {
 	Rescan(*chainhash.Hash, []address.Address,
 		map[wire.OutPoint]address.Address) error
 	NotifyReceived([]address.Address) error
+
+	// WatchAddrsFromTip requests address notification registration after a
+	// context cancellation preflight. Btcd and bitcoind add only live filter
+	// entries. Neutrino temporarily retains NotifyReceived's legacy historical
+	// behavior until its live-watch lifecycle receives a dedicated design.
+	WatchAddrsFromTip(context.Context, []address.Address) error
 	NotifyBlocks() error
 	Notifications() <-chan interface{}
 	BackEnd() string

--- a/chain/neutrino.go
+++ b/chain/neutrino.go
@@ -586,6 +586,22 @@ func (s *NeutrinoClient) NotifyReceived(addrs []address.Address) error {
 	return nil
 }
 
+// WatchAddrsFromTip temporarily routes address registration through the
+// existing Neutrino notification rescan after honoring pre-call cancellation.
+func (s *NeutrinoClient) WatchAddrsFromTip(ctx context.Context,
+	addrs []address.Address) error {
+
+	err := ctx.Err()
+	if err != nil {
+		return err
+	}
+
+	// TODO(yy): NotifyReceived can start a birthday-based scan or widen an
+	// active historical rescan. Replace this compatibility shim after the
+	// Neutrino live-watch lifecycle has a dedicated design.
+	return s.NotifyReceived(addrs)
+}
+
 // Notifications replicates the RPC client's Notifications method.
 func (s *NeutrinoClient) Notifications() <-chan interface{} {
 	return s.dequeueNotification

--- a/docs/developer/adr/0002-controller-syncer-architecture.md
+++ b/docs/developer/adr/0002-controller-syncer-architecture.md
@@ -1,5 +1,20 @@
 # ADR 0002: Controller-Syncer-State Architecture
 
+## Status
+
+- **Status:** Superseded
+- **Date:** 2025-12-25
+
+## Relationships
+
+- **Amends:** None.
+- **Supersedes:** None.
+- **Amended by:** None.
+- **Superseded by:**
+  [ADR 0015](0015-sql-shared-chain-ownership.md), which replaces this
+  lifecycle model for all maintained Managers and this synchronization model
+  for SQL Managers.
+
 ## 1. Context
 
 The legacy `btcwallet` architecture tightly coupled lifecycle management, synchronization logic, and state tracking within a single `Wallet` struct. This monolithic design led to several issues:
@@ -45,7 +60,3 @@ Instead of a single status enum, we track three separate dimensions:
 ### Cons
 *   **Complexity:** Increases the number of distinct types and files.
 *   **Indirection:** Calls to sync functionality now go through a channel-based request mechanism rather than direct method calls.
-
-## 4. Status
-
-Accepted and Implemented.

--- a/docs/developer/adr/0004-targeted-rescan-vs-rewind.md
+++ b/docs/developer/adr/0004-targeted-rescan-vs-rewind.md
@@ -1,12 +1,27 @@
 # ADR 0004: Targeted Rescan vs. Global Rewind
 
-> **Superseded in part:** ADR 0005 supersedes Section 2.2's automatic import
+## Status
+
+- **Status:** Accepted
+- **Date:** 2025-12-25
+
+## Relationships
+
+- **Amends:** None.
+- **Supersedes:** None.
+- **Amended by:** [ADR 0005](0005-no-auto-rescan-on-import.md) for explicit
+  import recovery and wallet-wide targets;
+  [ADR 0015](0015-sql-shared-chain-ownership.md) for SQL targeted-rescan
+  ownership.
+- **Superseded by:** None.
+
+> **Amended by ADR 0005:** ADR 0005 changes Section 2.2's automatic import
 > trigger. Imports may register a live watch after persistence, but they do not
-> start historical recovery; callers invoke `Rescan(...)` explicitly. Section
-> 2.2's account-exclusive target description is also superseded: requested
-> accounts limit derivation horizons, while recovery-relevant addresses and
-> UTXOs are loaded wallet-wide. A targeted rescan still does not rewind the
-> global `SyncedTo` watermark.
+> start historical recovery; callers invoke `Rescan(...)` explicitly. It also
+> amends Section 2.2's account-exclusive target description: requested accounts
+> limit derivation horizons, while recovery-relevant addresses and UTXOs are
+> loaded wallet-wide. A targeted rescan still does not rewind the global
+> `SyncedTo` watermark.
 
 ## 1. Context
 
@@ -60,7 +75,3 @@ To prevent race conditions during these operations, we enforce strict access con
 ### Cons
 *   **Complexity:** The `Syncer` logic must handle two different "modes" of operation (Global Loop vs. Ad-hoc Job).
 *   **Database Complexity:** We must ensure that inserting transactions during a targeted rescan doesn't conflict with the global sync loop if they happen to overlap (though the design serializes them in the `chainLoop`).
-
-## 5. Status
-
-Accepted and Implemented.

--- a/docs/developer/adr/0005-no-auto-rescan-on-import.md
+++ b/docs/developer/adr/0005-no-auto-rescan-on-import.md
@@ -1,5 +1,18 @@
 # ADR 0005: Explicit Rescan on Import
 
+## Status
+
+- **Status:** Accepted
+- **Date:** 2025-12-25
+
+## Relationships
+
+- **Amends:** [ADR 0004](0004-targeted-rescan-vs-rewind.md) for explicit
+  import recovery and wallet-wide targets.
+- **Supersedes:** None.
+- **Amended by:** None.
+- **Superseded by:** None.
+
 ## 1. Context
 
 When importing new keys, addresses, or accounts into a wallet, the wallet needs
@@ -50,7 +63,3 @@ The user (or calling software) retains control over system resources. They may c
 ### Cons
 *   **Usability Pitfall:** A naive user might import a key and be confused why their balance shows `0`. Documentation and RPC output must clearly indicate that a rescan is required to see funds.
 *   **Client Burden:** Clients must implement the "Import -> Rescan" logic themselves.
-
-## 5. Status
-
-Accepted and Implemented.

--- a/docs/developer/adr/0006-wtxmgr-sql-schema.md
+++ b/docs/developer/adr/0006-wtxmgr-sql-schema.md
@@ -1,5 +1,18 @@
 # ADR 0006: Wallet Transaction Manager SQL Schema
 
+## Status
+
+- **Status:** Accepted
+- **Date:** 2026-01-28
+
+## Relationships
+
+- **Amends:** None.
+- **Supersedes:** None.
+- **Amended by:** [ADR 0015](0015-sql-shared-chain-ownership.md) for SQL block
+  identity and canonical-frontier semantics.
+- **Superseded by:** None.
+
 ## 1. Context
 
 As part of the migration from a Key-Value store to a relational SQL backend, the Wallet Transaction Manager (`wtxmgr`) requires a new schema design. The `wtxmgr` is responsible for tracking:
@@ -249,7 +262,3 @@ This ADR defines the target schema and invariants. Production operations still r
 
 Monitoring note:
 *   Track table growth, count of active leases, and lease cleanup latency. These are important for long-running nodes and multi-process deployments.
-
-## 5. Status
-
-Accepted.

--- a/docs/developer/adr/0015-sql-shared-chain-ownership.md
+++ b/docs/developer/adr/0015-sql-shared-chain-ownership.md
@@ -1,0 +1,223 @@
+# ADR 0015: Manager Lifecycle and SQL Shared-Chain Ownership
+
+## Status
+
+- **Status:** Accepted
+- **Date:** 2026-08-13
+
+## Relationships
+
+- **Amends:** [ADR 0004](0004-targeted-rescan-vs-rewind.md) for SQL
+  targeted-rescan ownership and [ADR 0006](0006-wtxmgr-sql-schema.md) for SQL
+  block identity and canonical-frontier semantics.
+- **Supersedes:** [ADR 0002](0002-controller-syncer-architecture.md).
+- **Amended by:** None.
+- **Superseded by:** None.
+
+## 1. Problem
+
+ADR 0002 gives each Wallet public lifecycle and chain-synchronization
+authority. Maintained Managers need aggregate lifecycle authority, while SQL
+Wallets also share one Store, canonical chain, rollback boundary, and chain
+source. Wallet resources and historical recovery remain wallet-scoped.
+
+## 2. Context
+
+A SQL Manager may own zero or many durable Wallets in one SQLite or PostgreSQL
+database. Canonical state, rollback, Store lifetime, and source ordering are
+database-wide. Transactions, UTXOs, scan horizons, readiness, and historical
+recovery are wallet-scoped.
+
+### Constraints
+
+- Every durable Wallet owned by a Running Manager is active.
+- No accepted Wallet call or chain operation may outlive the Store.
+- One waiter's cancellation cannot cancel accepted aggregate work.
+- Cleanup ownership and error order are deterministic.
+- Modern-kvdb remains isolated until backend retirement.
+
+## 3. Decision
+
+### 3.1 Manager lifecycle and active set
+
+`Manager` is the sole public lifecycle authority. `NewManager` constructs an
+Initialized Manager with terminal states:
+
+`Initialized -> Starting -> Running -> Stopping -> Stopped`.
+
+`Manager.Start(ctx)` fixes an ordered pointer set internally. Zero-Wallet
+startup succeeds with an empty set; otherwise it is the complete active set in
+stable Wallet-ID order. Each successful caller receives a separate
+caller-owned slice copy. Running has no dormant, unloaded, restartable, or
+independently stoppable Wallet.
+
+One Start outcome is fixed before publication. The first accepted terminal
+cause wins: publication returns the stable set; owner cancellation returns its
+context error; assembly or private-start failure returns its exact primary
+error; and Stop entering Stopping first returns `ErrManagerStopped`. Failed
+Start returns a nil slice. Concurrent callers share the outcome, but waiter
+cancellation ends only that wait.
+
+Terminal Start failure records cleanup ownership before releasing admission,
+transitions through Stopping, and reaches Stopped after cleanup. Waiters then
+receive its result. Assembly reports its primary error separately from cleanup
+outcomes; Manager records the latter for Stop and never cleans those resources
+twice. After successful handoff, Manager owns the full candidate set. Start on
+Stopping or Stopped returns a nil slice and `ErrManagerStopped`; reopening
+creates a fresh Manager.
+
+### 3.2 Private Wallet lifecycle and call admission
+
+Manager alone calls each Wallet's private one-shot `start(ctx)` and `stop()`.
+Wallet owns admission and draining for its public calls, workers, cancellation,
+Vault, and components.
+
+An admitted call keeps its ordinary result and drains before Store closure. A
+later call returns `ErrWalletStopped` without Store access. Admission does not
+serialize operation bodies.
+
+Manager admission is separate and returns `ErrManagerStopped` after Stopping
+begins. Manager passes no lifecycle capability into Wallet. The final surface
+removes public Wallet and Controller Start/Stop plus Manager StartWallet,
+StopWallet, Load, Unload, and Close, without aliases or a replacement lookup.
+A retained Wallet pointer is inert after Manager Stop.
+
+### 3.3 Create and publication
+
+`Manager.Create(ctx, ...)` is accepted only after Create serialization and a
+Running recheck. It durably creates, assembles, privately starts, and then
+publishes the exact fully started pointer. An incomplete candidate is never
+visible in the active set. The Wallet-set lock protects only publication and
+set mutation; durable creation, assembly, and private startup run without it.
+
+After a proven commit and start failure, Create joins the candidate. One
+bounded reconciliation is allowed only when an exact durable reread matches
+the accepted Create, all Store and worker results are determinate, and one
+fresh candidate fully starts. Success publishes that pointer.
+
+Mismatch, indeterminate state, or fresh-start failure fixes that exact error
+and enters or observes Stopping. Create stops and joins all unpublished
+candidates and attempt resources before releasing serialization and admission;
+cleanup errors belong to Stop. The caller then waits outside admission and
+returns its fixed error after shutdown, independently of Stop's result.
+
+### 3.4 Live synchronization and historical recovery
+
+Manager owns Store lifetime, the Wallet registry, one SQL chain source,
+canonical frontier and reorg decisions, live ordering and backpressure,
+database-wide mutation coordination, and aggregate failure policy. One
+coordinator delivers admitted events to the complete active-Wallet snapshot;
+Wallet processors retain matching and wallet-scoped persistence.
+
+Canonical source/frontier state, Wallet live readiness/tip, and Wallet
+historical-rescan state are independent. Historical blocks do not establish
+canonical membership. Historical recovery cannot move the frontier, roll back
+the database, or change another Wallet.
+
+Account import does not rescan. Address or script import registers a live-watch
+obligation at the live tip. Explicit historical recovery is Wallet-scoped and
+uses verified history, not the shared live stream.
+
+Accepted live events are bounded, ordered, and never dropped for a target.
+Reorg handling stops forward admission, quiesces affected Wallets in stable
+Wallet-ID order, performs one database-wide rollback, reconciles it, and
+resumes only from proven state.
+
+### 3.5 Failure and shutdown ownership
+
+- Validation, caller cancellation, and determinate request-local Store errors
+  remain local.
+- Recoverable source errors are retried or reconciled.
+- Historical-rescan failures remain Wallet-scoped.
+- Fatal Wallet invariants, indeterminate persistence, processor failures, or
+  unsafe shared state stop Manager unless isolation preserves the complete
+  active-set invariant.
+
+`Manager.Stop(ctx)` rejects new Manager work, settles accepted Start and
+Create, freezes the Wallet set, closes source admission, joins the source,
+privately stops Wallets and drains their calls and workers, joins accepted
+delivery and the coordinator, and closes Store last and once. Wallet never
+closes Store.
+
+Stop work is independent of caller contexts. Cancellation ends only that
+wait; later callers join or receive the cached result. Teardown continues
+after errors.
+
+The cached aggregate orders every cleanup failure by published Wallet ID,
+unpublished attempt and fixed Wallet-resource order, then source, coordinator,
+and Store. Completion timing cannot change it. Cleanup never replaces a fixed
+Start or Create error, and repeated Stop returns the same aggregate.
+
+### 3.6 Lease and scope
+
+At most one Manager may be Starting or Running for a canonical database target
+within one process. Its process-local lease lasts through all joins and Store
+closure. This is not a global singleton or cross-process fence.
+
+The lifecycle, admission, Create, failure, and shutdown contract applies to
+every maintained Manager. Shared-chain coordination applies only to SQL.
+Modern-kvdb follows the aggregate lifecycle but temporarily keeps its isolated
+single-Wallet source path until retirement and does not join the SQL
+coordinator.
+
+Implementation machinery, durable rescan jobs, generic write locks, replay
+state machines, create manifests, idle-Wallet eviction, and cross-process
+coordination are out of scope.
+
+## 4. Rationale
+
+Only Manager spans every Wallet, the shared source and state, and Store.
+Wallet-owned admission keeps call safety beside Wallet resources without
+leaking Manager capability. Separating live synchronization from historical
+recovery prevents one Wallet's scan from changing database-wide truth.
+
+## 5. Alternatives Considered
+
+### Public per-Wallet lifecycle
+
+It permits partial active sets and races aggregate Store and source ownership.
+
+### Manager-owned Wallet call admission
+
+It couples Wallet safety to Manager internals and cannot prove Wallet resources
+have drained.
+
+### Combined live-sync and rescan state
+
+It lets Wallet history work affect canonical state and aggregate failure.
+
+### Cross-process fencing
+
+It requires a durable lease protocol beyond this process-local contract.
+
+## 6. Consequences
+
+### Positive
+
+- Lifecycle, shared state, and Store closure each have one owner.
+- Running means the complete Wallet set is active.
+- Wallet calls and chain work drain before Store closure.
+- Historical recovery cannot mutate canonical state.
+
+### Negative and Risks
+
+- Start and Create settle aggregate work before returning.
+- A fatal Wallet or shared-state failure can stop every Wallet.
+- Slow admitted work delays Store closure.
+- Other processes can still contend for the database.
+
+## 7. Implementation Overview
+
+Roadmap ownership is: Task 331, terminal Manager lifecycle; Tasks 458 and 368,
+Wallet drain/private mechanics and public-surface removal; Tasks 456 and 459,
+runtime configuration and startup assembly; Task 457, the process-local lease;
+Tasks 370, 371, 372, and 423, shared delivery, frontier, rollback, and source
+cutover; and Task 353, modern-kvdb retirement.
+
+## 8. References
+
+- [ADR 0001](0001-multi-wallet-architecture.md): multi-Wallet Manager scope.
+- [ADR 0002](0002-controller-syncer-architecture.md): superseded lifecycle and
+  per-Wallet synchronization model.
+- [ADR 0004](0004-targeted-rescan-vs-rewind.md): historical scan boundaries.
+- [ADR 0006](0006-wtxmgr-sql-schema.md): SQL block and frontier semantics.

--- a/docs/developer/adr/README.md
+++ b/docs/developer/adr/README.md
@@ -35,11 +35,20 @@ relationship metadata, but do not rewrite its historical decision body.
 ## Existing ADRs
 
 - [ADR 0001: Multi-Wallet Architecture](./0001-multi-wallet-architecture.md) - Decides on the architecture for managing multiple distinct wallets and networks within a single daemon instance.
-- [ADR 0002: Controller-Syncer-State Architecture](./0002-controller-syncer-architecture.md) - Decouples lifecycle management, synchronization logic, and state tracking from the monolithic `Wallet` struct.
+- [ADR 0002: Controller-Syncer-State
+  Architecture](./0002-controller-syncer-architecture.md)
+  is the historical Controller/Syncer/State decision superseded by ADR 0015.
 - [ADR 0003: Optimistic CFilter Batch Scanning](./0003-optimistic-cfilter-batching.md) - Optimizes BIP 157/158 Compact Filter synchronization using optimistic batch scanning.
-- [ADR 0004: Targeted Rescan vs. Global Rewind](./0004-targeted-rescan-vs-rewind.md) - Introduces "Targeted Rescans" to replace global "Rewinds" for more efficient transaction discovery.
-- [ADR 0005: Explicit Rescan on Import](./0005-no-auto-rescan-on-import.md) - Disables automatic blockchain scanning during import operations, requiring explicit user initiation.
-- [ADR 0006: Wallet Transaction Manager SQL Schema](./0006-wtxmgr-sql-schema.md) - Defines the relational SQL schema for the Wallet Transaction Manager (`wtxmgr`) migration.
+- [ADR 0004: Targeted Rescan vs. Global
+  Rewind](./0004-targeted-rescan-vs-rewind.md) introduces targeted rescans in
+  place of global rewinds; amended by ADR 0005 for explicit import recovery
+  and by ADR 0015 for SQL targeted-rescan ownership.
+- [ADR 0005: Explicit Rescan on Import](./0005-no-auto-rescan-on-import.md)
+  requires callers to initiate historical recovery after imports and amends
+  ADR 0004's import trigger and target scope.
+- [ADR 0006: Wallet Transaction Manager SQL
+  Schema](./0006-wtxmgr-sql-schema.md) defines the relational `wtxmgr` schema;
+  amended by ADR 0015 for SQL block identity and canonical-frontier semantics.
 - [ADR 0007: XChaCha20-Poly1305 Encryption](./0007-xchacha20-poly1305-encryption.md) - Replaces XSalsa20-Poly1305 with XChaCha20-Poly1305 for encrypting private key material.
 - [ADR 0008: Integration Test Framework](./0008-integration-test-framework.md) - Defines a modular integration test framework for chain and database backend permutations.
 - [ADR 0009: Single-Passphrase Encryption Model](./0009-single-passphrase-encryption.md) - Adopts a single-passphrase model that encrypts private data only while keeping public wallet metadata in plaintext.
@@ -50,3 +59,7 @@ relationship metadata, but do not rewrite its historical decision body.
 - [ADR 0014: Durable SQL Database Identity](./0014-sql-database-identity.md) -
   Defines the durable role-wallet identity and identity-first initialization
   order for SQLite and PostgreSQL.
+- [ADR 0015: Manager Lifecycle and SQL Shared-Chain
+  Ownership](./0015-sql-shared-chain-ownership.md) supersedes ADR 0002, applies
+  aggregate lifecycle and admission to every maintained Manager, and assigns
+  SQL shared-chain ownership.

--- a/wallet/internal/db/pg/walletstore_updatewalletsecrets.go
+++ b/wallet/internal/db/pg/walletstore_updatewalletsecrets.go
@@ -1,24 +1,132 @@
 package pg
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	dbruntime "github.com/btcsuite/btcwallet/wallet/internal/db/runtime"
 	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 )
 
-// UpdateWalletSecrets updates the secrets for the wallet.
+// walletSecretsCommitVerificationTimeout bounds the independent read used when
+// PostgreSQL loses the database connection after sending COMMIT. The server may
+// already have made the transaction durable even though the client missed its
+// acknowledgement, so a short limit keeps verification through another pooled
+// connection from stalling the caller.
+const walletSecretsCommitVerificationTimeout = 5 * time.Second
+
+// UpdateWalletSecrets updates the wallet secrets through one PostgreSQL
+// transaction. If the database connection is lost while awaiting the COMMIT
+// acknowledgement, the Store never retries the mutation; it performs one
+// detached, bounded read through another pooled connection and returns success
+// only when every attempted field is visible. A failed read or mismatch returns
+// an ordinary Store error without exposing the runtime ambiguity marker.
 func (s *Store) UpdateWalletSecrets(ctx context.Context,
 	params db.UpdateWalletSecretsParams) error {
 
-	return s.execWrite(ctx, func(qtx *sqlc.Queries) error {
+	err := s.execWrite(ctx, func(qtx *sqlc.Queries) error {
 		return db.UpdateWalletSecretsWithOps(
 			ctx, params, updateWalletSecretsOps{q: qtx},
 		)
 	})
+
+	return verifyWalletSecretsCommit(
+		ctx, params, walletSecretsCommitVerificationTimeout, err,
+		s.GetWalletSecrets,
+	)
+}
+
+// verifyWalletSecretsCommit applies the binary Store contract to a completed
+// PostgreSQL write. Definite outcomes pass through unchanged; a lost commit
+// reply triggers one bounded read that proves success only from an exact match
+// with the attempted persisted tuple.
+func verifyWalletSecretsCommit(ctx context.Context,
+	params db.UpdateWalletSecretsParams, verificationTimeout time.Duration,
+	updateErr error, getWalletSecrets func(context.Context,
+		uint32) (*db.WalletSecrets, error)) error {
+
+	if updateErr == nil ||
+		!errors.Is(updateErr, dbruntime.ErrAmbiguousTxCommit) {
+
+		return updateErr
+	}
+
+	// Detach verification from the failed mutation context because a canceled
+	// connection must not prevent another pooled connection from observing the
+	// durable row. The explicit timeout keeps that independent read bounded.
+	verificationCtx, cancel := context.WithTimeout(
+		context.WithoutCancel(ctx), verificationTimeout,
+	)
+	defer cancel()
+
+	persisted, readErr := getWalletSecrets(
+		verificationCtx, params.WalletID,
+	)
+	if persisted != nil {
+		// The Store owns this verification-only read, so destroy every returned
+		// credential buffer after comparison rather than leaking a second copy.
+		defer clearWalletSecrets(persisted)
+	}
+
+	commitErr := walletSecretsCommitError(updateErr)
+	if readErr != nil {
+		return errors.Join(
+			commitErr,
+			fmt.Errorf("verify wallet secrets after commit: %w", readErr),
+		)
+	}
+
+	if walletSecretsMatchUpdate(persisted, params) {
+		return nil
+	}
+
+	return fmt.Errorf("verify wallet secrets after commit: "+
+		"persisted values differ: %w", commitErr)
+}
+
+// walletSecretsMatchUpdate requires all verifier and ciphertext fields to
+// equal the attempted PostgreSQL update, preventing a partial or unrelated
+// row from converting an uncertain commit into success.
+func walletSecretsMatchUpdate(secrets *db.WalletSecrets,
+	params db.UpdateWalletSecretsParams) bool {
+
+	if secrets == nil {
+		return false
+	}
+
+	return bytes.Equal(secrets.MasterPrivParams, params.MasterPrivParams) &&
+		bytes.Equal(secrets.EncryptedCryptoPrivKey,
+			params.EncryptedCryptoPrivKey) &&
+		bytes.Equal(secrets.EncryptedCryptoScriptKey,
+			params.EncryptedCryptoScriptKey) &&
+		bytes.Equal(secrets.EncryptedMasterHdPrivKey,
+			params.EncryptedMasterHdPrivKey)
+}
+
+// clearWalletSecrets destroys the verification read in place so resolving a
+// lost commit reply does not extend the lifetime of encrypted credential data.
+func clearWalletSecrets(secrets *db.WalletSecrets) {
+	clear(secrets.MasterPrivParams)
+	clear(secrets.EncryptedCryptoPrivKey)
+	clear(secrets.EncryptedCryptoScriptKey)
+	clear(secrets.EncryptedMasterHdPrivKey)
+}
+
+// walletSecretsCommitError removes the runtime ambiguity marker before the
+// PostgreSQL Store returns an unresolved failure, preserving the classified
+// transport cause without exposing transaction policy to db.Store callers.
+func walletSecretsCommitError(err error) error {
+	var ambiguousErr *dbruntime.AmbiguousTxCommitError
+	if errors.As(err, &ambiguousErr) && ambiguousErr.Err != nil {
+		return ambiguousErr.Err
+	}
+
+	return errors.New("postgres wallet secrets commit failed")
 }
 
 // updateWalletSecretsOps adapts PostgreSQL sqlc queries to the shared

--- a/wallet/internal/db/pg/walletstore_updatewalletsecrets_test.go
+++ b/wallet/internal/db/pg/walletstore_updatewalletsecrets_test.go
@@ -1,0 +1,290 @@
+package pg
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// mockWalletSecretsSQL drives Store through its production database/sql path
+// while retaining strict mock.Mock call expectations.
+type mockWalletSecretsSQL struct {
+	mock.Mock
+}
+
+// Compile-time assertions cover every database/sql driver seam used here.
+var (
+	_ driver.Driver         = (*mockWalletSecretsSQL)(nil)
+	_ driver.Conn           = (*mockWalletSecretsSQL)(nil)
+	_ driver.ConnBeginTx    = (*mockWalletSecretsSQL)(nil)
+	_ driver.ExecerContext  = (*mockWalletSecretsSQL)(nil)
+	_ driver.QueryerContext = (*mockWalletSecretsSQL)(nil)
+	_ driver.Tx             = (*mockWalletSecretsSQL)(nil)
+)
+
+// Open returns the one connection registered for this isolated test.
+func (m *mockWalletSecretsSQL) Open(name string) (driver.Conn, error) {
+	args := m.Called(name)
+	conn, _ := args.Get(0).(driver.Conn)
+
+	return conn, args.Error(1)
+}
+
+// Prepare rejects unused statements so tests cannot bypass context
+// expectations.
+func (m *mockWalletSecretsSQL) Prepare(query string) (driver.Stmt, error) {
+	args := m.Called(query)
+	stmt, _ := args.Get(0).(driver.Stmt)
+
+	return stmt, args.Error(1)
+}
+
+// Close succeeds because database/sql owns the mock connection lifecycle.
+func (m *mockWalletSecretsSQL) Close() error {
+	args := m.Called()
+
+	return args.Error(0)
+}
+
+// Begin supplies the legacy interface; database/sql selects BeginTx instead.
+func (m *mockWalletSecretsSQL) Begin() (driver.Tx, error) {
+	args := m.Called()
+	tx, _ := args.Get(0).(driver.Tx)
+
+	return tx, args.Error(1)
+}
+
+// BeginTx records the sole transaction and returns this mock for Commit.
+func (m *mockWalletSecretsSQL) BeginTx(ctx context.Context,
+	opts driver.TxOptions) (driver.Tx, error) {
+
+	args := m.Called(ctx, opts)
+	tx, _ := args.Get(0).(driver.Tx)
+
+	return tx, args.Error(1)
+}
+
+// ExecContext records the generated update through the real SQL transaction.
+func (m *mockWalletSecretsSQL) ExecContext(ctx context.Context, query string,
+	args []driver.NamedValue) (driver.Result, error) {
+
+	result := m.Called(ctx, query, args)
+	rows, _ := result.Get(0).(driver.Result)
+
+	return rows, result.Error(1)
+}
+
+// QueryContext records either the wallet lookup or verification read.
+func (m *mockWalletSecretsSQL) QueryContext(ctx context.Context, query string,
+	args []driver.NamedValue) (driver.Rows, error) {
+
+	result := m.Called(ctx, query, args)
+	rows, _ := result.Get(0).(driver.Rows)
+
+	return rows, result.Error(1)
+}
+
+// Commit exposes its configured result to the shared runtime classifier.
+func (m *mockWalletSecretsSQL) Commit() error {
+	args := m.Called()
+
+	return args.Error(0)
+}
+
+// Rollback permits defensive cleanup without another behavioral expectation.
+func (m *mockWalletSecretsSQL) Rollback() error {
+	args := m.Called()
+
+	return args.Error(0)
+}
+
+// mockWalletSecretsRows supplies one generated-query row and then EOF.
+type mockWalletSecretsRows struct {
+	mock.Mock
+}
+
+// Columns returns the scanner shape associated with the configured SQL query.
+func (r *mockWalletSecretsRows) Columns() []string {
+	args := r.Called()
+	columns, _ := args.Get(0).([]string)
+
+	return columns
+}
+
+// Close succeeds because the single in-memory row owns no external resource.
+func (r *mockWalletSecretsRows) Close() error {
+	args := r.Called()
+
+	return args.Error(0)
+}
+
+// Next copies the configured row once and then reports EOF.
+func (r *mockWalletSecretsRows) Next(dest []driver.Value) error {
+	args := r.Called(dest)
+
+	return args.Error(0)
+}
+
+// testWalletSecretsUpdate builds distinct field values so mismatch tests prove
+// that every credential fact participates in exact commit verification.
+func testWalletSecretsUpdate() db.UpdateWalletSecretsParams {
+	return db.UpdateWalletSecretsParams{
+		WalletID:                 7,
+		MasterPrivParams:         []byte{1, 2},
+		EncryptedCryptoPrivKey:   []byte{3, 4},
+		EncryptedCryptoScriptKey: []byte{5, 6},
+		EncryptedMasterHdPrivKey: []byte{7, 8},
+	}
+}
+
+// walletSecretsDriverSeq keeps database/sql registration names unique across
+// parallel subtests and repeated -count runs because drivers cannot be removed.
+var walletSecretsDriverSeq atomic.Uint64
+
+// newMockWalletSecretsStore binds both Store SQL paths to one test driver.
+func newMockWalletSecretsStore(t *testing.T) (*Store, *mockWalletSecretsSQL) {
+	t.Helper()
+
+	sqlMock := &mockWalletSecretsSQL{}
+	driverName := fmt.Sprintf(
+		"wallet-secrets-%s-%d", t.Name(), walletSecretsDriverSeq.Add(1),
+	)
+	sql.Register(driverName, sqlMock)
+
+	dbConn, err := sql.Open(driverName, "")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, dbConn.Close())
+	})
+
+	return &Store{
+		db:      dbConn,
+		queries: sqlc.New(dbConn),
+	}, sqlMock
+}
+
+// newMockWalletSecretsRows configures one scanner row entirely through
+// mock.Mock so its lifecycle and returned values remain explicit expectations.
+func newMockWalletSecretsRows(t *testing.T,
+	values []driver.Value) *mockWalletSecretsRows {
+
+	t.Helper()
+
+	rows := &mockWalletSecretsRows{}
+	rows.On("Columns").Return(make([]string, len(values))).Once()
+	rows.On("Next", mock.Anything).Run(func(args mock.Arguments) {
+		// Populate database/sql's destination inside the declared mock action
+		// so the mock remains the sole authority for scanner behavior.
+		dest, ok := args.Get(0).([]driver.Value)
+		require.True(t, ok)
+		copy(dest, values)
+	}).Return(nil).Once()
+	rows.On("Close").Return(nil).Once()
+
+	return rows
+}
+
+// testWalletRow returns one non-watch-only generated-query row.
+func testWalletRow(t *testing.T, walletID uint32) *mockWalletSecretsRows {
+	t.Helper()
+
+	return newMockWalletSecretsRows(t, []driver.Value{
+		int64(walletID), "wallet", false, int64(1), false, []byte{1},
+		nil, nil, nil, nil, nil, nil, nil, nil,
+	})
+}
+
+// testWalletSecretsRow returns the exact persisted scanner tuple.
+func testWalletSecretsRow(t *testing.T,
+	params db.UpdateWalletSecretsParams) *mockWalletSecretsRows {
+
+	t.Helper()
+
+	return newMockWalletSecretsRows(t, []driver.Value{
+		int64(params.WalletID), params.MasterPrivParams,
+		params.EncryptedCryptoPrivKey,
+		params.EncryptedCryptoScriptKey,
+		params.EncryptedMasterHdPrivKey,
+	})
+}
+
+// TestStoreUpdateWalletSecretsBypassesRead verifies the public Store method
+// performs one authoritative transaction and no verification read for ordinary
+// binary results.
+func TestStoreUpdateWalletSecretsBypassesRead(t *testing.T) {
+	t.Parallel()
+
+	errDefinite := errors.New("definite commit failure")
+	tests := []struct {
+		name      string
+		commitErr error
+	}{
+		{name: "successful commit"},
+		{name: "definite commit failure", commitErr: errDefinite},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: Bind the public Store to a mock.Mock-backed SQL driver.
+			// Every required connection, transaction, query, row, and cleanup
+			// call is declared once; no secret-read expectation is present, so
+			// verification would fail immediately as an unexpected call.
+			params := testWalletSecretsUpdate()
+			store, sqlMock := newMockWalletSecretsStore(t)
+			walletRow := testWalletRow(t, params.WalletID)
+
+			sqlMock.On("Open", "").Return(sqlMock, nil).Once()
+			sqlMock.On(
+				"BeginTx", mock.Anything, driver.TxOptions{},
+			).Return(sqlMock, nil).Once()
+			sqlMock.On(
+				"QueryContext", mock.Anything, sqlc.GetWalletByID,
+				[]driver.NamedValue{{
+					Ordinal: 1, Value: int64(params.WalletID),
+				}},
+			).Return(walletRow, nil).Once()
+			sqlMock.On(
+				"ExecContext", mock.Anything, sqlc.UpdateWalletSecrets,
+				[]driver.NamedValue{
+					{Ordinal: 1, Value: params.MasterPrivParams},
+					{Ordinal: 2, Value: params.EncryptedCryptoPrivKey},
+					{Ordinal: 3, Value: params.EncryptedCryptoScriptKey},
+					{Ordinal: 4, Value: params.EncryptedMasterHdPrivKey},
+					{Ordinal: 5, Value: int64(params.WalletID)},
+				},
+			).Return(driver.RowsAffected(1), nil).Once()
+			sqlMock.On("Commit").Return(test.commitErr).Once()
+			sqlMock.On("Close").Return(nil).Once()
+
+			// Act: Call the public API so transaction construction, generated
+			// queries, runtime commit classification, and result policy all run
+			// through their production authorities.
+			err := store.UpdateWalletSecrets(t.Context(), params)
+
+			// Assert: A successful commit remains success and a definite
+			// commit failure remains an error. Closing the Store completes its
+			// lifecycle; the two direct expectation checks then prove every SQL
+			// and row call occurred exactly once with no retry or extra read.
+			if test.commitErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, test.commitErr)
+			}
+
+			require.NoError(t, store.Close())
+			sqlMock.AssertExpectations(t)
+			walletRow.AssertExpectations(t)
+		})
+	}
+}

--- a/wallet/internal/db/pg/walletstore_updatewalletsecrets_test.go
+++ b/wallet/internal/db/pg/walletstore_updatewalletsecrets_test.go
@@ -6,10 +6,13 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+	"io"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	dbruntime "github.com/btcsuite/btcwallet/wallet/internal/db/runtime"
 	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -287,4 +290,284 @@ func TestStoreUpdateWalletSecretsBypassesRead(t *testing.T) {
 			walletRow.AssertExpectations(t)
 		})
 	}
+}
+
+// TestStoreUpdateWalletSecretsVerifiesAmbiguousCommit verifies the public Store
+// method performs one durable read after the runtime classifies one lost commit
+// acknowledgement, without retrying the mutation.
+func TestStoreUpdateWalletSecretsVerifiesAmbiguousCommit(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Drive an exact wallet update through database/sql, make the real
+	// transaction Commit return EOF, and expose the matching tuple only through
+	// the Store's generated read query. Strict expectations establish the sole
+	// write and sole verification-read budget at the authoritative boundary.
+	params := testWalletSecretsUpdate()
+	store, sqlMock := newMockWalletSecretsStore(t)
+	walletRow := testWalletRow(t, params.WalletID)
+	secretsRow := testWalletSecretsRow(t, params)
+
+	sqlMock.On("Open", "").Return(sqlMock, nil).Once()
+	sqlMock.On(
+		"BeginTx", mock.Anything, driver.TxOptions{},
+	).Return(sqlMock, nil).Once()
+	sqlMock.On(
+		"QueryContext", mock.Anything, sqlc.GetWalletByID,
+		[]driver.NamedValue{{
+			Ordinal: 1, Value: int64(params.WalletID),
+		}},
+	).Return(walletRow, nil).Once()
+	sqlMock.On(
+		"ExecContext", mock.Anything, sqlc.UpdateWalletSecrets,
+		[]driver.NamedValue{
+			{Ordinal: 1, Value: params.MasterPrivParams},
+			{Ordinal: 2, Value: params.EncryptedCryptoPrivKey},
+			{Ordinal: 3, Value: params.EncryptedCryptoScriptKey},
+			{Ordinal: 4, Value: params.EncryptedMasterHdPrivKey},
+			{Ordinal: 5, Value: int64(params.WalletID)},
+		},
+	).Return(driver.RowsAffected(1), nil).Once()
+	sqlMock.On("Commit").Return(io.EOF).Once()
+	sqlMock.On(
+		"QueryContext", mock.Anything, sqlc.GetWalletSecrets,
+		[]driver.NamedValue{{
+			Ordinal: 1, Value: int64(params.WalletID),
+		}},
+	).Return(secretsRow, nil).Once()
+	sqlMock.On("Close").Return(nil).Once()
+
+	// Act: Invoke the public Store method so the shared runtime discovers the
+	// ambiguous commit and the Store resolves it with its real read path.
+	err := store.UpdateWalletSecrets(t.Context(), params)
+
+	// Assert: The exact durable tuple converts the lost acknowledgement to the
+	// binary success result. Closing the Store completes its expected
+	// lifecycle; direct SQL and row expectation checks prove one transaction,
+	// no mutation retry, and one verification read through production wiring.
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), store.StatsSnapshot().AmbiguousTxCommits)
+	require.NoError(t, store.Close())
+	sqlMock.AssertExpectations(t)
+	walletRow.AssertExpectations(t)
+	secretsRow.AssertExpectations(t)
+}
+
+// mockWalletSecretsReader controls verifier-only reads while using mock.Mock
+// to retain strict expectations for focused policy tests.
+type mockWalletSecretsReader struct {
+	mock.Mock
+}
+
+// GetWalletSecrets returns one configured durable row so verifier tests can
+// cover matching, unavailable, and bounded-read outcomes independently.
+func (m *mockWalletSecretsReader) GetWalletSecrets(ctx context.Context,
+	walletID uint32) (*db.WalletSecrets, error) {
+
+	args := m.Called(ctx, walletID)
+	secrets, _ := args.Get(0).(*db.WalletSecrets)
+
+	return secrets, args.Error(1)
+}
+
+// TestVerifyWalletSecretsCommitClassifiesRead verifies exact success and every
+// single-field mismatch without leaking the runtime ambiguity marker.
+func TestVerifyWalletSecretsCommitClassifiesRead(t *testing.T) {
+	t.Parallel()
+
+	params := testWalletSecretsUpdate()
+	errTransport := errors.New("commit connection lost")
+	tests := []struct {
+		name      string
+		persisted db.WalletSecrets
+		wantNil   bool
+	}{
+		{
+			name: "exact tuple",
+			persisted: db.WalletSecrets{
+				MasterPrivParams:         []byte{1, 2},
+				EncryptedCryptoPrivKey:   []byte{3, 4},
+				EncryptedCryptoScriptKey: []byte{5, 6},
+				EncryptedMasterHdPrivKey: []byte{7, 8},
+			},
+			wantNil: true,
+		},
+		{
+			name: "master parameters differ",
+			persisted: db.WalletSecrets{
+				MasterPrivParams:         []byte{9, 2},
+				EncryptedCryptoPrivKey:   []byte{3, 4},
+				EncryptedCryptoScriptKey: []byte{5, 6},
+				EncryptedMasterHdPrivKey: []byte{7, 8},
+			},
+		},
+		{
+			name: "private crypto key differs",
+			persisted: db.WalletSecrets{
+				MasterPrivParams:         []byte{1, 2},
+				EncryptedCryptoPrivKey:   []byte{9, 4},
+				EncryptedCryptoScriptKey: []byte{5, 6},
+				EncryptedMasterHdPrivKey: []byte{7, 8},
+			},
+		},
+		{
+			name: "script crypto key differs",
+			persisted: db.WalletSecrets{
+				MasterPrivParams:         []byte{1, 2},
+				EncryptedCryptoPrivKey:   []byte{3, 4},
+				EncryptedCryptoScriptKey: []byte{9, 6},
+				EncryptedMasterHdPrivKey: []byte{7, 8},
+			},
+		},
+		{
+			name: "master HD private key differs",
+			persisted: db.WalletSecrets{
+				MasterPrivParams:         []byte{1, 2},
+				EncryptedCryptoPrivKey:   []byte{3, 4},
+				EncryptedCryptoScriptKey: []byte{5, 6},
+				EncryptedMasterHdPrivKey: []byte{9, 8},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: Return the case's complete data-only tuple for one
+			// ambiguous result. Canceling the caller proves the follow-up
+			// read receives an independent live context with a deadline.
+			persisted := test.persisted
+			callerCtx, cancel := context.WithCancel(t.Context())
+			cancel()
+
+			ambiguousErr := &dbruntime.AmbiguousTxCommitError{
+				Err: errTransport,
+			}
+			reader := &mockWalletSecretsReader{}
+			reader.On(
+				"GetWalletSecrets", mock.MatchedBy(
+					func(ctx context.Context) bool {
+						deadline, bounded := ctx.Deadline()
+
+						return ctx.Err() == nil && bounded &&
+							deadline.After(time.Now())
+					},
+				), params.WalletID,
+			).Return(&persisted, nil).Once()
+
+			// Act: Resolve the lost commit reply from the configured
+			// PostgreSQL observation without retrying the mutation.
+			err := verifyWalletSecretsCommit(
+				callerCtx, params, time.Second, ambiguousErr,
+				reader.GetWalletSecrets,
+			)
+
+			// Assert: Only the exact tuple succeeds. Every other
+			// observation is an ordinary error retaining its useful
+			// causes. The explicit field checks show that every populated
+			// verification buffer is destroyed before the helper returns.
+			if test.wantNil {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.ErrorIs(t, err, errTransport)
+				require.NotErrorIs(
+					t, err, dbruntime.ErrAmbiguousTxCommit,
+				)
+			}
+
+			require.Equal(t, []byte{0, 0}, persisted.MasterPrivParams)
+			require.Equal(
+				t, []byte{0, 0}, persisted.EncryptedCryptoPrivKey,
+			)
+			require.Equal(
+				t, []byte{0, 0}, persisted.EncryptedCryptoScriptKey,
+			)
+			require.Equal(
+				t, []byte{0, 0}, persisted.EncryptedMasterHdPrivKey,
+			)
+			reader.AssertExpectations(t)
+		})
+	}
+}
+
+// TestVerifyWalletSecretsCommitReturnsReadError verifies an unavailable
+// verification read returns both useful causes without fabricating a row.
+func TestVerifyWalletSecretsCommitReturnsReadError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Configure the reader to return the valid Store failure shape
+	// of a nil row plus an error after PostgreSQL loses the commit
+	// acknowledgement.
+	params := testWalletSecretsUpdate()
+	errTransport := errors.New("commit connection lost")
+	errRead := errors.New("verification unavailable")
+	ambiguousErr := &dbruntime.AmbiguousTxCommitError{Err: errTransport}
+	reader := &mockWalletSecretsReader{}
+	reader.On(
+		"GetWalletSecrets", mock.Anything, params.WalletID,
+	).Return(nil, errRead).Once()
+
+	// Act: Ask the verifier to settle the ambiguous write from the unavailable
+	// read, using the same method value that the public Store passes.
+	err := verifyWalletSecretsCommit(
+		t.Context(), params, time.Second, ambiguousErr,
+		reader.GetWalletSecrets,
+	)
+
+	// Assert: The ordinary Store error retains both the transport and read
+	// causes, omits the runtime marker, and satisfies the sole read
+	// expectation.
+	require.ErrorIs(t, err, errTransport)
+	require.ErrorIs(t, err, errRead)
+	require.NotErrorIs(t, err, dbruntime.ErrAmbiguousTxCommit)
+	reader.AssertExpectations(t)
+}
+
+// TestUpdateWalletSecretsWithCommitVerificationBoundsRead verifies that a
+// detached verification cannot hang after PostgreSQL loses the commit reply.
+func TestUpdateWalletSecretsWithCommitVerificationBoundsRead(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Make the verification read block until its own context expires,
+	// using a short injected bound so the test proves both deadline propagation
+	// and termination without waiting for the production timeout.
+	params := testWalletSecretsUpdate()
+	errTransport := errors.New("commit connection lost")
+	ambiguousErr := &dbruntime.AmbiguousTxCommitError{Err: errTransport}
+	reader := &mockWalletSecretsReader{}
+	reader.On(
+		"GetWalletSecrets", mock.MatchedBy(func(ctx context.Context) bool {
+			_, bounded := ctx.Deadline()
+
+			return bounded
+		}), params.WalletID,
+	).Run(func(args mock.Arguments) {
+		// Waiting on the supplied context makes this mock model an unavailable
+		// read whose only shutdown path is the production verification bound.
+		ctx, ok := args.Get(0).(context.Context)
+		if !ok {
+			t.Fatalf("verification context has type %T", args.Get(0))
+		}
+
+		<-ctx.Done()
+	}).Return(nil, context.DeadlineExceeded).Once()
+
+	// Act: Resolve with a millisecond-scale bound and measure the complete call
+	// so an accidentally unbounded detached context makes the test time out.
+	started := time.Now()
+	err := verifyWalletSecretsCommit(
+		t.Context(), params, 10*time.Millisecond, ambiguousErr,
+		reader.GetWalletSecrets,
+	)
+	elapsed := time.Since(started)
+
+	// Assert: The read exits from its deadline, retains the transport and
+	// timeout causes as an ordinary Store error, and finishes well below a
+	// defensive ceiling that tolerates normal scheduler delay.
+	require.ErrorIs(t, err, errTransport)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.NotErrorIs(t, err, dbruntime.ErrAmbiguousTxCommit)
+	require.Less(t, elapsed, time.Second)
+	reader.AssertExpectations(t)
 }

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -107,6 +107,12 @@ var (
 	// ErrInvalidParam is returned when a parameter is invalid.
 	ErrInvalidParam = errors.New("invalid config parameter")
 
+	// ErrIndeterminateCommit is returned when a durable mutation receives an
+	// ambiguous commit response and the wallet's public boundary cannot prove
+	// whether the mutation persisted. Callers should use errors.Is to match
+	// this identity through operation-specific context.
+	ErrIndeterminateCommit = errors.New("indeterminate commit")
+
 	// Namespace bucket keys.
 	waddrmgrNamespaceKey = []byte("waddrmgr")
 	wtxmgrNamespaceKey   = []byte("wtxmgr")

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -41,6 +41,25 @@ var (
 	}
 )
 
+// TestErrIndeterminateCommitWrapping verifies that operation context can wrap
+// an indeterminate durable-mutation result without hiding its public identity.
+func TestErrIndeterminateCommitWrapping(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: choose representative context that a wallet operation would
+	// retain while reporting an indeterminate commit to its caller.
+	operation := "create wallet"
+
+	// Act: wrap the sentinel with the standard error-chain mechanism used to
+	// preserve operation-specific context at public boundaries.
+	err := fmt.Errorf("%s: %w", operation, ErrIndeterminateCommit)
+
+	// Assert: confirm callers can match the stable identity without losing
+	// the useful context that identifies the affected operation.
+	require.ErrorIs(t, err, ErrIndeterminateCommit)
+	require.ErrorContains(t, err, operation)
+}
+
 // TestConfigValidate ensures that the Config.validate method correctly
 // identifies missing required parameters.
 func TestConfigValidate(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements roadmap Task 401.

Adds the context-aware `WatchAddrsFromTip` chain operation while keeping this
PR limited to the Wallet-owned interface and existing backend notification
mechanisms.

## Change Description

`NotifyReceived` is a live registration primitive for btcd, but not for every
backend. Neutrino can start a birthday-based scan or add addresses to an
already-active historical rescan, allowing matches from blocks before the
registration call. That is a correctness concern for callers that require a
strict live-tip boundary.

Btcd delegates to its existing receive-notification RPC without starting a
rescan. Both bitcoind event modes extend their existing in-memory live filter.
The shared conformance test proves those RPC-backed paths ignore a payment
mined before registration, tolerate repeated registration, deliver one future
payment, and remain quiet through a later block barrier.

Native Neutrino support is intentionally not implemented in this PR. Enforcing
a strict live-tip boundary safely requires a substantially larger rescan
lifecycle design, including coordination with birthday and active historical
rescans. That work is deferred to a dedicated follow-up because its size and
complexity are outside the deliberately minimal scope of this PR.

For interface compatibility only, Neutrino checks pre-call cancellation and
delegates to the unchanged `NotifyReceived` path. A `TODO(yy)` documents that
this temporary shim retains birthday-scan and active-rescan widening behavior
until the deferred Neutrino live-watch design is implemented.