### PR TITLE
itest: add TxWriter label integration tests

### DIFF
--- a/itest/fixtures_test.go
+++ b/itest/fixtures_test.go
@@ -21,6 +21,12 @@ const (
 	// to constrain the upper confirmation range.
 	maxConfsLimit = math.MaxInt32
 
+	// unminedHeight is the height that stands for "no confirming block" in
+	// the range ListTxns takes. A negative start includes the unmined
+	// transactions before the confirmed ones, a negative end includes them
+	// after, and both negative asks for the unmined transactions alone.
+	unminedHeight = -1
+
 	// leaseDuration is the standard lease length for tests. It is long
 	// enough that the lease never expires mid-test.
 	leaseDuration = 10 * time.Minute

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -253,4 +253,8 @@ var allTestCases = []*testCase{
 		Name:     "txreader durable reopen",
 		TestFunc: testTxReaderDurableReopen,
 	},
+	{
+		Name:     "txwriter label transaction",
+		TestFunc: testLabelTx,
+	},
 }

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -277,4 +277,8 @@ var allTestCases = []*testCase{
 		Name:     "txwriter label survives reload",
 		TestFunc: testLabelTxSurvivesReload,
 	},
+	{
+		Name:     "txwriter wallet state",
+		TestFunc: testLabelTxWalletState,
+	},
 }

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -269,4 +269,8 @@ var allTestCases = []*testCase{
 		Name:     "txwriter reject unknown transaction",
 		TestFunc: testLabelTxRejectUnknown,
 	},
+	{
+		Name:     "txwriter reject oversize label",
+		TestFunc: testLabelTxRejectOversize,
+	},
 }

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -273,4 +273,8 @@ var allTestCases = []*testCase{
 		Name:     "txwriter reject oversize label",
 		TestFunc: testLabelTxRejectOversize,
 	},
+	{
+		Name:     "txwriter label survives reload",
+		TestFunc: testLabelTxSurvivesReload,
+	},
 }

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -257,4 +257,8 @@ var allTestCases = []*testCase{
 		Name:     "txwriter label transaction",
 		TestFunc: testLabelTx,
 	},
+	{
+		Name:     "txwriter replace label",
+		TestFunc: testLabelTxReplace,
+	},
 }

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -265,4 +265,8 @@ var allTestCases = []*testCase{
 		Name:     "txwriter label boundaries",
 		TestFunc: testLabelTxBoundaries,
 	},
+	{
+		Name:     "txwriter reject unknown transaction",
+		TestFunc: testLabelTxRejectUnknown,
+	},
 }

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -261,4 +261,8 @@ var allTestCases = []*testCase{
 		Name:     "txwriter replace label",
 		TestFunc: testLabelTxReplace,
 	},
+	{
+		Name:     "txwriter label boundaries",
+		TestFunc: testLabelTxBoundaries,
+	},
 }

--- a/itest/tx_reader_test.go
+++ b/itest/tx_reader_test.go
@@ -26,12 +26,6 @@ const txReaderFundingType = waddrmgr.WitnessPubKey
 // address belongs to.
 const txReaderScriptClass = txscript.WitnessV0PubKeyHashTy
 
-// unminedHeight is the height that stands for "no confirming block" in the
-// range ListTxns takes. A negative start includes the unmined transactions
-// before the confirmed ones, a negative end includes them after, and both
-// negative asks for the unmined transactions alone.
-const unminedHeight = -1
-
 // Every transaction a case here can produce is one the wallet published, since
 // no public wallet API records a transaction in any other state: Broadcast and
 // the syncer both record published transactions, and nothing else writes a

--- a/itest/tx_writer_test.go
+++ b/itest/tx_writer_test.go
@@ -191,3 +191,55 @@ func testLabelTxRejectUnknown(h *bwtest.HarnessTest) {
 		h, kept, detail.Label, "refused label displaced the stored one",
 	)
 }
