### PR TITLE
wallet+db: add account manager error boundary

### DIFF
--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -350,6 +350,33 @@ type newAccountReq struct {
 	resp  chan accountResp
 }
 
+// requireAccountNameAvailable reports a name already taken within scope as
+// ErrAccountAlreadyExists. The lookup is read-only and skips the balance query
+// because only the name matters here. An absent account leaves the name
+// available, a missing scope included, so the first account of a scope can
+// still be created.
+func (w *Wallet) requireAccountNameAvailable(ctx context.Context,
+	scope waddrmgr.KeyScope, name string) error {
+
+	_, err := w.cache.GetAccount(ctx, db.GetAccountQuery{
+		WalletID:    w.id,
+		Scope:       db.KeyScope(scope),
+		Name:        &name,
+		SkipBalance: true,
+	})
+	if err == nil {
+		return fmt.Errorf("%w: %q in scope %d/%d",
+			ErrAccountAlreadyExists, name, scope.Purpose, scope.Coin)
+	}
+
+	translated := accountManagerErr(err)
+	if errors.Is(translated, ErrAccountNotFound) {
+		return nil
+	}
+
+	return translated
+}
+
 // NewAccount creates the next account and returns its account info. The name
 // must be unique under the key scope. In order to support automatic seed
 // restoring, new accounts may not be created when all of the previous 100
