### PR TITLE
wallet: assemble startup candidates

### DIFF
--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"sync"
 	"time"
@@ -173,6 +174,11 @@ func NewManager(ctx context.Context, cfg ManagerConfig) (*Manager, error) {
 
 	cfg.ChainParams = chainParams
 
+	// Startup has no load request from which to recover a legacy public
+	// passphrase, so isolate the configured bytes before the backend retains
+	// them for aggregate startup.
+	cfg.KVDBPubPassphrase = slices.Clone(cfg.KVDBPubPassphrase)
+
 	if cfg.WalletSyncRetryInterval == 0 {
 		cfg.WalletSyncRetryInterval = initialBackoff
 	}
@@ -202,6 +208,10 @@ func NewManager(ctx context.Context, cfg ManagerConfig) (*Manager, error) {
 	if err != nil {
 		return nil, translateDatabaseIdentityError(err)
 	}
+
+	// The kvdb backend now owns the cloned startup credential. Do not retain
+	// another reference in the Manager's otherwise immutable configuration.
+	cfg.KVDBPubPassphrase = nil
 
 	return &Manager{
 		wallets: make(map[string]*Wallet),

--- a/wallet/manager_backend.go
+++ b/wallet/manager_backend.go
@@ -18,6 +18,10 @@ const defaultWalletDBDirPerm = 0o700
 // managerBackend owns the database used by a Manager and resolves the storage
 // dependencies needed to assemble a Wallet.
 type managerBackend interface {
+	// listWallets returns all durable Wallet data owned by this backend. SQL
+	// backends may return many entries, while kvdb returns at most one.
+	listWallets(ctx context.Context) ([]*walletData, error)
+
 	// create persists only identity and initialization data; runtime policy
 	// remains outside the backend and is applied by Manager assembly.
 	create(ctx context.Context, params CreateWalletParams,
@@ -35,6 +39,7 @@ type managerBackend interface {
 // owns no resources; the managerBackend that returned it remains their owner.
 type walletData struct {
 	id                uint32
+	name              string
 	store             db.Store
 	addressStore      waddrmgr.AddrStore
 	transactionStore  wtxmgr.TxStore

--- a/wallet/manager_config.go
+++ b/wallet/manager_config.go
@@ -53,6 +53,7 @@ var errUnsupportedBackend = errors.New("unsupported database backend")
 //	MaxConnections                     SQL backends
 //	SignetChallengeDigest              SQL backends
 //	NoFreelistSync, Timeout            kvdb only
+//	KVDBPubPassphrase                  kvdb only
 type ManagerConfig struct {
 	// Backend selects the database implementation. Required.
 	Backend DBBackend
@@ -107,6 +108,14 @@ type ManagerConfig struct {
 	// in returned array order. It is nil off signet; its first four bytes,
 	// decoded little-endian, must equal ChainParams.Net.
 	SignetChallengeDigest []byte
+
+	// KVDBPubPassphrase opens the sole legacy Wallet during aggregate
+	// startup. It is an input to Manager rather than retained Wallet policy
+	// because no caller request exists when durable Wallets are assembled.
+	//
+	// TODO(yy): Remove KVDBPubPassphrase once legacy kvdb support is fully
+	// deprecated and removed.
+	KVDBPubPassphrase []byte
 
 	// NoFreelistSync controls bbolt freelist synchronization.
 	//

--- a/wallet/manager_kvdb.go
+++ b/wallet/manager_kvdb.go
@@ -24,6 +24,7 @@ import (
 type kvdbManagerBackend struct {
 	db          walletdb.DB
 	chainParams *chaincfg.Params
+	pubPass     []byte
 	store       *kvdb.Store //nolint:staticcheck // Remove with kvdb support.
 	addressMgr  *waddrmgr.Manager
 	walletName  string
@@ -64,6 +65,7 @@ func newKVDBManagerBackend(cfg ManagerConfig) (*kvdbManagerBackend, error) {
 	return &kvdbManagerBackend{
 		db:          dbConn,
 		chainParams: &cfg.ChainParams,
+		pubPass:     cfg.KVDBPubPassphrase,
 	}, nil
 }
 

--- a/wallet/manager_kvdb.go
+++ b/wallet/manager_kvdb.go
@@ -11,6 +11,7 @@ import (
 	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	kvdb "github.com/btcsuite/btcwallet/wallet/internal/db/kvdb"
 	"github.com/btcsuite/btcwallet/walletdb"
 	_ "github.com/btcsuite/btcwallet/walletdb/bdb" // Register bdb.
@@ -98,6 +99,29 @@ func (b *kvdbManagerBackend) create(ctx context.Context,
 	return b.open(ctx, params.Name, adapterCfg)
 }
 
+// listWallets loads the sole legacy Wallet once. A pristine database is the
+// only successful empty result because kvdb cannot contain a second identity.
+func (b *kvdbManagerBackend) listWallets(
+	ctx context.Context) ([]*walletData, error) {
+
+	data, err := b.load(ctx, LoadWalletParams{
+		PubPassphrase: b.pubPass,
+	})
+	// Missing durable state is kvdb's only zero-Wallet representation. Every
+	// partial namespace, credential, and storage failure remains visible.
+	switch {
+	case err == nil:
+
+	case errors.Is(err, db.ErrWalletNotFound):
+		return []*walletData{}, nil
+
+	default:
+		return nil, err
+	}
+
+	return []*walletData{data}, nil
+}
+
 // load opens the one existing legacy wallet served by the backend.
 func (b *kvdbManagerBackend) load(ctx context.Context,
 	params LoadWalletParams) (*walletData, error) {
@@ -146,6 +170,7 @@ func (b *kvdbManagerBackend) open(ctx context.Context, walletName string,
 
 	data := &walletData{
 		id:                info.ID,
+		name:              walletName,
 		store:             store,
 		addressStore:      addressMgr,
 		transactionStore:  store.TxStore(),

--- a/wallet/manager_sql.go
+++ b/wallet/manager_sql.go
@@ -9,8 +9,13 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/db/page"
 	vault "github.com/btcsuite/btcwallet/wallet/internal/keyvault"
 )
+
+// managerWalletBatchSize supplies the mandatory positive Store iterator batch
+// size; IterWallets remains responsible for exhausting the durable Wallet set.
+const managerWalletBatchSize = 100
 
 // sqlManagerBackend owns the SQL Store shared by a Manager's wallets.
 type sqlManagerBackend struct {
@@ -19,6 +24,34 @@ type sqlManagerBackend struct {
 }
 
 var _ managerBackend = (*sqlManagerBackend)(nil)
+
+// listWallets resolves every SQL Wallet in the Store's durable-ID order.
+func (b *sqlManagerBackend) listWallets(
+	ctx context.Context) ([]*walletData, error) {
+
+	pageReq, err := page.NewRequest[uint32](managerWalletBatchSize)
+	if err != nil {
+		return nil, fmt.Errorf("create wallet page request: %w", err)
+	}
+
+	wallets := make([]*walletData, 0)
+	query := db.ListWalletsQuery{Page: pageReq}
+
+	for info, iterErr := range b.store.IterWallets(ctx, query) {
+		if iterErr != nil {
+			return nil, fmt.Errorf("list runtime wallets: %w", iterErr)
+		}
+
+		data, err := b.walletData(&info)
+		if err != nil {
+			return nil, fmt.Errorf("resolve runtime wallet: %w", err)
+		}
+
+		wallets = append(wallets, data)
+	}
+
+	return wallets, nil
+}
 
 // create atomically creates a SQL wallet and returns its committed data.
 func (b *sqlManagerBackend) create(ctx context.Context,
@@ -63,6 +96,7 @@ func (b *sqlManagerBackend) walletData(
 
 	return &walletData{
 		id:                w.ID,
+		name:              w.Name,
 		store:             b.store,
 		vault:             vault.NewWalletVault(b.store, w.ID, w.IsWatchOnly),
 		masterFingerprint: fingerprint,

--- a/wallet/manager_test.go
+++ b/wallet/manager_test.go
@@ -381,7 +381,20 @@ func TestCreateWalletParamsPolicy(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			backend := &recordingManagerBackend{}
+			// Arrange: Install a strict backend expectation only when the
+			// input is valid enough to reach durable creation. Invalid cases
+			// intentionally leave the mock with no accepted calls.
+			backend := &managerBackendMock{}
+			params := tc.params
+			params.Name = testWalletName
+
+			if tc.valid {
+				backend.On(
+					"create", mock.Anything, params,
+					mock.Anything,
+				).Return(nil, errManagerBackendCreate).Once()
+			}
+
 			m := &Manager{
 				wallets: make(map[string]*Wallet),
 				backend: backend,
@@ -390,59 +403,84 @@ func TestCreateWalletParamsPolicy(t *testing.T) {
 					ChainParams: chainParams,
 				},
 			}
-			params := tc.params
-			params.Name = testWalletName
+
+			// Act: Ask Manager to create from the selected parameter shape,
+			// allowing validation to decide whether backend mutation begins.
 			wallet, err := m.Create(params)
+
+			// Assert: Valid parameters reach exactly one expected backend
+			// call; invalid parameters stop at validation with no mock call.
 			require.Nil(t, wallet)
 
 			if tc.valid {
-				require.ErrorIs(
-					t, err, errRecordingManagerBackendCreate,
-				)
-				require.True(t, backend.createCalled)
+				require.ErrorIs(t, err, errManagerBackendCreate)
+			} else {
+				require.ErrorIs(t, err, ErrWalletParams)
 
-				return
+				if tc.wantErrMsg != "" {
+					require.ErrorContains(t, err, tc.wantErrMsg)
+				}
 			}
 
-			require.ErrorIs(t, err, ErrWalletParams)
-
-			if tc.wantErrMsg != "" {
-				require.ErrorContains(t, err, tc.wantErrMsg)
-			}
-
-			require.False(t, backend.createCalled)
+			backend.AssertExpectations(t)
 		})
 	}
 }
 
-var errRecordingManagerBackendCreate = errors.New("backend create called")
+var errManagerBackendCreate = errors.New("backend create called")
 
-// recordingManagerBackend records whether Manager.Create reached backend
-// mutation during creation-policy tests.
-type recordingManagerBackend struct{ createCalled bool }
-
-// recordingManagerBackend implements managerBackend.
-var _ managerBackend = (*recordingManagerBackend)(nil)
-
-// create records an unexpected backend creation attempt.
-func (b *recordingManagerBackend) create(_ context.Context,
-	_ CreateWalletParams, _ *hdkeychain.ExtendedKey) (*walletData, error) {
-
-	b.createCalled = true
-
-	return nil, errRecordingManagerBackendCreate
+// managerBackendMock is the strict Manager storage-boundary test double.
+type managerBackendMock struct {
+	mock.Mock
 }
 
-// load is not used by creation-policy tests.
-func (*recordingManagerBackend) load(context.Context, LoadWalletParams) (
+// managerBackendMock implements managerBackend.
+var _ managerBackend = (*managerBackendMock)(nil)
+
+// listWallets returns the durable data configured by the current test.
+func (b *managerBackendMock) listWallets(
+	ctx context.Context) ([]*walletData, error) {
+
+	args := b.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	//nolint:forcetypeassert // The strict expectation owns this return type.
+	return args.Get(0).([]*walletData), args.Error(1)
+}
+
+// create returns the storage result configured by the current test.
+func (b *managerBackendMock) create(ctx context.Context,
+	params CreateWalletParams, rootKey *hdkeychain.ExtendedKey) (
 	*walletData, error) {
 
-	return nil, ErrInvalidParam
+	args := b.Called(ctx, params, rootKey)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	//nolint:forcetypeassert // The strict expectation owns this return type.
+	return args.Get(0).(*walletData), args.Error(1)
 }
 
-// close is not used by creation-policy tests.
-func (*recordingManagerBackend) close() error {
-	return nil
+// load returns the identity lookup configured by the current test.
+func (b *managerBackendMock) load(ctx context.Context,
+	params LoadWalletParams) (*walletData, error) {
+
+	args := b.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	//nolint:forcetypeassert // The strict expectation owns this return type.
+	return args.Get(0).(*walletData), args.Error(1)
+}
+
+// close returns the configured backend ownership-release result.
+func (b *managerBackendMock) close() error {
+	args := b.Called()
+	return args.Error(0)
 }
 
 // TestManagerCreateRejectsMissingIdentityBeforeAssembly verifies Create

--- a/wallet/manager_test.go
+++ b/wallet/manager_test.go
@@ -578,6 +578,78 @@ func TestSQLManagerBackendListsWallets(t *testing.T) {
 	}
 }
 
+// TestKVDBManagerBackendListsZeroOrOneWallet verifies legacy startup listing
+// treats an uninitialized database as empty and an initialized database as the
+// backend's sole anonymous Wallet, without inventing another identity.
+func TestKVDBManagerBackendListsZeroOrOneWallet(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty database", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange: Open a fresh legacy database whose address and transaction
+		// namespaces have never been created.
+		manager := testKVDBManager(t)
+		backend, ok := manager.backend.(*kvdbManagerBackend)
+		require.True(t, ok)
+
+		// Act: List startup data through the backend's zero-or-one boundary.
+		wallets, err := backend.listWallets(t.Context())
+
+		// Assert: Absence is a successful, initialized empty result rather
+		// than an attempted load or a missing-Wallet error.
+		require.NoError(t, err)
+		require.NotNil(t, wallets)
+		require.Empty(t, wallets)
+	})
+
+	t.Run("initialized database", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange: Create and close the sole legacy Wallet with a non-empty
+		// public passphrase, then configure a new Manager with the same bytes.
+		// Mutating the caller slice after construction proves listing uses the
+		// Manager's immutable copy through the existing load path.
+		dbPath := testKVDBPath(t)
+		pubPassphrase := []byte("startup-public")
+		creator := testKVDBManagerAt(t, dbPath)
+		_, err := creator.Create(CreateWalletParams{
+			Name:              testWalletName,
+			Mode:              ModeShell,
+			WatchOnly:         true,
+			PubPassphrase:     pubPassphrase,
+			PrivatePassphrase: []byte("private"),
+			Birthday:          time.Now(),
+		})
+		require.NoError(t, err)
+		require.NoError(t, creator.Close())
+
+		manager, err := NewManager(t.Context(), ManagerConfig{
+			Backend:           DBBackendKVDB,
+			DataSource:        dbPath,
+			ChainParams:       chainParams,
+			ChainSource:       &bwmock.Chain{},
+			KVDBPubPassphrase: pubPassphrase,
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = manager.Close() })
+
+		pubPassphrase[0] ^= 0xff
+
+		backend, ok := manager.backend.(*kvdbManagerBackend)
+		require.True(t, ok)
+
+		// Act: List the occupied database through the backend boundary.
+		wallets, err := backend.listWallets(t.Context())
+
+		// Assert: The existing loader returns one Wallet under kvdb's absent
+		// durable name rather than inventing an alias or a second identity.
+		require.NoError(t, err)
+		require.Len(t, wallets, 1)
+		require.Empty(t, wallets[0].name)
+	})
+}
+
 // TestManagerCreateRejectsMissingIdentityBeforeAssembly verifies Create
 // rejects an absent durable key before Store work.
 func TestManagerCreateRejectsMissingIdentityBeforeAssembly(t *testing.T) {

--- a/wallet/manager_test.go
+++ b/wallet/manager_test.go
@@ -3,6 +3,7 @@ package wallet
 import (
 	"context"
 	"errors"
+	"iter"
 	"testing"
 	"time"
 
@@ -481,6 +482,100 @@ func (b *managerBackendMock) load(ctx context.Context,
 func (b *managerBackendMock) close() error {
 	args := b.Called()
 	return args.Error(0)
+}
+
+// TestSQLManagerBackendListsWallets verifies ordered complete listing and
+// all-or-nothing iterator failures.
+func TestSQLManagerBackendListsWallets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		rows      []db.WalletInfo
+		iterErr   error
+		wantIDs   []uint32
+		wantNames []string
+	}{
+		{
+			name:      "empty store",
+			wantIDs:   []uint32{},
+			wantNames: []string{},
+		},
+		{
+			name: "ordered store rows",
+			rows: []db.WalletInfo{
+				{
+					ID:   4,
+					Name: "first",
+				},
+				{
+					ID:   9,
+					Name: "second",
+				},
+			},
+			wantIDs:   []uint32{4, 9},
+			wantNames: []string{"first", "second"},
+		},
+		{
+			name:    "iterator failure",
+			iterErr: errDBMock,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: Yield ordered rows and an optional terminal error from
+			// the Store iterator used by the backend discovery boundary.
+			store := &walletmock.Store{}
+			sequence := iter.Seq2[db.WalletInfo, error](func(
+				yield func(db.WalletInfo, error) bool) {
+
+				for _, row := range test.rows {
+					if !yield(row, nil) {
+						return
+					}
+				}
+
+				if test.iterErr != nil {
+					yield(db.WalletInfo{}, test.iterErr)
+				}
+			})
+			store.On(
+				"IterWallets", mock.Anything, mock.Anything,
+			).Return(sequence, nil).Once()
+
+			backend := &sqlManagerBackend{store: store}
+
+			// Act: Resolve the complete startup listing through the SQL
+			// backend boundary rather than calling the Store directly.
+			wallets, err := backend.listWallets(t.Context())
+
+			// Assert: Iterator failure prevents a partial handoff; otherwise
+			// the non-nil result preserves each durable ID and name exactly.
+			if test.iterErr != nil {
+				require.ErrorIs(t, err, test.iterErr)
+				require.Nil(t, wallets)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, wallets)
+
+				ids := make([]uint32, 0, len(wallets))
+				names := make([]string, 0, len(wallets))
+
+				for _, wallet := range wallets {
+					ids = append(ids, wallet.id)
+					names = append(names, wallet.name)
+				}
+
+				require.Equal(t, test.wantIDs, ids)
+				require.Equal(t, test.wantNames, names)
+			}
+
+			store.AssertExpectations(t)
+		})
+	}
 }
 
 // TestManagerCreateRejectsMissingIdentityBeforeAssembly verifies Create

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -227,12 +227,6 @@ type Config struct {
 	// LoadWalletParams.
 	Name string
 
-	// PubPassphrase is the legacy public passphrase.
-	//
-	// Deprecated: Manager APIs carry this credential in their narrow request
-	// parameters, and managed Wallets do not retain it.
-	PubPassphrase []byte
-
 	// MaxCFilterItems is the threshold of watched items (addresses +
 	// outpoints) above which the wallet will fallback to full block
 	// scanning when SyncMethodAuto is used. This avoids the CPU bottleneck


### PR DESCRIPTION
## Summary

Add the minimal backend discovery seam needed for later aggregate Manager startup.

## Change Description

- list every durable SQL Wallet through the existing exhaustive Store iterator
- load the legacy kvdb Wallet exactly once, returning either an empty result or its sole unnamed Wallet
- keep the legacy kvdb startup public passphrase on ManagerConfig with its removal TODO, copy it only into the kvdb backend, and remove the unused field from Wallet Config
- reuse the existing context-aware durable metadata lookup without adding cancellation guards around the legacy Store open
- do not add `assembleWalletCandidates`, candidate result or cleanup helpers, or an equivalent assembler; later aggregate Manager startup will consume backend discovery directly

## Notes

- base branch: `sql-wallet`; prerequisite PR #1373 has merged into that base, so this PR's review scope contains only its four Wallet discovery commits
- intentionally narrows roadmap Task 459 by omitting its planned assembler and cleanup helpers entirely rather than deferring those helpers to later work
- leaves aggregate Manager lifecycle cancellation, cleanup, and wiring for a later task

Implements roadmap Task 459
