### PR TITLE
txauthor+wallet: validate transaction output and fee arithmetic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -127,3 +127,5 @@ go 1.25.11
 replace github.com/btcsuite/btcwallet/wtxmgr => ./wtxmgr
 
 replace github.com/btcsuite/btcwallet/wallet/txsizes => ./wallet/txsizes
+
+replace github.com/btcsuite/btcwallet/wallet/txauthor => ./wallet/txauthor

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,6 @@ github.com/btcsuite/btcd/wire/v2 v2.0.0 h1:mYSKzZZ0a1sK+aMhXzfDSVsSzRkWkU3x2U04T
 github.com/btcsuite/btcd/wire/v2 v2.0.0/go.mod h1:bGxkPkk8IiDvUo1D96wE03llBIk7p2MdWYRyAQwLmqM=
 github.com/btcsuite/btclog v1.0.0 h1:sEkpKJMmfGiyZjADwEIgB1NSwMyfdD1FB8v6+w1T0Ns=
 github.com/btcsuite/btclog v1.0.0/go.mod h1:w7xnGOhwT3lmrS4H3b/D1XAXxvh+tbhUm8xeHN2y3TQ=
-github.com/btcsuite/btcwallet/wallet/txauthor v1.4.0 h1:oIkGj32YK1CvWaJGlVwZA1f+y/KVHkfrd2PoST0ZpQs=
-github.com/btcsuite/btcwallet/wallet/txauthor v1.4.0/go.mod h1:sGrBjcqQ8UPexuRajFs72+o544CJn3Pavv/5H0VAWVk=
 github.com/btcsuite/btcwallet/wallet/txrules v1.3.0 h1:D5aGMwWIxdqek3xEJs4eOdMoh6iga2EI2xSlaXCdnNo=
 github.com/btcsuite/btcwallet/wallet/txrules v1.3.0/go.mod h1:ZzSdn2XrsUDPa193Q/su1sJY+716rlFK2H1mYwbY/18=
 github.com/btcsuite/btcwallet/walletdb v1.6.0 h1:Yund5XbdqFxNW7+R2Sxs02bMC5fMrmORj4GN8MV55no=

--- a/wallet/deprecated_test.go
+++ b/wallet/deprecated_test.go
@@ -1915,6 +1915,56 @@ func TestInputYield(t *testing.T) {
 	require.False(t, inputYieldsPositively(credit, 20000))
 }
 