@@ -366,6 +393,22 @@ func (w *Wallet) NewAccount(ctx context.Context, scope waddrmgr.KeyScope,
 	err = ctx.Err()
 	if err != nil {
 		return nil, err
+	}
+
+	err = waddrmgr.ValidateAccountName(name)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidParam, err.Error())
+	}
+
+	// Hardened derivation needs the master HD private key, which stays sealed
+	// while the wallet is locked. A watch-only wallet holds no such key at
+	// all, so it is refused as unsupported below instead of being reported as
+	// locked.
+	if !w.IsWatchOnly() {
+		err = w.state.canSign()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	req := newAccountReq{
@@ -391,10 +434,31 @@ func (w *Wallet) NewAccount(ctx context.Context, scope waddrmgr.KeyScope,
 // handleNewAccount performs derivation and persistence only after mainLoop
 // admits the request; handleReq owns its shutdown completion.
 func (w *Wallet) handleNewAccount(req newAccountReq) {
-	deriveFn, err := w.buildAccountDeriveFn(req.ctx)
+	// An occupied name is reported ahead of the watch-only refusal and ahead
+	// of an exhausted derivation range, so the caller hears about the part of
+	// the request it can restate.
+	err := w.requireAccountNameAvailable(req.ctx, req.scope, req.name)
 	if err != nil {
 		req.resp <- accountResp{err: err}
+		return
+	}
 
+	// Refuse before any write is attempted. Hardened account derivation needs
+	// the master HD private key, which a watch-only wallet does not hold, and
+	// the backends otherwise refuse at different points: the SQL stores reach
+	// the derivation callback while a rootless legacy wallet fails its scope
+	// lookup first and would report a missing account instead.
+	if w.IsWatchOnly() {
+		req.resp <- accountResp{
+			err: accountManagerErr(errWatchOnlyAccountDerivation),
+		}
+
+		return
+	}
+
+	deriveFn, err := w.buildAccountDeriveFn(req.ctx)
+	if err != nil {
+		req.resp <- accountResp{err: accountManagerErr(err)}
 		return
 	}
 
@@ -406,17 +470,16 @@ func (w *Wallet) handleNewAccount(req newAccountReq) {
 		}, deriveFn,
 	)
 	if err != nil {
-		// Preserve the legacy waddrmgr.ManagerError contract so that
-		// callers using waddrmgr.IsError(err, ...) keep working after
-		// kvdb wraps the underlying manager error via fmt.Errorf.
-		var mErr waddrmgr.ManagerError
-		if errors.As(err, &mErr) {
-			req.resp <- accountResp{err: mErr}
+		mappedErr := accountManagerErr(err)
+		if errors.Is(err, db.ErrUnknownKeyScope) &&
+			!errors.Is(mappedErr, context.Canceled) &&
+			!errors.Is(mappedErr, context.DeadlineExceeded) {
 
-			return
+			mappedErr = fmt.Errorf("%w: %s", ErrInvalidParam,
+				err.Error())
 		}
 
-		req.resp <- accountResp{err: err}
+		req.resp <- accountResp{err: mappedErr}
 
 		return
 	}
@@ -424,7 +487,7 @@ func (w *Wallet) handleNewAccount(req newAccountReq) {
 	account, err := w.accountInfoFromStore(info)
 	req.resp <- accountResp{
 		info: account,
-		err:  err,
+		err:  accountManagerErr(err),
 	}
 }
 

--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -209,6 +209,9 @@ func (w *Wallet) buildAccountDeriveFn(
 //     account is created for each of the default key scopes and CAN be renamed.
 //   - "imported": A special account that holds all individually imported keys.
 //     This account is global and CANNOT be renamed.
+//
+// Errors use wallet-owned sentinels without exposing backend error identities.
+// Context cancellation and deadlines are preserved.
 type AccountManager interface {
 	// NewAccount creates a new account for a given key scope and name. The
 	// provided name must be unique within that key scope.
@@ -242,10 +245,10 @@ type AccountManager interface {
 		oldName string, newName string) error
 
 	// ImportAccount imports an account from an extended public key.
-	// Private extended keys are rejected. The key scope is derived from
-	// the version bytes of the extended key. The account name must be
-	// unique within the derived scope. If dryRun is true, the import is
-	// validated but not persisted. SQL wallets accept this XPub-only
+	// Invalid or private keys return ErrInvalidAccountKey. The key scope is
+	// derived from the version bytes of the extended key. The account name
+	// must be unique within the derived scope. If dryRun is true, the import
+	// is validated but not persisted. SQL wallets accept this XPub-only
 	// material only when the wallet is watch-only under ADR 0012. The
 	// legacy kvdb backend retains its grandfathered mixed-mode import
 	// behavior until migration; neither path imports signing material.
@@ -904,7 +907,7 @@ type importAccountReq struct {
 // ImportAccount imports an account from an extended public key. Private
 // extended keys are rejected. The key scope is derived from the version
 // bytes of the extended key. The account name must be unique within the
-// derived scope.
+// derived scope. Invalid account keys return ErrInvalidAccountKey.
 //
 // SQL wallets accept this XPub-only material only when the wallet is
 // watch-only under ADR 0012. The legacy kvdb backend retains its grandfathered
@@ -961,65 +964,115 @@ func (w *Wallet) ImportAccount(ctx context.Context,
 	return resp.info, resp.err
 }
 
-// handleImportAccount invokes the existing non-admitting implementation for
-// a request that mainLoop has already accepted and handleReq will complete.
+// handleImportAccount validates and persists an admitted import while keeping
+// public error translation separate from pre-start Manager imports.
 func (w *Wallet) handleImportAccount(req importAccountReq) {
-	info, err := w.importAccountInternal(
-		req.ctx, req.name, req.accountKey, req.masterKeyFingerprint,
+	err := waddrmgr.ValidateAccountName(req.name)
+	if err != nil {
+		req.resp <- accountResp{
+			err: fmt.Errorf("%w: %s", ErrInvalidParam, err.Error()),
+		}
+
+		return
+	}
+
+	// The key's version bytes select the scope the name has to be unique in,
+	// so the request is built before that name can be looked up.
+	params, err := w.importAccountParams(
+		req.name, req.accountKey, req.masterKeyFingerprint,
 		req.addrType, req.dryRun,
 	)
+	if err != nil {
+		if errors.Is(err, ErrInvalidAccountKey) {
+			req.resp <- accountResp{err: err}
+			return
+		}
+
+		req.resp <- accountResp{
+			err: fmt.Errorf("%w: %s", ErrInvalidParam, err.Error()),
+		}
+
+		return
+	}
+
+	err = w.requireAccountNameAvailable(
+		req.ctx, waddrmgr.KeyScope(params.Scope), req.name,
+	)
+	if err != nil {
+		req.resp <- accountResp{err: err}
+		return
+	}
+
+	info, err := w.persistImportedAccount(req.ctx, params)
 	req.resp <- accountResp{
 		info: info,
-		err:  err,
+		err:  accountManagerErr(err),
 	}
 }
 
 // importAccountInternal is the internal implementation of ImportAccount,
-// allowing Manager.Create to bypass the started check.
+// allowing Manager.Create to bypass the started check. It leaves request
+// validation and Store errors untranslated so only the public method applies
+// the AccountManager contract.
 func (w *Wallet) importAccountInternal(ctx context.Context,
 	name string, accountKey *hdkeychain.ExtendedKey,
 	masterKeyFingerprint uint32, addrType waddrmgr.AddressType,
 	dryRun bool) (*AccountInfo, error) {
 
-	err := validateExtendedPubKey(
-		accountKey, true, w.cfg.ChainParams,
+	params, err := w.importAccountParams(
+		name, accountKey, masterKeyFingerprint, addrType, dryRun,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	keyScope, addrSchema, err := keyScopeFromPubKey(
-		accountKey, &addrType,
-	)
+	return w.persistImportedAccount(ctx, params)
+}
+
+// importAccountParams validates the supplied key material and builds the Store
+// request for an XPub import, resolving the key scope and the per-account
+// address schema that the key version and requested address type select.
+func (w *Wallet) importAccountParams(name string,
+	accountKey *hdkeychain.ExtendedKey, masterKeyFingerprint uint32,
+	addrType waddrmgr.AddressType, dryRun bool) (
+	db.CreateImportedAccountParams, error) {
+
+	var params db.CreateImportedAccountParams
+
+	err := validateExtendedPubKey(accountKey, true, w.cfg.ChainParams)
 	if err != nil {
-		return nil, err
+		return params, err
+	}
+
+	keyScope, addrSchema, err := keyScopeFromPubKey(accountKey, &addrType)
+	if err != nil {
+		return params, err
 	}
 
 	dbAddrSchema, err := dbScopeAddrSchema(addrSchema)
 	if err != nil {
-		return nil, err
+		return params, err
 	}
 
-	info, err := w.store.CreateImportedAccount(ctx,
-		db.CreateImportedAccountParams{
-			WalletID:          w.id,
-			Name:              name,
-			Scope:             db.KeyScope(keyScope),
-			MasterFingerprint: masterKeyFingerprint,
-			PublicKey:         []byte(accountKey.String()),
-			DryRun:            dryRun,
-			AddrSchema:        dbAddrSchema,
-		},
-	)
-	if err != nil {
-		// Preserve waddrmgr.ManagerError semantics so callers using
-		// waddrmgr.IsError(err, ...) keep working when kvdb wraps the
-		// underlying manager error via fmt.Errorf.
-		var mErr waddrmgr.ManagerError
-		if errors.As(err, &mErr) {
-			return nil, mErr
-		}
+	return db.CreateImportedAccountParams{
+		WalletID:          w.id,
+		Name:              name,
+		Scope:             db.KeyScope(keyScope),
+		MasterFingerprint: masterKeyFingerprint,
+		PublicKey:         []byte(accountKey.String()),
+		DryRun:            dryRun,
+		AddrSchema:        dbAddrSchema,
+	}, nil
+}
 
+// persistImportedAccount writes a prepared import request and converts the
+// resulting Store snapshot. Its errors stay internal, so each caller applies
+// its own contract.
+func (w *Wallet) persistImportedAccount(ctx context.Context,
+	params db.CreateImportedAccountParams) (*AccountInfo, error) {
+
+	info, err := w.store.CreateImportedAccount(ctx, params)
+	if err != nil {
 		return nil, err
 	}
 

--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -236,8 +236,8 @@ type AccountManager interface {
 
 	// RenameAccount renames an existing account. To uniquely identify the
 	// account, the key scope must be provided. The new name must be unique
-	// within that same key scope. The reserved "imported" account cannot
-	// be renamed.
+	// within that same key scope, including against the account's own
+	// current name. The reserved "imported" account cannot be renamed.
 	RenameAccount(ctx context.Context, scope waddrmgr.KeyScope,
 		oldName string, newName string) error
 
@@ -809,7 +809,9 @@ type renameAccountReq struct {
 }
 
 // RenameAccount renames an existing account. The new name must be unique within
-// the same key scope. The reserved "imported" account cannot be renamed.
+// the same key scope, so renaming an account to the name it already holds
+// returns ErrAccountAlreadyExists. The reserved "imported" account cannot be
+// renamed.
 func (w *Wallet) RenameAccount(ctx context.Context,
 	scope waddrmgr.KeyScope, oldName, newName string) error {
 
@@ -847,9 +849,32 @@ func (w *Wallet) RenameAccount(ctx context.Context,
 // handleRenameAccount validates and applies an admitted rename while
 // handleReq retains responsibility for releasing the Wallet WaitGroup.
 func (w *Wallet) handleRenameAccount(req renameAccountReq) {
-	err := waddrmgr.ValidateAccountName(req.newName)
+	err := waddrmgr.ValidateAccountName(req.oldName)
+	if err != nil {
+		req.resp <- fmt.Errorf("%w: %s", ErrInvalidParam, err.Error())
+		return
+	}
+
+	err = waddrmgr.ValidateAccountName(req.newName)
+	if err != nil {
+		req.resp <- fmt.Errorf("%w: %s", ErrInvalidParam, err.Error())
+		return
+	}
+
+	err = w.requireAccountNameAvailable(req.ctx, req.scope, req.newName)
 	if err != nil {
 		req.resp <- err
+		return
+	}
+
+	// The backends disagree on a self-rename: the legacy store rejects it as
+	// a duplicate while the SQL stores update the row to its current value
+	// and report success. Settle it here so the answer does not depend on
+	// which backend is mounted. The name being free means the account this
+	// call names does not exist, which outranks the naming conflict.
+	if req.oldName == req.newName {
+		req.resp <- fmt.Errorf("%w: %q in scope %d/%d",
+			ErrAccountNotFound, req.oldName, req.scope.Purpose, req.scope.Coin)
 
 		return
 	}
@@ -860,19 +885,7 @@ func (w *Wallet) handleRenameAccount(req renameAccountReq) {
 		OldName:  req.oldName,
 		NewName:  req.newName,
 	})
-	if err != nil {
-		// Preserve waddrmgr.ManagerError semantics so callers using
-		// waddrmgr.IsError(err, ...) keep working when kvdb wraps the
-		// underlying manager error via fmt.Errorf.
-		var mErr waddrmgr.ManagerError
-		if errors.As(err, &mErr) {
-			req.resp <- mErr
-
-			return
-		}
-	}
-
-	req.resp <- err
+	req.resp <- accountManagerErr(err)
 }
 
 // importAccountReq carries every import option through Wallet admission while

--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -27,8 +27,7 @@ import (
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/addresstype"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
-	"github.com/btcsuite/btcwallet/wallet/internal/db/pg"
-	"github.com/btcsuite/btcwallet/wallet/internal/db/sqlite"
+	dberr "github.com/btcsuite/btcwallet/wallet/internal/db/err"
 	"github.com/btcsuite/btcwallet/wallet/internal/keyvault"
 )
 
@@ -82,7 +81,7 @@ func accountManagerErr(err error) error {
 
 		mappedErr = ErrAccountNotFound
 
-	case pg.IsAccountNameConflict(err), sqlite.IsAccountNameConflict(err),
+	case dberr.IsAccountNameConflict(err),
 		isAddrMgrErr(err, waddrmgr.ErrDuplicateAccount):
 
 		mappedErr = ErrAccountAlreadyExists

--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -27,7 +27,103 @@ import (
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/addresstype"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/db/pg"
+	"github.com/btcsuite/btcwallet/wallet/internal/db/sqlite"
+	"github.com/btcsuite/btcwallet/wallet/internal/keyvault"
 )
+
+var (
+	// ErrAccountAlreadyExists is returned when an account operation would
+	// take a name that is already used within the same key scope. Renaming
+	// an account to its current name reports the same outcome.
+	ErrAccountAlreadyExists = errors.New("account already exists")
+
+	// ErrAccountOperationUnsupported is returned when the requested account
+	// operation cannot be served by the wallet in its current mode, such as
+	// deriving a new account on a watch-only wallet or importing an
+	// XPub-only account into a spendable SQL wallet.
+	ErrAccountOperationUnsupported = errors.New(
+		"account operation unsupported by this wallet",
+	)
+
+	// ErrAccountDerivationExhausted is returned when a key scope has no
+	// account number left to allocate.
+	ErrAccountDerivationExhausted = errors.New(
+		"account derivation range exhausted",
+	)
+)
+
+// accountManagerErr translates a store, legacy manager, or Vault failure into
+// the wallet-owned identity for that outcome. Only the source text is kept so
+// no internal identity crosses the boundary; unclassified errors keep only
+// their text, and caller-owned cancellation keeps its identity.
+//
+//nolint:cyclop // One explicit mapping switch is the clearest form here.
+func accountManagerErr(err error) error {
+	var mappedErr error
+	switch {
+	case err == nil:
+		return nil
+
+	case errors.Is(err, context.Canceled):
+		mappedErr = context.Canceled
+
+	case errors.Is(err, context.DeadlineExceeded):
+		mappedErr = context.DeadlineExceeded
+
+	// Key validation is already wallet-owned and wraps nothing internal.
+	case errors.Is(err, ErrInvalidAccountKey):
+		return err
+
+	case errors.Is(err, db.ErrAccountNotFound),
+		errors.Is(err, db.ErrKeyScopeNotFound),
+		isAddrMgrErr(err, waddrmgr.ErrAccountNotFound),
+		isAddrMgrErr(err, waddrmgr.ErrScopeNotFound):
+
+		mappedErr = ErrAccountNotFound
+
+	case pg.IsAccountNameConflict(err), sqlite.IsAccountNameConflict(err),
+		isAddrMgrErr(err, waddrmgr.ErrDuplicateAccount):
+
+		mappedErr = ErrAccountAlreadyExists
+
+	case errors.Is(err, errWatchOnlyAccountDerivation),
+		errors.Is(err, db.ErrWatchOnlyViolation),
+		errors.Is(err, db.ErrSpendableWalletNeedsAccountPrivKey),
+		isAddrMgrErr(err, waddrmgr.ErrWatchingOnly):
+
+		mappedErr = ErrAccountOperationUnsupported
+
+	case errors.Is(err, db.ErrMaxAccountNumberReached),
+		isAddrMgrErr(err, waddrmgr.ErrAccountNumTooHigh):
+
+		mappedErr = ErrAccountDerivationExhausted
+
+	case errors.Is(err, keyvault.ErrVaultLocked),
+		isAddrMgrErr(err, waddrmgr.ErrLocked):
+
+		mappedErr = ErrStateForbidden
+
+	default:
+		return errors.New(err.Error())
+	}
+
+	if err.Error() == mappedErr.Error() {
+		return mappedErr
+	}
+
+	return fmt.Errorf("%w: %s", mappedErr, err.Error())
+}
+
+// isAddrMgrErr reports whether err carries a waddrmgr.ManagerError with the
+// given code. waddrmgr.IsError is a bare type assertion, so it cannot see a
+// manager error that a store wrapped for context, which is how the legacy
+// backend returns every one of them.
+func isAddrMgrErr(err error, code waddrmgr.ErrorCode) bool {
+	var mErr waddrmgr.ManagerError
+
+	return errors.As(err, &mErr) && mErr.ErrorCode == code
+}
 
 // buildAccountDeriveFn returns an AccountDerivationFunc closure. Spendable
 // wallets normally preload the master HD private key before the store opens
@@ -183,6 +279,10 @@ func (w *Wallet) canonicalStoreAccountInfo(
 // wallet-owned result. Every pointer and byte slice in the result is copied so
 // callers cannot mutate Store-owned data or another independently converted
 // result.
+//
+// Its failures are internal identities such as addresstype.ErrUnknown, so
+// public callers route the result through accountManagerErr rather than
+// returning it directly.
 func (w *Wallet) accountInfoFromStore(
 	storeInfo *db.AccountInfo) (*AccountInfo, error) {
 
@@ -447,7 +547,7 @@ func (w *Wallet) listAccountInfos(ctx context.Context,
 
 	infos, err := w.cache.ListAccounts(ctx, query)
 	if err != nil {
-		return nil, err
+		return nil, accountManagerErr(err)
 	}
 
 	if infos == nil {
@@ -458,7 +558,7 @@ func (w *Wallet) listAccountInfos(ctx context.Context,
 	for i := range infos {
 		result, err := w.accountInfoFromStore(&infos[i])
 		if err != nil {
-			return nil, err
+			return nil, accountManagerErr(err)
 		}
 
 		results[i] = *result
@@ -598,24 +698,14 @@ func (w *Wallet) handleGetAccount(req getAccountReq) {
 		Name:     &req.name,
 	})
 	if err != nil {
-		// Preserve waddrmgr.ManagerError semantics so callers using
-		// waddrmgr.IsError(err, ...) keep working when kvdb wraps the
-		// underlying manager error via fmt.Errorf.
-		var mErr waddrmgr.ManagerError
-		if errors.As(err, &mErr) {
-			req.resp <- accountResp{err: mErr}
-			return
-		}
-
-		req.resp <- accountResp{err: err}
-
+		req.resp <- accountResp{err: accountManagerErr(err)}
 		return
 	}
 
 	account, err := w.accountInfoFromStore(info)
 	req.resp <- accountResp{
 		info: account,
-		err:  err,
+		err:  accountManagerErr(err),
 	}
 }
 

--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -363,6 +363,11 @@ func (w *Wallet) NewAccount(ctx context.Context, scope waddrmgr.KeyScope,
 		return nil, err
 	}
 
+	err = ctx.Err()
+	if err != nil {
+		return nil, err
+	}
+
 	req := newAccountReq{
 		reqCtx: reqCtx{ctx: ctx},
 		scope:  scope,
@@ -519,6 +524,11 @@ func (w *Wallet) ListAccounts(ctx context.Context) ([]AccountInfo, error) {
 		return nil, err
 	}
 
+	err = ctx.Err()
+	if err != nil {
+		return nil, err
+	}
+
 	req := listAccountsReq{
 		reqCtx: reqCtx{ctx: ctx},
 		query: db.ListAccountsQuery{
@@ -586,6 +596,11 @@ func (w *Wallet) ListAccountsByScope(ctx context.Context,
 		return nil, err
 	}
 
+	err = ctx.Err()
+	if err != nil {
+		return nil, err
+	}
+
 	dbScope := db.KeyScope(scope)
 
 	req := listAccountsReq{
@@ -615,6 +630,11 @@ func (w *Wallet) ListAccountsByName(ctx context.Context,
 	name string) ([]AccountInfo, error) {
 
 	err := w.state.validateStarted()
+	if err != nil {
+		return nil, err
+	}
+
+	err = ctx.Err()
 	if err != nil {
 		return nil, err
 	}
@@ -665,6 +685,11 @@ func (w *Wallet) GetAccount(ctx context.Context, scope waddrmgr.KeyScope,
 	name string) (*AccountInfo, error) {
 
 	err := w.state.validateStarted()
+	if err != nil {
+		return nil, err
+	}
+
+	err = ctx.Err()
 	if err != nil {
 		return nil, err
 	}
@@ -726,6 +751,11 @@ func (w *Wallet) RenameAccount(ctx context.Context,
 	scope waddrmgr.KeyScope, oldName, newName string) error {
 
 	err := w.state.validateStarted()
+	if err != nil {
+		return err
+	}
+
+	err = ctx.Err()
 	if err != nil {
 		return err
 	}
@@ -823,6 +853,11 @@ func (w *Wallet) ImportAccount(ctx context.Context,
 	accountKeySnapshot, err := snapshotExtendedPubKey(
 		accountKey, true, w.cfg.ChainParams,
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	err = ctx.Err()
 	if err != nil {
 		return nil, err
 	}

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -1971,6 +1971,128 @@ func TestListAccountsTranslatesStoreError(t *testing.T) {
 	}
 }
 
+// TestImportAccountInternalPreservesStoreError verifies the Manager-owned
+// initial-account path does not inherit the public AccountManager translation.
+func TestImportAccountInternalPreservesStoreError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: an internal import whose Store write returns a db identity.
+	w, deps := createStartedWalletWithMocks(t)
+	acctPubKey, masterFP := importAccountTestKey(t, 84)
+
+	deps.store.On("CreateImportedAccount", mock.Anything, mock.Anything).
+		Return((*db.AccountInfo)(nil), db.ErrWatchOnlyViolation).Once()
+
+	// Act: import through the Manager-owned initialization path.
+	account, err := w.importAccountInternal(
+		t.Context(), testAccountName, acctPubKey, masterFP,
+		waddrmgr.WitnessPubKey, false,
+	)
+
+	// Assert: the internal call retains the Store identity for its caller.
+	require.Nil(t, account)
+	require.ErrorIs(t, err, db.ErrWatchOnlyViolation)
+	require.NotErrorIs(t, err, ErrAccountOperationUnsupported)
+
+	// The public name preflight belongs to the public contract only.
+	deps.store.AssertNotCalled(t, "GetAccount", mock.Anything, mock.Anything)
+}
+
+// TestImportAccountInvalidRequest verifies the request shape is settled before
+// any name lookup or Store work, with unusable key material keeping its own
+// identity and invalid names or unsupported address types reported as invalid
+// parameters.
+func TestImportAccountInvalidRequest(t *testing.T) {
+	t.Parallel()
+
+	acctPubKey, masterFP := importAccountTestKey(t, 44)
+
+	privKey, err := hdkeychain.NewMaster(fixedTestSeed(), &chainParams)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		acctName string
+		key      *hdkeychain.ExtendedKey
+		addrType waddrmgr.AddressType
+		want     error
+	}{{
+		name:     "missing key material",
+		acctName: testAccountName,
+		addrType: waddrmgr.WitnessPubKey,
+		want:     ErrInvalidAccountKey,
+	}, {
+		name:     "private key material",
+		acctName: testAccountName,
+		key:      privKey,
+		addrType: waddrmgr.WitnessPubKey,
+		want:     ErrInvalidAccountKey,
+	}, {
+		name:     "address type the key version cannot serve",
+		acctName: testAccountName,
+		key:      acctPubKey,
+		addrType: waddrmgr.PubKeyHash,
+		want:     ErrInvalidParam,
+	}, {
+		name:     "empty account name",
+		acctName: "",
+		key:      acctPubKey,
+		addrType: waddrmgr.WitnessPubKey,
+		want:     ErrInvalidParam,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: a started wallet awaiting the import.
+			w, deps := createStartedWalletWithMocks(t)
+
+			// Act: import the unusable request.
+			account, err := w.ImportAccount(
+				t.Context(), tc.acctName, tc.key, masterFP,
+				tc.addrType, false,
+			)
+
+			// Assert: the wallet-owned identity is the only one
+			// reported, and neither the name lookup nor the write
+			// happened.
+			require.Nil(t, account)
+			require.Equal(t, []string{tc.want.Error()},
+				reportedIdentities(err))
+			requireNoInternalIdentity(t, err)
+			deps.store.AssertNotCalled(t, "GetAccount",
+				mock.Anything, mock.Anything)
+			deps.store.AssertNotCalled(t, "CreateImportedAccount",
+				mock.Anything, mock.Anything)
+		})
+	}
+}
+
+// TestImportAccountInternalPreservesRequestError verifies the Manager-owned
+// initialization path keeps its raw request failure, so an unusable initial
+// account is not restated through the public contract.
+func TestImportAccountInternalPreservesRequestError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: an internal import whose address type serves no key scope.
+	w, deps := createStartedWalletWithMocks(t)
+	acctPubKey, masterFP := importAccountTestKey(t, 44)
+
+	// Act: import through the Manager-owned initialization path.
+	account, err := w.importAccountInternal(
+		t.Context(), testAccountName, acctPubKey, masterFP,
+		waddrmgr.PubKeyHash, false,
+	)
+
+	// Assert: the raw diagnostic survives with no public identity attached.
+	require.Nil(t, account)
+	require.ErrorContains(t, err, "unsupported address type")
+	require.Empty(t, reportedIdentities(err))
+	deps.store.AssertNotCalled(t, "CreateImportedAccount", mock.Anything,
+		mock.Anything)
+}
+
 // TestNewAccountVaultLockedForbidden verifies a Vault that locks after the
 // wallet admitted the request surfaces as ErrStateForbidden without leaking
 // the Vault sentinel.
@@ -2354,6 +2476,7 @@ func TestRenameAccountOccupiedTarget(t *testing.T) {
 func TestImportAccount(t *testing.T) {
 	t.Parallel()
 
+	// Arrange: a valid account key and an available name in its derived scope.
 	w, deps := createStartedWalletWithMocks(t)
 
 	acctPubKey, masterFP := importAccountTestKey(t, 84)
@@ -2365,6 +2488,7 @@ func TestImportAccount(t *testing.T) {
 		Coin:    scope.Coin,
 	}
 
+	expectAccountNameFree(t, deps, scope, testAccountName)
 	deps.store.On("CreateImportedAccount", mock.Anything,
 		db.CreateImportedAccountParams{
 			WalletID:          0,
@@ -2380,10 +2504,13 @@ func TestImportAccount(t *testing.T) {
 		PublicKey:   []byte(acctPubKey.String()),
 	}, nil).Once()
 
+	// Act: import the account through the public boundary.
 	props, err := w.ImportAccount(
 		t.Context(), testAccountName, acctPubKey,
 		masterFP, addrType, false,
 	)
+
+	// Assert: the imported account is returned and all Store calls occurred.
 	require.NoError(t, err)
 	require.Equal(t, testAccountName, props.AccountName)
 }
@@ -2393,6 +2520,7 @@ func TestImportAccount(t *testing.T) {
 func TestImportAccountDryRun(t *testing.T) {
 	t.Parallel()
 
+	// Arrange: a valid dry-run import under an available account name.
 	w, deps := createStartedWalletWithMocks(t)
 
 	acctPubKey, masterFP := importAccountTestKey(t, 84)
@@ -2404,6 +2532,7 @@ func TestImportAccountDryRun(t *testing.T) {
 		Coin:    scope.Coin,
 	}
 
+	expectAccountNameFree(t, deps, scope, testAccountName)
 	deps.store.On("CreateImportedAccount", mock.Anything,
 		db.CreateImportedAccountParams{
 			WalletID:          0,
@@ -2420,10 +2549,13 @@ func TestImportAccountDryRun(t *testing.T) {
 		PublicKey:   []byte(acctPubKey.String()),
 	}, nil).Once()
 
+	// Act: validate the import without persisting it.
 	props, err := w.ImportAccount(
 		t.Context(), testAccountName, acctPubKey,
 		masterFP, addrType, true,
 	)
+
+	// Assert: the Store receives the dry-run flag and returns the account view.
 	require.NoError(t, err)
 	require.Equal(t, testAccountName, props.AccountName)
 }
@@ -2433,6 +2565,8 @@ func TestImportAccountDryRun(t *testing.T) {
 func TestImportAccountAddrSchema(t *testing.T) {
 	t.Parallel()
 
+	// Arrange: a BIP49 account key whose derived scope requires a nested
+	// witness address-schema override.
 	w, deps := createStartedWalletWithMocks(t)
 
 	acctPubKey, masterFP := importAccountTestKey(t, 49)
@@ -2448,6 +2582,7 @@ func TestImportAccountAddrSchema(t *testing.T) {
 		InternalAddrType: db.NestedWitnessPubKey,
 	}
 
+	expectAccountNameFree(t, deps, scope, testAccountName)
 	deps.store.On("CreateImportedAccount", mock.Anything,
 		db.CreateImportedAccountParams{
 			WalletID:          0,
@@ -2464,10 +2599,13 @@ func TestImportAccountAddrSchema(t *testing.T) {
 		PublicKey:   []byte(acctPubKey.String()),
 	}, nil).Once()
 
+	// Act: import the account with the matching public address type.
 	props, err := w.ImportAccount(
 		t.Context(), testAccountName, acctPubKey,
 		masterFP, addrType, false,
 	)
+
+	// Assert: the Store receives the converted schema and returns the account.
 	require.NoError(t, err)
 	require.Equal(t, testAccountName, props.AccountName)
 }
@@ -2685,6 +2823,69 @@ func TestImportAccountRejectsStopped(t *testing.T) {
 	// Assert: The terminal sentinel proves shutdown wins before key validation
 	// or Store access.
 	require.ErrorIs(t, err, ErrWalletStopped)
+}
+
+// TestImportAccountOccupiedName verifies the name is resolved in the scope the
+// key version selects, before the account is written.
+func TestImportAccountOccupiedName(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: a valid key whose derived scope already holds the name.
+	w, deps := createStartedWalletWithMocks(t)
+	acctPubKey, masterFP := importAccountTestKey(t, 84)
+
+	expectAccountNameTaken(
+		t, deps, waddrmgr.KeyScopeBIP0084, testAccountName,
+	)
+
+	// Act: import the account under the occupied name.
+	account, err := w.ImportAccount(
+		t.Context(), testAccountName, acctPubKey, masterFP,
+		waddrmgr.WitnessPubKey, false,
+	)
+
+	// Assert: the conflict is reported and nothing is written.
+	require.Nil(t, account)
+	require.ErrorIs(t, err, ErrAccountAlreadyExists)
+	require.ErrorContains(t, err, testAccountName)
+	deps.store.AssertNotCalled(t, "CreateImportedAccount", mock.Anything,
+		mock.Anything)
+}
+
+// TestImportAccountSpendableWalletUnsupported verifies a store that demands
+// account signing material from a spendable wallet, as ADR 0012 requires,
+// reports an unsupported operation without leaking its own sentinel.
+func TestImportAccountSpendableWalletUnsupported(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: a spendable wallet importing XPub-only material.
+	w, deps := createStartedWalletWithMocks(t)
+	acctPubKey, masterFP := importAccountTestKey(t, 84)
+
+	expectAccountNameFree(
+		t, deps, waddrmgr.KeyScopeBIP0084, testAccountName,
+	)
+	deps.store.On("CreateImportedAccount", mock.Anything, mock.Anything).
+		Return((*db.AccountInfo)(nil),
+			db.ErrSpendableWalletNeedsAccountPrivKey).Once()
+
+	// Act: import the watch-only account key.
+	account, err := w.ImportAccount(
+		t.Context(), testAccountName, acctPubKey, masterFP,
+		waddrmgr.WitnessPubKey, false,
+	)
+
+	// Assert: the refusal is reported as unsupported by this wallet.
+	require.Nil(t, account)
+	require.ErrorContains(
+		t, err, db.ErrSpendableWalletNeedsAccountPrivKey.Error(),
+	)
+	require.Equal(
+		t, []string{ErrAccountOperationUnsupported.Error()},
+		reportedIdentities(err),
+	)
+	require.NotErrorIs(t, err, db.ErrSpendableWalletNeedsAccountPrivKey)
+	requireNoInternalIdentity(t, err)
 }
 
 // TestDBScopeAddrSchemaMapsTypes verifies dbScopeAddrSchema converts a

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -18,7 +19,9 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcwallet/waddrmgr"
+	"github.com/btcsuite/btcwallet/wallet/internal/addresstype"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	"github.com/btcsuite/btcwallet/wallet/internal/keyvault"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -459,10 +462,12 @@ func TestListAccountsByScope(t *testing.T) {
 	require.Len(t, accounts, 1)
 }
 
-// TestListAccountsByScopeUnknownScope verifies backend errors are propagated.
+// TestListAccountsByScopeUnknownScope verifies an unexpected scope error from
+// a read does not become a caller-validation error.
 func TestListAccountsByScopeUnknownScope(t *testing.T) {
 	t.Parallel()
 
+	// Arrange: a started wallet whose Store rejects an unknown scope.
 	w, deps := createStartedWalletWithMocks(t)
 
 	scope := waddrmgr.KeyScope{Purpose: 123, Coin: 456}
@@ -472,8 +477,13 @@ func TestListAccountsByScopeUnknownScope(t *testing.T) {
 		Scope:    &dbScope,
 	}).Return(nil, db.ErrUnknownKeyScope).Once()
 
+	// Act: list accounts under the unknown scope.
 	_, err := w.ListAccountsByScope(t.Context(), scope)
-	require.ErrorIs(t, err, db.ErrUnknownKeyScope)
+
+	// Assert: only the diagnostic crosses the boundary.
+	require.EqualError(t, err, db.ErrUnknownKeyScope.Error())
+	require.Empty(t, reportedIdentities(err))
+	require.NotErrorIs(t, err, db.ErrUnknownKeyScope)
 }
 
 // TestListAccountsByName verifies the name filter narrows the query.
@@ -645,26 +655,24 @@ func TestGetAccountIncludesImportedPseudoAccount(t *testing.T) {
 	require.Equal(t, uint32(3), account.ImportedKeyCount)
 }
 
-// TestGetAccountErrors verifies that request routing preserves both ordinary
-// Store failures and the legacy ManagerError identity expected by callers.
+// TestGetAccountErrors verifies that routed lookups apply the public error
+// contract to ordinary Store failures and legacy ManagerError values.
 func TestGetAccountErrors(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		storeErr    error
-		managerCode bool
+		name     string
+		storeErr error
+		want     error
 	}{
 		{
 			name:     "store error",
 			storeErr: errDBMock,
 		},
 		{
-			name:        "manager error",
-			managerCode: true,
-			storeErr: waddrmgr.ManagerError{
-				ErrorCode: waddrmgr.ErrAccountNotFound,
-			},
+			name:     "manager error",
+			storeErr: legacyErr(waddrmgr.ErrAccountNotFound),
+			want:     ErrAccountNotFound,
 		},
 	}
 
@@ -689,14 +697,16 @@ func TestGetAccountErrors(t *testing.T) {
 			// account handler.
 			_, err := w.GetAccount(t.Context(), scope, name)
 
-			// Assert: The public result preserves the Store error identity
-			// expected by callers.
-			if test.managerCode {
-				require.True(t, waddrmgr.IsError(
-					err, waddrmgr.ErrAccountNotFound))
+			// Assert: Only the wallet-owned identity reaches callers.
+			if test.want != nil {
+				require.ErrorIs(t, err, test.want)
 			} else {
-				require.ErrorIs(t, err, errDBMock)
+				require.EqualError(t, err, test.storeErr.Error())
+				require.Empty(t, reportedIdentities(err))
 			}
+
+			require.NotErrorIs(t, err, test.storeErr)
+			requireNoInternalIdentity(t, err)
 		})
 	}
 }
@@ -856,6 +866,160 @@ func TestGetAccountCanceledCallerDrains(t *testing.T) {
 	require.NoError(t, <-stopResult)
 }
 
+// TestGetAccountTranslatesStoreError verifies an account either backend cannot
+// resolve is reported as the wallet-owned absence.
+func TestGetAccountTranslatesStoreError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		inject error
+		want   error
+	}{{
+		name:   "account absent",
+		inject: db.ErrAccountNotFound,
+		want:   ErrAccountNotFound,
+	}, {
+		name:   "key scope absent",
+		inject: db.ErrKeyScopeNotFound,
+		want:   ErrAccountNotFound,
+	}, {
+		name:   "legacy account absent",
+		inject: wrapped(legacyErr(waddrmgr.ErrAccountNotFound)),
+		want:   ErrAccountNotFound,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: a started wallet whose account read fails.
+			w, deps := createStartedWalletWithMocks(t)
+			deps.store.On("GetAccount", mock.Anything,
+				mock.Anything).
+				Return((*db.AccountInfo)(nil), tc.inject).Once()
+
+			// Act: read the account by name.
+			account, err := w.GetAccount(
+				t.Context(), waddrmgr.KeyScopeBIP0084,
+				testAccountName,
+			)
+
+			// Assert: only the wallet-owned identity is reported.
+			require.Nil(t, account)
+			require.ErrorContains(t, err, tc.inject.Error())
+			require.Equal(
+				t, []string{tc.want.Error()}, reportedIdentities(err),
+			)
+			require.NotErrorIs(t, err, tc.inject)
+			requireNoInternalIdentity(t, err)
+		})
+	}
+}
+
+// TestGetAccountKeepsCallerCancellation verifies a cancellation or deadline the
+// backend reports keeps the caller-owned identity, while a store identity
+// joined to it stops at the boundary.
+func TestGetAccountKeepsCallerCancellation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		inject error
+		want   error
+	}{{
+		name:   "cancelled with joined store failure",
+		inject: errors.Join(context.Canceled, db.ErrAccountNotFound),
+		want:   context.Canceled,
+	}, {
+		name:   "deadline exceeded",
+		inject: context.DeadlineExceeded,
+		want:   context.DeadlineExceeded,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: a started wallet whose read is abandoned.
+			w, deps := createStartedWalletWithMocks(t)
+			deps.store.On("GetAccount", mock.Anything,
+				mock.Anything).
+				Return((*db.AccountInfo)(nil), tc.inject).Once()
+
+			// Act: read the account by name.
+			account, err := w.GetAccount(
+				t.Context(), waddrmgr.KeyScopeBIP0084,
+				testAccountName,
+			)
+
+			// Assert: the caller keeps its identity and no account
+			// outcome is claimed.
+			require.Nil(t, account)
+			require.ErrorIs(t, err, tc.want)
+			require.Empty(t, reportedIdentities(err))
+			requireNoInternalIdentity(t, err)
+		})
+	}
+}
+
+// TestGetAccountDropsUnknownIdentity verifies a failure the contract does not
+// name reaches the caller as diagnostic text alone, so no unmapped outcome can
+// be matched by accident.
+func TestGetAccountDropsUnknownIdentity(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: a started wallet whose account read fails unexpectedly.
+	w, deps := createStartedWalletWithMocks(t)
+	injected := wrapped(errors.New("backend exploded"))
+
+	deps.store.On("GetAccount", mock.Anything, mock.Anything).
+		Return((*db.AccountInfo)(nil), injected).Once()
+
+	// Act: read the account by name.
+	account, err := w.GetAccount(
+		t.Context(), waddrmgr.KeyScopeBIP0084, testAccountName,
+	)
+
+	// Assert: the text survives, the identity does not.
+	require.Nil(t, account)
+	require.EqualError(t, err, injected.Error())
+	require.NotErrorIs(t, err, injected)
+	require.Empty(t, reportedIdentities(err))
+	requireNoInternalIdentity(t, err)
+}
+
+// TestGetAccountConversionFailure verifies a Store snapshot the wallet cannot
+// convert fails the read instead of returning a partial account, and that the
+// internal conversion identity does not escape either.
+func TestGetAccountConversionFailure(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: a started wallet whose Store reports an address schema the
+	// public result cannot represent.
+	w, deps := createStartedWalletWithMocks(t)
+	deps.store.On("GetAccount", mock.Anything, mock.Anything).
+		Return(&db.AccountInfo{
+			AccountName: testAccountName,
+			AddrSchema: db.ScopeAddrSchema{
+				ExternalAddrType: db.Anchor,
+				InternalAddrType: db.WitnessPubKey,
+			},
+		}, nil).Once()
+
+	// Act: read the account by name.
+	account, err := w.GetAccount(
+		t.Context(), waddrmgr.KeyScopeBIP0084, testAccountName,
+	)
+
+	// Assert: the read fails with the conversion diagnostic only.
+	require.Nil(t, account)
+	require.ErrorContains(t, err, "external account address schema")
+	require.Empty(t, reportedIdentities(err))
+	require.NotErrorIs(t, err, addresstype.ErrUnknown)
+	requireNoInternalIdentity(t, err)
+}
+
 // TestNewAccount verifies NewAccount routes through
 // w.store.CreateDerivedAccount.
 func TestNewAccount(t *testing.T) {
@@ -986,6 +1150,189 @@ func TestRenameAccount(t *testing.T) {
 
 	err = w.RenameAccount(t.Context(), scope, "missing", "x")
 	require.ErrorIs(t, err, db.ErrAccountNotFound)
+}
+
+// accountManagerIdentities lists every wallet-owned identity the
+// AccountManager boundary may report. Assertions compare against the whole
+// set so a translation that reports the wrong outcome fails on the identity it
+// leaked, not only on the one it missed.
+var accountManagerIdentities = []error{
+	ErrAccountNotFound, ErrAccountAlreadyExists,
+	ErrAccountOperationUnsupported, ErrAccountDerivationExhausted,
+	ErrInvalidParam, ErrInvalidAccountKey, ErrStateForbidden,
+}
+
+// internalIdentities lists the Store, vault, and wallet-internal identities
+// that must never reach a caller of a public AccountManager method.
+var internalIdentities = []error{
+	db.ErrAccountNotFound, db.ErrKeyScopeNotFound,
+	db.ErrWatchOnlyViolation, db.ErrSpendableWalletNeedsAccountPrivKey,
+	db.ErrMaxAccountNumberReached, db.ErrMissingAccountName,
+	db.ErrMissingAccountPublicKey, db.ErrMissingField, db.ErrInvalidParam,
+	db.ErrReservedAccountName, db.ErrInvalidAccountQuery,
+	db.ErrUnknownKeyScope, keyvault.ErrVaultLocked, addresstype.ErrUnknown,
+	errWatchOnlyAccountDerivation,
+}
+
+// reportedIdentities names the wallet-owned identities err reports, ordered as
+// accountManagerIdentities lists them. Naming them lets a case state its whole
+// expectation as one equality instead of an assertion per identity.
+func reportedIdentities(err error) []string {
+	var reported []string
+	for _, identity := range accountManagerIdentities {
+		if errors.Is(err, identity) {
+			reported = append(reported, identity.Error())
+		}
+	}
+
+	return reported
+}
+
+// legacyErr builds the error the legacy waddrmgr backend reports for code.
+func legacyErr(code waddrmgr.ErrorCode) error {
+	return waddrmgr.ManagerError{
+		ErrorCode:   code,
+		Description: "address manager operation failed",
+	}
+}
+
+// wrapped restates err the way the legacy backend and the SQL stores do, which
+// is why the boundary has to unwrap rather than type-assert.
+func wrapped(err error) error {
+	return fmt.Errorf("create account: %w", err)
+}
+
+// requireNoInternalIdentity asserts no Store, vault, or legacy manager
+// identity survived the boundary. The diagnostic text may still name the
+// source failure; only the identity has to be gone.
+func requireNoInternalIdentity(t *testing.T, got error) {
+	t.Helper()
+
+	for _, internal := range internalIdentities {
+		require.NotErrorIs(t, got, internal)
+	}
+
+	var mgrErr waddrmgr.ManagerError
+	require.NotErrorAs(t, got, &mgrErr)
+}
+
+// TestAccountManagerErrTranslatesIdentities verifies the classifications no
+// public method exercises directly: each store or legacy waddrmgr failure is
+// reported as its wallet-owned identity and as no other, with the source text
+// preserved and the source identity dropped.
+func TestAccountManagerErrTranslatesIdentities(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		inject error
+		want   error
+	}{{
+		name:   "legacy scope not found",
+		inject: legacyErr(waddrmgr.ErrScopeNotFound),
+		want:   ErrAccountNotFound,
+	}, {
+		name:   "watch-only import violation",
+		inject: db.ErrWatchOnlyViolation,
+		want:   ErrAccountOperationUnsupported,
+	}, {
+		name:   "legacy watching only",
+		inject: legacyErr(waddrmgr.ErrWatchingOnly),
+		want:   ErrAccountOperationUnsupported,
+	}, {
+		name:   "legacy locked",
+		inject: legacyErr(waddrmgr.ErrLocked),
+		want:   ErrStateForbidden,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := accountManagerErr(tc.inject)
+
+			require.ErrorContains(t, err, tc.inject.Error())
+			require.Equal(
+				t, []string{tc.want.Error()}, reportedIdentities(err),
+			)
+			require.NotErrorIs(t, err, tc.inject)
+			requireNoInternalIdentity(t, err)
+		})
+	}
+}
+
+// TestAccountManagerErrKeepsCallerIdentity verifies a cancellation or deadline
+// belongs to the caller, so its identity survives the restatement a backend
+// wraps it in. Neither is an account outcome, so they must claim no
+// wallet-owned identity.
+func TestAccountManagerErrKeepsCallerIdentity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		inject error
+		want   error
+	}{{
+		name:   "wrapped cancelled",
+		inject: wrapped(context.Canceled),
+		want:   context.Canceled,
+	}, {
+		name:   "wrapped deadline exceeded",
+		inject: wrapped(context.DeadlineExceeded),
+		want:   context.DeadlineExceeded,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := accountManagerErr(tc.inject)
+
+			require.ErrorIs(t, err, tc.want)
+			require.ErrorContains(t, err, tc.inject.Error())
+			require.Empty(t, reportedIdentities(err))
+			requireNoInternalIdentity(t, err)
+		})
+	}
+}
+
+// TestListAccountsTranslatesStoreError verifies the query surface crosses the
+// same boundary as the mutations.
+func TestListAccountsTranslatesStoreError(t *testing.T) {
+	t.Parallel()
+
+	for _, storeErr := range []error{
+		db.ErrUnknownKeyScope,
+		db.ErrMissingAccountName,
+		db.ErrMissingAccountPublicKey,
+		db.ErrMissingField,
+		db.ErrInvalidParam,
+		db.ErrReservedAccountName,
+		db.ErrInvalidAccountQuery,
+		legacyErr(waddrmgr.ErrInvalidAccount),
+	} {
+		t.Run(storeErr.Error(), func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: an unfiltered query fails inside the Store.
+			w, deps := createStartedWalletWithMocks(t)
+			injected := fmt.Errorf("list accounts: %w", storeErr)
+			deps.store.On(
+				"ListAccounts", mock.Anything,
+				db.ListAccountsQuery{WalletID: w.id},
+			).Return([]db.AccountInfo(nil), injected).Once()
+
+			// Act: list every account without caller-supplied filters.
+			accounts, err := w.ListAccounts(t.Context())
+
+			// Assert: preserve diagnostics without a public outcome.
+			require.Nil(t, accounts)
+			require.EqualError(t, err, injected.Error())
+			require.Empty(t, reportedIdentities(err))
+			require.NotErrorIs(t, err, storeErr)
+			requireNoInternalIdentity(t, err)
+		})
+	}
 }
 
 // TestImportAccount verifies the normal import path routes through

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -1216,6 +1216,532 @@ func requireNoInternalIdentity(t *testing.T, got error) {
 	require.NotErrorAs(t, got, &mgrErr)
 }
 
+// TestNewAccountAdmission verifies lifecycle and context errors are
+// returned before Store access.
+func TestNewAccountAdmission(t *testing.T) {
+	t.Parallel()
+
+	t.Run("not started", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange.
+		w, deps := createTestWalletWithMocks(t)
+
+		// Act.
+		account, err := w.NewAccount(
+			t.Context(), waddrmgr.KeyScopeBIP0084, testAccountName,
+		)
+
+		// Assert.
+		require.Nil(t, account)
+		require.ErrorIs(t, err, ErrStateForbidden)
+		requireNoInternalIdentity(t, err)
+		deps.store.AssertNotCalled(
+			t, "GetAccount", mock.Anything, mock.Anything,
+		)
+	})
+
+	t.Run("cancelled", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange: cancellation must precede the watch-only refusal.
+		w, deps := createStartedWalletWithMocks(t)
+		w.isWatchOnly = true
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		// Act.
+		account, err := w.NewAccount(
+			ctx, waddrmgr.KeyScopeBIP0084, testAccountName,
+		)
+
+		// Assert.
+		require.Nil(t, account)
+		require.Equal(t, context.Canceled, err)
+		require.Empty(t, reportedIdentities(err))
+		requireNoInternalIdentity(t, err)
+		deps.store.AssertNotCalled(
+			t, "GetAccount", mock.Anything, mock.Anything,
+		)
+	})
+
+	t.Run("deadline exceeded", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange: the deadline must precede the watch-only refusal.
+		w, deps := createStartedWalletWithMocks(t)
+		w.isWatchOnly = true
+		ctx, cancel := context.WithDeadline(
+			t.Context(), time.Now().Add(-time.Second),
+		)
+		t.Cleanup(cancel)
+
+		// Act.
+		account, err := w.NewAccount(
+			ctx, waddrmgr.KeyScopeBIP0084, testAccountName,
+		)
+
+		// Assert.
+		require.Nil(t, account)
+		require.Equal(t, context.DeadlineExceeded, err)
+		require.Empty(t, reportedIdentities(err))
+		requireNoInternalIdentity(t, err)
+		deps.store.AssertNotCalled(
+			t, "GetAccount", mock.Anything, mock.Anything,
+		)
+	})
+}
+
+// TestListAccountsAdmission verifies lifecycle and context errors are
+// returned before Store access.
+func TestListAccountsAdmission(t *testing.T) {
+	t.Parallel()
+
+	t.Run("not started", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange.
+		w, deps := createTestWalletWithMocks(t)
+
+		// Act.
+		accounts, err := w.ListAccounts(t.Context())
+
+		// Assert.
+		require.Nil(t, accounts)
+		require.ErrorIs(t, err, ErrStateForbidden)
+		requireNoInternalIdentity(t, err)
+		deps.store.AssertNotCalled(
+			t, "GetAccount", mock.Anything, mock.Anything,
+		)
+	})
+
+	t.Run("cancelled", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange.
+		w, deps := createStartedWalletWithMocks(t)
+		w.isWatchOnly = true
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		// Act.
+		accounts, err := w.ListAccounts(ctx)
+
+		// Assert.
+		require.Nil(t, accounts)
+		require.Equal(t, context.Canceled, err)
+		require.Empty(t, reportedIdentities(err))
+		requireNoInternalIdentity(t, err)
+		deps.store.AssertNotCalled(
+			t, "GetAccount", mock.Anything, mock.Anything,
+		)
+	})
+
+	t.Run("deadline exceeded", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange.
+		w, deps := createStartedWalletWithMocks(t)
+		w.isWatchOnly = true
+		ctx, cancel := context.WithDeadline(
+			t.Context(), time.Now().Add(-time.Second),
+		)
+		t.Cleanup(cancel)
+
+		// Act.
+		accounts, err := w.ListAccounts(ctx)
+
+		// Assert.
+		require.Nil(t, accounts)
+		require.Equal(t, context.DeadlineExceeded, err)
+		require.Empty(t, reportedIdentities(err))
+		requireNoInternalIdentity(t, err)
+		deps.store.AssertNotCalled(
+			t, "GetAccount", mock.Anything, mock.Anything,
+		)
+	})
+}
+
+// TestListAccountsByScopeAdmission verifies lifecycle and context errors are
+// returned before Store access.
+func TestListAccountsByScopeAdmission(t *testing.T) {
+	t.Parallel()
+
+	t.Run("not started", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange.
+		w, deps := createTestWalletWithMocks(t)
+
+		// Act.
+		accounts, err := w.ListAccountsByScope(
+			t.Context(), waddrmgr.KeyScopeBIP0084,
+		)
+
+		// Assert.
+		require.Nil(t, accounts)
+		require.ErrorIs(t, err, ErrStateForbidden)
+		requireNoInternalIdentity(t, err)
+		deps.store.AssertNotCalled(
+			t, "GetAccount", mock.Anything, mock.Anything,
+		)
+	})
+
+	t.Run("cancelled", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange.
+		w, deps := createStartedWalletWithMocks(t)
+		w.isWatchOnly = true
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		// Act.
+		accounts, err := w.ListAccountsByScope(
+			ctx, waddrmgr.KeyScopeBIP0084,
+		)
+
+		// Assert.
+		require.Nil(t, accounts)
+		require.Equal(t, context.Canceled, err)
+		require.Empty(t, reportedIdentities(err))
+		requireNoInternalIdentity(t, err)
+		deps.store.AssertNotCalled(
+			t, "GetAccount", mock.Anything, mock.Anything,
+		)
+	})
+
+	t.Run("deadline exceeded", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange.
+		w, deps := createStartedWalletWithMocks(t)
+		w.isWatchOnly = true
+		ctx, cancel := context.WithDeadline(
+			t.Context(), time.Now().Add(-time.Second),
+		)
+		t.Cleanup(cancel)
+
+		// Act.
+		accounts, err := w.ListAccountsByScope(
+			ctx, waddrmgr.KeyScopeBIP0084,
+		)
+
+		// Assert.
+		require.Nil(t, accounts)
+		require.Equal(t, context.DeadlineExceeded, err)
+		require.Empty(t, reportedIdentities(err))
+		requireNoInternalIdentity(t, err)
+		deps.store.AssertNotCalled(
+			t, "GetAccount", mock.Anything, mock.Anything,
+		)
+	})
+}
+
+// TestListAccountsByNameAdmission verifies lifecycle and context errors are
+// returned before Store access.
+func TestListAccountsByNameAdmission(t *testing.T) {
+	t.Parallel()
+
+	t.Run("not started", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange.
+		w, deps := createTestWalletWithMocks(t)
+
+		// Act.
+		accounts, err := w.ListAccountsByName(t.Context(), testAccountName)
+
+		// Assert.
+		require.Nil(t, accounts)
+		require.ErrorIs(t, err, ErrStateForbidden)
+		requireNoInternalIdentity(t, err)
+		deps.store.AssertNotCalled(
+			t, "GetAccount", mock.Anything, mock.Anything,
+		)
+	})
+
+	t.Run("cancelled", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange.
+		w, deps := createStartedWalletWithMocks(t)
+		w.isWatchOnly = true
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		// Act.
+		accounts, err := w.ListAccountsByName(ctx, testAccountName)
+
+		// Assert.
+		require.Nil(t, accounts)
+		require.Equal(t, context.Canceled, err)
+		require.Empty(t, reportedIdentities(err))
+		requireNoInternalIdentity(t, err)
+		deps.store.AssertNotCalled(
+			t, "GetAccount", mock.Anything, mock.Anything,
+		)
+	})
+
+	t.Run("deadline exceeded", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange.
+		w, deps := createStartedWalletWithMocks(t)
+		w.isWatchOnly = true
+		ctx, cancel := context.WithDeadline(
+			t.Context(), time.Now().Add(-time.Second),
+		)
+		t.Cleanup(cancel)
+
+		// Act.
+		accounts, err := w.ListAccountsByName(ctx, testAccountName)
+
+		// Assert.
+		require.Nil(t, accounts)
+		require.Equal(t, context.DeadlineExceeded, err)
+		require.Empty(t, reportedIdentities(err))
+		requireNoInternalIdentity(t, err)
+		deps.store.AssertNotCalled(
+			t, "GetAccount", mock.Anything, mock.Anything,
+		)
+	})
+}
+
+// TestGetAccountAdmission verifies lifecycle and context errors are
+// returned before Store access.
+func TestGetAccountAdmission(t *testing.T) {
+	t.Parallel()
+
+	t.Run("not started", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange.
+		w, deps := createTestWalletWithMocks(t)
+
+		// Act.
+		account, err := w.GetAccount(
+			t.Context(), waddrmgr.KeyScopeBIP0084, testAccountName,
+		)
+
+		// Assert.
+		require.Nil(t, account)
+		require.ErrorIs(t, err, ErrStateForbidden)
+		requireNoInternalIdentity(t, err)
+		deps.store.AssertNotCalled(
+			t, "GetAccount", mock.Anything, mock.Anything,
+		)
+	})
+
+	t.Run("cancelled", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange.
+		w, deps := createStartedWalletWithMocks(t)
+		w.isWatchOnly = true
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		// Act.
+		account, err := w.GetAccount(
+			ctx, waddrmgr.KeyScopeBIP0084, testAccountName,
+		)
+
+		// Assert.
+		require.Nil(t, account)
+		require.Equal(t, context.Canceled, err)
+		require.Empty(t, reportedIdentities(err))
+		requireNoInternalIdentity(t, err)
+		deps.store.AssertNotCalled(
+			t, "GetAccount", mock.Anything, mock.Anything,
+		)
+	})
+
+	t.Run("deadline exceeded", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange.
+		w, deps := createStartedWalletWithMocks(t)
+		w.isWatchOnly = true
+		ctx, cancel := context.WithDeadline(
+			t.Context(), time.Now().Add(-time.Second),
+		)
+		t.Cleanup(cancel)
+
+		// Act.
+		account, err := w.GetAccount(
+			ctx, waddrmgr.KeyScopeBIP0084, testAccountName,
+		)
+
+		// Assert.
+		require.Nil(t, account)
+		require.Equal(t, context.DeadlineExceeded, err)
+		require.Empty(t, reportedIdentities(err))
+		requireNoInternalIdentity(t, err)
+		deps.store.AssertNotCalled(
+			t, "GetAccount", mock.Anything, mock.Anything,
+		)
+	})
+}
+
+// TestRenameAccountAdmission verifies lifecycle and context errors are
+// returned before Store access.
+func TestRenameAccountAdmission(t *testing.T) {
+	t.Parallel()
+
+	t.Run("not started", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange.
+		w, deps := createTestWalletWithMocks(t)
+
+		// Act.
+		err := w.RenameAccount(
+			t.Context(), waddrmgr.KeyScopeBIP0084, testAccountName, "renamed",
+		)
+
+		// Assert.
+		require.ErrorIs(t, err, ErrStateForbidden)
+		requireNoInternalIdentity(t, err)
+		deps.store.AssertNotCalled(
+			t, "GetAccount", mock.Anything, mock.Anything,
+		)
+	})
+
+	t.Run("cancelled", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange.
+		w, deps := createStartedWalletWithMocks(t)
+		w.isWatchOnly = true
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		// Act.
+		err := w.RenameAccount(
+			ctx, waddrmgr.KeyScopeBIP0084, testAccountName, "renamed",
+		)
+
+		// Assert.
+		require.Equal(t, context.Canceled, err)
+		require.Empty(t, reportedIdentities(err))
+		requireNoInternalIdentity(t, err)
+		deps.store.AssertNotCalled(
+			t, "GetAccount", mock.Anything, mock.Anything,
+		)
+	})
+
+	t.Run("deadline exceeded", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange.
+		w, deps := createStartedWalletWithMocks(t)
+		w.isWatchOnly = true
+		ctx, cancel := context.WithDeadline(
+			t.Context(), time.Now().Add(-time.Second),
+		)
+		t.Cleanup(cancel)
+
+		// Act.
+		err := w.RenameAccount(
+			ctx, waddrmgr.KeyScopeBIP0084, testAccountName, "renamed",
+		)
+
+		// Assert.
+		require.Equal(t, context.DeadlineExceeded, err)
+		require.Empty(t, reportedIdentities(err))
+		requireNoInternalIdentity(t, err)
+		deps.store.AssertNotCalled(
+			t, "GetAccount", mock.Anything, mock.Anything,
+		)
+	})
+}
+
+// TestImportAccountAdmission verifies lifecycle and context errors are
+// returned before Store access.
+func TestImportAccountAdmission(t *testing.T) {
+	t.Parallel()
+
+	t.Run("not started", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange.
+		w, deps := createTestWalletWithMocks(t)
+
+		acctPubKey, masterFP := importAccountTestKey(t, 84)
+
+		// Act.
+		account, err := w.ImportAccount(
+			t.Context(), testAccountName, acctPubKey, masterFP,
+			waddrmgr.WitnessPubKey, false,
+		)
+
+		// Assert.
+		require.Nil(t, account)
+		require.ErrorIs(t, err, ErrStateForbidden)
+		requireNoInternalIdentity(t, err)
+		deps.store.AssertNotCalled(
+			t, "GetAccount", mock.Anything, mock.Anything,
+		)
+	})
+
+	t.Run("cancelled", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange.
+		w, deps := createStartedWalletWithMocks(t)
+		w.isWatchOnly = true
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		acctPubKey, masterFP := importAccountTestKey(t, 84)
+
+		// Act.
+		account, err := w.ImportAccount(
+			ctx, testAccountName, acctPubKey, masterFP,
+			waddrmgr.WitnessPubKey, false,
+		)
+
+		// Assert.
+		require.Nil(t, account)
+		require.Equal(t, context.Canceled, err)
+		require.Empty(t, reportedIdentities(err))
+		requireNoInternalIdentity(t, err)
+		deps.store.AssertNotCalled(
+			t, "GetAccount", mock.Anything, mock.Anything,
+		)
+	})
+
+	t.Run("deadline exceeded", func(t *testing.T) {
+		t.Parallel()
+
+		// Arrange.
+		w, deps := createStartedWalletWithMocks(t)
+		w.isWatchOnly = true
+		ctx, cancel := context.WithDeadline(
+			t.Context(), time.Now().Add(-time.Second),
+		)
+		t.Cleanup(cancel)
+
+		acctPubKey, masterFP := importAccountTestKey(t, 84)
+
+		// Act.
+		account, err := w.ImportAccount(
+			ctx, testAccountName, acctPubKey, masterFP,
+			waddrmgr.WitnessPubKey, false,
+		)
+
+		// Assert.
+		require.Nil(t, account)
+		require.Equal(t, context.DeadlineExceeded, err)
+		require.Empty(t, reportedIdentities(err))
+		requireNoInternalIdentity(t, err)
+		deps.store.AssertNotCalled(
+			t, "GetAccount", mock.Anything, mock.Anything,
+		)
+	})
+}
+
 // TestAccountManagerErrTranslatesIdentities verifies the classifications no
 // public method exercises directly: each store or legacy waddrmgr failure is
 // reported as its wallet-owned identity and as no other, with the source text

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -1894,14 +1894,14 @@ func TestRenameAccountTranslatesPostgresNameConflict(t *testing.T) {
 	w, deps := createStartedWalletWithMocks(t)
 	scope := waddrmgr.KeyScopeBIP0084
 	driverErr := &pgconn.PgError{
-		Code:           "23505",
-		ConstraintName: "uidx_accounts_wallet_scope_account_name",
-		Message:        "duplicate key value violates unique constraint",
+		Code:    "23505",
+		Message: "duplicate key value violates unique constraint",
 	}
 	sqlErr := dberr.NewSQLError(
 		dberr.BackendPostgres, dberr.ReasonConstraint,
 		driverErr.Code, driverErr,
 	)
+	sqlErr.Constraint = dberr.ConstraintAccountName
 	storeErr := fmt.Errorf("rename account: %w", sqlErr)
 
 	expectAccountNameFree(t, deps, scope, "renamed")

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -282,6 +282,45 @@ func expectAccountDeriveSetup(t *testing.T, deps *mockWalletDeps,
 	).Once()
 }
 
