### PR TITLE
wallet+waddrmgr+wtxmgr: add RemoveAccount

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,3 +64,11 @@ require (
 // If you change this please run `make lint` to see where else it needs to be
 // updated as well.
 go 1.25.11
+
+// We use a replace directive here for our internal wtxmgr module. This ensures
+// that we can freely move between tagged releases and development commits of
+// this module without needing to constantly update the go.mod file.
+//
+// TODO: Remove once a new wtxmgr version containing RemoveCredits has been
+// tagged and pinned here.
+replace github.com/btcsuite/btcwallet/wtxmgr => ./wtxmgr

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,6 @@ github.com/btcsuite/btcwallet/wallet/txsizes v1.3.0 h1:2W9qt0edMoX8crx0Wm4Cv+eAj
 github.com/btcsuite/btcwallet/wallet/txsizes v1.3.0/go.mod h1:42aE6+LMZSSEisQAa15Xml25ncuJFfhCrkcpB5OmkZk=
 github.com/btcsuite/btcwallet/walletdb v1.6.0 h1:Yund5XbdqFxNW7+R2Sxs02bMC5fMrmORj4GN8MV55no=
 github.com/btcsuite/btcwallet/walletdb v1.6.0/go.mod h1:q9xif0Csp52GVb3l252BbHCuyiCnuEbrPWu/HAsvaYc=
-github.com/btcsuite/btcwallet/wtxmgr v1.6.0 h1:ivSSnYCD4Kb5yAMZVyBA1VMYABIFcopPEcmHCrRZXcE=
-github.com/btcsuite/btcwallet/wtxmgr v1.6.0/go.mod h1:Raor7IBIwHSIKE9Lr5o+R9rwX7sRMHU1zjxgEQgn9h8=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd h1:R/opQEbFEy9JGkIguV40SvRY1uliPX8ifOvi6ICsFCw=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd/go.mod h1:HHNXQzUsZCxOoE+CPiyCTO6x34Zs86zZUiwtpXoGdtg=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792 h1:R8vQdOQdZ9Y3SkEwmHoWBmX1DNXhXZqlTpq6s4tyJGc=

--- a/waddrmgr/db.go
+++ b/waddrmgr/db.go
@@ -1157,6 +1157,110 @@ func deleteAccountIDIndex(ns walletdb.ReadWriteBucket, scope *KeyScope,
 	return nil
 }
 
+// deleteAccountRow removes the given account's row from the account bucket of
+// the database.
+func deleteAccountRow(ns walletdb.ReadWriteBucket, scope *KeyScope,
+	account uint32) error {
+
+	scopedBucket, err := fetchWriteScopeBucket(ns, scope)
+	if err != nil {
+		return err
+	}
+
+	bucket := scopedBucket.NestedReadWriteBucket(acctBucketName)
+
+	err = bucket.Delete(uint32ToBytes(account))
+	if err != nil {
+		str := fmt.Sprintf("failed to delete account %d", account)
+		return managerError(ErrDatabase, str, err)
+	}
+	return nil
+}
+
+// deleteAddressByHash removes the address row identified by the given address
+// hash from the address bucket, along with its used-address marker, if any.
+func deleteAddressByHash(ns walletdb.ReadWriteBucket, scope *KeyScope,
+	addrHash []byte) error {
+
+	scopedBucket, err := fetchWriteScopeBucket(ns, scope)
+	if err != nil {
+		return err
+	}
+
+	bucket := scopedBucket.NestedReadWriteBucket(addrBucketName)
+	if err := bucket.Delete(addrHash); err != nil {
+		str := fmt.Sprintf("failed to delete address hash %x", addrHash)
+		return managerError(ErrDatabase, str, err)
+	}
+
+	bucket = scopedBucket.NestedReadWriteBucket(usedAddrBucketName)
+	if err := bucket.Delete(addrHash); err != nil {
+		str := fmt.Sprintf("failed to delete used address marker %x",
+			addrHash)
+		return managerError(ErrDatabase, str, err)
+	}
+	return nil
+}
+
+// deleteAddrAccountIndex removes the given account's entries from the address
+// account index: the per-address entries recorded for the account's addresses
+// as well as the account's own sub-bucket. The hashes of the account's
+// addresses are returned so that the caller can remove the address rows they
+// key.
+func deleteAddrAccountIndex(ns walletdb.ReadWriteBucket, scope *KeyScope,
+	account uint32) ([][]byte, error) {
+
+	scopedBucket, err := fetchWriteScopeBucket(ns, scope)
+	if err != nil {
+		return nil, err
+	}
+
+	bucket := scopedBucket.NestedReadWriteBucket(addrAcctIdxBucketName)
+
+	// If the index has no sub-bucket for the account, no addresses were
+	// ever recorded for it.
+	acctKey := uint32ToBytes(account)
+	acctBucket := bucket.NestedReadWriteBucket(acctKey)
+	if acctBucket == nil {
+		return nil, nil
+	}
+
+	// Collect the address hashes first: the bucket cannot be mutated
+	// while it is being iterated.
+	var addrHashes [][]byte
+	err = acctBucket.ForEach(func(k, v []byte) error {
+		// Skip buckets.
+		if v == nil {
+			return nil
+		}
+
+		addrHash := make([]byte, len(k))
+		copy(addrHash, k)
+		addrHashes = append(addrHashes, addrHash)
+		return nil
+	})
+	if err != nil {
+		return nil, maybeConvertDbError(err)
+	}
+
+	// Remove the per-address entries of the account's addresses, then the
+	// account's sub-bucket itself.
+	for _, addrHash := range addrHashes {
+		if err := bucket.Delete(addrHash); err != nil {
+			str := fmt.Sprintf("failed to delete address account "+
+				"index key %x", addrHash)
+			return nil, managerError(ErrDatabase, str, err)
+		}
+	}
+	if err := bucket.DeleteNestedBucket(acctKey); err != nil {
+		str := fmt.Sprintf("failed to delete address account index "+
+			"bucket for account %d", account)
+		return nil, managerError(ErrDatabase, str, err)
+	}
+
+	return addrHashes, nil
+}
+
 // putAccountNameIndex stores the given key to the account name index of the
 // database.
 func putAccountNameIndex(ns walletdb.ReadWriteBucket, scope *KeyScope,

--- a/waddrmgr/manager_test.go
+++ b/waddrmgr/manager_test.go
@@ -3301,3 +3301,306 @@ func TestManagedAddressValidation(t *testing.T) {
 	}
 
 }
+
+// TestRemoveAccount asserts that removing a watch-only account deletes the
+// account row, its name indexes and every address derived from it, without
+// disturbing other accounts, and that the account's name becomes usable again
+// while its number is never reused.
+func TestRemoveAccount(t *testing.T) {
+	t.Parallel()
+
+	teardown, db := emptyDB(t)
+	defer teardown()
+
+	// We'll start the test by creating a new watch-only root manager that
+	// will be used for the duration of the test.
+	var mgr *Manager
+	err := walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns, err := tx.CreateTopLevelBucket(waddrmgrNamespaceKey)
+		if err != nil {
+			return err
+		}
+		err = Create(
+			ns, nil, pubPassphrase, nil,
+			&chaincfg.MainNetParams, fastScrypt, time.Time{},
+		)
+		if err != nil {
+			return err
+		}
+		mgr, err = Open(ns, pubPassphrase, &chaincfg.MainNetParams)
+		if err != nil {
+			return err
+		}
+
+		_, err = mgr.NewScopedKeyManager(
+			ns, KeyScopeBIP0044, ScopeAddrMap[KeyScopeBIP0044])
+		return err
+	})
+	if err != nil {
+		t.Fatalf("create/open: unexpected error: %v", err)
+	}
+	defer mgr.Close()
+
+	scopedMgr, err := mgr.FetchScopedKeyManager(KeyScopeBIP0044)
+	if err != nil {
+		t.Fatalf("unable to fetch scope %v: %v", KeyScopeBIP0044, err)
+	}
+
+	// Derive three distinct account public keys: one account to remove,
+	// one that must survive the removal untouched, and one for proving the
+	// name becomes reusable.
+	masterKey, err := hdkeychain.NewMaster(seed, &chaincfg.MainNetParams)
+	if err != nil {
+		t.Fatalf("NewMaster: unexpected error: %v", err)
+	}
+	scopeKey, err := deriveCoinTypeKey(masterKey, KeyScopeBIP0044)
+	if err != nil {
+		t.Fatalf("derive: unexpected error: %v", err)
+	}
+	acctKeys := make([]*hdkeychain.ExtendedKey, 4)
+	for i := range acctKeys {
+		acctKey, err := deriveAccountKey(scopeKey, uint32(i))
+		if err != nil {
+			t.Fatalf("derive: unexpected error: %v", err)
+		}
+		acctKeys[i], err = acctKey.Neuter()
+		if err != nil {
+			t.Fatalf("neuter: unexpected error: %v", err)
+		}
+	}
+
+	// Create the removal candidate and the surviving account, and derive
+	// external and internal addresses for both.
+	const removedName = "external"
+	var (
+		removedAcct, keptAcct   uint32
+		removedAddrs, keptAddrs []ManagedAddress
+	)
+	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+		// The first account created takes the default account number,
+		// which is not removable, so create a placeholder for it
+		// before the removal candidate.
+		_, err = scopedMgr.NewAccountWatchingOnly(
+			ns, "first", acctKeys[0], 0, nil,
+		)
+		if err != nil {
+			return err
+		}
+
+		removedAcct, err = scopedMgr.NewAccountWatchingOnly(
+			ns, removedName, acctKeys[1], 0, nil,
+		)
+		if err != nil {
+			return err
+		}
+		keptAcct, err = scopedMgr.NewAccountWatchingOnly(
+			ns, "keep", acctKeys[2], 0, nil,
+		)
+		if err != nil {
+			return err
+		}
+
+		extAddrs, err := scopedMgr.NextExternalAddresses(
+			ns, removedAcct, 2,
+		)
+		if err != nil {
+			return err
+		}
+		intAddrs, err := scopedMgr.NextInternalAddresses(
+			ns, removedAcct, 1,
+		)
+		if err != nil {
+			return err
+		}
+		removedAddrs = append(extAddrs, intAddrs...)
+
+		keptAddrs, err = scopedMgr.NextExternalAddresses(
+			ns, keptAcct, 1,
+		)
+		if err != nil {
+			return err
+		}
+
+		// Mark one of the doomed addresses as used so that the
+		// used-address marker's removal is exercised too.
+		return scopedMgr.MarkUsed(ns, removedAddrs[0].Address())
+	})
+	if err != nil {
+		t.Fatalf("unable to set up accounts: %v", err)
+	}
+
+	usedAddrID := removedAddrs[0].Address().ScriptAddress()
+	scope := scopedMgr.Scope()
+	err = walletdb.View(db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+		if !fetchAddressUsed(ns, &scope, usedAddrID) {
+			t.Fatal("expected address to be marked used")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Remove the account.
+	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+		return scopedMgr.RemoveAccount(ns, removedAcct)
+	})
+	if err != nil {
+		t.Fatalf("unable to remove account: %v", err)
+	}
+
+	// The account, its name and all of its addresses must be gone, while
+	// the second account is untouched.
+	err = walletdb.View(db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+
+		_, err := scopedMgr.AccountName(ns, removedAcct)
+		checkManagerError(
+			t, "removed account name", err, ErrAccountNotFound,
+		)
+
+		_, err = scopedMgr.LookupAccount(ns, removedName)
+		checkManagerError(
+			t, "removed account lookup", err, ErrAccountNotFound,
+		)
+
+		for i, addr := range removedAddrs {
+			_, err := scopedMgr.Address(ns, addr.Address())
+			checkManagerError(
+				t, fmt.Sprintf("removed address %d", i), err,
+				ErrAddressNotFound,
+			)
+		}
+
+		if fetchAddressUsed(ns, &scope, usedAddrID) {
+			t.Fatal("expected used-address marker to be removed")
+		}
+
+		numAddrs := 0
+		err = scopedMgr.ForEachAccountAddress(
+			ns, removedAcct, func(ManagedAddress) error {
+				numAddrs++
+				return nil
+			},
+		)
+		if err != nil {
+			return err
+		}
+		if numAddrs != 0 {
+			t.Fatalf("expected no addresses for removed account, "+
+				"got %d", numAddrs)
+		}
+
+		name, err := scopedMgr.AccountName(ns, keptAcct)
+		if err != nil {
+			return err
+		}
+		if name != "keep" {
+			t.Fatalf("expected kept account name 'keep', got %q",
+				name)
+		}
+		if _, err := scopedMgr.Address(ns, keptAddrs[0].Address()); err != nil {
+			t.Fatalf("expected kept address to resolve: %v", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The removed account's name is available again, but its number is not
+	// reused.
+	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+		newAcct, err := scopedMgr.NewAccountWatchingOnly(
+			ns, removedName, acctKeys[3], 0, nil,
+		)
+		if err != nil {
+			return err
+		}
+		if newAcct == removedAcct {
+			t.Fatalf("account number %d was reused", removedAcct)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unable to reuse account name: %v", err)
+	}
+
+	// Reserved accounts, the default account and unknown accounts are all
+	// refused.
+	guards := []struct {
+		name    string
+		account uint32
+		code    ErrorCode
+	}{
+		{"default account", DefaultAccountNum, ErrInvalidAccount},
+		{"imported account", ImportedAddrAccount, ErrInvalidAccount},
+		{"unknown account", 9999, ErrAccountNotFound},
+	}
+	for _, guard := range guards {
+		err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+			ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+			return scopedMgr.RemoveAccount(ns, guard.account)
+		})
+		checkManagerError(t, guard.name, err, guard.code)
+	}
+}
+
+// TestRemoveAccountNonWatchOnly asserts that an account derived from the
+// wallet's own master key cannot be removed.
+func TestRemoveAccountNonWatchOnly(t *testing.T) {
+	t.Parallel()
+
+	teardown, db, mgr := setupManager(t)
+	defer teardown()
+
+	scopedMgr, err := mgr.FetchScopedKeyManager(KeyScopeBIP0044)
+	if err != nil {
+		t.Fatalf("unable to fetch scope %v: %v", KeyScopeBIP0044, err)
+	}
+
+	// Deriving a new account from the seed requires the manager to be
+	// unlocked.
+	var account uint32
+	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+		if err := mgr.Unlock(ns, privPassphrase); err != nil {
+			return err
+		}
+
+		account, err = scopedMgr.NewAccount(ns, "seeded")
+		return err
+	})
+	if err != nil {
+		t.Fatalf("unable to create seeded account: %v", err)
+	}
+
+	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+		return scopedMgr.RemoveAccount(ns, account)
+	})
+	checkManagerError(t, "non-watch-only account", err, ErrInvalidAccount)
+
+	// The refused account must still be intact.
+	err = walletdb.View(db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+		name, err := scopedMgr.AccountName(ns, account)
+		if err != nil {
+			return err
+		}
+		if name != "seeded" {
+			t.Fatalf("expected account name 'seeded', got %q", name)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/waddrmgr/scoped_manager.go
+++ b/waddrmgr/scoped_manager.go
@@ -1892,6 +1892,90 @@ func (s *ScopedKeyManager) RenameAccount(ns walletdb.ReadWriteBucket,
 	return err
 }
 
+// RemoveAccount removes the given watch-only account from the manager,
+// together with every address derived from it. The manager stops tracking the
+// account entirely: its addresses no longer resolve and its name becomes
+// available again. Callers are responsible for removing any transaction store
+// state referencing the removed addresses.
+//
+// Only watch-only accounts, i.e. accounts backed by an imported account
+// public key rather than by the wallet's own master key, can be removed. The
+// manager's reserved accounts and the default account are refused. The last
+// account counter is deliberately left untouched, so a removed account's
+// number is never reused.
+//
+// This function must be called from within a database transaction that is
+// aborted when an error is returned, as a failure partway leaves the account
+// only partially removed.
+func (s *ScopedKeyManager) RemoveAccount(ns walletdb.ReadWriteBucket,
+	account uint32) error {
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	// Ensure that a reserved account is not being removed.
+	if isReservedAccountNum(account) {
+		str := "reserved account cannot be removed"
+		return managerError(ErrInvalidAccount, str, nil)
+	}
+
+	// The wallet's first account is created together with the wallet
+	// itself and is assumed to exist throughout its lifetime.
+	if account == DefaultAccountNum {
+		str := "default account cannot be removed"
+		return managerError(ErrInvalidAccount, str, nil)
+	}
+
+	rowInterface, err := fetchAccountInfo(ns, &s.scope, account)
+	if err != nil {
+		return err
+	}
+
+	// Only removing a watch-only account is supported: any other kind is
+	// backed by the wallet's own key material, and removing it would
+	// orphan keys the wallet cannot give up.
+	row, ok := rowInterface.(*dbWatchOnlyAccountRow)
+	if !ok {
+		str := fmt.Sprintf("account %d is not a watch-only account "+
+			"and cannot be removed", account)
+		return managerError(ErrInvalidAccount, str, nil)
+	}
+
+	// Remove the account's addresses first. The account's index sub-bucket
+	// holds the hash of every address ever derived for it, and those
+	// hashes key both the address rows and the used-address markers.
+	addrHashes, err := deleteAddrAccountIndex(ns, &s.scope, account)
+	if err != nil {
+		return err
+	}
+	for _, addrHash := range addrHashes {
+		err := deleteAddressByHash(ns, &s.scope, addrHash)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Then remove the account row together with both of its indexes.
+	if err := deleteAccountIDIndex(ns, &s.scope, account); err != nil {
+		return err
+	}
+	if err := deleteAccountNameIndex(ns, &s.scope, row.name); err != nil {
+		return err
+	}
+	if err := deleteAccountRow(ns, &s.scope, account); err != nil {
+		return err
+	}
+
+	// Finally, drop the cached state: the account's info, and the address
+	// cache wholesale, since it is keyed by script address rather than by
+	// account. Watch-only accounts never contribute to deriveOnUnlock, so
+	// there is nothing to clean up there.
+	delete(s.acctInfo, account)
+	s.addrs = make(map[addrKey]ManagedAddress)
+
+	return nil
+}
+
 // ImportPrivateKey imports a WIF private key into the address manager.  The
 // imported address is created using either a compressed or uncompressed
 // serialized public key, depending on the CompressPubKey bool of the WIF.

--- a/wallet/import.go
+++ b/wallet/import.go
@@ -9,6 +9,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
+	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/netparams"
 	"github.com/btcsuite/btcwallet/waddrmgr"
@@ -296,6 +297,93 @@ func (w *Wallet) importAccountScope(ns walletdb.ReadWriteBucket, name string,
 		return nil, err
 	}
 	return scopedMgr.AccountProperties(ns, account)
+}
+
+// RemoveAccount removes the watch-only account with the given name from the
+// given key scope, together with every address derived from it and every
+// unspent transaction output paying to one of those addresses. The wallet
+// stops tracking the account entirely: its addresses no longer resolve, its
+// UTXOs no longer count towards the wallet's balance and its name becomes
+// available for a new import. The funds themselves are unaffected — whoever
+// holds the account's keys retains full control, and re-importing the same
+// account public key followed by a rescan restores tracking.
+//
+// Only watch-only accounts, i.e. accounts registered through ImportAccount,
+// can be removed; the wallet's reserved accounts and its default account are
+// refused. The removal is also refused while one of the account's outputs is
+// leased for coin selection or spent by an unmined transaction, since
+// removing it would leave that state dangling.
+//
+// NOTE: The chain backend's notification filters are additive, so the removed
+// addresses remain watched until the next restart. Notifications for them are
+// dropped once their addresses are no longer known to the wallet, though
+// transactions paying to them may still be recorded (without any credit)
+// until then. Confirmed transaction history involving the account remains in
+// the store.
+func (w *Wallet) RemoveAccount(keyScope waddrmgr.KeyScope, name string) error {
+	return walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+		txmgrNs := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+
+		scopedMgr, err := w.Manager.FetchScopedKeyManager(keyScope)
+		if err != nil {
+			return err
+		}
+
+		account, err := scopedMgr.LookupAccount(addrmgrNs, name)
+		if err != nil {
+			return err
+		}
+
+		// Collect the output scripts of every address the account has
+		// derived, so that the account's outputs can be identified in
+		// the transaction store below.
+		ownedScripts := make(map[string]struct{})
+		err = scopedMgr.ForEachAccountAddress(
+			addrmgrNs, account,
+			func(maddr waddrmgr.ManagedAddress) error {
+				script, err := txscript.PayToAddrScript(
+					maddr.Address(),
+				)
+				if err != nil {
+					return err
+				}
+
+				ownedScripts[string(script)] = struct{}{}
+				return nil
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		// Find every output the store still considers ours that pays
+		// to one of the account's addresses. OutputsToWatch includes
+		// leased outputs and outputs spent by unmined transactions,
+		// both of which RemoveCredits refuses, so such outputs fail
+		// the removal cleanly instead of being missed.
+		outputs, err := w.TxStore.OutputsToWatch(txmgrNs)
+		if err != nil {
+			return err
+		}
+		var removedOps []wire.OutPoint
+		for _, output := range outputs {
+			if _, ok := ownedScripts[string(output.PkScript)]; ok {
+				removedOps = append(removedOps, output.OutPoint)
+			}
+		}
+		err = w.TxStore.RemoveCredits(txmgrNs, removedOps)
+		if err != nil {
+			return err
+		}
+
+		// With the account's outputs withdrawn from the transaction
+		// store, the account itself and all of its addresses can go.
+		// Doing this within the same database transaction keeps the
+		// address manager and the transaction store consistent with
+		// each other no matter where a failure happens.
+		return scopedMgr.RemoveAccount(addrmgrNs, account)
+	})
 }
 
 // ImportAccountDryRun serves as a dry run implementation of ImportAccount. This

--- a/wallet/import_test.go
+++ b/wallet/import_test.go
@@ -4,12 +4,16 @@ import (
 	"encoding/binary"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/address/v2"
+	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
+	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/stretchr/testify/require"
 )
 
@@ -292,4 +296,131 @@ func testImportAccount(t *testing.T, w *Wallet, tc *testCase, watchOnly bool,
 	addrManaged, err := w.AddressInfo(intAddr)
 	require.NoError(t, err)
 	require.Equal(t, true, addrManaged.Imported())
+}
+
+// TestRemoveAccount asserts that removing an imported watch-only account
+// deletes the account, its addresses and its unspent outputs from the wallet,
+// without disturbing the wallet's own accounts, and that the account's name
+// becomes importable again.
+func TestRemoveAccount(t *testing.T) {
+	t.Parallel()
+
+	w, cleanup := testWallet(t)
+	defer cleanup()
+
+	// Import an account using the BIP-0084 test vector.
+	var tc *testCase
+	for _, candidate := range testCases {
+		if candidate.name == "bip84" {
+			tc = candidate
+		}
+	}
+	require.NotNil(t, tc)
+
+	root, err := hdkeychain.NewKeyFromString(tc.masterPriv)
+	require.NoError(t, err)
+	acctPub := deriveAcctPubKey(
+		t, root, tc.expectedScope, hardenedKey(tc.accountIndex),
+	)
+
+	const acctName = "removable"
+	acct, err := w.ImportAccount(
+		acctName, acctPub, root.ParentFingerprint(), &tc.addrType,
+	)
+	require.NoError(t, err)
+	require.Equal(t, tc.expectedScope, acct.KeyScope)
+
+	// Derive an address on the imported account and one on the wallet's
+	// own default account, then confirm one deposit to each in a single
+	// transaction, so that removal provably only takes the imported
+	// account's credit with it.
+	importedAddr, err := w.NewAddress(
+		acct.AccountNumber, acct.KeyScope,
+	)
+	require.NoError(t, err)
+	defaultAddr, err := w.CurrentAddress(0, waddrmgr.KeyScopeBIP0084)
+	require.NoError(t, err)
+
+	importedScript, err := txscript.PayToAddrScript(importedAddr)
+	require.NoError(t, err)
+	defaultScript, err := txscript.PayToAddrScript(defaultAddr)
+	require.NoError(t, err)
+
+	const importedAmt, defaultAmt = int64(2e6), int64(3e6)
+	incomingTx := &wire.MsgTx{
+		TxIn: []*wire.TxIn{{}},
+		TxOut: []*wire.TxOut{
+			{Value: importedAmt, PkScript: importedScript},
+			{Value: defaultAmt, PkScript: defaultScript},
+		},
+	}
+	addUtxo(t, w, incomingTx)
+
+	// Mark the wallet as synced to the block the deposit confirmed in, so
+	// that balance calculations see it as confirmed.
+	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+		return w.Manager.SetSyncedTo(ns, &waddrmgr.BlockStamp{
+			Height:    testBlockHeight,
+			Hash:      *testBlockHash,
+			Timestamp: time.Unix(1387737310, 0),
+		})
+	})
+	require.NoError(t, err)
+
+	balance, err := w.CalculateBalance(1)
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(importedAmt+defaultAmt), balance)
+
+	// The imported account reports its deposit before the removal.
+	balances, err := w.AccountBalances(tc.expectedScope, 1)
+	require.NoError(t, err)
+	balanceByName := make(map[string]btcutil.Amount)
+	for _, acctBalance := range balances {
+		balanceByName[acctBalance.AccountName] =
+			acctBalance.AccountBalance
+	}
+	require.Equal(
+		t, btcutil.Amount(importedAmt), balanceByName[acctName],
+	)
+
+	// Remove the account, deposit and all.
+	require.NoError(t, w.RemoveAccount(tc.expectedScope, acctName))
+
+	// The account is gone entirely: it no longer resolves, its balance no
+	// longer counts towards the wallet's and its output is neither listed
+	// nor misattributed to another account.
+	_, err = w.AccountNumber(tc.expectedScope, acctName)
+	require.Error(t, err)
+
+	balance, err = w.CalculateBalance(1)
+	require.NoError(t, err)
+	require.Equal(t, btcutil.Amount(defaultAmt), balance)
+
+	balances, err = w.AccountBalances(tc.expectedScope, 1)
+	require.NoError(t, err)
+	for _, acctBalance := range balances {
+		require.NotEqual(t, acctName, acctBalance.AccountName)
+	}
+
+	unspent, err := w.ListUnspent(0, testBlockHeight, "")
+	require.NoError(t, err)
+	require.Len(t, unspent, 1)
+	require.Equal(t, defaultAddr.String(), unspent[0].Address)
+
+	// The same extended public key can be imported again under the same
+	// name, with a fresh account number.
+	acct2, err := w.ImportAccount(
+		acctName, acctPub, root.ParentFingerprint(), &tc.addrType,
+	)
+	require.NoError(t, err)
+	require.NotEqual(t, acct.AccountNumber, acct2.AccountNumber)
+
+	// The wallet's own accounts cannot be removed, nor can accounts that
+	// do not exist.
+	err = w.RemoveAccount(waddrmgr.KeyScopeBIP0084, "default")
+	require.ErrorContains(t, err, "cannot be removed")
+
+	err = w.RemoveAccount(tc.expectedScope, "does-not-exist")
+	require.Error(t, err)
 }

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -2866,22 +2866,35 @@ func (w *Wallet) AccountBalances(scope waddrmgr.KeyScope,
 
 		syncBlock := w.Manager.SyncedTo()
 
-		// Fill out all account info except for the balances.
+		// Fill out all account info except for the balances. A removed
+		// account leaves a gap in the account number sequence, since
+		// account numbers are never reused, so a missing account is
+		// skipped rather than treated as an error.
 		lastAcct, err := manager.LastAccount(addrmgrNs)
 		if err != nil {
 			return err
 		}
-		results = make([]AccountBalanceResult, lastAcct+2)
-		for i := range results[:len(results)-1] {
-			accountName, err := manager.AccountName(addrmgrNs, uint32(i))
+		results = make([]AccountBalanceResult, 0, lastAcct+2)
+		resultIdx := make(map[uint32]int, lastAcct+2)
+		for i := uint32(0); i <= lastAcct; i++ {
+			accountName, err := manager.AccountName(addrmgrNs, i)
+			if waddrmgr.IsError(err, waddrmgr.ErrAccountNotFound) {
+				continue
+			}
 			if err != nil {
 				return err
 			}
-			results[i].AccountNumber = uint32(i)
-			results[i].AccountName = accountName
+			resultIdx[i] = len(results)
+			results = append(results, AccountBalanceResult{
+				AccountNumber: i,
+				AccountName:   accountName,
+			})
 		}
-		results[len(results)-1].AccountNumber = waddrmgr.ImportedAddrAccount
-		results[len(results)-1].AccountName = waddrmgr.ImportedAddrAccountName
+		resultIdx[waddrmgr.ImportedAddrAccount] = len(results)
+		results = append(results, AccountBalanceResult{
+			AccountNumber: waddrmgr.ImportedAddrAccount,
+			AccountName:   waddrmgr.ImportedAddrAccountName,
+		})
 
 		// Fetch all unspent outputs, and iterate over them tallying each
 		// account's balance where the output script pays to an account address
@@ -2917,15 +2930,17 @@ func (w *Wallet) AccountBalances(scope waddrmgr.KeyScope,
 			if err != nil {
 				continue
 			}
-			switch {
-			case outputAcct == waddrmgr.ImportedAddrAccount:
-				results[len(results)-1].AccountBalance += output.Amount
-			case outputAcct > lastAcct:
+			if outputAcct != waddrmgr.ImportedAddrAccount &&
+				outputAcct > lastAcct {
+
 				return errors.New("waddrmgr.Manager.AddrAccount returned " +
 					"account beyond recorded last account")
-			default:
-				results[outputAcct].AccountBalance += output.Amount
 			}
+			idx, ok := resultIdx[outputAcct]
+			if !ok {
+				continue
+			}
+			results[idx].AccountBalance += output.Amount
 		}
 		return nil
 	})

--- a/wtxmgr/tx.go
+++ b/wtxmgr/tx.go
@@ -398,6 +398,90 @@ func (s *Store) RemoveUnminedTx(ns walletdb.ReadWriteBucket, rec *TxRecord) erro
 	return s.removeConflict(ns, rec)
 }
 