+// TestTxToOutputsRejectsNonPositiveFeeRate verifies that the legacy authoring
+// path refuses a fee rate at or below zero.
+//
+// Nothing between the deprecated wallet interface and txauthor bounds this
+// rate: txToOutputs backs CreateSimpleTx, SendOutputs and SendOutputsWithInput,
+// and it hands whatever the caller passed straight to NewUnsignedTransaction. A
+// zero rate used to author a zero-fee transaction. The in-tree legacy RPC always
+// supplies txrules.DefaultRelayFeePerKb, so it is unaffected, but external
+// callers of the deprecated interface set their own rate and this test records
+// the change for them.
+func TestTxToOutputsRejectsNonPositiveFeeRate(t *testing.T) {
+	t.Parallel()
+
+	w := testWallet(t)
+
+	keyScope := waddrmgr.KeyScopeBIP0049Plus
+	addr, err := w.CurrentAddress(0, keyScope)
+	require.NoError(t, err)
+
+	p2shAddr, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	// Fund the wallet so the refusal cannot be mistaken for a shortfall.
+	addUtxo(t, w, &wire.MsgTx{
+		TxIn:  []*wire.TxIn{{}},
+		TxOut: []*wire.TxOut{wire.NewTxOut(100000, p2shAddr)},
+	})
+
+	txOuts := []*wire.TxOut{{PkScript: p2shAddr, Value: 10000}}
+
+	for _, feeRate := range []btcutil.Amount{0, -1000} {
+		tx, err := w.txToOutputs(
+			txOuts, nil, nil, 0, 1, feeRate,
+			CoinSelectionLargest, true, nil, alwaysAllowUtxo,
+		)
+		require.ErrorIs(t, err, txauthor.ErrFeeRateNotPositive,
+			"fee rate %d not rejected", feeRate)
+		require.Nil(t, tx)
+	}
+
+	// A positive rate still authors against the same fixture, so the
+	// rejection above is about the rate and nothing else.
+	tx, err := w.txToOutputs(
+		txOuts, nil, nil, 0, 1, 1000, CoinSelectionLargest, true, nil,
+		alwaysAllowUtxo,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, tx)
+}
+
 // TestTxToOutputsRandom tests random coin selection.
 func TestTxToOutputsRandom(t *testing.T) {
 	t.Parallel()

--- a/wallet/psbt_manager_test.go
+++ b/wallet/psbt_manager_test.go
@@ -964,6 +964,77 @@ func TestFundPsbtInvalidTxIntent(t *testing.T) {
 	require.Equal(t, int64(10_000), packet.UnsignedTx.TxOut[0].Value)
 }
 
+// TestFundPsbtTranslatesAmountError verifies that a checked-arithmetic failure
+// raised inside transaction authoring reaches a FundPsbt caller under the
+// wallet's own error, not the nested module's.
+//
+// The aggregate output total is the one such condition a public wrapper can
+// reach: validateTxIntent bounds each output on its own but never sums them, so
+// two individually payable outputs can still overflow the maximum. Asserting it
+// here rather than only through CreateTransaction is what pins translation to
+// the shared authoring boundary, where both wrappers pick it up.
+func TestFundPsbtTranslatesAmountError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Prepare a synced wallet and a packet whose two outputs are
+	// each below the maximum but together exceed it.
+	w, mocks := createStartedWalletWithMocks(t)
+	mocks.syncer.On("syncState").Return(syncStateSynced).Once()
+
+	script := append([]byte{0x00, 0x14}, make([]byte, 20)...)
+	tx := wire.NewMsgTx(wire.TxVersion)
+	tx.AddTxOut(&wire.TxOut{
+		Value: btcutil.MaxSatoshi - 1e8, PkScript: script,
+	})
+	tx.AddTxOut(&wire.TxOut{Value: 1e8 + 1, PkScript: script})
+
+	packet, err := psbt.NewFromUnsignedTx(tx)
+	require.NoError(t, err)
+
+	originalTx := packet.UnsignedTx
+
+	// Arrange: Register only the lookups source preparation performs. The
+	// change script is never requested, because authoring rejects the
+	// output set before it reaches the change callback, so registering
+	// NewDerivedAddress would leave an unmet expectation at cleanup.
+	defaultAccountNum := uint32(waddrmgr.DefaultAccountNum)
+	scope := db.KeyScope(waddrmgr.KeyScopeBIP0086)
+	accountInfo := &db.AccountInfo{
+		AccountNumber: &defaultAccountNum,
+		AccountName:   waddrmgr.DefaultAccountName,
+		AddrSchema:    db.ScopeAddrMap[scope],
+	}
+	mocks.store.On("GetAccount", mock.Anything, db.GetAccountQuery{
+		WalletID: w.id, Scope: scope, Name: &defaultAccountName,
+	}).Return(accountInfo, nil).Once()
+	mocks.store.On("GetAccount", mock.Anything, db.GetAccountQuery{
+		WalletID: w.id, Scope: scope, AccountNumber: &defaultAccountNum,
+	}).Return(accountInfo, nil).Once()
+	mocks.chain.On("BlockStamp").Return(
+		&waddrmgr.BlockStamp{Height: 100}, nil,
+	).Once()
+	mocks.store.On("ListUTXOs", mock.Anything, db.ListUtxosQuery{
+		WalletID: w.id, Scope: &scope, AccountName: &defaultAccountName,
+	}).Return([]db.UtxoInfo{}, nil).Once()
+
+	// Act: Fund the packet with an otherwise valid intent.
+	funded, changeIndex, err := w.FundPsbt(t.Context(), &FundIntent{
+		Packet:  packet,
+		Policy:  &InputsPolicy{},
+		FeeRate: defaultFeeRate,
+	})
+
+	// Assert: The wallet's own sentinel identifies the violation, the
+	// originating txauthor error stays in the chain, and the caller's packet
+	// is left as it arrived.
+	require.ErrorIs(t, err, ErrOutputTotalExceedsMax)
+	require.ErrorIs(t, err, txauthor.ErrOutputTotalExceedsMax)
+	require.Nil(t, funded)
+	require.Zero(t, changeIndex)
+	require.Same(t, originalTx, packet.UnsignedTx)
+	require.Len(t, packet.UnsignedTx.TxOut, 2)
+}
+
 // TestValidateFundIntentSuccess tests that validateFundIntent returns no error
 // for valid funding intents.
 func TestValidateFundIntentSuccess(t *testing.T) {

--- a/wallet/tx_creator.go
+++ b/wallet/tx_creator.go
@@ -82,6 +82,27 @@ var (
 	// errNegativeHeight is returned when a height expected to be non-negative
 	// is negative.
 	errNegativeHeight = errors.New("negative height")
+
+	// The two errors below name the same conditions as their txauthor
+	// counterparts, deliberately including their names. They exist so a
+	// caller can match an authoring failure without importing the nested
+	// module; the originating txauthor error stays in the chain for anyone
+	// who wants the finer distinction.
+
+	// ErrOutputTotalExceedsMax is returned when a transaction's outputs are
+	// individually valid but sum to more than the maximum representable
+	// amount. Unlike the per-output bounds, this one has no counterpart in
+	// validateTxIntent, so it is reported from the authoring boundary.
+	ErrOutputTotalExceedsMax = errors.New(
+		"total output amount exceeds maximum value",
+	)
+
+	// ErrFeeOutOfRange is returned when the fee a transaction would pay is
+	// not a representable amount. DefaultMaxFeeRate keeps this out of reach
+	// at its default value, but that bound is a mutable package variable
+	// intended to become configurable: raised far enough, an ordinary
+	// multi-input transaction can price a fee above MaxSatoshi.
+	ErrFeeOutOfRange = errors.New("transaction fee out of range")
 )
 
 var (
@@ -677,7 +698,7 @@ func (w *Wallet) authorTransaction(outputs []wire.TxOut,
 		txOutputs, feeSatPerKb, inputSource, changeSource,
 	)
 	if err != nil {
-		return nil, err
+		return nil, translateAuthorError(err)
 	}
 
 	// Randomize the position of the change output, if one was created. This
@@ -688,6 +709,80 @@ func (w *Wallet) authorTransaction(outputs []wire.TxOut,
 	}
 
 	return tx, nil
+}
+
+// authorError gives an authoring failure a wallet-facing identity without
+// restating it. Its message is the originating error's alone, while errors.Is
+// resolves both the wallet sentinel, through Is, and everything the originating
+// error already matched, through Unwrap. Wrapping with a second %w verb would
+// match both too, but would render the wallet sentinel's text and the txauthor
+// error's text one after the other, and for most of these classes those say the
+// same thing twice.
+//
+// This mirrors AmbiguousTxCommitError in wallet/internal/db/runtime.
+type authorError struct {
+	// sentinel is the wallet-facing identity this failure reports as.
+	sentinel error
+
+	// cause is the originating txauthor error, which supplies the message.
+	cause error
+}
+
+// Error returns the originating error's message.
+func (e *authorError) Error() string {
+	return e.cause.Error()
+}
+
+// Unwrap returns the originating txauthor error.
+func (e *authorError) Unwrap() error {
+	return e.cause
+}
+
+// Is reports whether target is the wallet sentinel this failure carries.
+func (e *authorError) Is(target error) bool {
+	return errors.Is(e.sentinel, target)
+}
+
+// translateAuthorError maps the checked-arithmetic errors the txauthor module
+// reports onto the wallet's own error vocabulary, so callers of the public
+// wrappers match on one set of sentinels. It is the single translation point
+// for both CreateTransaction and FundPsbt.
+//
+// Conditions validateTxIntent already names keep that identity, which costs no
+// new API and leaves one wallet-level error per condition however it was
+// reached: the txrules errors for an output value, and ErrMissingFeeRate for a
+// rate that is not positive. Only the output total has no intent-level
+// counterpart and needs a sentinel of its own.
+//
+// Everything else is returned untouched: an InputSourceError, so "cannot fund
+// this" stays distinguishable from "will not author this", and the checked
+// arithmetic classes no caller can observe. A nil output cannot occur, because
+// authorTransaction takes its outputs by value; the add and subtract guards
+// cannot fire, because CheckOutputsAmount bounds the target before every
+// addition and the sufficiency checks bound the rest. Naming those in the
+// wallet would be exported API with nothing behind it.
+func translateAuthorError(err error) error {
+	switch {
+	case errors.Is(err, txauthor.ErrOutputValueNegative):
+		return &authorError{txrules.ErrAmountNegative, err}
+
+	case errors.Is(err, txauthor.ErrOutputValueExceedsMax):
+		return &authorError{txrules.ErrAmountExceedsMax, err}
+
+	case errors.Is(err, txauthor.ErrOutputTotalExceedsMax):
+		return &authorError{ErrOutputTotalExceedsMax, err}
+
+	case errors.Is(err, txauthor.ErrFeeRateNotPositive):
+		return &authorError{ErrMissingFeeRate, err}
+
+	case errors.Is(err, txauthor.ErrFeeOverflow),
+		errors.Is(err, txauthor.ErrFeeOutOfRange):
+
+		return &authorError{ErrFeeOutOfRange, err}
+
+	default:
+		return err
+	}
 }
 
 // determineChangeSource determines the source for the transaction's change

--- a/wallet/tx_creator_test.go
+++ b/wallet/tx_creator_test.go
@@ -2,6 +2,7 @@ package wallet
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/btcsuite/btcd/address/v2"
@@ -707,9 +708,10 @@ func TestAuthorTransaction(t *testing.T) {
 			require.Equal(t, inputScript, authored.PrevScripts[0])
 			require.Equal(t, inputTarget+tc.changeAmount,
 				authored.TotalInput)
-			fee := authored.TotalInput - txauthor.SumOutputValues(
-				authored.Tx.TxOut,
-			)
+			paid, err := txauthor.CheckOutputsAmount(authored.Tx.TxOut)
+			require.NoError(t, err)
+
+			fee := authored.TotalInput - paid
 			require.Equal(t, inputTarget-btcutil.Amount(output.Value), fee)
 
 			if tc.changeAmount == 0 {
@@ -730,6 +732,210 @@ func TestAuthorTransaction(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestAuthorTransactionChecksAmounts verifies that an output set which is
+// individually payable but sums above the maximum is refused at the authoring
+// boundary, under the wallet's own error, before either callback is consulted.
+//
+// This is the only amount condition the boundary uniquely owns. Every other one
+// txauthor reports is either screened earlier by validateTxIntent, so it never
+// arrives here, or unreachable through this entry point: the boundary takes its
+// outputs by value, so a nil element is unrepresentable, and the checked add
+// and subtract guards cannot fire behind CheckOutputsAmount. The nested module
+// covers those conditions and TestTranslateAuthorError covers their mappings.
+func TestAuthorTransactionChecksAmounts(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Two outputs, each payable on its own, whose total is one
+	// satoshi past the maximum. Count both callbacks so the test can prove
+	// the refusal landed before either was consulted.
+	script := append([]byte{0x00, 0x14}, make([]byte, 20)...)
+	outputs := []wire.TxOut{{
+		Value: btcutil.MaxSatoshi - 1e8, PkScript: script,
+	}, {
+		Value: 1e8 + 1, PkScript: script,
+	}}
+
+	w, _ := createTestWalletWithMocks(t)
+
+	var inputCalls, changeCalls int
+
+	inputSource := func(target btcutil.Amount) (btcutil.Amount,
+		[]*wire.TxIn, []btcutil.Amount, [][]byte, error) {
+
+		inputCalls++
+
+		return target, []*wire.TxIn{{}}, []btcutil.Amount{target},
+			[][]byte{script}, nil
+	}
+	changeSource := &txauthor.ChangeSource{
+		ScriptSize: len(script),
+		NewScript: func() ([]byte, error) {
+			changeCalls++
+
+			return script, nil
+		},
+	}
+
+	// Act: Author directly, bypassing the intent-level checks the public
+	// wrappers apply.
+	authored, err := w.authorTransaction(
+		outputs, defaultFeeRate, inputSource, changeSource,
+	)
+
+	// Assert: The wallet's own error identifies the violation, the
+	// originating txauthor error stays in the chain, no transaction is
+	// produced, and neither callback ran.
+	require.ErrorIs(t, err, ErrOutputTotalExceedsMax)
+	require.ErrorIs(t, err, txauthor.ErrOutputTotalExceedsMax)
+	require.Nil(t, authored)
+	require.Zero(t, inputCalls)
+	require.Zero(t, changeCalls)
+}
+
+// TestTranslateAuthorError verifies that each txauthor condition the wallet
+// names is given a wallet-facing identity, that the originating error stays in
+// the chain, that translation leaves the message alone, and that everything
+// else passes through untouched.
+func TestTranslateAuthorError(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		err  error
+		want error
+	}{{
+		name: "negative output value",
+		err:  txauthor.ErrOutputValueNegative,
+		want: txrules.ErrAmountNegative,
+	}, {
+		name: "output value above the maximum",
+		err:  txauthor.ErrOutputValueExceedsMax,
+		want: txrules.ErrAmountExceedsMax,
+	}, {
+		name: "output total above the maximum",
+		err:  txauthor.ErrOutputTotalExceedsMax,
+		want: ErrOutputTotalExceedsMax,
+	}, {
+		name: "non-positive fee rate",
+		err:  txauthor.ErrFeeRateNotPositive,
+		want: ErrMissingFeeRate,
+	}, {
+		name: "fee product overflow",
+		err:  txauthor.ErrFeeOverflow,
+		want: ErrFeeOutOfRange,
+	}, {
+		name: "fee out of range",
+		err:  txauthor.ErrFeeOutOfRange,
+		want: ErrFeeOutOfRange,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// A wrapped error must translate exactly as the bare
+			// sentinel does, since that is how txauthor reports it.
+			wrapped := fmt.Errorf("authoring: %w", tc.err)
+
+			got := translateAuthorError(wrapped)
+
+			// Both identities resolve: the wallet's, so callers need
+			// not import the nested module, and the originating one,
+			// for anyone who wants the finer distinction.
+			require.ErrorIs(t, got, tc.want)
+			require.ErrorIs(t, got, tc.err)
+
+			// Translation must not restate what the originating error
+			// already says. Several wallet sentinels carry text that
+			// duplicates their txauthor counterpart word for word, so
+			// composing the two would print the same clause twice.
+			require.Equal(t, wrapped.Error(), got.Error())
+		})
+	}
+
+	// Conditions the wallet deliberately does not name arrive unchanged.
+	// A nil output cannot occur through authorTransaction, which takes its
+	// outputs by value, and the checked add and subtract guards cannot fire
+	// behind CheckOutputsAmount and the sufficiency checks.
+	unnamed := []struct {
+		name string
+		err  error
+	}{{
+		name: "nil output",
+		err:  txauthor.ErrNilOutput,
+	}, {
+		name: "amount overflow",
+		err:  txauthor.ErrAmountOverflow,
+	}, {
+		name: "amount underflow",
+		err:  txauthor.ErrAmountUnderflow,
+	}}
+
+	for _, tc := range unnamed {
+		t.Run(tc.name+" passes through", func(t *testing.T) {
+			t.Parallel()
+
+			wrapped := fmt.Errorf("authoring: %w", tc.err)
+
+			got := translateAuthorError(wrapped)
+			require.Equal(t, wrapped, got)
+		})
+	}
+
+	// An error the wallet has no name for is returned as it arrived. An
+	// InputSourceError in particular must keep its type, because callers
+	// distinguish "cannot fund this" from "will not author this".
+	t.Run("unrecognised error passes through", func(t *testing.T) {
+		t.Parallel()
+
+		sourceErr := insufficientFundsError(t)
+
+		got := translateAuthorError(sourceErr)
+		require.Equal(t, sourceErr, got)
+
+		var typed txauthor.InputSourceError
+		require.ErrorAs(t, got, &typed)
+	})
+
+	t.Run("nil error passes through", func(t *testing.T) {
+		t.Parallel()
+
+		require.NoError(t, translateAuthorError(nil))
+	})
+}
+
+// insufficientFundsError returns txauthor's own InputSourceError. The concrete
+// type is unexported, so it is obtained the only way a caller can: by authoring
+// a payment the input source cannot cover.
+func insufficientFundsError(t *testing.T) error {
+	t.Helper()
+
+	emptySource := func(btcutil.Amount) (btcutil.Amount, []*wire.TxIn,
+		[]btcutil.Amount, [][]byte, error) {
+
+		return 0, nil, nil, nil, nil
+	}
+
+	_, err := txauthor.NewUnsignedTransaction(
+		[]*wire.TxOut{{
+			Value:    1e8,
+			PkScript: make([]byte, txsizes.P2WPKHPkScriptSize),
+		}}, 1e3, emptySource, &txauthor.ChangeSource{
+			ScriptSize: txsizes.P2WPKHPkScriptSize,
+			NewScript: func() ([]byte, error) {
+				return make(
+					[]byte, txsizes.P2WPKHPkScriptSize,
+				), nil
+			},
+		},
+	)
+
+	var sourceErr txauthor.InputSourceError
+	require.ErrorAs(t, err, &sourceErr)
+
+	return err
 }
 
 // TestCreateTransactionDefaultPolicy verifies nil inputs still select from the

--- a/wallet/txauthor/amounts.go
+++ b/wallet/txauthor/amounts.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package txauthor
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+)
+
+// feeRateDivisor is the number of virtual bytes a fee rate is quoted per. Fee
+// rates are expressed in satoshis per kilo-virtual-byte, so the fee for a given
+// size is the rate-by-size product divided by this value.
+const feeRateDivisor = 1000
+
+// Amount arithmetic violations. Transaction construction reports these instead
+// of wrapping, truncating, or clamping a value that cannot be represented.
+var (
+	// ErrNilOutput is returned when an output set contains a nil element.
+	ErrNilOutput = errors.New("nil transaction output")
+
+	// ErrOutputValueNegative is returned when a single output carries a
+	// negative value.
+	ErrOutputValueNegative = errors.New(
+		"transaction output amount is negative",
+	)
+
+	// ErrOutputValueExceedsMax is returned when a single output carries
+	// more than the maximum representable amount.
+	ErrOutputValueExceedsMax = errors.New(
+		"transaction output amount exceeds maximum value",
+	)
+
+	// ErrOutputTotalExceedsMax is returned when an output set is
+	// individually valid but sums to more than the maximum representable
+	// amount.
+	ErrOutputTotalExceedsMax = errors.New(
+		"transaction output total exceeds maximum value",
+	)
+
+	// ErrAmountOverflow is returned when adding two amounts would overflow.
+	ErrAmountOverflow = errors.New("amount addition overflows")
+
+	// ErrAmountUnderflow is returned when subtracting two amounts would
+	// underflow.
+	ErrAmountUnderflow = errors.New("amount subtraction underflows")
+
+	// ErrFeeRateNotPositive is returned when a fee rate operand is zero or
+	// negative. Such a rate cannot produce a meaningful fee, so it is
+	// rejected before it is ever multiplied by a size.
+	ErrFeeRateNotPositive = errors.New("fee rate must be positive")
+
+	// ErrFeeOverflow is returned when the fee-rate-by-size product
+	// overflows.
+	ErrFeeOverflow = errors.New("fee calculation overflows")
+
+	// ErrFeeOutOfRange is returned when a rounded fee falls outside the
+	// range of representable amounts.
+	ErrFeeOutOfRange = errors.New("fee is not a representable amount")
+)
+
+// addAmounts returns the sum of two amounts, reporting ErrAmountOverflow
+// rather than wrapping when the sum is not representable.
+func addAmounts(a, b btcutil.Amount) (btcutil.Amount, error) {
+	sum := a + b
+
+	// A sum that moved the wrong way relative to the sign of the addend is
+	// the signed-overflow signature.
+	if (b > 0 && sum < a) || (b < 0 && sum > a) {
+		return 0, fmt.Errorf("%w: %d + %d", ErrAmountOverflow, a, b)
+	}
+
+	return sum, nil
+}
+
+// subAmounts returns the difference of two amounts, reporting
+// ErrAmountUnderflow rather than wrapping when the difference is not
+// representable. It is the counterpart of addAmounts and is used for every
+// subtraction that establishes sufficiency or change.
+func subAmounts(a, b btcutil.Amount) (btcutil.Amount, error) {
+	diff := a - b
+
+	// A difference that moved the wrong way relative to the sign of the
+	// subtrahend is the signed-overflow signature.
+	if (b > 0 && diff > a) || (b < 0 && diff < a) {
+		return 0, fmt.Errorf("%w: %d - %d", ErrAmountUnderflow, a, b)
+	}
+
+	return diff, nil
+}
+
+// CheckOutputsAmount validates an output set and returns its checked total so
+// callers can reuse the sum instead of re-deriving it. Every element must be
+// non-nil and carry a value in 0..MaxSatoshi, and the set as a whole must not
+// sum above MaxSatoshi.
+//
+// A nil or empty set is valid and totals zero: a sweep authors a transaction
+// whose only output is change, and has no non-change outputs to declare.
+//
+// The aggregate bound is applied before each addition rather than to the
+// finished sum. Checking afterwards would let a long enough set of individually
+// valid outputs wrap the accumulator first and report an overflow instead of
+// the bound that was actually exceeded: MaxSatoshi divides into an int64 just
+// over 4392 times, so 4393 maximum-value outputs are enough. Applying it first
+// also makes the addition provably safe, so it needs no further guard.
+func CheckOutputsAmount(outputs []*wire.TxOut) (btcutil.Amount, error) {
+	total := btcutil.Amount(0)
+
+	for i, output := range outputs {
+		if output == nil {
+			return 0, fmt.Errorf("%w: index %d", ErrNilOutput, i)
+		}
+
+		if output.Value < 0 {
+			return 0, fmt.Errorf("%w: index %d has %d",
+				ErrOutputValueNegative, i, output.Value)
+		}
+
+		if output.Value > btcutil.MaxSatoshi {
+			return 0, fmt.Errorf("%w: index %d has %d",
+				ErrOutputValueExceedsMax, i, output.Value)
+		}
+
+		// Both operands are now within 0..MaxSatoshi, so the remaining
+		// headroom below cannot go negative and the comparison cannot
+		// overflow.
+		value := btcutil.Amount(output.Value)
+		if total > btcutil.MaxSatoshi-value {
+			return 0, fmt.Errorf("%w: exceeded at index %d",
+				ErrOutputTotalExceedsMax, i)
+		}
+
+		total += value
+	}
+
+	return total, nil
+}
+
+// CheckedFeeForSerializeSize calculates the fee for a transaction of some
+// virtual size at the given rate, reporting an error instead of returning a
+// value that cannot be represented.
+//
+// Both operands are rejected before they are multiplied: a rate at or below
+// zero, because no meaningful fee can follow from it, and a negative size,
+// because it can only come from a caller error. The rate-by-size product is
+// then checked for overflow, and the rounded fee must land within
+// 0..MaxSatoshi. A fee that rounds down to zero is charged the rate itself,
+// matching the one-kilo-virtual-byte floor mempools apply; the rate is positive
+// by then, so the floor is too.
+//
+// Sizes themselves belong to the size estimator, not here. Rejecting a negative
+// one is not an opinion about how sizes are computed: it keeps a wrapped
+// product from landing back inside the representable range and yielding a
+// plausible but wrong fee, which the final bound alone could not rule out.
+func CheckedFeeForSerializeSize(feeRatePerKb btcutil.Amount,
+	txSerializeSize int) (btcutil.Amount, error) {
+
+	if feeRatePerKb <= 0 {
+		return 0, fmt.Errorf("%w: %d", ErrFeeRateNotPositive,
+			feeRatePerKb)
+	}
+
+	if txSerializeSize < 0 {
+		return 0, fmt.Errorf("%w: negative size %d", ErrFeeOutOfRange,
+			txSerializeSize)
+	}
+
+	size := btcutil.Amount(txSerializeSize)
+	product := feeRatePerKb * size
+
+	// Both operands are now non-negative, so a size of zero is the only one
+	// that makes the division round-trip undefined; it trivially cannot
+	// overflow.
+	if size != 0 && product/size != feeRatePerKb {
+		return 0, fmt.Errorf("%w: %d * %d", ErrFeeOverflow,
+			feeRatePerKb, size)
+	}
+
+	fee := product / feeRateDivisor
+	if fee == 0 {
+		fee = feeRatePerKb
+	}
+
+	if fee > btcutil.MaxSatoshi {
+		return 0, fmt.Errorf("%w: %d", ErrFeeOutOfRange, fee)
+	}
+
+	return fee, nil
+}

--- a/wallet/txauthor/amounts_test.go
+++ b/wallet/txauthor/amounts_test.go
@@ -1,0 +1,371 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package txauthor
+
+import (
+	"math"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// maxAmount is the largest representable output or fee amount.
+	maxAmount = btcutil.Amount(btcutil.MaxSatoshi)
+
+	// maxInt64Amount and minInt64Amount are the arithmetic boundaries the
+	// checked add and subtract helpers guard, independent of the consensus
+	// bound above.
+	maxInt64Amount = btcutil.Amount(math.MaxInt64)
+	minInt64Amount = btcutil.Amount(math.MinInt64)
+)
+
+// TestAddAmounts verifies that the checked addition helper reports an overflow
+// instead of wrapping, in both directions.
+func TestAddAmounts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		a       btcutil.Amount
+		b       btcutil.Amount
+		want    btcutil.Amount
+		wantErr bool
+	}{{
+		name: "two positive amounts",
+		a:    1e8,
+		b:    2e8,
+		want: 3e8,
+	}, {
+		name: "adding zero is the identity",
+		a:    maxInt64Amount,
+		b:    0,
+		want: maxInt64Amount,
+	}, {
+		name: "a negative addend reduces the sum",
+		a:    3e8,
+		b:    -1e8,
+		want: 2e8,
+	}, {
+		name: "the largest representable sum",
+		a:    maxInt64Amount - 1,
+		b:    1,
+		want: maxInt64Amount,
+	}, {
+		name:    "positive overflow",
+		a:       maxInt64Amount,
+		b:       1,
+		wantErr: true,
+	}, {
+		name:    "negative overflow",
+		a:       minInt64Amount,
+		b:       -1,
+		wantErr: true,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := addAmounts(tc.a, tc.b)
+
+			if tc.wantErr {
+				require.ErrorIs(t, err, ErrAmountOverflow)
+				require.Zero(t, got)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestSubAmounts verifies that the checked subtraction helper reports an
+// underflow instead of wrapping, in both directions.
+func TestSubAmounts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		a       btcutil.Amount
+		b       btcutil.Amount
+		want    btcutil.Amount
+		wantErr bool
+	}{{
+		name: "two positive amounts",
+		a:    3e8,
+		b:    1e8,
+		want: 2e8,
+	}, {
+		name: "subtracting zero is the identity",
+		a:    minInt64Amount,
+		b:    0,
+		want: minInt64Amount,
+	}, {
+		name: "a larger subtrahend yields a negative difference",
+		a:    1e8,
+		b:    3e8,
+		want: -2e8,
+	}, {
+		name: "the smallest representable difference",
+		a:    minInt64Amount + 1,
+		b:    1,
+		want: minInt64Amount,
+	}, {
+		name:    "negative underflow",
+		a:       minInt64Amount,
+		b:       1,
+		wantErr: true,
+	}, {
+		name:    "positive underflow",
+		a:       maxInt64Amount,
+		b:       -1,
+		wantErr: true,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := subAmounts(tc.a, tc.b)
+
+			if tc.wantErr {
+				require.ErrorIs(t, err, ErrAmountUnderflow)
+				require.Zero(t, got)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// outputsWithValues builds an output set carrying the given values. A negative
+// count of scripts is never needed here, so every output gets the same
+// throwaway script: only the values matter to the validator.
+func outputsWithValues(values ...int64) []*wire.TxOut {
+	outputs := make([]*wire.TxOut, 0, len(values))
+	for _, value := range values {
+		outputs = append(outputs, &wire.TxOut{
+			Value:    value,
+			PkScript: []byte{0x00},
+		})
+	}
+
+	return outputs
+}
+
+// repeatedOutputs builds an output set of n elements all carrying value.
+func repeatedOutputs(n int, value int64) []*wire.TxOut {
+	values := make([]int64, n)
+	for i := range values {
+		values[i] = value
+	}
+
+	return outputsWithValues(values...)
+}
+
+// maxValueOutputsToOverflow is the smallest number of maximum-value outputs
+// whose running sum leaves the int64 range. MaxSatoshi divides into MaxInt64
+// just over 4392 times, so the 4393rd addition is the one that would wrap.
+const maxValueOutputsToOverflow = 4393
+
+// TestCheckOutputsAmount verifies that the output-set validator rejects a nil,
+// a negative, an individually oversized, and an aggregately oversized output
+// set, and returns the checked total for every set it accepts.
+func TestCheckOutputsAmount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		outputs []*wire.TxOut
+		want    btcutil.Amount
+		wantErr error
+	}{{
+		// A sweep authors with no non-change outputs at all, so a nil
+		// set must remain valid and total zero.
+		name:    "a nil set totals zero",
+		outputs: nil,
+		want:    0,
+	}, {
+		name:    "an empty set totals zero",
+		outputs: []*wire.TxOut{},
+		want:    0,
+	}, {
+		name:    "a single output totals its own value",
+		outputs: outputsWithValues(1e8),
+		want:    1e8,
+	}, {
+		name:    "several outputs total their sum",
+		outputs: outputsWithValues(1e8, 2e8, 3e8),
+		want:    6e8,
+	}, {
+		name:    "a zero-valued output is permitted",
+		outputs: outputsWithValues(0, 1e8),
+		want:    1e8,
+	}, {
+		name:    "the maximum output value is permitted",
+		outputs: outputsWithValues(btcutil.MaxSatoshi),
+		want:    maxAmount,
+	}, {
+		name: "an aggregate at exactly the maximum is permitted",
+		outputs: outputsWithValues(
+			btcutil.MaxSatoshi-1e8, 1e8,
+		),
+		want: maxAmount,
+	}, {
+		name:    "a nil element is rejected",
+		outputs: []*wire.TxOut{{Value: 1e8}, nil},
+		wantErr: ErrNilOutput,
+	}, {
+		name:    "a negative value is rejected",
+		outputs: outputsWithValues(1e8, -1),
+		wantErr: ErrOutputValueNegative,
+	}, {
+		name:    "a value above the maximum is rejected",
+		outputs: outputsWithValues(btcutil.MaxSatoshi + 1),
+		wantErr: ErrOutputValueExceedsMax,
+	}, {
+		// Each element is individually valid; only their sum is not.
+		name: "an aggregate above the maximum is rejected",
+		outputs: outputsWithValues(
+			btcutil.MaxSatoshi, btcutil.MaxSatoshi,
+		),
+		wantErr: ErrOutputTotalExceedsMax,
+	}, {
+		name: "an aggregate one satoshi above the maximum is rejected",
+		outputs: outputsWithValues(
+			btcutil.MaxSatoshi-1e8, 1e8+1,
+		),
+		wantErr: ErrOutputTotalExceedsMax,
+	}, {
+		// Enough maximum-value outputs to wrap the accumulator if the
+		// aggregate bound were applied to the finished sum instead of
+		// before each addition. The set must still be refused for the
+		// bound it exceeds, not for an arithmetic overflow.
+		name: "a set large enough to wrap the sum reports the bound",
+		outputs: repeatedOutputs(
+			maxValueOutputsToOverflow, btcutil.MaxSatoshi,
+		),
+		wantErr: ErrOutputTotalExceedsMax,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := CheckOutputsAmount(tc.outputs)
+
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				require.Zero(t, got)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestCheckedFeeForSerializeSize verifies that the checked fee helper rejects a
+// non-positive rate and a negative size before multiplying, reports a product
+// overflow, and refuses a rounded fee outside the representable range instead
+// of clamping it.
+func TestCheckedFeeForSerializeSize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		rate    btcutil.Amount
+		size    int
+		want    btcutil.Amount
+		wantErr error
+	}{{
+		name: "an ordinary rate and size",
+		rate: 1e3,
+		size: 1000,
+		want: 1e3,
+	}, {
+		// 2550 * 1234 is 3,146,700, so the division leaves a remainder
+		// of 700 that is dropped rather than rounded up.
+		name: "a fractional fee truncates toward zero",
+		rate: 2.55e3,
+		size: 1234,
+		want: 3146,
+	}, {
+		// The smallest rate a caller may pass. Its product rounds down
+		// to zero, so the one-kilo-virtual-byte floor charges the rate
+		// itself.
+		name: "the smallest valid positive rate",
+		rate: 1,
+		size: 100,
+		want: 1,
+	}, {
+		name: "a zero size is charged the rate floor",
+		rate: 1e3,
+		size: 0,
+		want: 1e3,
+	}, {
+		name: "a fee at exactly the maximum",
+		rate: maxAmount,
+		size: feeRateDivisor,
+		want: maxAmount,
+	}, {
+		name:    "a zero rate is rejected",
+		rate:    0,
+		size:    1000,
+		wantErr: ErrFeeRateNotPositive,
+	}, {
+		name:    "a negative rate is rejected",
+		rate:    -1,
+		size:    1000,
+		wantErr: ErrFeeRateNotPositive,
+	}, {
+		name:    "a product overflow is rejected",
+		rate:    maxInt64Amount / 2,
+		size:    4,
+		wantErr: ErrFeeOverflow,
+	}, {
+		// The product is representable but the fee it rounds to is not
+		// a valid amount, so it is reported rather than clamped.
+		name:    "a rounded fee above the maximum is rejected",
+		rate:    maxAmount,
+		size:    feeRateDivisor + 1,
+		wantErr: ErrFeeOutOfRange,
+	}, {
+		// Rejected by its own guard, before the multiplication, rather
+		// than incidentally by the final bound on a negative fee.
+		name:    "a negative size is rejected",
+		rate:    1e3,
+		size:    -1000,
+		wantErr: ErrFeeOutOfRange,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := CheckedFeeForSerializeSize(tc.rate, tc.size)
+
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				require.Zero(t, got)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/wallet/txauthor/author.go
+++ b/wallet/txauthor/author.go
@@ -18,6 +18,10 @@ import (
 )
 
 // SumOutputValues sums up the list of TxOuts and returns an Amount.
+//
+// Deprecated: this sum is unchecked. It panics on a nil element, admits a
+// negative or over-maximum value, and wraps silently on overflow. Use
+// CheckOutputsAmount, which validates the set and returns the same total.
 func SumOutputValues(outputs []*wire.TxOut) (totalOutput btcutil.Amount) {
 	for _, txOut := range outputs {
 		totalOutput += btcutil.Amount(txOut.Value)
@@ -90,48 +94,80 @@ type ChangeSource struct {
 // enough input value to pay for every output any any necessary fees, an
 // InputSourceError is returned.
 //
+// Every amount this function forms is checked. The output set is validated and
+// the fee rate is rejected at or below zero before the first fetchInputs call,
+// so a malformed request never reaches a callback. The per-iteration fee and
+// change arithmetic depends on the inputs that were selected, so it necessarily
+// follows input selection, but it still completes before changeSource.NewScript
+// is called.
+//
 // BUGS: Fee estimation may be off when redeeming non-compressed P2PKH outputs.
 func NewUnsignedTransaction(outputs []*wire.TxOut, feeRatePerKb btcutil.Amount,
 	fetchInputs InputSource, changeSource *ChangeSource) (*AuthoredTx, error) {
 
-	targetAmount := SumOutputValues(outputs)
+	targetAmount, err := CheckOutputsAmount(outputs)
+	if err != nil {
+		return nil, err
+	}
+
 	estimatedSize := txsizes.EstimateVirtualSize(
 		0, 0, 1, 0, outputs, changeSource.ScriptSize,
 	)
-	targetFee := txrules.FeeForSerializeSize(feeRatePerKb, estimatedSize)
 
+	targetFee, err := CheckedFeeForSerializeSize(
+		feeRatePerKb, estimatedSize,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// The three checked add and subtract calls below cannot currently fail.
+	// CheckOutputsAmount bounds the target and CheckedFeeForSerializeSize bounds
+	// the fee, so their sum stays far inside an int64; each subtraction is
+	// guarded by the comparison immediately above it. They are checked
+	// anyway, so that a later change to either bound cannot reintroduce a
+	// silent wrap, but a reader should not go looking for the input that
+	// trips them.
 	for {
-		inputAmount, inputs, inputValues, scripts, err := fetchInputs(targetAmount + targetFee)
+		// Form the target the inputs must cover once, and hold on to it
+		// so the sufficiency comparison below tests the very same value
+		// the input source was asked for.
+		targetTotal, err := addAmounts(targetAmount, targetFee)
 		if err != nil {
 			return nil, err
 		}
-		if inputAmount < targetAmount+targetFee {
+
+		inputAmount, inputs, inputValues, scripts, err := fetchInputs(
+			targetTotal,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		if inputAmount < targetTotal {
 			return nil, insufficientFundsError{}
 		}
 
 		// We count the types of inputs, which we'll use to estimate
 		// the vsize of the transaction.
-		var nested, p2wpkh, p2tr, p2pkh int
-		for _, pkScript := range scripts {
-			switch {
-			// If this is a p2sh output, we assume this is a
-			// nested P2WKH.
-			case txscript.IsPayToScriptHash(pkScript):
-				nested++
-			case txscript.IsPayToWitnessPubKeyHash(pkScript):
-				p2wpkh++
-			case txscript.IsPayToTaproot(pkScript):
-				p2tr++
-			default:
-				p2pkh++
-			}
-		}
+		p2pkh, p2tr, p2wpkh, nested := countInputTypes(scripts)
 
 		maxSignedSize := txsizes.EstimateVirtualSize(
 			p2pkh, p2tr, p2wpkh, nested, outputs, changeSource.ScriptSize,
 		)
-		maxRequiredFee := txrules.FeeForSerializeSize(feeRatePerKb, maxSignedSize)
-		remainingAmount := inputAmount - targetAmount
+
+		maxRequiredFee, err := CheckedFeeForSerializeSize(
+			feeRatePerKb, maxSignedSize,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		remainingAmount, err := subAmounts(inputAmount, targetAmount)
+		if err != nil {
+			return nil, err
+		}
+
 		if remainingAmount < maxRequiredFee {
 			targetFee = maxRequiredFee
 			continue
@@ -145,7 +181,14 @@ func NewUnsignedTransaction(outputs []*wire.TxOut, feeRatePerKb btcutil.Amount,
 		}
 
 		changeIndex := -1
-		changeAmount := inputAmount - targetAmount - maxRequiredFee
+
+		// Reuse the sufficiency remainder rather than re-deriving the
+		// change from the input total a second time.
+		changeAmount, err := subAmounts(remainingAmount, maxRequiredFee)
+		if err != nil {
+			return nil, err
+		}
+
 		changeScript, err := changeSource.NewScript()
 		if err != nil {
 			return nil, err
@@ -167,6 +210,29 @@ func NewUnsignedTransaction(outputs []*wire.TxOut, feeRatePerKb btcutil.Amount,
 			ChangeIndex:     changeIndex,
 		}, nil
 	}
+}
+
+// countInputTypes classifies the previous output scripts an input set redeems.
+// The counts drive the virtual size estimate, since each script type costs a
+// different amount of witness and signature data to spend. The results are
+// named because they are four values of the same type: transposing any two at
+// the call site would compile and surface only as a slightly wrong fee.
+func countInputTypes(scripts [][]byte) (p2pkh, p2tr, p2wpkh, nested int) {
+	for _, pkScript := range scripts {
+		switch {
+		// If this is a p2sh output, we assume this is a nested P2WKH.
+		case txscript.IsPayToScriptHash(pkScript):
+			nested++
+		case txscript.IsPayToWitnessPubKeyHash(pkScript):
+			p2wpkh++
+		case txscript.IsPayToTaproot(pkScript):
+			p2tr++
+		default:
+			p2pkh++
+		}
+	}
+
+	return p2pkh, p2tr, p2wpkh, nested
 }
 
 // RandomizeOutputPosition randomizes the position of a transaction's output by

--- a/wallet/txauthor/author_test.go
+++ b/wallet/txauthor/author_test.go
@@ -5,12 +5,15 @@
 package txauthor
 
 import (
+	"math"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/wallet/txrules"
 	"github.com/btcsuite/btcwallet/wallet/txsizes"
+	"github.com/stretchr/testify/require"
 )
 
 func p2pkhOutputs(amounts ...btcutil.Amount) []*wire.TxOut {
@@ -164,13 +167,16 @@ func TestNewUnsignedTransaction(t *testing.T) {
 		},
 
 		// Test that zero change outputs are not included
-		// (ChangeAmount=0 means don't include any change output).
+		// (ChangeAmount=0 means don't include any change output). The
+		// single unspent output covers the payment and the maximum
+		// required fee exactly, leaving nothing over.
 		12: {
 			UnspentOutputs: p2pkhOutputs(1e8),
-			Outputs:        p2pkhOutputs(1e8),
-			RelayFee:       0,
-			ChangeAmount:   0,
-			InputCount:     1,
+			Outputs: p2pkhOutputs(1e8 - txrules.FeeForSerializeSize(1e3,
+				txsizes.EstimateVirtualSize(1, 0, 0, 0, p2pkhOutputs(0), txsizes.P2WPKHPkScriptSize))),
+			RelayFee:     1e3,
+			ChangeAmount: 0,
+			InputCount:   1,
 		},
 	}
 
@@ -221,4 +227,191 @@ func TestNewUnsignedTransaction(t *testing.T) {
 				i, len(tx.Tx.TxIn), test.InputCount)
 		}
 	}
+}
+
+// p2wpkhScript returns a well-formed pay-to-witness-pubkey-hash script. An
+// input redeeming this script is sized identically to the one the initial fee
+// estimate assumes, so construction settles on a fee in a single pass.
+func p2wpkhScript() []byte {
+	script := make([]byte, txsizes.P2WPKHPkScriptSize)
+	script[0] = txscript.OP_0
+	script[1] = txscript.OP_DATA_20
+
+	return script
+}
+
+// countedSources bundles an input source and a change source with the tally of
+// how often each was invoked, so a test can prove a request was rejected before
+// either callback ran.
+type countedSources struct {
+	// input funds the requested target plus surplus.
+	input InputSource
+
+	// change hands out a fixed P2WPKH-sized script.
+	change *ChangeSource
+
+	// inputCalls and changeCalls count invocations of the two callbacks.
+	inputCalls  int
+	changeCalls int
+}
+
+// newCountedSources builds a counted input and change source pair whose input
+// source funds the requested target plus surplus. A surplus of zero leaves
+// nothing over for change; anything above the dust threshold produces a change
+// output carrying exactly that amount.
+func newCountedSources(t *testing.T, surplus btcutil.Amount) *countedSources {
+	t.Helper()
+
+	s := &countedSources{}
+
+	s.input = func(target btcutil.Amount) (btcutil.Amount, []*wire.TxIn,
+		[]btcutil.Amount, [][]byte, error) {
+
+		s.inputCalls++
+
+		total := target + surplus
+
+		return total, []*wire.TxIn{{}}, []btcutil.Amount{total},
+			[][]byte{p2wpkhScript()}, nil
+	}
+
+	s.change = &ChangeSource{
+		NewScript: func() ([]byte, error) {
+			s.changeCalls++
+
+			return make([]byte, txsizes.P2WPKHPkScriptSize), nil
+		},
+		ScriptSize: txsizes.P2WPKHPkScriptSize,
+	}
+
+	return s
+}
+
+// TestNewUnsignedTransactionChecksAmounts verifies that a malformed output set
+// or fee rate is refused by transaction construction, and that the refusal
+// happens before either the input source or the change source is consulted.
+func TestNewUnsignedTransactionChecksAmounts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		outputs  []*wire.TxOut
+		relayFee btcutil.Amount
+		wantErr  error
+	}{{
+		name:     "a zero fee rate is rejected",
+		outputs:  p2pkhOutputs(1e6),
+		relayFee: 0,
+		wantErr:  ErrFeeRateNotPositive,
+	}, {
+		name:     "a negative fee rate is rejected",
+		outputs:  p2pkhOutputs(1e6),
+		relayFee: -1e3,
+		wantErr:  ErrFeeRateNotPositive,
+	}, {
+		name:     "a nil output is rejected",
+		outputs:  []*wire.TxOut{nil},
+		relayFee: 1e3,
+		wantErr:  ErrNilOutput,
+	}, {
+		name:     "a negative output value is rejected",
+		outputs:  p2pkhOutputs(-1),
+		relayFee: 1e3,
+		wantErr:  ErrOutputValueNegative,
+	}, {
+		name:     "an output above the maximum is rejected",
+		outputs:  p2pkhOutputs(btcutil.MaxSatoshi + 1),
+		relayFee: 1e3,
+		wantErr:  ErrOutputValueExceedsMax,
+	}, {
+		name: "an output set summing above the maximum is rejected",
+		outputs: p2pkhOutputs(
+			btcutil.MaxSatoshi-1e8, 1e8+1,
+		),
+		relayFee: 1e3,
+		wantErr:  ErrOutputTotalExceedsMax,
+	}, {
+		// The rounded fee this rate implies cannot be represented, so
+		// it is reported rather than silently clamped to the maximum.
+		name:     "an unrepresentable rounded fee is rejected",
+		outputs:  p2pkhOutputs(1e6),
+		relayFee: 2e16,
+		wantErr:  ErrFeeOutOfRange,
+	}, {
+		// This rate does not even survive multiplication by the size.
+		name:     "a fee product overflow is rejected",
+		outputs:  p2pkhOutputs(1e6),
+		relayFee: math.MaxInt64 / 2,
+		wantErr:  ErrFeeOverflow,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sources := newCountedSources(t, 0)
+
+			tx, err := NewUnsignedTransaction(
+				tc.outputs, tc.relayFee, sources.input,
+				sources.change,
+			)
+
+			require.ErrorIs(t, err, tc.wantErr)
+			require.Nil(t, tx)
+			require.Zero(t, sources.inputCalls)
+			require.Zero(t, sources.changeCalls)
+		})
+	}
+}
+
+// TestNewUnsignedTransactionSweep verifies the change-only authoring a sweep
+// performs: it declares no non-change outputs, so the checked output set must
+// accept a nil slice, and everything the inputs carry beyond the fee must come
+// back as a single change output.
+func TestNewUnsignedTransactionSweep(t *testing.T) {
+	t.Parallel()
+
+	// Fund well clear of the dust threshold, so the surplus survives as a
+	// change output rather than being absorbed into the fee.
+	const surplus = btcutil.Amount(50_000)
+
+	sources := newCountedSources(t, surplus)
+
+	tx, err := NewUnsignedTransaction(nil, 1e3, sources.input, sources.change)
+	require.NoError(t, err)
+	require.NotNil(t, tx)
+	require.Equal(t, 1, sources.inputCalls)
+	require.Equal(t, 1, sources.changeCalls)
+
+	// The sweep's only output is the change, so it takes index zero and
+	// carries the whole surplus.
+	require.Equal(t, 0, tx.ChangeIndex)
+	require.Len(t, tx.Tx.TxOut, 1)
+	require.Equal(t, int64(surplus), tx.Tx.TxOut[0].Value)
+	require.Len(t, tx.Tx.TxOut[0].PkScript, txsizes.P2WPKHPkScriptSize)
+}
+
+// TestNewUnsignedTransactionNoChange verifies that a nil output set funded to
+// exactly the fee authors without appending a zero-valued change output.
+func TestNewUnsignedTransactionNoChange(t *testing.T) {
+	t.Parallel()
+
+	sources := newCountedSources(t, 0)
+
+	tx, err := NewUnsignedTransaction(nil, 1e3, sources.input, sources.change)
+	require.NoError(t, err)
+	require.NotNil(t, tx)
+	require.Equal(t, 1, sources.inputCalls)
+
+	// The change script is allocated even though the result carries no
+	// change output. That is the allocation timing Task 356 owns, not
+	// something this test asserts as desirable: when 356 lands and the
+	// script is only requested once a change output is known to survive,
+	// this expectation becomes zero.
+	require.Equal(t, 1, sources.changeCalls)
+
+	// The input source funds exactly the requested target, which is the fee
+	// alone, so there is nothing left over to pay out as change.
+	require.Equal(t, -1, tx.ChangeIndex)
+	require.Empty(t, tx.Tx.TxOut)
 }

--- a/wallet/txauthor/go.mod
+++ b/wallet/txauthor/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/btcsuite/btcd/wire/v2 v2.0.0
 	github.com/btcsuite/btcwallet/wallet/txrules v1.3.0
 	github.com/btcsuite/btcwallet/wallet/txsizes v1.3.0
+	github.com/stretchr/testify v1.10.0
 )
 
 require (
@@ -23,7 +24,6 @@ require (
 	github.com/kkdai/bstream v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
 	golang.org/x/crypto v0.40.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/wallet/txrules/rules.go
+++ b/wallet/txrules/rules.go
@@ -54,6 +54,11 @@ func CheckOutput(output *wire.TxOut, relayFeePerKb btcutil.Amount) error {
 
 // FeeForSerializeSize calculates the required fee for a transaction of some
 // arbitrary size given a mempool's relay fee policy.
+//
+// This rounds the same way txauthor.CheckedFeeForSerializeSize does, but
+// accepts a non-positive rate and clamps an unrepresentable result to
+// MaxSatoshi rather than reporting either. Transaction construction uses the
+// checked variant; keep the two rounding rules in step.
 func FeeForSerializeSize(relayFeePerKb btcutil.Amount, txSerializeSize int) btcutil.Amount {
 	fee := relayFeePerKb * btcutil.Amount(txSerializeSize) / 1000
 


### PR DESCRIPTION
Task 357 — validate transaction output and fee arithmetic.

Transaction construction did every amount computation with raw `btcutil.Amount`
arithmetic: `SumOutputValues` wrapped silently, the target-plus-fee addition was
unchecked and formed twice per iteration, the sufficiency and change
subtractions were unchecked, and `txrules.FeeForSerializeSize` accepted a
non-positive rate and clamped an unrepresentable fee to `MaxSatoshi` instead of
reporting it.

`wallet/txauthor` now owns the checked primitives:

- `CheckOutputs` — rejects a nil element, a negative or over-`MaxSatoshi` value,
  and an aggregate above `MaxSatoshi`, returning the checked total for reuse. A
  nil set stays valid and totals zero, so a change-only sweep still authors.
- `CheckedFeeForSerializeSize` — rejects a rate at or below zero and a negative
  size before multiplying, reports a product overflow, and requires the rounded
  fee to land in `0..MaxSatoshi`.
- Internal checked add and subtract behind both.

`NewUnsignedTransaction` carries their results through construction: the output
set and the fee rate are validated before the first `fetchInputs` call, the
target is formed once and reused for the sufficiency test, and change is
derived from the sufficiency remainder rather than re-derived from the input
total. `SumOutputValues` stays exported for external callers but is deprecated
and no longer used.

TxCreator translates the result once, at the shared authoring boundary, so
`CreateTransaction` and `FundPsbt` both report the wallet's own sentinels.
Output value violations reuse the `txrules` errors `validateTxIntent` already
reports; only `ErrOutputTotalExceedsMax`, `ErrFeeOutOfRange` and
`ErrInvalidFeeRate` are new. Conditions no caller can observe are not named at
the wallet level and pass through unchanged, alongside `InputSourceError`.

Target-plus-fee is checked for **overflow only**, never against `MaxSatoshi`: a
single output of exactly `MaxSatoshi` must still reach the input source and fail
for want of coins, which `txcreator output boundaries` asserts.

### Notes for review

- **Behaviour change on the deprecated interface.** Nothing between
  `CreateSimpleTx` / `SendOutputs` / `SendOutputsWithInput` /
  `FundPsbtDeprecated` and `txauthor` bounded the fee rate, so a zero rate used
  to author a zero-fee transaction and now returns an error. The in-tree legacy
  RPC always passes `txrules.DefaultRelayFeePerKb` and is unaffected, but
  external callers set their own rate. Pinned by
  `TestTxToOutputsRejectsNonPositiveFeeRate`.
- **What is reachable from the public API.** `validateTxIntent` front-runs the
  per-output bounds and the fee-rate bounds, so the aggregate output total is
  the only class a public wrapper reaches today; it has no intent-level
  counterpart. `ErrFeeOutOfRange` is reachable once `DefaultMaxFeeRate` is
  raised — it is a mutable package variable meant to become configurable, and at
  9e15 sat/kvb any transaction over ~234 vbytes prices a fee above `MaxSatoshi`.
  The rest is defence for the internal boundary.
- **`btcunit` overflow, separate defect.** `CalcSatPerKVByte` computes
  `fee * kilo` in int64, so `NewSatPerKVByte` silently wraps to a negative rate
  above ~9.22e15 sat/kvb (`NewSatPerKVByte(3e16).Val()` returns
  `-6893488147419104`). Outside this task's scope; needs its own roadmap task.
- The suggested fix names one add helper; the Details require every sufficiency
  and change subtraction to be checked, so its subtraction counterpart ships
  with it. Both stay unexported — every call site is bounded by the checks
  around it and cannot currently fail, which is recorded at the loop.
- The root module gains a `replace` for the local `txauthor`, matching the ones
  `wtxmgr` and `wallet/txsizes` already carry. Without it none of this reaches
  TxCreator. It is load-bearing, as `wtxmgr`'s already is on this branch, and
  wants converting to a tagged release before `sql-wallet` lands.
- `countInputTypes` is extracted so the added error handling does not push
  `NewUnsignedTransaction` past the `funlen` limit.

### Testing

Nested-module and wallet tests cover nil, negative, individually over-maximum,
checked-sum overflow, aggregate-over-maximum, zero and negative direct fee
rates, negative size, fee-product overflow, a rounded fee above `MaxSatoshi`,
target-plus-fee overflow, the smallest valid positive rate, and the exact
maximum boundaries; every failure case asserts both callbacks went unused.
Translation is covered per class, through `FundPsbt`, and for message
stability.

Full `go test ./wallet/...`, the `txauthor` module tests, and the complete itest
suite pass. golangci-lint reports 0 issues on the root module.