+// accountNameQuery is the read-only lookup the account mutations perform to
+// learn whether a name is already taken within a key scope.
+func accountNameQuery(scope waddrmgr.KeyScope,
+	name string) db.GetAccountQuery {
+
+	return db.GetAccountQuery{
+		WalletID:    0,
+		Scope:       db.KeyScope(scope),
+		Name:        &name,
+		SkipBalance: true,
+	}
+}
+
+// expectAccountNameFree answers the name lookup with an absent account, which
+// lets the mutation proceed.
+func expectAccountNameFree(t *testing.T, deps *mockWalletDeps,
+	scope waddrmgr.KeyScope, name string) {
+
+	t.Helper()
+
+	deps.store.On("GetAccount", mock.Anything,
+		accountNameQuery(scope, name)).
+		Return((*db.AccountInfo)(nil), db.ErrAccountNotFound).Once()
+}
+
+// expectAccountNameTaken answers the same lookup with an existing account.
+func expectAccountNameTaken(t *testing.T, deps *mockWalletDeps,
+	scope waddrmgr.KeyScope, name string) {
+
+	t.Helper()
+
+	deps.store.On("GetAccount", mock.Anything,
+		accountNameQuery(scope, name)).
+		Return(&db.AccountInfo{
+			AccountName: name,
+			KeyScope:    db.KeyScope(scope),
+		}, nil).Once()
+}
+
 // hardenedKey converts a plain BIP32 child index to its hardened
 // counterpart by adding hdkeychain.HardenedKeyStart.
 func hardenedKey(key uint32) uint32 {
@@ -1025,7 +1064,9 @@ func TestGetAccountConversionFailure(t *testing.T) {
 func TestNewAccount(t *testing.T) {
 	t.Parallel()
 
-	w, deps := createStartedWalletWithMocks(t)
+	// Arrange: an unlocked wallet with an available account name and valid
+	// derivation material.
+	w, deps := createUnlockedWalletWithMocks(t)
 	stub := newStubAccountDeriveFn(t)
 	w.masterFingerprint = stub.masterKeyFingerprint
 
@@ -1036,7 +1077,7 @@ func TestNewAccount(t *testing.T) {
 	}
 	accountNumber := uint32(1)
 
-	// Success path.
+	expectAccountNameFree(t, deps, scope, testAccountName)
 	expectAccountDeriveSetup(t, deps, stub)
 	deps.store.On("CreateDerivedAccount", mock.Anything,
 		db.CreateDerivedAccountParams{
@@ -1051,27 +1092,17 @@ func TestNewAccount(t *testing.T) {
 		}, nil,
 	).Once()
 
+	// Act: create the next account in the scope.
 	account, err := w.NewAccount(t.Context(), scope, testAccountName)
+
+	// Assert: the account result contains the allocated number and canonical
+	// master fingerprint, and every required dependency call occurred.
 	require.NoError(t, err)
 	require.NotNil(t, account.AccountNumber)
 	require.Equal(t, AccountNumber(1), *account.AccountNumber)
 	require.NotNil(t, account.MasterKeyFingerprint)
 	require.Equal(t, MasterFingerprint(stub.masterKeyFingerprint),
 		*account.MasterKeyFingerprint)
-
-	// Duplicate-name path.
-	expectAccountDeriveSetup(t, deps, stub)
-	deps.store.On("CreateDerivedAccount", mock.Anything, mock.Anything,
-		mock.Anything).Return((*db.AccountInfo)(nil),
-		waddrmgr.ManagerError{
-			ErrorCode: waddrmgr.ErrDuplicateAccount,
-		}).Once()
-
-	_, err = w.NewAccount(t.Context(), scope, testAccountName)
-	require.Error(t, err)
-	require.True(t,
-		waddrmgr.IsError(err, waddrmgr.ErrDuplicateAccount),
-	)
 }
 
 // TestNewAccountMissingHDSeedDefersToStore verifies that neutered-root kvdb
@@ -1079,7 +1110,9 @@ func TestNewAccount(t *testing.T) {
 func TestNewAccountMissingHDSeedDefersToStore(t *testing.T) {
 	t.Parallel()
 
-	w, deps := createStartedWalletWithMocks(t)
+	// Arrange: an unlocked wallet whose root seed is absent, allowing the
+	// legacy Store callback to derive from its scoped key instead.
+	w, deps := createUnlockedWalletWithMocks(t)
 
 	scope := waddrmgr.KeyScopeBIP0084
 	dbScope := db.KeyScope{
@@ -1088,6 +1121,7 @@ func TestNewAccountMissingHDSeedDefersToStore(t *testing.T) {
 	}
 	accountNumber := uint32(1)
 
+	expectAccountNameFree(t, deps, scope, testAccountName)
 	deps.store.On("GetEncryptedHDSeed", mock.Anything, uint32(0)).
 		Return(nil, db.ErrSecretNotFound).Once()
 	deps.store.On("CreateDerivedAccount", mock.Anything,
@@ -1109,7 +1143,11 @@ func TestNewAccountMissingHDSeedDefersToStore(t *testing.T) {
 		KeyScope:      dbScope,
 	}, nil).Once()
 
+	// Act: create an account through the deferred derivation path.
 	account, err := w.NewAccount(t.Context(), scope, testAccountName)
+
+	// Assert: the Store-provided result is returned and all expected admission
+	// and derivation calls occurred.
 	require.NoError(t, err)
 	require.NotNil(t, account.AccountNumber)
 	require.Equal(t, AccountNumber(1), *account.AccountNumber)
@@ -1857,6 +1895,251 @@ func TestListAccountsTranslatesStoreError(t *testing.T) {
 			require.Empty(t, reportedIdentities(err))
 			require.NotErrorIs(t, err, storeErr)
 			requireNoInternalIdentity(t, err)
+		})
+	}
+}
+
+// TestNewAccountVaultLockedForbidden verifies a Vault that locks after the
+// wallet admitted the request surfaces as ErrStateForbidden without leaking
+// the Vault sentinel.
+func TestNewAccountVaultLockedForbidden(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: an unlocked wallet whose vault locks again between the
+	// wallet's own lock check and the master-key read.
+	w, deps := createUnlockedWalletWithMocks(t)
+	stub := newStubAccountDeriveFn(t)
+	scope := waddrmgr.KeyScopeBIP0084
+
+	expectAccountNameFree(t, deps, scope, testAccountName)
+	deps.store.On("GetEncryptedHDSeed", mock.Anything, uint32(0)).
+		Return(append([]byte(nil), stub.encryptedSeed...), nil).Once()
+	deps.vault.On("Decrypt", waddrmgr.CKTPrivate, mock.Anything).
+		Return([]byte(nil), keyvault.ErrVaultLocked).Once()
+
+	// Act: create an account while the vault is locked.
+	account, err := w.NewAccount(t.Context(), scope, testAccountName)
+
+	// Assert: the lock is reported as a forbidden state, the vault
+	// identity does not escape, and no account row was attempted.
+	require.Nil(t, account)
+	require.ErrorIs(t, err, ErrStateForbidden)
+	require.NotErrorIs(t, err, keyvault.ErrVaultLocked)
+
+	deps.store.AssertNotCalled(t, "CreateDerivedAccount", mock.Anything,
+		mock.Anything, mock.Anything)
+}
+
+// TestNewAccountWatchOnlyUnsupported verifies that a watch-only wallet is
+// refused before any write is attempted, as an unsupported operation rather
+// than as the locked wallet it also is, since it holds no signing material.
+func TestNewAccountWatchOnlyUnsupported(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: a started wallet holding no master HD private key.
+	w, deps := createStartedWalletWithMocks(t)
+	w.isWatchOnly = true
+
+	scope := waddrmgr.KeyScopeBIP0084
+
+	expectAccountNameFree(t, deps, scope, testAccountName)
+
+	// Act: create a derived account on the watch-only wallet.
+	account, err := w.NewAccount(t.Context(), scope, testAccountName)
+
+	// Assert: the refusal is reported as unsupported, the internal
+	// derivation sentinel does not escape, and the only Store call was the
+	// read-only name lookup.
+	require.Nil(t, account)
+	require.ErrorIs(t, err, ErrAccountOperationUnsupported)
+	require.NotErrorIs(t, err, ErrStateForbidden)
+	require.NotErrorIs(t, err, errWatchOnlyAccountDerivation)
+
+	deps.store.AssertNotCalled(t, "CreateDerivedAccount", mock.Anything,
+		mock.Anything, mock.Anything)
+}
+
+// TestNewAccountLocked verifies a spendable wallet refuses derivation while it
+// is locked, before it reads or writes anything.
+func TestNewAccountLocked(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: a started but still locked spendable wallet.
+	w, deps := createStartedWalletWithMocks(t)
+
+	// Act: create an account while the wallet is locked.
+	account, err := w.NewAccount(
+		t.Context(), waddrmgr.KeyScopeBIP0084, testAccountName,
+	)
+
+	// Assert: the wallet reports its own forbidden state and performs
+	// neither the name lookup nor the account write.
+	require.Nil(t, account)
+	require.ErrorIs(t, err, ErrStateForbidden)
+	requireNoInternalIdentity(t, err)
+
+	deps.store.AssertNotCalled(t, "GetAccount", mock.Anything, mock.Anything)
+	deps.store.AssertNotCalled(t, "CreateDerivedAccount", mock.Anything,
+		mock.Anything, mock.Anything)
+}
+
+// TestNewAccountOccupiedName verifies a taken name is settled by the read-only
+// preflight in every wallet mode, before any derivation material is touched
+// and ahead of the watch-only refusal.
+func TestNewAccountOccupiedName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		watchOnly bool
+	}{{
+		name: "spendable unlocked wallet",
+	}, {
+		name:      "watch-only locked wallet",
+		watchOnly: true,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: a wallet whose scope already holds the name.
+			// A watch-only wallet holds no signing material, so it
+			// stays locked and its own refusal would answer first
+			// if the occupied name did not outrank it.
+			w, deps := createUnlockedWalletWithMocks(t)
+			if tc.watchOnly {
+				w.isWatchOnly = true
+				w.state.toLocked()
+			}
+
+			scope := waddrmgr.KeyScopeBIP0084
+			expectAccountNameTaken(t, deps, scope, testAccountName)
+
+			// Act: create an account under the occupied name.
+			account, err := w.NewAccount(
+				t.Context(), scope, testAccountName,
+			)
+
+			// Assert: the conflict is the only outcome reported, and
+			// nothing was derived or written.
+			require.Nil(t, account)
+			require.ErrorContains(t, err, testAccountName)
+			require.Equal(t,
+				[]string{ErrAccountAlreadyExists.Error()},
+				reportedIdentities(err))
+
+			deps.store.AssertNotCalled(t, "GetEncryptedHDSeed",
+				mock.Anything, mock.Anything)
+			deps.store.AssertNotCalled(t, "CreateDerivedAccount",
+				mock.Anything, mock.Anything, mock.Anything)
+		})
+	}
+}
+
+// TestNewAccountTranslatesStoreError verifies account write failures use the
+// expected public identities without exposing Store errors.
+func TestNewAccountTranslatesStoreError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		scope  waddrmgr.KeyScope
+		inject error
+		want   error
+	}{{
+		name:   "sql derivation range exhausted",
+		scope:  waddrmgr.KeyScopeBIP0084,
+		inject: db.ErrMaxAccountNumberReached,
+		want:   ErrAccountDerivationExhausted,
+	}, {
+		name:   "kvdb derivation range exhausted",
+		scope:  waddrmgr.KeyScopeBIP0084,
+		inject: wrapped(legacyErr(waddrmgr.ErrAccountNumTooHigh)),
+		want:   ErrAccountDerivationExhausted,
+	}, {
+		name:   "kvdb duplicate account",
+		scope:  waddrmgr.KeyScopeBIP0084,
+		inject: wrapped(legacyErr(waddrmgr.ErrDuplicateAccount)),
+		want:   ErrAccountAlreadyExists,
+	}, {
+		name:   "scope cannot be created",
+		scope:  waddrmgr.KeyScope{Purpose: 123, Coin: 456},
+		inject: wrapped(db.ErrUnknownKeyScope),
+		want:   ErrInvalidParam,
+	}, {
+		name:  "cancellation before scope validation",
+		scope: waddrmgr.KeyScope{Purpose: 123, Coin: 456},
+		inject: errors.Join(
+			context.Canceled, db.ErrUnknownKeyScope,
+		),
+		want: context.Canceled,
+	}, {
+		name:  "deadline before scope validation",
+		scope: waddrmgr.KeyScope{Purpose: 123, Coin: 456},
+		inject: errors.Join(
+			context.DeadlineExceeded, db.ErrUnknownKeyScope,
+		),
+		want: context.DeadlineExceeded,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: an unlocked wallet whose write fails.
+			w, deps := createUnlockedWalletWithMocks(t)
+			stub := newStubAccountDeriveFn(t)
+
+			expectAccountNameFree(t, deps, tc.scope, testAccountName)
+			expectAccountDeriveSetup(t, deps, stub)
+			deps.store.On("CreateDerivedAccount", mock.Anything,
+				mock.Anything, mock.Anything).
+				Return((*db.AccountInfo)(nil), tc.inject).Once()
+
+			// Act: create the next account in the scope.
+			account, err := w.NewAccount(
+				t.Context(), tc.scope, testAccountName,
+			)
+
+			// Assert: only the expected error identity is reported.
+			require.Nil(t, account)
+			require.ErrorIs(t, err, tc.want)
+			require.ErrorContains(t, err, tc.inject.Error())
+			require.NotErrorIs(t, err, tc.inject)
+			requireNoInternalIdentity(t, err)
+
+			for _, sentinel := range accountManagerIdentities {
+				if !errors.Is(tc.want, sentinel) {
+					require.NotErrorIs(t, err, sentinel)
+				}
+			}
+		})
+	}
+}
+
+// TestNewAccountInvalidName verifies name validation outranks the watch-only
+// refusal, which would otherwise short-circuit the store's own name checks.
+func TestNewAccountInvalidName(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"", waddrmgr.ImportedAddrAccountName} {
+		t.Run("invalid name "+name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange.
+			w, _ := createStartedWalletWithMocks(t)
+			w.isWatchOnly = true
+
+			// Act.
+			account, err := w.NewAccount(
+				t.Context(), waddrmgr.KeyScopeBIP0084, name,
+			)
+
+			// Assert: validation outranks the watch-only refusal.
+			require.Nil(t, account)
+			require.ErrorIs(t, err, ErrInvalidParam)
+			require.NotErrorIs(t, err, ErrAccountOperationUnsupported)
 		})
 	}
 }

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -21,7 +21,9 @@ import (
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/addresstype"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	dberr "github.com/btcsuite/btcwallet/wallet/internal/db/err"
 	"github.com/btcsuite/btcwallet/wallet/internal/keyvault"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -1154,11 +1156,12 @@ func TestNewAccountMissingHDSeedDefersToStore(t *testing.T) {
 }
 
 // TestRenameAccount verifies RenameAccount routes through
-// w.store.RenameAccount with the correct params and preserves
-// db.ErrAccountNotFound passthrough.
+// w.store.RenameAccount with the correct params and reports a missing
+// account through the wallet-owned ErrAccountNotFound.
 func TestRenameAccount(t *testing.T) {
 	t.Parallel()
 
+	// Arrange: a started wallet whose store accepts the rename.
 	w, deps := createStartedWalletWithMocks(t)
 
 	scope := waddrmgr.KeyScopeBIP0084
@@ -1167,6 +1170,7 @@ func TestRenameAccount(t *testing.T) {
 		Coin:    scope.Coin,
 	}
 
+	expectAccountNameFree(t, deps, scope, "renamed")
 	deps.store.On("RenameAccount", mock.Anything, db.RenameAccountParams{
 		WalletID: 0,
 		Scope:    dbScope,
@@ -1174,20 +1178,11 @@ func TestRenameAccount(t *testing.T) {
 		NewName:  "renamed",
 	}).Return(nil).Once()
 
+	// Act: rename the account to the available name.
 	err := w.RenameAccount(t.Context(), scope, testAccountName, "renamed")
+
+	// Assert: the Store accepted the exact rename request.
 	require.NoError(t, err)
-
-	// Invalid new name path (validated locally before the store call).
-	err = w.RenameAccount(t.Context(), scope, testAccountName, "")
-	require.Error(t, err)
-
-	// Not-found path.
-	deps.store.On("RenameAccount", mock.Anything, mock.Anything).Return(
-		db.ErrAccountNotFound,
-	).Once()
-
-	err = w.RenameAccount(t.Context(), scope, "missing", "x")
-	require.ErrorIs(t, err, db.ErrAccountNotFound)
 }
 
 // accountManagerIdentities lists every wallet-owned identity the
@@ -1860,8 +1855,85 @@ func TestAccountManagerErrKeepsCallerIdentity(t *testing.T) {
 	}
 }
 
-// TestListAccountsTranslatesStoreError verifies the query surface crosses the
-// same boundary as the mutations.
+// TestRenameAccountTranslatesStoreError verifies RenameAccount reports an
+// absent source through the wallet-owned identity.
+func TestRenameAccountTranslatesStoreError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: a started wallet whose source account does not exist.
+	w, deps := createStartedWalletWithMocks(t)
+	scope := waddrmgr.KeyScopeBIP0084
+
+	expectAccountNameFree(t, deps, scope, "renamed")
+	deps.store.On("RenameAccount", mock.Anything, db.RenameAccountParams{
+		WalletID: 0,
+		Scope:    db.KeyScope(scope),
+		OldName:  "missing",
+		NewName:  "renamed",
+	}).Return(db.ErrAccountNotFound).Once()
+
+	// Act: rename the missing account.
+	err := w.RenameAccount(t.Context(), scope, "missing", "renamed")
+
+	// Assert: the wallet identity is public, the Store identity is scrubbed,
+	// and both expected Store calls occurred.
+	require.ErrorContains(t, err, db.ErrAccountNotFound.Error())
+	require.Equal(
+		t, []string{ErrAccountNotFound.Error()}, reportedIdentities(err),
+	)
+	require.NotErrorIs(t, err, db.ErrAccountNotFound)
+	requireNoInternalIdentity(t, err)
+}
+
+// TestRenameAccountTranslatesPostgresNameConflict verifies a SQL name conflict
+// returns only the wallet-owned error through the public rename method.
+func TestRenameAccountTranslatesPostgresNameConflict(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: the target becomes occupied after the initial name lookup.
+	w, deps := createStartedWalletWithMocks(t)
+	scope := waddrmgr.KeyScopeBIP0084
+	driverErr := &pgconn.PgError{
+		Code:           "23505",
+		ConstraintName: "uidx_accounts_wallet_scope_account_name",
+		Message:        "duplicate key value violates unique constraint",
+	}
+	sqlErr := dberr.NewSQLError(
+		dberr.BackendPostgres, dberr.ReasonConstraint,
+		driverErr.Code, driverErr,
+	)
+	storeErr := fmt.Errorf("rename account: %w", sqlErr)
+
+	expectAccountNameFree(t, deps, scope, "renamed")
+	deps.store.On("RenameAccount", mock.Anything, db.RenameAccountParams{
+		WalletID: 0,
+		Scope:    db.KeyScope(scope),
+		OldName:  testAccountName,
+		NewName:  "renamed",
+	}).Return(storeErr).Once()
+
+	// Act.
+	err := w.RenameAccount(t.Context(), scope, testAccountName, "renamed")
+
+	// Assert.
+	require.ErrorIs(t, err, ErrAccountAlreadyExists)
+	require.ErrorContains(t, err, storeErr.Error())
+	require.Equal(
+		t, []string{ErrAccountAlreadyExists.Error()}, reportedIdentities(err),
+	)
+	require.NotErrorIs(t, err, storeErr)
+	require.NotErrorIs(t, err, driverErr)
+	requireNoInternalIdentity(t, err)
+
+	var leakedSQL *dberr.SQLError
+	require.NotErrorAs(t, err, &leakedSQL)
+
+	var leakedDriver *pgconn.PgError
+	require.NotErrorAs(t, err, &leakedDriver)
+}
+
+// TestListAccountsTranslatesStoreError verifies unexpected Store validation
+// errors do not blame the caller of an unfiltered listing.
 func TestListAccountsTranslatesStoreError(t *testing.T) {
 	t.Parallel()
 
@@ -2142,6 +2214,139 @@ func TestNewAccountInvalidName(t *testing.T) {
 			require.NotErrorIs(t, err, ErrAccountOperationUnsupported)
 		})
 	}
