### PR TITLE
wallet: validate transaction input amounts

### DIFF
--- a/wallet/psbt_manager_test.go
+++ b/wallet/psbt_manager_test.go
@@ -4711,3 +4711,104 @@ func TestFinalizePsbtLocked(t *testing.T) {
 	err := w.FinalizePsbt(t.Context(), packet)
 	require.ErrorIs(t, err, ErrStateForbidden)
 }
+
+// TestFundPsbtRejectsCorruptInputAmounts verifies that a store result carrying
+// an unrepresentable or inconsistent amount is refused by FundPsbt too, on both
+// the automatic and the manual selection path, without mutating the caller's
+// packet.
+//
+// Both public wrappers prepare their sources at the same boundary, so asserting
+// it here rather than only through CreateTransaction is what pins the check to
+// that boundary instead of to one wrapper. The amount sets and the violations
+// they must be refused under are shared with
+// TestCreateTransactionRejectsCorruptInputAmounts.
+func TestFundPsbtRejectsCorruptInputAmounts(t *testing.T) {
+	t.Parallel()
+
+	// fundPacket builds a packet requesting one 99,700-sat payment and
+	// funds it. A packet carrying no inputs asks the wallet to select
+	// automatically; one carrying the fixture outpoints selects those
+	// exact coins instead, which is how FundPsbt expresses a manual
+	// selection.
+	fundPacket := func(manual bool) func(*testing.T, *Wallet,
+		[]wire.OutPoint) error {
+
+		return func(t *testing.T, w *Wallet,
+			outpoints []wire.OutPoint) error {
+
+			t.Helper()
+
+			tx := wire.NewMsgTx(wire.TxVersion)
+			tx.AddTxOut(&wire.TxOut{
+				Value: 99_700, PkScript: corruptAmountPkScript(),
+			})
+
+			if manual {
+				for i := range outpoints {
+					tx.AddTxIn(wire.NewTxIn(
+						&outpoints[i], nil, nil,
+					))
+				}
+			}
+
+			packet, err := psbt.NewFromUnsignedTx(tx)
+			require.NoError(t, err)
+
+			originalTx := packet.UnsignedTx
+			originalInputs := len(packet.UnsignedTx.TxIn)
+
+			// A packet that already carries inputs may not also
+			// carry a selection policy, so the policy is supplied
+			// only for the automatic case.
+			fundIntent := &FundIntent{
+				Packet: packet, FeeRate: defaultFeeRate,
+			}
+			if !manual {
+				fundIntent.Policy = &InputsPolicy{}
+			}
+
+			funded, changeIndex, err := w.FundPsbt(
+				t.Context(), fundIntent,
+			)
+
+			// The refusal must leave the caller's packet as it was
+			// found: the same transaction object, the inputs it
+			// arrived with, and its sole payment output.
+			require.Nil(t, funded)
+			require.Zero(t, changeIndex)
+			require.Same(t, originalTx, packet.UnsignedTx)
+			require.Len(t, packet.UnsignedTx.TxIn, originalInputs)
+			require.Len(t, packet.UnsignedTx.TxOut, 1)
+
+			return err
+		}
+	}
+
+	t.Run("automatic selection", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tc := range automaticCorruptAmountCases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				requireCorruptAmountRejected(
+					t, tc, fundPacket(false),
+				)
+			})
+		}
+	})
+
+	t.Run("manual selection", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tc := range manualCorruptAmountCases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				requireCorruptAmountRejected(
+					t, tc, fundPacket(true),
+				)
+			})
+		}
+	})
+}

