### PR TITLE
wtxmgr: keep confirmation leases past wall-clock expiry

### DIFF
--- a/wallet/interface.go
+++ b/wallet/interface.go
@@ -228,7 +228,9 @@ type Interface interface {
 		duration time.Duration) (time.Time, error)
 
 	// LeaseOutputWithOptions locks an output and applies optional persisted
-	// transaction-store lock behavior.
+	// transaction-store lock behavior. Confirmation-controlled leases ignore
+	// the returned wall-clock expiration and require explicit release if no
+	// spend reaches their requested depth.
 	LeaseOutputWithOptions(id wtxmgr.LockID, op wire.OutPoint,
 		duration time.Duration,
 		optFuncs ...wtxmgr.LockOutputOption) (time.Time, error)

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -3297,7 +3297,9 @@ func (w *Wallet) LeaseOutput(id wtxmgr.LockID, op wire.OutPoint,
 }
 
 // LeaseOutputWithOptions locks an output to the given ID and applies optional
-// transaction-store lock behavior.
+// transaction-store lock behavior. Confirmation-controlled leases ignore the
+// returned wall-clock expiration and require explicit release if no spend
+// reaches their requested depth.
 func (w *Wallet) LeaseOutputWithOptions(id wtxmgr.LockID, op wire.OutPoint,
 	duration time.Duration,
 	optFuncs ...wtxmgr.LockOutputOption) (time.Time, error) {

--- a/wtxmgr/db.go
+++ b/wtxmgr/db.go
@@ -1341,22 +1341,21 @@ func fetchLockedOutput(ns walletdb.ReadBucket,
 }
 
 // isLockedOutput determines whether an output is locked. If it is, its assigned
-// ID is returned, along with its absolute expiration time. If the output lock
-// exists, but its expiration has been met, then the output is considered
-// unlocked.
+// ID is returned, along with its absolute expiration time. Confirmation-
+// controlled locks ignore that time and remain active until explicit release or
+// spend maturity. Other locks become inactive when their expiration is met.
 func isLockedOutput(ns walletdb.ReadBucket, op wire.OutPoint,
 	timeNow time.Time) (LockID, time.Time, bool) {
 
-	lockID, expiry, releaseAfterSpendConfs, spendHeight, exists :=
+	lockID, expiry, releaseAfterSpendConfs, _, exists :=
 		fetchLockedOutput(ns, op)
 	if !exists {
 		return LockID{}, time.Time{}, false
 	}
 
-	// Once a retained lease has observed a confirmed spend, its wall clock
-	// expiry no longer applies. A negative spend height means that the observed
-	// spend was disconnected and is waiting to confirm again.
-	if releaseAfterSpendConfs > 0 && spendHeight != 0 {
+	// A confirmation-controlled lease uses explicit release or spend maturity
+	// instead of wall-clock expiry for its complete lifetime.
+	if releaseAfterSpendConfs > 0 {
 		return lockID, expiry, true
 	}
 

--- a/wtxmgr/tx.go
+++ b/wtxmgr/tx.go
@@ -129,13 +129,15 @@ type TxRecord struct {
 // LockedOutput is a type that contains an outpoint of an UTXO and its lock
 // lease information.
 type LockedOutput struct {
-	Outpoint   wire.OutPoint
-	LockID     LockID
+	Outpoint wire.OutPoint
+	LockID   LockID
+
+	// Expiration controls a wall-clock lease. Confirmation-controlled leases
+	// retain this value for storage compatibility but do not apply it.
 	Expiration time.Time
 
-	// ReleaseAfterSpendConfs is the confirmation depth that replaces
-	// wall-clock expiry after a confirmed spend is observed. A value of
-	// zero preserves the normal wall-clock-only lease behavior.
+	// ReleaseAfterSpendConfs is the confirmation depth that controls release
+	// instead of Expiration. A value of zero selects wall-clock expiry.
 	ReleaseAfterSpendConfs uint32
 
 	// ConfirmedSpendHeight records spend confirmation progress. Zero means
@@ -153,15 +155,15 @@ type lockOutputOptions struct {
 	releaseAfterSpendConfsSet bool
 }
 
-// WithReleaseAfterSpend keeps an output locked after a confirmed spend is
-// observed until that spend reaches the requested confirmation count. Before
-// the spend is confirmed, the normal wall-clock expiration applies. A
-// reorganization that disconnects the spend resets its confirmation progress
-// and keeps the lock active. A zero confirmation count preserves the normal
-// wall-clock-only lease behavior. Older software reads the record as a
-// time-only lease, so do not downgrade while a retained lease still protects
-// a spend below this threshold. On an active same-owner renewal, omitting this
-// option preserves the existing depth; passing it replaces that depth.
+// WithReleaseAfterSpend keeps an output locked until its spend reaches the
+// requested confirmation count or the owner explicitly releases it. A
+// confirmation-controlled lease ignores wall-clock expiry, including before its
+// first confirmed spend. A reorganization that disconnects the spend resets its
+// confirmation progress and keeps the lock active. A zero confirmation count
+// selects normal wall-clock expiry. Older software reads the record as a
+// time-only lease, so do not downgrade while a confirmation-controlled lease is
+// active. On an active same-owner renewal, omitting this option preserves the
+// existing depth; passing it replaces that depth.
 func WithReleaseAfterSpend(confirmations uint32) LockOutputOption {
 	return func(opts *lockOutputOptions) {
 		opts.releaseAfterSpendConfs = confirmations
@@ -497,13 +499,11 @@ func (s *Store) insertMinedTx(ns walletdb.ReadWriteBucket, rec *TxRecord,
 	// Clear normal output locks after a confirmed spend. Maturity-tracked
 	// locks record the spend height and remain until enough blocks bury it.
 	for _, txIn := range rec.MsgTx.TxIn {
-		lockID, expiry, releaseAfterSpendConfs, spendHeight, exists :=
+		lockID, expiry, releaseAfterSpendConfs, _, exists :=
 			fetchLockedOutput(
 				ns, txIn.PreviousOutPoint,
 			)
-		retainedLockActive := s.clock.Now().Before(expiry) ||
-			spendHeight != 0
-		if exists && releaseAfterSpendConfs > 0 && retainedLockActive {
+		if exists && releaseAfterSpendConfs > 0 {
 			if err := lockOutput(
 				ns, lockID, txIn.PreviousOutPoint, expiry,
 				releaseAfterSpendConfs, block.Height,
@@ -1329,9 +1329,10 @@ func isKnownOutput(ns walletdb.ReadWriteBucket, op wire.OutPoint) bool {
 }
 
 // LockOutput locks an output to the given ID, preventing it from being
-// available for coin selection. The absolute time of the lock's expiration is
-// returned. The expiration of the lock can be extended by successive
-// invocations of this call.
+// available for coin selection. It returns the absolute wall-clock expiration.
+// Successive calls can extend that time. A confirmation-controlled lock stores
+// the time for compatibility but ignores it until the owner explicitly releases
+// the lock or its spend reaches the requested depth.
 //
 // Outputs can be unlocked before their expiration through `UnlockOutput`.
 // Otherwise, they are unlocked lazily through calls which iterate through all
@@ -1397,10 +1398,10 @@ func (s *Store) UnlockOutput(ns walletdb.ReadWriteBucket, id LockID,
 	// Retained locks can outlive the confirmed spend of their output. Read
 	// the lock before checking whether the output is currently known so the
 	// owner can explicitly release it while it is spent.
-	lockedID, expiry, releaseAfterSpendConfs, spendHeight, exists :=
+	lockedID, expiry, releaseAfterSpendConfs, _, exists :=
 		fetchLockedOutput(ns, op)
 	isLocked := exists && (s.clock.Now().Before(expiry) ||
-		releaseAfterSpendConfs > 0 && spendHeight != 0)
+		releaseAfterSpendConfs > 0)
 	if !isLocked {
 		if !isKnownOutput(ns, op) {
 			return ErrUnknownOutput
@@ -1426,9 +1427,9 @@ func (s *Store) DeleteExpiredLockedOutputs(ns walletdb.ReadWriteBucket) error {
 	var expiredOutputs []wire.OutPoint
 	err := forEachLockedOutput(
 		ns, func(op wire.OutPoint, _ LockID, expiration time.Time) {
-			_, _, releaseAfterSpendConfs, spendHeight, _ :=
+			_, _, releaseAfterSpendConfs, _, _ :=
 				fetchLockedOutput(ns, op)
-			if releaseAfterSpendConfs > 0 && spendHeight != 0 {
+			if releaseAfterSpendConfs > 0 {
 				return
 			}
 
@@ -1450,10 +1451,10 @@ func (s *Store) DeleteExpiredLockedOutputs(ns walletdb.ReadWriteBucket) error {
 	return nil
 }
 
-// DeleteMaturedLockedOutputs removes leases whose confirmed spending
-// transaction has reached the release depth requested when the output was
-// locked. Once a confirmed spend has been observed, wall clock expiration is
-// disabled until this depth is reached or the lease is explicitly released.
+// DeleteMaturedLockedOutputs removes confirmation-controlled leases whose
+// spending transaction has reached its requested release depth. These leases
+// ignore wall-clock expiration throughout their lifetime and otherwise require
+// explicit release.
 func (s *Store) DeleteMaturedLockedOutputs(ns walletdb.ReadWriteBucket,
 	chainHeight int32) error {
 
@@ -1500,7 +1501,7 @@ func (s *Store) DeleteMaturedLockedOutputs(ns walletdb.ReadWriteBucket,
 
 // resetLockedOutputSpendHeights clears confirmation progress for spends in a
 // block being disconnected by a rollback. A negative height records that a
-// spend has already been observed, so wall clock expiry remains disabled.
+// spend has already been observed and is waiting to confirm again.
 func resetLockedOutputSpendHeights(ns walletdb.ReadWriteBucket,
 	rollbackHeight int32) error {
 
@@ -1564,10 +1565,10 @@ func (s *Store) ListLockedOutputs(ns walletdb.ReadBucket) ([]*LockedOutput,
 			_, _, releaseAfterSpendConfs, spendHeight, _ :=
 				fetchLockedOutput(ns, op)
 
-			// Skip expired leases. They will be cleaned up with the
-			// next call to DeleteExpiredLockedOutputs.
+			// Skip expired wall-clock leases. Confirmation-controlled
+			// leases remain visible until maturity or explicit release.
 			if !s.clock.Now().Before(expiration) &&
-				!(releaseAfterSpendConfs > 0 && spendHeight != 0) {
+				releaseAfterSpendConfs == 0 {
 
 				return
 			}

--- a/wtxmgr/tx_test.go
+++ b/wtxmgr/tx_test.go
@@ -2752,17 +2752,17 @@ func TestOutputLocks(t *testing.T) {
 			},
 		},
 		{
-			// Asserts that reusing an ID after its retained lease
-			// expires does not carry the old release policy into the
-			// new lease.
-			name: "reuse lock ID after expiry",
+			// Asserts that a confirmation-controlled lease ignores its
+			// wall-clock expiry but still permits explicit owner release.
+			name: "confirmation lease ignores wall clock",
 			run: func(t *testing.T, s *Store, ns walletdb.ReadWriteBucket) {
 				t.Helper()
 
-				lockID := LockID{1}
+				lockID1 := LockID{1}
+				lockID2 := LockID{2}
 
 				expiry, err := s.LockOutput(
-					ns, lockID, confirmedOutPoint, 10*time.Minute,
+					ns, lockID1, confirmedOutPoint, 10*time.Minute,
 					WithReleaseAfterSpend(3),
 				)
 				if err != nil {
@@ -2778,34 +2778,36 @@ func TestOutputLocks(t *testing.T) {
 
 				testClock.SetTime(expiry)
 				assertLocked(
-					t, ns, confirmedOutPoint, s.clock.Now(), false,
+					t, ns, confirmedOutPoint, s.clock.Now(), true,
 				)
+
+				err = s.DeleteExpiredLockedOutputs(ns)
+				if err != nil {
+					t.Fatal(err)
+				}
+				assertRetainedLock(t, s, ns, 3, 0)
 
 				_, err = s.LockOutput(
-					ns, lockID, confirmedOutPoint, 10*time.Minute,
+					ns, lockID2, confirmedOutPoint, 10*time.Minute,
+				)
+				if err != ErrOutputAlreadyLocked {
+					t.Fatalf("expected %v, got %v",
+						ErrOutputAlreadyLocked, err)
+				}
+
+				unlock(
+					t, s, ns, lockID2, confirmedOutPoint,
+					ErrOutputUnlockNotAllowed,
+				)
+				unlock(t, s, ns, lockID1, confirmedOutPoint, nil)
+
+				_, err = s.LockOutput(
+					ns, lockID1, confirmedOutPoint, 10*time.Minute,
 				)
 				if err != nil {
 					t.Fatal(err)
 				}
-
 				assertRetainedLock(t, s, ns, 0, 0)
-
-				txHash := confirmedTx.TxHash()
-				spendTx := spendOutput(&txHash, 0, 500)
-
-				spendRec, err := NewTxRecordFromMsgTx(
-					spendTx, time.Now(),
-				)
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				err = s.InsertTx(ns, spendRec, block)
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				assertOutputLocksExist(t, s, ns)
 			},
 		},
 		{
@@ -3066,6 +3068,14 @@ func TestOutputLockReleaseAfterSpendAcrossReorg(t *testing.T) {
 			return err
 		}
 
+		// The first confirmation may arrive after the wall-clock deadline.
+		// Confirmation-controlled leases must still record that spend.
+		store.clock.(*clock.TestClock).SetTime(expiry.Add(time.Second))
+		if err := store.DeleteExpiredLockedOutputs(ns); err != nil {
+			return err
+		}
+		assertRetainedLock(t, store, ns, 3, 0)
+
 		if err := store.InsertTx(ns, spendRec, spendBlock); err != nil {
 			return err
 		}
@@ -3083,7 +3093,7 @@ func TestOutputLockReleaseAfterSpendAcrossReorg(t *testing.T) {
 
 		// Renewing the lease must preserve the disconnected spend state
 		// and its configured release depth.
-		_, err = store.LockOutput(
+		renewedExpiry, err := store.LockOutput(
 			ns, lockID, creditOutpoint, 10*time.Minute,
 		)
 		if err != nil {
@@ -3118,7 +3128,9 @@ func TestOutputLockReleaseAfterSpendAcrossReorg(t *testing.T) {
 
 		// A lease that has observed a spend must survive its wall clock
 		// expiry while that spend is disconnected.
-		store.clock.(*clock.TestClock).SetTime(expiry.Add(time.Second))
+		store.clock.(*clock.TestClock).SetTime(
+			renewedExpiry.Add(time.Second),
+		)
 		if err := store.DeleteExpiredLockedOutputs(ns); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Problem

#1351 made output leases survive a shallow reorg after their spend confirms.
Before the first confirmation, the lease still used its wall-clock deadline.

If confirmation took longer than that deadline, expired-lock cleanup deleted
the row. A later confirmation could no longer start confirmation tracking. This
breaks the reorg protection needed by lightningnetwork/lnd#11125 during a fee
spike or other slow-confirmation period.

## Fix

Treat a non-zero `WithReleaseAfterSpend` depth as a separate lease lifetime:

- `depth == 0`: release at the wall-clock expiration
- `depth > 0`: ignore wall-clock expiration and release at the requested spend
  depth or by an explicit owner `UnlockOutput`

The database encoding is unchanged.

## Safety invariant

Elapsed wall-clock time cannot remove a confirmation-controlled lease. Only
spend maturity or an authenticated owner release can remove it.

An abandoned confirmation-controlled lease now requires explicit owner
release. This trades bounded availability for the requested reorg guarantee.

## Compatibility

- Existing time-only leases keep their current behavior.
- `WithReleaseAfterSpend(0)` remains time-only.
- Surviving non-zero-depth rows written by #1351 gain the corrected behavior
  immediately after upgrade.
- Older software treats these rows as time-only leases. Do not downgrade while
  a confirmation-controlled lease is active.

## Tests

- expiry before the first spend confirmation
- expired cleanup preserves a confirmation-controlled lease
- another owner remains blocked and cannot release the lease
- the correct owner can release it explicitly
- a later time-only lease does not inherit the old release depth
- late confirmation records its spend height
- rollback, expiry while disconnected, reconfirmation, and final maturity

Local checks:

- `go test ./...` and `go test -race ./...` in `wtxmgr`
- `go test ./wallet` and `go test -race ./wallet`
- `go vet` for both changed modules
- `make fmt-check`
- `make tidy-module-check`