+}
+
+// TestRenameAccountInvalidName verifies that the locally validated name rules
+// also cross the boundary as a wallet-owned error rather than as the
+// waddrmgr.ManagerError that waddrmgr.ValidateAccountName returns.
+func TestRenameAccountInvalidName(t *testing.T) {
+	t.Parallel()
+
+	names := []struct {
+		name    string
+		oldName string
+		newName string
+	}{
+		{
+			name:    "empty source before occupied target",
+			oldName: "",
+			newName: "occupied",
+		},
+		{
+			name:    "empty target",
+			oldName: testAccountName,
+			newName: "",
+		},
+		{
+			name:    "reserved",
+			oldName: testAccountName,
+			newName: waddrmgr.ImportedAddrAccountName,
+		},
+	}
+
+	for _, tc := range names {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: a started wallet and a target name the
+			// account-name rules reject.
+			w, deps := createStartedWalletWithMocks(t)
+
+			// Act: rename an account to that target.
+			err := w.RenameAccount(
+				t.Context(), waddrmgr.KeyScopeBIP0084,
+				tc.oldName, tc.newName,
+			)
+
+			// Assert: the rejection is a wallet-owned invalid
+			// parameter, carries no legacy identity, and never
+			// reached the store.
+			require.ErrorIs(t, err, ErrInvalidParam)
+
+			var mErr waddrmgr.ManagerError
+			require.NotErrorAs(t, err, &mErr)
+
+			deps.store.AssertNotCalled(t, "RenameAccount",
+				mock.Anything, mock.Anything)
+		})
+	}
+}
+
+// TestRenameAccountSelfRename verifies that renaming an account to the name it
+// already holds is settled at the wallet boundary, rather than being handed to
+// a store that answers it differently, and that a self-rename of an account
+// that does not exist reports the absence instead of the conflict.
+func TestRenameAccountSelfRename(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		exists bool
+		want   error
+	}{{
+		name:   "existing account",
+		exists: true,
+		want:   ErrAccountAlreadyExists,
+	}, {
+		name:   "missing account",
+		exists: false,
+		want:   ErrAccountNotFound,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: a started wallet that holds the name, or not.
+			w, deps := createStartedWalletWithMocks(t)
+			scope := waddrmgr.KeyScopeBIP0084
+
+			if tc.exists {
+				expectAccountNameTaken(
+					t, deps, scope, testAccountName,
+				)
+			} else {
+				expectAccountNameFree(
+					t, deps, scope, testAccountName,
+				)
+			}
+
+			// Act: rename the account to the name it already holds.
+			err := w.RenameAccount(
+				t.Context(), scope, testAccountName,
+				testAccountName,
+			)
+
+			// Assert: the wallet-owned outcome is the only identity
+			// reported and no write is attempted.
+			require.Equal(t, []string{tc.want.Error()},
+				reportedIdentities(err))
+			requireNoInternalIdentity(t, err)
+			deps.store.AssertNotCalled(t, "RenameAccount",
+				mock.Anything, mock.Anything)
+		})
+	}
+}
+
+// TestRenameAccountOccupiedTarget verifies the target name is resolved before
+// the write, so a conflict cannot move the source account.
+func TestRenameAccountOccupiedTarget(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: a started wallet whose scope already holds the target name.
+	w, deps := createStartedWalletWithMocks(t)
+	scope := waddrmgr.KeyScopeBIP0084
+
+	expectAccountNameTaken(t, deps, scope, "occupied")
+
+	// Act: rename the source account onto the occupied name.
+	err := w.RenameAccount(t.Context(), scope, testAccountName, "occupied")
+
+	// Assert: the conflict names the target and no write is attempted.
+	require.ErrorIs(t, err, ErrAccountAlreadyExists)
+	require.ErrorContains(t, err, "occupied")
+	deps.store.AssertNotCalled(t, "RenameAccount", mock.Anything,
+		mock.Anything)
 }
 
 // TestImportAccount verifies the normal import path routes through