+// RemoveCredits removes the unspent credits identified by the given outpoints
+// from the store, both mined and unmined, so that the wallet stops treating
+// them as its own. The mined balance is decremented by the amount of every
+// removed mined credit. This is to be used when the wallet withdraws ownership
+// of outputs it previously tracked, such as when an imported account is
+// removed together with its addresses.
+//
+// The transaction records the credits are part of are deliberately left in
+// place: other credits of the same transactions may still belong to the
+// wallet, and the balance and pkScript lookups both resolve through the
+// record.
+//
+// A credit that is locked for coin selection or already spent by an unmined
+// transaction is refused with ErrInput rather than removed, since deleting it
+// would leave the lease or the spending chain dangling. An outpoint with no
+// corresponding unspent credit is ignored, making the call idempotent.
+//
+// This function must be called from within a database transaction that is
+// aborted when an error is returned, as a refused outpoint would otherwise
+// leave the removals that preceded it committed.
+func (s *Store) RemoveCredits(ns walletdb.ReadWriteBucket,
+	ops []wire.OutPoint) error {
+
+	minedBalance, err := fetchMinedBalance(ns)
+	if err != nil {
+		return err
+	}
+	balanceChanged := false
+	now := s.clock.Now()
+
+	for i := range ops {
+		op := ops[i]
+		opKey := canonicalOutPoint(&op.Hash, op.Index)
+
+		if _, _, isLocked := isLockedOutput(ns, op, now); isLocked {
+			str := fmt.Sprintf("output %v is locked for coin "+
+				"selection and cannot be removed", op)
+			return storeError(ErrInput, str, nil)
+		}
+		if existsRawUnminedInput(ns, opKey) != nil {
+			str := fmt.Sprintf("output %v is spent by an unmined "+
+				"transaction and cannot be removed", op)
+			return storeError(ErrInput, str, nil)
+		}
+
+		// An unmined credit is a single row keyed by the outpoint and
+		// never part of the mined balance.
+		if existsRawUnminedCredit(ns, opKey) != nil {
+			err := deleteRawUnminedCredit(ns, opKey)
+			if err != nil {
+				return err
+			}
+			continue
+		}
+
+		// A mined credit is found through the unspent index, which
+		// resolves the outpoint to the credit's key in its block.
+		unspentKey, credKey := existsUnspent(ns, &op)
+		if credKey == nil {
+			continue
+		}
+
+		amt, err := fetchRawCreditAmount(existsRawCredit(ns, credKey))
+		if err != nil {
+			return err
+		}
+		if err := deleteRawCredit(ns, credKey); err != nil {
+			return err
+		}
+		if err := deleteRawUnspent(ns, unspentKey); err != nil {
+			return err
+		}
+
+		minedBalance -= amt
+		balanceChanged = true
+	}
+
+	if balanceChanged {
+		return putMinedBalance(ns, minedBalance)
+	}
+
+	return nil
+}
+
 // insertMinedTx inserts a new transaction record for a mined transaction into
 // the database under the confirmed bucket. It guarantees that, if the
 // tranasction was previously unconfirmed, then it will take care of cleaning up

