### PR TITLE
itest: add Controller credential integration tests

### DIFF
--- a/itest/controller_credential_test.go
+++ b/itest/controller_credential_test.go
@@ -1,0 +1,261 @@
+//go:build itest
+
+package itest
+
+import (
+	"github.com/btcsuite/btcwallet/bwtest"
+	"github.com/btcsuite/btcwallet/wallet"
+	"github.com/stretchr/testify/require"
+)
+
+// testControllerChangePassphraseLocked verifies private passphrase rotation
+// while locked and durable credential enforcement after reload.
+func testControllerChangePassphraseLocked(h *bwtest.HarnessTest) {
+	const (
+		oldPassphrase = bwtest.TestWalletPrivatePassphrase
+		newPassphrase = "controller-new-private-passphrase"
+	)
+
+	w, _ := h.NewWallet(bwtest.WalletFixture{})
+	requireLocked(h, w, true)
+
+	err := w.ChangePassphrase(h.Context(), wallet.ChangePassphraseRequest{
+		ChangePrivate: true,
+		PrivateOld:    []byte(oldPassphrase),
+		PrivateNew:    []byte(newPassphrase),
+	})
+	require.NoError(h, err, "failed to change private passphrase")
+	requireLocked(h, w, true)
+
+	err = w.Unlock(h.Context(), wallet.UnlockRequest{
+		Passphrase: []byte(oldPassphrase),
+		Timeout:    -1,
+	})
+	require.ErrorIs(
+		h, err, wallet.ErrInvalidPassphrase,
+		"old passphrase should be rejected after change",
+	)
+	requireLocked(h, w, true)
+
+	// A zero timeout uses the default auto-lock duration; -1 keeps the wallet
+	// unlocked until Lock so credential assertions cannot race a timer.
+	err = w.Unlock(h.Context(), wallet.UnlockRequest{
+		Passphrase: []byte(newPassphrase),
+		Timeout:    -1,
+	})
+	require.NoError(h, err, "new passphrase should unlock wallet")
+	requireLocked(h, w, false)
+
+	// ReloadWallet crosses the durable close-and-reopen boundary and returns
+	// a fresh started wallet that must require the rotated credential.
+	w = h.ReloadWallet(w)
+	requireLocked(h, w, true)
+
+	err = w.Unlock(h.Context(), wallet.UnlockRequest{
+		Passphrase: []byte(oldPassphrase),
+		Timeout:    -1,
+	})
+	require.ErrorIs(
+		h, err, wallet.ErrInvalidPassphrase,
+		"old passphrase should stay rejected after reload",
+	)
+	requireLocked(h, w, true)
+
+	err = w.Unlock(h.Context(), wallet.UnlockRequest{
+		Passphrase: []byte(newPassphrase),
+		Timeout:    -1,
+	})
+	require.NoError(h, err, "new passphrase should unlock reloaded wallet")
+	requireLocked(h, w, false)
+}
+
+// testControllerChangePassphraseUnlocked verifies private passphrase rotation
+// while unlocked preserves the public unlocked state.
+func testControllerChangePassphraseUnlocked(h *bwtest.HarnessTest) {
+	const (
+		oldPassphrase = bwtest.TestWalletPrivatePassphrase
+		newPassphrase = "controller-unlocked-private-passphrase"
+	)
+
+	w, _ := h.NewWallet(bwtest.WalletFixture{Unlocked: true})
+	requireLocked(h, w, false)
+
+	err := w.ChangePassphrase(h.Context(), wallet.ChangePassphraseRequest{
+		ChangePrivate: true,
+		PrivateOld:    []byte(oldPassphrase),
+		PrivateNew:    []byte(newPassphrase),
+	})
+	require.NoError(
+		h, err, "failed to change private passphrase while unlocked",
+	)
+	requireLocked(h, w, false)
+
+	require.NoError(h, w.Lock(h.Context()), "failed to lock wallet")
+	requireLocked(h, w, true)
+
+	err = w.Unlock(h.Context(), wallet.UnlockRequest{
+		Passphrase: []byte(oldPassphrase),
+		Timeout:    -1,
+	})
+	require.ErrorIs(
+		h, err, wallet.ErrInvalidPassphrase,
+		"previous passphrase should be rejected after unlocked change",
+	)
+	requireLocked(h, w, true)
+
+	err = w.Unlock(h.Context(), wallet.UnlockRequest{
+		Passphrase: []byte(newPassphrase),
+		Timeout:    -1,
+	})
+	require.NoError(
+		h, err, "unlocked change passphrase should unlock wallet",
+	)
+	requireLocked(h, w, false)
+}
+
+// testControllerChangePassphraseLifecycle verifies lifecycle state gates for
+// passphrase rotation.
+func testControllerChangePassphraseLifecycle(h *bwtest.HarnessTest) {
+	const (
+		oldPassphrase  = bwtest.TestWalletPrivatePassphrase
+		nextPassphrase = "controller-next-private-passphrase"
+	)
+
+	w, _ := h.NewWallet(bwtest.WalletFixture{Unstarted: true})
+
+	err := w.ChangePassphrase(h.Context(), wallet.ChangePassphraseRequest{
+		ChangePrivate: true,
+		PrivateOld:    []byte(oldPassphrase),
+		PrivateNew:    []byte(nextPassphrase),
+	})
+	require.ErrorIs(
+		h, err, wallet.ErrStateForbidden,
+		"change passphrase before start not rejected",
+	)
+
+	require.NoError(h, w.Start(h.Context()), "failed to start wallet")
+	requireLocked(h, w, true)
+
+	err = w.Unlock(h.Context(), wallet.UnlockRequest{
+		Passphrase: []byte(nextPassphrase),
+		Timeout:    -1,
+	})
+	require.ErrorIs(
+		h, err, wallet.ErrInvalidPassphrase,
+		"pre-start rejection should not install new passphrase",
+	)
+	requireLocked(h, w, true)
+
+	err = w.Unlock(h.Context(), wallet.UnlockRequest{
+		Passphrase: []byte(oldPassphrase),
+		Timeout:    -1,
+	})
+	require.NoError(
+		h, err, "old passphrase should survive pre-start rejection",
+	)
+	requireLocked(h, w, false)
+
+	require.NoError(h, w.Lock(h.Context()), "failed to lock wallet")
+	requireLocked(h, w, true)
+
+	require.NoError(h, w.Stop(h.Context()), "failed to stop wallet")
+
+	err = w.ChangePassphrase(h.Context(), wallet.ChangePassphraseRequest{
+		ChangePrivate: true,
+		PrivateOld:    []byte(oldPassphrase),
+		PrivateNew:    []byte(nextPassphrase),
+	})
+	require.ErrorIs(
+		h, err, wallet.ErrStateForbidden,
+		"change passphrase after stop not rejected",
+	)
+
+	require.NoError(h, w.Start(h.Context()), "failed to restart wallet")
+	requireLocked(h, w, true)
+
+	err = w.Unlock(h.Context(), wallet.UnlockRequest{
+		Passphrase: []byte(nextPassphrase),
+		Timeout:    -1,
+	})
+	require.ErrorIs(
+		h, err, wallet.ErrInvalidPassphrase,
+		"post-stop rejection should not install new passphrase",
+	)
+	requireLocked(h, w, true)
+
+	err = w.Unlock(h.Context(), wallet.UnlockRequest{
+		Passphrase: []byte(oldPassphrase),
+		Timeout:    -1,
+	})
+	require.NoError(
+		h, err, "old passphrase should survive post-stop rejection",
+	)
+	requireLocked(h, w, false)
+}
+
+// testControllerChangePassphraseRejectLocked verifies a wrong current
+// passphrase is rejected while the Wallet is locked.
+func testControllerChangePassphraseRejectLocked(h *bwtest.HarnessTest) {
+	const (
+		wrongPassphrase = "wrong-private-passphrase"
+		nextPassphrase  = "controller-next-private-passphrase"
+	)
+
+	w, _ := h.NewWallet(bwtest.WalletFixture{})
+	requireLocked(h, w, true)
+
+	err := w.ChangePassphrase(h.Context(), wallet.ChangePassphraseRequest{
+		ChangePrivate: true,
+		PrivateOld:    []byte(wrongPassphrase),
+		PrivateNew:    []byte(nextPassphrase),
+	})
+	require.ErrorIs(
+		h, err, wallet.ErrInvalidPassphrase,
+		"wrong current passphrase did not return invalid-passphrase error",
+	)
+	requireLocked(h, w, true)
+
+	err = w.Unlock(h.Context(), wallet.UnlockRequest{
+		Passphrase: []byte(bwtest.TestWalletPrivatePassphrase),
+		Timeout:    -1,
+	})
+	require.NoError(
+		h, err, "old passphrase should survive locked rejection",
+	)
+	requireLocked(h, w, false)
+}
+
+// testControllerChangePassphraseRejectUnlocked verifies a wrong current
+// passphrase is rejected while the Wallet is unlocked.
+func testControllerChangePassphraseRejectUnlocked(h *bwtest.HarnessTest) {
+	const (
+		wrongPassphrase = "wrong-private-passphrase"
+		nextPassphrase  = "controller-next-private-passphrase"
+	)
+
+	w, _ := h.NewWallet(bwtest.WalletFixture{Unlocked: true})
+	requireLocked(h, w, false)
+
+	err := w.ChangePassphrase(h.Context(), wallet.ChangePassphraseRequest{
+		ChangePrivate: true,
+		PrivateOld:    []byte(wrongPassphrase),
+		PrivateNew:    []byte(nextPassphrase),
+	})
+	require.ErrorIs(
+		h, err, wallet.ErrInvalidPassphrase,
+		"wrong current passphrase should be rejected while unlocked",
+	)
+	requireLocked(h, w, false)
+
+	require.NoError(h, w.Lock(h.Context()), "failed to lock wallet")
+	requireLocked(h, w, true)
+
+	err = w.Unlock(h.Context(), wallet.UnlockRequest{
+		Passphrase: []byte(bwtest.TestWalletPrivatePassphrase),
+		Timeout:    -1,
+	})
+	require.NoError(
+		h, err, "old passphrase should survive unlocked rejection",
+	)
+	requireLocked(h, w, false)
+}

