### PR TITLE
wallet: retain output leases through spend confirmation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,9 @@
 module github.com/btcsuite/btcwallet
 
+// TODO: Remove this replace after publishing a wtxmgr release that contains
+// release-after-spend output leases.
+replace github.com/btcsuite/btcwallet/wtxmgr => ./wtxmgr
+
 require (
 	github.com/btcsuite/btcd v0.26.0
 	github.com/btcsuite/btcd/address/v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,6 @@ github.com/btcsuite/btcwallet/wallet/txsizes v1.3.0 h1:2W9qt0edMoX8crx0Wm4Cv+eAj
 github.com/btcsuite/btcwallet/wallet/txsizes v1.3.0/go.mod h1:42aE6+LMZSSEisQAa15Xml25ncuJFfhCrkcpB5OmkZk=
 github.com/btcsuite/btcwallet/walletdb v1.6.0 h1:Yund5XbdqFxNW7+R2Sxs02bMC5fMrmORj4GN8MV55no=
 github.com/btcsuite/btcwallet/walletdb v1.6.0/go.mod h1:q9xif0Csp52GVb3l252BbHCuyiCnuEbrPWu/HAsvaYc=
-github.com/btcsuite/btcwallet/wtxmgr v1.6.0 h1:ivSSnYCD4Kb5yAMZVyBA1VMYABIFcopPEcmHCrRZXcE=
-github.com/btcsuite/btcwallet/wtxmgr v1.6.0/go.mod h1:Raor7IBIwHSIKE9Lr5o+R9rwX7sRMHU1zjxgEQgn9h8=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd h1:R/opQEbFEy9JGkIguV40SvRY1uliPX8ifOvi6ICsFCw=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd/go.mod h1:HHNXQzUsZCxOoE+CPiyCTO6x34Zs86zZUiwtpXoGdtg=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792 h1:R8vQdOQdZ9Y3SkEwmHoWBmX1DNXhXZqlTpq6s4tyJGc=

--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -33,56 +33,6 @@ func (w *Wallet) handleChainNotifications() {
 		return
 	}
 
-	catchUpHashes := func(w *Wallet, client chain.Interface,
-		height int32) error {
-		// TODO(aakselrod): There's a race condition here, which
-		// happens when a reorg occurs between the
-		// rescanProgress notification and the last GetBlockHash
-		// call. The solution when using btcd is to make btcd
-		// send blockconnected notifications with each block
-		// the way Neutrino does, and get rid of the loop. The
-		// other alternative is to check the final hash and,
-		// if it doesn't match the original hash returned by
-		// the notification, to roll back and restart the
-		// rescan.
-		log.Infof("Catching up block hashes to height %d, this"+
-			" might take a while", height)
-		err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-			ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-
-			startBlock := w.Manager.SyncedTo()
-
-			for i := startBlock.Height + 1; i <= height; i++ {
-				hash, err := client.GetBlockHash(int64(i))
-				if err != nil {
-					return err
-				}
-				header, err := chainClient.GetBlockHeader(hash)
-				if err != nil {
-					return err
-				}
-
-				bs := waddrmgr.BlockStamp{
-					Height:    i,
-					Hash:      *hash,
-					Timestamp: header.Timestamp,
-				}
-				err = w.Manager.SetSyncedTo(ns, &bs)
-				if err != nil {
-					return err
-				}
-			}
-			return nil
-		})
-		if err != nil {
-			log.Errorf("Failed to update address manager "+
-				"sync state for height %d: %v", height, err)
-		}
-
-		log.Info("Done catching up block hashes")
-		return err
-	}
-
 	waitForSync := func(birthdayBlock *waddrmgr.BlockStamp) error {
 		// We start with a retry delay of 0 to execute the first attempt
 		// immediately.
@@ -194,7 +144,7 @@ func (w *Wallet) handleChainNotifications() {
 			// The following require some database maintenance, but also
 			// need to be reported to the wallet's rescan goroutine.
 			case *chain.RescanProgress:
-				err = catchUpHashes(w, chainClient, n.Height)
+				err = w.catchUpHashes(chainClient, n.Height)
 				notificationName = "rescan progress"
 				select {
 				case w.rescanNotifications <- n:
@@ -202,7 +152,7 @@ func (w *Wallet) handleChainNotifications() {
 					return
 				}
 			case *chain.RescanFinished:
-				err = catchUpHashes(w, chainClient, n.Height)
+				err = w.catchUpHashes(chainClient, n.Height)
 				notificationName = "rescan finished"
 				w.SetChainSynced(true)
 				select {
@@ -237,11 +187,70 @@ func (w *Wallet) handleChainNotifications() {
 	}
 }
 
+// catchUpHashes advances the wallet's synced tip after an offline rescan.
+func (w *Wallet) catchUpHashes(client chainConn, height int32) error {
+	// TODO(aakselrod): There's a race condition here, which happens when a
+	// reorg occurs between the rescanProgress notification and the last
+	// GetBlockHash call. The solution when using btcd is to make btcd send
+	// blockconnected notifications with each block the way Neutrino does,
+	// and get rid of the loop. The other alternative is to check the final
+	// hash and, if it doesn't match the original hash returned by the
+	// notification, to roll back and restart the rescan.
+	log.Infof("Catching up block hashes to height %d, this might take a while",
+		height)
+
+	err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+		txmgrNs := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+
+		startBlock := w.Manager.SyncedTo()
+		catchUpHeight := startBlock.Height
+
+		for i := startBlock.Height + 1; i <= height; i++ {
+			hash, err := client.GetBlockHash(int64(i))
+			if err != nil {
+				return err
+			}
+
+			header, err := client.GetBlockHeader(hash)
+			if err != nil {
+				return err
+			}
+
+			bs := waddrmgr.BlockStamp{
+				Height:    i,
+				Hash:      *hash,
+				Timestamp: header.Timestamp,
+			}
+
+			err = w.Manager.SetSyncedTo(addrmgrNs, &bs)
+			if err != nil {
+				return err
+			}
+
+			catchUpHeight = i
+		}
+
+		return w.TxStore.DeleteMaturedLockedOutputs(
+			txmgrNs, catchUpHeight,
+		)
+	})
+	if err != nil {
+		log.Errorf("Failed to update address manager sync state for height "+
+			"%d: %v", height, err)
+	}
+
+	log.Info("Done catching up block hashes")
+
+	return err
+}
+
 // connectBlock handles a chain server notification by marking a wallet
 // that's currently in-sync with the chain server as being synced up to
 // the passed block.
 func (w *Wallet) connectBlock(dbtx walletdb.ReadWriteTx, b wtxmgr.BlockMeta) error {
 	addrmgrNs := dbtx.ReadWriteBucket(waddrmgrNamespaceKey)
+	txmgrNs := dbtx.ReadWriteBucket(wtxmgrNamespaceKey)
 
 	bs := waddrmgr.BlockStamp{
 		Height:    b.Height,
@@ -249,6 +258,13 @@ func (w *Wallet) connectBlock(dbtx walletdb.ReadWriteTx, b wtxmgr.BlockMeta) err
 		Timestamp: b.Time,
 	}
 	err := w.Manager.SetSyncedTo(addrmgrNs, &bs)
+	if err != nil {
+		return err
+	}
+
+	err = w.TxStore.DeleteMaturedLockedOutputs(
+		txmgrNs, b.Height,
+	)
 	if err != nil {
 		return err
 	}

--- a/wallet/chainntfns_test.go
+++ b/wallet/chainntfns_test.go
@@ -10,7 +10,10 @@ import (
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/walletdb"
 	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
+	"github.com/btcsuite/btcwallet/wtxmgr"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -99,6 +102,111 @@ func (c *mockChainConn) GetBlockHeader(hash *chainhash.Hash) (*wire.BlockHeader,
 	}
 
 	return &block.Header, nil
+}
+
+func addMaturingOutputLock(t *testing.T, w *Wallet, spendHeight int32) {
+	t.Helper()
+
+	creditTx := &wire.MsgTx{
+		TxIn:  []*wire.TxIn{{}},
+		TxOut: []*wire.TxOut{{Value: 1000}},
+	}
+
+	creditRec, err := wtxmgr.NewTxRecordFromMsgTx(creditTx, time.Now())
+	require.NoError(t, err)
+
+	creditBlock := &wtxmgr.BlockMeta{
+		Block: wtxmgr.Block{
+			Hash:   chainhash.Hash{1},
+			Height: spendHeight - 1,
+		},
+		Time: time.Now(),
+	}
+	creditOutpoint := wire.OutPoint{
+		Hash:  creditRec.Hash,
+		Index: 0,
+	}
+
+	spendTx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: creditOutpoint,
+		}},
+		TxOut: []*wire.TxOut{{Value: 900}},
+	}
+
+	spendRec, err := wtxmgr.NewTxRecordFromMsgTx(spendTx, time.Now())
+	require.NoError(t, err)
+
+	spendBlock := &wtxmgr.BlockMeta{
+		Block: wtxmgr.Block{
+			Hash:   chainhash.Hash{2},
+			Height: spendHeight,
+		},
+		Time: time.Now(),
+	}
+
+	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+
+		err := w.TxStore.InsertTx(ns, creditRec, creditBlock)
+		if err != nil {
+			return err
+		}
+
+		err = w.TxStore.AddCredit(
+			ns, creditRec, creditBlock, 0, false,
+		)
+		if err != nil {
+			return err
+		}
+
+		_, err = w.TxStore.LockOutput(
+			ns, wtxmgr.LockID{1}, creditOutpoint, time.Hour,
+			wtxmgr.WithReleaseAfterSpend(3),
+		)
+		if err != nil {
+			return err
+		}
+
+		return w.TxStore.InsertTx(ns, spendRec, spendBlock)
+	})
+	require.NoError(t, err)
+}
+
+// TestCatchUpHashesMaturesOutputLocks verifies that offline rescan progress
+// releases retained output leases at the validated catch-up tip.
+func TestCatchUpHashesMaturesOutputLocks(t *testing.T) {
+	t.Parallel()
+
+	w, cleanup := testWallet(t)
+	defer cleanup()
+
+	const (
+		spendHeight   = 2
+		catchUpHeight = 4
+	)
+	addMaturingOutputLock(t, w, spendHeight)
+
+	chainConn := createMockChainConn(
+		w.chainParams.GenesisBlock, catchUpHeight, defaultBlockInterval,
+	)
+	err := w.catchUpHashes(chainConn, catchUpHeight)
+	require.NoError(t, err)
+
+	var locks []*wtxmgr.LockedOutput
+
+	err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(wtxmgrNamespaceKey)
+
+		var err error
+
+		locks, err = w.TxStore.ListLockedOutputs(ns)
+
+		return err
+	})
+	require.NoError(t, err)
+	require.Empty(t, locks)
+	require.Equal(t, int32(catchUpHeight), w.Manager.SyncedTo().Height)
 }
 
 // mockBirthdayStore is a mock in-memory implementation of the birthdayStore interface