--- a/wallet/internal/db/err/errors.go
+++ b/wallet/internal/db/err/errors.go
@@ -252,6 +252,18 @@ func (r Reason) Valid() bool {
 	return r <= ReasonCorrupt
 }
 
+// Constraint identifies a backend-neutral constraint violation.
+type Constraint uint8
+
+const (
+	// ConstraintUnknown leaves an unrecognized constraint unclassified.
+	ConstraintUnknown Constraint = iota
+
+	// ConstraintAccountName identifies a duplicate account name within a
+	// wallet and key scope, not an account-number or other unique violation.
+	ConstraintAccountName
+)
+
 // SQLError wraps a backend or transport error with stable SQL classification
 // metadata.
 //
@@ -264,6 +276,10 @@ type SQLError struct {
 
 	// Reason identifies the specific backend failure bucket.
 	Reason Reason
+
+	// Constraint refines a constraint failure without changing its runtime
+	// policy or statistics bucket. Its zero value means unclassified.
+	Constraint Constraint
 
 	// Code stores the raw backend code used for classification.
 	Code string
@@ -320,6 +336,14 @@ func (e *SQLError) Unwrap() error {
 	}
 
 	return e.Err
+}
+
+// IsAccountNameConflict reports whether err carries a classified account-name
+// constraint violation, including through caller-added wrappers.
+func IsAccountNameConflict(err error) bool {
+	sqlErr := extractSQLError(err)
+
+	return sqlErr != nil && sqlErr.Constraint == ConstraintAccountName
 }
 
 // Normalize converts one backend error into the shared SQL error model.