+
+// testLabelTxRejectOversize verifies that the first label longer than the
+// wallet stores is refused by every backend, and that the refusal leaves the
+// transaction's existing label in place rather than truncating it to fit.
+//
+// The rejection is asserted only as an error. Every backend enforces the limit
+// itself, so the caller receives whichever of three unrelated values that
+// backend produces: kvdb reports wtxmgr.ErrLabelTooLong, SQLite a violated
+// CHECK constraint, and PostgreSQL an overlong value for its column type. There
+// is no wallet error identity to match on, and matching any one backend's text
+// would tie this case to a detail no contract promises. That missing identity
+// is a gap in LabelTx, not in this case.
+//
+// The identities LabelTx does publish are ruled out instead, so the case still
+// fails if the write is ever refused for a reason other than the label it was
+// given.
+func testLabelTxRejectOversize(h *bwtest.HarnessTest) {
+	const kept = "rent for march"
+
+	w, funding := h.NewWallet(bwtest.WalletFixture{
+		AddrType: txWriterFundingType,
+		Amounts:  []btcutil.Amount{oneBTC},
+	})
+
+	txHash := funding.WalletOutpoints[0].Hash
+
+	err := w.LabelTx(h.Context(), txHash, kept)
+	require.NoError(h, err, "failed to label the funding transaction")
+
+	// One character past the longest label testLabelTxBoundaries stores, so
+	// length is the only thing wrong with it.
+	oversize := strings.Repeat("x", wtxmgr.TxLabelLimit+1)
+
+	err = w.LabelTx(h.Context(), txHash, oversize)
+
+	require.Error(h, err, "label longer than the limit was accepted")
+	require.NotErrorIs(
+		h, err, wallet.ErrTxNotFound,
+		"label was refused for a transaction the wallet holds",
+	)
+	require.NotErrorIs(
+		h, err, wallet.ErrStateForbidden,
+		"label was refused by the lifecycle gate on a running wallet",
+	)
+
+	detail, err := w.GetTx(h.Context(), txHash)
+	require.NoError(h, err, "failed to read the labeled transaction")
+	require.Equal(
+		h, kept, detail.Label,
+		"refused label replaced or truncated the stored one",
+	)
+}

--- a/itest/tx_writer_test.go
+++ b/itest/tx_writer_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcwallet/bwtest"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet"
 	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/stretchr/testify/require"
 )
@@ -143,4 +144,50 @@ func testLabelTxBoundaries(h *bwtest.HarnessTest) {
 			tc.name,
 		)
 	}
+}
+
+// testLabelTxRejectUnknown verifies that labeling a transaction the wallet does
+// not hold is refused with the same identity a read of it reports, and that the
+// refusal leaves no trace: no transaction is invented for the label to hang on,
+// and the label already stored elsewhere is untouched.
+func testLabelTxRejectUnknown(h *bwtest.HarnessTest) {
+	const (
+		kept     = "rent for march"
+		rejected = "for a transaction the wallet has never seen"
+	)
+
+	w, funding := h.NewWallet(bwtest.WalletFixture{
+		AddrType: txWriterFundingType,
+		Amounts:  []btcutil.Amount{oneBTC},
+	})
+
+	txHash := funding.WalletOutpoints[0].Hash
+
+	err := w.LabelTx(h.Context(), txHash, kept)
+	require.NoError(h, err, "failed to label the funding transaction")
+
+	// The outpoint no wallet knows names a transaction no wallet knows.
+	unknown := unknownOutpoint().Hash
+
+	err = w.LabelTx(h.Context(), unknown, rejected)
+
+	require.ErrorIs(
+		h, err, wallet.ErrTxNotFound,
+		"labeling an unknown transaction was accepted",
+	)
+
+	// A label cannot bring its transaction into existence, so the wallet
+	// still does not hold the one it just refused to label.
+	_, err = w.GetTx(h.Context(), unknown)
+	require.ErrorIs(
+		h, err, wallet.ErrTxNotFound,
+		"refused label created a transaction",
+	)
+
+	// Nor may the refusal reach the transaction the wallet does hold.
+	detail, err := w.GetTx(h.Context(), txHash)
+	require.NoError(h, err, "failed to read the labeled transaction")
+	require.Equal(
+		h, kept, detail.Label, "refused label displaced the stored one",
+	)
 }

--- a/itest/tx_writer_test.go
+++ b/itest/tx_writer_test.go
@@ -283,3 +283,39 @@ func testLabelTxSurvivesReload(h *bwtest.HarnessTest) {
 		"reloaded wallet listed the transaction without its label",
 	)
 }