--- a/wallet/tx_creator.go
+++ b/wallet/tx_creator.go
@@ -829,21 +829,39 @@ func (w *Wallet) determineChangeSource(intent *TxIntent) *ScopedAccount {
 func (w *Wallet) createInputSource(ctx context.Context, intent *TxIntent) (
 	txauthor.InputSource, error) {
 
+	var (
+		source txauthor.InputSource
+		err    error
+	)
+
 	switch inputs := intent.Inputs.(type) {
 	// If the inputs are manually specified, we create a "constant" input
 	// source that will only ever return the specified UTXOs.
 	case *InputsManual:
-		return w.createManualInputSource(ctx, inputs)
+		source, err = w.createManualInputSource(ctx, inputs)
 
 	// If the inputs are policy-based, we create an input source that will
 	// perform coin selection.
 	case *InputsPolicy:
-		return w.createPolicyInputSource(ctx, inputs, intent.FeeRate)
+		source, err = w.createPolicyInputSource(
+			ctx, inputs, intent.FeeRate,
+		)
 
 	// Any other type is unsupported.
 	default:
 		return nil, ErrUnsupportedTxInputs
 	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate whichever source was built before handing it to authoring.
+	// This is the one boundary every maintained caller crosses -
+	// CreateTransaction and FundPsbt both prepare their sources here - so
+	// wrapping it once covers automatic, manual, and selected results
+	// without each adapter having to remember to.
+	return checkInputSource(source), nil
 }
 
 // createManualInputSource creates an input source from a list of manually
@@ -1140,6 +1158,10 @@ func (w *Wallet) getEligibleUTXOsFromList(ctx context.Context,
 
 // makeInputSource creates an input source that spends arranged coins until the
 // requested target amount is reached.
+//
+// The running total is accumulated through the checked add, so a coin whose
+// stored value cannot be added is reported rather than wrapping the total it
+// would have funded.
 func makeInputSource(eligible []Coin) txauthor.InputSource {
 	// Current inputs and their total value. These are closed over by the
 	// returned input source and reused across multiple calls.
@@ -1155,10 +1177,23 @@ func makeInputSource(eligible []Coin) txauthor.InputSource {
 			nextCredit := eligible[0]
 			prevOut := nextCredit.TxOut
 			outpoint := nextCredit.OutPoint
+
+			// Take the coin only once its value is known to be
+			// addable. This state outlives the call, so a failed
+			// add must neither record an input against a total that
+			// never took it, nor drop the offending coin and let a
+			// later call succeed without it.
+			nextTotal, err := addInputAmounts(
+				currentTotal, btcutil.Amount(prevOut.Value),
+			)
+			if err != nil {
+				return 0, nil, nil, nil, err
+			}
+
 			eligible = eligible[1:]
 
 			nextInput := wire.NewTxIn(&outpoint, nil, nil)
-			currentTotal += btcutil.Amount(prevOut.Value)
+			currentTotal = nextTotal
 
 			currentInputs = append(currentInputs, nextInput)
 			currentScripts = append(
@@ -1197,6 +1232,10 @@ func constantInputSource[T constantInputCredit](
 }
 
 // constantUtxoInputSource adapts static UTXO info into an input source.
+//
+// The total is accumulated through the checked add. The sum is formed once
+// here rather than per call, so a failure to form it is held until the source
+// is asked, which is the first moment there is a caller to report it to.
 func constantUtxoInputSource(eligible []db.UtxoInfo) txauthor.InputSource {
 	// Current inputs and their total value. These won't change over
 	// different invocations as we want our inputs to remain static since
@@ -1206,9 +1245,18 @@ func constantUtxoInputSource(eligible []db.UtxoInfo) txauthor.InputSource {
 	currentScripts := make([][]byte, 0, len(eligible))
 	currentInputValues := make([]btcutil.Amount, 0, len(eligible))
 
+	var sourceErr error
+
 	for _, credit := range eligible {
+		nextTotal, err := addInputAmounts(currentTotal, credit.Amount)
+		if err != nil {
+			sourceErr = err
+
+			break
+		}
+
 		nextInput := wire.NewTxIn(&credit.OutPoint, nil, nil)
-		currentTotal += credit.Amount
+		currentTotal = nextTotal
 
 		currentInputs = append(currentInputs, nextInput)
 		currentScripts = append(currentScripts, credit.PkScript)
@@ -1217,6 +1265,13 @@ func constantUtxoInputSource(eligible []db.UtxoInfo) txauthor.InputSource {
 
 	return func(_ btcutil.Amount) (btcutil.Amount, []*wire.TxIn,
 		[]btcutil.Amount, [][]byte, error) {
+
+		// The selection is fixed, so a partial one is never offered:
+		// the failure is reported instead of the coins that preceded
+		// it.
+		if sourceErr != nil {
+			return 0, nil, nil, nil, sourceErr
+		}
 
 		return currentTotal, currentInputs, currentInputValues,
 			currentScripts, nil

--- a/wallet/tx_creator_test.go
+++ b/wallet/tx_creator_test.go
@@ -3,6 +3,7 @@ package wallet
 import (
 	"context"
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/btcsuite/btcd/address/v2"
@@ -1971,4 +1972,296 @@ func TestFilterEligibleOutputsExcludesImmatureCoinbase(t *testing.T) {
 			}
 		})
 	}
+}
+
+// corruptAmountPkScript returns the P2WPKH script the corrupt-amount fixtures
+// pay to. Its contents are irrelevant to amount validation; it only has to be
+// a spendable script shape so nothing rejects the set before the amounts are
+// read.
+func corruptAmountPkScript() []byte {
+	return append([]byte{0x00, 0x14}, make([]byte, 20)...)
+}
+
+// expectCorruptAmountSources stands the store up to return one default-account
+// UTXO per given amount and registers the account and chain lookups an input
+// source performs on the way. It serves both selection paths: automatic
+// selection lists the account's UTXOs, while manual selection fetches each of
+// the returned outpoints by name.
+//
+// No change-script derivation is registered. A refusal that arrived late enough
+// to allocate change would call NewDerivedAddress, and the mock fails an
+// unexpected call, so the omission is what pins every rejection ahead of change
+// allocation. Nothing leases either: authoring fails inside the input source,
+// which is before any wrapper reaches its lease obligations.
+func expectCorruptAmountSources(t *testing.T, w *Wallet,
+	mocks *mockWalletDeps, amounts []btcutil.Amount) []wire.OutPoint {
+
+	t.Helper()
+
+	defaultAccountNum := uint32(waddrmgr.DefaultAccountNum)
+	scope := db.KeyScope(waddrmgr.KeyScopeBIP0086)
+	accountInfo := &db.AccountInfo{
+		AccountNumber: &defaultAccountNum,
+		AccountName:   waddrmgr.DefaultAccountName,
+		AddrSchema:    db.ScopeAddrMap[scope],
+	}
+
+	// The account and chain reads differ in number between the two paths
+	// and are only scaffolding for the amounts under test, so they are not
+	// pinned to a count.
+	mocks.store.On("GetAccount", mock.Anything, db.GetAccountQuery{
+		WalletID: w.id, Scope: scope, Name: &defaultAccountName,
+	}).Return(accountInfo, nil).Maybe()
+	mocks.store.On("GetAccount", mock.Anything, db.GetAccountQuery{
+		WalletID: w.id, Scope: scope, AccountNumber: &defaultAccountNum,
+	}).Return(accountInfo, nil).Maybe()
+	mocks.chain.On("BlockStamp").Return(
+		&waddrmgr.BlockStamp{Height: 100}, nil,
+	).Maybe()
+
+	script := corruptAmountPkScript()
+	utxos := make([]db.UtxoInfo, len(amounts))
+	outpoints := make([]wire.OutPoint, len(amounts))
+
+	for i, amount := range amounts {
+		outpoints[i] = wire.OutPoint{
+			Hash: [32]byte{byte(i + 1)}, Index: 0,
+		}
+		utxos[i] = db.UtxoInfo{
+			OutPoint: outpoints[i], Amount: amount,
+			PkScript: script, Height: 1,
+		}
+
+		mocks.store.On("GetUtxo", mock.Anything, db.GetUtxoQuery{
+			WalletID: w.id, OutPoint: outpoints[i],
+		}).Return(&utxos[i], nil).Maybe()
+	}
+
+	mocks.store.On("ListUTXOs", mock.Anything, db.ListUtxosQuery{
+		WalletID: w.id, Scope: &scope, AccountName: &defaultAccountName,
+	}).Return(utxos, nil).Maybe()
+
+	return outpoints
+}
+
+// corruptAmountCase is one set of store amounts a wallet input source must
+// refuse, together with the violation it must be refused under.
+type corruptAmountCase struct {
+	name    string
+	amounts []btcutil.Amount
+	wantErr error
+}
+
+// automaticCorruptAmountCases enumerates the corrupt store amounts automatic
+// selection must refuse.
+//
+// The amounts are shaped around how that source consumes coins: it takes them
+// largest first and stops as soon as the running total reaches the target, so a
+// set whose first coin already funds the payment never reveals what follows it.
+// The sets below therefore keep the total below the 99,700-sat payment until
+// the offending coin has been taken.
+var automaticCorruptAmountCases = []corruptAmountCase{{
+	// Both coins are consumed because neither funds the payment, so the
+	// negative one reaches the check with the total still non-negative.
+	name:    "a negative amount is rejected",
+	amounts: []btcutil.Amount{50_000, -10_000},
+	wantErr: errInputValueNegative,
+}, {
+	name:    "an amount below the negative total is rejected",
+	amounts: []btcutil.Amount{-1e8, -2e8},
+	wantErr: errInputTotalNegative,
+}, {
+	name:    "an amount above the maximum is rejected",
+	amounts: []btcutil.Amount{btcutil.MaxSatoshi + 1},
+	wantErr: errInputTotalExceedsMax,
+}, {
+	// Accumulating downwards is the only way this source can climb to the
+	// overflow point: the loop stops once the total reaches the target, so
+	// a rising total can never get there.
+	name: "an overflowing accumulation is rejected",
+	amounts: []btcutil.Amount{
+		math.MinInt64 / 2, math.MinInt64 / 2, -1,
+	},
+	wantErr: errInputAmountOverflow,
+}}
+
+// manualCorruptAmountCases enumerates the corrupt store amounts manual
+// selection must refuse.
+//
+// This source sums every selected coin regardless of the target, so it reaches
+// aggregate violations an automatic selection stops short of.
+var manualCorruptAmountCases = []corruptAmountCase{{
+	name:    "a negative amount is rejected",
+	amounts: []btcutil.Amount{2e8, -1e8},
+	wantErr: errInputValueNegative,
+}, {
+	name:    "a negative total is rejected",
+	amounts: []btcutil.Amount{-1e8},
+	wantErr: errInputTotalNegative,
+}, {
+	name:    "an amount above the maximum is rejected",
+	amounts: []btcutil.Amount{btcutil.MaxSatoshi + 1},
+	wantErr: errInputTotalExceedsMax,
+}, {
+	// Each coin is individually payable; only the set is not.
+	name: "individually valid amounts summing above the maximum " +
+		"are rejected",
+	amounts: []btcutil.Amount{btcutil.MaxSatoshi - 1e8, 1e8 + 1},
+	wantErr: errInputTotalExceedsMax,
+}, {
+	name:    "an overflowing accumulation is rejected",
+	amounts: []btcutil.Amount{math.MaxInt64, math.MaxInt64},
+	wantErr: errInputAmountOverflow,
+}}
+
+// requireCorruptAmountRejected drives fund with a wallet whose store returns
+// tc's amounts and asserts the call was refused under tc's violation before any
+// change script was derived.
+func requireCorruptAmountRejected(t *testing.T, tc corruptAmountCase,
+	fund func(t *testing.T, w *Wallet, outpoints []wire.OutPoint) error) {
+
+	t.Helper()
+
+	w, mocks := createStartedWalletWithMocks(t)
+	mocks.syncer.On("syncState").Return(syncStateSynced).Once()
+
+	outpoints := expectCorruptAmountSources(t, w, mocks, tc.amounts)
+
+	err := fund(t, w, outpoints)
+
+	require.ErrorIs(t, err, tc.wantErr)
+	mocks.store.AssertNotCalled(
+		t, "NewDerivedAddress", mock.Anything, mock.Anything,
+	)
+}
+
+// TestCreateTransactionRejectsCorruptInputAmounts verifies that a store result
+// carrying an unrepresentable or inconsistent amount is refused by
+// CreateTransaction, on both the automatic and the manual selection path,
+// before any change is allocated against it.
+//
+// The two violations no store result can produce - a value count unequal to the
+// inputs, and a total that is not the sum of the values - are covered by
+// TestCheckInputResult, which reaches the validator directly. Both wallet
+// sources report the total they actually accumulated, so neither can be driven
+// into those classes from here.
+func TestCreateTransactionRejectsCorruptInputAmounts(t *testing.T) {
+	t.Parallel()
+
+	payment := wire.TxOut{
+		Value: 99_700, PkScript: corruptAmountPkScript(),
+	}
+
+	t.Run("automatic selection", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tc := range automaticCorruptAmountCases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				requireCorruptAmountRejected(t, tc, func(
+					t *testing.T, w *Wallet,
+					_ []wire.OutPoint) error {
+
+					t.Helper()
+
+					authored, err := w.CreateTransaction(
+						t.Context(), &TxIntent{
+							Outputs: []wire.TxOut{
+								payment,
+							},
+							Inputs:  &InputsPolicy{},
+							FeeRate: defaultFeeRate,
+						},
+					)
+					require.Nil(t, authored)
+
+					return err
+				})
+			})
+		}
+	})
+
+	t.Run("manual selection", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tc := range manualCorruptAmountCases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				requireCorruptAmountRejected(t, tc, func(
+					t *testing.T, w *Wallet,
+					outpoints []wire.OutPoint) error {
+
+					t.Helper()
+
+					authored, err := w.CreateTransaction(
+						t.Context(), &TxIntent{
+							Outputs: []wire.TxOut{
+								payment,
+							},
+							Inputs: &InputsManual{
+								UTXOs: outpoints,
+							},
+							FeeRate: defaultFeeRate,
+						},
+					)
+					require.Nil(t, authored)
+
+					return err
+				})
+			})
+		}
+	})
+}
+
+// TestCreateTransactionManualSelectionAccepted verifies that a sound manual
+// selection still authors once every input result is validated. It is the
+// positive counterpart to TestCreateTransactionRejectsCorruptInputAmounts on
+// the path automatic selection does not cover.
+// TestCreateTransactionDefaultPolicy already proves the same for an automatic
+// one.
+func TestCreateTransactionManualSelectionAccepted(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Prepare a synced wallet whose store holds one mature
+	// 100,000-sat UTXO, and select it by outpoint. The 99,700-sat payment
+	// leaves only a sub-dust remainder after fees, so no change output
+	// survives.
+	w, mocks := createStartedWalletWithMocks(t)
+	mocks.syncer.On("syncState").Return(syncStateSynced).Once()
+
+	outpoints := expectCorruptAmountSources(
+		t, w, mocks, []btcutil.Amount{100_000},
+	)
+
+	scope := db.KeyScope(waddrmgr.KeyScopeBIP0086)
+	mocks.store.On("NewDerivedAddress", mock.Anything,
+		db.NewDerivedAddressParams{
+			WalletID: w.id, AccountName: defaultAccountName,
+			Scope: scope, Change: true,
+		},
+	).Return(&db.AddressInfo{
+		ScriptPubKey: make([]byte, txsizes.P2TRPkScriptSize),
+	}, nil).Once()
+
+	payment := wire.TxOut{
+		Value: 99_700, PkScript: corruptAmountPkScript(),
+	}
+
+	// Act: Author the payment from the manually selected UTXO.
+	authored, err := w.CreateTransaction(t.Context(), &TxIntent{
+		Outputs: []wire.TxOut{payment},
+		Inputs:  &InputsManual{UTXOs: outpoints},
+		FeeRate: defaultFeeRate,
+	})
+
+	// Assert: The validated source dispensed its coin unchanged, so the
+	// selection is spent, the payment is preserved, and no change survived.
+	require.NoError(t, err)
+	require.Equal(t, -1, authored.ChangeIndex)
+	require.Len(t, authored.Tx.TxIn, 1)
+	require.Equal(t, outpoints[0], authored.Tx.TxIn[0].PreviousOutPoint)
+	require.Len(t, authored.Tx.TxOut, 1)
+	require.Equal(t, payment, *authored.Tx.TxOut[0])
 }