--- a/wallet/internal/db/err/errors_test.go
+++ b/wallet/internal/db/err/errors_test.go
@@ -14,6 +14,39 @@ import (
 
 var errConstraint = errors.New("constraint")
 
+// TestIsAccountNameConflict verifies the shared marker survives wrapping
+// without changing error text, classification policy, or the underlying cause.
+func TestIsAccountNameConflict(t *testing.T) {
+	t.Parallel()
+
+	for _, backend := range []Backend{BackendPostgres, BackendSQLite} {
+		t.Run(backend.String(), func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange.
+			sqlErr := NewSQLError(
+				backend, ReasonConstraint, "", errConstraint,
+			)
+			require.False(t, IsAccountNameConflict(sqlErr))
+			sqlErr.Constraint = ConstraintAccountName
+
+			// Act.
+			err := fmt.Errorf("insert account: %w", sqlErr)
+
+			// Assert.
+			require.True(t, IsAccountNameConflict(err))
+			require.Equal(t, ReasonConstraint, sqlErr.Reason)
+			require.Equal(t, ClassPermanent, sqlErr.Class())
+			require.Equal(t, "insert account: constraint", err.Error())
+			require.ErrorIs(t, err, errConstraint)
+			require.Same(t, err, Normalize(backend, noOpMapper, err))
+		})
+	}
+
+	require.False(t, IsAccountNameConflict(nil))
+	require.False(t, IsAccountNameConflict(errConstraint))
+}
+
 // noOpMapper is a test helper that disables backend-specific classification.
 func noOpMapper(error) *SQLError {
 	return nil

--- a/wallet/internal/db/itest/accountstore_createderived_test.go
+++ b/wallet/internal/db/itest/accountstore_createderived_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	dberr "github.com/btcsuite/btcwallet/wallet/internal/db/err"
 	"github.com/stretchr/testify/require"
 )
 
