### PR TITLE
Change loglevel from WRN to DBG when non-standard input sig is logged

### DIFF
--- a/chain/bitcoind_client.go
+++ b/chain/bitcoind_client.go
@@ -1280,7 +1280,7 @@ func (c *BitcoindClient) filterTx(txDetails *btcutil.Tx,
 		pkScript, err := txscript.ComputePkScript(sig, witness)
 		if err != nil {
 			// Non-standard outputs can be safely skipped.
-			log.Warnf("Received non-standard input sig=%x, "+
+			log.Debugf("Received non-standard input sig=%x, "+
 				"witness=%x", sig, witness)
 
 			continue


### PR DESCRIPTION
## Motivation

Currently, a non-standard input sig triggers a log event at the `WRN` level.

```
2026-08-25 16:45:50.747 [WRN] BTWL: Received non-standard input sig=, witness=[]
2026-08-25 16:45:50.748 [WRN] BTWL: Received non-standard input sig=, witness=[]
2026-08-25 16:45:50.749 [WRN] BTWL: Received non-standard input sig=, witness=[]
2026-08-25 16:45:50.757 [WRN] BTWL: Received non-standard input sig=, witness=[]
2026-08-25 16:45:50.758 [WRN] BTWL: Received non-standard input sig=, witness=[]
2026-08-25 16:45:50.758 [WRN] BTWL: Received non-standard input sig=, witness=[]
2026-08-25 16:45:50.776 [WRN] BTWL: Received non-standard input sig=, witness=[]
2026-08-25 16:45:50.776 [WRN] BTWL: Received non-standard input sig=, witness=[]
2026-08-25 16:45:50.776 [WRN] BTWL: Received non-standard input sig=, witness=[]
```

As these can be quite common, the logs are cluttered with warnings that are likely not useful to the user. As the existing code comment states:

> Non-standard outputs can be safely skipped.

## Change Description

In this pull request, the log level of such events is changed from `Warnf` to `Debugf`

No other changes are made.