### PR TITLE
wallet: centralize managed runtime config

### DIFF
--- a/bwtest/harness.go
+++ b/bwtest/harness.go
@@ -233,11 +233,18 @@ func (h *HarnessTest) NewWalletManager() *wallet.Manager {
 			"kvdb, sqlite, and postgres", h.dbType)
 	}
 
-	manager, err := wallet.NewManager(h.Context(), wallet.ManagerConfig{
-		Backend:     backend,
-		DataSource:  h.WalletDBSource,
-		ChainParams: h.NetParams(),
-	})
+	// The Manager owns one immutable runtime policy. Harness scenarios share
+	// their existing chain client with every Wallet assembled by that Manager.
+	managerCfg := wallet.ManagerConfig{
+		Backend:                 backend,
+		DataSource:              h.WalletDBSource,
+		ChainParams:             *h.NetParams(),
+		ChainSource:             h.ChainClient,
+		RecoveryWindow:          defaultWalletRecoveryWindow,
+		WalletSyncRetryInterval: defaultWalletSyncRetryInterval,
+	}
+
+	manager, err := wallet.NewManager(h.Context(), managerCfg)
 	require.NoError(h, err, "failed to create wallet manager")
 
 	h.mu.Lock()

--- a/bwtest/harness.go
+++ b/bwtest/harness.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
+	"slices"
 	"sync"
 	"testing"
 
@@ -39,9 +40,9 @@ const (
 )
 
 // walletRegistration tracks every wallet owned by one Manager. Each map value
-// is a copied reload configuration, or nil for wallets registered through
-// RegisterWallet.
-type walletRegistration map[*wallet.Wallet]*wallet.Config
+// is a copied reload request, or nil for wallets registered only for lifecycle
+// ownership.
+type walletRegistration map[*wallet.Wallet]*wallet.LoadWalletParams
 
 // HarnessTest is the integration test harness.
 type HarnessTest struct {
@@ -368,10 +369,10 @@ func (h *HarnessTest) RegisterWallet(manager *wallet.Manager,
 	h.registerWallet(manager, w, nil)
 }
 
-// registerWallet records a wallet under manager and copies reloadConfig when
-// provided.
+// registerWallet records a wallet under manager and owns a copy of optional
+// reloadParams so fixture mutations cannot alter a later reload credential.
 func (h *HarnessTest) registerWallet(manager *wallet.Manager, w *wallet.Wallet,
-	reloadConfig *wallet.Config) {
+	reloadParams *wallet.LoadWalletParams) {
 
 	h.Helper()
 
@@ -390,13 +391,16 @@ func (h *HarnessTest) registerWallet(manager *wallet.Manager, w *wallet.Wallet,
 		)
 	}
 
-	var config *wallet.Config
-	if reloadConfig != nil {
-		copiedConfig := *reloadConfig
-		config = &copiedConfig
+	var params *wallet.LoadWalletParams
+	if reloadParams != nil {
+		copiedParams := *reloadParams
+		copiedParams.PubPassphrase = slices.Clone(
+			reloadParams.PubPassphrase,
+		)
+		params = &copiedParams
 	}
 
-	registration[w] = config
+	registration[w] = params
 }
 
 // DeregisterWallet releases a wallet from harness ownership.

--- a/bwtest/harness_test.go
+++ b/bwtest/harness_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	bwmock "github.com/btcsuite/btcwallet/bwtest/mock"
 	"github.com/btcsuite/btcwallet/wallet"
 	"github.com/stretchr/testify/require"
 )
@@ -132,10 +133,14 @@ func TestReleaseManagerRemovesRegisteredManager(t *testing.T) {
 func TestReleaseManagerTransfersTeardownOwnership(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: a Manager owned by a harness.
+	// Arrange: give the harness the strict chain mock required by the
+	// Manager's shared runtime policy. This lifecycle-only test does not
+	// expect any chain calls.
+	chainSource := &bwmock.Chain{}
 	h := &HarnessTest{
 		T:              t,
 		dbType:         "kvdb",
+		ChainClient:    chainSource,
 		WalletDBSource: filepath.Join(t.TempDir(), "wallet.db"),
 	}
 	manager := h.NewWalletManager()
@@ -152,12 +157,14 @@ func TestReleaseManagerTransfersTeardownOwnership(t *testing.T) {
 		//nolint:staticcheck // This test intentionally reopens legacy kvdb.
 		Backend:     wallet.DBBackendKVDB,
 		DataSource:  h.WalletDBSource,
-		ChainParams: h.NetParams(),
+		ChainParams: *h.NetParams(),
+		ChainSource: h.ChainClient,
 	})
 	require.NoError(
 		t, err, "released Manager must leave the database available",
 	)
 	require.NoError(t, reopened.Close())
+	chainSource.AssertExpectations(t)
 }
 
 // TestTeardownWalletsClosesManagerAfterFailedCreate verifies that centralized