--- a/wallet/interface.go
+++ b/wallet/interface.go
@@ -227,6 +227,12 @@ type Interface interface {
 	LeaseOutput(id wtxmgr.LockID, op wire.OutPoint,
 		duration time.Duration) (time.Time, error)
 
+	// LeaseOutputWithOptions locks an output and applies optional persisted
+	// transaction-store lock behavior.
+	LeaseOutputWithOptions(id wtxmgr.LockID, op wire.OutPoint,
+		duration time.Duration,
+		optFuncs ...wtxmgr.LockOutputOption) (time.Time, error)
+
 	// ReleaseOutput unlocks an output, allowing it to be available for
 	// coin selection if it remains unspent. The ID should match the one
 	// used to originally lock the output.

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -3293,11 +3293,23 @@ func (w *Wallet) LockedOutpoints() []btcjson.TransactionInput {
 func (w *Wallet) LeaseOutput(id wtxmgr.LockID, op wire.OutPoint,
 	duration time.Duration) (time.Time, error) {
 
+	return w.LeaseOutputWithOptions(id, op, duration)
+}
+
+// LeaseOutputWithOptions locks an output to the given ID and applies optional
+// transaction-store lock behavior.
+func (w *Wallet) LeaseOutputWithOptions(id wtxmgr.LockID, op wire.OutPoint,
+	duration time.Duration,
+	optFuncs ...wtxmgr.LockOutputOption) (time.Time, error) {
+
 	var expiry time.Time
 	err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
 		ns := tx.ReadWriteBucket(wtxmgrNamespaceKey)
 		var err error
-		expiry, err = w.TxStore.LockOutput(ns, id, op, duration)
+
+		expiry, err = w.TxStore.LockOutput(
+			ns, id, op, duration, optFuncs...,
+		)
 		return err
 	})
 	return expiry, err

--- a/wtxmgr/db.go
+++ b/wtxmgr/db.go
@@ -1288,20 +1288,56 @@ func deleteRawUnminedInput(ns walletdb.ReadWriteBucket, outPointKey []byte,
 	return nil
 }
 
-// serializeLockedOutput serializes the value of a locked output.
-func serializeLockedOutput(id LockID, expiry time.Time) []byte {
-	var v [len(id) + 8]byte
+// serializeLockedOutput serializes the value of a locked output. Values written
+// before spend maturity tracking was introduced remain valid and deserialize
+// with zero maturity and spend height.
+func serializeLockedOutput(id LockID, expiry time.Time,
+	releaseAfterSpendConfs uint32, spendHeight int32) []byte {
+
+	var v [len(id) + 8 + 4 + 4]byte
 	copy(v[:len(id)], id[:])
 	byteOrder.PutUint64(v[len(id):], uint64(expiry.Unix()))
+	byteOrder.PutUint32(v[len(id)+8:], releaseAfterSpendConfs)
+	byteOrder.PutUint32(v[len(id)+12:], uint32(spendHeight))
+
 	return v[:]
 }
 
 // deserializeLockedOutput deserializes the value of a locked output.
-func deserializeLockedOutput(v []byte) (LockID, time.Time) {
+func deserializeLockedOutput(v []byte) (LockID, time.Time, uint32, int32) {
 	var id LockID
 	copy(id[:], v[:len(id)])
 	expiry := time.Unix(int64(byteOrder.Uint64(v[len(id):])), 0)
-	return id, expiry
+	if len(v) < len(id)+16 {
+		return id, expiry, 0, 0
+	}
+
+	releaseAfterSpendConfs := byteOrder.Uint32(v[len(id)+8:])
+	spendHeight := int32(byteOrder.Uint32(v[len(id)+12:]))
+
+	return id, expiry, releaseAfterSpendConfs, spendHeight
+}
+
+// fetchLockedOutput returns the persisted lock fields without applying expiry
+// semantics. The final result reports whether a record exists.
+func fetchLockedOutput(ns walletdb.ReadBucket,
+	op wire.OutPoint) (LockID, time.Time, uint32, int32, bool) {
+
+	lockedOutputs := ns.NestedReadBucket(bucketLockedOutputs)
+	if lockedOutputs == nil {
+		return LockID{}, time.Time{}, 0, 0, false
+	}
+
+	k := canonicalOutPoint(&op.Hash, op.Index)
+	v := lockedOutputs.Get(k)
+	if v == nil {
+		return LockID{}, time.Time{}, 0, 0, false
+	}
+
+	lockID, expiry, releaseAfterSpendConfs, spendHeight :=
+		deserializeLockedOutput(v)
+
+	return lockID, expiry, releaseAfterSpendConfs, spendHeight, true
 }
 
 // isLockedOutput determines whether an output is locked. If it is, its assigned
@@ -1311,20 +1347,18 @@ func deserializeLockedOutput(v []byte) (LockID, time.Time) {
 func isLockedOutput(ns walletdb.ReadBucket, op wire.OutPoint,
 	timeNow time.Time) (LockID, time.Time, bool) {
 
-	// The bucket may not exist, indicating that no outputs have ever been
-	// locked, so we can just return now.
-	lockedOutputs := ns.NestedReadBucket(bucketLockedOutputs)
-	if lockedOutputs == nil {
+	lockID, expiry, releaseAfterSpendConfs, spendHeight, exists :=
+		fetchLockedOutput(ns, op)
+	if !exists {
 		return LockID{}, time.Time{}, false
 	}
 
-	// Retrieve the output lock, if any, and extract the relevant fields.
-	k := canonicalOutPoint(&op.Hash, op.Index)
-	v := lockedOutputs.Get(k)
-	if v == nil {
-		return LockID{}, time.Time{}, false
+	// Once a retained lease has observed a confirmed spend, its wall clock
+	// expiry no longer applies. A negative spend height means that the observed
+	// spend was disconnected and is waiting to confirm again.
+	if releaseAfterSpendConfs > 0 && spendHeight != 0 {
+		return lockID, expiry, true
 	}
-	lockID, expiry := deserializeLockedOutput(v)
 
 	// If the output lock has already expired, delete it now.
 	if !timeNow.Before(expiry) {
@@ -1337,7 +1371,8 @@ func isLockedOutput(ns walletdb.ReadBucket, op wire.OutPoint,
 // lockOutput creates a lock for `duration` over an output assigned to the `id`,
 // preventing it from becoming eligible for coin selection.
 func lockOutput(ns walletdb.ReadWriteBucket, id LockID, op wire.OutPoint,
-	expiry time.Time) error {
+	expiry time.Time, releaseAfterSpendConfs uint32,
+	spendHeight int32) error {
 
 	// Create the corresponding bucket if necessary.
 	lockedOutputs, err := ns.CreateBucketIfNotExists(bucketLockedOutputs)
@@ -1348,7 +1383,9 @@ func lockOutput(ns walletdb.ReadWriteBucket, id LockID, op wire.OutPoint,
 
 	// Store a mapping of outpoint -> (id, expiry).
 	k := canonicalOutPoint(&op.Hash, op.Index)
-	v := serializeLockedOutput(id, expiry)
+	v := serializeLockedOutput(
+		id, expiry, releaseAfterSpendConfs, spendHeight,
+	)
 
 	if err := lockedOutputs.Put(k, v[:]); err != nil {
 		str := fmt.Sprintf("%s: put failed for %v", bucketLockedOutputs,
@@ -1397,7 +1434,7 @@ func forEachLockedOutput(ns walletdb.ReadBucket,
 		if err := readCanonicalOutPoint(k, &op); err != nil {
 			return err
 		}
-		lockID, expiry := deserializeLockedOutput(v)
+		lockID, expiry, _, _ := deserializeLockedOutput(v)
 
 		f(op, lockID, expiry)
 

--- a/wtxmgr/tx.go
+++ b/wtxmgr/tx.go
@@ -132,6 +132,41 @@ type LockedOutput struct {
 	Outpoint   wire.OutPoint
 	LockID     LockID
 	Expiration time.Time
+
+	// ReleaseAfterSpendConfs is the confirmation depth that replaces
+	// wall-clock expiry after a confirmed spend is observed. A value of
+	// zero preserves the normal wall-clock-only lease behavior.
+	ReleaseAfterSpendConfs uint32
+
+	// ConfirmedSpendHeight records spend confirmation progress. Zero means
+	// no confirmed spend has been observed, -1 means an observed spend was
+	// disconnected, and a positive value is its current confirmation
+	// height.
+	ConfirmedSpendHeight int32
+}
+
+// LockOutputOption configures the lifetime of an output lock.
+type LockOutputOption func(*lockOutputOptions)
+
+type lockOutputOptions struct {
+	releaseAfterSpendConfs    uint32
+	releaseAfterSpendConfsSet bool
+}
+
+// WithReleaseAfterSpend keeps an output locked after a confirmed spend is
+// observed until that spend reaches the requested confirmation count. Before
+// the spend is confirmed, the normal wall-clock expiration applies. A
+// reorganization that disconnects the spend resets its confirmation progress
+// and keeps the lock active. A zero confirmation count preserves the normal
+// wall-clock-only lease behavior. Older software reads the record as a
+// time-only lease, so do not downgrade while a retained lease still protects
+// a spend below this threshold. On an active same-owner renewal, omitting this
+// option preserves the existing depth; passing it replaces that depth.
+func WithReleaseAfterSpend(confirmations uint32) LockOutputOption {
+	return func(opts *lockOutputOptions) {
+		opts.releaseAfterSpendConfs = confirmations
+		opts.releaseAfterSpendConfsSet = true
+	}
 }
 
 // NewTxRecord creates a new transaction record that may be inserted into the
@@ -459,15 +494,31 @@ func (s *Store) insertMinedTx(ns walletdb.ReadWriteBucket, rec *TxRecord,
 		return err
 	}
 
-	// Clear any locked outputs since we now have a confirmed spend for
-	// them, making them not eligible for coin selection anyway.
+	// Clear normal output locks after a confirmed spend. Maturity-tracked
+	// locks record the spend height and remain until enough blocks bury it.
 	for _, txIn := range rec.MsgTx.TxIn {
+		lockID, expiry, releaseAfterSpendConfs, spendHeight, exists :=
+			fetchLockedOutput(
+				ns, txIn.PreviousOutPoint,
+			)
+		retainedLockActive := s.clock.Now().Before(expiry) ||
+			spendHeight != 0
+		if exists && releaseAfterSpendConfs > 0 && retainedLockActive {
+			if err := lockOutput(
+				ns, lockID, txIn.PreviousOutPoint, expiry,
+				releaseAfterSpendConfs, block.Height,
+			); err != nil {
+				return err
+			}
+			continue
+		}
+
 		if err := unlockOutput(ns, txIn.PreviousOutPoint); err != nil {
 			return err
 		}
 	}
 
-	return nil
+	return s.DeleteMaturedLockedOutputs(ns, block.Height)
 }
 
 // AddCredit marks a transaction record as containing a transaction output
@@ -566,6 +617,10 @@ func (s *Store) Rollback(ns walletdb.ReadWriteBucket, height int32) error {
 }
 
 func (s *Store) rollback(ns walletdb.ReadWriteBucket, height int32) error {
+	if err := resetLockedOutputSpendHeights(ns, height); err != nil {
+		return err
+	}
+
 	minedBalance, err := fetchMinedBalance(ns)
 	if err != nil {
 		return err
@@ -1286,7 +1341,13 @@ func isKnownOutput(ns walletdb.ReadWriteBucket, op wire.OutPoint) bool {
 // already been locked to a different ID, then ErrOutputAlreadyLocked is
 // returned.
 func (s *Store) LockOutput(ns walletdb.ReadWriteBucket, id LockID,
-	op wire.OutPoint, duration time.Duration) (time.Time, error) {
+	op wire.OutPoint, duration time.Duration,
+	optFuncs ...LockOutputOption) (time.Time, error) {
+
+	var opts lockOutputOptions
+	for _, optFunc := range optFuncs {
+		optFunc(&opts)
+	}
 
 	// Make sure the output is known.
 	if !isKnownOutput(ns, op) {
@@ -1299,8 +1360,28 @@ func (s *Store) LockOutput(ns walletdb.ReadWriteBucket, id LockID,
 		return time.Time{}, ErrOutputAlreadyLocked
 	}
 
+	// A renewal by the same owner must not discard confirmation progress.
+	// Preserve its release depth as well unless the caller explicitly
+	// replaces it.
+	var (
+		releaseAfterSpendConfs = opts.releaseAfterSpendConfs
+		spendHeight            int32
+	)
+
+	if isLocked && lockedID == id {
+		_, _, existingReleaseConfs, existingSpendHeight, _ :=
+			fetchLockedOutput(ns, op)
+		spendHeight = existingSpendHeight
+
+		if !opts.releaseAfterSpendConfsSet {
+			releaseAfterSpendConfs = existingReleaseConfs
+		}
+	}
+
 	expiry := s.clock.Now().Add(duration)
-	if err := lockOutput(ns, id, op, expiry); err != nil {
+	if err := lockOutput(
+		ns, id, op, expiry, releaseAfterSpendConfs, spendHeight,
+	); err != nil {
 		return time.Time{}, err
 	}
 
@@ -1313,14 +1394,18 @@ func (s *Store) LockOutput(ns walletdb.ReadWriteBucket, id LockID,
 func (s *Store) UnlockOutput(ns walletdb.ReadWriteBucket, id LockID,
 	op wire.OutPoint) error {
 
-	// Make sure the output is known.
-	if !isKnownOutput(ns, op) {
-		return ErrUnknownOutput
-	}
-
-	// If the output has already been unlocked, we can return now.
-	lockedID, _, isLocked := isLockedOutput(ns, op, s.clock.Now())
+	// Retained locks can outlive the confirmed spend of their output. Read
+	// the lock before checking whether the output is currently known so the
+	// owner can explicitly release it while it is spent.
+	lockedID, expiry, releaseAfterSpendConfs, spendHeight, exists :=
+		fetchLockedOutput(ns, op)
+	isLocked := exists && (s.clock.Now().Before(expiry) ||
+		releaseAfterSpendConfs > 0 && spendHeight != 0)
 	if !isLocked {
+		if !isKnownOutput(ns, op) {
+			return ErrUnknownOutput
+		}
+
 		return nil
 	}
 
@@ -1341,6 +1426,12 @@ func (s *Store) DeleteExpiredLockedOutputs(ns walletdb.ReadWriteBucket) error {
 	var expiredOutputs []wire.OutPoint
 	err := forEachLockedOutput(
 		ns, func(op wire.OutPoint, _ LockID, expiration time.Time) {
+			_, _, releaseAfterSpendConfs, spendHeight, _ :=
+				fetchLockedOutput(ns, op)
+			if releaseAfterSpendConfs > 0 && spendHeight != 0 {
+				return
+			}
+
 			if !s.clock.Now().Before(expiration) {
 				expiredOutputs = append(expiredOutputs, op)
 			}
@@ -1359,6 +1450,109 @@ func (s *Store) DeleteExpiredLockedOutputs(ns walletdb.ReadWriteBucket) error {
 	return nil
 }
 
+// DeleteMaturedLockedOutputs removes leases whose confirmed spending
+// transaction has reached the release depth requested when the output was
+// locked. Once a confirmed spend has been observed, wall clock expiration is
+// disabled until this depth is reached or the lease is explicitly released.
+func (s *Store) DeleteMaturedLockedOutputs(ns walletdb.ReadWriteBucket,
+	chainHeight int32) error {
+
+	var maturedOutputs []wire.OutPoint
+	lockedOutputs := ns.NestedReadBucket(bucketLockedOutputs)
+	if lockedOutputs == nil {
+		return nil
+	}
+
+	err := lockedOutputs.ForEach(func(k, v []byte) error {
+		_, _, releaseAfterSpendConfs, spendHeight :=
+			deserializeLockedOutput(v)
+		if releaseAfterSpendConfs == 0 || spendHeight <= 0 ||
+			chainHeight < spendHeight {
+
+			return nil
+		}
+
+		confirmations := uint32(chainHeight-spendHeight) + 1
+		if confirmations < releaseAfterSpendConfs {
+			return nil
+		}
+
+		var op wire.OutPoint
+		if err := readCanonicalOutPoint(k, &op); err != nil {
+			return err
+		}
+		maturedOutputs = append(maturedOutputs, op)
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, op := range maturedOutputs {
+		if err := unlockOutput(ns, op); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// resetLockedOutputSpendHeights clears confirmation progress for spends in a
+// block being disconnected by a rollback. A negative height records that a
+// spend has already been observed, so wall clock expiry remains disabled.
+func resetLockedOutputSpendHeights(ns walletdb.ReadWriteBucket,
+	rollbackHeight int32) error {
+
+	type lockToReset struct {
+		op                     wire.OutPoint
+		id                     LockID
+		expiry                 time.Time
+		releaseAfterSpendConfs uint32
+	}
+
+	var locks []lockToReset
+	lockedOutputs := ns.NestedReadBucket(bucketLockedOutputs)
+	if lockedOutputs == nil {
+		return nil
+	}
+
+	err := lockedOutputs.ForEach(func(k, v []byte) error {
+		id, expiry, releaseAfterSpendConfs, spendHeight :=
+			deserializeLockedOutput(v)
+		if spendHeight == 0 || spendHeight < rollbackHeight {
+			return nil
+		}
+
+		var op wire.OutPoint
+		if err := readCanonicalOutPoint(k, &op); err != nil {
+			return err
+		}
+		locks = append(locks, lockToReset{
+			op:                     op,
+			id:                     id,
+			expiry:                 expiry,
+			releaseAfterSpendConfs: releaseAfterSpendConfs,
+		})
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, lock := range locks {
+		if err := lockOutput(
+			ns, lock.id, lock.op, lock.expiry,
+			lock.releaseAfterSpendConfs, -1,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // ListLockedOutputs returns a list of objects representing the currently locked
 // utxos.
 func (s *Store) ListLockedOutputs(ns walletdb.ReadBucket) ([]*LockedOutput,
@@ -1367,16 +1561,23 @@ func (s *Store) ListLockedOutputs(ns walletdb.ReadBucket) ([]*LockedOutput,
 	var outputs []*LockedOutput
 	err := forEachLockedOutput(
 		ns, func(op wire.OutPoint, id LockID, expiration time.Time) {
+			_, _, releaseAfterSpendConfs, spendHeight, _ :=
+				fetchLockedOutput(ns, op)
+
 			// Skip expired leases. They will be cleaned up with the
 			// next call to DeleteExpiredLockedOutputs.
-			if !s.clock.Now().Before(expiration) {
+			if !s.clock.Now().Before(expiration) &&
+				!(releaseAfterSpendConfs > 0 && spendHeight != 0) {
+
 				return
 			}
 
 			outputs = append(outputs, &LockedOutput{
-				Outpoint:   op,
-				LockID:     id,
-				Expiration: expiration,
+				Outpoint:               op,
+				LockID:                 id,
+				Expiration:             expiration,
+				ReleaseAfterSpendConfs: releaseAfterSpendConfs,
+				ConfirmedSpendHeight:   spendHeight,
 			})
 		},
 	)

--- a/wtxmgr/tx_test.go
+++ b/wtxmgr/tx_test.go
@@ -2460,6 +2460,10 @@ func assertUtxos(t *testing.T, s *Store, ns walletdb.ReadWriteBucket,
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	if len(utxos) != len(exp) {
+		t.Fatalf("expected %d utxos, got %d", len(exp), len(utxos))
+	}
 	for _, expUtxo := range exp {
 		found := false
 		for _, utxo := range utxos {
@@ -2514,6 +2518,32 @@ func assertOutputLocksExist(t *testing.T, s *Store, ns walletdb.ReadBucket,
 		if !exists {
 			t.Fatalf("expected output lock for %v to exist", expOp)
 		}
+	}
+}
+
+func assertRetainedLock(t *testing.T, s *Store, ns walletdb.ReadBucket,
+	releaseConfs uint32, spendHeight int32) {
+
+	t.Helper()
+
+	locks, err := s.ListLockedOutputs(ns)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(locks) != 1 {
+		t.Fatalf("expected one retained lock, got %d", len(locks))
+	}
+
+	lock := locks[0]
+	if lock.ReleaseAfterSpendConfs != releaseConfs {
+		t.Fatalf("expected maturity %d, got %d", releaseConfs,
+			lock.ReleaseAfterSpendConfs)
+	}
+
+	if lock.ConfirmedSpendHeight != spendHeight {
+		t.Fatalf("expected spend height %d, got %d", spendHeight,
+			lock.ConfirmedSpendHeight)
 	}
 }
 
@@ -2722,6 +2752,63 @@ func TestOutputLocks(t *testing.T) {
 			},
 		},
 		{
+			// Asserts that reusing an ID after its retained lease
+			// expires does not carry the old release policy into the
+			// new lease.
+			name: "reuse lock ID after expiry",
+			run: func(t *testing.T, s *Store, ns walletdb.ReadWriteBucket) {
+				t.Helper()
+
+				lockID := LockID{1}
+
+				expiry, err := s.LockOutput(
+					ns, lockID, confirmedOutPoint, 10*time.Minute,
+					WithReleaseAfterSpend(3),
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				assertRetainedLock(t, s, ns, 3, 0)
+
+				testClock, ok := s.clock.(*clock.TestClock)
+				if !ok {
+					t.Fatal("expected test clock")
+				}
+
+				testClock.SetTime(expiry)
+				assertLocked(
+					t, ns, confirmedOutPoint, s.clock.Now(), false,
+				)
+
+				_, err = s.LockOutput(
+					ns, lockID, confirmedOutPoint, 10*time.Minute,
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				assertRetainedLock(t, s, ns, 0, 0)
+
+				txHash := confirmedTx.TxHash()
+				spendTx := spendOutput(&txHash, 0, 500)
+
+				spendRec, err := NewTxRecordFromMsgTx(
+					spendTx, time.Now(),
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				err = s.InsertTx(ns, spendRec, block)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				assertOutputLocksExist(t, s, ns)
+			},
+		},
+		{
 			// Asserts that balances are reflected properly after
 			// locking confirmed and unconfirmed outputs.
 			name: "balance after locked outputs",
@@ -2899,5 +2986,176 @@ func TestOutputLocks(t *testing.T) {
 				testCase.run(t, store, ns)
 			})
 		})
+	}
+}
+
+// TestDeserializeLegacyLockedOutput verifies that lock rows written before
+// release-after-spend support remain readable with the legacy lease behavior.
+func TestDeserializeLegacyLockedOutput(t *testing.T) {
+	t.Parallel()
+
+	lockID := LockID{1, 2, 3}
+	expiry := time.Unix(123456789, 0)
+	legacyValue := make([]byte, len(lockID)+8)
+	copy(legacyValue, lockID[:])
+	byteOrder.PutUint64(legacyValue[len(lockID):], uint64(expiry.Unix()))
+
+	gotID, gotExpiry, releaseConfs, spendHeight :=
+		deserializeLockedOutput(legacyValue)
+	if gotID != lockID {
+		t.Fatalf("expected lock ID %x, got %x", lockID, gotID)
+	}
+	if !gotExpiry.Equal(expiry) {
+		t.Fatalf("expected expiry %v, got %v", expiry, gotExpiry)
+	}
+	if releaseConfs != 0 {
+		t.Fatalf("expected legacy release depth 0, got %d", releaseConfs)
+	}
+	if spendHeight != 0 {
+		t.Fatalf("expected legacy spend height 0, got %d", spendHeight)
+	}
+}
+
+// TestOutputLockReleaseAfterSpendAcrossReorg verifies that a lock follows the
+// confirmed spend, resets on rollback, and releases only after the
+// re-confirmed spend reaches its requested depth.
+func TestOutputLockReleaseAfterSpendAcrossReorg(t *testing.T) {
+	t.Parallel()
+
+	store, db, err := testStore(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	startTime := time.Now()
+	store.clock = clock.NewTestClock(startTime)
+
+	creditBlock := &BlockMeta{
+		Block: Block{
+			Hash:   chainhash.Hash{1},
+			Height: 100,
+		},
+		Time: time.Now(),
+	}
+	spendBlock := &BlockMeta{
+		Block: Block{
+			Hash:   chainhash.Hash{2},
+			Height: 101,
+		},
+		Time: time.Now().Add(time.Minute),
+	}
+
+	creditTx := newCoinBase(btcutil.SatoshiPerBitcoin)
+	insertConfirmedCredit(t, store, db, creditTx, 0, creditBlock)
+	creditHash := creditTx.TxHash()
+	creditOutpoint := wire.OutPoint{Hash: creditHash, Index: 0}
+	spendTx := spendOutput(&creditHash, 0, btcutil.SatoshiPerBitcoin-1000)
+	spendRec, err := NewTxRecordFromMsgTx(spendTx, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lockID := LockID{1}
+	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(namespaceKey)
+		expiry, err := store.LockOutput(
+			ns, lockID, creditOutpoint, 10*time.Minute,
+			WithReleaseAfterSpend(3),
+		)
+		if err != nil {
+			return err
+		}
+
+		if err := store.InsertTx(ns, spendRec, spendBlock); err != nil {
+			return err
+		}
+
+		assertRetainedLock(t, store, ns, 3, spendBlock.Height)
+		assertLocked(t, ns, creditOutpoint, store.clock.Now(), true)
+		if err := store.DeleteMaturedLockedOutputs(ns, 102); err != nil {
+			return err
+		}
+		assertLocked(t, ns, creditOutpoint, store.clock.Now(), true)
+
+		if err := store.Rollback(ns, spendBlock.Height); err != nil {
+			return err
+		}
+
+		// Renewing the lease must preserve the disconnected spend state
+		// and its configured release depth.
+		_, err = store.LockOutput(
+			ns, lockID, creditOutpoint, 10*time.Minute,
+		)
+		if err != nil {
+			return err
+		}
+
+		assertRetainedLock(t, store, ns, 3, -1)
+
+		// An explicit option replaces the release depth without clearing
+		// the disconnected spend state.
+		_, err = store.LockOutput(
+			ns, lockID, creditOutpoint, 10*time.Minute,
+			WithReleaseAfterSpend(4),
+		)
+		if err != nil {
+			return err
+		}
+
+		assertRetainedLock(t, store, ns, 4, -1)
+		if err := store.RemoveUnminedTx(ns, spendRec); err != nil {
+			return err
+		}
+
+		assertLocked(t, ns, creditOutpoint, store.clock.Now(), true)
+		// The funding credit was restored, but the retained lease keeps
+		// it out of the spendable UTXO set.
+		assertUtxos(t, store, ns, nil)
+		if err := store.DeleteMaturedLockedOutputs(ns, 102); err != nil {
+			return err
+		}
+		assertLocked(t, ns, creditOutpoint, store.clock.Now(), true)
+
+		// A lease that has observed a spend must survive its wall clock
+		// expiry while that spend is disconnected.
+		store.clock.(*clock.TestClock).SetTime(expiry.Add(time.Second))
+		if err := store.DeleteExpiredLockedOutputs(ns); err != nil {
+			return err
+		}
+		assertLocked(t, ns, creditOutpoint, store.clock.Now(), true)
+		assertOutputLocksExist(t, store, ns, creditOutpoint)
+
+		reconfirmedBlock := &BlockMeta{
+			Block: Block{
+				Hash:   chainhash.Hash{3},
+				Height: 103,
+			},
+			Time: time.Now().Add(2 * time.Minute),
+		}
+		if err := store.InsertTx(ns, spendRec, reconfirmedBlock); err != nil {
+			return err
+		}
+		if err := store.DeleteMaturedLockedOutputs(ns, 104); err != nil {
+			return err
+		}
+		assertLocked(t, ns, creditOutpoint, store.clock.Now(), true)
+
+		if err := store.DeleteMaturedLockedOutputs(ns, 105); err != nil {
+			return err
+		}
+
+		assertLocked(t, ns, creditOutpoint, store.clock.Now(), true)
+
+		err = store.DeleteMaturedLockedOutputs(ns, 106)
+		if err != nil {
+			return err
+		}
+
+		assertLocked(t, ns, creditOutpoint, store.clock.Now(), false)
+
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
## Change Description

Add an opt-in output lease mode that releases a locked output only after its
spending transaction reaches a requested confirmation depth.

The existing lease is wall-clock based. It prevents concurrent coin selection
while an operation is being assembled, but btcwallet removes it as soon as a
confirmed spend is observed. That is correct for ordinary callers. It is not
enough for callers that must preserve the identity of a previously broadcast
transaction across a shallow chain reorganization. If the spend is disconnected,
the input becomes available again and another wallet transaction can consume it.

This PR keeps the default behavior unchanged. A caller opts in through
`LeaseOutputWithOptions` and `wtxmgr.WithReleaseAfterSpend(confirmations)`.

The retained lease follows this lifecycle:

1. Before the output is spent, the normal wall-clock expiry applies.
2. When btcwallet observes a confirmed spend, it records the spend height and
   disables wall-clock expiry for that lease.
3. A rollback that disconnects the spend clears its confirmation progress while
   keeping the lease active.
4. A later confirmation records the new height.
5. The lease is removed only when that spend reaches the requested depth, or
   when its owner explicitly calls `ReleaseOutput`.

This owns the invariant at the wallet boundary. Callers do not need a separate
UTXO tracker or a loop that repeatedly renews leases while blocks connect and
disconnect.

### Storage compatibility

The locked-output value keeps its existing `(lock ID, expiry)` prefix and appends
the release depth and observed spend height. Legacy rows remain readable and
decode with a zero release depth, which preserves the existing behavior. No
migration is required.

Compatibility is one-way while a retained lease is active. Older software can
decode the prefix but applies time-only release semantics. Do not downgrade
while a retained lease protects a spend below its configured confirmation
depth.

The root module temporarily replaces the standalone `wtxmgr` dependency with
the in-tree module. That replace can be removed after a `wtxmgr` version
containing the first commit is published.

### Compatibility and limits

- `LeaseOutput` is unchanged and delegates to the new options method with no
  options.
- A zero release depth preserves the existing lease behavior.
- Explicit release remains available after the output is spent.
- The protection horizon is the requested confirmation depth. Once the lease is
  released, a reorganization at or beyond that depth is outside this mechanism's
  guarantee.

## Steps to Test

```bash
cd wtxmgr
go test ./...

cd ..
go test ./wallet
```

`TestOutputLockReleaseAfterSpendAcrossReorg` covers confirmation, rollback,
wall-clock expiry while disconnected, reconfirmation at a new height, and final
release. `TestDeserializeLegacyLockedOutput` covers the upgrade path.

Local result:

- `go test ./...` in `wtxmgr`: pass
- `go test ./wallet`: pass

## Pull Request Checklist

### Testing

- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative paths are included.
- [x] The reorganization regression is covered by a test.

### Code Style and Documentation

- [x] The change is substantial and scoped to output lease lifetime.
- [x] Exported additions are documented and formatted with `gofmt`.
- [x] Commits follow the ideal structure and are signed.
- [x] No logging statements were added.
