### PR TITLE
wallet: route account requests during stop

### DIFF
--- a/itest/account_manager_test.go
+++ b/itest/account_manager_test.go
@@ -331,7 +331,7 @@ func testAccountManagerEnforceAccountCreationLifecycle(h *bwtest.HarnessTest) {
 
 	_, err = w.NewAccount(ctx, scope, stoppedName)
 
-	require.ErrorIs(h, err, wallet.ErrStateForbidden)
+	require.ErrorIs(h, err, wallet.ErrWalletStopped)
 
 	// An admission rejected before or after the wallet stops must leave no
 	// partial account, so neither name resolves across a reopen and the
@@ -644,7 +644,7 @@ func testAccountManagerEnforceAccountRenameLifecycle(h *bwtest.HarnessTest) {
 
 	err = w.RenameAccount(ctx, scope, lockedName, stoppedName)
 
-	require.ErrorIs(h, err, wallet.ErrStateForbidden)
+	require.ErrorIs(h, err, wallet.ErrWalletStopped)
 
 	// The rejected rename must not move the account, so the source keeps
 	// its complete result and the target stays absent across a reopen.
@@ -993,7 +993,7 @@ func testAccountManagerEnforceAccountImportLifecycle(h *bwtest.HarnessTest) {
 		keys.addrType, false,
 	)
 
-	require.ErrorIs(h, err, wallet.ErrStateForbidden)
+	require.ErrorIs(h, err, wallet.ErrWalletStopped)
 
 	// A rejected import must leave no partial account, so the target stays
 	// absent across a reopen and the account set is unchanged.

--- a/itest/controller_credential_test.go
+++ b/itest/controller_credential_test.go
@@ -170,11 +170,13 @@ func testControllerChangePassphraseLifecycle(h *bwtest.HarnessTest) {
 		PrivateNew:    []byte(nextPassphrase),
 	})
 	require.ErrorIs(
-		h, err, wallet.ErrStateForbidden,
+		h, err, wallet.ErrWalletStopped,
 		"change passphrase after stop not rejected",
 	)
 
-	require.NoError(h, w.Start(h.Context()), "failed to restart wallet")
+	// Reload through the Manager because a stopped Wallet instance is
+	// terminal; the fresh instance also exposes any persisted mutation.
+	w = h.ReloadWallet(w)
 	requireLocked(h, w, true)
 
 	err = w.Unlock(h.Context(), wallet.UnlockRequest{

--- a/itest/controller_test.go
+++ b/itest/controller_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 // testControllerStartStop verifies the wallet lifecycle: a wallet starts and
-// stops cleanly, Stop is idempotent, a stopped instance restarts cleanly, and
-// a fresh Load yields a working instance.
+// stops cleanly, Stop is idempotent, the stopped instance is terminal, and a
+// fresh Load yields a working instance.
 func testControllerStartStop(h *bwtest.HarnessTest) {
 	params := h.TestWalletParams()
 
@@ -26,11 +26,19 @@ func testControllerStartStop(h *bwtest.HarnessTest) {
 	// A second Stop is a no-op.
 	require.NoError(h, w.Stop(h.Context()), "second stop should be a no-op")
 
-	require.NoError(h, w.Start(h.Context()), "failed to restart stopped wallet")
+	// A stopped Wallet is terminal. Both lifecycle restart and maintained
+	// access must fail on the retained pointer before any backend work begins.
+	require.ErrorIs(
+		h, w.Start(h.Context()), wallet.ErrWalletStopped,
+		"stopped wallet restarted",
+	)
+	_, err = w.Info(h.Context())
+	require.ErrorIs(
+		h, err, wallet.ErrWalletStopped,
+		"stopped wallet accepted maintained access",
+	)
 
-	// Keep the original wallet registered until Stop succeeds. Then remove it
-	// so MineBlocks cannot poll a stopped wallet during reload.
-	require.NoError(h, w.Stop(h.Context()), "failed to stop restarted wallet")
+	// Remove the terminal Wallet so MineBlocks cannot poll it during reload.
 	require.True(h, h.DeregisterWallet(w), "failed to deregister wallet")
 
 	// Keep the Manager registered until Close succeeds, then reload from disk.

--- a/itest/tx_creator_test.go
+++ b/itest/tx_creator_test.go
@@ -1022,7 +1022,7 @@ func testCreateTransactionWalletState(h *bwtest.HarnessTest) {
 
 	_, err = w.CreateTransaction(h.Context(), intent)
 	require.ErrorIs(
-		h, err, wallet.ErrStateForbidden,
+		h, err, wallet.ErrWalletStopped,
 		"create transaction after stop not rejected",
 	)
 }

--- a/itest/tx_publisher_test.go
+++ b/itest/tx_publisher_test.go
@@ -444,7 +444,7 @@ func testCheckMempoolAcceptanceWalletState(h *bwtest.HarnessTest) {
 
 	err = w.CheckMempoolAcceptance(h.Context(), tx)
 	require.ErrorIs(
-		h, err, wallet.ErrStateForbidden,
+		h, err, wallet.ErrWalletStopped,
 		"acceptance check after stop not rejected",
 	)
 }
@@ -476,7 +476,7 @@ func testBroadcastWalletState(h *bwtest.HarnessTest) {
 
 	err = w.Broadcast(h.Context(), tx, "")
 	require.ErrorIs(
-		h, err, wallet.ErrStateForbidden,
+		h, err, wallet.ErrWalletStopped,
 		"broadcast after stop not rejected",
 	)
 }

--- a/itest/tx_writer_test.go
+++ b/itest/tx_writer_test.go
@@ -315,7 +315,7 @@ func testLabelTxWalletState(h *bwtest.HarnessTest) {
 
 	err = w.LabelTx(h.Context(), txHash, label)
 	require.ErrorIs(
-		h, err, wallet.ErrStateForbidden,
+		h, err, wallet.ErrWalletStopped,
 		"labeling after stop not rejected",
 	)
 }

--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -424,6 +424,23 @@ func (w *Wallet) ListAccountsByName(ctx context.Context,
 	})
 }
 
+// accountResp carries one account snapshot or the lookup error so an accepted
+// handler can always finish even when its caller stops waiting.
+type accountResp struct {
+	info *AccountInfo
+	err  error
+}
+
+// getAccountReq owns the immutable lookup inputs and buffered response path
+// that cross the Wallet's request boundary.
+type getAccountReq struct {
+	reqCtx
+
+	scope waddrmgr.KeyScope
+	name  string
+	resp  chan accountResp
+}
+
 // GetAccount returns the account for a given account name and key scope.
 // The account snapshot, including the running balance, is fetched in a
 // single Store read.
@@ -435,24 +452,54 @@ func (w *Wallet) GetAccount(ctx context.Context, scope waddrmgr.KeyScope,
 		return nil, err
 	}
 
-	info, err := w.cache.GetAccount(ctx, db.GetAccountQuery{
-		WalletID: w.id,
-		Scope:    db.KeyScope(scope),
-		Name:     &name,
-	})
-	if err != nil {
-		// Preserve waddrmgr.ManagerError semantics so callers
-		// using waddrmgr.IsError(err, ...) keep working when kvdb
-		// wraps the underlying manager error via fmt.Errorf.
-		var mErr waddrmgr.ManagerError
-		if errors.As(err, &mErr) {
-			return nil, mErr
-		}
+	req := getAccountReq{
+		reqCtx: reqCtx{ctx: ctx},
+		scope:  scope,
+		name:   name,
+		resp:   make(chan accountResp, 1),
+	}
 
+	err = w.sendReq(ctx, req)
+	if err != nil {
 		return nil, err
 	}
 
-	return w.accountInfoFromStore(info)
+	resp, err := waitForReq(ctx, req.resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.info, resp.err
+}
+
+// handleGetAccount executes an accepted lookup with its caller context and
+// sends exactly one buffered response so shutdown never depends on a receiver.
+func (w *Wallet) handleGetAccount(req getAccountReq) {
+	info, err := w.cache.GetAccount(req.ctx, db.GetAccountQuery{
+		WalletID: w.id,
+		Scope:    db.KeyScope(req.scope),
+		Name:     &req.name,
+	})
+	if err != nil {
+		// Preserve waddrmgr.ManagerError semantics so callers using
+		// waddrmgr.IsError(err, ...) keep working when kvdb wraps the
+		// underlying manager error via fmt.Errorf.
+		var mErr waddrmgr.ManagerError
+		if errors.As(err, &mErr) {
+			req.resp <- accountResp{err: mErr}
+			return
+		}
+
+		req.resp <- accountResp{err: err}
+
+		return
+	}
+
+	account, err := w.accountInfoFromStore(info)
+	req.resp <- accountResp{
+		info: account,
+		err:  err,
+	}
 }
 
 // RenameAccount renames an existing account. The new name must be unique within

--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -692,6 +692,19 @@ func (w *Wallet) handleRenameAccount(req renameAccountReq) {
 	req.resp <- err
 }
 
+// importAccountReq carries every import option through Wallet admission while
+// retaining the existing private implementation for pre-start Manager use.
+type importAccountReq struct {
+	reqCtx
+
+	name                 string
+	accountKey           *hdkeychain.ExtendedKey
+	masterKeyFingerprint uint32
+	addrType             waddrmgr.AddressType
+	dryRun               bool
+	resp                 chan accountResp
+}
+
 // ImportAccount imports an account from an extended public key. Private
 // extended keys are rejected. The key scope is derived from the version
 // bytes of the extended key. The account name must be unique within the
@@ -717,9 +730,47 @@ func (w *Wallet) ImportAccount(ctx context.Context,
 		return nil, err
 	}
 
-	return w.importAccountInternal(
-		ctx, name, accountKey, masterKeyFingerprint, addrType, dryRun,
+	accountKeySnapshot, err := snapshotExtendedPubKey(
+		accountKey, true, w.cfg.ChainParams,
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	req := importAccountReq{
+		reqCtx:               reqCtx{ctx: ctx},
+		name:                 name,
+		accountKey:           accountKeySnapshot,
+		masterKeyFingerprint: masterKeyFingerprint,
+		addrType:             addrType,
+		dryRun:               dryRun,
+		resp:                 make(chan accountResp, 1),
+	}
+
+	err = w.sendReq(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := waitForReq(ctx, req.resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.info, resp.err
+}
+
+// handleImportAccount invokes the existing non-admitting implementation for
+// a request that mainLoop has already accepted and handleReq will complete.
+func (w *Wallet) handleImportAccount(req importAccountReq) {
+	info, err := w.importAccountInternal(
+		req.ctx, req.name, req.accountKey, req.masterKeyFingerprint,
+		req.addrType, req.dryRun,
+	)
+	req.resp <- accountResp{
+		info: info,
+		err:  err,
+	}
 }
 
 // importAccountInternal is the internal implementation of ImportAccount,
@@ -801,6 +852,28 @@ func dbScopeAddrSchema(
 	return &converted, nil
 }
 
+// snapshotExtendedPubKey validates caller-owned key material before copying
+// it into a request. Validation prevents private key serialization, while the
+// reparse ensures an admitted handler never retains a mutable caller pointer
+// after cancellation returns.
+func snapshotExtendedPubKey(pubKey *hdkeychain.ExtendedKey,
+	isAccountKey bool, chainParams *chaincfg.Params) (
+	*hdkeychain.ExtendedKey, error) {
+
+	err := validateExtendedPubKey(pubKey, isAccountKey, chainParams)
+	if err != nil {
+		return nil, err
+	}
+
+	snapshot, err := hdkeychain.NewKeyFromString(pubKey.String())
+	if err != nil {
+		return nil, fmt.Errorf("%w: copy extended public key: %s",
+			ErrInvalidAccountKey, err.Error())
+	}
+
+	return snapshot, nil
+}
+
 // validateExtendedPubKey ensures a sane derived public key is provided.
 func validateExtendedPubKey(pubKey *hdkeychain.ExtendedKey,
 	isAccountKey bool, chainParams *chaincfg.Params) error {
@@ -815,6 +888,13 @@ func validateExtendedPubKey(pubKey *hdkeychain.ExtendedKey,
 	// Private keys are not allowed.
 	if pubKey.IsPrivate() {
 		return fmt.Errorf("%w: private keys cannot be imported",
+			ErrInvalidAccountKey)
+	}
+
+	// A zeroed or otherwise malformed key has no four-byte network version.
+	// Reject it before isPubKeyForNet decodes the version as a uint32.
+	if len(pubKey.Version()) != binary.Size(waddrmgr.HDVersion(0)) {
+		return fmt.Errorf("%w: invalid extended public key version",
 			ErrInvalidAccountKey)
 	}
 

--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -353,6 +353,22 @@ func propertiesToAccountInfo(props *waddrmgr.AccountProperties,
 	}
 }
 
+// listAccountsResp lets a list handler finish even if caller cancellation
+// causes the public method to stop receiving its result.
+type listAccountsResp struct {
+	infos []AccountInfo
+	err   error
+}
+
+// listAccountsReq carries one fully formed Store query so every public list
+// variant shares the same admitted handler without losing its filter.
+type listAccountsReq struct {
+	reqCtx
+
+	query db.ListAccountsQuery
+	resp  chan listAccountsResp
+}
+
 // ListAccounts returns every account across all key scopes with its balance.
 func (w *Wallet) ListAccounts(ctx context.Context) ([]AccountInfo, error) {
 	err := w.state.validateStarted()
@@ -360,9 +376,25 @@ func (w *Wallet) ListAccounts(ctx context.Context) ([]AccountInfo, error) {
 		return nil, err
 	}
 
-	return w.listAccountInfos(ctx, db.ListAccountsQuery{
-		WalletID: w.id,
-	})
+	req := listAccountsReq{
+		reqCtx: reqCtx{ctx: ctx},
+		query: db.ListAccountsQuery{
+			WalletID: w.id,
+		},
+		resp: make(chan listAccountsResp, 1),
+	}
+
+	err = w.sendReq(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := waitForReq(ctx, req.resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.infos, resp.err
 }
 
 // listAccountInfos converts cache.ListAccounts snapshots into wallet-owned
@@ -392,6 +424,16 @@ func (w *Wallet) listAccountInfos(ctx context.Context,
 	return results, nil
 }
 
+// handleListAccounts performs the Store read for any admitted list variant;
+// handleReq owns the matching shutdown accounting.
+func (w *Wallet) handleListAccounts(req listAccountsReq) {
+	infos, err := w.listAccountInfos(req.ctx, req.query)
+	req.resp <- listAccountsResp{
+		infos: infos,
+		err:   err,
+	}
+}
+
 // ListAccountsByScope returns all accounts for the given key scope.
 func (w *Wallet) ListAccountsByScope(ctx context.Context,
 	scope waddrmgr.KeyScope) ([]AccountInfo, error) {
@@ -403,10 +445,26 @@ func (w *Wallet) ListAccountsByScope(ctx context.Context,
 
 	dbScope := db.KeyScope(scope)
 
-	return w.listAccountInfos(ctx, db.ListAccountsQuery{
-		WalletID: w.id,
-		Scope:    &dbScope,
-	})
+	req := listAccountsReq{
+		reqCtx: reqCtx{ctx: ctx},
+		query: db.ListAccountsQuery{
+			WalletID: w.id,
+			Scope:    &dbScope,
+		},
+		resp: make(chan listAccountsResp, 1),
+	}
+
+	err = w.sendReq(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := waitForReq(ctx, req.resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.infos, resp.err
 }
 
 // ListAccountsByName returns every account matching name across all scopes.
@@ -418,10 +476,26 @@ func (w *Wallet) ListAccountsByName(ctx context.Context,
 		return nil, err
 	}
 
-	return w.listAccountInfos(ctx, db.ListAccountsQuery{
-		WalletID: w.id,
-		Name:     &name,
-	})
+	req := listAccountsReq{
+		reqCtx: reqCtx{ctx: ctx},
+		query: db.ListAccountsQuery{
+			WalletID: w.id,
+			Name:     &name,
+		},
+		resp: make(chan listAccountsResp, 1),
+	}
+
+	err = w.sendReq(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := waitForReq(ctx, req.resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.infos, resp.err
 }
 
 // accountResp carries one account snapshot or the lookup error so an accepted

--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -240,6 +240,16 @@ func (w *Wallet) accountInfoFromStore(
 	}, nil
 }
 
+// newAccountReq carries derived-account inputs and a buffered result across
+// the Wallet's terminal admission boundary.
+type newAccountReq struct {
+	reqCtx
+
+	scope waddrmgr.KeyScope
+	name  string
+	resp  chan accountResp
+}
+
 // NewAccount creates the next account and returns its account info. The name
 // must be unique under the key scope. In order to support automatic seed
 // restoring, new accounts may not be created when all of the previous 100
@@ -253,16 +263,41 @@ func (w *Wallet) NewAccount(ctx context.Context, scope waddrmgr.KeyScope,
 		return nil, err
 	}
 
-	deriveFn, err := w.buildAccountDeriveFn(ctx)
+	req := newAccountReq{
+		reqCtx: reqCtx{ctx: ctx},
+		scope:  scope,
+		name:   name,
+		resp:   make(chan accountResp, 1),
+	}
+
+	err = w.sendReq(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 
-	info, err := w.store.CreateDerivedAccount(ctx,
+	resp, err := waitForReq(ctx, req.resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.info, resp.err
+}
+
+// handleNewAccount performs derivation and persistence only after mainLoop
+// admits the request; handleReq owns its shutdown completion.
+func (w *Wallet) handleNewAccount(req newAccountReq) {
+	deriveFn, err := w.buildAccountDeriveFn(req.ctx)
+	if err != nil {
+		req.resp <- accountResp{err: err}
+
+		return
+	}
+
+	info, err := w.store.CreateDerivedAccount(req.ctx,
 		db.CreateDerivedAccountParams{
 			WalletID: w.id,
-			Scope:    db.KeyScope(scope),
-			Name:     name,
+			Scope:    db.KeyScope(req.scope),
+			Name:     req.name,
 		}, deriveFn,
 	)
 	if err != nil {
@@ -271,13 +306,21 @@ func (w *Wallet) NewAccount(ctx context.Context, scope waddrmgr.KeyScope,
 		// kvdb wraps the underlying manager error via fmt.Errorf.
 		var mErr waddrmgr.ManagerError
 		if errors.As(err, &mErr) {
-			return nil, mErr
+			req.resp <- accountResp{err: mErr}
+
+			return
 		}
 
-		return nil, err
+		req.resp <- accountResp{err: err}
+
+		return
 	}
 
-	return w.accountInfoFromStore(info)
+	account, err := w.accountInfoFromStore(info)
+	req.resp <- accountResp{
+		info: account,
+		err:  err,
+	}
 }
 
 // propertiesToAccountInfo wraps a waddrmgr.AccountProperties + total balance
@@ -576,6 +619,17 @@ func (w *Wallet) handleGetAccount(req getAccountReq) {
 	}
 }
 
+// renameAccountReq carries immutable rename inputs and a buffered error result
+// so handler completion never depends on the caller remaining present.
+type renameAccountReq struct {
+	reqCtx
+
+	scope   waddrmgr.KeyScope
+	oldName string
+	newName string
+	resp    chan error
+}
+
 // RenameAccount renames an existing account. The new name must be unique within
 // the same key scope. The reserved "imported" account cannot be renamed.
 func (w *Wallet) RenameAccount(ctx context.Context,
@@ -586,16 +640,42 @@ func (w *Wallet) RenameAccount(ctx context.Context,
 		return err
 	}
 
-	err = waddrmgr.ValidateAccountName(newName)
+	req := renameAccountReq{
+		reqCtx:  reqCtx{ctx: ctx},
+		scope:   scope,
+		oldName: oldName,
+		newName: newName,
+		resp:    make(chan error, 1),
+	}
+
+	err = w.sendReq(ctx, req)
 	if err != nil {
 		return err
 	}
 
-	err = w.store.RenameAccount(ctx, db.RenameAccountParams{
+	respErr, err := waitForReq(ctx, req.resp)
+	if err != nil {
+		return err
+	}
+
+	return respErr
+}
+
+// handleRenameAccount validates and applies an admitted rename while
+// handleReq retains responsibility for releasing the Wallet WaitGroup.
+func (w *Wallet) handleRenameAccount(req renameAccountReq) {
+	err := waddrmgr.ValidateAccountName(req.newName)
+	if err != nil {
+		req.resp <- err
+
+		return
+	}
+
+	err = w.store.RenameAccount(req.ctx, db.RenameAccountParams{
 		WalletID: w.id,
-		Scope:    db.KeyScope(scope),
-		OldName:  oldName,
-		NewName:  newName,
+		Scope:    db.KeyScope(req.scope),
+		OldName:  req.oldName,
+		NewName:  req.newName,
 	})
 	if err != nil {
 		// Preserve waddrmgr.ManagerError semantics so callers using
@@ -603,13 +683,13 @@ func (w *Wallet) RenameAccount(ctx context.Context,
 		// underlying manager error via fmt.Errorf.
 		var mErr waddrmgr.ManagerError
 		if errors.As(err, &mErr) {
-			return mErr
-		}
+			req.resp <- mErr
 
-		return err
+			return
+		}
 	}
 
-	return nil
+	req.resp <- err
 }
 
 // ImportAccount imports an account from an extended public key. Private

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -5,6 +5,7 @@
 package wallet
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"strings"
@@ -642,6 +643,217 @@ func TestGetAccountIncludesImportedPseudoAccount(t *testing.T) {
 	require.True(t, account.IsImported)
 	require.Nil(t, account.AccountNumber)
 	require.Equal(t, uint32(3), account.ImportedKeyCount)
+}
+
+// TestGetAccountErrors verifies that request routing preserves both ordinary
+// Store failures and the legacy ManagerError identity expected by callers.
+func TestGetAccountErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		storeErr    error
+		managerCode bool
+	}{
+		{
+			name:     "store error",
+			storeErr: errDBMock,
+		},
+		{
+			name:        "manager error",
+			managerCode: true,
+			storeErr: waddrmgr.ManagerError{
+				ErrorCode: waddrmgr.ErrAccountNotFound,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: Start a Wallet and require the exact account query
+			// to return the error identity under test once.
+			w, deps := createStartedWalletWithMocks(t)
+			scope := waddrmgr.KeyScopeBIP0084
+			name := testAccountName
+			deps.store.On(
+				"GetAccount", mock.Anything, db.GetAccountQuery{
+					WalletID: 0,
+					Scope:    db.KeyScope(scope),
+					Name:     &name,
+				},
+			).Return((*db.AccountInfo)(nil), test.storeErr).Once()
+
+			// Act: Route the lookup through mainLoop and its concurrent
+			// account handler.
+			_, err := w.GetAccount(t.Context(), scope, name)
+
+			// Assert: The public result preserves the Store error identity
+			// expected by callers.
+			if test.managerCode {
+				require.True(t, waddrmgr.IsError(
+					err, waddrmgr.ErrAccountNotFound))
+			} else {
+				require.ErrorIs(t, err, errDBMock)
+			}
+		})
+	}
+}
+
+// TestGetAccountLifecycle verifies pre-start and terminal calls are rejected
+// before the Store can be reached.
+func TestGetAccountLifecycle(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a fresh Wallet with no GetAccount expectation because
+	// neither lifecycle state should admit Store access.
+	w, _ := createTestWalletWithMocks(t)
+	scope := waddrmgr.KeyScopeBIP0084
+
+	// Act: Attempt a lookup before Start, then make the Wallet terminal and
+	// attempt the same lookup through the retained pointer.
+	_, initializedErr := w.GetAccount(t.Context(), scope, testAccountName)
+	require.NoError(t, w.Stop(t.Context()))
+	_, stoppedErr := w.GetAccount(t.Context(), scope, testAccountName)
+
+	// Assert: Initialized retains the broad state error, terminal access
+	// gains the specific sentinel, and neither attempt reaches Store.
+	require.ErrorIs(t, initializedErr, ErrStateForbidden)
+	require.NotErrorIs(t, initializedErr, ErrWalletStopped)
+	require.ErrorIs(t, stoppedErr, ErrWalletStopped)
+}
+
+// TestGetAccountConcurrentDrain verifies account lookups overlap, accepted
+// work delays Stop, and a late lookup is rejected before Store access.
+func TestGetAccountConcurrentDrain(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Block two exact Store calls after they enter. Observing both
+	// entries before release proves mainLoop launched the handlers in
+	// parallel instead of executing either lookup inline.
+	w, deps := createStartedWalletWithMocks(t)
+	scope := waddrmgr.KeyScopeBIP0084
+	name := testAccountName
+	accountNumber := uint32(1)
+	entered := make(chan struct{}, 2)
+	release := make(chan struct{})
+	deps.store.On("GetAccount", mock.Anything, db.GetAccountQuery{
+		WalletID: 0,
+		Scope:    db.KeyScope(scope),
+		Name:     &name,
+	}).Run(func(mock.Arguments) {
+		entered <- struct{}{}
+		<-release
+	}).Return(&db.AccountInfo{
+		AccountNumber: &accountNumber,
+		AccountName:   name,
+		KeyScope:      db.KeyScope(scope),
+	}, nil).Twice()
+
+	results := make(chan accountResp, 2)
+	for range 2 {
+		go func() {
+			info, err := w.GetAccount(t.Context(), scope, name)
+			results <- accountResp{info: info, err: err}
+		}()
+	}
+
+	for range 2 {
+		select {
+		case <-entered:
+		case <-time.After(time.Second):
+			t.Fatal("account lookups did not overlap")
+		}
+	}
+
+	// Act: Begin Stop while both accepted handlers are blocked, then issue
+	// a third lookup after lifetime cancellation has closed admission.
+	stopResult := make(chan error, 1)
+	go func() {
+		stopResult <- w.Stop(t.Context())
+	}()
+
+	<-w.lifetimeCtx.Done()
+	_, lateErr := w.GetAccount(t.Context(), scope, name)
+
+	// Assert: The late call is rejected and Stop remains blocked until both
+	// accepted handlers deliver ordinary results.
+	require.ErrorIs(t, lateErr, ErrWalletStopped)
+
+	select {
+	case err := <-stopResult:
+		t.Fatalf("Stop returned before account handlers: %v", err)
+	default:
+	}
+
+	close(release)
+
+	for range 2 {
+		result := <-results
+		require.NoError(t, result.err)
+		require.NotNil(t, result.info)
+	}
+
+	require.NoError(t, <-stopResult)
+}
+
+// TestGetAccountCanceledCallerDrains verifies caller cancellation does not
+// release an accepted lookup from the Wallet's shutdown responsibility.
+func TestGetAccountCanceledCallerDrains(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Accept one lookup whose Store call ignores caller
+	// cancellation until the test explicitly releases it.
+	w, deps := createStartedWalletWithMocks(t)
+	scope := waddrmgr.KeyScopeBIP0084
+	name := testAccountName
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	deps.store.On("GetAccount", mock.Anything, db.GetAccountQuery{
+		WalletID: 0,
+		Scope:    db.KeyScope(scope),
+		Name:     &name,
+	}).Run(func(mock.Arguments) {
+		close(entered)
+		<-release
+	}).Return(&db.AccountInfo{
+		AccountName: name,
+		KeyScope:    db.KeyScope(scope),
+	}, nil).Once()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	callResult := make(chan error, 1)
+
+	go func() {
+		_, err := w.GetAccount(ctx, scope, name)
+		callResult <- err
+	}()
+
+	<-entered
+
+	// Act: Cancel only the caller, wait for its prompt return, then begin
+	// Wallet shutdown while the accepted handler still owns Store work.
+	cancel()
+	require.ErrorIs(t, <-callResult, context.Canceled)
+
+	stopResult := make(chan error, 1)
+	go func() {
+		stopResult <- w.Stop(t.Context())
+	}()
+
+	<-w.lifetimeCtx.Done()
+
+	// Assert: Stop waits after the caller has gone until Store release lets
+	// the buffered handler response complete without a stranded goroutine.
+	select {
+	case err := <-stopResult:
+		t.Fatalf("Stop returned before canceled caller's handler: %v", err)
+	default:
+	}
+
+	close(release)
+	require.NoError(t, <-stopResult)
 }
 
 // TestNewAccount verifies NewAccount routes through

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -1111,6 +1111,221 @@ func TestImportAccountAddrSchema(t *testing.T) {
 	require.Equal(t, testAccountName, props.AccountName)
 }
 
+// TestImportAccountCanceledCallerKeepsKeySnapshot verifies an accepted import
+// owns its extended key after caller cancellation permits the caller to zero
+// the original key.
+func TestImportAccountCanceledCallerKeepsKeySnapshot(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Mark a fixture Wallet started without launching mainLoop so the
+	// test can receive the submitted request before any handler consumes it.
+	w, _ := createTestWalletWithMocks(t)
+	require.NoError(t, w.state.toStarting())
+	require.NoError(t, w.state.toStarted())
+
+	accountKey, masterFP := importAccountTestKey(t, 84)
+	wantKey := accountKey.String()
+	ctx, cancel := context.WithCancel(t.Context())
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := w.ImportAccount(
+			ctx, testAccountName, accountKey, masterFP,
+			waddrmgr.WitnessPubKey, false,
+		)
+		result <- err
+	}()
+
+	// Act: Accept the request, let the public call return on cancellation,
+	// then zero the original key as its caller is now entitled to do.
+	rawReq := <-w.requestChan
+
+	cancel()
+
+	callErr := <-result
+
+	accountKey.Zero()
+
+	// Assert: Cancellation reaches the caller while the accepted request owns
+	// an independent key that retains the original serialized account data.
+	require.ErrorIs(t, callErr, context.Canceled)
+
+	req, ok := rawReq.(importAccountReq)
+	require.True(t, ok)
+	require.NotSame(t, accountKey, req.accountKey)
+	require.Equal(t, wantKey, req.accountKey.String())
+}
+
+// TestImportAccountRejectsInvalidKeyBeforeAdmission verifies invalid key
+// material is classified before request submission could retain it.
+func TestImportAccountRejectsInvalidKeyBeforeAdmission(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Build private and malformed public key inputs that must share
+	// the same pre-admission error contract without entering mainLoop.
+	privateKey, err := hdkeychain.NewMaster(fixedTestSeed(), &chainParams)
+	require.NoError(t, err)
+
+	zeroedKey, err := privateKey.Neuter()
+	require.NoError(t, err)
+	zeroedKey.Zero()
+
+	tests := []struct {
+		name string
+		key  *hdkeychain.ExtendedKey
+	}{
+		{
+			name: "private key",
+			key:  privateKey,
+		},
+		{
+			name: "zeroed public key",
+			key:  zeroedKey,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: Mark a fixture Wallet started without a mainLoop
+			// receiver, then cancel its caller context so any submission
+			// attempt returns cancellation instead of the key sentinel.
+			w, _ := createTestWalletWithMocks(t)
+			require.NoError(t, w.state.toStarting())
+			require.NoError(t, w.state.toStarted())
+
+			ctx, cancel := context.WithCancel(t.Context())
+			cancel()
+
+			// Act: Attempt to import the invalid key through the public API.
+			_, err := w.ImportAccount(
+				ctx, testAccountName, test.key, 0,
+				waddrmgr.WitnessPubKey, false,
+			)
+
+			// Assert: The account-key sentinel, rather than caller
+			// cancellation, proves rejection preceded request submission.
+			require.ErrorIs(t, err, ErrInvalidAccountKey)
+			require.NotErrorIs(t, err, context.Canceled)
+		})
+	}
+}
+
+// TestNewAccountRejectsStopped verifies account creation does not cross a
+// terminal Wallet's request boundary.
+func TestNewAccountRejectsStopped(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Stop a fresh Wallet before startup so no request handler or
+	// Store expectation exists for the attempted account creation.
+	w, _ := createTestWalletWithMocks(t)
+	require.NoError(t, w.Stop(t.Context()))
+
+	// Act: Attempt to create an account through the terminal Wallet.
+	_, err := w.NewAccount(
+		t.Context(), waddrmgr.KeyScopeBIP0084, testAccountName,
+	)
+
+	// Assert: The terminal sentinel proves the request was rejected before
+	// account derivation or Store access began.
+	require.ErrorIs(t, err, ErrWalletStopped)
+}
+
+// TestListAccountsRejectsStopped verifies an unfiltered account listing does
+// not cross a terminal Wallet's request boundary.
+func TestListAccountsRejectsStopped(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Stop a fresh Wallet with no Store expectations because the
+	// list request must be rejected before reaching the cache.
+	w, _ := createTestWalletWithMocks(t)
+	require.NoError(t, w.Stop(t.Context()))
+
+	// Act: Attempt to list every account through the terminal Wallet.
+	_, err := w.ListAccounts(t.Context())
+
+	// Assert: The terminal sentinel confirms no list request was admitted.
+	require.ErrorIs(t, err, ErrWalletStopped)
+}
+
+// TestListAccountsByScopeRejectsStopped verifies a scope-filtered account
+// listing does not cross a terminal Wallet's request boundary.
+func TestListAccountsByScopeRejectsStopped(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Stop a fresh Wallet without Store expectations so any admitted
+	// scope query would fail the fixture's mock verification.
+	w, _ := createTestWalletWithMocks(t)
+	require.NoError(t, w.Stop(t.Context()))
+
+	// Act: Attempt the filtered listing through the terminal Wallet.
+	_, err := w.ListAccountsByScope(
+		t.Context(), waddrmgr.KeyScopeBIP0084,
+	)
+
+	// Assert: The terminal sentinel confirms the scope query was not admitted.
+	require.ErrorIs(t, err, ErrWalletStopped)
+}
+
+// TestListAccountsByNameRejectsStopped verifies a name-filtered account
+// listing does not cross a terminal Wallet's request boundary.
+func TestListAccountsByNameRejectsStopped(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Stop a fresh Wallet without Store expectations so the name
+	// filter cannot reach the account cache after shutdown.
+	w, _ := createTestWalletWithMocks(t)
+	require.NoError(t, w.Stop(t.Context()))
+
+	// Act: Attempt the name-filtered listing through the terminal Wallet.
+	_, err := w.ListAccountsByName(t.Context(), testAccountName)
+
+	// Assert: The terminal sentinel confirms the name query was not admitted.
+	require.ErrorIs(t, err, ErrWalletStopped)
+}
+
+// TestRenameAccountRejectsStopped verifies an account rename does not cross a
+// terminal Wallet's request boundary.
+func TestRenameAccountRejectsStopped(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Stop a fresh Wallet without Store expectations so validation
+	// and persistence remain behind the terminal request boundary.
+	w, _ := createTestWalletWithMocks(t)
+	require.NoError(t, w.Stop(t.Context()))
+
+	// Act: Attempt to rename an account through the terminal Wallet.
+	err := w.RenameAccount(
+		t.Context(), waddrmgr.KeyScopeBIP0084, testAccountName, "renamed",
+	)
+
+	// Assert: The terminal sentinel confirms validation and Store mutation
+	// were both bypassed.
+	require.ErrorIs(t, err, ErrWalletStopped)
+}
+
+// TestImportAccountRejectsStopped verifies an account import does not cross a
+// terminal Wallet's request boundary.
+func TestImportAccountRejectsStopped(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Stop a fresh Wallet and intentionally provide no key or Store
+	// expectation so lifecycle rejection must precede argument validation.
+	w, _ := createTestWalletWithMocks(t)
+	require.NoError(t, w.Stop(t.Context()))
+
+	// Act: Attempt to import the invalid key through the terminal Wallet.
+	_, err := w.ImportAccount(
+		t.Context(), testAccountName, nil, 0,
+		waddrmgr.WitnessPubKey, false,
+	)
+
+	// Assert: The terminal sentinel proves shutdown wins before key validation
+	// or Store access.
+	require.ErrorIs(t, err, ErrWalletStopped)
+}
+
 // TestDBScopeAddrSchemaMapsTypes verifies dbScopeAddrSchema converts a
 // per-account schema override through the explicit wallet->store address-type
 // mapping rather than a raw enum cast. The two enums do not share ordinals

--- a/wallet/benchmark_helpers_test.go
+++ b/wallet/benchmark_helpers_test.go
@@ -1,6 +1,7 @@
 package wallet
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -326,12 +327,31 @@ func setupBenchmarkWallet(tb testing.TB,
 		}
 	}
 
+	// Legacy benchmark setup lacks the maintained lifetime. Initialize it so
+	// routed calls and mainLoop share production shutdown semantics.
+	if w.lifetimeCtx == nil {
+		w.lifetimeCtx, w.cancel = context.WithCancel(context.Background())
+	}
+
 	// Force state to Started to satisfy validateStarted() in new APIs.
 	err := w.state.toStarting()
 	if err == nil {
 		err = w.state.toStarted()
 		require.NoError(tb, err)
 	}
+
+	// Start mainLoop for routed calls. Cleanup also stops legacy goroutines
+	// whose synthetic testing.T hooks never run because all share w.wg.
+	w.wg.Add(1)
+
+	go w.mainLoop()
+
+	tb.Cleanup(func() {
+		w.cancel()
+		w.StopDeprecated()
+		w.WaitForShutdown()
+	})
+
 	// Transition to Unlocked so signing operations are permitted.
 	w.state.toUnlocked()
 

--- a/wallet/common_test.go
+++ b/wallet/common_test.go
@@ -157,13 +157,27 @@ func testSQLManager(tb testing.TB, store db.Store) *Manager {
 	}
 }
 
-// startLoadedWalletForTest marks a loaded wallet as started without launching
-// chain sync goroutines.
+// startLoadedWalletForTest starts the request loop for a loaded wallet without
+// launching chain sync goroutines. This lets tests exercise maintained public
+// methods without requiring an active chain backend.
 func startLoadedWalletForTest(t *testing.T, w *Wallet) {
 	t.Helper()
 
 	require.NoError(t, w.state.toStarting())
 	require.NoError(t, w.state.toStarted())
+
+	// The request loop is part of the started Wallet contract, so keep it
+	// alive until the test finishes even though chain sync remains disabled.
+	w.wg.Add(1)
+
+	go w.mainLoop()
+
+	t.Cleanup(func() {
+		// Canceling the Wallet releases the request loop before waiting for
+		// its WaitGroup, matching the production shutdown order.
+		w.cancel()
+		w.wg.Wait()
+	})
 }
 
 // testKVDBManagerAt opens a Manager over an existing kvdb path, so a test can

--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -686,6 +686,8 @@ func (w *Wallet) handleReq(req any) {
 		w.handleNewAccount(r)
 	case renameAccountReq:
 		w.handleRenameAccount(r)
+	case importAccountReq:
+		w.handleImportAccount(r)
 	case getAccountReq:
 		w.handleGetAccount(r)
 	case listAccountsReq:

--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -682,6 +682,10 @@ func (w *Wallet) handleReq(req any) {
 	defer w.wg.Done()
 
 	switch r := req.(type) {
+	case newAccountReq:
+		w.handleNewAccount(r)
+	case renameAccountReq:
+		w.handleRenameAccount(r)
 	case getAccountReq:
 		w.handleGetAccount(r)
 	case listAccountsReq:

--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -646,8 +646,11 @@ func (w *Wallet) mainLoop() {
 				w.handleChangePassphraseReq(r)
 
 			default:
-				log.Errorf("Wallet received unknown request "+
-					"type: %T", req)
+				// Non-control requests run concurrently. Register the handler
+				// before launch so Stop drains every accepted request.
+				w.wg.Add(1)
+
+				go w.handleReq(req)
 			}
 
 		// The auto-lock timer has expired. We trigger a lock with a
@@ -662,6 +665,17 @@ func (w *Wallet) mainLoop() {
 
 			return
 		}
+	}
+}
+
+// handleReq owns completion bookkeeping for requests accepted by mainLoop. Its
+// type switch is the single routing table for concurrent public method work.
+func (w *Wallet) handleReq(req any) {
+	defer w.wg.Done()
+
+	switch req.(type) {
+	default:
+		log.Errorf("Wallet received unknown request type: %T", req)
 	}
 }
 

--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -179,6 +179,8 @@ type Controller interface {
 }
 
 // Start starts the background processes necessary to manage the wallet.
+// The Manager owns lifecycle sequencing and calls Start at most once for a
+// Wallet instance; a stopped Wallet must be loaded as a new instance.
 //
 // This is part of the Controller interface.
 func (w *Wallet) Start(startCtx context.Context) error {
@@ -358,9 +360,18 @@ func (w *Wallet) performRuntimeSetup(startCtx context.Context) error {
 // Stop signals all wallet background processes to shutdown and blocks until
 // they have all exited. It returns an error if the context is canceled before
 // the shutdown is complete.
+// The Manager serializes Stop with Start, so Stop can transition an
+// Initialized Wallet directly to its terminal Stopped state.
 //
 // This is part of the Controller interface.
 func (w *Wallet) Stop(stopCtx context.Context) error {
+	// A Wallet stopped before its first Start has no workers to cancel or
+	// join, but it must still become terminal so a retained pointer cannot
+	// start a new runtime later.
+	if lifecycle(w.state.lifecycle.Load()) == lifecycleInitialized {
+		return w.state.toStopped()
+	}
+
 	// Attempt to transition from Started to Stopping.
 	err := w.state.toStopping()
 	if err != nil {
@@ -434,8 +445,14 @@ func (w *Wallet) Unlock(ctx context.Context, req UnlockRequest) error {
 		return err
 	}
 
-	// Wait for the result from the mainLoop.
-	return w.waitForResp(ctx, r.resp)
+	// Wait for the accepted request's result even if wallet shutdown begins.
+	// The caller context remains the only way to stop waiting early.
+	reqErr, err := waitForReq(ctx, r.resp)
+	if err != nil {
+		return err
+	}
+
+	return reqErr
 }
 
 // Lock locks the wallet.
@@ -455,8 +472,14 @@ func (w *Wallet) Lock(ctx context.Context) error {
 		return err
 	}
 
-	// Wait for the result.
-	return w.waitForResp(ctx, r.resp)
+	// Wait for the accepted request's result even if wallet shutdown begins.
+	// The caller context remains the only way to stop waiting early.
+	reqErr, err := waitForReq(ctx, r.resp)
+	if err != nil {
+		return err
+	}
+
+	return reqErr
 }
 
 // ChangePassphrase changes the wallet's passphrases according to the request.
@@ -478,7 +501,14 @@ func (w *Wallet) ChangePassphrase(ctx context.Context,
 		return err
 	}
 
-	return w.waitForResp(ctx, r.resp)
+	// Wait for the accepted request's result even if wallet shutdown begins.
+	// The caller context remains the only way to stop waiting early.
+	reqErr, err := waitForReq(ctx, r.resp)
+	if err != nil {
+		return err
+	}
+
+	return reqErr
 }
 
 // Info returns a comprehensive snapshot of the wallet's static configuration
@@ -882,31 +912,34 @@ func (w *Wallet) handleChangePassphraseReq(req changePassphraseReq) {
 	req.resp <- err
 }
 
-// sendReq sends an operation request to the main loop or handles cancellation.
+// sendReq transfers an operation request to mainLoop, which makes receipt the
+// Wallet-owned admission point. A successful send means shutdown must drain
+// the accepted handler; cancellation before receipt leaves no admitted work.
 func (w *Wallet) sendReq(ctx context.Context, req any) error {
 	select {
 	case w.requestChan <- req:
 		return nil
 
 	case <-w.lifetimeCtx.Done():
-		return ErrWalletShuttingDown
+		return ErrWalletStopped
 
 	case <-ctx.Done():
 		return ctx.Err()
 	}
 }
 
-// waitForResp waits for the response from an operation request or handles
-// cancellation.
-func (w *Wallet) waitForResp(ctx context.Context, resp <-chan error) error {
+// waitForReq waits for a typed result after sendReq has transferred ownership
+// to mainLoop. It intentionally observes only caller cancellation: Wallet
+// shutdown must continue draining the accepted handler, whose response channel
+// is buffered so completion never depends on the caller remaining present.
+func waitForReq[T any](ctx context.Context, respChan <-chan T) (T, error) {
 	select {
-	case err := <-resp:
-		return err
-
-	case <-w.lifetimeCtx.Done():
-		return ErrWalletShuttingDown
+	case result := <-respChan:
+		return result, nil
 
 	case <-ctx.Done():
-		return ctx.Err()
+		var zero T
+
+		return zero, ctx.Err()
 	}
 }

--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -668,12 +668,22 @@ func (w *Wallet) mainLoop() {
 	}
 }
 
+// reqCtx carries caller cancellation and values across the Wallet request
+// boundary. Keeping the context in one embedded type centralizes the bounded
+// retention contract and its lint exemption for every routed request.
+type reqCtx struct {
+	//nolint:containedctx // Store calls must inherit the caller context.
+	ctx context.Context
+}
+
 // handleReq owns completion bookkeeping for requests accepted by mainLoop. Its
 // type switch is the single routing table for concurrent public method work.
 func (w *Wallet) handleReq(req any) {
 	defer w.wg.Done()
 
-	switch req.(type) {
+	switch r := req.(type) {
+	case getAccountReq:
+		w.handleGetAccount(r)
 	default:
 		log.Errorf("Wallet received unknown request type: %T", req)
 	}

--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -684,6 +684,8 @@ func (w *Wallet) handleReq(req any) {
 	switch r := req.(type) {
 	case getAccountReq:
 		w.handleGetAccount(r)
+	case listAccountsReq:
+		w.handleListAccounts(r)
 	default:
 		log.Errorf("Wallet received unknown request type: %T", req)
 	}

--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -161,9 +161,9 @@ type Controller interface {
 	// It returns an error if the wallet is already started.
 	Start(ctx context.Context) error
 
-	// Stop signals all wallet background processes to shutdown and blocks
-	// until they have all exited. It returns an error if the context is
-	// canceled before the shutdown is complete.
+	// Stop synchronously shuts down the wallet. The context remains in this
+	// temporary public interface for compatibility but is not consulted,
+	// because terminal teardown cannot be abandoned after it begins.
 	Stop(ctx context.Context) error
 
 	// Resync rewinds the wallet's synchronization state to a specific
@@ -357,14 +357,21 @@ func (w *Wallet) performRuntimeSetup(startCtx context.Context) error {
 	return nil
 }
 
-// Stop signals all wallet background processes to shutdown and blocks until
-// they have all exited. It returns an error if the context is canceled before
-// the shutdown is complete.
+// Stop synchronously shuts down the Wallet through its private lifecycle
+// operation. The context remains only for Controller compatibility and is not
+// consulted, because terminal teardown cannot be abandoned after it begins.
 // The Manager serializes Stop with Start, so Stop can transition an
 // Initialized Wallet directly to its terminal Stopped state.
 //
 // This is part of the Controller interface.
-func (w *Wallet) Stop(stopCtx context.Context) error {
+func (w *Wallet) Stop(_ context.Context) error {
+	return w.stop()
+}
+
+// stop performs the Wallet's complete terminal teardown synchronously. The
+// Manager serializes lifecycle operations, so this method never runs alongside
+// Start or another stop and needs no additional synchronization primitive.
+func (w *Wallet) stop() error {
 	// A Wallet stopped before its first Start has no workers to cancel or
 	// join, but it must still become terminal so a retained pointer cannot
 	// start a new runtime later.
@@ -392,18 +399,10 @@ func (w *Wallet) Stop(stopCtx context.Context) error {
 	// guarantees we only reach this point once).
 	w.cancel()
 
-	// Wait for all goroutines to finish.
-	done := make(chan struct{})
-	go func() {
-		w.wg.Wait()
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-stopCtx.Done():
-		return fmt.Errorf("stop request cancelled: %w", stopCtx.Err())
-	}
+	// Terminal teardown cannot be abandoned by a caller deadline. Draining
+	// here ensures no accepted request or Wallet worker can retain Store or
+	// key material after stop returns.
+	w.wg.Wait()
 
 	// Lock the key vault so no decrypted signing keys outlive the shutdown.
 	// The background goroutines have exited, so no signer is running.

--- a/wallet/controller_test.go
+++ b/wallet/controller_test.go
@@ -164,12 +164,15 @@ func TestControllerChangePassphrase_Interrupted_WaitCancelled(t *testing.T) {
 	}
 }
 
-// TestControllerChangePassphrase_Interrupted_WaitShutdown verifies
-// ChangePassphrase when response wait is interrupted by wallet shutdown.
-func TestControllerChangePassphrase_Interrupted_WaitShutdown(t *testing.T) {
+// TestControllerChangePassphraseWaitsForAcceptedResultDuringShutdown verifies
+// that shutdown does not hide the result of an accepted passphrase change.
+func TestControllerChangePassphraseWaitsForAcceptedResultDuringShutdown(
+	t *testing.T) {
+
 	t.Parallel()
 
-	// Arrange: Block during response wait and trigger shutdown.
+	// Arrange: Start a wallet and call ChangePassphrase asynchronously so the
+	// test can capture the request after the wallet has accepted ownership.
 	w, _ := createTestWalletWithMocks(t)
 
 	require.NoError(t, w.state.toStarting())
@@ -181,19 +184,31 @@ func TestControllerChangePassphrase_Interrupted_WaitShutdown(t *testing.T) {
 			ChangePassphraseRequest{})
 	}()
 
+	var accepted changePassphraseReq
 	select {
-	case <-w.requestChan:
+	case rawReq := <-w.requestChan:
+		var ok bool
+
+		accepted, ok = rawReq.(changePassphraseReq)
+		require.True(t, ok, "expected a change passphrase request")
+
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for request")
 	}
 
-	// Act: Stop wallet.
+	// Act: Begin shutdown after admission, then deliver the handler result.
+	// This ordering reproduces the race where shutdown previously preempted
+	// the response even though the accepted operation could still complete.
 	w.cancel()
 
-	// Assert: Verify error.
+	accepted.resp <- errDBMock
+
+	// Assert: The caller receives the accepted request's exact result instead
+	// of a lifecycle error produced solely because shutdown began.
 	select {
 	case err := <-errChan:
-		require.ErrorIs(t, err, ErrWalletShuttingDown)
+		require.ErrorIs(t, err, errDBMock)
+
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for response")
 	}
@@ -452,7 +467,7 @@ func TestControllerUnlock_Interrupted_SendShutdown(t *testing.T) {
 	// Assert: Verify shutdown error.
 	select {
 	case err := <-errChan2:
-		require.ErrorIs(t, err, ErrWalletShuttingDown)
+		require.ErrorIs(t, err, ErrWalletStopped)
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for response")
 	}
@@ -496,12 +511,13 @@ func TestControllerUnlock_Interrupted_WaitCancelled(t *testing.T) {
 	}
 }
 
-// TestControllerUnlock_Interrupted_WaitShutdown verifies Unlock when the
-// response wait is interrupted by wallet shutdown.
-func TestControllerUnlock_Interrupted_WaitShutdown(t *testing.T) {
+// TestControllerUnlockWaitsForAcceptedResultDuringShutdown verifies that
+// shutdown does not hide the result of an accepted unlock request.
+func TestControllerUnlockWaitsForAcceptedResultDuringShutdown(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Setup a wallet and trigger shutdown during response wait.
+	// Arrange: Start a wallet and call Unlock asynchronously so the test can
+	// capture the request after the wallet has accepted ownership.
 	w4, _ := createTestWalletWithMocks(t)
 	require.NoError(t, w4.state.toStarting())
 	require.NoError(t, w4.state.toStarted())
@@ -512,19 +528,31 @@ func TestControllerUnlock_Interrupted_WaitShutdown(t *testing.T) {
 			UnlockRequest{Passphrase: []byte("pw")})
 	}()
 
+	var accepted unlockReq
 	select {
-	case <-w4.requestChan:
+	case rawReq := <-w4.requestChan:
+		var ok bool
+
+		accepted, ok = rawReq.(unlockReq)
+		require.True(t, ok, "expected an unlock request")
+
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for request")
 	}
 
-	// Act: Stop wallet.
+	// Act: Begin shutdown after admission, then deliver the handler result.
+	// This ordering reproduces the race where shutdown previously preempted
+	// the response even though the accepted operation could still complete.
 	w4.cancel()
 
-	// Assert: Verify shutdown error.
+	accepted.resp <- errDBMock
+
+	// Assert: The caller receives the accepted request's exact result instead
+	// of a lifecycle error produced solely because shutdown began.
 	select {
 	case err := <-errChan4:
-		require.ErrorIs(t, err, ErrWalletShuttingDown)
+		require.ErrorIs(t, err, errDBMock)
+
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for response")
 	}
@@ -694,6 +722,33 @@ func TestControllerStop(t *testing.T) {
 	// Assert: Verify that subsequent Stop calls are safe and return no
 	// error.
 	require.NoError(t, err)
+
+	// Act: Attempt to restart the terminal Wallet after both Stop calls
+	// have completed.
+	err = w.Start(t.Context())
+
+	// Assert: A stopped Wallet cannot create a second runtime and returns
+	// the stable terminal sentinel.
+	require.ErrorIs(t, err, ErrWalletStopped)
+}
+
+// TestControllerStopBeforeStart verifies that Stop makes an Initialized
+// Wallet terminal without attempting to cancel workers that do not exist.
+func TestControllerStopBeforeStart(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Create a Wallet whose maintained runtime has never started,
+	// so no startup dependency or background-worker expectation is needed.
+	w, _ := createTestWalletWithMocks(t)
+
+	// Act: Stop the fresh Wallet and then attempt its first Start.
+	stopErr := w.Stop(t.Context())
+	startErr := w.Start(t.Context())
+
+	// Assert: Stop succeeds directly and permanently prevents the retained
+	// Wallet instance from starting later.
+	require.NoError(t, stopErr)
+	require.ErrorIs(t, startErr, ErrWalletStopped)
 }
 
 // TestControllerLock verifies the Lock method. It ensures that the wallet
@@ -1042,7 +1097,7 @@ func TestControllerLock_Interrupted_SendShutdown(t *testing.T) {
 	err := w.Lock(t.Context())
 
 	// Assert: Verify error.
-	require.ErrorIs(t, err, ErrWalletShuttingDown)
+	require.ErrorIs(t, err, ErrWalletStopped)
 }
 
 // TestControllerLock_Interrupted_WaitCancelled verifies Lock when response
@@ -1082,12 +1137,13 @@ func TestControllerLock_Interrupted_WaitCancelled(t *testing.T) {
 	}
 }
 
-// TestControllerLock_Interrupted_WaitShutdown verifies Lock when response
-// wait is interrupted by wallet shutdown.
-func TestControllerLock_Interrupted_WaitShutdown(t *testing.T) {
+// TestControllerLockWaitsForAcceptedResultDuringShutdown verifies that
+// shutdown does not hide the result of an accepted lock request.
+func TestControllerLockWaitsForAcceptedResultDuringShutdown(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Block during response wait and trigger shutdown.
+	// Arrange: Start a wallet and call Lock asynchronously so the test can
+	// capture the request after the wallet has accepted ownership.
 	w, _ := createTestWalletWithMocks(t)
 
 	require.NoError(t, w.state.toStarting())
@@ -1098,19 +1154,31 @@ func TestControllerLock_Interrupted_WaitShutdown(t *testing.T) {
 		errChan <- w.Lock(t.Context())
 	}()
 
+	var accepted lockReq
 	select {
-	case <-w.requestChan:
+	case rawReq := <-w.requestChan:
+		var ok bool
+
+		accepted, ok = rawReq.(lockReq)
+		require.True(t, ok, "expected a lock request")
+
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for request")
 	}
 
-	// Act: Stop wallet.
+	// Act: Begin shutdown after admission, then deliver the handler result.
+	// This ordering reproduces the race where shutdown previously preempted
+	// the response even though the accepted operation could still complete.
 	w.cancel()
 
-	// Assert: Verify error.
+	accepted.resp <- errDBMock
+
+	// Assert: The caller receives the accepted request's exact result instead
+	// of a lifecycle error produced solely because shutdown began.
 	select {
 	case err := <-errChan:
-		require.ErrorIs(t, err, ErrWalletShuttingDown)
+		require.ErrorIs(t, err, errDBMock)
+
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for response")
 	}
@@ -1172,7 +1240,7 @@ func TestControllerChangePassphrase_Interrupted_SendShutdown(t *testing.T) {
 		ChangePassphraseRequest{})
 
 	// Assert: Verify error.
-	require.ErrorIs(t, err, ErrWalletShuttingDown)
+	require.ErrorIs(t, err, ErrWalletStopped)
 }
 
 // TestHandleChangePassphraseReq_Errors verifies error handling for the
@@ -1445,6 +1513,13 @@ func TestControllerStart_VerifyBirthdayFail(t *testing.T) {
 	// Assert: Verify failure.
 	require.ErrorIs(t, err, errDBMock)
 	require.False(t, w.state.isStarted())
+
+	// Act: Attempt to start again after setup canceled the Wallet-owned
+	// runtime and moved the lifecycle to terminal Stopped.
+	err = w.Start(t.Context())
+
+	// Assert: Startup failure is terminal for this Wallet instance.
+	require.ErrorIs(t, err, ErrWalletStopped)
 }
 
 // TestControllerStart_DBGetAllAccountsFail verifies Start fails when

--- a/wallet/controller_test.go
+++ b/wallet/controller_test.go
@@ -667,15 +667,18 @@ func TestSubmitRescanRequest_Errors(t *testing.T) {
 	})
 }
 
-// TestControllerStop verifies that the Stop method correctly shuts down the
-// wallet, waiting for the syncer and other background processes to exit.
+// TestControllerStop verifies that Stop completes terminal teardown even when
+// its compatibility context is already canceled, and remains safe to repeat.
 func TestControllerStop(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Create and start a test wallet.
+	// Arrange: Start a Wallet whose sync worker observes shutdown but cannot
+	// return until released. A pre-canceled Stop context proves terminal
+	// cleanup is owned by the Wallet rather than by that caller's deadline.
 	w, deps := createTestWalletWithMocks(t)
+	draining := make(chan struct{})
+	release := make(chan struct{})
 
-	// Setup mocks for the startup sequence.
 	deps.store.On("GetWallet", mock.Anything, mock.Anything).Return(
 		&db.WalletInfo{BirthdayBlock: &db.Block{}}, nil).Once()
 	deps.store.On("ListAccounts", mock.Anything,
@@ -684,8 +687,8 @@ func TestControllerStop(t *testing.T) {
 	deps.store.On("DeleteExpiredLeases", mock.Anything,
 		mock.Anything).Return(nil).Once()
 
-	// Mock syncer.run to simulate a long-running process that exits when
-	// the context is cancelled.
+	// Keep the worker alive after it observes Wallet cancellation so the test
+	// can distinguish shutdown initiation from complete teardown.
 	deps.syncer.On("run", mock.Anything).Run(func(args mock.Arguments) {
 		ctx, ok := args.Get(0).(context.Context)
 		if !ok {
@@ -693,6 +696,8 @@ func TestControllerStop(t *testing.T) {
 		}
 
 		<-ctx.Done()
+		close(draining)
+		<-release
 	}).Return(nil).Once()
 
 	require.NoError(t, w.Start(t.Context()))
@@ -707,20 +712,40 @@ func TestControllerStop(t *testing.T) {
 
 	deps.vault.On("Lock").Return().Once()
 
-	// Act: Stop the wallet.
-	err := w.Stop(t.Context())
+	stopCtx, cancelStop := context.WithCancel(t.Context())
+	cancelStop()
 
-	// Assert: Verify that Stop returned no error and the wallet state is
-	// no longer 'Started'.
-	require.NoError(t, err)
+	stopResult := make(chan error, 1)
+
+	// Act: Invoke Stop with the canceled compatibility context, wait until
+	// its worker begins draining, and keep teardown blocked until the test
+	// has observed that Stop did not return early.
+	go func() {
+		stopResult <- w.Stop(stopCtx)
+	}()
+
+	<-draining
+
+	// Assert: Cancellation cannot abandon teardown while the Wallet worker
+	// remains active; after release, Stop locks the Vault and records the
+	// terminal state before returning its ordinary result.
+	select {
+	case err := <-stopResult:
+		t.Fatalf("Stop returned before worker drain: %v", err)
+	default:
+	}
+
+	close(release)
+	require.NoError(t, <-stopResult)
 	require.False(t, w.state.isStarted())
+	require.Equal(t, uint32(lifecycleStopped), w.state.lifecycle.Load())
 	deps.vault.AssertExpectations(t)
 
-	// Act: Call Stop again to verify idempotency.
-	err = w.Stop(t.Context())
+	// Act: Call Stop again after the serialized teardown has completed.
+	err := w.Stop(t.Context())
 
-	// Assert: Verify that subsequent Stop calls are safe and return no
-	// error.
+	// Assert: A sequential repeated Stop returns the same successful terminal
+	// outcome without running Vault cleanup again.
 	require.NoError(t, err)
 
 	// Act: Attempt to restart the terminal Wallet after both Stop calls

--- a/wallet/state.go
+++ b/wallet/state.go
@@ -15,14 +15,21 @@ var (
 	// due to the current state of the wallet (e.g., locked, not started,
 	// not synced).
 	ErrStateForbidden = errors.New("operation forbidden in current state")
+
+	// ErrWalletStopped is returned when an operation targets a Wallet that
+	// has begun or completed its terminal shutdown. It is independent from
+	// ErrStateForbidden so callers can distinguish terminal shutdown from a
+	// generic state rejection.
+	ErrWalletStopped = errors.New("wallet stopped")
 )
 
 // lifecycle represents the lifecycle state of the wallet's main event loop.
 type lifecycle uint32
 
 const (
-	// lifecycleStopped indicates the wallet is stopped.
-	lifecycleStopped lifecycle = iota
+	// lifecycleInitialized indicates the wallet has not started yet. This is
+	// distinct from lifecycleStopped because a stopped Wallet is terminal.
+	lifecycleInitialized lifecycle = iota
 
 	// lifecycleStarting indicates the wallet is starting up.
 	lifecycleStarting
@@ -32,11 +39,17 @@ const (
 
 	// lifecycleStopping indicates the wallet is currently stopping.
 	lifecycleStopping
+
+	// lifecycleStopped indicates the wallet has completed terminal shutdown.
+	lifecycleStopped
 )
 
 // String returns the string representation of a lifecycle.
 func (l lifecycle) String() string {
 	switch l {
+	case lifecycleInitialized:
+		return "initialized"
+
 	case lifecycleStopped:
 		return "stopped"
 
@@ -95,7 +108,7 @@ type walletState struct {
 
 // newWalletState creates a new walletState initialized with the provided
 // syncer and secure defaults:
-//   - Lifecycle: Stopped (awaiting Start() call).
+//   - Lifecycle: Initialized (awaiting its one permitted Start call).
 //   - Synchronization: BackendSyncing (until syncer is running and connected).
 //   - Authentication: Locked (secure by default).
 func newWalletState(syncer chainSyncer) walletState {
@@ -113,15 +126,19 @@ func (s *walletState) String() string {
 	return fmt.Sprintf("status=%v, sync=%v, locked=%v", lc, sync, !unlocked)
 }
 
-// toStarting transitions the wallet state from Stopped to Starting.
+// toStarting transitions the wallet state from Initialized to Starting.
 // It initializes the synchronization and authentication states to their
-// secure defaults. It returns an error if the wallet is already started or
-// not in the Stopped state.
+// secure defaults. A Wallet that reached Stopped is terminal and cannot start
+// again.
 func (s *walletState) toStarting() error {
-	// 1. Lifecycle (System State): Atomic transition from Stopped to
+	if lifecycle(s.lifecycle.Load()) == lifecycleStopped {
+		return ErrWalletStopped
+	}
+
+	// 1. Lifecycle (System State): Atomic transition from Initialized to
 	// Starting.
 	if !s.lifecycle.CompareAndSwap(
-		uint32(lifecycleStopped), uint32(lifecycleStarting)) {
+		uint32(lifecycleInitialized), uint32(lifecycleStarting)) {
 
 		return fmt.Errorf("%w: current state is %v",
 			ErrWalletAlreadyStarted, lifecycle(s.lifecycle.Load()))
@@ -166,10 +183,11 @@ func (s *walletState) toStopping() error {
 	return nil
 }
 
-// toStopped marks the wallet as fully stopped.
+// toStopped marks the wallet as terminally stopped. An Initialized Wallet can
+// transition directly to Stopped when Stop is called before Start.
 func (s *walletState) toStopped() error {
-	// We allow transition from Stopping (normal shutdown) or Starting
-	// (failure during startup).
+	// We allow transition from Initialized (stop before start), Stopping
+	// (normal shutdown), or Starting (failure during startup).
 	//
 	// We use a CAS loop here to handle potential races where the state
 	// might change between Load and CompareAndSwap.
@@ -184,7 +202,9 @@ func (s *walletState) toStopped() error {
 		current := s.lifecycle.Load()
 		lc := lifecycle(current)
 
-		if lc != lifecycleStopping && lc != lifecycleStarting {
+		if lc != lifecycleInitialized && lc != lifecycleStopping &&
+			lc != lifecycleStarting {
+
 			return fmt.Errorf("%w: cannot transition to stopped "+
 				"from %v", ErrStateForbidden, lc)
 		}
@@ -238,18 +258,19 @@ func (s *walletState) isStarted() bool {
 	return lifecycle(s.lifecycle.Load()) == lifecycleStarted
 }
 
-// isRunning returns true if the wallet is in any active state (not stopped
-// or stopping).
+// isRunning returns true while the wallet is starting or started.
 func (s *walletState) isRunning() bool {
 	lc := lifecycle(s.lifecycle.Load())
-	return lc != lifecycleStopped && lc != lifecycleStopping
+
+	return lc == lifecycleStarting || lc == lifecycleStarted
 }
 
 // canSign checks if the wallet is in a state allowing message/transaction
 // signing. The wallet must be Started and Unlocked.
 func (s *walletState) canSign() error {
-	if !s.isStarted() {
-		return fmt.Errorf("%w: wallet not started", ErrStateForbidden)
+	err := s.validateStarted()
+	if err != nil {
+		return err
 	}
 
 	if !s.isUnlocked() {
@@ -263,8 +284,9 @@ func (s *walletState) canSign() error {
 // It returns an error if the wallet is not started or if it is currently
 // syncing/rescanning.
 func (s *walletState) validateSynced() error {
-	if !s.isStarted() {
-		return fmt.Errorf("%w: wallet not started", ErrStateForbidden)
+	err := s.validateStarted()
+	if err != nil {
+		return err
 	}
 
 	// TODO(yy): Should we allow creating txs while syncing?
@@ -280,11 +302,20 @@ func (s *walletState) validateSynced() error {
 
 // validateStarted checks if the wallet is currently running.
 func (s *walletState) validateStarted() error {
-	if !s.isStarted() {
-		return fmt.Errorf("%w: wallet not started", ErrStateForbidden)
-	}
+	switch lifecycle(s.lifecycle.Load()) {
+	case lifecycleStarted:
+		return nil
 
-	return nil
+	case lifecycleStopping, lifecycleStopped:
+		return ErrWalletStopped
+
+	case lifecycleInitialized, lifecycleStarting:
+		return fmt.Errorf("%w: wallet not started", ErrStateForbidden)
+
+	default:
+		return fmt.Errorf("%w: unknown wallet lifecycle",
+			ErrStateForbidden)
+	}
 }
 
 // canUnlock checks if the wallet is in a state that allows unlocking.

--- a/wallet/state_test.go
+++ b/wallet/state_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 // TestStateSecureByDefault verifies that the zero-value of walletState
-// represents a safe, locked condition.
+// represents a safe, locked condition that has not started yet.
 func TestStateSecureByDefault(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Create a new state in Stopped (default) mode.
+	// Arrange: Create a new state in Initialized (default) mode.
 	syncer := &mockChainSyncer{}
 	s := newWalletState(syncer)
 
@@ -95,8 +95,55 @@ func TestStateAuthentication(t *testing.T) {
 	// Manually unlock while stopped to test canSign check.
 	s.toUnlocked()
 	err = s.canSign()
-	require.ErrorIs(t, err, ErrStateForbidden)
-	require.ErrorContains(t, err, "wallet not started")
+	require.ErrorIs(t, err, ErrWalletStopped)
+	require.ErrorContains(t, err, "wallet stopped")
+}
+
+// TestStateCanSignLifecycle verifies signing preserves the lifecycle error
+// that distinguishes a Wallet which has not started from one that is terminal.
+func TestStateCanSignLifecycle(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		lifecycle lifecycle
+		expected  error
+	}{
+		{
+			name:      "rejects initialized",
+			lifecycle: lifecycleInitialized,
+			expected:  ErrStateForbidden,
+		},
+		{
+			name:      "rejects stopping",
+			lifecycle: lifecycleStopping,
+			expected:  ErrWalletStopped,
+		},
+		{
+			name:      "rejects stopped",
+			lifecycle: lifecycleStopped,
+			expected:  ErrWalletStopped,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: Force the lifecycle under test and unlock the
+			// state so only lifecycle admission can reject signing.
+			state := newWalletState(nil)
+			state.lifecycle.Store(uint32(test.lifecycle))
+			state.toUnlocked()
+
+			// Act: Ask the state boundary whether signing is allowed.
+			err := state.canSign()
+
+			// Assert: The guard preserves the sentinel assigned to the
+			// selected non-running lifecycle.
+			require.ErrorIs(t, err, test.expected)
+		})
+	}
 }
 
 // TestStateSynchronization verifies that the wallet state correctly reflects
@@ -212,6 +259,53 @@ func TestValidateSynced(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestStateValidateSyncedLifecycle verifies synchronization checks preserve
+// the lifecycle error before consulting the chain synchronization state.
+func TestStateValidateSyncedLifecycle(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		lifecycle lifecycle
+		expected  error
+	}{
+		{
+			name:      "rejects initialized",
+			lifecycle: lifecycleInitialized,
+			expected:  ErrStateForbidden,
+		},
+		{
+			name:      "rejects stopping",
+			lifecycle: lifecycleStopping,
+			expected:  ErrWalletStopped,
+		},
+		{
+			name:      "rejects stopped",
+			lifecycle: lifecycleStopped,
+			expected:  ErrWalletStopped,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: Build a state with no syncer and force the
+			// lifecycle under test. A syncer access would therefore
+			// expose a failure to reject at the lifecycle boundary.
+			state := newWalletState(nil)
+			state.lifecycle.Store(uint32(test.lifecycle))
+
+			// Act: Validate an operation that requires synchronization.
+			err := state.validateSynced()
+
+			// Assert: Lifecycle rejection returns the expected sentinel
+			// without attempting to inspect synchronization state.
+			require.ErrorIs(t, err, test.expected)
+		})
+	}
+}
+
 // TestStateLifecycleTransitions verifies valid and invalid lifecycle
 // state transitions.
 func TestStateLifecycleTransitions(t *testing.T) {
@@ -222,6 +316,11 @@ func TestStateLifecycleTransitions(t *testing.T) {
 		lifecycle lifecycle
 		running   bool
 	}{
+		{
+			name:      "initialized is not running",
+			lifecycle: lifecycleInitialized,
+			running:   false,
+		},
 		{
 			name:      "started is running",
 			lifecycle: lifecycleStarted,
@@ -309,6 +408,24 @@ func TestStateStartStop(t *testing.T) {
 		require.ErrorIs(t, err, ErrWalletAlreadyStarted)
 	})
 
+	t.Run("start fail terminally stopped", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange: Set the lifecycle to its terminal Stopped state to
+		// model a Wallet whose only runtime has already ended.
+		state := newWalletState(nil)
+		state.lifecycle.Store(uint32(lifecycleStopped))
+
+		// Act: Attempt to start the same state instance again.
+		err := state.toStarting()
+
+		// Assert: A terminal Wallet reports only the specific stopped
+		// sentinel so callers can distinguish final shutdown from other
+		// state-based rejections.
+		require.ErrorIs(t, err, ErrWalletStopped)
+		require.NotErrorIs(t, err, ErrStateForbidden)
+	})
+
 	t.Run("stop success", func(t *testing.T) {
 		t.Parallel()
 
@@ -333,6 +450,24 @@ func TestStateStartStop(t *testing.T) {
 		err := state.toStopping()
 		require.ErrorIs(t, err, ErrStateForbidden)
 	})
+
+	t.Run("stop initialized", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange: Use a fresh state to represent Stop arriving before
+		// the Wallet's first Start.
+		state := newWalletState(nil)
+
+		// Act: Transition directly from Initialized to terminal Stopped.
+		err := state.toStopped()
+
+		// Assert: The direct transition succeeds and prevents a later
+		// Start on the retained state instance.
+		require.NoError(t, err)
+		require.Equal(t, uint32(lifecycleStopped),
+			state.lifecycle.Load())
+		require.ErrorIs(t, state.toStarting(), ErrWalletStopped)
+	})
 }
 
 // TestStateValidateStarted verifies the validateStarted check.
@@ -350,9 +485,31 @@ func TestStateValidateStarted(t *testing.T) {
 	t.Run("fail stopped", func(t *testing.T) {
 		t.Parallel()
 
+		// Arrange: Put the state in its terminal Stopped condition.
 		state := newWalletState(nil)
 		state.lifecycle.Store(uint32(lifecycleStopped))
-		require.ErrorIs(t, state.validateStarted(), ErrStateForbidden)
+
+		// Act: Validate an operation that requires a running Wallet.
+		err := state.validateStarted()
+
+		// Assert: The specific stopped sentinel distinguishes terminal
+		// shutdown from a non-terminal state rejection.
+		require.ErrorIs(t, err, ErrWalletStopped)
+	})
+
+	t.Run("fail initialized", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange: Leave a fresh state in Initialized to distinguish a
+		// Wallet that has never run from one that has stopped.
+		state := newWalletState(nil)
+
+		// Act: Validate an operation before the first Start.
+		err := state.validateStarted()
+
+		// Assert: Pre-start access retains the original broad state
+		// error and does not claim that the Wallet has stopped.
+		require.ErrorIs(t, err, ErrStateForbidden)
 	})
 }
 
@@ -379,13 +536,25 @@ func TestStateAuthChecks(t *testing.T) {
 	t.Run("stopped forbidden", func(t *testing.T) {
 		t.Parallel()
 
+		// Arrange: Put the state in its terminal Stopped condition so
+		// every authentication check reaches lifecycle validation first.
 		state := newWalletState(nil)
-
 		setState(&state, lifecycleStopped)
-		require.ErrorIs(t, state.canUnlock(), ErrStateForbidden)
-		require.ErrorIs(t, state.canLock(), ErrStateForbidden)
-		require.ErrorIs(t, state.canChangePassphrase(),
-			ErrStateForbidden)
+
+		// Act: Exercise each authentication transition after terminal
+		// shutdown has made the Wallet permanently unavailable.
+		unlockErr := state.canUnlock()
+		lockErr := state.canLock()
+		changeErr := state.canChangePassphrase()
+
+		// Assert: All three operations report the specific terminal
+		// sentinel without also matching the generic state rejection.
+		require.ErrorIs(t, unlockErr, ErrWalletStopped)
+		require.NotErrorIs(t, unlockErr, ErrStateForbidden)
+		require.ErrorIs(t, lockErr, ErrWalletStopped)
+		require.NotErrorIs(t, lockErr, ErrStateForbidden)
+		require.ErrorIs(t, changeErr, ErrWalletStopped)
+		require.NotErrorIs(t, changeErr, ErrStateForbidden)
 	})
 }
 
@@ -425,7 +594,7 @@ func TestStateAuxiliaryMethods(t *testing.T) {
 	syncer := &mockChainSyncer{}
 	s := newWalletState(syncer)
 
-	// Case 1: Stopped -> All forbidden.
+	// Case 1: Initialized -> All forbidden.
 	require.ErrorIs(t, s.canUnlock(), ErrStateForbidden)
 	require.ErrorIs(t, s.canLock(), ErrStateForbidden)
 	require.ErrorIs(t, s.canChangePassphrase(), ErrStateForbidden)


### PR DESCRIPTION
## Summary

Implements roadmap Task 458

Admit public AccountManager requests through the Wallet's existing main loop
and make terminal shutdown observable through a stable error.

## Change Description

- Distinguish initialized and terminally stopped Wallet state and return the
  standalone `ErrWalletStopped` sentinel after shutdown begins.
- Route public AccountManager methods through the existing request channel,
  execute accepted handlers concurrently, and drain them through the existing
  Wallet WaitGroup.
- Preserve the private pre-start account import path used during Wallet
  construction.
- Add lifecycle, concurrency, cancellation, error-propagation, and stopped-call
  coverage in existing test files.

## Notes

PR #1353, the former prerequisite, has merged. This draft is based directly on
`sql-wallet`.

Stacking after Task 456 was a review-order choice even though the roadmap lists
Tasks 456 and 458 as sibling dependencies of Task 459.

The intentional divergence from the current roadmap task plan is that this PR
limits request-loop migration to AccountManager. Other maintained Wallet
components and full private lifecycle teardown are not included.