--- a/itest/controller_credential_test.go
+++ b/itest/controller_credential_test.go
@@ -3,7 +3,11 @@
 package itest
 
 import (
+	"errors"
+	"time"
+
 	"github.com/btcsuite/btcwallet/bwtest"
+	"github.com/btcsuite/btcwallet/bwtest/wait"
 	"github.com/btcsuite/btcwallet/wallet"
 	"github.com/stretchr/testify/require"
 )
@@ -258,4 +262,37 @@ func testControllerChangePassphraseRejectUnlocked(h *bwtest.HarnessTest) {
 		h, err, "old passphrase should survive unlocked rejection",
 	)
 	requireLocked(h, w, false)
+}
+
+// testControllerUnlockTimeout verifies that a positive Unlock timeout returns
+// the Wallet to its public locked state.
+func testControllerUnlockTimeout(h *bwtest.HarnessTest) {
+	w, _ := h.NewWallet(bwtest.WalletFixture{})
+	requireLocked(h, w, true)
+
+	// Use a positive timeout long enough that the immediate unlocked
+	// assertion observes the post-Unlock state before the timer can fire.
+	err := w.Unlock(h.Context(), wallet.UnlockRequest{
+		Passphrase: []byte(bwtest.TestWalletPrivatePassphrase),
+		Timeout:    5 * time.Second,
+	})
+	require.NoError(h, err, "failed to unlock wallet")
+	requireLocked(h, w, false)
+
+	err = wait.NoError(
+		func() error {
+			info, err := w.Info(h.Context())
+			if err != nil {
+				return err
+			}
+
+			if !info.Locked {
+				return errors.New("wallet still unlocked")
+			}
+
+			return nil
+		},
+		pollTimeout,
+	)
+	require.NoError(h, err, "wallet did not lock after unlock timeout")
 }