--- a/wallet/tx_input_amounts.go
+++ b/wallet/tx_input_amounts.go
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/btcsuite/btcwallet/wallet/txauthor"
+)
+
+// Input amount violations. The wallet's own input sources report these instead
+// of handing authoring a set of amounts that cannot be represented or
+// reconciled.
+//
+// None of them is exported. A caller cannot ask for a malformed input set: the
+// values come from the store, so reaching one of these means the store returned
+// an amount it could not have written, not that the request was wrong. There is
+// nothing for a caller to match on and nothing it could do differently.
+var (
+	// errInputCountMismatch is returned when a source reports a different
+	// number of input values than inputs.
+	errInputCountMismatch = errors.New(
+		"input value count does not match input count",
+	)
+
+	// errInputValueNegative is returned when a single input carries a
+	// negative value.
+	errInputValueNegative = errors.New(
+		"transaction input amount is negative",
+	)
+
+	// errInputValueExceedsMax is returned when a single input carries more
+	// than the maximum representable amount.
+	errInputValueExceedsMax = errors.New(
+		"transaction input amount exceeds maximum value",
+	)
+
+	// errInputTotalNegative is returned when a source reports a negative
+	// total.
+	errInputTotalNegative = errors.New(
+		"transaction input total is negative",
+	)
+
+	// errInputTotalExceedsMax is returned when an input total is more than
+	// the maximum representable amount, whether as reported by the source
+	// or as summed from the values it supplied.
+	errInputTotalExceedsMax = errors.New(
+		"transaction input total exceeds maximum value",
+	)
+
+	// errInputTotalMismatch is returned when the total a source reports is
+	// not the sum of the values it supplied.
+	errInputTotalMismatch = errors.New(
+		"transaction input total does not match input values",
+	)
+
+	// errInputAmountOverflow is returned when accumulating an input value
+	// would overflow the running total.
+	errInputAmountOverflow = errors.New("input amount addition overflows")
+)
+
+// addInputAmounts returns the sum of two input amounts, reporting
+// errInputAmountOverflow rather than wrapping when the sum is not
+// representable. It bounds nothing else: an operand or a sum outside
+// 0..MaxSatoshi is arithmetically fine here and is rejected by
+// checkInputResult, which sees the whole set.
+//
+// The wallet owns this rather than borrowing the authoring module's equivalent.
+// The two are the same three lines, but they answer to different callers: this
+// one guards amounts the store produced, and keeping it here leaves the
+// authoring arithmetic free to change without a wallet source depending on it.
+func addInputAmounts(a, b btcutil.Amount) (btcutil.Amount, error) {
+	sum := a + b
+
+	// A sum that moved the wrong way relative to the sign of the addend is
+	// the signed-overflow signature.
+	if (b > 0 && sum < a) || (b < 0 && sum > a) {
+		return 0, fmt.Errorf("%w: %d + %d", errInputAmountOverflow, a, b)
+	}
+
+	return sum, nil
+}
+
+// checkInputSource wraps one of the wallet's input sources so that every result
+// it produces is validated before authoring can act on it. Authoring asks a
+// source for coins and then spends the total it reports: on that total rest the
+// sufficiency test, the fee the transaction can afford, and the change paid
+// back to the wallet. A source that reports more than it supplied therefore
+// funds change out of value that does not exist, and one that reports a value
+// outside the representable range skews the fee. Neither is visible at the
+// point of use, so it is checked at the point of return.
+//
+// A source error is returned untouched and its result is not inspected. That
+// keeps an InputSourceError - "I cannot fund this" - distinct from a violation
+// of this contract, which says the source is wrong rather than short.
+//
+// A nil source is returned as nil: there is nothing to wrap, and wrapping it
+// would turn authoring's own nil-callback panic into one raised from here.
+func checkInputSource(source txauthor.InputSource) txauthor.InputSource {
+	if source == nil {
+		return nil
+	}
+
+	return func(target btcutil.Amount) (btcutil.Amount, []*wire.TxIn,
+		[]btcutil.Amount, [][]byte, error) {
+
+		total, inputs, inputValues, scripts, err := source(target)
+		if err != nil {
+			return 0, nil, nil, nil, err
+		}
+
+		err = checkInputResult(total, inputs, inputValues)
+		if err != nil {
+			return 0, nil, nil, nil, err
+		}
+
+		return total, inputs, inputValues, scripts, nil
+	}
+}
+
+// checkInputResult validates one input-source result: every value and the
+// reported total must lie in 0..MaxSatoshi, the values must be as many as the
+// inputs, and their bounded sum must be the total the source reported.
+//
+// An empty result is valid and totals zero. A source that has nothing to give
+// says so by reporting less than the target, which is authoring's business, not
+// a malformed answer.
+//
+// The scripts a source returns are not checked here. This validates amounts,
+// and whether an input set may go unscripted belongs to the signing
+// precondition rather than to this arithmetic.
+func checkInputResult(total btcutil.Amount, inputs []*wire.TxIn,
+	inputValues []btcutil.Amount) error {
+
+	if len(inputValues) != len(inputs) {
+		return fmt.Errorf("%w: %d values for %d inputs",
+			errInputCountMismatch, len(inputValues), len(inputs))
+	}
+
+	// Bound what the source claims before summing what it supplied, so a
+	// nonsense total is named as such rather than surfacing as a mismatch
+	// against a perfectly good value set.
+	if total < 0 {
+		return fmt.Errorf("%w: %d", errInputTotalNegative, total)
+	}
+
+	if total > btcutil.MaxSatoshi {
+		return fmt.Errorf("%w: reported %d", errInputTotalExceedsMax,
+			total)
+	}
+
+	sum := btcutil.Amount(0)
+
+	for i, value := range inputValues {
+		if value < 0 {
+			return fmt.Errorf("%w: index %d has %d",
+				errInputValueNegative, i, value)
+		}
+
+		if value > btcutil.MaxSatoshi {
+			return fmt.Errorf("%w: index %d has %d",
+				errInputValueExceedsMax, i, value)
+		}
+
+		// The aggregate bound is applied before the addition rather
+		// than to the finished sum. Both operands are within
+		// 0..MaxSatoshi by now, so the remaining headroom cannot go
+		// negative and the sum cannot wrap. Checking afterwards would
+		// let a long enough set of individually valid inputs wrap the
+		// accumulator first and report an overflow instead of the bound
+		// that was actually exceeded.
+		if sum > btcutil.MaxSatoshi-value {
+			return fmt.Errorf("%w: exceeded at index %d",
+				errInputTotalExceedsMax, i)
+		}
+
+		sum += value
+	}
+
+	if sum != total {
+		return fmt.Errorf("%w: reported %d, values sum to %d",
+			errInputTotalMismatch, total, sum)
+	}
+
+	return nil
+}