@@ -201,19 +208,25 @@ func testManagerTeardownAfterFailedCreate(t *testing.T, dbType string,
 
 	t.Helper()
 
+	// Arrange: provide the complete Manager policy, including a strict chain
+	// mock with no expected calls because this test stops before chain sync.
+	chainSource := &bwmock.Chain{}
 	h := &HarnessTest{
 		T:              t,
 		dbType:         dbType,
+		ChainClient:    chainSource,
 		WalletDBSource: filepath.Join(t.TempDir(), "wallet.db"),
 	}
 
 	manager := h.NewWalletManager()
 	require.NotNil(t, manager)
 
-	// Force Create to fail after the Manager has opened its database.
+	// Act: force Create to fail after the Manager has opened its database,
+	// then run centralized teardown through the same path used by the
+	// integration harness.
 	pubPass := []byte("public")
 	cfg := wallet.Config{
-		Name:          "failed-create",
+		Name:          "",
 		PubPassphrase: pubPass,
 	}
 	w, err := manager.Create(cfg, wallet.CreateWalletParams{
@@ -239,14 +252,19 @@ func testManagerTeardownAfterFailedCreate(t *testing.T, dbType string,
 			"probably never closed")
 	}
 
-	// A fresh Manager proves the database was released.
-	reopened, err := wallet.NewManager(t.Context(), wallet.ManagerConfig{
+	// Assert: a fresh Manager proves teardown released the database, while
+	// the strict chain mock proves neither failed creation nor cleanup
+	// crossed into chain synchronization.
+	reopenCfg := wallet.ManagerConfig{
 		Backend:     backend,
 		DataSource:  h.WalletDBSource,
-		ChainParams: h.NetParams(),
-	})
+		ChainParams: *h.NetParams(),
+		ChainSource: h.ChainClient,
+	}
+	reopened, err := wallet.NewManager(t.Context(), reopenCfg)
 	require.NoError(t, err, "teardown must release the database")
 	require.NoError(t, reopened.Close())
+	chainSource.AssertExpectations(t)
 }
 
 // TestBackendArtifactPostgresRejectsInvalidDSN verifies that PostgreSQL

--- a/bwtest/harness_test.go
+++ b/bwtest/harness_test.go
@@ -224,14 +224,8 @@ func testManagerTeardownAfterFailedCreate(t *testing.T, dbType string,
 	// Act: force Create to fail after the Manager has opened its database,
 	// then run centralized teardown through the same path used by the
 	// integration harness.
-	pubPass := []byte("public")
-	cfg := wallet.Config{
-		Name:          "",
-		PubPassphrase: pubPass,
-	}
-	w, err := manager.Create(cfg, wallet.CreateWalletParams{
+	w, err := manager.Create(wallet.CreateWalletParams{
 		Mode:              wallet.ModeGenSeed,
-		PubPassphrase:     pubPass,
 		PrivatePassphrase: []byte("private"),
 	})
 	require.ErrorIs(t, err, wallet.ErrMissingParam)

--- a/bwtest/harness_wallet.go
+++ b/bwtest/harness_wallet.go
@@ -33,30 +33,15 @@ const (
 	defaultWalletSyncRetryInterval = 500 * time.Millisecond
 )
 
-// TestWalletConfig builds the standard Config and CreateWalletParams for a
-// harness test wallet. Callers retain ownership of the wallet lifecycle.
-func (h *HarnessTest) TestWalletConfig() (wallet.Config,
-	wallet.CreateWalletParams) {
-
+// TestWalletParams builds the durable initialization request for a harness
+// Wallet. Runtime policy is configured once by NewWalletManager.
+func (h *HarnessTest) TestWalletParams() wallet.CreateWalletParams {
 	h.Helper()
 
-	cfg := wallet.Config{
-		// The chain client is prepared by the harness; the database is
-		// owned by the Manager built below.
-		Chain:       h.ChainClient,
-		ChainParams: h.NetParams(),
-
-		// Keep network and startup behavior deterministic across tests.
-		RecoveryWindow:          defaultWalletRecoveryWindow,
-		WalletSyncRetryInterval: defaultWalletSyncRetryInterval,
-
-		// Use a unique wallet name per test to avoid collisions in logs.
-		Name:          "itest-" + strings.ReplaceAll(h.Name(), "/", "_"),
-		PubPassphrase: []byte(defaultPubPass),
-	}
-
 	params := wallet.CreateWalletParams{
-		// Generate a fresh seed for each test wallet.
+		// A unique durable name avoids collisions in logs, while ModeGenSeed
+		// keeps generated key material local to each test Wallet.
+		Name:              "itest-" + strings.ReplaceAll(h.Name(), "/", "_"),
 		Mode:              wallet.ModeGenSeed,
 		PubPassphrase:     []byte(defaultPubPass),
 		PrivatePassphrase: []byte(TestWalletPrivatePassphrase),
@@ -66,7 +51,7 @@ func (h *HarnessTest) TestWalletConfig() (wallet.Config,
 		Birthday: time.Now().Add(-1 * time.Hour),
 	}
 
-	return cfg, params
+	return params
 }
 
 // WalletFixture describes the wallet a test case needs. It is the harness's
@@ -114,14 +99,14 @@ func (h *HarnessTest) NewWallet(fixture WalletFixture) (*wallet.Wallet,
 
 	h.Helper()
 
-	cfg, params := h.TestWalletConfig()
+	params := h.TestWalletParams()
 	if fixture.WatchOnly || len(fixture.InitialAccounts) != 0 {
 		params.Mode, params.WatchOnly = wallet.ModeShell, true
 		params.InitialAccounts = fixture.InitialAccounts
 	}
 
 	manager := h.NewWalletManager()
-	w, err := manager.Create(cfg, params)
+	w, err := manager.Create(params)
 	require.NoError(h, err, "failed to create wallet")
 
 	// Register before Start, and only register: teardownWallets is the single
@@ -129,7 +114,7 @@ func (h *HarnessTest) NewWallet(fixture WalletFixture) (*wallet.Wallet,
 	// failed unregistered, and a second direct Stop callback here would stop a
 	// successful one twice, out of order with the Manager close.
 	reloadParams := &wallet.LoadWalletParams{
-		Name:          cfg.Name,
+		Name:          params.Name,
 		PubPassphrase: params.PubPassphrase,
 	}
 	h.registerWallet(manager, w, reloadParams)

--- a/bwtest/harness_wallet.go
+++ b/bwtest/harness_wallet.go
@@ -128,7 +128,11 @@ func (h *HarnessTest) NewWallet(fixture WalletFixture) (*wallet.Wallet,
 	// cleanup owner. Registering after Start would leave a wallet whose Start
 	// failed unregistered, and a second direct Stop callback here would stop a
 	// successful one twice, out of order with the Manager close.
-	h.registerWallet(manager, w, &cfg)
+	reloadParams := &wallet.LoadWalletParams{
+		Name:          cfg.Name,
+		PubPassphrase: params.PubPassphrase,
+	}
+	h.registerWallet(manager, w, reloadParams)
 
 	if fixture.Unstarted {
 		require.Empty(
@@ -166,18 +170,18 @@ func (h *HarnessTest) ReloadWallet(current *wallet.Wallet) *wallet.Wallet {
 
 	var (
 		manager           *wallet.Manager
-		reloadConfig      *wallet.Config
+		reloadParams      *wallet.LoadWalletParams
 		registeredWallets int
 	)
 
 	for candidate, registration := range h.wallets {
-		config, ok := registration[current]
+		params, ok := registration[current]
 		if !ok {
 			continue
 		}
 
 		manager = candidate
-		reloadConfig = config
+		reloadParams = params
 		registeredWallets = len(registration)
 
 		break
@@ -186,13 +190,11 @@ func (h *HarnessTest) ReloadWallet(current *wallet.Wallet) *wallet.Wallet {
 	h.mu.Unlock()
 
 	require.NotNil(h, manager, "wallet is not registered with this harness")
-	require.NotNil(h, reloadConfig, "wallet is not reloadable")
+	require.NotNil(h, reloadParams, "wallet is not reloadable")
 	require.Equal(
 		h, 1, registeredWallets,
 		"wallet manager has sibling registered wallets",
 	)
-
-	cfg := *reloadConfig
 
 	ctx := h.Context()
 	require.NoError(
@@ -209,11 +211,11 @@ func (h *HarnessTest) ReloadWallet(current *wallet.Wallet) *wallet.Wallet {
 	)
 
 	manager = h.NewWalletManager()
-	w, err := manager.Load(cfg)
+	w, err := manager.Load(*reloadParams)
 	require.NoError(h, err, "failed to reload wallet")
 	require.NotSame(h, current, w, "reload returned the original wallet")
 
-	h.registerWallet(manager, w, &cfg)
+	h.registerWallet(manager, w, reloadParams)
 	require.NoError(h, w.Start(ctx), "failed to start reloaded wallet")
 
 	return w

--- a/itest/controller_test.go
+++ b/itest/controller_test.go
@@ -12,10 +12,10 @@ import (
 // stops cleanly, Stop is idempotent, a stopped instance restarts cleanly, and
 // a fresh Load yields a working instance.
 func testControllerStartStop(h *bwtest.HarnessTest) {
-	cfg, params := h.TestWalletConfig()
+	params := h.TestWalletParams()
 
 	manager := h.NewWalletManager()
-	w, err := manager.Create(cfg, params)
+	w, err := manager.Create(params)
 	require.NoError(h, err, "failed to create wallet")
 	h.RegisterWallet(manager, w)
 
@@ -38,7 +38,7 @@ func testControllerStartStop(h *bwtest.HarnessTest) {
 	require.True(h, h.ReleaseManager(manager), "failed to release manager")
 	manager = h.NewWalletManager()
 	reloaded, err := manager.Load(wallet.LoadWalletParams{
-		Name:          cfg.Name,
+		Name:          params.Name,
 		PubPassphrase: params.PubPassphrase,
 	})
 	require.NoError(h, err, "failed to reload wallet")
@@ -54,10 +54,10 @@ func testControllerStartStop(h *bwtest.HarnessTest) {
 func testControllerUnlockLock(h *bwtest.HarnessTest) {
 	const wrongPassphrase = "wrong-private-passphrase"
 
-	cfg, params := h.TestWalletConfig()
+	params := h.TestWalletParams()
 
 	manager := h.NewWalletManager()
-	w, err := manager.Create(cfg, params)
+	w, err := manager.Create(params)
 	require.NoError(h, err, "failed to create wallet")
 	h.RegisterWallet(manager, w)
 
@@ -124,10 +124,10 @@ func testControllerUnlockLock(h *bwtest.HarnessTest) {
 // reports the configured backend and chain params, and tracks synchronization
 // as a block is mined.
 func testControllerInfo(h *bwtest.HarnessTest) {
-	cfg, params := h.TestWalletConfig()
+	params := h.TestWalletParams()
 
 	manager := h.NewWalletManager()
-	w, err := manager.Create(cfg, params)
+	w, err := manager.Create(params)
 	require.NoError(h, err, "failed to create wallet")
 	h.RegisterWallet(manager, w)
 

--- a/itest/controller_test.go
+++ b/itest/controller_test.go
@@ -37,7 +37,10 @@ func testControllerStartStop(h *bwtest.HarnessTest) {
 	require.NoError(h, manager.Close(), "failed to close wallet manager")
 	require.True(h, h.ReleaseManager(manager), "failed to release manager")
 	manager = h.NewWalletManager()
-	reloaded, err := manager.Load(cfg)
+	reloaded, err := manager.Load(wallet.LoadWalletParams{
+		Name:          cfg.Name,
+		PubPassphrase: params.PubPassphrase,
+	})
 	require.NoError(h, err, "failed to reload wallet")
 	h.RegisterWallet(manager, reloaded)
 	require.NoError(

--- a/itest/manager_test.go
+++ b/itest/manager_test.go
@@ -19,10 +19,10 @@ func testManagerLoadConcurrent(h *bwtest.HarnessTest) {
 	// test Manager opens the same backend with an empty runtime cache. Using
 	// two Managers is required to exercise a true cold Load on kvdb as well
 	// as SQL.
-	cfg, params := h.TestWalletConfig()
+	params := h.TestWalletParams()
 	setupManager := h.NewWalletManager()
 
-	created, err := setupManager.Create(cfg, params)
+	created, err := setupManager.Create(params)
 	require.NoError(h, err, "failed to create wallet")
 	require.NoError(h, created.Stop(h.Context()), "failed to stop wallet")
 	require.NoError(h, setupManager.Close(), "failed to close setup manager")
@@ -58,7 +58,7 @@ func testManagerLoadConcurrent(h *bwtest.HarnessTest) {
 			<-start
 
 			w, err := manager.Load(wallet.LoadWalletParams{
-				Name:          cfg.Name,
+				Name:          params.Name,
 				PubPassphrase: params.PubPassphrase,
 			})
 			results <- result{wallet: w, err: err}
@@ -87,10 +87,10 @@ func testManagerLoadConcurrent(h *bwtest.HarnessTest) {
 func testCreateWallet(h *bwtest.HarnessTest) {
 	// This is a manager-focused test, so drive the Manager API directly
 	// rather than the harness's CreateEmptyWallet convenience helper.
-	cfg, params := h.TestWalletConfig()
+	params := h.TestWalletParams()
 	manager := h.NewWalletManager()
 
-	w, err := manager.Create(cfg, params)
+	w, err := manager.Create(params)
 	require.NoError(h, err, "failed to create wallet")
 
 	// Register before Start so teardown owns the wallet even if Start fails.
@@ -113,10 +113,10 @@ func testCreateWallet(h *bwtest.HarnessTest) {
 // testManagerCreateDuplicate verifies that both a live wallet cache entry and
 // a completed wallet in the durable store reject a duplicate creation.
 func testManagerCreateDuplicate(h *bwtest.HarnessTest) {
-	cfg, params := h.TestWalletConfig()
+	params := h.TestWalletParams()
 
 	manager := h.NewWalletManager()
-	w, err := manager.Create(cfg, params)
+	w, err := manager.Create(params)
 	require.NoError(h, err, "failed to create wallet")
 	h.RegisterWallet(manager, w)
 
@@ -125,7 +125,7 @@ func testManagerCreateDuplicate(h *bwtest.HarnessTest) {
 
 	// Creating a duplicate while the original is still cached must fail before
 	// the manager consults the durable store.
-	duplicate, err := manager.Create(cfg, params)
+	duplicate, err := manager.Create(params)
 	require.Error(h, err, "duplicate create not rejected by live wallet cache")
 	require.Nil(h, duplicate, "duplicate create returned a wallet")
 
@@ -138,7 +138,7 @@ func testManagerCreateDuplicate(h *bwtest.HarnessTest) {
 	manager = h.NewWalletManager()
 
 	// A fresh manager must reject creation over the completed durable wallet.
-	duplicate, err = manager.Create(cfg, params)
+	duplicate, err = manager.Create(params)
 	require.Error(h, err, "duplicate create not rejected against durable store")
 	require.Nil(h, duplicate, "duplicate create returned a wallet")
 }
@@ -146,7 +146,7 @@ func testManagerCreateDuplicate(h *bwtest.HarnessTest) {
 // testManagerLoadReload verifies Manager cache identity, durable reload, and
 // birthday metadata while preserving lifecycle ownership.
 func testManagerLoadReload(h *bwtest.HarnessTest) {
-	cfg, params := h.TestWalletConfig()
+	params := h.TestWalletParams()
 
 	// Keep the effective birthday five days ahead of the chain after the
 	// wallet's two-day safety margin. With every candidate too early, one real
@@ -154,7 +154,7 @@ func testManagerLoadReload(h *bwtest.HarnessTest) {
 	params.Birthday = time.Now().Add(7 * 24 * time.Hour)
 
 	manager := h.NewWalletManager()
-	w, err := manager.Create(cfg, params)
+	w, err := manager.Create(params)
 	require.NoError(h, err, "failed to create wallet")
 	h.RegisterWallet(manager, w)
 
@@ -177,7 +177,7 @@ func testManagerLoadReload(h *bwtest.HarnessTest) {
 	// Loading an already-loaded wallet returns the same live instance
 	// without rebuilding.
 	wCached, err := manager.Load(wallet.LoadWalletParams{
-		Name:          cfg.Name,
+		Name:          params.Name,
 		PubPassphrase: params.PubPassphrase,
 	})
 	require.NoError(h, err, "failed to load cached wallet")
@@ -193,7 +193,7 @@ func testManagerLoadReload(h *bwtest.HarnessTest) {
 
 	// Reload a fresh instance from the same durable store.
 	reloaded, err := manager.Load(wallet.LoadWalletParams{
-		Name:          cfg.Name,
+		Name:          params.Name,
 		PubPassphrase: params.PubPassphrase,
 	})
 	require.NoError(h, err, "failed to reload wallet")
@@ -225,12 +225,12 @@ func testManagerLoadReload(h *bwtest.HarnessTest) {
 func testManagerLoadMissing(h *bwtest.HarnessTest) {
 	// Arrange a manager whose durable store has never contained the named
 	// wallet from the standard test configuration.
-	cfg, params := h.TestWalletConfig()
+	params := h.TestWalletParams()
 	manager := h.NewWalletManager()
 
 	// Act by asking the manager to load the never-created wallet.
 	w, err := manager.Load(wallet.LoadWalletParams{
-		Name:          cfg.Name,
+		Name:          params.Name,
 		PubPassphrase: params.PubPassphrase,
 	})
 
@@ -248,12 +248,12 @@ func testManagerLoadMissing(h *bwtest.HarnessTest) {
 // The wallet is rootless: that is the one watch-only shape every backend can
 // represent, and its keyspace arrives later as account-level xpub imports.
 func testManagerCreateWatchOnly(h *bwtest.HarnessTest) {
-	cfg, params := h.TestWalletConfig()
+	params := h.TestWalletParams()
 	params.Mode = wallet.ModeShell
 	params.WatchOnly = true
 
 	manager := h.NewWalletManager()
-	w, err := manager.Create(cfg, params)
+	w, err := manager.Create(params)
 	require.NoError(h, err, "failed to create watch-only wallet")
 	h.RegisterWallet(manager, w)
 
@@ -274,7 +274,7 @@ func testManagerCreateWatchOnly(h *bwtest.HarnessTest) {
 
 	manager = h.NewWalletManager()
 	reloaded, err := manager.Load(wallet.LoadWalletParams{
-		Name:          cfg.Name,
+		Name:          params.Name,
 		PubPassphrase: params.PubPassphrase,
 	})
 	require.NoError(h, err, "failed to reload watch-only wallet")

--- a/itest/manager_test.go
+++ b/itest/manager_test.go
@@ -57,7 +57,10 @@ func testManagerLoadConcurrent(h *bwtest.HarnessTest) {
 			ready.Done()
 			<-start
 
-			w, err := manager.Load(cfg)
+			w, err := manager.Load(wallet.LoadWalletParams{
+				Name:          cfg.Name,
+				PubPassphrase: params.PubPassphrase,
+			})
 			results <- result{wallet: w, err: err}
 		}()
 	}
@@ -173,7 +176,10 @@ func testManagerLoadReload(h *bwtest.HarnessTest) {
 
 	// Loading an already-loaded wallet returns the same live instance
 	// without rebuilding.
-	wCached, err := manager.Load(cfg)
+	wCached, err := manager.Load(wallet.LoadWalletParams{
+		Name:          cfg.Name,
+		PubPassphrase: params.PubPassphrase,
+	})
 	require.NoError(h, err, "failed to load cached wallet")
 	require.Same(h, w, wCached, "load of cached wallet rebuilt the instance")
 
@@ -186,7 +192,10 @@ func testManagerLoadReload(h *bwtest.HarnessTest) {
 	manager = h.NewWalletManager()
 
 	// Reload a fresh instance from the same durable store.
-	reloaded, err := manager.Load(cfg)
+	reloaded, err := manager.Load(wallet.LoadWalletParams{
+		Name:          cfg.Name,
+		PubPassphrase: params.PubPassphrase,
+	})
 	require.NoError(h, err, "failed to reload wallet")
 	h.RegisterWallet(manager, reloaded)
 	require.NotSame(h, w, reloaded, "reload returned the torn-down instance")
@@ -216,11 +225,14 @@ func testManagerLoadReload(h *bwtest.HarnessTest) {
 func testManagerLoadMissing(h *bwtest.HarnessTest) {
 	// Arrange a manager whose durable store has never contained the named
 	// wallet from the standard test configuration.
-	cfg, _ := h.TestWalletConfig()
+	cfg, params := h.TestWalletConfig()
 	manager := h.NewWalletManager()
 
 	// Act by asking the manager to load the never-created wallet.
-	w, err := manager.Load(cfg)
+	w, err := manager.Load(wallet.LoadWalletParams{
+		Name:          cfg.Name,
+		PubPassphrase: params.PubPassphrase,
+	})
 
 	// Assert that the public missing-wallet contract is returned without a
 	// partially assembled wallet.
@@ -261,7 +273,10 @@ func testManagerCreateWatchOnly(h *bwtest.HarnessTest) {
 	require.True(h, h.ReleaseManager(manager), "failed to release manager")
 
 	manager = h.NewWalletManager()
-	reloaded, err := manager.Load(cfg)
+	reloaded, err := manager.Load(wallet.LoadWalletParams{
+		Name:          cfg.Name,
+		PubPassphrase: params.PubPassphrase,
+	})
 	require.NoError(h, err, "failed to reload watch-only wallet")
 	h.RegisterWallet(manager, reloaded)
 

--- a/wallet/common_test.go
+++ b/wallet/common_test.go
@@ -127,7 +127,8 @@ func testSQLiteManager(tb testing.TB) *Manager {
 	m, err := NewManager(context.Background(), ManagerConfig{
 		Backend:     DBBackendSQLite,
 		DataSource:  filepath.Join(tb.TempDir(), "runtime.sqlite"),
-		ChainParams: &chainParams,
+		ChainParams: chainParams,
+		ChainSource: &bwmock.Chain{},
 	})
 	require.NoError(tb, err)
 	tb.Cleanup(func() { _ = m.Close() })
@@ -169,7 +170,8 @@ func testKVDBManagerAt(tb testing.TB, dbPath string) *Manager {
 	m, err := NewManager(context.Background(), ManagerConfig{
 		Backend:     DBBackendKVDB,
 		DataSource:  dbPath,
-		ChainParams: &chainParams,
+		ChainParams: chainParams,
+		ChainSource: &bwmock.Chain{},
 	})
 	require.NoError(tb, err)
 	tb.Cleanup(func() { _ = m.Close() })

--- a/wallet/common_test.go
+++ b/wallet/common_test.go
@@ -148,7 +148,12 @@ func testSQLManager(tb testing.TB, store db.Store) *Manager {
 			store:   store,
 			closeFn: func() error { return nil },
 		},
-		chainParams: &chainParams,
+		config: ManagerConfig{
+			ChainSource:             &bwmock.Chain{},
+			ChainParams:             chainParams,
+			WalletSyncRetryInterval: initialBackoff,
+			AutoLockDuration:        defaultLockDuration,
+		},
 	}
 }
 

--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -235,7 +235,7 @@ func (w *Wallet) Start(startCtx context.Context) error {
 // retries and exponential backoff. It ensures the wallet attempts to stay
 // synced even if the backend connection is flaky.
 func (w *Wallet) runSyncLoop() {
-	backoff := initialBackoff
+	backoff := w.initialSyncBackoff()
 
 	for {
 		startTime := time.Now()
@@ -270,6 +270,16 @@ func (w *Wallet) runSyncLoop() {
 	}
 }
 
+// initialSyncBackoff returns the Wallet-local retry policy, preserving the
+// controller default for legacy or test Wallets assembled without Manager.
+func (w *Wallet) initialSyncBackoff() time.Duration {
+	if w.cfg.WalletSyncRetryInterval <= 0 {
+		return initialBackoff
+	}
+
+	return w.cfg.WalletSyncRetryInterval
+}
+
 // waitForBackoff handles the delay between synchronization retry attempts. It
 // resets the backoff if the previous run was stable, waits for the calculated
 // delay, and then returns the updated backoff duration for the next attempt.
@@ -280,7 +290,7 @@ func (w *Wallet) waitForBackoff(startTime time.Time, backoff time.Duration,
 	// If the syncer ran for a significant amount of time, we consider it a
 	// "stable" run and reset the backoff.
 	if time.Since(startTime) > stableRunTime {
-		backoff = initialBackoff
+		backoff = w.initialSyncBackoff()
 	}
 
 	log.Infof("Restarting sync loop in %v...", backoff)

--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -486,10 +486,17 @@ func (w *Wallet) Info(ctx context.Context) (*Info, error) {
 		return nil, fmt.Errorf("decode wallet sync tip: %w", err)
 	}
 
+	// Info is an ownership boundary, so return a fresh network snapshot
+	// instead of exposing the Wallet's retained mutable configuration.
+	chainParams, err := cloneChainParams(*w.cfg.ChainParams)
+	if err != nil {
+		return nil, fmt.Errorf("copy chain parameters: %w", err)
+	}
+
 	info := &Info{
 		BirthdayBlock:    w.birthdayBlock,
 		Backend:          w.cfg.Chain.BackEnd(),
-		ChainParams:      w.cfg.ChainParams,
+		ChainParams:      &chainParams,
 		Locked:           !w.state.isUnlocked(),
 		Synced:           w.state.isSynced(),
 		SyncedTo:         syncedTo,

--- a/wallet/controller_benchmark_test.go
+++ b/wallet/controller_benchmark_test.go
@@ -257,15 +257,10 @@ func runNewSync(b *testing.B, miner *rpctest.Harness, method SyncMethod) {
 		// Connect a fresh chain client.
 		chainClient := setupChainClient(b, miner)
 
-		// Configure for the specified sync mode.
-		cfg := defaultWalletConfig(b)
-		cfg.Chain = chainClient
-		cfg.SyncMethod = method
-
 		// Setup a fresh modern wallet.
 		seed, err := hdkeychain.GenerateSeed(hdkeychain.MinSeedBytes)
 		require.NoError(b, err)
-		w := setupNewWallet(b, seed, cfg)
+		w := setupNewWallet(b, seed, chainClient, method)
 
 		stopProfile := startProfiling(b)
 
@@ -310,11 +305,7 @@ func runNewSyncData(b *testing.B, miner *rpctest.Harness, seed []byte,
 		b.StopTimer()
 
 		chainClient := setupChainClient(b, miner)
-		cfg := defaultWalletConfig(b)
-		cfg.Chain = chainClient
-		cfg.SyncMethod = method
-
-		w := setupNewWallet(b, seed, cfg)
+		w := setupNewWallet(b, seed, chainClient, method)
 
 		stopProfile := startProfiling(b)
 
@@ -386,32 +377,44 @@ func setupLegacyWallet(tb testing.TB, seed []byte) *Wallet {
 	return w
 }
 
-// setupNewWallet initializes a modern wallet using the Manager API. It accepts
-// a Config which should at least have the Chain client populated. It
-// automatically registers resource cleanup.
-func setupNewWallet(tb testing.TB, seed []byte, cfg Config) *Wallet {
+// setupNewWallet initializes a modern benchmark Wallet with runtime inputs on
+// its Manager and automatically registers ordered resource cleanup.
+func setupNewWallet(tb testing.TB, seed []byte, chainSource chain.Interface,
+	method SyncMethod) *Wallet {
+
 	tb.Helper()
 
 	privPass := []byte("private")
 	params := CreateWalletParams{
+		Name:              "bench-wallet",
 		Mode:              ModeImportSeed,
 		Seed:              seed,
+		PubPassphrase:     []byte("public"),
 		PrivatePassphrase: privPass,
-		PubPassphrase:     cfg.PubPassphrase,
 		Birthday:          time.Now().Add(-48 * time.Hour),
 	}
 
-	// Create the wallet using the new Manager API. This returns a loaded
-	// but unstarted wallet instance.
-	manager := testKVDBManager(tb)
-	w, err := manager.Create(cfg, params)
+	// The Manager retains every runtime input, including the shared chain
+	// source; the request below carries only durable initialization data.
+	manager, err := NewManager(tb.Context(), ManagerConfig{
+		Backend:                 DBBackendKVDB,
+		DataSource:              testKVDBPath(tb),
+		ChainParams:             chaincfg.RegressionNetParams,
+		ChainSource:             chainSource,
+		SyncMethod:              method,
+		WalletSyncRetryInterval: 10 * time.Millisecond,
+		RecoveryWindow:          testRecoveryWindow,
+	})
 	require.NoError(tb, err)
 
-	// Register cleanup function to handle the Controller shutdown and close
-	// the database handle after the benchmark subtest.
+	w, err := manager.Create(params)
+	require.NoError(tb, err)
+
+	// Cleanup follows ownership order: stop the Wallet before closing the
+	// Manager-owned database handle used by its storage dependencies.
 	tb.Cleanup(func() {
 		_ = w.Stop(tb.Context())
-		// The Manager owns the store; the wallet closes nothing.
+		_ = manager.Close()
 	})
 
 	return w
@@ -454,10 +457,9 @@ func setupChainWithWalletData(tb testing.TB, seed []byte,
 	miner := setupChain(tb, 0)
 
 	// 1. Setup a template wallet to extract addresses for the chain.
-	cfg := defaultWalletConfig(tb)
-	cfg.Chain = setupChainClient(tb, miner)
-
-	templateW := setupNewWallet(tb, seed, cfg)
+	templateW := setupNewWallet(
+		tb, seed, setupChainClient(tb, miner), SyncMethodAuto,
+	)
 
 	err := templateW.Start(tb.Context())
 	require.NoError(tb, err)
@@ -784,19 +786,6 @@ func setupChainClient(tb testing.TB, miner *rpctest.Harness) chain.Interface {
 	}, 30*time.Second, 100*time.Millisecond)
 
 	return btcClient
-}
-
-// defaultWalletConfig returns a Config with standard benchmark settings.
-func defaultWalletConfig(tb testing.TB) Config {
-	tb.Helper()
-
-	return Config{
-		ChainParams:             &chaincfg.RegressionNetParams,
-		Name:                    "bench-wallet",
-		PubPassphrase:           []byte("public"),
-		WalletSyncRetryInterval: 10 * time.Millisecond,
-		RecoveryWindow:          testRecoveryWindow,
-	}
 }
 
 // assertUTXOCount verifies the number of unspent outputs in a modern wallet.

--- a/wallet/controller_test.go
+++ b/wallet/controller_test.go
@@ -1527,41 +1527,57 @@ func TestControllerStart_BirthdayNotSet(t *testing.T) {
 	w.wg.Wait()
 }
 
-// TestControllerUnlock_DefaultTimeout verifies default timeout usage.
-func TestControllerUnlock_DefaultTimeout(t *testing.T) {
+// TestControllerUnlockDefaultTimeout verifies an omitted request timeout is
+// replaced with the Manager-normalized Wallet policy before timer handling.
+func TestControllerUnlockDefaultTimeout(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Setup a wallet with an auto-lock duration and start the
-	// main loop.
-	w, deps := createTestWalletWithMocks(t)
-
-	w.cfg.AutoLockDuration = time.Minute
+	// Arrange: Put a Wallet in the state accepted by Unlock and configure a
+	// distinctive default. Leave its main loop stopped so the test can inspect
+	// the serialized request at the boundary immediately before handleUnlockReq
+	// uses the request timeout to reset the auto-lock timer.
+	w, _ := createTestWalletWithMocks(t)
+	autoLockDuration := time.Minute
+	w.cfg.AutoLockDuration = autoLockDuration
 
 	require.NoError(t, w.state.toStarting())
 	require.NoError(t, w.state.toStarted())
 
-	w.wg.Add(1)
+	// Act: Invoke Unlock asynchronously because it waits for the main loop's
+	// response, then intercept the exact request the main loop would handle.
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- w.Unlock(t.Context(), UnlockRequest{
+			Passphrase: []byte("pass"),
+		})
+	}()
 
-	go w.mainLoop()
+	var req unlockReq
+	select {
+	case rawReq := <-w.requestChan:
+		var ok bool
 
-	pass := []byte("pass")
-	req := UnlockRequest{Passphrase: pass}
-	deps.vault.On(
-		"Unlock", mock.Anything, pass,
-	).Return(nil).Once()
-	// Auto-lock might trigger if the test runs slowly, but it's not
-	// guaranteed.
-	deps.vault.On("Lock").Return().Maybe()
+		req, ok = rawReq.(unlockReq)
+		require.True(t, ok)
 
-	// Act: Perform Unlock with default timeout.
-	err := w.Unlock(t.Context(), req)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for unlock request")
+	}
 
-	// Assert: Verify success.
-	require.NoError(t, err)
+	// Assert: The serialized request carries the configured default into the
+	// timer handler. Complete the intercepted request and verify Unlock returns
+	// successfully so its caller-facing response path is not left blocked.
+	require.Equal(t, autoLockDuration, req.req.Timeout)
 
-	// Clean up.
-	w.cancel()
-	w.wg.Wait()
+	req.resp <- nil
+
+	select {
+	case err := <-errChan:
+		require.NoError(t, err)
+
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for unlock response")
+	}
 }
 
 // TestControllerStart_DeleteExpiredFail verifies Start fails when

--- a/wallet/controller_test.go
+++ b/wallet/controller_test.go
@@ -8,9 +8,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
+	bwmock "github.com/btcsuite/btcwallet/bwtest/mock"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	walletmock "github.com/btcsuite/btcwallet/wallet/internal/bwtest/mock"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wallet/internal/keyvault"
 	"github.com/stretchr/testify/mock"
@@ -1249,6 +1252,56 @@ func TestControllerInfo(t *testing.T) {
 	err = w.Stop(t.Context())
 	require.NoError(t, err)
 	w.wg.Wait()
+}
+
+// TestControllerInfoCopiesChainParams verifies the information API never
+// exposes the Wallet's retained network policy through a mutable pointer.
+func TestControllerInfoCopiesChainParams(t *testing.T) {
+	t.Parallel()
+
+	const mutatedName = "mutated"
+
+	// Arrange: Build a started Wallet around strict Store and Chain mocks.
+	// Two calls are expected so a mutation of the first result can be checked
+	// against a separately produced second snapshot.
+	store := &walletmock.Store{}
+	chain := &bwmock.Chain{}
+
+	store.On("GetWallet", mock.Anything, "isolated").Return(
+		&db.WalletInfo{}, nil,
+	).Twice()
+	chain.On("BackEnd").Return("mock").Twice()
+
+	params := chaincfg.MainNetParams
+	w := &Wallet{
+		store: store,
+		cfg: Config{
+			Name:        "isolated",
+			Chain:       chain,
+			ChainParams: &params,
+		},
+		state: newWalletState(nil),
+	}
+	require.NoError(t, w.state.toStarting())
+	require.NoError(t, w.state.toStarted())
+
+	// Act: Mutate nested values in the first Info result, then request a new
+	// snapshot from the same retained Wallet configuration.
+	first, err := w.Info(t.Context())
+	require.NoError(t, err)
+
+	first.ChainParams.Name = mutatedName
+	first.ChainParams.PowLimit.SetInt64(1)
+
+	second, err := w.Info(t.Context())
+
+	// Assert: Verify the second result still matches the Wallet's policy and
+	// every mocked interaction occurred with its exact planned cardinality.
+	require.NoError(t, err)
+	require.Equal(t, params.Name, second.ChainParams.Name)
+	require.Equal(t, params.PowLimit, second.ChainParams.PowLimit)
+	store.AssertExpectations(t)
+	chain.AssertExpectations(t)
 }
 
 // TestControllerInfoSyncTipErrors verifies Info preserves Store errors and

--- a/wallet/controller_test.go
+++ b/wallet/controller_test.go
@@ -1751,24 +1751,24 @@ func TestControllerLock_StateError(t *testing.T) {
 	require.ErrorIs(t, err, ErrStateForbidden)
 }
 
-// TestWaitForBackoff_StableRun verifies that the backoff is reset to the
-// initial value if the syncer has been running for a stable amount of time.
-func TestWaitForBackoff_StableRun(t *testing.T) {
+// TestWaitForBackoffStableRun verifies a stable sync run resets to the
+// Wallet-local retry policy instead of an independent controller constant.
+func TestWaitForBackoffStableRun(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Create a wallet with a canceled context to avoid waiting.
+	// Arrange: Give a Wallet a distinctive Manager-owned retry interval and a
+	// timer seam that records the reset value while firing immediately.
+	retryInterval := 3 * time.Second
 	w := &Wallet{
 		lifetimeCtx: context.Background(),
+		cfg: Config{
+			WalletSyncRetryInterval: retryInterval,
+		},
 	}
-
-	// Mock a start time that exceeds the stable run time.
 	startTime := time.Now().Add(-stableRunTime - time.Minute)
 	currentBackoff := maxBackoff
-
-	// Mock the timer function to fire immediately.
 	timerFn := func(d time.Duration) <-chan time.Time {
-		// Verify that the backoff was reset to initial before waiting.
-		require.Equal(t, initialBackoff, d)
+		require.Equal(t, retryInterval, d)
 
 		c := make(chan time.Time, 1)
 		c <- time.Now()
@@ -1776,12 +1776,13 @@ func TestWaitForBackoff_StableRun(t *testing.T) {
 		return c
 	}
 
-	// Act: Wait for backoff.
+	// Act: Apply retry backoff after a run long enough to be stable.
 	nextBackoff, ok := w.waitForBackoff(startTime, currentBackoff, timerFn)
 
-	// Assert: Verify that the operation continued and backoff doubled.
+	// Assert: Verify the configured interval was used and exponential growth
+	// continues from that Manager-owned reset point.
 	require.True(t, ok)
-	require.Equal(t, initialBackoff*2, nextBackoff)
+	require.Equal(t, retryInterval*2, nextBackoff)
 }
 
 // TestWaitForBackoff_UnstableRun verifies that the backoff duration doubles

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -67,6 +67,9 @@ type WatchOnlyAccount struct {
 // CreateWalletParams holds the parameters required to initialize a new wallet.
 // These are one-time inputs used during the creation process.
 type CreateWalletParams struct {
+	// Name is the durable identity used for Manager cache and Store operations.
+	Name string
+
 	// Mode determines which fields below are required.
 	Mode CreateMode
 
@@ -88,11 +91,10 @@ type CreateWalletParams struct {
 	// Birthday is the wallet's birthday.
 	Birthday time.Time
 
-	// PubPassphrase is the public passphrase for the wallet.
+	// PubPassphrase creates the legacy kvdb wallet. SQL backends ignore it
+	// because they have no public encryption passphrase.
 	//
-	// Deprecated: only the kvdb backend has a public passphrase. A SQL
-	// wallet seals its metadata under a single passphrase, so this field is
-	// ignored there and goes away with kvdb support.
+	// Remove this field with kvdb support.
 	PubPassphrase []byte
 
 	// PrivatePassphrase is the private passphrase for the wallet.
@@ -226,15 +228,11 @@ func validateManagedWalletName(name string) error {
 	return nil
 }
 
-// Create creates a new wallet based on the provided configuration and
-// initialization parameters. It initializes the database structure and then
-// loads the wallet.
-func (m *Manager) Create(cfg Config,
-	params CreateWalletParams) (*Wallet, error) {
-
-	// Only the durable name is still read from Config until the maintained API
-	// is narrowed; all chain and runtime policy comes from Manager.
-	err := validateManagedWalletName(cfg.Name)
+// Create persists and assembles a Wallet with Manager-owned runtime policy.
+func (m *Manager) Create(params CreateWalletParams) (*Wallet, error) {
+	// Validate identity before key derivation or Store work can produce a less
+	// useful error or side effect.
+	err := validateManagedWalletName(params.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -244,20 +242,23 @@ func (m *Manager) Create(cfg Config,
 		return nil, err
 	}
 
-	walletCfg, err := m.config.walletConfig(cfg.Name)
-	if err != nil {
-		return nil, err
-	}
-
-	rootKey, err := m.deriveRootKey(walletCfg, params)
+	rootKey, err := m.deriveRootKey(params)
 	if err != nil {
 		return nil, err
 	}
 
 	m.Lock()
-	data, err := m.backend.create(
-		context.Background(), walletCfg, params, rootKey,
-	)
+
+	// The Manager mutex keeps runtime assembly, Store mutation, and cache
+	// publication atomic so no partial Wallet becomes observable.
+	walletCfg, err := m.config.walletConfig(params.Name)
+	if err != nil {
+		m.Unlock()
+
+		return nil, err
+	}
+
+	data, err := m.backend.create(context.Background(), params, rootKey)
 	if err != nil {
 		m.Unlock()
 
@@ -461,15 +462,15 @@ func (m *Manager) Load(params LoadWalletParams) (*Wallet, error) {
 
 // deriveRootKey resolves the master extended key after creation parameters have
 // passed validation.
-func (m *Manager) deriveRootKey(cfg Config,
+func (m *Manager) deriveRootKey(
 	params CreateWalletParams) (*hdkeychain.ExtendedKey, error) {
 
 	if params.Mode == ModeGenSeed {
-		return m.genRootKey(cfg)
+		return m.genRootKey()
 	}
 
 	if params.Mode == ModeImportSeed {
-		return m.deriveFromSeed(cfg, params.Seed)
+		return m.deriveFromSeed(params.Seed)
 	}
 
 	if params.Mode == ModeImportExtKey {
@@ -483,18 +484,18 @@ func (m *Manager) deriveRootKey(cfg Config,
 
 // genRootKey generates a fresh random seed and derives its master extended
 // private key.
-func (m *Manager) genRootKey(cfg Config) (*hdkeychain.ExtendedKey, error) {
+func (m *Manager) genRootKey() (*hdkeychain.ExtendedKey, error) {
 	seed, err := hdkeychain.GenerateSeed(hdkeychain.RecommendedSeedLen)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate seed: %w", err)
 	}
 
-	return m.deriveFromSeed(cfg, seed)
+	return m.deriveFromSeed(seed)
 }
 
 // deriveFromSeed derives the master extended private key from the provided
 // seed.
-func (m *Manager) deriveFromSeed(cfg Config, seed []byte) (
+func (m *Manager) deriveFromSeed(seed []byte) (
 	*hdkeychain.ExtendedKey, error) {
 
 	// Ensure a seed was provided for restoration.
@@ -503,7 +504,7 @@ func (m *Manager) deriveFromSeed(cfg Config, seed []byte) (
 	}
 
 	// Derive the master extended private key from the provided seed.
-	key, err := hdkeychain.NewMaster(seed, cfg.ChainParams)
+	key, err := hdkeychain.NewMaster(seed, &m.config.ChainParams)
 	if err != nil {
 		return nil, fmt.Errorf("failed to derive master key: %w", err)
 	}

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -398,39 +398,47 @@ func validateInitialAccountKeys(accounts []WatchOnlyAccount) error {
 // for tracking. If the named wallet does not exist, Load returns
 // ErrWalletNotFound.
 func (m *Manager) Load(cfg Config) (*Wallet, error) {
-	// The Manager owns the network for every wallet it serves; see Create.
-	cfg.ChainParams = &m.config.ChainParams
-
-	err := cfg.validate()
+	err := validateManagedWalletName(cfg.Name)
 	if err != nil {
 		return nil, err
 	}
 
+	name := cfg.Name
 	m.Lock()
 	defer m.Unlock()
 
 	// A wallet already installed under this name is returned as is. The
 	// Manager lock makes a miss the sole assembly owner until installation.
-	existingW, ok := m.wallets[cfg.Name]
+	existingW, ok := m.wallets[name]
 	if ok {
 		return existingW, nil
 	}
 
+	// A cache miss receives a fresh Wallet-local policy assembled from the
+	// Manager's immutable configuration snapshot.
+	walletCfg, err := m.config.walletConfig(name)
+	if err != nil {
+		return nil, err
+	}
+
+	// The backend still receives the request Config at this compatibility
+	// boundary because kvdb needs its public passphrase. Runtime policy comes
+	// exclusively from walletCfg and is never read from the request.
 	data, err := m.backend.load(context.Background(), cfg)
 	if err != nil {
 		// Hide the database sentinel at the public Manager boundary while
 		// retaining the requested wallet name for caller diagnostics.
 		if errors.Is(err, db.ErrWalletNotFound) {
 			return nil, fmt.Errorf(
-				"wallet %q: %w", cfg.Name, ErrWalletNotFound,
+				"wallet %q: %w", name, ErrWalletNotFound,
 			)
 		}
 
 		return nil, err
 	}
 
-	w := newManagedWallet(cfg, data)
-	m.wallets[cfg.Name] = w
+	w := newManagedWallet(walletCfg, data)
+	m.wallets[walletCfg.Name] = w
 
 	return w, nil
 }

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -99,6 +99,21 @@ type CreateWalletParams struct {
 	PrivatePassphrase []byte
 }
 
+// LoadWalletParams identifies an existing Wallet and carries inputs needed
+// only while its backend opens durable state.
+type LoadWalletParams struct {
+	// Name is the required runtime identity used by the Manager cache and SQL
+	// wallet lookup. The legacy kvdb backend also uses it for the one Wallet
+	// instance it can serve, but does not persist it as an alias.
+	Name string
+
+	// PubPassphrase opens the legacy kvdb wallet. SQL backends ignore it
+	// because they have no public encryption passphrase.
+	//
+	// Remove this field with kvdb support.
+	PubPassphrase []byte
+}
+
 // Manager is a high-level manager that handles the lifecycle of multiple
 // wallets. It acts as a factory for creating and loading wallets, and can
 // optionally track the active wallets.
@@ -143,11 +158,13 @@ func NewManager(ctx context.Context, cfg ManagerConfig) (*Manager, error) {
 	if err != nil {
 		return nil, fmt.Errorf("copy chain parameters: %w", err)
 	}
+
 	cfg.ChainParams = chainParams
 
 	if cfg.WalletSyncRetryInterval == 0 {
 		cfg.WalletSyncRetryInterval = initialBackoff
 	}
+
 	if cfg.AutoLockDuration <= 0 {
 		cfg.AutoLockDuration = defaultLockDuration
 	}
@@ -238,7 +255,6 @@ func (m *Manager) Create(cfg Config,
 	}
 
 	m.Lock()
-
 	data, err := m.backend.create(
 		context.Background(), walletCfg, params, rootKey,
 	)
@@ -393,22 +409,23 @@ func validateInitialAccountKeys(accounts []WatchOnlyAccount) error {
 	return nil
 }
 
-// Load loads an existing wallet from the provided configuration. It opens the
-// database, initializes the wallet structure, and registers it with the manager
-// for tracking. If the named wallet does not exist, Load returns
-// ErrWalletNotFound.
-func (m *Manager) Load(cfg Config) (*Wallet, error) {
-	err := validateManagedWalletName(cfg.Name)
+// Load opens the requested durable Wallet and assembles it from Manager-owned
+// runtime policy. If it does not exist, Load returns ErrWalletNotFound.
+func (m *Manager) Load(params LoadWalletParams) (*Wallet, error) {
+	// Validate identity before cache or backend work so every backend reports
+	// the same caller error for an empty name.
+	err := validateManagedWalletName(params.Name)
 	if err != nil {
 		return nil, err
 	}
 
-	name := cfg.Name
+	name := params.Name
+
 	m.Lock()
 	defer m.Unlock()
 
-	// A wallet already installed under this name is returned as is. The
-	// Manager lock makes a miss the sole assembly owner until installation.
+	// Serializing the cache check through installation ensures concurrent cold
+	// Loads share the one Wallet assembled by the first caller.
 	existingW, ok := m.wallets[name]
 	if ok {
 		return existingW, nil
@@ -421,10 +438,9 @@ func (m *Manager) Load(cfg Config) (*Wallet, error) {
 		return nil, err
 	}
 
-	// The backend still receives the request Config at this compatibility
-	// boundary because kvdb needs its public passphrase. Runtime policy comes
-	// exclusively from walletCfg and is never read from the request.
-	data, err := m.backend.load(context.Background(), cfg)
+	// Only the narrow request reaches the backend. The assembled Wallet never
+	// retains a legacy public passphrase.
+	data, err := m.backend.load(context.Background(), params)
 	if err != nil {
 		// Hide the database sentinel at the public Manager boundary while
 		// retaining the requested wallet name for caller diagnostics.

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
-	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 )
@@ -121,8 +120,8 @@ type Manager struct {
 	// every wallet this Manager serves.
 	backend managerBackend
 
-	// chainParams is fixed at construction and shared by every wallet.
-	chainParams *chaincfg.Params
+	// config is the immutable shared policy retained at construction.
+	config ManagerConfig
 }
 
 // NewManager opens the one database described by cfg and returns a Manager that
@@ -135,6 +134,22 @@ func NewManager(ctx context.Context, cfg ManagerConfig) (*Manager, error) {
 	err := cfg.validate()
 	if err != nil {
 		return nil, err
+	}
+
+	// Clone mutable network state and resolve defaults before the backend is
+	// opened, making the retained configuration the sole runtime authority for
+	// every Wallet assembled by this Manager.
+	chainParams, err := cloneChainParams(cfg.ChainParams)
+	if err != nil {
+		return nil, fmt.Errorf("copy chain parameters: %w", err)
+	}
+	cfg.ChainParams = chainParams
+
+	if cfg.WalletSyncRetryInterval == 0 {
+		cfg.WalletSyncRetryInterval = initialBackoff
+	}
+	if cfg.AutoLockDuration <= 0 {
+		cfg.AutoLockDuration = defaultLockDuration
 	}
 
 	var backend managerBackend
@@ -155,9 +170,9 @@ func NewManager(ctx context.Context, cfg ManagerConfig) (*Manager, error) {
 	}
 
 	return &Manager{
-		wallets:     make(map[string]*Wallet),
-		backend:     backend,
-		chainParams: &cfg.ChainParams,
+		wallets: make(map[string]*Wallet),
+		backend: backend,
+		config:  cfg,
 	}, nil
 }
 
@@ -184,21 +199,25 @@ func (m *Manager) String() string {
 	return fmt.Sprintf("active_wallets=%v", names)
 }
 
+// validateManagedWalletName rejects an absent durable identity before cache,
+// key-derivation, or Store work can obscure the caller error.
+func validateManagedWalletName(name string) error {
+	if name == "" {
+		return fmt.Errorf("%w: Name", ErrMissingParam)
+	}
+
+	return nil
+}
+
 // Create creates a new wallet based on the provided configuration and
 // initialization parameters. It initializes the database structure and then
 // loads the wallet.
 func (m *Manager) Create(cfg Config,
 	params CreateWalletParams) (*Wallet, error) {
 
-	// The Manager owns the network for every wallet it serves, so overwrite
-	// the caller's copy before validating. A caller that leaves it unset, or
-	// sets a conflicting one, gets the Manager's.
-	cfg.ChainParams = m.chainParams
-
-	// Validate the configuration and parameters before touching the cache
-	// or any store, so a malformed request fails on its own merits rather
-	// than on a name collision or store error.
-	err := cfg.validate()
+	// Only the durable name is still read from Config until the maintained API
+	// is narrowed; all chain and runtime policy comes from Manager.
+	err := validateManagedWalletName(cfg.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +227,12 @@ func (m *Manager) Create(cfg Config,
 		return nil, err
 	}
 
-	rootKey, err := m.deriveRootKey(cfg, params)
+	walletCfg, err := m.config.walletConfig(cfg.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	rootKey, err := m.deriveRootKey(walletCfg, params)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +240,7 @@ func (m *Manager) Create(cfg Config,
 	m.Lock()
 
 	data, err := m.backend.create(
-		context.Background(), cfg, params, rootKey,
+		context.Background(), walletCfg, params, rootKey,
 	)
 	if err != nil {
 		m.Unlock()
@@ -224,8 +248,8 @@ func (m *Manager) Create(cfg Config,
 		return nil, err
 	}
 
-	w := newManagedWallet(cfg, data)
-	m.wallets[cfg.Name] = w
+	w := newManagedWallet(walletCfg, data)
+	m.wallets[walletCfg.Name] = w
 	m.Unlock()
 
 	// If we are in shell mode and have initial accounts, we import them now.
@@ -375,7 +399,7 @@ func validateInitialAccountKeys(accounts []WatchOnlyAccount) error {
 // ErrWalletNotFound.
 func (m *Manager) Load(cfg Config) (*Wallet, error) {
 	// The Manager owns the network for every wallet it serves; see Create.
-	cfg.ChainParams = m.chainParams
+	cfg.ChainParams = &m.config.ChainParams
 
 	err := cfg.validate()
 	if err != nil {

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -111,7 +111,7 @@ type Manager struct {
 	sync.RWMutex
 
 	// wallets holds the active wallets keyed by their unique name. The
-	// Manager lock serializes Create and Load through assembly and cache
+	// Manager lock serializes runtime assembly, Store access, and cache
 	// installation. A ModeShell Create imports its initial accounts after
 	// installation, so a wallet can be observed here before that import
 	// finishes.
@@ -157,7 +157,7 @@ func NewManager(ctx context.Context, cfg ManagerConfig) (*Manager, error) {
 	return &Manager{
 		wallets:     make(map[string]*Wallet),
 		backend:     backend,
-		chainParams: cfg.ChainParams,
+		chainParams: &cfg.ChainParams,
 	}, nil
 }
 

--- a/wallet/manager_backend.go
+++ b/wallet/manager_backend.go
@@ -18,8 +18,9 @@ const defaultWalletDBDirPerm = 0o700
 // managerBackend owns the database used by a Manager and resolves the storage
 // dependencies needed to assemble a Wallet.
 type managerBackend interface {
-	// create initializes and opens a wallet on the backend.
-	create(ctx context.Context, cfg Config, params CreateWalletParams,
+	// create persists only identity and initialization data; runtime policy
+	// remains outside the backend and is applied by Manager assembly.
+	create(ctx context.Context, params CreateWalletParams,
 		rootKey *hdkeychain.ExtendedKey) (*walletData, error)
 
 	// load opens durable wallet data with a narrow request that cannot alter

--- a/wallet/manager_backend.go
+++ b/wallet/manager_backend.go
@@ -22,8 +22,9 @@ type managerBackend interface {
 	create(ctx context.Context, cfg Config, params CreateWalletParams,
 		rootKey *hdkeychain.ExtendedKey) (*walletData, error)
 
-	// load opens an existing wallet on the backend.
-	load(ctx context.Context, cfg Config) (*walletData, error)
+	// load opens durable wallet data with a narrow request that cannot alter
+	// the Manager-owned Wallet runtime policy.
+	load(ctx context.Context, params LoadWalletParams) (*walletData, error)
 
 	// close releases the database and any live managers owned by the backend.
 	close() error

--- a/wallet/manager_config.go
+++ b/wallet/manager_config.go
@@ -117,7 +117,7 @@ type ManagerConfig struct {
 
 // validate checks Manager-wide ownership and backend consistency before any
 // Store is opened. Safe duration defaults are applied only when the immutable
-// runtime snapshot is built after this validation succeeds.
+// configuration snapshot is built after this validation succeeds.
 func (c ManagerConfig) validate() error {
 	err := c.validateBackend()
 	if err != nil {
@@ -182,6 +182,27 @@ func (c ManagerConfig) validateRuntimePolicy() error {
 	}
 
 	return nil
+}
+
+// walletConfig constructs one Wallet-local policy from the Manager snapshot.
+// It shares the caller-owned chain source and copies mutable values again so
+// sibling Wallets cannot alter each other's runtime configuration.
+func (c ManagerConfig) walletConfig(name string) (Config, error) {
+	chainParams, err := cloneChainParams(c.ChainParams)
+	if err != nil {
+		return Config{}, fmt.Errorf("copy wallet chain parameters: %w", err)
+	}
+
+	return Config{
+		Chain:                   c.ChainSource,
+		ChainParams:             &chainParams,
+		RecoveryWindow:          c.RecoveryWindow,
+		WalletSyncRetryInterval: c.WalletSyncRetryInterval,
+		SyncMethod:              c.SyncMethod,
+		AutoLockDuration:        c.AutoLockDuration,
+		Name:                    name,
+		MaxCFilterItems:         c.MaxCFilterItems,
+	}, nil
 }
 
 // timeout returns the configured walletdb timeout or the default.

--- a/wallet/manager_config.go
+++ b/wallet/manager_config.go
@@ -115,10 +115,21 @@ type ManagerConfig struct {
 	Timeout time.Duration
 }
 
-// validate checks a ManagerConfig once, at construction. There is no
-// defaulting: an unset backend or data source is an error rather than a guess,
-// so a wallet is never opened somewhere the caller did not name.
+// validate checks Manager-wide ownership and backend consistency before any
+// Store is opened. Safe duration defaults are applied only when the immutable
+// runtime snapshot is built after this validation succeeds.
 func (c ManagerConfig) validate() error {
+	err := c.validateBackend()
+	if err != nil {
+		return err
+	}
+
+	return c.validateRuntimePolicy()
+}
+
+// validateBackend checks the Store selector and its common connection inputs
+// together so backend errors remain independent from Wallet runtime policy.
+func (c ManagerConfig) validateBackend() error {
 	switch c.Backend {
 	case DBBackendKVDB, DBBackendSQLite, DBBackendPostgres:
 
@@ -133,15 +144,41 @@ func (c ManagerConfig) validate() error {
 		return fmt.Errorf("%w: DataSource", ErrMissingParam)
 	}
 
-	if c.ChainParams.Name == "" {
-		return fmt.Errorf("%w: ChainParams", ErrMissingParam)
-	}
-
 	// MaxConnections is a SQL pool bound; kvdb ignores it, so only the SQL
 	// backends validate it.
 	if c.Backend != DBBackendKVDB && c.MaxConnections < 0 {
 		return fmt.Errorf("%w: MaxConnections must not be negative",
 			ErrInvalidParam)
+	}
+
+	return nil
+}
+
+// validateRuntimePolicy checks the chain and synchronization values copied
+// into every managed Wallet before any backend can observe the configuration.
+func (c ManagerConfig) validateRuntimePolicy() error {
+	if c.ChainParams.Name == "" {
+		return fmt.Errorf("%w: ChainParams", ErrMissingParam)
+	}
+
+	switch c.SyncMethod {
+	case SyncMethodAuto, SyncMethodCFilters, SyncMethodFullBlocks:
+
+	default:
+		return fmt.Errorf("%w: SyncMethod %d", ErrInvalidParam,
+			c.SyncMethod)
+	}
+
+	if c.WalletSyncRetryInterval < 0 ||
+		c.WalletSyncRetryInterval > maxBackoff {
+
+		return fmt.Errorf("%w: WalletSyncRetryInterval must be between 0 "+
+			"and %v", ErrInvalidParam, maxBackoff)
+	}
+
+	if c.RecoveryWindow > MaxRecoveryWindow {
+		return fmt.Errorf("%w: RecoveryWindow must not exceed %d",
+			ErrInvalidParam, MaxRecoveryWindow)
 	}
 
 	return nil

--- a/wallet/manager_config.go
+++ b/wallet/manager_config.go
@@ -3,6 +3,8 @@ package wallet
 import (
 	"errors"
 	"fmt"
+	"math/big"
+	"slices"
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/v2"
@@ -117,4 +119,77 @@ func (c ManagerConfig) timeout() time.Duration {
 	}
 
 	return c.Timeout
+}
+
+// cloneChainParams returns an ownership-isolated network snapshot. The copy
+// includes every nested mutable value so later caller or Info mutations cannot
+// change the network policy retained by a Manager or Wallet.
+func cloneChainParams(params chaincfg.Params) (chaincfg.Params, error) {
+	cloned := params
+	cloned.DNSSeeds = slices.Clone(params.DNSSeeds)
+
+	cloned.GenesisBlock = params.GenesisBlock.Copy()
+	genesisHash := *params.GenesisHash
+	cloned.GenesisHash = &genesisHash
+	cloned.PowLimit = new(big.Int).Set(params.PowLimit)
+
+	// RegressionNetParams has no BIP0034Hash, so preserve that legitimate
+	// absence while isolating the hash used by networks that define one.
+	if params.BIP0034Hash != nil {
+		bip0034Hash := *params.BIP0034Hash
+		cloned.BIP0034Hash = &bip0034Hash
+	}
+
+	cloned.Checkpoints = slices.Clone(params.Checkpoints)
+	for i := range cloned.Checkpoints {
+		checkpointHash := *params.Checkpoints[i].Hash
+		cloned.Checkpoints[i].Hash = &checkpointHash
+	}
+
+	for i, deployment := range params.Deployments {
+		deployment, err := cloneDeployment(deployment)
+		if err != nil {
+			return chaincfg.Params{}, fmt.Errorf(
+				"clone deployment %d: %w", i, err,
+			)
+		}
+
+		cloned.Deployments[i] = deployment
+	}
+
+	return cloned, nil
+}
+
+// cloneDeployment recreates supported time boundaries without retaining their
+// mutable clock state. Unknown implementations fail closed because copying an
+// interface value would silently share caller state.
+func cloneDeployment(deployment chaincfg.ConsensusDeployment) (
+	chaincfg.ConsensusDeployment, error) {
+
+	cloned := deployment
+	switch starter := deployment.DeploymentStarter.(type) {
+	case *chaincfg.MedianTimeDeploymentStarter:
+		cloned.DeploymentStarter = chaincfg.NewMedianTimeDeploymentStarter(
+			starter.StartTime(),
+		)
+
+	default:
+		return chaincfg.ConsensusDeployment{}, fmt.Errorf(
+			"%w: unsupported deployment starter %T",
+			ErrInvalidParam, starter)
+	}
+
+	switch ender := deployment.DeploymentEnder.(type) {
+	case *chaincfg.MedianTimeDeploymentEnder:
+		cloned.DeploymentEnder = chaincfg.NewMedianTimeDeploymentEnder(
+			ender.EndTime(),
+		)
+
+	default:
+		return chaincfg.ConsensusDeployment{}, fmt.Errorf(
+			"%w: unsupported deployment ender %T",
+			ErrInvalidParam, ender)
+	}
+
+	return cloned, nil
 }

--- a/wallet/manager_config.go
+++ b/wallet/manager_config.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcwallet/chain"
 )
 
 const (
@@ -47,10 +48,10 @@ var errUnsupportedBackend = errors.New("unsupported database backend")
 // fields apply to only certain backends, which is documented here rather than
 // prevented by a second validation layer:
 //
-//	field                      kvdb    sqlite    postgres
-//	DataSource, ChainParams    all backends
-//	MaxConnections             SQL backends
-//	NoFreelistSync, Timeout    kvdb only
+//	field                       kvdb    sqlite    postgres
+//	DataSource, runtime policy         all backends
+//	MaxConnections                     SQL backends
+//	NoFreelistSync, Timeout            kvdb only
 type ManagerConfig struct {
 	// Backend selects the database implementation. Required.
 	Backend DBBackend
@@ -64,8 +65,42 @@ type ManagerConfig struct {
 	MaxConnections int
 
 	// ChainParams identifies the network every wallet in this Manager runs
-	// on. Required; the Manager copies it into each wallet's config.
-	ChainParams *chaincfg.Params
+	// on.
+	//
+	// NOTE: The Manager retains an ownership-isolated value. Callers must
+	// provide complete canonical parameters with non-nil genesis data,
+	// proof-of-work limit, checkpoint hashes, and deployment boundaries.
+	// Manager does not validate those invariants; malformed parameters may
+	// panic while the snapshot is built or a managed Wallet uses it.
+	ChainParams chaincfg.Params
+
+	// ChainSource is the caller-owned source shared by every managed Wallet.
+	// Callers must supply a usable implementation. Manager neither starts,
+	// stops, nor validates it, so nil or typed-nil values may panic when a
+	// managed Wallet uses the source.
+	//
+	// TODO(yy): Replace direct Wallet consumption with Manager-owned fan-out
+	// so one source can deliver every event to each managed Wallet without
+	// competing receivers.
+	ChainSource chain.Interface
+
+	// SyncMethod selects the synchronization strategy shared by all Wallets.
+	SyncMethod SyncMethod
+
+	// WalletSyncRetryInterval sets the initial synchronization retry delay.
+	// Zero preserves the current default; values above maxBackoff are invalid.
+	WalletSyncRetryInterval time.Duration
+
+	// RecoveryWindow sets the shared address-discovery lookahead.
+	RecoveryWindow uint32
+
+	// AutoLockDuration sets the omitted-timeout unlock duration. Non-positive
+	// values use the safe default rather than disabling automatic locking.
+	AutoLockDuration time.Duration
+
+	// MaxCFilterItems sets the automatic compact-filter fallback threshold.
+	// Zero uses the syncer's default threshold.
+	MaxCFilterItems uint32
 
 	// NoFreelistSync controls bbolt freelist synchronization.
 	//
@@ -98,7 +133,7 @@ func (c ManagerConfig) validate() error {
 		return fmt.Errorf("%w: DataSource", ErrMissingParam)
 	}
 
-	if c.ChainParams == nil {
+	if c.ChainParams.Name == "" {
 		return fmt.Errorf("%w: ChainParams", ErrMissingParam)
 	}
 

--- a/wallet/manager_config_test.go
+++ b/wallet/manager_config_test.go
@@ -31,7 +31,7 @@ func TestManagerConfigValidate(t *testing.T) {
 			cfg: ManagerConfig{
 				Backend:     DBBackendKVDB,
 				DataSource:  WalletDBName,
-				ChainParams: &chaincfg.SimNetParams,
+				ChainParams: chaincfg.SimNetParams,
 			},
 		},
 		{
@@ -39,7 +39,7 @@ func TestManagerConfigValidate(t *testing.T) {
 			cfg: ManagerConfig{
 				Backend:     DBBackendSQLite,
 				DataSource:  testSQLiteDBName,
-				ChainParams: &chaincfg.SimNetParams,
+				ChainParams: chaincfg.SimNetParams,
 			},
 		},
 		{
@@ -47,7 +47,7 @@ func TestManagerConfigValidate(t *testing.T) {
 			cfg: ManagerConfig{
 				Backend:     DBBackendPostgres,
 				DataSource:  "postgres://user:pass@localhost/wallet",
-				ChainParams: &chaincfg.SimNetParams,
+				ChainParams: chaincfg.SimNetParams,
 			},
 		},
 		{
@@ -57,7 +57,7 @@ func TestManagerConfigValidate(t *testing.T) {
 			cfg: ManagerConfig{
 				Backend:        DBBackendSQLite,
 				DataSource:     testSQLiteDBName,
-				ChainParams:    &chaincfg.SimNetParams,
+				ChainParams:    chaincfg.SimNetParams,
 				NoFreelistSync: true,
 				Timeout:        time.Second,
 			},
@@ -73,7 +73,7 @@ func TestManagerConfigValidate(t *testing.T) {
 			cfg: ManagerConfig{
 				Backend:     DBBackend("mysql"),
 				DataSource:  WalletDBName,
-				ChainParams: &chaincfg.SimNetParams,
+				ChainParams: chaincfg.SimNetParams,
 			},
 			wantIs:  errUnsupportedBackend,
 			wantMsg: "mysql",
@@ -82,7 +82,7 @@ func TestManagerConfigValidate(t *testing.T) {
 			name: "no data source",
 			cfg: ManagerConfig{
 				Backend:     DBBackendKVDB,
-				ChainParams: &chaincfg.SimNetParams,
+				ChainParams: chaincfg.SimNetParams,
 			},
 			wantIs:  ErrMissingParam,
 			wantMsg: "DataSource",
@@ -101,7 +101,7 @@ func TestManagerConfigValidate(t *testing.T) {
 			cfg: ManagerConfig{
 				Backend:        DBBackendSQLite,
 				DataSource:     testSQLiteDBName,
-				ChainParams:    &chaincfg.SimNetParams,
+				ChainParams:    chaincfg.SimNetParams,
 				MaxConnections: -1,
 			},
 			wantIs:  ErrInvalidParam,
@@ -112,7 +112,7 @@ func TestManagerConfigValidate(t *testing.T) {
 			cfg: ManagerConfig{
 				Backend:        DBBackendPostgres,
 				DataSource:     "postgres://localhost/wallet",
-				ChainParams:    &chaincfg.SimNetParams,
+				ChainParams:    chaincfg.SimNetParams,
 				MaxConnections: -1,
 			},
 			wantIs:  ErrInvalidParam,

--- a/wallet/manager_config_test.go
+++ b/wallet/manager_config_test.go
@@ -242,14 +242,12 @@ func TestManagerRetainsRuntimeSnapshot(t *testing.T) {
 	params.Name = "mutated"
 	params.PowLimit.SetInt64(1)
 
-	w, err := m.Create(
-		Config{Name: testWalletName},
-		CreateWalletParams{
-			Mode:          ModeShell,
-			WatchOnly:     true,
-			PubPassphrase: []byte("public"),
-		},
-	)
+	w, err := m.Create(CreateWalletParams{
+		Name:          testWalletName,
+		Mode:          ModeShell,
+		WatchOnly:     true,
+		PubPassphrase: []byte("public"),
+	})
 	require.NoError(t, err)
 
 	// Assert: Verify constructor copying and both normalization paths first,

--- a/wallet/manager_config_test.go
+++ b/wallet/manager_config_test.go
@@ -203,6 +203,80 @@ func TestManagerConfigValidate(t *testing.T) {
 	}
 }
 
+// TestManagerRetainsRuntimeSnapshot verifies NewManager copies and normalizes
+// caller policy before that snapshot is assembled into a managed Wallet.
+func TestManagerRetainsRuntimeSnapshot(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Give a kvdb Manager mutable network inputs plus distinctive
+	// scalar policy. Prepare independent data sources for negative and zero
+	// auto-lock durations so both default predicates are exercised through the
+	// public constructor before any Wallet receives the policy.
+	params, err := cloneChainParams(chainParams)
+	require.NoError(t, err)
+
+	chainSource := &bwmock.Chain{}
+	cfg := ManagerConfig{
+		Backend:          DBBackendKVDB,
+		DataSource:       testKVDBPath(t),
+		ChainParams:      params,
+		ChainSource:      chainSource,
+		SyncMethod:       SyncMethodFullBlocks,
+		RecoveryWindow:   12,
+		AutoLockDuration: -time.Second,
+		MaxCFilterItems:  50,
+	}
+
+	// Act: Construct Managers with both non-positive auto-lock duration forms.
+	// Mutate the caller-owned input, then create a Wallet so assembly must
+	// consume only the retained immutable snapshot.
+	m, err := NewManager(t.Context(), cfg)
+	require.NoError(t, err)
+
+	zeroCfg := cfg
+	zeroCfg.DataSource = testKVDBPath(t)
+	zeroCfg.AutoLockDuration = 0
+	zeroManager, err := NewManager(t.Context(), zeroCfg)
+	require.NoError(t, err)
+
+	params.Name = "mutated"
+	params.PowLimit.SetInt64(1)
+
+	w, err := m.Create(
+		Config{Name: testWalletName},
+		CreateWalletParams{
+			Mode:          ModeShell,
+			WatchOnly:     true,
+			PubPassphrase: []byte("public"),
+		},
+	)
+	require.NoError(t, err)
+
+	// Assert: Verify constructor copying and both normalization paths first,
+	// then require the assembled Wallet to carry that exact policy and
+	// independent mutable values before releasing each Manager-owned backend.
+	require.NotEqual(t, params.Name, m.config.ChainParams.Name)
+	require.NotEqual(t, params.PowLimit, m.config.ChainParams.PowLimit)
+	require.Equal(t, SyncMethodFullBlocks, m.config.SyncMethod)
+	require.Equal(t, initialBackoff, m.config.WalletSyncRetryInterval)
+	require.Equal(t, uint32(12), m.config.RecoveryWindow)
+	require.Equal(t, defaultLockDuration, m.config.AutoLockDuration)
+	require.Equal(t, defaultLockDuration,
+		zeroManager.config.AutoLockDuration)
+	require.Equal(t, uint32(50), m.config.MaxCFilterItems)
+
+	require.Same(t, chainSource, w.cfg.Chain)
+	require.Equal(t, m.config.ChainParams, *w.cfg.ChainParams)
+	require.Equal(t, m.config.SyncMethod, w.cfg.SyncMethod)
+	require.Equal(t, m.config.WalletSyncRetryInterval,
+		w.cfg.WalletSyncRetryInterval)
+	require.Equal(t, m.config.RecoveryWindow, w.cfg.RecoveryWindow)
+	require.Equal(t, m.config.AutoLockDuration, w.cfg.AutoLockDuration)
+	require.Equal(t, m.config.MaxCFilterItems, w.cfg.MaxCFilterItems)
+	require.NoError(t, m.Close())
+	require.NoError(t, zeroManager.Close())
+}
+
 // TestManagerConfigTimeout verifies that an unset walletdb timeout falls
 // back to the default instead of zero, which walletdb treats as no wait.
 func TestManagerConfigTimeout(t *testing.T) {

--- a/wallet/manager_config_test.go
+++ b/wallet/manager_config_test.go
@@ -1,10 +1,13 @@
 package wallet
 
 import (
+	"math/big"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/v2"
+	"github.com/btcsuite/btcd/chainhash/v2"
+	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,7 +20,6 @@ const testSQLiteDBName = "wallet.sqlite"
 // opened somewhere the caller did not name.
 func TestManagerConfigValidate(t *testing.T) {
 	t.Parallel()
-
 	tests := []struct {
 		name    string
 		cfg     ManagerConfig
@@ -144,4 +146,100 @@ func TestManagerConfigTimeout(t *testing.T) {
 	require.Equal(
 		t, time.Second, ManagerConfig{Timeout: time.Second}.timeout(),
 	)
+}
+
+// testDeploymentStarter supplies an intentionally unsupported deployment
+// boundary so the clone test can prove unknown mutable implementations fail
+// closed instead of being retained through an interface value.
+type testDeploymentStarter struct{}
+
+// HasStarted implements the deployment boundary; its result is irrelevant
+// because cloneChainParams must reject this type without invoking it.
+func (*testDeploymentStarter) HasStarted(*wire.BlockHeader) (bool, error) {
+	return false, nil
+}
+
+// TestChainParamsCloneIsolated verifies every nested mutable network value is
+// owned by the clone, including consensus deployment boundary instances.
+func TestChainParamsCloneIsolated(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Build a compact parameter set with every mutable field backed
+	// by test-owned storage, then snapshot the original values for comparison.
+	genesisBlock := chaincfg.MainNetParams.GenesisBlock.Copy()
+	genesisHash := chainhash.Hash{1}
+	bip0034Hash := chainhash.Hash{2}
+	checkpointHash := chainhash.Hash{3}
+	startTime := time.Unix(10, 0)
+	endTime := time.Unix(20, 0)
+	params := chaincfg.MainNetParams
+	params.DNSSeeds = []chaincfg.DNSSeed{{Host: "seed.example"}}
+	params.GenesisBlock = genesisBlock
+	params.GenesisHash = &genesisHash
+	params.PowLimit = big.NewInt(100)
+	params.BIP0034Hash = &bip0034Hash
+	params.Checkpoints = []chaincfg.Checkpoint{{Hash: &checkpointHash}}
+	params.Deployments[0] = chaincfg.ConsensusDeployment{
+		DeploymentStarter: chaincfg.NewMedianTimeDeploymentStarter(
+			startTime,
+		),
+		DeploymentEnder: chaincfg.NewMedianTimeDeploymentEnder(
+			endTime,
+		),
+	}
+	originalNonce := genesisBlock.Header.Nonce
+	originalScriptByte := genesisBlock.Transactions[0].TxOut[0].PkScript[0]
+
+	// Act: Clone the parameters, then mutate every caller-owned nested value
+	// that could otherwise alter the retained network definition.
+	cloned, err := cloneChainParams(params)
+	require.NoError(t, err)
+
+	params.DNSSeeds[0].Host = "mutated.example"
+	params.GenesisBlock.Header.Nonce++
+	params.GenesisBlock.Transactions[0].TxOut[0].PkScript[0]++
+	params.GenesisHash[0]++
+	params.PowLimit.SetInt64(200)
+	params.BIP0034Hash[0]++
+	params.Checkpoints[0].Hash[0]++
+
+	// Assert: Verify scalar content survived every mutation and deployment
+	// boundaries were recreated rather than sharing mutable clock instances.
+	require.Equal(t, "seed.example", cloned.DNSSeeds[0].Host)
+	require.Equal(t, originalNonce, cloned.GenesisBlock.Header.Nonce)
+	require.Equal(
+		t, originalScriptByte,
+		cloned.GenesisBlock.Transactions[0].TxOut[0].PkScript[0],
+	)
+	require.Equal(t, byte(1), cloned.GenesisHash[0])
+	require.Equal(t, int64(100), cloned.PowLimit.Int64())
+	require.Equal(t, byte(2), cloned.BIP0034Hash[0])
+	require.Equal(t, byte(3), cloned.Checkpoints[0].Hash[0])
+	require.NotSame(
+		t, params.Deployments[0].DeploymentStarter,
+		cloned.Deployments[0].DeploymentStarter,
+	)
+	require.NotSame(
+		t, params.Deployments[0].DeploymentEnder,
+		cloned.Deployments[0].DeploymentEnder,
+	)
+}
+
+// TestChainParamsCloneRejectsUnknownDeployment verifies a clone never falls
+// back to retaining an implementation whose mutable state it cannot copy.
+func TestChainParamsCloneRejectsUnknownDeployment(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Install an otherwise valid deployment with an implementation
+	// outside the two chaincfg time-boundary types the clone understands.
+	params := chaincfg.SimNetParams
+	params.Deployments[0].DeploymentStarter = &testDeploymentStarter{}
+
+	// Act: Attempt to cross the ownership boundary with the unknown type.
+	_, err := cloneChainParams(params)
+
+	// Assert: Require the invalid-parameter sentinel and type context so the
+	// caller can correct the configuration without any state being retained.
+	require.ErrorIs(t, err, ErrInvalidParam)
+	require.ErrorContains(t, err, "testDeploymentStarter")
 }

--- a/wallet/manager_config_test.go
+++ b/wallet/manager_config_test.go
@@ -8,18 +8,45 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
+	bwmock "github.com/btcsuite/btcwallet/bwtest/mock"
 	"github.com/stretchr/testify/require"
 )
 
 // testSQLiteDBName is the SQLite data source the config tests share.
 const testSQLiteDBName = "wallet.sqlite"
 
-// TestManagerConfigValidate verifies that a Manager's database configuration is
-// checked once, at construction, and that nothing is defaulted: an unset
-// backend or data source is an error rather than a guess, so a wallet is never
-// opened somewhere the caller did not name.
+// validRuntimeManagerConfig builds a complete SQLite configuration. Validation
+// tests mutate one field at a time so failures cannot be masked by an unrelated
+// missing input.
+func validRuntimeManagerConfig() ManagerConfig {
+	cfg := ManagerConfig{
+		Backend:     DBBackendSQLite,
+		DataSource:  testSQLiteDBName,
+		ChainParams: chaincfg.SimNetParams,
+		ChainSource: &bwmock.Chain{},
+	}
+
+	return cfg
+}
+
+// TestManagerConfigValidate verifies database and runtime policy are checked
+// together before Manager construction can open caller-selected storage.
 func TestManagerConfigValidate(t *testing.T) {
 	t.Parallel()
+
+	// Arrange: Derive runtime cases from complete backend configurations and
+	// mutate one field at a time, alongside the existing database boundaries,
+	// so no unrelated missing input can mask the decision under test.
+	unknownSync := validRuntimeManagerConfig()
+	unknownSync.SyncMethod = SyncMethodFullBlocks + 1
+	negativeRetry := validRuntimeManagerConfig()
+	negativeRetry.WalletSyncRetryInterval = -time.Second
+	maximumRetry := validRuntimeManagerConfig()
+	maximumRetry.WalletSyncRetryInterval = maxBackoff
+	aboveMaximumRetry := validRuntimeManagerConfig()
+	aboveMaximumRetry.WalletSyncRetryInterval = maxBackoff + 1
+	aboveMaximumRecovery := validRuntimeManagerConfig()
+	aboveMaximumRecovery.RecoveryWindow = MaxRecoveryWindow + 1
 	tests := []struct {
 		name    string
 		cfg     ManagerConfig
@@ -32,6 +59,7 @@ func TestManagerConfigValidate(t *testing.T) {
 				Backend:     DBBackendKVDB,
 				DataSource:  WalletDBName,
 				ChainParams: chaincfg.SimNetParams,
+				ChainSource: &bwmock.Chain{},
 			},
 		},
 		{
@@ -40,6 +68,7 @@ func TestManagerConfigValidate(t *testing.T) {
 				Backend:     DBBackendSQLite,
 				DataSource:  testSQLiteDBName,
 				ChainParams: chaincfg.SimNetParams,
+				ChainSource: &bwmock.Chain{},
 			},
 		},
 		{
@@ -48,6 +77,7 @@ func TestManagerConfigValidate(t *testing.T) {
 				Backend:     DBBackendPostgres,
 				DataSource:  "postgres://user:pass@localhost/wallet",
 				ChainParams: chaincfg.SimNetParams,
+				ChainSource: &bwmock.Chain{},
 			},
 		},
 		{
@@ -58,6 +88,7 @@ func TestManagerConfigValidate(t *testing.T) {
 				Backend:        DBBackendSQLite,
 				DataSource:     testSQLiteDBName,
 				ChainParams:    chaincfg.SimNetParams,
+				ChainSource:    &bwmock.Chain{},
 				NoFreelistSync: true,
 				Timeout:        time.Second,
 			},
@@ -102,6 +133,7 @@ func TestManagerConfigValidate(t *testing.T) {
 				Backend:        DBBackendSQLite,
 				DataSource:     testSQLiteDBName,
 				ChainParams:    chaincfg.SimNetParams,
+				ChainSource:    &bwmock.Chain{},
 				MaxConnections: -1,
 			},
 			wantIs:  ErrInvalidParam,
@@ -113,10 +145,39 @@ func TestManagerConfigValidate(t *testing.T) {
 				Backend:        DBBackendPostgres,
 				DataSource:     "postgres://localhost/wallet",
 				ChainParams:    chaincfg.SimNetParams,
+				ChainSource:    &bwmock.Chain{},
 				MaxConnections: -1,
 			},
 			wantIs:  ErrInvalidParam,
 			wantMsg: "MaxConnections",
+		},
+		{
+			name:    "unknown sync method",
+			cfg:     unknownSync,
+			wantIs:  ErrInvalidParam,
+			wantMsg: "SyncMethod",
+		},
+		{
+			name:    "negative retry interval",
+			cfg:     negativeRetry,
+			wantIs:  ErrInvalidParam,
+			wantMsg: "WalletSyncRetryInterval",
+		},
+		{
+			name: "maximum retry interval",
+			cfg:  maximumRetry,
+		},
+		{
+			name:    "retry interval above maximum",
+			cfg:     aboveMaximumRetry,
+			wantIs:  ErrInvalidParam,
+			wantMsg: "WalletSyncRetryInterval",
+		},
+		{
+			name:    "recovery window above maximum",
+			cfg:     aboveMaximumRecovery,
+			wantIs:  ErrInvalidParam,
+			wantMsg: "RecoveryWindow",
 		},
 	}
 
@@ -124,7 +185,12 @@ func TestManagerConfigValidate(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
+			// Act: Validate only the case's immutable constructor input,
+			// without opening the configured data source.
 			err := test.cfg.validate()
+
+			// Assert: Successful cases remain accepted, while failures
+			// preserve both their sentinel and caller-facing field context.
 			if test.wantIs == nil {
 				require.NoError(t, err)
 

--- a/wallet/manager_kvdb.go
+++ b/wallet/manager_kvdb.go
@@ -98,7 +98,7 @@ func (b *kvdbManagerBackend) create(ctx context.Context, cfg Config,
 
 // load opens the one existing legacy wallet served by the backend.
 func (b *kvdbManagerBackend) load(ctx context.Context,
-	cfg Config) (*walletData, error) {
+	params LoadWalletParams) (*walletData, error) {
 
 	if b.store != nil {
 		return nil, fmt.Errorf("%w: kvdb serves one wallet per "+
@@ -106,10 +106,10 @@ func (b *kvdbManagerBackend) load(ctx context.Context,
 			b.walletName)
 	}
 
-	return b.open(ctx, cfg.Name, kvdb.Config{
+	return b.open(ctx, params.Name, kvdb.Config{
 		DB:            b.db,
 		ChainParams:   b.chainParams,
-		PubPassphrase: cfg.PubPassphrase,
+		PubPassphrase: params.PubPassphrase,
 	})
 }
 

--- a/wallet/manager_kvdb.go
+++ b/wallet/manager_kvdb.go
@@ -68,7 +68,7 @@ func newKVDBManagerBackend(cfg ManagerConfig) (*kvdbManagerBackend, error) {
 }
 
 // create initializes and opens the one legacy wallet served by the backend.
-func (b *kvdbManagerBackend) create(ctx context.Context, cfg Config,
+func (b *kvdbManagerBackend) create(ctx context.Context,
 	params CreateWalletParams, rootKey *hdkeychain.ExtendedKey) (
 	*walletData, error) {
 
@@ -93,7 +93,7 @@ func (b *kvdbManagerBackend) create(ctx context.Context, cfg Config,
 		return nil, fmt.Errorf("create legacy wallet: %w", err)
 	}
 
-	return b.open(ctx, cfg.Name, adapterCfg)
+	return b.open(ctx, params.Name, adapterCfg)
 }
 
 // load opens the one existing legacy wallet served by the backend.

--- a/wallet/manager_kvdb.go
+++ b/wallet/manager_kvdb.go
@@ -63,7 +63,7 @@ func newKVDBManagerBackend(cfg ManagerConfig) (*kvdbManagerBackend, error) {
 
 	return &kvdbManagerBackend{
 		db:          dbConn,
-		chainParams: cfg.ChainParams,
+		chainParams: &cfg.ChainParams,
 	}, nil
 }
 

--- a/wallet/manager_postgres.go
+++ b/wallet/manager_postgres.go
@@ -14,7 +14,7 @@ func newPostgresManagerBackend(ctx context.Context,
 	store, err := pg.NewStore(ctx, pg.Config{
 		Dsn:            cfg.DataSource,
 		MaxConnections: cfg.MaxConnections,
-		DeriveAddress:  newSQLAddressDeriver(cfg.ChainParams),
+		DeriveAddress:  newSQLAddressDeriver(&cfg.ChainParams),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("open postgres store: %w", err)

--- a/wallet/manager_postgres_test.go
+++ b/wallet/manager_postgres_test.go
@@ -3,6 +3,7 @@ package wallet
 import (
 	"testing"
 
+	bwmock "github.com/btcsuite/btcwallet/bwtest/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -11,11 +12,18 @@ import (
 func TestManagerPostgresRejectsInvalidDSN(t *testing.T) {
 	t.Parallel()
 
+	// Arrange: Supply every Manager runtime requirement while keeping only
+	// the PostgreSQL data source malformed, so validation reaches the Store.
+	// Act: Construct the Manager and let the backend parse the invalid DSN.
 	m, err := NewManager(t.Context(), ManagerConfig{
 		Backend:     DBBackendPostgres,
 		DataSource:  "://invalid",
-		ChainParams: &chainParams,
+		ChainParams: chainParams,
+		ChainSource: &bwmock.Chain{},
 	})
+
+	// Assert: Verify construction failed at the PostgreSQL boundary and no
+	// partially initialized Manager escaped to the caller.
 	require.Error(t, err)
 	require.ErrorContains(t, err, "open postgres store")
 	require.ErrorContains(t, err, "invalid config")

--- a/wallet/manager_sql.go
+++ b/wallet/manager_sql.go
@@ -42,9 +42,9 @@ func (b *sqlManagerBackend) create(ctx context.Context, cfg Config,
 
 // load reads an existing SQL wallet and resolves its runtime dependencies.
 func (b *sqlManagerBackend) load(ctx context.Context,
-	cfg Config) (*walletData, error) {
+	params LoadWalletParams) (*walletData, error) {
 
-	info, err := b.store.GetWallet(ctx, cfg.Name)
+	info, err := b.store.GetWallet(ctx, params.Name)
 	if err != nil {
 		return nil, fmt.Errorf("get runtime wallet: %w", err)
 	}

--- a/wallet/manager_sql.go
+++ b/wallet/manager_sql.go
@@ -21,11 +21,11 @@ type sqlManagerBackend struct {
 var _ managerBackend = (*sqlManagerBackend)(nil)
 
 // create atomically creates a SQL wallet and returns its committed data.
-func (b *sqlManagerBackend) create(ctx context.Context, cfg Config,
+func (b *sqlManagerBackend) create(ctx context.Context,
 	params CreateWalletParams, rootKey *hdkeychain.ExtendedKey) (
 	*walletData, error) {
 
-	createParams, err := sqlCreateWalletParams(cfg, params, rootKey,
+	createParams, err := sqlCreateWalletParams(params, rootKey,
 		birthdayWithSafetyMargin(params.Birthday),
 	)
 	if err != nil {
@@ -80,12 +80,12 @@ func (b *sqlManagerBackend) close() error {
 }
 
 // sqlCreateWalletParams converts wallet creation inputs into SQL rows.
-func sqlCreateWalletParams(cfg Config, params CreateWalletParams,
+func sqlCreateWalletParams(params CreateWalletParams,
 	rootKey *hdkeychain.ExtendedKey, birthday time.Time) (
 	db.CreateWalletParams, error) {
 
 	createParams := db.CreateWalletParams{
-		Name: cfg.Name,
+		Name: params.Name,
 		IsImported: params.Mode == ModeImportSeed ||
 			params.Mode == ModeImportExtKey,
 		// LatestMgrVersion is a small constant that fits int32.

--- a/wallet/manager_sqlite.go
+++ b/wallet/manager_sqlite.go
@@ -21,7 +21,7 @@ func newSQLiteManagerBackend(ctx context.Context,
 	store, err := sqlite.NewStore(ctx, sqlite.Config{
 		DBPath:         cfg.DataSource,
 		MaxConnections: cfg.MaxConnections,
-		DeriveAddress:  newSQLAddressDeriver(cfg.ChainParams),
+		DeriveAddress:  newSQLAddressDeriver(&cfg.ChainParams),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite store: %w", err)

--- a/wallet/manager_sqlite_test.go
+++ b/wallet/manager_sqlite_test.go
@@ -230,7 +230,8 @@ func TestManagerSQLiteReopenDerivesAddress(t *testing.T) {
 		m, err := NewManager(t.Context(), ManagerConfig{
 			Backend:     DBBackendSQLite,
 			DataSource:  dbPath,
-			ChainParams: &chainParams,
+			ChainParams: chainParams,
+			ChainSource: &bwmock.Chain{},
 		})
 		require.NoError(t, err)
 

--- a/wallet/manager_sqlite_test.go
+++ b/wallet/manager_sqlite_test.go
@@ -56,19 +56,21 @@ func TestManagerLoadPreservesBackendFailure(t *testing.T) {
 	// backend sentinel instead of the database not-found classification.
 	cfg, _ := sqliteCreateConfig(t)
 	store := &walletmock.Store{}
-	t.Cleanup(func() { store.AssertExpectations(t) })
 
 	store.On("GetWallet", mock.Anything, cfg.Name).
 		Return(nil, errDBMock).Once()
 
-	// Act by loading the wallet through the public Manager boundary.
-	w, err := testSQLManager(t, store).Load(cfg)
+	// Act by loading the wallet identity through the public Manager boundary.
+	w, err := testSQLManager(t, store).Load(LoadWalletParams{
+		Name: cfg.Name,
+	})
 
-	// Assert that the original backend failure remains discoverable and is
-	// not replaced with the public missing-wallet sentinel.
+	// Assert: Verify the original backend failure remains discoverable, no
+	// Wallet escapes, and the one expected Store call was satisfied.
 	require.ErrorIs(t, err, errDBMock)
 	require.NotErrorIs(t, err, ErrWalletNotFound)
 	require.Nil(t, w)
+	store.AssertExpectations(t)
 }
 
 // sqliteCreateConfig returns a SQLite-backed create config and a spendable
@@ -133,7 +135,7 @@ func TestManagerSQLiteCreateLoadCached(t *testing.T) {
 
 	// Create publishes the wallet, so Load returns the same pointer over the
 	// Manager-owned store.
-	loaded, err := m.Load(cfg)
+	loaded, err := m.Load(LoadWalletParams{Name: cfg.Name})
 	require.NoError(t, err)
 	require.Same(t, w, loaded)
 }
@@ -265,7 +267,7 @@ func TestManagerSQLiteReopenDerivesAddress(t *testing.T) {
 	m := newManager()
 	t.Cleanup(func() { _ = m.Close() })
 
-	w, err := m.Load(cfg)
+	w, err := m.Load(LoadWalletParams{Name: testWalletName})
 	require.NoError(t, err)
 
 	startLoadedWalletForTest(t, w)

--- a/wallet/manager_sqlite_test.go
+++ b/wallet/manager_sqlite_test.go
@@ -224,14 +224,18 @@ func TestBirthdayWithSafetyMargin(t *testing.T) {
 func TestManagerSQLiteReopenDerivesAddress(t *testing.T) {
 	t.Parallel()
 
+	// Arrange: Prepare a shared strict chain mock with one required address
+	// notification, then create and close the durable SQLite Wallet so no
+	// runtime instance remains cached.
 	dbPath := filepath.Join(t.TempDir(), "runtime.sqlite")
+	chainMock := &bwmock.Chain{}
 
 	newManager := func() *Manager {
 		m, err := NewManager(t.Context(), ManagerConfig{
 			Backend:     DBBackendSQLite,
 			DataSource:  dbPath,
 			ChainParams: chainParams,
-			ChainSource: &bwmock.Chain{},
+			ChainSource: chainMock,
 		})
 		require.NoError(t, err)
 
@@ -241,15 +245,11 @@ func TestManagerSQLiteReopenDerivesAddress(t *testing.T) {
 	seed, err := hdkeychain.GenerateSeed(hdkeychain.RecommendedSeedLen)
 	require.NoError(t, err)
 
-	chain := &bwmock.Chain{}
-	cfg := Config{
-		Chain:       chain,
-		ChainParams: &chainParams,
-		Name:        testWalletName,
-	}
+	cfg := Config{Name: testWalletName}
 	privPass := []byte("private")
 
-	// Arrange: create, then close the Manager so nothing is cached.
+	chainMock.On("NotifyReceived", mock.Anything).Return(nil).Once()
+
 	creator := newManager()
 	_, err = creator.Create(cfg, CreateWalletParams{
 		Mode:              ModeImportSeed,
@@ -260,7 +260,8 @@ func TestManagerSQLiteReopenDerivesAddress(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, creator.Close())
 
-	// Act: a fresh Manager reads the wallet back off disk.
+	// Act: Have a fresh Manager load the Wallet, unlock its vault, and derive
+	// an address through the Store callback installed during construction.
 	m := newManager()
 	t.Cleanup(func() { _ = m.Close() })
 
@@ -277,13 +278,14 @@ func TestManagerSQLiteReopenDerivesAddress(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	chain.On("NotifyReceived", mock.Anything).Return(nil).Maybe()
-
-	// Assert: NewAddress goes through the store's installed address deriver.
 	addr, err := w.NewAddress(
 		t.Context(), waddrmgr.DefaultAccountName,
 		waddrmgr.WitnessPubKey, false,
 	)
+
+	// Assert: The public derivation succeeds and its required notification
+	// proves the loaded Wallet received the Manager-owned chain source.
 	require.NoError(t, err, "NewAddress requires the installed deriver")
 	require.NotNil(t, addr)
+	chainMock.AssertExpectations(t)
 }

--- a/wallet/manager_sqlite_test.go
+++ b/wallet/manager_sqlite_test.go
@@ -23,11 +23,10 @@ import (
 func TestManagerCreateUsesCommittedWalletRow(t *testing.T) {
 	t.Parallel()
 
-	cfg, params := sqliteCreateConfig(t)
-
+	// Arrange: Build one durable create request and require exactly one Store
+	// mutation returning the committed row used for Wallet assembly.
+	params := sqliteCreateParams(t)
 	store := &walletmock.Store{}
-	t.Cleanup(func() { store.AssertExpectations(t) })
-
 	rootKey, err := hdkeychain.NewMaster(params.Seed, &chainParams)
 	require.NoError(t, err)
 
@@ -38,13 +37,19 @@ func TestManagerCreateUsesCommittedWalletRow(t *testing.T) {
 		mock.AnythingOfType("db.CreateWalletParams")).
 		Return(&db.WalletInfo{
 			ID:           7,
-			Name:         cfg.Name,
+			Name:         params.Name,
 			MasterPubKey: []byte(masterPubKey.String()),
 		}, nil).Once()
 
-	w, err := testSQLManager(t, store).Create(cfg, params)
+	// Act: Create through Manager so a forbidden readback would reach the
+	// strict Store mock as an unexpected call.
+	w, err := testSQLManager(t, store).Create(params)
+
+	// Assert: Verify the returned Wallet uses the committed row ID and the
+	// required Store call was consumed exactly once.
 	require.NoError(t, err)
 	require.Equal(t, uint32(7), w.ID())
+	store.AssertExpectations(t)
 }
 
 // TestManagerLoadPreservesBackendFailure verifies that a non-not-found SQL
@@ -52,17 +57,17 @@ func TestManagerCreateUsesCommittedWalletRow(t *testing.T) {
 func TestManagerLoadPreservesBackendFailure(t *testing.T) {
 	t.Parallel()
 
-	// Arrange a SQL manager whose wallet lookup returns an unrelated
-	// backend sentinel instead of the database not-found classification.
-	cfg, _ := sqliteCreateConfig(t)
+	// Arrange: Configure a strict SQL Store whose one required lookup returns
+	// an unrelated backend sentinel instead of the not-found classification.
+	params := sqliteCreateParams(t)
 	store := &walletmock.Store{}
 
-	store.On("GetWallet", mock.Anything, cfg.Name).
+	store.On("GetWallet", mock.Anything, params.Name).
 		Return(nil, errDBMock).Once()
 
-	// Act by loading the wallet identity through the public Manager boundary.
+	// Act: Load the durable identity through the maintained Manager boundary.
 	w, err := testSQLManager(t, store).Load(LoadWalletParams{
-		Name: cfg.Name,
+		Name: params.Name,
 	})
 
 	// Assert: Verify the original backend failure remains discoverable, no
@@ -73,28 +78,23 @@ func TestManagerLoadPreservesBackendFailure(t *testing.T) {
 	store.AssertExpectations(t)
 }
 
-// sqliteCreateConfig returns a SQLite-backed create config and a spendable
-// seed-import params pair sharing fresh temp paths, for tests that exercise
-// the SQL create path end to end.
-func sqliteCreateConfig(t *testing.T) (Config, CreateWalletParams) {
+// sqliteCreateParams returns a spendable seed-import request with a durable
+// identity for tests that exercise the maintained SQL Manager create path.
+func sqliteCreateParams(t *testing.T) CreateWalletParams {
 	t.Helper()
 
 	seed, err := hdkeychain.GenerateSeed(hdkeychain.RecommendedSeedLen)
 	require.NoError(t, err)
 
-	cfg := Config{
-		Chain:       &bwmock.Chain{},
-		ChainParams: &chainParams,
-		Name:        testWalletName,
-	}
 	params := CreateWalletParams{
+		Name:              testWalletName,
 		Mode:              ModeImportSeed,
 		Seed:              seed,
 		PrivatePassphrase: []byte("private"),
 		Birthday:          time.Now(),
 	}
 
-	return cfg, params
+	return params
 }
 
 // TestSQLiteCreateWalletParamsCreatesSpendableSecrets verifies that SQL wallet
@@ -103,13 +103,13 @@ func sqliteCreateConfig(t *testing.T) (Config, CreateWalletParams) {
 func TestSQLiteCreateWalletParamsCreatesSpendableSecrets(t *testing.T) {
 	t.Parallel()
 
-	cfg, params := sqliteCreateConfig(t)
+	params := sqliteCreateParams(t)
 
 	rootKey, err := hdkeychain.NewMaster(params.Seed, &chainParams)
 	require.NoError(t, err)
 
 	got, err := sqlCreateWalletParams(
-		cfg, params, rootKey, birthdayWithSafetyMargin(params.Birthday),
+		params, rootKey, birthdayWithSafetyMargin(params.Birthday),
 	)
 	require.NoError(t, err)
 
@@ -126,16 +126,16 @@ func TestSQLiteCreateWalletParamsCreatesSpendableSecrets(t *testing.T) {
 func TestManagerSQLiteCreateLoadCached(t *testing.T) {
 	t.Parallel()
 
-	cfg, params := sqliteCreateConfig(t)
+	params := sqliteCreateParams(t)
 	m := testSQLiteManager(t)
 
-	w, err := m.Create(cfg, params)
+	w, err := m.Create(params)
 	require.NoError(t, err)
 	require.NotNil(t, w)
 
 	// Create publishes the wallet, so Load returns the same pointer over the
 	// Manager-owned store.
-	loaded, err := m.Load(LoadWalletParams{Name: cfg.Name})
+	loaded, err := m.Load(LoadWalletParams{Name: params.Name})
 	require.NoError(t, err)
 	require.Same(t, w, loaded)
 }
@@ -184,8 +184,8 @@ func TestSQLiteCreateWalletParamsBirthdayVerbatim(t *testing.T) {
 			// non-empty private passphrase is required because
 			// the store-backed key vault rejects an empty
 			// passphrase for a spendable wallet.
-			cfg := Config{Name: testWalletName}
 			params := CreateWalletParams{
+				Name:              testWalletName,
 				Mode:              ModeImportSeed,
 				PrivatePassphrase: []byte("private"),
 			}
@@ -193,7 +193,7 @@ func TestSQLiteCreateWalletParamsBirthdayVerbatim(t *testing.T) {
 			// Act: build the SQL runtime create params with the
 			// already-resolved birthday.
 			got, err := sqlCreateWalletParams(
-				cfg, params, rootKey, tc.birthday,
+				params, rootKey, tc.birthday,
 			)
 			require.NoError(t, err)
 
@@ -247,13 +247,13 @@ func TestManagerSQLiteReopenDerivesAddress(t *testing.T) {
 	seed, err := hdkeychain.GenerateSeed(hdkeychain.RecommendedSeedLen)
 	require.NoError(t, err)
 
-	cfg := Config{Name: testWalletName}
 	privPass := []byte("private")
 
 	chainMock.On("NotifyReceived", mock.Anything).Return(nil).Once()
 
 	creator := newManager()
-	_, err = creator.Create(cfg, CreateWalletParams{
+	_, err = creator.Create(CreateWalletParams{
+		Name:              testWalletName,
 		Mode:              ModeImportSeed,
 		Seed:              seed,
 		PrivatePassphrase: privPass,

--- a/wallet/manager_test.go
+++ b/wallet/manager_test.go
@@ -443,8 +443,8 @@ func (b *recordingManagerBackend) create(_ context.Context, _ Config,
 }
 
 // load is not used by creation-policy tests.
-func (*recordingManagerBackend) load(context.Context, Config) (*walletData,
-	error) {
+func (*recordingManagerBackend) load(context.Context, LoadWalletParams) (
+	*walletData, error) {
 
 	return nil, ErrInvalidParam
 }
@@ -454,45 +454,51 @@ func (*recordingManagerBackend) close() error {
 	return nil
 }
 
-// TestManagerLoadSuccess verifies that an existing wallet can be successfully
-// loaded from the database. This tests the persistence and restoration flow.
+// TestManagerLoadSuccess verifies that an existing KVDB wallet can be reopened
+// with the empty public passphrase supported by the legacy address manager.
 func TestManagerLoadSuccess(t *testing.T) {
 	t.Parallel()
 
+	// Arrange: Use one database path for both Managers and deliberately omit
+	// the public passphrase from both creation carriers. The private
+	// passphrase remains non-empty because spendable wallets require it.
 	dbPath := testKVDBPath(t)
 
 	m := testKVDBManagerAt(t, dbPath)
 	cfg := Config{
-		Chain:         &bwmock.Chain{},
-		ChainParams:   &chainParams,
-		Name:          "test-wallet",
-		PubPassphrase: []byte("public"),
+		Chain:       &bwmock.Chain{},
+		ChainParams: &chainParams,
+		Name:        "test-wallet",
 	}
 	params := CreateWalletParams{
 		Mode:              ModeGenSeed,
-		PubPassphrase:     []byte("public"),
 		PrivatePassphrase: []byte("private"),
 		Birthday:          time.Now(),
 	}
 
+	// Act: Create the wallet through the first Manager using the empty public
+	// credential that the underlying KVDB format accepts.
 	wCreated, err := m.Create(cfg, params)
+
+	// Assert: Creation succeeds and returns the live wallet that will later be
+	// compared with the reopened metadata.
 	require.NoError(t, err)
 	require.NotNil(t, wCreated)
 
-	// Release the database so a second Manager can open the same file: one
-	// bbolt handle per file, and the Manager owns it.
+	// Act: Release the first bbolt handle, then open the same wallet through a
+	// second Manager while again supplying the empty public passphrase.
 	require.NoError(t, m.Close())
-
-	// Open a second Manager over the same database to simulate a fresh start
-	// (e.g. daemon restart) and load the wallet from it.
 	m2 := testKVDBManagerAt(t, dbPath)
-	w, err := m2.Load(cfg)
+	w, err := m2.Load(LoadWalletParams{
+		Name:          cfg.Name,
+		PubPassphrase: cfg.PubPassphrase,
+	})
 
-	// Verify that the load operation succeeded and returned a valid wallet.
+	// Assert: Reopening succeeds, registers the Wallet under its durable name,
+	// and restores the same persisted master fingerprint.
 	require.NoError(t, err)
 	require.NotNil(t, w)
 
-	// Ensure the loaded wallet is correctly registered in the new manager.
 	m2.RLock()
 	loadedW, ok := m2.wallets["test-wallet"]
 	m2.RUnlock()
@@ -500,16 +506,13 @@ func TestManagerLoadSuccess(t *testing.T) {
 	require.Same(t, w, loadedW)
 	require.Zero(t, w.ID())
 
-	// The master HD fingerprint is read through the Store during load. A
-	// ModeGenSeed wallet persists a master HD public key, so the cached
-	// fingerprint is non-zero and matches the value resolved at create time.
 	require.NotZero(t, w.masterFingerprint)
 	require.Equal(t, wCreated.masterFingerprint, w.masterFingerprint)
 }
 
-// TestManagerLoad_ExistingWallet verifies that if Load is called for a wallet
+// TestManagerLoadExistingWallet verifies that if Load is called for a wallet
 // that is already managed in memory, the Manager detects this.
-func TestManagerLoad_ExistingWallet(t *testing.T) {
+func TestManagerLoadExistingWallet(t *testing.T) {
 	t.Parallel()
 
 	dbPath := testKVDBPath(t)
@@ -534,7 +537,10 @@ func TestManagerLoad_ExistingWallet(t *testing.T) {
 	// Attempt to load the same wallet again using the same manager instance.
 	// Since it's already loaded in memory, the manager should return the
 	// existing instance rather than reloading from disk.
-	wLoaded, err := m.Load(cfg)
+	wLoaded, err := m.Load(LoadWalletParams{
+		Name:          cfg.Name,
+		PubPassphrase: cfg.PubPassphrase,
+	})
 
 	// Verify that we got the same wallet instance back.
 	require.NoError(t, err)
@@ -549,11 +555,18 @@ func TestManagerLoadError(t *testing.T) {
 	t.Run("Invalid Config", func(t *testing.T) {
 		t.Parallel()
 
+		// Arrange: Use a valid kvdb Manager so the empty request name is the
+		// only invalid input observed before cache or backend lookup.
 		m := testKVDBManager(t)
 
-		// Attempt to load with an empty config. This should fail validation.
-		w, err := m.Load(Config{})
+		// Act: Attempt to load without the required durable identity.
+		w, err := m.Load(LoadWalletParams{})
+
+		// Assert: The shared request boundary rejects the call before backend
+		// lookup and does not expose a partial Wallet.
+		require.ErrorIs(t, err, ErrMissingParam)
 		require.ErrorContains(t, err, "missing config parameter")
+		require.ErrorContains(t, err, "Name")
 		require.Nil(t, w)
 	})
 
@@ -564,15 +577,12 @@ func TestManagerLoadError(t *testing.T) {
 		// contained wallet state. This distinguishes absence from a
 		// partially initialized or corrupt wallet.
 		m := testKVDBManager(t)
-		cfg := Config{
-			Chain:       &bwmock.Chain{},
-			ChainParams: &chainParams,
-			Name:        "test",
-		}
-
 		// Act by loading the never-created wallet through the public
 		// Manager boundary.
-		w, err := m.Load(cfg)
+		w, err := m.Load(LoadWalletParams{
+			Name:          "test",
+			PubPassphrase: []byte("public"),
+		})
 
 		// Assert that the Manager replaces the internal database sentinel
 		// with its public missing-wallet contract and returns no partial
@@ -595,10 +605,7 @@ func TestManagerLoadMissingSQLite(t *testing.T) {
 	const walletName = "no-such-wallet"
 
 	// Act by loading the absent wallet through the public Manager method.
-	w, err := m.Load(Config{
-		Chain: &bwmock.Chain{},
-		Name:  walletName,
-	})
+	w, err := m.Load(LoadWalletParams{Name: walletName})
 
 	// Assert that callers receive only the wallet-owned sentinel, retain the
 	// requested name for context, and never receive a partial Wallet.
@@ -804,12 +811,18 @@ func TestManagerKVDBRejectsSecondName(t *testing.T) {
 	require.ErrorIs(t, err, ErrInvalidParam)
 	require.ErrorContains(t, err, "one wallet per database")
 
-	_, err = m.Load(second)
+	_, err = m.Load(LoadWalletParams{
+		Name:          second.Name,
+		PubPassphrase: second.PubPassphrase,
+	})
 	require.ErrorIs(t, err, ErrInvalidParam)
 
 	// The rejected call did not replace the backend's wallet: the original
 	// name still resolves to the same wallet, and that wallet still works.
-	again, err := m.Load(cfg)
+	again, err := m.Load(LoadWalletParams{
+		Name:          cfg.Name,
+		PubPassphrase: cfg.PubPassphrase,
+	})
 	require.NoError(t, err)
 	require.Same(t, first, again)
 
@@ -923,13 +936,17 @@ func TestManagerCreateHonoursCreatePubPassphrase(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, w)
 	require.NoError(t, m.Close())
+
 	// Assert: a fresh Manager opens the wallet with the passphrase it was
 	// created under.
 	loadCfg := cfg
 	loadCfg.PubPassphrase = createPub
 
 	reopened := testKVDBManagerAt(t, dbPath)
-	loaded, err := reopened.Load(loadCfg)
+	loaded, err := reopened.Load(LoadWalletParams{
+		Name:          loadCfg.Name,
+		PubPassphrase: loadCfg.PubPassphrase,
+	})
 	require.NoError(t, err)
 	require.NotNil(t, loaded)
 	require.NoError(t, reopened.Close())

--- a/wallet/manager_test.go
+++ b/wallet/manager_test.go
@@ -31,7 +31,7 @@ func TestManagerBuildsWalletsFromRuntimePolicy(t *testing.T) {
 	t.Parallel()
 
 	// Arrange: Configure two exact Store creations and a distinctive Manager
-	// snapshot; the caller Config values deliberately conflict with that policy.
+	// snapshot shared by both identity-only creation requests.
 	const secondWalletName = "second"
 
 	store := &walletmock.Store{}
@@ -63,15 +63,14 @@ func TestManagerBuildsWalletsFromRuntimePolicy(t *testing.T) {
 		PrivatePassphrase: []byte("private"),
 	}
 
-	// Act: Create two Wallets while supplying conflicting per-call policy,
-	// then mutate one Wallet's network snapshot after both are assembled.
-	first, err := manager.Create(Config{
-		Name:           "first",
-		Chain:          &bwmock.Chain{},
-		RecoveryWindow: 99,
-	}, params)
+	// Act: Create two Wallets with different durable names, then mutate one
+	// Wallet's network snapshot after both are assembled.
+	params.Name = "first"
+	first, err := manager.Create(params)
 	require.NoError(t, err)
-	second, err := manager.Create(Config{Name: "second"}, params)
+
+	params.Name = secondWalletName
+	second, err := manager.Create(params)
 	require.NoError(t, err)
 
 	first.cfg.ChainParams.Name = "mutated"
@@ -133,7 +132,6 @@ func TestManagerCreateSuccess(t *testing.T) {
 			name: "ModeGenSeed",
 			params: CreateWalletParams{
 				Mode:              ModeGenSeed,
-				PubPassphrase:     []byte("public"),
 				PrivatePassphrase: []byte("private"),
 				Birthday:          time.Now(),
 			},
@@ -143,7 +141,6 @@ func TestManagerCreateSuccess(t *testing.T) {
 			params: CreateWalletParams{
 				Mode:              ModeImportSeed,
 				Seed:              seed,
-				PubPassphrase:     []byte("public"),
 				PrivatePassphrase: []byte("private"),
 				Birthday:          time.Now(),
 			},
@@ -153,7 +150,6 @@ func TestManagerCreateSuccess(t *testing.T) {
 			params: CreateWalletParams{
 				Mode:              ModeImportExtKey,
 				RootKey:           rootKey,
-				PubPassphrase:     []byte("public"),
 				PrivatePassphrase: []byte("private"),
 				Birthday:          time.Now(),
 			},
@@ -169,9 +165,8 @@ func TestManagerCreateSuccess(t *testing.T) {
 					Name:                 "test-shell-account",
 					AddrType:             waddrmgr.NestedWitnessPubKey,
 				}},
-				WatchOnly:     true,
-				PubPassphrase: []byte("public"),
-				Birthday:      time.Now(),
+				WatchOnly: true,
+				Birthday:  time.Now(),
 			},
 		},
 	}
@@ -181,15 +176,13 @@ func TestManagerCreateSuccess(t *testing.T) {
 			t.Parallel()
 
 			m := testKVDBManager(t)
-			cfg := Config{
-				Chain:         &bwmock.Chain{},
-				ChainParams:   &chainParams,
-				Name:          "test-wallet",
-				PubPassphrase: []byte("public"),
-			}
 
-			// Attempt to create the wallet with the specified parameters.
-			w, err := m.Create(cfg, tc.params)
+			// Act: Attach the durable identity to the mode-specific request and
+			// create it through the Manager-owned runtime policy.
+			params := tc.params
+			params.Name = testWalletName
+			params.PubPassphrase = []byte("public")
+			w, err := m.Create(params)
 
 			// Verify that the wallet was created successfully and returned
 			// without error.
@@ -199,9 +192,9 @@ func TestManagerCreateSuccess(t *testing.T) {
 
 			// Verify internal state: Ensure the manager is tracking the
 			// newly created wallet in its internal map, keyed by the
-			// configuration name.
+			// durable request name.
 			m.RLock()
-			loadedW, ok := m.wallets["test-wallet"]
+			loadedW, ok := m.wallets[testWalletName]
 			m.RUnlock()
 			require.True(t, ok)
 			require.Same(t, w, loadedW)
@@ -397,11 +390,9 @@ func TestCreateWalletParamsPolicy(t *testing.T) {
 					ChainParams: chainParams,
 				},
 			}
-			cfg := Config{
-				Chain: &bwmock.Chain{}, Name: "test-wallet",
-			}
-
-			wallet, err := m.Create(cfg, tc.params)
+			params := tc.params
+			params.Name = testWalletName
+			wallet, err := m.Create(params)
 			require.Nil(t, wallet)
 
 			if tc.valid {
@@ -434,7 +425,7 @@ type recordingManagerBackend struct{ createCalled bool }
 var _ managerBackend = (*recordingManagerBackend)(nil)
 
 // create records an unexpected backend creation attempt.
-func (b *recordingManagerBackend) create(_ context.Context, _ Config,
+func (b *recordingManagerBackend) create(_ context.Context,
 	_ CreateWalletParams, _ *hdkeychain.ExtendedKey) (*walletData, error) {
 
 	b.createCalled = true
@@ -454,23 +445,43 @@ func (*recordingManagerBackend) close() error {
 	return nil
 }
 
+// TestManagerCreateRejectsMissingIdentityBeforeAssembly verifies Create
+// rejects an absent durable key before Store work.
+func TestManagerCreateRejectsMissingIdentityBeforeAssembly(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Give Create a strict Store mock with no expectations. The
+	// otherwise empty request makes the missing durable identity the only
+	// relevant input.
+	store := &walletmock.Store{}
+	manager := testSQLManager(t, store)
+
+	// Act: Invoke Create without the durable identity required for cache and
+	// Store selection.
+	w, err := manager.Create(CreateWalletParams{})
+
+	// Assert: The identity error is primary, no partial Wallet escapes, and
+	// the strict Store confirms validation happened before durable work or
+	// Wallet assembly.
+	require.ErrorIs(t, err, ErrMissingParam)
+	require.ErrorContains(t, err, "Name")
+	require.Nil(t, w)
+	store.AssertExpectations(t)
+}
+
 // TestManagerLoadSuccess verifies that an existing KVDB wallet can be reopened
 // with the empty public passphrase supported by the legacy address manager.
 func TestManagerLoadSuccess(t *testing.T) {
 	t.Parallel()
 
 	// Arrange: Use one database path for both Managers and deliberately omit
-	// the public passphrase from both creation carriers. The private
-	// passphrase remains non-empty because spendable wallets require it.
+	// the public passphrase from the creation request. The private passphrase
+	// remains non-empty because spendable wallets require it.
 	dbPath := testKVDBPath(t)
 
 	m := testKVDBManagerAt(t, dbPath)
-	cfg := Config{
-		Chain:       &bwmock.Chain{},
-		ChainParams: &chainParams,
-		Name:        "test-wallet",
-	}
 	params := CreateWalletParams{
+		Name:              testWalletName,
 		Mode:              ModeGenSeed,
 		PrivatePassphrase: []byte("private"),
 		Birthday:          time.Now(),
@@ -478,7 +489,7 @@ func TestManagerLoadSuccess(t *testing.T) {
 
 	// Act: Create the wallet through the first Manager using the empty public
 	// credential that the underlying KVDB format accepts.
-	wCreated, err := m.Create(cfg, params)
+	wCreated, err := m.Create(params)
 
 	// Assert: Creation succeeds and returns the live wallet that will later be
 	// compared with the reopened metadata.
@@ -490,8 +501,8 @@ func TestManagerLoadSuccess(t *testing.T) {
 	require.NoError(t, m.Close())
 	m2 := testKVDBManagerAt(t, dbPath)
 	w, err := m2.Load(LoadWalletParams{
-		Name:          cfg.Name,
-		PubPassphrase: cfg.PubPassphrase,
+		Name:          params.Name,
+		PubPassphrase: params.PubPassphrase,
 	})
 
 	// Assert: Reopening succeeds, registers the Wallet under its durable name,
@@ -500,7 +511,7 @@ func TestManagerLoadSuccess(t *testing.T) {
 	require.NotNil(t, w)
 
 	m2.RLock()
-	loadedW, ok := m2.wallets["test-wallet"]
+	loadedW, ok := m2.wallets[testWalletName]
 	m2.RUnlock()
 	require.True(t, ok)
 	require.Same(t, w, loadedW)
@@ -518,28 +529,23 @@ func TestManagerLoadExistingWallet(t *testing.T) {
 	dbPath := testKVDBPath(t)
 
 	m := testKVDBManagerAt(t, dbPath)
-	cfg := Config{
-		Chain:         &bwmock.Chain{},
-		ChainParams:   &chainParams,
-		Name:          "test-wallet",
-		PubPassphrase: []byte("public"),
-	}
 	params := CreateWalletParams{
+		Name:              testWalletName,
 		Mode:              ModeGenSeed,
 		PubPassphrase:     []byte("public"),
 		PrivatePassphrase: []byte("private"),
 		Birthday:          time.Now(),
 	}
 
-	wCreated, err := m.Create(cfg, params)
+	wCreated, err := m.Create(params)
 	require.NoError(t, err)
 
 	// Attempt to load the same wallet again using the same manager instance.
 	// Since it's already loaded in memory, the manager should return the
 	// existing instance rather than reloading from disk.
 	wLoaded, err := m.Load(LoadWalletParams{
-		Name:          cfg.Name,
-		PubPassphrase: cfg.PubPassphrase,
+		Name:          params.Name,
+		PubPassphrase: params.PubPassphrase,
 	})
 
 	// Verify that we got the same wallet instance back.
@@ -651,14 +657,13 @@ func TestManagerString(t *testing.T) {
 	}
 }
 
-// TestManager_deriveFromSeed verifies the internal helper method
+// TestManagerDeriveFromSeed verifies the internal helper method
 // deriveFromSeed, checking that it correctly derives a master private key
 // from a seed and validates inputs.
-func TestManager_deriveFromSeed(t *testing.T) {
+func TestManagerDeriveFromSeed(t *testing.T) {
 	t.Parallel()
 
 	m := testKVDBManager(t)
-	cfg := Config{ChainParams: &chainParams}
 
 	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
@@ -666,7 +671,7 @@ func TestManager_deriveFromSeed(t *testing.T) {
 		seed, err := hdkeychain.GenerateSeed(hdkeychain.RecommendedSeedLen)
 		require.NoError(t, err)
 
-		key, err := m.deriveFromSeed(cfg, seed)
+		key, err := m.deriveFromSeed(seed)
 
 		// Verify we got a valid private extended key.
 		require.NoError(t, err)
@@ -677,7 +682,7 @@ func TestManager_deriveFromSeed(t *testing.T) {
 	t.Run("Empty Seed", func(t *testing.T) {
 		t.Parallel()
 
-		key, err := m.deriveFromSeed(cfg, nil)
+		key, err := m.deriveFromSeed(nil)
 		require.ErrorIs(t, err, ErrWalletParams)
 		require.ErrorContains(t, err, "seed is required")
 		require.Nil(t, key)
@@ -687,23 +692,22 @@ func TestManager_deriveFromSeed(t *testing.T) {
 		t.Parallel()
 
 		// Providing a seed that is too short for hdkeychain.NewMaster.
-		key, err := m.deriveFromSeed(cfg, []byte{0x01})
+		key, err := m.deriveFromSeed([]byte{0x01})
 		require.ErrorContains(t, err, "failed to derive master key")
 		require.Nil(t, key)
 	})
 }
 
-// TestManager_genRootKey verifies the internal helper method genRootKey,
+// TestManagerGenRootKey verifies the internal helper method genRootKey,
 // ensuring it generates a random seed and derives a valid master key.
-func TestManager_genRootKey(t *testing.T) {
+func TestManagerGenRootKey(t *testing.T) {
 	t.Parallel()
 
 	m := testKVDBManager(t)
-	cfg := Config{ChainParams: &chainParams}
 
 	// With no configured kvdb path there is no legacy wallet to recover, so
 	// genRootKey takes the fresh-generation branch.
-	key, err := m.genRootKey(cfg)
+	key, err := m.genRootKey()
 
 	// Verify we got a valid private extended key.
 	require.NoError(t, err)
@@ -711,20 +715,19 @@ func TestManager_genRootKey(t *testing.T) {
 	require.True(t, key.IsPrivate())
 }
 
-// TestManager_deriveRootKey verifies the high-level key derivation logic,
+// TestManagerDeriveRootKey verifies the high-level key derivation logic,
 // checking that it correctly dispatches to the appropriate helper based on
 // the creation mode.
-func TestManager_deriveRootKey(t *testing.T) {
+func TestManagerDeriveRootKey(t *testing.T) {
 	t.Parallel()
 
 	m := testKVDBManager(t)
-	cfg := Config{ChainParams: &chainParams}
 
 	// ModeShell should return nil/nil because it has no root key.
 	t.Run("ModeShell", func(t *testing.T) {
 		t.Parallel()
 
-		key, err := m.deriveRootKey(cfg, CreateWalletParams{Mode: ModeShell})
+		key, err := m.deriveRootKey(CreateWalletParams{Mode: ModeShell})
 		require.NoError(t, err)
 		require.Nil(t, key)
 	})
@@ -733,7 +736,7 @@ func TestManager_deriveRootKey(t *testing.T) {
 	t.Run("ModeGenSeed", func(t *testing.T) {
 		t.Parallel()
 
-		key, err := m.deriveRootKey(cfg, CreateWalletParams{Mode: ModeGenSeed})
+		key, err := m.deriveRootKey(CreateWalletParams{Mode: ModeGenSeed})
 		require.NoError(t, err)
 		require.NotNil(t, key)
 		require.True(t, key.IsPrivate())
@@ -747,6 +750,7 @@ func TestManagerKVDBCreateWatchOnlyShell(t *testing.T) {
 	t.Parallel()
 
 	params := CreateWalletParams{
+		Name:              testWalletName,
 		Mode:              ModeShell,
 		WatchOnly:         true,
 		PubPassphrase:     []byte("public"),
@@ -754,7 +758,7 @@ func TestManagerKVDBCreateWatchOnlyShell(t *testing.T) {
 		Birthday:          time.Now(),
 	}
 
-	w, err := testKVDBManager(t).Create(testWatchOnlyConfig(), params)
+	w, err := testKVDBManager(t).Create(params)
 	require.NoError(t, err)
 	require.NotNil(t, w)
 	require.True(t, w.IsWatchOnly())
@@ -765,70 +769,34 @@ func TestManagerKVDBCreateWatchOnlyShell(t *testing.T) {
 	require.Zero(t, w.masterFingerprint)
 }
 
-// testWatchOnlyConfig returns the wallet Config shared by the watch-only
-// Manager tests.
-func testWatchOnlyConfig() Config {
-	return Config{
-		Chain:         &bwmock.Chain{},
-		ChainParams:   &chainParams,
-		Name:          "watch-only",
-		PubPassphrase: []byte("public"),
-	}
-}
-
-// TestManagerKVDBRejectsSecondName verifies that a kvdb Manager serves one
-// wallet per database.
-//
-// The deprecated kvdb backend owns one live address manager, so it rejects a
-// second wallet name. Restart-stable name identity is a separate question;
-// this covers the in-process limit retained until kvdb support is removed.
-func TestManagerKVDBRejectsSecondName(t *testing.T) {
+// TestManagerKVDBRejectsSecondCreate verifies the legacy backend enforces its
+// one-Wallet limit even when the second request has another runtime name.
+func TestManagerKVDBRejectsSecondCreate(t *testing.T) {
 	t.Parallel()
 
+	// Arrange: Create the one Wallet the kvdb backend can keep open.
 	m := testKVDBManager(t)
-	cfg := Config{
-		Chain:         &bwmock.Chain{},
-		ChainParams:   &chainParams,
-		Name:          "first",
-		PubPassphrase: []byte("public"),
-	}
 	params := CreateWalletParams{
+		Name:              "first",
 		Mode:              ModeGenSeed,
 		PubPassphrase:     []byte("public"),
 		PrivatePassphrase: []byte("private"),
 		Birthday:          time.Now(),
 	}
 
-	first, err := m.Create(cfg, params)
+	first, err := m.Create(params)
 	require.NoError(t, err)
 	require.NotNil(t, first)
 
-	// A different name on the same Manager is refused.
-	second := cfg
-	second.Name = "second"
+	// Act: Attempt to create a sibling identity through the same Manager.
+	params.Name = "second"
+	second, err := m.Create(params)
 
-	_, err = m.Create(second, params)
+	// Assert: The backend reports its single-Wallet constraint and does not
+	// return a second runtime instance.
 	require.ErrorIs(t, err, ErrInvalidParam)
 	require.ErrorContains(t, err, "one wallet per database")
-
-	_, err = m.Load(LoadWalletParams{
-		Name:          second.Name,
-		PubPassphrase: second.PubPassphrase,
-	})
-	require.ErrorIs(t, err, ErrInvalidParam)
-
-	// The rejected call did not replace the backend's wallet: the original
-	// name still resolves to the same wallet, and that wallet still works.
-	again, err := m.Load(LoadWalletParams{
-		Name:          cfg.Name,
-		PubPassphrase: cfg.PubPassphrase,
-	})
-	require.NoError(t, err)
-	require.Same(t, first, again)
-
-	startLoadedWalletForTest(t, again)
-	_, err = again.ListAccounts(t.Context())
-	require.NoError(t, err)
+	require.Nil(t, second)
 }
 
 // TestManagerCreateFailureLeavesManagerReusable verifies that a failed Create
@@ -842,11 +810,9 @@ func TestManagerCreateFailureLeavesManagerReusable(t *testing.T) {
 	testCases := []struct {
 		name    string
 		manager func(testing.TB) *Manager
-		pubPass []byte
 	}{{
 		name:    "kvdb",
 		manager: testKVDBManager,
-		pubPass: []byte("public"),
 	}, {
 		name:    "sqlite",
 		manager: testSQLiteManager,
@@ -857,13 +823,6 @@ func TestManagerCreateFailureLeavesManagerReusable(t *testing.T) {
 			t.Parallel()
 
 			m := tc.manager(t)
-			cfg := Config{
-				Chain:         &bwmock.Chain{},
-				ChainParams:   &chainParams,
-				Name:          testWalletName,
-				PubPassphrase: tc.pubPass,
-			}
-
 			// Arrange + Act: a seed too short for BIP32 fails root
 			// derivation, after the Manager has already opened its
 			// database.
@@ -872,10 +831,11 @@ func TestManagerCreateFailureLeavesManagerReusable(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			w, err := m.Create(cfg, CreateWalletParams{
+			w, err := m.Create(CreateWalletParams{
+				Name:              testWalletName,
 				Mode:              ModeImportSeed,
 				Seed:              seed[:hdkeychain.MinSeedBytes-1],
-				PubPassphrase:     tc.pubPass,
+				PubPassphrase:     []byte("public"),
 				PrivatePassphrase: []byte("private"),
 				Birthday:          time.Now(),
 			})
@@ -884,10 +844,11 @@ func TestManagerCreateFailureLeavesManagerReusable(t *testing.T) {
 
 			// Assert: nothing was published, so the name is free and
 			// a corrected create succeeds over the same database.
-			w, err = m.Create(cfg, CreateWalletParams{
+			w, err = m.Create(CreateWalletParams{
+				Name:              testWalletName,
 				Mode:              ModeImportSeed,
 				Seed:              seed,
-				PubPassphrase:     tc.pubPass,
+				PubPassphrase:     []byte("public"),
 				PrivatePassphrase: []byte("private"),
 				Birthday:          time.Now(),
 			})
@@ -899,55 +860,4 @@ func TestManagerCreateFailureLeavesManagerReusable(t *testing.T) {
 			require.NoError(t, m.Close())
 		})
 	}
-}
-
-// TestManagerCreateHonoursCreatePubPassphrase verifies that a kvdb wallet is
-// created under CreateWalletParams.PubPassphrase, not Config.PubPassphrase. The
-// two are separate credentials — the request's is the create one, the config's
-// is what a later Load supplies — so a test that sets them to the same bytes
-// cannot tell the two apart and would mask a create path reading the wrong
-// field.
-func TestManagerCreateHonoursCreatePubPassphrase(t *testing.T) {
-	t.Parallel()
-
-	seed, err := hdkeychain.GenerateSeed(hdkeychain.RecommendedSeedLen)
-	require.NoError(t, err)
-
-	dbPath := testKVDBPath(t)
-
-	createPub := []byte("create-public-passphrase")
-	configPub := []byte("config-public-passphrase")
-
-	// Arrange + Act: create under createPub while the Config names configPub.
-	m := testKVDBManagerAt(t, dbPath)
-	cfg := Config{
-		Chain:         &bwmock.Chain{},
-		ChainParams:   &chainParams,
-		Name:          testWalletName,
-		PubPassphrase: configPub,
-	}
-	w, err := m.Create(cfg, CreateWalletParams{
-		Mode:              ModeImportSeed,
-		Seed:              seed,
-		PubPassphrase:     createPub,
-		PrivatePassphrase: []byte("private"),
-		Birthday:          time.Now(),
-	})
-	require.NoError(t, err)
-	require.NotNil(t, w)
-	require.NoError(t, m.Close())
-
-	// Assert: a fresh Manager opens the wallet with the passphrase it was
-	// created under.
-	loadCfg := cfg
-	loadCfg.PubPassphrase = createPub
-
-	reopened := testKVDBManagerAt(t, dbPath)
-	loaded, err := reopened.Load(LoadWalletParams{
-		Name:          loadCfg.Name,
-		PubPassphrase: loadCfg.PubPassphrase,
-	})
-	require.NoError(t, err)
-	require.NotNil(t, loaded)
-	require.NoError(t, reopened.Close())
 }

--- a/wallet/manager_test.go
+++ b/wallet/manager_test.go
@@ -923,7 +923,6 @@ func TestManagerCreateHonoursCreatePubPassphrase(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, w)
 	require.NoError(t, m.Close())
-
 	// Assert: a fresh Manager opens the wallet with the passphrase it was
 	// created under.
 	loadCfg := cfg

--- a/wallet/manager_test.go
+++ b/wallet/manager_test.go
@@ -890,13 +890,15 @@ func TestManagerIgnoresPerWalletDBAndChainParams(t *testing.T) {
 
 			dbPath := filepath.Join(t.TempDir(), tc.file)
 			open := func() (*Manager, error) {
-				return NewManager(
-					t.Context(), ManagerConfig{
-						Backend:     tc.backend,
-						DataSource:  dbPath,
-						ChainParams: &chainParams,
-					},
-				)
+				// Populate only inputs owned by the selected backend so SQL
+				// cases cannot accidentally depend on legacy credentials.
+				cfg := ManagerConfig{
+					Backend:     tc.backend,
+					DataSource:  dbPath,
+					ChainParams: chainParams,
+					ChainSource: &bwmock.Chain{},
+				}
+				return NewManager(t.Context(), cfg)
 			}
 
 			seed, err := hdkeychain.GenerateSeed(

--- a/wallet/manager_test.go
+++ b/wallet/manager_test.go
@@ -3,15 +3,16 @@ package wallet
 import (
 	"context"
 	"errors"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
 	bwmock "github.com/btcsuite/btcwallet/bwtest/mock"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	walletmock "github.com/btcsuite/btcwallet/wallet/internal/bwtest/mock"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,6 +23,78 @@ func TestWalletID(t *testing.T) {
 	w := &Wallet{id: 42}
 
 	require.Equal(t, uint32(42), w.ID())
+}
+
+// TestManagerBuildsWalletsFromRuntimePolicy verifies sibling SQL Wallets use
+// identical Manager policy while retaining independent mutable snapshots.
+func TestManagerBuildsWalletsFromRuntimePolicy(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Configure two exact Store creations and a distinctive Manager
+	// snapshot; the caller Config values deliberately conflict with that policy.
+	const secondWalletName = "second"
+
+	store := &walletmock.Store{}
+	for i, name := range []string{"first", secondWalletName} {
+		walletID := uint32(i + 1)
+		store.On(
+			"CreateWallet", mock.Anything,
+			mock.MatchedBy(func(params db.CreateWalletParams) bool {
+				return params.Name == name
+			}),
+		).Return(&db.WalletInfo{
+			ID:          walletID,
+			Name:        name,
+			IsWatchOnly: true,
+		}, nil).Once()
+	}
+
+	chainSource := &bwmock.Chain{}
+	manager := testSQLManager(t, store)
+	manager.config.ChainSource = chainSource
+	manager.config.SyncMethod = SyncMethodFullBlocks
+	manager.config.WalletSyncRetryInterval = 2 * time.Second
+	manager.config.RecoveryWindow = 12
+	manager.config.AutoLockDuration = 3 * time.Minute
+	manager.config.MaxCFilterItems = 50
+	params := CreateWalletParams{
+		Mode:              ModeShell,
+		WatchOnly:         true,
+		PrivatePassphrase: []byte("private"),
+	}
+
+	// Act: Create two Wallets while supplying conflicting per-call policy,
+	// then mutate one Wallet's network snapshot after both are assembled.
+	first, err := manager.Create(Config{
+		Name:           "first",
+		Chain:          &bwmock.Chain{},
+		RecoveryWindow: 99,
+	}, params)
+	require.NoError(t, err)
+	second, err := manager.Create(Config{Name: "second"}, params)
+	require.NoError(t, err)
+
+	first.cfg.ChainParams.Name = "mutated"
+
+	// Assert: Verify the caller-owned source is shared while scalar policy is
+	// identical, network snapshots are independent, and each Store call occurs
+	// exactly once.
+	require.Same(t, chainSource, first.cfg.Chain)
+	require.Same(t, chainSource, second.cfg.Chain)
+	require.Equal(t, SyncMethodFullBlocks, first.cfg.SyncMethod)
+	require.Equal(t, first.cfg.SyncMethod, second.cfg.SyncMethod)
+	require.Equal(t, 2*time.Second, first.cfg.WalletSyncRetryInterval)
+	require.Equal(t, first.cfg.WalletSyncRetryInterval,
+		second.cfg.WalletSyncRetryInterval)
+	require.Equal(t, uint32(12), first.cfg.RecoveryWindow)
+	require.Equal(t, first.cfg.RecoveryWindow, second.cfg.RecoveryWindow)
+	require.Equal(t, 3*time.Minute, first.cfg.AutoLockDuration)
+	require.Equal(t, first.cfg.AutoLockDuration, second.cfg.AutoLockDuration)
+	require.Equal(t, uint32(50), first.cfg.MaxCFilterItems)
+	require.Equal(t, first.cfg.MaxCFilterItems, second.cfg.MaxCFilterItems)
+	require.NotEqual(t, first.cfg.ChainParams.Name,
+		second.cfg.ChainParams.Name)
+	store.AssertExpectations(t)
 }
 
 // TestManagerCreateSuccess verifies that a wallet can be successfully created
@@ -317,9 +390,12 @@ func TestCreateWalletParamsPolicy(t *testing.T) {
 
 			backend := &recordingManagerBackend{}
 			m := &Manager{
-				wallets:     make(map[string]*Wallet),
-				backend:     backend,
-				chainParams: &chainParams,
+				wallets: make(map[string]*Wallet),
+				backend: backend,
+				config: ManagerConfig{
+					ChainSource: &bwmock.Chain{},
+					ChainParams: chainParams,
+				},
 			}
 			cfg := Config{
 				Chain: &bwmock.Chain{}, Name: "test-wallet",
@@ -376,53 +452,6 @@ func (*recordingManagerBackend) load(context.Context, Config) (*walletData,
 // close is not used by creation-policy tests.
 func (*recordingManagerBackend) close() error {
 	return nil
-}
-
-// TestManagerCreate_InvalidConfig verifies that the Create method performs
-// configuration validation before proceeding with any operations.
-func TestManagerCreate_InvalidConfig(t *testing.T) {
-	t.Parallel()
-
-	m := testKVDBManager(t)
-
-	// Call Create with an empty Config struct. This should fail because
-	// required fields like Chain and ChainParams are missing.
-	w, err := m.Create(Config{}, CreateWalletParams{})
-
-	require.ErrorIs(t, err, ErrMissingParam)
-	require.ErrorContains(t, err, "Chain")
-	require.Nil(t, w)
-}
-
-// TestManagerCreateExcessRecoveryWindow verifies that a recovery window above
-// the public maximum is rejected on the configuration's own merits, before
-// Create reaches the store or the chain backend that would serve it.
-func TestManagerCreateExcessRecoveryWindow(t *testing.T) {
-	t.Parallel()
-
-	// A chain mock with no registered calls fails the test if the request
-	// reaches the chain backend.
-	chainMock := &bwmock.Chain{}
-	defer chainMock.AssertExpectations(t)
-
-	backend := &recordingManagerBackend{}
-	m := &Manager{
-		wallets:     make(map[string]*Wallet),
-		backend:     backend,
-		chainParams: &chainParams,
-	}
-	cfg := Config{
-		Chain:          chainMock,
-		Name:           "test-wallet",
-		RecoveryWindow: MaxRecoveryWindow + 1,
-	}
-
-	w, err := m.Create(cfg, CreateWalletParams{Mode: ModeGenSeed})
-
-	require.Nil(t, w)
-	require.ErrorIs(t, err, ErrInvalidParam)
-	require.ErrorContains(t, err, "RecoveryWindow")
-	require.False(t, backend.createCalled)
 }
 
 // TestManagerLoadSuccess verifies that an existing wallet can be successfully
@@ -855,91 +884,6 @@ func TestManagerCreateFailureLeavesManagerReusable(t *testing.T) {
 			// Close releases the one database the Manager owns. It is
 			// called once, after quiescence.
 			require.NoError(t, m.Close())
-		})
-	}
-}
-
-// TestManagerIgnoresPerWalletDBAndChainParams verifies that the Manager owns
-// the database and the network for every wallet it serves: a per-wallet Config
-// that leaves both unset still yields a working wallet on the Manager's own
-// database and chain parameters, on both backends.
-// Config.DB is deprecated and Config.ChainParams is overwritten, so neither
-// can steer a wallet somewhere the Manager did not open.
-func TestManagerIgnoresPerWalletDBAndChainParams(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		name    string
-		backend DBBackend
-		file    string
-		pubPass []byte
-	}{{
-		name:    "kvdb",
-		backend: DBBackendKVDB,
-		file:    "wallet.db",
-		pubPass: []byte("public"),
-	}, {
-		name:    "sqlite",
-		backend: DBBackendSQLite,
-		file:    "wallet.sqlite",
-	}}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			dbPath := filepath.Join(t.TempDir(), tc.file)
-			open := func() (*Manager, error) {
-				// Populate only inputs owned by the selected backend so SQL
-				// cases cannot accidentally depend on legacy credentials.
-				cfg := ManagerConfig{
-					Backend:     tc.backend,
-					DataSource:  dbPath,
-					ChainParams: chainParams,
-					ChainSource: &bwmock.Chain{},
-				}
-				return NewManager(t.Context(), cfg)
-			}
-
-			seed, err := hdkeychain.GenerateSeed(
-				hdkeychain.RecommendedSeedLen,
-			)
-			require.NoError(t, err)
-
-			m, err := open()
-			require.NoError(t, err)
-
-			// Arrange: no DB and no network at all — the Manager
-			// must supply both.
-			cfg := Config{
-				Chain:         &bwmock.Chain{},
-				ChainParams:   nil,
-				DB:            nil,
-				Name:          testWalletName,
-				PubPassphrase: tc.pubPass,
-			}
-
-			w, err := m.Create(cfg, CreateWalletParams{
-				Mode:              ModeImportSeed,
-				Seed:              seed,
-				PubPassphrase:     tc.pubPass,
-				PrivatePassphrase: []byte("private"),
-				Birthday:          time.Now(),
-			})
-			require.NoError(t, err)
-
-			// Assert: a *fresh* Manager over the same database performs
-			// a real Load with the same nil-field Config, so the
-			// injection is proven off the cached-hit path too.
-			require.NoError(t, m.Close())
-
-			reopened, err := open()
-			require.NoError(t, err)
-			t.Cleanup(func() { _ = reopened.Close() })
-
-			fresh, err := reopened.Load(cfg)
-			require.NoError(t, err)
-			require.NotSame(t, w, fresh)
 		})
 	}
 }

--- a/wallet/manager_wallet.go
+++ b/wallet/manager_wallet.go
@@ -8,10 +8,6 @@ import (
 // newManagedWallet constructs a Wallet from backend-validated storage data.
 // The backend remains the owner of every resource referenced by data.
 func newManagedWallet(cfg Config, data *walletData) *Wallet {
-	if cfg.AutoLockDuration == 0 {
-		cfg.AutoLockDuration = defaultLockDuration
-	}
-
 	lockTimer := time.NewTimer(0)
 	if !lockTimer.Stop() {
 		<-lockTimer.C

--- a/wallet/syncer.go
+++ b/wallet/syncer.go
@@ -1552,7 +1552,7 @@ func (s *syncer) fetchAndFilterBlocks(ctx context.Context,
 // bypassing filters and streaming full blocks (especially from a local node)
 // is often more performant and uses less CPU time overall. This threshold is
 // conservative to favor CFilters for typical wallet sizes (<10k items).
-const defaultMaxCFilterItems = 100000
+const defaultMaxCFilterItems uint32 = 100000
 
 // dispatchScanStrategy chooses and executes the appropriate scanning strategy
 // based on the wallet's configuration and heuristics.
@@ -1583,10 +1583,11 @@ func (s *syncer) dispatchScanStrategy(ctx context.Context,
 			threshold = defaultMaxCFilterItems
 		}
 
-		if scanState.WatchListSize() > threshold {
+		watchListSize := scanState.WatchListSize()
+		if int64(watchListSize) > int64(threshold) {
 			log.Infof("Auto sync: Watchlist size %d > %d, "+
 				"switching to full blocks for performance",
-				scanState.WatchListSize(), threshold)
+				watchListSize, threshold)
 
 			return s.scanBatchWithFullBlocks(
 				ctx, scanState, startHeight, hashes,

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -238,7 +238,7 @@ type Config struct {
 	// scanning when SyncMethodAuto is used. This avoids the CPU bottleneck
 	// of client-side filter matching for large watchlists. If 0, a default
 	// of 100,000 is used.
-	MaxCFilterItems int
+	MaxCFilterItems uint32
 }
 
 // validate checks the configuration for consistency and completeness.

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -174,8 +174,9 @@ const (
 	SyncMethodFullBlocks
 )
 
-// Config holds the configuration options for creating a new
-// WalletController.
+// Config holds Wallet-local runtime policy assembled internally by Manager or
+// supplied to deprecated constructors. Maintained Manager callers configure
+// runtime policy through ManagerConfig instead.
 type Config struct {
 	// DB is the underlying database for the wallet.
 	//
@@ -221,15 +222,15 @@ type Config struct {
 	// request.
 	AutoLockDuration time.Duration
 
-	// Name is the unique identifier for the wallet. It is used to track
-	// active wallet instances within the Manager.
+	// Name is the durable identity attached during internal Wallet assembly.
+	// Maintained callers supply it through CreateWalletParams or
+	// LoadWalletParams.
 	Name string
 
-	// PubPassphrase is the public passphrase for the wallet.
+	// PubPassphrase is the legacy public passphrase.
 	//
-	// Deprecated: only the kvdb backend has a public passphrase. A SQL
-	// wallet seals its metadata under a single passphrase, so this field is
-	// ignored there and goes away with kvdb support.
+	// Deprecated: Manager APIs carry this credential in their narrow request
+	// parameters, and managed Wallets do not retain it.
 	PubPassphrase []byte
 
 	// MaxCFilterItems is the threshold of watched items (addresses +

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -15,7 +15,6 @@ package wallet
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
@@ -239,28 +238,6 @@ type Config struct {
 	// of client-side filter matching for large watchlists. If 0, a default
 	// of 100,000 is used.
 	MaxCFilterItems uint32
-}
-
-// validate checks the configuration for consistency and completeness.
-func (c *Config) validate() error {
-	if c.Chain == nil {
-		return fmt.Errorf("%w: Chain", ErrMissingParam)
-	}
-
-	if c.ChainParams == nil {
-		return fmt.Errorf("%w: ChainParams", ErrMissingParam)
-	}
-
-	if c.Name == "" {
-		return fmt.Errorf("%w: Name", ErrMissingParam)
-	}
-
-	if c.RecoveryWindow > MaxRecoveryWindow {
-		return fmt.Errorf("%w: RecoveryWindow must not exceed %d",
-			ErrInvalidParam, MaxRecoveryWindow)
-	}
-
-	return nil
 }
 
 // locateBirthdayBlock returns a block that meets the given birthday timestamp

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/wire/v2"
-	bwmock "github.com/btcsuite/btcwallet/bwtest/mock"
 	walletmock "github.com/btcsuite/btcwallet/wallet/internal/bwtest/mock"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wtxmgr"
@@ -58,109 +57,6 @@ func TestErrIndeterminateCommitWrapping(t *testing.T) {
 	// the useful context that identifies the affected operation.
 	require.ErrorIs(t, err, ErrIndeterminateCommit)
 	require.ErrorContains(t, err, operation)
-}
-
-// TestConfigValidate ensures that the Config.validate method correctly
-// identifies missing required parameters.
-func TestConfigValidate(t *testing.T) {
-	t.Parallel()
-
-	_, cleanup := setupTestDB(t)
-	t.Cleanup(cleanup)
-
-	testCases := []struct {
-		name        string
-		config      Config
-		expectedErr string
-	}{
-		{
-			name: "valid config",
-			config: Config{
-				Chain:       &bwmock.Chain{},
-				ChainParams: &chainParams,
-				Name:        "test-wallet",
-			},
-		},
-		{
-			name: "missing Chain",
-			config: Config{
-				ChainParams: &chainParams,
-				Name:        "test-wallet",
-			},
-			expectedErr: "Chain",
-		},
-		{
-			name: "missing ChainParams",
-			config: Config{
-				Chain: &bwmock.Chain{},
-				Name:  "test-wallet",
-			},
-			expectedErr: "ChainParams",
-		},
-		{
-			name: "missing Name",
-			config: Config{
-				Chain:       &bwmock.Chain{},
-				ChainParams: &chainParams,
-			},
-			expectedErr: "Name",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			err := tc.config.validate()
-			if tc.expectedErr == "" {
-				require.NoError(t, err)
-			} else {
-				require.ErrorContains(t, err, tc.expectedErr)
-			}
-		})
-	}
-}
-
-// TestConfigValidateRecoveryWindow ensures the configuration accepts every
-// recovery window from zero through the public maximum and rejects the first
-// value above it.
-func TestConfigValidateRecoveryWindow(t *testing.T) {
-	t.Parallel()
-
-	// A zero window asks for no look-ahead at all, and recovery already
-	// runs with windows far below the twenty this configuration used to
-	// demand, so every one of these is a request the wallet serves as
-	// written.
-	accepted := []uint32{0, 1, 2, 19, 20, MaxRecoveryWindow}
-	for _, window := range accepted {
-		t.Run(fmt.Sprintf("accepts %d", window), func(t *testing.T) {
-			t.Parallel()
-
-			cfg := Config{
-				Chain:          &bwmock.Chain{},
-				ChainParams:    &chainParams,
-				Name:           "test-wallet",
-				RecoveryWindow: window,
-			}
-
-			require.NoError(t, cfg.validate())
-		})
-	}
-
-	t.Run("rejects the first excess window", func(t *testing.T) {
-		t.Parallel()
-
-		cfg := Config{
-			Chain:          &bwmock.Chain{},
-			ChainParams:    &chainParams,
-			Name:           "test-wallet",
-			RecoveryWindow: MaxRecoveryWindow + 1,
-		}
-
-		err := cfg.validate()
-		require.ErrorIs(t, err, ErrInvalidParam)
-		require.ErrorContains(t, err, "RecoveryWindow")
-	})
 }
 
 // TestWalletSyncedToUsesStore verifies that a wallet without a legacy address


### PR DESCRIPTION
## Summary

Centralizes managed Wallet runtime configuration in one validated,
Manager-owned snapshot.

Implements roadmap Task 456.

## Changes

- Moves backend, chain, synchronization, retry, recovery, auto-lock, and
  compact-filter policy into `ManagerConfig`.
- Deep-copies mutable chain parameters at Manager, Wallet, and `Wallet.Info`
  ownership boundaries. Callers must provide canonical, fully populated chain
  parameters; malformed programmer inputs may panic.
- Narrows managed creation and loading to `CreateWalletParams` and
  `LoadWalletParams`, validating wallet identity before cache or backend work.
- Keeps the legacy KVDB public passphrase request-scoped and enforces its
  one-Wallet-per-Manager constraint without introducing a runtime alias.
- Uses Manager-normalized retry and auto-lock defaults as the single runtime
  authority.

## Scope

- Base: upstream `sql-wallet`.
- Uses the existing caller-owned `chain.Interface` and shared `db.Store`.
- Adds no Manager worker, event fan-out, chain-source factory, Store wrapper,
  KVDB alias, durable metadata, CLI, RPC, or daemon behavior.
- Keeps the upstream `task-runtime-config` branch published as the base for the
  next dependent PR.

## Intentional roadmap divergence

Under the approved best-fit implementation exception, this PR does not add the
roadmap's temporary chain-source factory or wallet Store adapter. Managed
Wallets temporarily consume the direct shared chain source; a `TODO(yy)`
records that later coordinator work must provide Manager-owned event fan-out.
The existing Store remains shared because wallet identity is already bound by
its operations.

The KVDB public passphrase remains a narrow create/load request input instead
of Manager configuration, and no KVDB alias is introduced. This keeps legacy
backend context out of Manager runtime policy while KVDB supports only one
Wallet per Manager.

The final identity-focused Create and Load request shape is adopted early;
later roadmap work still owns any context-first API transition.