--- a/itest/controller_credential_test.go
+++ b/itest/controller_credential_test.go
@@ -229,6 +229,74 @@ func testControllerChangePassphraseRejectLocked(h *bwtest.HarnessTest) {
 	requireLocked(h, w, false)
 }
 
+// testControllerChangePassphraseRejectEmpty verifies that a missing selection
+// and incomplete private passphrase pairs are rejected without changing the
+// credential state.
+func testControllerChangePassphraseRejectEmpty(h *bwtest.HarnessTest) {
+	const (
+		oldPassphrase   = bwtest.TestWalletPrivatePassphrase
+		wrongPassphrase = "wrong-private-passphrase"
+		newPassphrase   = "controller-new-private-passphrase"
+	)
+
+	w, _ := h.NewWallet(bwtest.WalletFixture{})
+	requireLocked(h, w, true)
+
+	tests := []struct {
+		name        string
+		req         wallet.ChangePassphraseRequest
+		wantContext string
+	}{
+		{
+			name:        "no selection",
+			wantContext: "no passphrase selected",
+		},
+		{
+			name: "empty private pair",
+			req: wallet.ChangePassphraseRequest{
+				ChangePrivate: true,
+			},
+			wantContext: "private old passphrase",
+		},
+		{
+			name: "private old without new",
+			req: wallet.ChangePassphraseRequest{
+				ChangePrivate: true,
+				PrivateOld:    []byte(wrongPassphrase),
+			},
+			wantContext: "private new passphrase",
+		},
+		{
+			name: "private new without old",
+			req: wallet.ChangePassphraseRequest{
+				ChangePrivate: true,
+				PrivateNew:    []byte(newPassphrase),
+			},
+			wantContext: "private old passphrase",
+		},
+	}
+
+	for _, test := range tests {
+		err := w.ChangePassphrase(h.Context(), test.req)
+		require.ErrorIs(
+			h, err, wallet.ErrEmptyPassphrase,
+			"%s should return empty-passphrase error", test.name,
+		)
+		require.ErrorContains(h, err, test.wantContext)
+	}
+
+	requireLocked(h, w, true)
+
+	err := w.Unlock(h.Context(), wallet.UnlockRequest{
+		Passphrase: []byte(oldPassphrase),
+		Timeout:    -1,
+	})
+	require.NoError(
+		h, err, "old passphrase should survive empty-passphrase rejections",
+	)
+	requireLocked(h, w, false)
+}
+
 // testControllerChangePassphraseRejectUnlocked verifies a wrong current
 // passphrase is rejected while the Wallet is unlocked.
 func testControllerChangePassphraseRejectUnlocked(h *bwtest.HarnessTest) {

--- a/itest/fixtures_test.go
+++ b/itest/fixtures_test.go
@@ -31,6 +31,10 @@ const (
 	// enough that the lease never expires mid-test.
 	leaseDuration = 10 * time.Minute
 
+	// pollTimeout bounds waits for asynchronous wallet state changes, such
+	// as unconfirmed transaction notifications and timer-driven locks.
+	pollTimeout = 30 * time.Second
+
 	// The funding and payment amounts shared by the component test cases.
 	halfBTC  = btcutil.SatoshiPerBitcoin / 2
 	oneBTC   = 1 * btcutil.SatoshiPerBitcoin

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -112,6 +112,26 @@ var allTestCases = []*testCase{
 		TestFunc: testControllerUnlockLock,
 	},
 	{
+		Name:     "controller change passphrase locked",
+		TestFunc: testControllerChangePassphraseLocked,
+	},
+	{
+		Name:     "controller change passphrase unlocked",
+		TestFunc: testControllerChangePassphraseUnlocked,
+	},
+	{
+		Name:     "controller change passphrase lifecycle",
+		TestFunc: testControllerChangePassphraseLifecycle,
+	},
+	{
+		Name:     "controller change passphrase reject locked",
+		TestFunc: testControllerChangePassphraseRejectLocked,
+	},
+	{
+		Name:     "controller change passphrase reject unlocked",
+		TestFunc: testControllerChangePassphraseRejectUnlocked,
+	},
+	{
 		Name:     "controller info",
 		TestFunc: testControllerInfo,
 	},

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -132,6 +132,10 @@ var allTestCases = []*testCase{
 		TestFunc: testControllerChangePassphraseRejectUnlocked,
 	},
 	{
+		Name:     "controller unlock timeout",
+		TestFunc: testControllerUnlockTimeout,
+	},
+	{
 		Name:     "controller info",
 		TestFunc: testControllerInfo,
 	},

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -128,6 +128,10 @@ var allTestCases = []*testCase{
 		TestFunc: testControllerChangePassphraseRejectLocked,
 	},
 	{
+		Name:     "controller change passphrase reject empty",
+		TestFunc: testControllerChangePassphraseRejectEmpty,
+	},
+	{
 		Name:     "controller change passphrase reject unlocked",
 		TestFunc: testControllerChangePassphraseRejectUnlocked,
 	},

--- a/itest/utxo_manager_test.go
+++ b/itest/utxo_manager_test.go
@@ -17,12 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	// pollTimeout bounds waits for asynchronous wallet state changes, such
-	// as unconfirmed transaction notifications and lease expiry.
-	pollTimeout = 30 * time.Second
-)
-
 // testListUnspent verifies ListUnspent field enrichment, amount ordering,
 // account and confirmation filters, and the pre-start state gate.
 func testListUnspent(h *bwtest.HarnessTest) {

--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -52,6 +52,10 @@ var (
 	// ErrInvalidPassphrase is returned when a supplied passphrase does not
 	// match the one guarding the wallet.
 	ErrInvalidPassphrase = keyvault.ErrInvalidPassphrase
+
+	// ErrEmptyPassphrase is returned when a passphrase change selects no
+	// passphrase or omits a required private passphrase.
+	ErrEmptyPassphrase = keyvault.ErrEmptyPassphrase
 )
 
 // UnlockRequest contains the parameters for unlocking the wallet.
@@ -103,7 +107,8 @@ type Info struct {
 // The two halves are selected independently. A SQL wallet has only the private
 // passphrase; kvdb additionally protects its public metadata with a separate
 // public passphrase, so a caller on that backend may rotate either half or
-// both.
+// both. At least one half must be selected. Private rotation requires non-empty
+// old and new passphrases; legacy public passphrases may be empty.
 type ChangePassphraseRequest struct {
 	// ChangePublic indicates whether the public passphrase should be
 	// changed.

--- a/wallet/controller_test.go
+++ b/wallet/controller_test.go
@@ -1888,6 +1888,12 @@ func TestWaitForBackoff_Shutdown(t *testing.T) {
 func TestPassphraseSentinelIsReachable(t *testing.T) {
 	t.Parallel()
 
-	require.ErrorIs(t, fmt.Errorf("vault: %w",
-		keyvault.ErrInvalidPassphrase), ErrInvalidPassphrase)
+	require.ErrorIs(
+		t, fmt.Errorf("vault: %w", keyvault.ErrInvalidPassphrase),
+		ErrInvalidPassphrase,
+	)
+	require.ErrorIs(
+		t, fmt.Errorf("vault: %w", keyvault.ErrEmptyPassphrase),
+		ErrEmptyPassphrase,
+	)
 }

--- a/wallet/internal/db/kvdb/vault.go
+++ b/wallet/internal/db/kvdb/vault.go
@@ -134,50 +134,61 @@ func (v *LegacyWalletVault) crypt(op func(waddrmgr.CryptoKeyType,
 func (v *LegacyWalletVault) ChangePassphrase(ctx context.Context,
 	params keyvault.ChangePassphraseParams) error {
 
+	err := params.Validate()
+	if err != nil {
+		return fmt.Errorf("legacy wallet vault ChangePassphrase: %w", err)
+	}
+
 	// Bail before the walletdb access and the expensive scrypt derivation
 	// when the request is already canceled.
-	err := checkContext(ctx)
+	err = checkContext(ctx)
 	if err != nil {
 		return err
 	}
 
 	changePublic := params.PublicOld != nil
-
 	changePrivate := params.PrivateOld != nil
-	if !changePublic && !changePrivate {
-		return nil
-	}
 
 	err = walletdb.Update(v.db, func(tx walletdb.ReadWriteTx) error {
-		ns := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
-		if ns == nil {
-			return errMissingAddrmgrNamespace
-		}
-
-		if changePublic {
-			err := v.mgr.ChangePassphrase(
-				ns, params.PublicOld, params.PublicNew, false,
-				&waddrmgr.DefaultScryptOptions,
-			)
-			if err != nil {
-				return err
-			}
-		}
-
-		if changePrivate {
-			err := v.mgr.ChangePassphrase(
-				ns, params.PrivateOld, params.PrivateNew, true,
-				&waddrmgr.DefaultScryptOptions,
-			)
-			if err != nil {
-				return err
-			}
-		}
-
-		return nil
+		return v.changePassphraseTx(
+			tx, params, changePublic, changePrivate,
+		)
 	})
 	if err != nil {
 		return fmt.Errorf("update: %w", translateVaultErr(err))
+	}
+
+	return nil
+}
+
+//nolint:staticcheck // Applies the legacy kvdb dual-passphrase fields.
+func (v *LegacyWalletVault) changePassphraseTx(tx walletdb.ReadWriteTx,
+	params keyvault.ChangePassphraseParams, changePublic,
+	changePrivate bool) error {
+
+	ns := tx.ReadWriteBucket(waddrmgr.NamespaceKey)
+	if ns == nil {
+		return errMissingAddrmgrNamespace
+	}
+
+	if changePublic {
+		err := v.mgr.ChangePassphrase(
+			ns, params.PublicOld, params.PublicNew, false,
+			&waddrmgr.DefaultScryptOptions,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	if changePrivate {
+		err := v.mgr.ChangePassphrase(
+			ns, params.PrivateOld, params.PrivateNew, true,
+			&waddrmgr.DefaultScryptOptions,
+		)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/wallet/internal/db/kvdb/vault_test.go
+++ b/wallet/internal/db/kvdb/vault_test.go
@@ -2,6 +2,7 @@ package kvdb
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/btcsuite/btclog"
@@ -9,6 +10,24 @@ import (
 	"github.com/btcsuite/btcwallet/wallet/internal/keyvault"
 	"github.com/stretchr/testify/require"
 )
+
+// TestLegacyWalletVaultChangePassphraseValidatesBeforeContext verifies that
+// invalid parameters retain their identity and operation context even when the
+// request context is already canceled.
+func TestLegacyWalletVaultChangePassphraseValidatesBeforeContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	vault := &LegacyWalletVault{}
+	err := vault.ChangePassphrase(ctx, keyvault.ChangePassphraseParams{
+		PrivateOld: []byte("wrong-private-passphrase"),
+		PrivateNew: []byte{},
+	})
+	require.ErrorIs(t, err, keyvault.ErrEmptyPassphrase)
+	require.ErrorContains(t, err, "vault ChangePassphrase")
+}
 
 // TestLegacyWalletVaultTranslatesManagerSentinels verifies that the adapter
 // surfaces keyvault sentinels rather than leaking the underlying waddrmgr
@@ -185,6 +204,14 @@ func TestLegacyWalletVaultChangePassphrase(t *testing.T) {
 			PublicNew: newPubPass,
 		},
 		wantErr:    keyvault.ErrInvalidPassphrase,
+		wantUnlock: testPrivPass,
+	}, {
+		name: "empty new private mutates nothing",
+		params: keyvault.ChangePassphraseParams{
+			PrivateOld: testPrivPass,
+			PrivateNew: []byte{},
+		},
+		wantErr:    keyvault.ErrEmptyPassphrase,
 		wantUnlock: testPrivPass,
 	}}
 

--- a/wallet/internal/keyvault/keyvault.go
+++ b/wallet/internal/keyvault/keyvault.go
@@ -4,12 +4,17 @@ package keyvault
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/btcsuite/btcwallet/waddrmgr"
 )
 
 // ErrInvalidPassphrase reports that the provided vault passphrase is wrong.
 var ErrInvalidPassphrase = errors.New("invalid vault passphrase")
+
+// ErrEmptyPassphrase reports that a passphrase rotation request selected no
+// passphrase or omitted a required private passphrase.
+var ErrEmptyPassphrase = errors.New("empty vault passphrase")
 
 // ErrVaultLocked reports that an operation requiring unlocked runtime state
 // was attempted while the vault was locked.
@@ -48,9 +53,10 @@ type Vault interface {
 	// ChangePassphrase re-wraps the persisted wallet secrets according to
 	// params.
 	//
-	// Implementations validate the whole request before reading or
-	// mutating any secret, so a request an implementation cannot serve in
-	// full changes nothing.
+	// Invalid parameters take precedence over context and backend-specific
+	// errors. A request with no selected passphrase or an incomplete private
+	// old/new pair returns ErrEmptyPassphrase before any secret is read or
+	// mutated.
 	//
 	// The rotation preserves the vault's original locked/unlocked state: an
 	// unlocked vault stays unlocked with its runtime keys unchanged, and a
@@ -75,7 +81,8 @@ var ErrPublicPassphraseUnsupported = errors.New(
 // The two halves are independent because the legacy kvdb format protects
 // public metadata and private key material under separate passphrases and can
 // rotate either or both in one transaction. A non-nil old passphrase selects
-// that half; this preserves a non-nil empty passphrase as a valid request.
+// that half. Private rotation requires non-empty old and new passphrases;
+// legacy public passphrases may be empty. At least one half must be selected.
 type ChangePassphraseParams struct {
 	// PublicOld and PublicNew contain the old and new public passphrases. A
 	// non-nil PublicOld requests their rotation.
@@ -89,4 +96,28 @@ type ChangePassphraseParams struct {
 	// A non-nil PrivateOld requests their rotation.
 	PrivateOld []byte
 	PrivateNew []byte
+}
+
+// Validate verifies backend-neutral passphrase rotation requirements.
+func (p ChangePassphraseParams) Validate() error {
+	publicChangeSelected := p.PublicOld != nil
+	privateChangeSelected := p.PrivateOld != nil
+
+	if !privateChangeSelected && p.PrivateNew != nil {
+		return fmt.Errorf("private old passphrase: %w", ErrEmptyPassphrase)
+	}
+
+	if !publicChangeSelected && !privateChangeSelected {
+		return fmt.Errorf("no passphrase selected: %w", ErrEmptyPassphrase)
+	}
+
+	if privateChangeSelected && len(p.PrivateOld) == 0 {
+		return fmt.Errorf("private old passphrase: %w", ErrEmptyPassphrase)
+	}
+
+	if privateChangeSelected && len(p.PrivateNew) == 0 {
+		return fmt.Errorf("private new passphrase: %w", ErrEmptyPassphrase)
+	}
+
+	return nil
 }

--- a/wallet/internal/keyvault/keyvault_test.go
+++ b/wallet/internal/keyvault/keyvault_test.go
@@ -1,0 +1,120 @@
+package keyvault
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestChangePassphraseParamsValidate verifies that rotation requests reject a
+// missing selection or an incomplete private passphrase pair.
+func TestChangePassphraseParamsValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		params      ChangePassphraseParams
+		wantContext string
+	}{
+		{
+			name:        "no rotation",
+			wantContext: "no passphrase selected",
+		},
+		{
+			name: "empty private pair",
+			params: ChangePassphraseParams{
+				PrivateOld: []byte{},
+				PrivateNew: []byte{},
+			},
+			wantContext: "private old passphrase",
+		},
+		{
+			name: "private old without new",
+			params: ChangePassphraseParams{
+				PrivateOld: []byte("old-private"),
+			},
+			wantContext: "private new passphrase",
+		},
+		{
+			name: "private new without old",
+			params: ChangePassphraseParams{
+				PrivateNew: []byte("new-private"),
+			},
+			wantContext: "private old passphrase",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := test.params.Validate()
+			require.ErrorIs(t, err, ErrEmptyPassphrase)
+			require.ErrorContains(t, err, test.wantContext)
+		})
+	}
+}
+
+// TestChangePassphraseParamsValidateSuccess verifies that supported rotation
+// selections pass backend-neutral validation.
+func TestChangePassphraseParamsValidateSuccess(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		params ChangePassphraseParams
+	}{
+		{
+			name: "public rotation",
+			params: ChangePassphraseParams{
+				PublicOld: []byte("old-public"),
+				PublicNew: []byte("new-public"),
+			},
+		},
+		{
+			name: "public rotation from empty",
+			params: ChangePassphraseParams{
+				PublicOld: []byte{},
+				PublicNew: []byte("new-public"),
+			},
+		},
+		{
+			name: "public rotation to empty",
+			params: ChangePassphraseParams{
+				PublicOld: []byte("old-public"),
+				PublicNew: []byte{},
+			},
+		},
+		{
+			name: "empty public rotation",
+			params: ChangePassphraseParams{
+				PublicOld: []byte{},
+				PublicNew: []byte{},
+			},
+		},
+		{
+			name: "private rotation",
+			params: ChangePassphraseParams{
+				PrivateOld: []byte("old-private"),
+				PrivateNew: []byte("new-private"),
+			},
+		},
+		{
+			name: "combined rotation",
+			params: ChangePassphraseParams{
+				PublicOld:  []byte("old-public"),
+				PublicNew:  []byte("new-public"),
+				PrivateOld: []byte("old-private"),
+				PrivateNew: []byte("new-private"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.NoError(t, test.params.Validate())
+		})
+	}
+}

--- a/wallet/internal/keyvault/vault_lifecycle.go
+++ b/wallet/internal/keyvault/vault_lifecycle.go
@@ -223,6 +223,12 @@ func decryptCryptoKey(masterPrivateKey *snacl.SecretKey,
 func (v *WalletVault) ChangePassphrase(ctx context.Context,
 	params ChangePassphraseParams) error {
 
+	err := params.Validate()
+	if err != nil {
+		return fmt.Errorf("wallet %d vault ChangePassphrase: %w",
+			v.walletID, err)
+	}
+
 	// Validate before touching any secret. A SQL wallet has no public
 	// passphrase, so a request naming one cannot be served in full and must
 	// leave the persisted state untouched rather than rotating the private
@@ -230,10 +236,6 @@ func (v *WalletVault) ChangePassphrase(ctx context.Context,
 	if params.PublicOld != nil {
 		return fmt.Errorf("wallet %d vault ChangePassphrase: %w",
 			v.walletID, ErrPublicPassphraseUnsupported)
-	}
-
-	if params.PrivateOld == nil {
-		return nil
 	}
 
 	oldPassphrase, newPassphrase := params.PrivateOld, params.PrivateNew

--- a/wallet/internal/keyvault/vault_lifecycle_test.go
+++ b/wallet/internal/keyvault/vault_lifecycle_test.go
@@ -1,6 +1,7 @@
 package keyvault
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -354,6 +355,34 @@ func TestWalletVaultChangePassphraseWrongOldPassphrase(t *testing.T) {
 		oldState.cryptoKeyPrivate[:],
 	)
 	require.False(t, vault.IsLocked())
+}
+
+// TestWalletVaultChangePassphraseEmptyPrivateNew verifies that an empty new
+// private passphrase takes precedence over context and credential errors before
+// persisted state is read or mutated.
+func TestWalletVaultChangePassphraseEmptyPrivateNew(t *testing.T) {
+	t.Parallel()
+
+	const walletID = uint32(22)
+
+	store := new(bwmock.Store)
+	t.Cleanup(func() {
+		store.AssertNotCalled(t, "GetWalletSecrets")
+		store.AssertNotCalled(t, "UpdateWalletSecrets")
+	})
+
+	vault := NewWalletVault(store, walletID, false)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := vault.ChangePassphrase(
+		ctx, ChangePassphraseParams{
+			PrivateOld: wrongPassphrase,
+			PrivateNew: []byte{},
+		},
+	)
+	require.ErrorIs(t, err, ErrEmptyPassphrase)
+	require.True(t, vault.IsLocked())
 }
 
 // TestWalletVaultChangePassphraseUpdateErrorPreservesState verifies that


### PR DESCRIPTION
## Summary

Implements roadmap Task 427 by adding Controller credential integration tests:
https://github.com/yyforyongyu/btcwallet-sql-roadmap/blob/main/tasks/427-controller-lifecycle-credential-itests.md

Also fixes the empty-new-private-passphrase behavior found while adding the
invalid credential coverage: `Vault.ChangePassphrase` now rejects an empty
`PrivateNew` for both SQL and kvdb, and RPC maps that stable error to
`InvalidArgument`.

## Change Description

Adds focused controller cases for the credential contracts:

- private `ChangePassphrase` succeeds while locked, rejects the old
  passphrase, accepts the new passphrase, and keeps the rotated credential
  authoritative after a durable reload;
- private `ChangePassphrase` succeeds while unlocked without changing the
  public unlocked state, then rejects the old passphrase after re-lock;
- lifecycle gates reject passphrase changes before `Start` and after `Stop`
  with `wallet.ErrStateForbidden`, while proving rejected mutations do not
  install the proposed credential;
- wrong current credentials are rejected with `wallet.ErrInvalidPassphrase`
  while locked and while unlocked, and the original credential still works;
- empty new private credentials are rejected with `wallet.ErrEmptyPassphrase`
  at the public Controller/Wallet boundary, and the original credential still
  works; and
- a positive `Unlock` timeout returns the wallet to the public locked state.

The empty-passphrase rejection is enforced inside the SQL and kvdb Vault
`ChangePassphrase` implementations so both backends share the same contract.

Every controller case is registered once and runs unchanged across kvdb,
SQLite and PostgreSQL. Assertions stay at the public Controller/Wallet
boundary; the tests do not reach into stores directly and do not branch by
backend.

This branch uses the `ReloadWallet` helper introduced by #1326. The branch has
been rebased onto `sql-wallet`, so the helper now comes from the base branch
rather than from a cherry-picked copy in this PR.

## Testing

```bash
make itest db=sqlite icase='controller (change passphrase|timed unlock)'
make itest db=kvdb icase='controller (change passphrase|timed unlock)'
make itest db=postgres icase='controller (change passphrase|timed unlock)'
```