--- a/wtxmgr/tx_test.go
+++ b/wtxmgr/tx_test.go
@@ -2901,3 +2901,193 @@ func TestOutputLocks(t *testing.T) {
 		})
 	}
 }
+
+// TestRemoveCredits asserts that removing unspent credits drops them from the
+// balance and the unspent set without touching their transaction records, and
+// that leased and unmined-spent outputs are refused.
+func TestRemoveCredits(t *testing.T) {
+	t.Parallel()
+
+	store, db, err := testStore(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	b100 := &BlockMeta{
+		Block: Block{Height: 100},
+		Time:  time.Now(),
+	}
+
+	// A mined deposit with two credits, so that one can be removed while
+	// the other proves removal does not bleed into sibling credits of the
+	// same transaction.
+	fundingHash := chainhash.Hash{1}
+	deposit := spendOutput(&fundingHash, 0, 1e8, 5e7)
+	depRec, err := NewTxRecordFromMsgTx(deposit, b100.Time)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commitDBTx(t, store, db, func(ns walletdb.ReadWriteBucket) {
+		if err := store.InsertTx(ns, depRec, b100); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.AddCredit(ns, depRec, b100, 0, false); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.AddCredit(ns, depRec, b100, 1, false); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	// An unmined deposit with a single credit.
+	otherFundingHash := chainhash.Hash{2}
+	unminedDeposit := spendOutput(&otherFundingHash, 0, 2e7)
+	unminedRec, err := NewTxRecordFromMsgTx(unminedDeposit, b100.Time)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commitDBTx(t, store, db, func(ns walletdb.ReadWriteBucket) {
+		if err := store.InsertTx(ns, unminedRec, nil); err != nil {
+			t.Fatal(err)
+		}
+		err := store.AddCredit(ns, unminedRec, nil, 0, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	// checkBalance compares the store's balance at the given minimum
+	// confirmations against an expected value.
+	checkBalance := func(expected btcutil.Amount, minConf int32) {
+		t.Helper()
+
+		commitDBTx(t, store, db, func(ns walletdb.ReadWriteBucket) {
+			b, err := store.Balance(ns, minConf, b100.Height)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if b != expected {
+				t.Fatalf("expected balance %v at minconf %d, "+
+					"got %v", expected, minConf, b)
+			}
+		})
+	}
+	checkBalance(1e8+5e7, 1)
+	checkBalance(1e8+5e7+2e7, 0)
+
+	// Remove the second mined credit and the unmined credit in one call.
+	removed := []wire.OutPoint{
+		{Hash: depRec.Hash, Index: 1},
+		{Hash: unminedRec.Hash, Index: 0},
+	}
+	commitDBTx(t, store, db, func(ns walletdb.ReadWriteBucket) {
+		if err := store.RemoveCredits(ns, removed); err != nil {
+			t.Fatal(err)
+		}
+	})
+	checkBalance(1e8, 1)
+	checkBalance(1e8, 0)
+
+	// Only the untouched sibling credit remains in the unspent set.
+	commitDBTx(t, store, db, func(ns walletdb.ReadWriteBucket) {
+		unspent, err := store.UnspentOutputs(ns)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(unspent) != 1 {
+			t.Fatalf("expected 1 unspent output, got %d",
+				len(unspent))
+		}
+		expectedOp := wire.OutPoint{Hash: depRec.Hash, Index: 0}
+		if unspent[0].OutPoint != expectedOp {
+			t.Fatalf("expected unspent output %v, got %v",
+				expectedOp, unspent[0].OutPoint)
+		}
+	})
+
+	// Removing the same outpoints again is a no-op.
+	commitDBTx(t, store, db, func(ns walletdb.ReadWriteBucket) {
+		if err := store.RemoveCredits(ns, removed); err != nil {
+			t.Fatal(err)
+		}
+	})
+	checkBalance(1e8, 0)
+
+	// A leased output is refused until the lease is released.
+	remainingOp := wire.OutPoint{Hash: depRec.Hash, Index: 0}
+	commitDBTx(t, store, db, func(ns walletdb.ReadWriteBucket) {
+		_, err := store.LockOutput(
+			ns, LockID{1}, remainingOp, 10*time.Minute,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+	err = walletdb.Update(db, func(dbTx walletdb.ReadWriteTx) error {
+		ns := dbTx.ReadWriteBucket(namespaceKey)
+		return store.RemoveCredits(ns, []wire.OutPoint{remainingOp})
+	})
+	if storeErr, ok := err.(Error); !ok || storeErr.Code != ErrInput {
+		t.Fatalf("expected ErrInput for leased output, got %v", err)
+	}
+
+	// The refusal must not have removed anything. The balance cannot show
+	// that while the lease still excludes the output from it, so release
+	// the lease first: the output reappears, and removing it then
+	// succeeds.
+	commitDBTx(t, store, db, func(ns walletdb.ReadWriteBucket) {
+		err := store.UnlockOutput(ns, LockID{1}, remainingOp)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+	checkBalance(1e8, 0)
+
+	commitDBTx(t, store, db, func(ns walletdb.ReadWriteBucket) {
+		err := store.RemoveCredits(ns, []wire.OutPoint{remainingOp})
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+	checkBalance(0, 0)
+
+	// An output spent by an unmined transaction is refused: removing it
+	// would leave the spending chain dangling.
+	b101 := &BlockMeta{
+		Block: Block{Height: 101},
+		Time:  time.Now(),
+	}
+	lateFundingHash := chainhash.Hash{3}
+	lateDeposit := spendOutput(&lateFundingHash, 0, 3e7)
+	lateRec, err := NewTxRecordFromMsgTx(lateDeposit, b101.Time)
+	if err != nil {
+		t.Fatal(err)
+	}
+	spender := spendOutput(&lateRec.Hash, 0, 1e7)
+	spenderRec, err := NewTxRecordFromMsgTx(spender, b101.Time)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commitDBTx(t, store, db, func(ns walletdb.ReadWriteBucket) {
+		if err := store.InsertTx(ns, lateRec, b101); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.AddCredit(ns, lateRec, b101, 0, false); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.InsertTx(ns, spenderRec, nil); err != nil {
+			t.Fatal(err)
+		}
+	})
+	err = walletdb.Update(db, func(dbTx walletdb.ReadWriteTx) error {
+		ns := dbTx.ReadWriteBucket(namespaceKey)
+		return store.RemoveCredits(ns, []wire.OutPoint{
+			{Hash: lateRec.Hash, Index: 0},
+		})
+	})
+	if storeErr, ok := err.(Error); !ok || storeErr.Code != ErrInput {
+		t.Fatalf("expected ErrInput for unmined-spent output, got %v",
+			err)
+	}
+}


### PR DESCRIPTION
## Change Description

Adds the ability to **remove a watch-only account** previously registered through
`ImportAccount`, together with every address derived from it and every unspent
output paying to one of those addresses.

Motivation: imported accounts (e.g. via lnd's `WalletKit.ImportAccount`) can
currently never be deleted — they clutter account listings and consume resources
forever. Unblocks [lightningnetwork/lnd#8654](https://github.com/lightningnetwork/lnd/issues/8654);
the corresponding lnd RPC is already implemented against the API added here
(`wallet.(*Wallet).RemoveAccount(scope waddrmgr.KeyScope, name string) error`).

The removal spans both stores atomically, in one `walletdb.Update`:

1. **`wtxmgr.(*Store).RemoveCredits(ns, []wire.OutPoint)`** (new): removes
   unspent credits — mined and unmined — by outpoint, decrementing the mined
   balance for each removed mined credit. Deleting the waddrmgr addresses alone
   is not enough: `Balance` counts credits unconditionally (total balance would
   over-report forever) and `ListUnspent` attributes unknown-address outputs to
   the `default` account. Transaction records are deliberately left in place —
   sibling credits of the same tx may still be ours, and both the balance
   block-walk and pkScript resolution read through the record. Leased outputs
   and outputs spent by unmined transactions are refused with `ErrInput`;
   unknown outpoints are ignored, making the call idempotent.

2. **`waddrmgr.(*ScopedKeyManager).RemoveAccount(ns, account)`** (new): deletes
   the account row, both name/ID index entries, every derived address row, the
   address-account index entries and used-address markers, then purges the
   in-memory caches. Only `dbWatchOnlyAccountRow` accounts can be removed —
   anything else is backed by the wallet's own key material. Reserved accounts
   and the default account are refused. The last-account counter is deliberately
   **not** rolled back, so account numbers are never reused, while the removed
   account's *name* becomes available again.

3. **`wallet.(*Wallet).RemoveAccount(scope, name)`** (new): resolves the
   account, collects its addresses' output scripts, matches them against
   `TxStore.OutputsToWatch` (which includes leased and unmined-spent outputs, so
   those fail the removal cleanly instead of being missed), calls
   `RemoveCredits`, then the waddrmgr removal — all in one db transaction so the
   two stores can never end up inconsistent.

`AccountBalances` previously assumed the account-number sequence has no gaps,
which removal introduces; it now skips missing accounts.

Semantics / caveats:

- Removal is allowed with a non-zero balance. Funds are unaffected — whoever
  holds the account's keys retains control, and re-importing the same xpub
  (plus rescan) restores tracking.
- Confirmed transaction *history* involving the account remains in the store;
  only unspent credits are withdrawn.
- Chain-backend notification filters are additive, so removed addresses stay
  watched until restart; notifications for them are dropped by the existing
  `ErrAddressNotFound` path in `addRelevantTx`.
- Removing the last account of a scope leaves the scoped key manager in place
  (symmetric with `ImportAccount`, which creates it on demand).

Module mechanics: `RemoveCredits` lives in the separately-tagged `wtxmgr`
module, so this PR re-adds the local
`replace github.com/btcsuite/btcwallet/wtxmgr => ./wtxmgr` directive, following
the repo's established workflow (cf. 59d3cf64, 302643a3, dropped in c6f1caf9).
After merge: tag `wtxmgr/v1.7.0`, bump the require, drop the replace.

## Steps to Test

```sh
cd wtxmgr && go test -run TestRemoveCredits ./... && cd ..
go test -run TestRemoveAccount ./waddrmgr/...
go test -run TestRemoveAccount ./wallet/...
```

New coverage, positive and negative paths:

- `wtxmgr`: `TestRemoveCredits` — mined + unmined removal, balance accounting,
  sibling-credit isolation, idempotency, lease refusal (and removal after
  release), unmined-spend refusal.
- `waddrmgr`: `TestRemoveAccount` — full deletion of account/indexes/addresses/
  used-markers, isolation of other accounts, name reusable / number not reused,
  reserved + default + unknown account guards; `TestRemoveAccountNonWatchOnly` —
  seed-derived accounts refused and left intact.
- `wallet`: `TestRemoveAccount` — end-to-end: import → deposit (imported +
  default account in one tx) → remove → balances and `ListUnspent` only reflect
  the default account → re-import same xpub under same name → guards.

Full `wtxmgr`, `waddrmgr` and `wallet` package suites pass. End-to-end against
lnd: the `RemoveAccount` RPC integration test (import Carol's xpub into Dave's
node, fund, remove with non-zero balance, assert no trace across restart,
re-import) passes against this branch via local replace directives.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#ideal-git-commit-structure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