@@ -247,6 +248,7 @@ func TestCreateDerivedAccountDuplicateName(t *testing.T) {
 	)
 	require.Error(t, err)
 	requireConstraintSQLError(t, err)
+	require.True(t, dberr.IsAccountNameConflict(err))
 
 	after := store.StatsSnapshot()
 	require.Equal(t, before.Unhealthy, after.Unhealthy)

--- a/wallet/internal/db/pg/account_test.go
+++ b/wallet/internal/db/pg/account_test.go
@@ -5,15 +5,9 @@ import (
 	"fmt"
 	"testing"
 
+	dberr "github.com/btcsuite/btcwallet/wallet/internal/db/err"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
-)
-
-// The unique indexes the accounts table declares. Both are unique-violation
-// sources, so the classifier has to tell them apart by name.
-const (
-	accountNameIndex   = "uidx_accounts_wallet_scope_account_name"
-	accountNumberIndex = "uidx_accounts_scope_account_number"
 )
 
 // TestIsAccountNameConflictMatchesNameIndex verifies a unique violation on the
@@ -25,12 +19,16 @@ func TestIsAccountNameConflictMatchesNameIndex(t *testing.T) {
 
 	err := &pgconn.PgError{
 		Code:           codeUniqueViolation,
-		ConstraintName: accountNameIndex,
+		ConstraintName: accountNameConstraint,
 	}
 
-	require.True(t, IsAccountNameConflict(err))
-	require.True(t, IsAccountNameConflict(
-		fmt.Errorf("insert account: %w", err),
+	store := &Store{}
+	classified := store.ClassifyError(err)
+
+	require.True(t, dberr.IsAccountNameConflict(classified))
+	require.ErrorIs(t, classified, err)
+	require.True(t, dberr.IsAccountNameConflict(
+		store.ClassifyError(fmt.Errorf("insert account: %w", err)),
 	))
 }
 
@@ -44,19 +42,17 @@ func TestIsAccountNameConflictRejectsOtherFailures(t *testing.T) {
 		name string
 		err  error
 	}{{
-		// A colliding account number is a distinct outcome the wallet
-		// reports separately, even though it shares the SQLSTATE.
-		name: "unique violation on the account-number index",
+		name: "unique violation on an unrelated index",
 		err: &pgconn.PgError{
 			Code:           codeUniqueViolation,
-			ConstraintName: accountNumberIndex,
+			ConstraintName: "other_unique_index",
 		},
 	}, {
 		// The name index appears in errors that are not collisions.
 		name: "foreign-key violation naming the account-name index",
 		err: &pgconn.PgError{
 			Code:           codeForeignKeyViolation,
-			ConstraintName: accountNameIndex,
+			ConstraintName: accountNameConstraint,
 		},
 	}, {
 		// Nothing but the driver's own typed error carries a constraint
@@ -67,9 +63,13 @@ func TestIsAccountNameConflictRejectsOtherFailures(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			require.False(t, IsAccountNameConflict(tc.err))
-			require.False(t, IsAccountNameConflict(
-				fmt.Errorf("insert account: %w", tc.err),
+			store := &Store{}
+
+			require.False(t, dberr.IsAccountNameConflict(
+				store.ClassifyError(tc.err),
+			))
+			require.False(t, dberr.IsAccountNameConflict(
+				store.ClassifyError(fmt.Errorf("insert account: %w", tc.err)),
 			))
 		})
 	}
@@ -80,5 +80,7 @@ func TestIsAccountNameConflictRejectsOtherFailures(t *testing.T) {
 func TestIsAccountNameConflictRejectsNil(t *testing.T) {
 	t.Parallel()
 
-	require.False(t, IsAccountNameConflict(nil))
+	store := &Store{}
+
+	require.False(t, dberr.IsAccountNameConflict(store.ClassifyError(nil)))
 }

--- a/wallet/internal/db/pg/account_test.go
+++ b/wallet/internal/db/pg/account_test.go
@@ -1,0 +1,84 @@
+package pg
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/require"
+)
+
+// The unique indexes the accounts table declares. Both are unique-violation
+// sources, so the classifier has to tell them apart by name.
+const (
+	accountNameIndex   = "uidx_accounts_wallet_scope_account_name"
+	accountNumberIndex = "uidx_accounts_scope_account_number"
+)
+
+// TestIsAccountNameConflictMatchesNameIndex verifies a unique violation on the
+// account-name index is reported as a name conflict, whether the driver error
+// arrives bare or wrapped for context. The wrapped case is why the classifier
+// unwraps instead of asserting the driver type directly.
+func TestIsAccountNameConflictMatchesNameIndex(t *testing.T) {
+	t.Parallel()
+
+	err := &pgconn.PgError{
+		Code:           codeUniqueViolation,
+		ConstraintName: accountNameIndex,
+	}
+
+	require.True(t, IsAccountNameConflict(err))
+	require.True(t, IsAccountNameConflict(
+		fmt.Errorf("insert account: %w", err),
+	))
+}
+
+// TestIsAccountNameConflictRejectsOtherFailures verifies every other failure
+// is left to another classifier, so a duplicate account name is the only thing
+// that can be reported as one.
+func TestIsAccountNameConflictRejectsOtherFailures(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{{
+		// A colliding account number is a distinct outcome the wallet
+		// reports separately, even though it shares the SQLSTATE.
+		name: "unique violation on the account-number index",
+		err: &pgconn.PgError{
+			Code:           codeUniqueViolation,
+			ConstraintName: accountNumberIndex,
+		},
+	}, {
+		// The name index appears in errors that are not collisions.
+		name: "foreign-key violation naming the account-name index",
+		err: &pgconn.PgError{
+			Code:           codeForeignKeyViolation,
+			ConstraintName: accountNameIndex,
+		},
+	}, {
+		// Nothing but the driver's own typed error carries a constraint
+		// name, so matching on message text would be a false positive.
+		name: "untyped error whose text mentions a duplicate",
+		err:  errors.New("duplicate key value"),
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.False(t, IsAccountNameConflict(tc.err))
+			require.False(t, IsAccountNameConflict(
+				fmt.Errorf("insert account: %w", tc.err),
+			))
+		})
+	}
+}
+
+// TestIsAccountNameConflictRejectsNil verifies a successful call is never
+// classified as a conflict.
+func TestIsAccountNameConflictRejectsNil(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, IsAccountNameConflict(nil))
+}

--- a/wallet/internal/db/pg/errors.go
+++ b/wallet/internal/db/pg/errors.go
@@ -76,6 +76,15 @@ var reasonByCode = map[string]dberr.Reason{
 	codeExclusionViolation:   dberr.ReasonConstraint,
 }
 
+// IsAccountNameConflict identifies the account-name unique constraint without
+// classifying unrelated uniqueness violations as duplicate accounts.
+func IsAccountNameConflict(err error) bool {
+	var pgErr *pgconn.PgError
+
+	return errors.As(err, &pgErr) && pgErr.Code == codeUniqueViolation &&
+		pgErr.ConstraintName == "uidx_accounts_wallet_scope_account_name"
+}
+
 // mapErr maps PostgreSQL driver and transport errors into SQLError.
 func mapErr(err error) *dberr.SQLError {
 	// Prefer SQLSTATE-based mapping first so a completed PostgreSQL statement

--- a/wallet/internal/db/pg/errors.go
+++ b/wallet/internal/db/pg/errors.go
@@ -8,6 +8,10 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
+// accountNameConstraint is the migrated unique index for account names
+// within a wallet and key scope.
+const accountNameConstraint = "uidx_accounts_wallet_scope_account_name"
+
 // SQLSTATE helper constants support PostgreSQL error classification.
 const (
 	// connectionExceptionClass identifies PostgreSQL SQLSTATE class 08,
@@ -76,13 +80,13 @@ var reasonByCode = map[string]dberr.Reason{
 	codeExclusionViolation:   dberr.ReasonConstraint,
 }
 
-// IsAccountNameConflict identifies the account-name unique constraint without
+// isAccountNameConflict identifies the account-name unique constraint without
 // classifying unrelated uniqueness violations as duplicate accounts.
-func IsAccountNameConflict(err error) bool {
+func isAccountNameConflict(err error) bool {
 	var pgErr *pgconn.PgError
 
 	return errors.As(err, &pgErr) && pgErr.Code == codeUniqueViolation &&
-		pgErr.ConstraintName == "uidx_accounts_wallet_scope_account_name"
+		pgErr.ConstraintName == accountNameConstraint
 }
 
 // mapErr maps PostgreSQL driver and transport errors into SQLError.
@@ -92,7 +96,12 @@ func mapErr(err error) *dberr.SQLError {
 	// transport fallback.
 	var pgErr *pgconn.PgError
 	if errors.As(err, &pgErr) {
-		return mapCode(pgErr.Code, err)
+		sqlErr := mapCode(pgErr.Code, err)
+		if isAccountNameConflict(err) {
+			sqlErr.Constraint = dberr.ConstraintAccountName
+		}
+
+		return sqlErr
 	}
 
 	var connectErr *pgconn.ConnectError

--- a/wallet/internal/db/sqlite/account_test.go
+++ b/wallet/internal/db/sqlite/account_test.go
@@ -1,0 +1,125 @@
+package sqlite
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	sqliteschema "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite"
+	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
+	"github.com/stretchr/testify/require"
+)
+
+// accountConflicts holds a real driver error for each unique constraint the
+// accounts table declares.
+type accountConflicts struct {
+	name   error
+	number error
+}
+
+// provokeAccountConflicts collides with each unique constraint on the accounts
+// table. SQLite names the offending columns in its message rather than the
+// index, so the classifier is exercised against the driver's own text instead
+// of a handwritten copy that could drift from it.
+func provokeAccountConflicts(t *testing.T) accountConflicts {
+	t.Helper()
+
+	conn, err := sql.Open("sqlite", ":memory:?_pragma=foreign_keys(1)")
+	require.NoError(t, err)
+	conn.SetMaxOpenConns(1)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+	require.NoError(t, sqliteschema.ApplyMigrations(conn))
+	queries := sqlc.New(conn)
+	ctx := t.Context()
+	walletID, err := queries.CreateWallet(ctx, sqlc.CreateWalletParams{
+		WalletName: "test",
+	})
+	require.NoError(t, err)
+	scopeID, err := queries.CreateKeyScope(ctx, sqlc.CreateKeyScopeParams{
+		WalletID:       walletID,
+		Purpose:        84,
+		InternalTypeID: int64(db.WitnessPubKey),
+		ExternalTypeID: int64(db.WitnessPubKey),
+	})
+	require.NoError(t, err)
+
+	params := sqlc.CreateDerivedAccountParams{
+		ScopeID:       scopeID,
+		AccountName:   "taken",
+		AccountNumber: sql.NullInt64{Int64: 7, Valid: true},
+	}
+	_, err = queries.CreateDerivedAccount(ctx, params)
+	require.NoError(t, err)
+
+	// Reuse the seeded name with a free number, then a free name with the
+	// seeded number, so each insert can only violate one constraint.
+	params.AccountNumber.Int64 = 8
+	_, nameErr := queries.CreateDerivedAccount(ctx, params)
+	require.Error(t, nameErr)
+
+	params.AccountName = "fresh"
+	params.AccountNumber.Int64 = 7
+	_, numberErr := queries.CreateDerivedAccount(ctx, params)
+	require.Error(t, numberErr)
+
+	return accountConflicts{name: nameErr, number: numberErr}
+}
+
+// TestIsAccountNameConflictMatchesNameColumns verifies a real collision on the
+// account-name constraint is reported as a name conflict, whether the driver
+// error arrives bare or wrapped for context. The wrapped case is why the
+// classifier unwraps instead of asserting the driver type directly.
+func TestIsAccountNameConflictMatchesNameColumns(t *testing.T) {
+	t.Parallel()
+
+	conflicts := provokeAccountConflicts(t)
+
+	require.True(t, IsAccountNameConflict(conflicts.name))
+	require.True(t, IsAccountNameConflict(
+		fmt.Errorf("insert account: %w", conflicts.name),
+	))
+}
+
+// TestIsAccountNameConflictRejectsOtherFailures verifies every other failure
+// is left to another classifier, so a duplicate account name is the only thing
+// that can be reported as one.
+func TestIsAccountNameConflictRejectsOtherFailures(t *testing.T) {
+	t.Parallel()
+
+	conflicts := provokeAccountConflicts(t)
+
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{{
+		// A colliding account number is a distinct outcome the wallet
+		// reports separately, even though it shares the result code.
+		name: "unique violation on the account-number columns",
+		err:  conflicts.number,
+	}, {
+		// Only the driver's typed error carries the result code, so
+		// matching the same words as plain text is a false positive.
+		name: "untyped error carrying the same message text",
+		err:  errors.New(conflicts.name.Error()),
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.False(t, IsAccountNameConflict(tc.err))
+			require.False(t, IsAccountNameConflict(
+				fmt.Errorf("insert account: %w", tc.err),
+			))
+		})
+	}
+}
+
+// TestIsAccountNameConflictRejectsNil verifies a successful call is never
+// classified as a conflict.
+func TestIsAccountNameConflictRejectsNil(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, IsAccountNameConflict(nil))
+}

--- a/wallet/internal/db/sqlite/account_test.go
+++ b/wallet/internal/db/sqlite/account_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	dberr "github.com/btcsuite/btcwallet/wallet/internal/db/err"
 	sqliteschema "github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite"
 	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
 	"github.com/stretchr/testify/require"
@@ -77,9 +78,13 @@ func TestIsAccountNameConflictMatchesNameColumns(t *testing.T) {
 
 	conflicts := provokeAccountConflicts(t)
 
-	require.True(t, IsAccountNameConflict(conflicts.name))
-	require.True(t, IsAccountNameConflict(
-		fmt.Errorf("insert account: %w", conflicts.name),
+	store := &Store{}
+	classified := store.ClassifyError(conflicts.name)
+
+	require.True(t, dberr.IsAccountNameConflict(classified))
+	require.ErrorIs(t, classified, conflicts.name)
+	require.True(t, dberr.IsAccountNameConflict(
+		store.ClassifyError(fmt.Errorf("insert account: %w", conflicts.name)),
 	))
 }
 
@@ -108,9 +113,13 @@ func TestIsAccountNameConflictRejectsOtherFailures(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			require.False(t, IsAccountNameConflict(tc.err))
-			require.False(t, IsAccountNameConflict(
-				fmt.Errorf("insert account: %w", tc.err),
+			store := &Store{}
+
+			require.False(t, dberr.IsAccountNameConflict(
+				store.ClassifyError(tc.err),
+			))
+			require.False(t, dberr.IsAccountNameConflict(
+				store.ClassifyError(fmt.Errorf("insert account: %w", tc.err)),
 			))
 		})
 	}
@@ -121,5 +130,7 @@ func TestIsAccountNameConflictRejectsOtherFailures(t *testing.T) {
 func TestIsAccountNameConflictRejectsNil(t *testing.T) {
 	t.Parallel()
 
-	require.False(t, IsAccountNameConflict(nil))
+	store := &Store{}
+
+	require.False(t, dberr.IsAccountNameConflict(store.ClassifyError(nil)))
 }

--- a/wallet/internal/db/sqlite/errors.go
+++ b/wallet/internal/db/sqlite/errors.go
@@ -37,9 +37,9 @@ var reasonByCode = map[int]dberr.Reason{
 	sqlite3.SQLITE_CANTOPEN:   dberr.ReasonUnknown,
 }
 
-// IsAccountNameConflict identifies the account-name unique constraint without
+// isAccountNameConflict identifies the account-name unique constraint without
 // classifying unrelated uniqueness violations as duplicate accounts.
-func IsAccountNameConflict(err error) bool {
+func isAccountNameConflict(err error) bool {
 	var sqliteErr *sqlite.Error
 
 	return errors.As(err, &sqliteErr) &&
@@ -72,7 +72,12 @@ func mapErr(err error) *dberr.SQLError {
 		reason = dberr.ReasonUnknown
 	}
 
-	return dberr.NewSQLError(dberr.BackendSQLite, reason, codeString, err)
+	sqlErr := dberr.NewSQLError(dberr.BackendSQLite, reason, codeString, err)
+	if isAccountNameConflict(err) {
+		sqlErr.Constraint = dberr.ConstraintAccountName
+	}
+
+	return sqlErr
 }
 
 // codeString formats a SQLite numeric result code for logs and stats.

--- a/wallet/internal/db/sqlite/errors.go
+++ b/wallet/internal/db/sqlite/errors.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"errors"
 	"strconv"
+	"strings"
 
 	dberr "github.com/btcsuite/btcwallet/wallet/internal/db/err"
 	"modernc.org/sqlite"
@@ -34,6 +35,20 @@ var reasonByCode = map[int]dberr.Reason{
 	sqlite3.SQLITE_NOTFOUND:   dberr.ReasonUnknown,
 	sqlite3.SQLITE_SCHEMA:     dberr.ReasonSchemaMismatch,
 	sqlite3.SQLITE_CANTOPEN:   dberr.ReasonUnknown,
+}
+
+// IsAccountNameConflict identifies the account-name unique constraint without
+// classifying unrelated uniqueness violations as duplicate accounts.
+func IsAccountNameConflict(err error) bool {
+	var sqliteErr *sqlite.Error
+
+	return errors.As(err, &sqliteErr) &&
+		sqliteErr.Code() == sqlite3.SQLITE_CONSTRAINT_UNIQUE &&
+		strings.Contains(
+			sqliteErr.Error(),
+			"UNIQUE constraint failed: accounts.wallet_id, "+
+				"accounts.scope_id, accounts.account_name",
+		)
 }
 
 // mapErr maps SQLite result codes into SQLError.


### PR DESCRIPTION
## Change Description

Implements Task [378](https://github.com/yyforyongyu/btcwallet-sql-roadmap/blob/main/tasks/378-account-manager-error-boundary.md) by translating public AccountManager failures to wallet-owned error identities instead of exposing `db`, `waddrmgr`, or `keyvault` sentinels.

This change:

- defines the AccountManager-specific `ErrAccountAlreadyExists`, `ErrAccountOperationUnsupported`, and `ErrAccountDerivationExhausted` identities;
- normalizes missing-account, duplicate-name, invalid-request, unsupported-operation, locked-state, and derivation-exhaustion outcomes across SQL and kvdb;
- preserves cancellation, deadline, lifecycle, and invalid-account-key identities while retaining diagnostic context without leaking backend identities;
- enforces validation, lock, and occupied-name precedence before account mutation; and
- classifies only account-name uniqueness violations in SQLite and PostgreSQL, leaving unrelated constraint failures unchanged.

The internal initial-account import path remains untranslated so this PR does not introduce an AccountManager error contract into `Manager.Create`. The broader real-backend mutation-error matrix remains owned by Task [462](https://github.com/yyforyongyu/btcwallet-sql-roadmap/blob/main/tasks/462-account-mutation-error-itests.md).

## Steps to Test

```bash
go test ./... -count=1

go test -race -shuffle=on ./wallet ./wallet/internal/db/pg \
  ./wallet/internal/db/sqlite \
  -run 'Test(AccountManager|AccountInfo|NewAccount|GetAccount|ListAccounts|RenameAccount|ImportAccount|IsAccountNameConflict)' \
  -count=1

scripts/check-each-commit.sh origin/sql-wallet

make itest-db db=sqlite
make itest-db db=postgres
```

## Pull Request Checklist

### Testing

- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation

- [x] The change is not [insubstantial](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md#ideal-git-commit-structure).
- [x] Any new logging statements use an appropriate subsystem and logging level.

Please see our [Contribution Guidelines](https://github.com/btcsuite/btcwallet/blob/master/docs/developer/contribution_guidelines.md) for further guidance.