+
+// testLabelTxWalletState verifies the lifecycle gate on labeling: it is
+// unavailable before the wallet starts and after it stops, so a caller writing
+// during startup or shutdown is told the wallet is not running rather than
+// something about the transaction.
+func testLabelTxWalletState(h *bwtest.HarnessTest) {
+	const label = "rent for march"
+
+	w, _ := h.NewWallet(bwtest.WalletFixture{
+		AddrType:  txWriterFundingType,
+		Unstarted: true,
+	})
+
+	// The gate refuses before anything looks the transaction up, so this
+	// only has to be a hash. Nothing is labeled.
+	txHash := unknownOutpoint().Hash
+
+	err := w.LabelTx(h.Context(), txHash, label)
+	require.ErrorIs(
+		h, err, wallet.ErrStateForbidden,
+		"labeling before start not rejected",
+	)
+
+	require.NoError(h, w.Start(h.Context()), "failed to start wallet")
+
+	// Stop the wallet, then deregister it so the harness does not drive a
+	// stopped wallet during teardown.
+	require.NoError(h, w.Stop(h.Context()), "failed to stop wallet")
+	require.True(h, h.DeregisterWallet(w), "failed to deregister wallet")
+
+	err = w.LabelTx(h.Context(), txHash, label)
+	require.ErrorIs(
+		h, err, wallet.ErrStateForbidden,
+		"labeling after stop not rejected",
+	)
+}

--- a/itest/tx_writer_test.go
+++ b/itest/tx_writer_test.go
@@ -1,0 +1,60 @@
+//go:build itest
+
+package itest
+
+import (
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcwallet/bwtest"
+	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/stretchr/testify/require"
+)
+
+// txWriterFundingType is the address type the TxWriter cases fund. A label
+// describes a transaction rather than the coins it pays, so the type is
+// immaterial here; naming one keeps the fixture explicit instead of resting on
+// a zero value that means something to other components.
+const txWriterFundingType = waddrmgr.WitnessPubKey
+
+// testLabelTx verifies that labeling a transaction the wallet holds succeeds
+// and that the label becomes what both maintained readers report for it.
+func testLabelTx(h *bwtest.HarnessTest) {
+	const label = "rent for march"
+
+	w, funding := h.NewWallet(bwtest.WalletFixture{
+		AddrType: txWriterFundingType,
+		Amounts:  []btcutil.Amount{oneBTC},
+	})
+
+	// The transaction that paid the wallet is mined and wallet-relevant, so
+	// it is a transaction the wallet's readers report, and nothing has
+	// labeled it yet.
+	txHash := funding.WalletOutpoints[0].Hash
+
+	before, err := w.GetTx(h.Context(), txHash)
+	require.NoError(h, err, "failed to read the funding transaction")
+	require.Empty(h, before.Label, "funding transaction arrived labeled")
+
+	err = w.LabelTx(h.Context(), txHash, label)
+
+	require.NoError(h, err, "failed to label transaction")
+
+	after, err := w.GetTx(h.Context(), txHash)
+	require.NoError(h, err, "failed to read the labeled transaction")
+	require.Equal(h, label, after.Label, "point read lost the label")
+
+	// The label is metadata of the transaction, not of the read, so the
+	// list reader must report the same one. The range covers everything the
+	// wallet holds, and the transaction is selected by hash rather than by
+	// position, so this asserts the label and nothing about what else that
+	// history contains.
+	details, err := w.ListTxns(h.Context(), unminedHeight, 0)
+	require.NoError(h, err, "failed to list transactions")
+
+	listed := make(map[chainhash.Hash]string, len(details))
+	for _, detail := range details {
+		listed[detail.Hash] = detail.Label
+	}
+
+	require.Equal(h, label, listed[txHash], "list read lost the label")
+}

--- a/itest/tx_writer_test.go
+++ b/itest/tx_writer_test.go
@@ -58,3 +58,34 @@ func testLabelTx(h *bwtest.HarnessTest) {
 
 	require.Equal(h, label, listed[txHash], "list read lost the label")
 }
