### PR TITLE
wallet: define indeterminate commit error

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -107,6 +107,12 @@ var (
 	// ErrInvalidParam is returned when a parameter is invalid.
 	ErrInvalidParam = errors.New("invalid config parameter")
 
+	// ErrIndeterminateCommit is returned when a durable mutation receives an
+	// ambiguous commit response and the wallet's public boundary cannot prove
+	// whether the mutation persisted. Callers should use errors.Is to match
+	// this identity through operation-specific context.
+	ErrIndeterminateCommit = errors.New("indeterminate commit")
+
 	// Namespace bucket keys.
 	waddrmgrNamespaceKey = []byte("waddrmgr")
 	wtxmgrNamespaceKey   = []byte("wtxmgr")

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -41,6 +41,25 @@ var (
 	}
 )
 
+// TestErrIndeterminateCommitWrapping verifies that operation context can wrap
+// an indeterminate durable-mutation result without hiding its public identity.
+func TestErrIndeterminateCommitWrapping(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: choose representative context that a wallet operation would
+	// retain while reporting an indeterminate commit to its caller.
+	operation := "create wallet"
+
+	// Act: wrap the sentinel with the standard error-chain mechanism used to
+	// preserve operation-specific context at public boundaries.
+	err := fmt.Errorf("%s: %w", operation, ErrIndeterminateCommit)
+
+	// Assert: confirm callers can match the stable identity without losing
+	// the useful context that identifies the affected operation.
+	require.ErrorIs(t, err, ErrIndeterminateCommit)
+	require.ErrorContains(t, err, operation)
+}
+
 // TestConfigValidate ensures that the Config.validate method correctly
 // identifies missing required parameters.
 func TestConfigValidate(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements roadmap Task 467.

## Change Description

Define `wallet.ErrIndeterminateCommit` as the stable public identity for ambiguous durable-mutation outcomes and cover `errors.Is` matching through contextual wrapping.

Follow-on wallet creation, account and address, genesis, and funding changes will use this identity when an ambiguous SQL commit leaves the durable result unprovable at their public boundary. Those operation-owning changes will add their mapping or reconciliation locally and wrap this sentinel with useful context.