--- a/wallet/tx_input_amounts_test.go
+++ b/wallet/tx_input_amounts_test.go
@@ -1,0 +1,290 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil/v2"
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// inputsWithCount returns a slice of the requested number of placeholder
+// inputs. Only its length matters to the validator, which compares it against
+// the number of values a source supplied.
+func inputsWithCount(count int) []*wire.TxIn {
+	inputs := make([]*wire.TxIn, count)
+	for i := range count {
+		inputs[i] = &wire.TxIn{}
+	}
+
+	return inputs
+}
+
+// TestAddInputAmounts verifies that the wallet's checked addition reports an
+// overflow instead of wrapping, and otherwise returns the plain sum.
+func TestAddInputAmounts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		a       btcutil.Amount
+		b       btcutil.Amount
+		want    btcutil.Amount
+		wantErr error
+	}{{
+		name: "two ordinary amounts sum",
+		a:    1e8,
+		b:    2e8,
+		want: 3e8,
+	}, {
+		name: "a zero addend leaves the total alone",
+		a:    1e8,
+		b:    0,
+		want: 1e8,
+	}, {
+		// The bound belongs to checkInputResult, which sees the whole
+		// set. Addition only refuses to wrap.
+		name: "a sum above the maximum is not itself an error",
+		a:    btcutil.MaxSatoshi,
+		b:    btcutil.MaxSatoshi,
+		want: 2 * btcutil.MaxSatoshi,
+	}, {
+		name:    "a positive overflow is reported",
+		a:       math.MaxInt64,
+		b:       1,
+		wantErr: errInputAmountOverflow,
+	}, {
+		name:    "a negative overflow is reported",
+		a:       math.MinInt64,
+		b:       -1,
+		wantErr: errInputAmountOverflow,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := addInputAmounts(tc.a, tc.b)
+
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				require.Zero(t, got)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestCheckInputResult verifies that the validator accepts a bounded,
+// internally consistent result and names the specific violation in every other
+// case.
+func TestCheckInputResult(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		total      btcutil.Amount
+		inputCount int
+		values     []btcutil.Amount
+		wantErr    error
+	}{{
+		name:       "a consistent result is accepted",
+		total:      3e8,
+		inputCount: 2,
+		values:     []btcutil.Amount{1e8, 2e8},
+	}, {
+		// A source with nothing to give reports a total below the
+		// target rather than a malformed result.
+		name:       "an empty result totalling zero is accepted",
+		total:      0,
+		inputCount: 0,
+		values:     []btcutil.Amount{},
+	}, {
+		name:       "a nil value set alongside no inputs is accepted",
+		total:      0,
+		inputCount: 0,
+		values:     nil,
+	}, {
+		name:       "a result summing to the maximum is accepted",
+		total:      btcutil.MaxSatoshi,
+		inputCount: 2,
+		values: []btcutil.Amount{
+			btcutil.MaxSatoshi - 1e8, 1e8,
+		},
+	}, {
+		name:       "fewer values than inputs is rejected",
+		total:      1e8,
+		inputCount: 2,
+		values:     []btcutil.Amount{1e8},
+		wantErr:    errInputCountMismatch,
+	}, {
+		name:       "more values than inputs is rejected",
+		total:      2e8,
+		inputCount: 1,
+		values:     []btcutil.Amount{1e8, 1e8},
+		wantErr:    errInputCountMismatch,
+	}, {
+		name:       "a negative reported total is rejected",
+		total:      -1,
+		inputCount: 1,
+		values:     []btcutil.Amount{1e8},
+		wantErr:    errInputTotalNegative,
+	}, {
+		name:       "a reported total above the maximum is rejected",
+		total:      btcutil.MaxSatoshi + 1,
+		inputCount: 1,
+		values:     []btcutil.Amount{btcutil.MaxSatoshi + 1},
+		wantErr:    errInputTotalExceedsMax,
+	}, {
+		name:       "a negative input value is rejected",
+		total:      1e8,
+		inputCount: 2,
+		values:     []btcutil.Amount{2e8, -1e8},
+		wantErr:    errInputValueNegative,
+	}, {
+		name:       "an input value above the maximum is rejected",
+		total:      btcutil.MaxSatoshi,
+		inputCount: 1,
+		values:     []btcutil.Amount{btcutil.MaxSatoshi + 1},
+		wantErr:    errInputValueExceedsMax,
+	}, {
+		// Every value is individually payable, but the set is not. The
+		// reported total is bounded so that the aggregate is what the
+		// check has left to catch.
+		name: "individually valid values summing above the " +
+			"maximum are rejected",
+		total:      btcutil.MaxSatoshi,
+		inputCount: 2,
+		values: []btcutil.Amount{
+			btcutil.MaxSatoshi, btcutil.MaxSatoshi,
+		},
+		wantErr: errInputTotalExceedsMax,
+	}, {
+		// Left unchecked, this is the result that funds change out of
+		// value the source never supplied.
+		name:       "an over-reported total is rejected",
+		total:      1e8,
+		inputCount: 1,
+		values:     []btcutil.Amount{1e6},
+		wantErr:    errInputTotalMismatch,
+	}, {
+		name:       "an under-reported total is rejected",
+		total:      1e6,
+		inputCount: 2,
+		values:     []btcutil.Amount{1e6, 1e6},
+		wantErr:    errInputTotalMismatch,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := checkInputResult(
+				tc.total, inputsWithCount(tc.inputCount),
+				tc.values,
+			)
+
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestCheckInputSource verifies that the decorator passes a sound result and a
+// source's own error through untouched, and that it replaces a malformed result
+// with the violation rather than letting any of it reach a caller.
+func TestCheckInputSource(t *testing.T) {
+	t.Parallel()
+
+	scripts := [][]byte{{0x01}, {0x02}}
+
+	t.Run("a nil source stays nil", func(t *testing.T) {
+		t.Parallel()
+
+		require.Nil(t, checkInputSource(nil))
+	})
+
+	t.Run("a sound result passes through", func(t *testing.T) {
+		t.Parallel()
+
+		var gotTarget btcutil.Amount
+
+		source := func(target btcutil.Amount) (btcutil.Amount,
+			[]*wire.TxIn, []btcutil.Amount, [][]byte, error) {
+
+			gotTarget = target
+
+			return 3e8, inputsWithCount(2),
+				[]btcutil.Amount{1e8, 2e8}, scripts, nil
+		}
+
+		total, inputs, values, gotScripts, err := checkInputSource(
+			source,
+		)(5e7)
+
+		require.NoError(t, err)
+		require.Equal(t, btcutil.Amount(5e7), gotTarget)
+		require.Equal(t, btcutil.Amount(3e8), total)
+		require.Len(t, inputs, 2)
+		require.Equal(t, []btcutil.Amount{1e8, 2e8}, values)
+		require.Equal(t, scripts, gotScripts)
+	})
+
+	t.Run("a malformed result is refused", func(t *testing.T) {
+		t.Parallel()
+
+		source := func(btcutil.Amount) (btcutil.Amount, []*wire.TxIn,
+			[]btcutil.Amount, [][]byte, error) {
+
+			return 1e8, inputsWithCount(1),
+				[]btcutil.Amount{1e6}, scripts[:1], nil
+		}
+
+		total, inputs, values, gotScripts, err := checkInputSource(
+			source,
+		)(1e8)
+
+		require.ErrorIs(t, err, errInputTotalMismatch)
+
+		// Nothing the source claimed survives the refusal, so a caller
+		// that ignores the error cannot act on the amounts anyway.
+		require.Zero(t, total)
+		require.Nil(t, inputs)
+		require.Nil(t, values)
+		require.Nil(t, gotScripts)
+	})
+
+	t.Run("a source error is not replaced", func(t *testing.T) {
+		t.Parallel()
+
+		sourceErr := errors.New("store is unavailable")
+
+		// The result accompanying the error is malformed. It must not
+		// be inspected, so the source's own error is what surfaces.
+		source := func(btcutil.Amount) (btcutil.Amount, []*wire.TxIn,
+			[]btcutil.Amount, [][]byte, error) {
+
+			return -1, nil, []btcutil.Amount{-1}, nil, sourceErr
+		}
+
+		_, _, _, _, err := checkInputSource(source)(1e8)
+
+		require.ErrorIs(t, err, sourceErr)
+		require.NotErrorIs(t, err, errInputTotalNegative)
+	})
+}


### PR DESCRIPTION
Implements [Task 404][task] — validate Wallet transaction input amounts.

`TxCreator.CreateTransaction` and `PsbtManager.FundPsbt` both fund from
Wallet-produced input sources. The automatic and manual closures accumulated their totals with
raw addition, so a negative, over-maximum, or overflowing stored amount
wrapped the total rather than being reported, and authoring then spent
that total on trust — the sufficiency test, the fee, and the change paid
back to the wallet all rest on it.

### Changes

- A wallet-owned checked addition and result validator: every value and
  the reported total must lie in `0..MaxSatoshi`, there must be one value
  per input, and the bounded aggregate must equal the reported total. The
  aggregate bound is applied before each addition, so a long enough set of
  individually valid inputs reports the bound it exceeded rather than an
  overflow.
- The validator is applied once in `createInputSource`, the boundary both
  public wrappers cross, so automatic, manual, and selected results are all
  covered without touching the sources the deprecated wrappers build.
- Both accumulating closures now use the checked add. The automatic source
  takes a coin only once its value is known to be addable — that state
  outlives the call, so a failed add must neither record an input against a
  total that never took it, nor drop the offending coin and let a later call
  succeed without it. The manual source forms its sum up front and holds a
  failure until it is asked, offering no partial selection.

The sentinels stay unexported. A caller cannot ask for a malformed input
set — the values come from the store — so reaching one means the store
returned an amount it could not have written, and there is nothing for a
caller to match on.

### Testing

`package wallet` tests drive both public calls through mocked Store results
on both selection paths, covering a negative value, a value or total above
`MaxSatoshi`, an overflowing accumulation, and a positive case on each path.
The amount sets differ per path because the sources consume differently:
automatic selection stops once the running total reaches the target, so it
can only reach an overflow by accumulating downward, while manual selection
always sums the whole selection and reaches aggregate violations automatic
never sees.

No change-script derivation is registered in the regression cases, so a
refusal arriving late enough to allocate change fails on the unexpected
mock call. Reverting the wrapper locally confirms it: the corrupt sets then
either report insufficient funds or reach `NewDerivedAddress`.

Count and reported-total mismatches are covered against the validator
directly, since both wallet sources report the total they actually
accumulated and no Store result can drive them into those classes.

### Scope

Per the task's exclusions, `wallet/txauthor` is untouched — Task 357's
private authoring arithmetic is neither exported nor consumed here — as are
the deprecated Wallet methods and `cmd/`.

Depends on #1348, now merged; rebased onto `sql-wallet`.

[task]: https://github.com/yyforyongyu/btcwallet-sql-roadmap/blob/main/tasks/404-transaction-input-amounts.md