+
+// testLabelTxReplace verifies the documented replacement contract: a label
+// written over an existing one takes its place, rather than being refused as a
+// duplicate or accumulating alongside it.
+func testLabelTxReplace(h *bwtest.HarnessTest) {
+	const (
+		original    = "rent for march"
+		replacement = "rent for april"
+	)
+
+	w, funding := h.NewWallet(bwtest.WalletFixture{
+		AddrType: txWriterFundingType,
+		Amounts:  []btcutil.Amount{oneBTC},
+	})
+
+	txHash := funding.WalletOutpoints[0].Hash
+
+	err := w.LabelTx(h.Context(), txHash, original)
+	require.NoError(h, err, "failed to write the original label")
+
+	err = w.LabelTx(h.Context(), txHash, replacement)
+
+	require.NoError(h, err, "labeling an already-labeled transaction "+
+		"was refused")
+
+	detail, err := w.GetTx(h.Context(), txHash)
+	require.NoError(h, err, "failed to read the relabeled transaction")
+	require.Equal(
+		h, replacement, detail.Label, "transaction kept its first label",
+	)
+}

--- a/itest/tx_writer_test.go
+++ b/itest/tx_writer_test.go
@@ -243,3 +243,43 @@ func testLabelTxRejectOversize(h *bwtest.HarnessTest) {
 		"refused label replaced or truncated the stored one",
 	)
 }
+
+// testLabelTxSurvivesReload verifies that a label is durable rather than
+// remembered by the running wallet: after the wallet is stopped, its database
+// closed, and the same wallet loaded again, both readers still report it.
+func testLabelTxSurvivesReload(h *bwtest.HarnessTest) {
+	const label = "rent for march"
+
+	w, funding := h.NewWallet(bwtest.WalletFixture{
+		AddrType: txWriterFundingType,
+		Amounts:  []btcutil.Amount{oneBTC},
+	})
+
+	txHash := funding.WalletOutpoints[0].Hash
+
+	err := w.LabelTx(h.Context(), txHash, label)
+	require.NoError(h, err, "failed to label transaction")
+
+	reloaded := h.ReloadWallet(w)
+
+	detail, err := reloaded.GetTx(h.Context(), txHash)
+	require.NoError(
+		h, err, "reloaded wallet lost the labeled transaction",
+	)
+	require.Equal(
+		h, label, detail.Label, "reloaded wallet lost the label",
+	)
+
+	details, err := reloaded.ListTxns(h.Context(), unminedHeight, 0)
+	require.NoError(h, err, "failed to list transactions")
+
+	listed := make(map[chainhash.Hash]string, len(details))
+	for _, detail := range details {
+		listed[detail.Hash] = detail.Label
+	}
+
+	require.Equal(
+		h, label, listed[txHash],
+		"reloaded wallet listed the transaction without its label",
+	)
+}

--- a/itest/tx_writer_test.go
+++ b/itest/tx_writer_test.go
@@ -3,10 +3,13 @@
 package itest
 
 import (
+	"strings"
+
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcwallet/bwtest"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/stretchr/testify/require"
 )
 
@@ -88,4 +91,56 @@ func testLabelTxReplace(h *bwtest.HarnessTest) {
 	require.Equal(
 		h, replacement, detail.Label, "transaction kept its first label",
 	)
+}
+
+// testLabelTxBoundaries verifies the ends of the label length range every
+// backend accepts: one character, and the longest label the wallet stores.
+//
+// The upper limit is wtxmgr.TxLabelLimit, which is the only exported name for
+// it; the SQL schemas restate the same number as a column constraint. Labels
+// are built from ASCII deliberately, because kvdb counts the limit in bytes
+// while the SQL schemas count it in characters, and only ASCII makes the one
+// number mean the same thing on all three backends.
+//
+// The values just outside this range are not rows here. One character above it
+// is refused by every backend, but with a backend-specific error rather than a
+// wallet error identity, so it is asserted separately in
+// testLabelTxRejectOversize. The empty label below it has no single behavior to
+// assert at all: the SQL backends accept it and clear the label, while kvdb
+// refuses it.
+func testLabelTxBoundaries(h *bwtest.HarnessTest) {
+	w, funding := h.NewWallet(bwtest.WalletFixture{
+		AddrType: txWriterFundingType,
+		Amounts:  []btcutil.Amount{oneBTC},
+	})
+
+	txHash := funding.WalletOutpoints[0].Hash
+
+	labels := []struct {
+		name  string
+		label string
+	}{
+		{
+			name:  "shortest label",
+			label: strings.Repeat("x", 1),
+		},
+		{
+			name:  "longest label",
+			label: strings.Repeat("x", wtxmgr.TxLabelLimit),
+		},
+	}
+
+	for _, tc := range labels {
+		err := w.LabelTx(h.Context(), txHash, tc.label)
+		require.NoError(h, err, "%s was refused", tc.name)
+
+		detail, err := w.GetTx(h.Context(), txHash)
+		require.NoError(
+			h, err, "failed to read transaction after %s", tc.name,
+		)
+		require.Equal(
+			h, tc.label, detail.Label, "%s came back altered",
+			tc.name,
+		)
+	}
 }


### PR DESCRIPTION
Addresses Task 437 of the [#1250](https://github.com/btcsuite/btcwallet/issues/1250)
integration-test lane. `LabelTx` is the whole `TxWriter` interface, and nothing
proved its contract through a real Store-backed wallet.

Seven cases, registered as `txwriter ...`, run unchanged on kvdb, SQLite and
PostgreSQL:

| Case | Contract |
|---|---|
| `txwriter label transaction` | A written label is what both maintained readers report. |
| `txwriter replace label` | A second label replaces the first, as documented. |
| `txwriter label boundaries` | The shortest and longest labels every backend stores survive unaltered. |
| `txwriter reject unknown transaction` | Labeling a transaction the wallet does not hold fails with `ErrTxNotFound`, creates nothing, and leaves the stored label alone. |
| `txwriter reject oversize label` | A label past the limit is refused and the previous one survives. |
| `txwriter label survives reload` | The label is still reported after the wallet is stopped, its database closed, and the same wallet loaded again. |
| `txwriter wallet state` | Labeling before `Start` and after `Stop` returns `ErrStateForbidden`. |

Rebased onto `sql-wallet` after #1346. The durability case crosses the
close-and-reload lifecycle through `bwtest.(*HarnessTest).ReloadWallet`, which
landed with that PR; the harness commit this branch used to carry was the same
helper under an earlier name and is dropped, so nothing here touches `bwtest`.

## Two gaps this exposed

Both are in production code and are left for their own tasks rather than fixed
inside a test change.

**1. The empty label has no single behavior.** `db.UpdateTxParams` documents the
empty string as valid and as clearing the label, and the SQL backends implement
that. kvdb refuses it: `UpdateTx` goes through `wtxmgr.PutTxLabel`, which
returns `ErrEmptyLabel` for a zero-length label. So the same call succeeds on
two backends and fails on the third, and no backend-neutral case can be written
for it at all. Clearing a label is not otherwise reachable through the public
API, so today a caller cannot portably remove one.

**2. An over-long label is refused three different ways.** Every backend
enforces the 500-character limit, but each reports its own violation:
`wtxmgr.ErrLabelTooLong` on kvdb, a failed `CHECK` constraint on SQLite, and an
overlong `VARCHAR(500)` value on PostgreSQL. `LabelTx` publishes no identity of
its own, so `txwriter reject oversize label` can only assert that some error
came back. A `wallet.ErrLabelTooLong` — with the length check in `LabelTx`,
above the stores — would make that case an `ErrorIs` like every other rejection
in the suite.

A related detail for whoever takes that on: `wtxmgr` counts the limit in bytes
while both SQL schemas count it in characters, so a 200-character label of
3-byte runes is stored by the SQL backends and refused by kvdb. The boundary
case uses ASCII deliberately for that reason.

## Testing

`txwriter` cases pass on every supported database and both available chain
backends:

- `make itest chain=btcd db=sqlite icase='txwriter'`
- `make itest chain=btcd db=kvdb icase='txwriter'`
- `make itest chain=btcd db=postgres icase='txwriter'`
- `make itest chain=bitcoind db=sqlite icase='txwriter'`

The full suite passes shuffled on both sqlite (`-shuffleseed=42`) and kvdb
(`-shuffleseed=7`), 66 cases, no failures and no skips.

