### PR TITLE
wallet: publish a transaction label limit

### DIFF
--- a/itest/tx_writer_test.go
+++ b/itest/tx_writer_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/btcsuite/btcwallet/bwtest"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet"
-	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/stretchr/testify/require"
 )
 
@@ -94,21 +93,18 @@ func testLabelTxReplace(h *bwtest.HarnessTest) {
 	)
 }
 
-// testLabelTxBoundaries verifies the ends of the label length range every
-// backend accepts: one character, and the longest label the wallet stores.
+// testLabelTxBoundaries verifies the ends of the label length range the wallet
+// accepts: one byte, and a label of exactly wallet.MaxTxLabelLength bytes.
 //
-// The upper limit is wtxmgr.TxLabelLimit, which is the only exported name for
-// it; the SQL schemas restate the same number as a column constraint. Labels
-// are built from ASCII deliberately, because kvdb counts the limit in bytes
-// while the SQL schemas count it in characters, and only ASCII makes the one
-// number mean the same thing on all three backends.
+// The limit is stated in bytes, so a label of multi-byte runes reaches it in
+// fewer characters. Both spellings of the longest accepted label are rows here,
+// because the stores under this API do not agree on the unit and the wallet's
+// own limit is what settles it.
 //
-// The values just outside this range are not rows here. One character above it
-// is refused by every backend, but with a backend-specific error rather than a
-// wallet error identity, so it is asserted separately in
-// testLabelTxRejectOversize. The empty label below it has no single behavior to
-// assert at all: the SQL backends accept it and clear the label, while kvdb
-// refuses it.
+// The first value past the limit is refused rather than accepted, so it is
+// asserted separately in testLabelTxRejectOversize. The empty label below this
+// range still has no single behavior to assert: the SQL backends accept it and
+// clear the label, while kvdb refuses it.
 func testLabelTxBoundaries(h *bwtest.HarnessTest) {
 	w, funding := h.NewWallet(bwtest.WalletFixture{
 		AddrType: txWriterFundingType,
@@ -127,7 +123,17 @@ func testLabelTxBoundaries(h *bwtest.HarnessTest) {
 		},
 		{
 			name:  "longest label",
-			label: strings.Repeat("x", wtxmgr.TxLabelLimit),
+			label: strings.Repeat("x", wallet.MaxTxLabelLength),
+		},
+		{
+			// Three bytes per rune, so a third of the limit in
+			// characters already spends nearly all of it in bytes.
+			// A character limit of the same size would leave room
+			// for three times as many.
+			name: "multi-byte label near the limit",
+			label: strings.Repeat(
+				"€", wallet.MaxTxLabelLength/3,
+			),
 		},
 	}
 
@@ -192,21 +198,14 @@ func testLabelTxRejectUnknown(h *bwtest.HarnessTest) {
 	)
 }
 
-// testLabelTxRejectOversize verifies that the first label longer than the
-// wallet stores is refused by every backend, and that the refusal leaves the
-// transaction's existing label in place rather than truncating it to fit.
+// testLabelTxRejectOversize verifies that the first label past the limit is
+// refused with the wallet's own identity on every backend, and that the refusal
+// leaves the transaction's existing label in place rather than truncating it to
+// fit.
 //
-// The rejection is asserted only as an error. Every backend enforces the limit
-// itself, so the caller receives whichever of three unrelated values that
-// backend produces: kvdb reports wtxmgr.ErrLabelTooLong, SQLite a violated
-// CHECK constraint, and PostgreSQL an overlong value for its column type. There
-// is no wallet error identity to match on, and matching any one backend's text
-// would tie this case to a detail no contract promises. That missing identity
-// is a gap in LabelTx, not in this case.
-//
-// The identities LabelTx does publish are ruled out instead, so the case still
-// fails if the write is ever refused for a reason other than the label it was
-// given.
+// One identity is the point of the case. Each store also enforces a limit and
+// reports its own violation, and before the wallet published a limit of its own
+// a caller met whichever of those three the backend happened to produce.
 func testLabelTxRejectOversize(h *bwtest.HarnessTest) {
 	const kept = "rent for march"
 
@@ -220,20 +219,15 @@ func testLabelTxRejectOversize(h *bwtest.HarnessTest) {
 	err := w.LabelTx(h.Context(), txHash, kept)
 	require.NoError(h, err, "failed to label the funding transaction")
 
-	// One character past the longest label testLabelTxBoundaries stores, so
+	// One byte past the longest label testLabelTxBoundaries stores, so
 	// length is the only thing wrong with it.
-	oversize := strings.Repeat("x", wtxmgr.TxLabelLimit+1)
+	oversize := strings.Repeat("x", wallet.MaxTxLabelLength+1)
 
 	err = w.LabelTx(h.Context(), txHash, oversize)
 
-	require.Error(h, err, "label longer than the limit was accepted")
-	require.NotErrorIs(
-		h, err, wallet.ErrTxNotFound,
-		"label was refused for a transaction the wallet holds",
-	)
-	require.NotErrorIs(
-		h, err, wallet.ErrStateForbidden,
-		"label was refused by the lifecycle gate on a running wallet",
+	require.ErrorIs(
+		h, err, wallet.ErrLabelTooLong,
+		"label longer than the limit was not refused as too long",
 	)
 
 	detail, err := w.GetTx(h.Context(), txHash)

--- a/wallet/tx_writer.go
+++ b/wallet/tx_writer.go
@@ -13,10 +13,25 @@ import (
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 )
 
+// MaxTxLabelLength is the longest transaction label the wallet stores,
+// measured in bytes.
+//
+// Every store enforces a limit of its own, but not the same one: the legacy
+// kvdb store counts bytes while the SQL schemas constrain characters. Counting
+// bytes here is the stricter reading, so a label this API accepts satisfies
+// every store and no backend constraint can reject a label the wallet already
+// approved. Those constraints remain as defence in depth.
+const MaxTxLabelLength = 500
+
+// ErrLabelTooLong is returned when a transaction label exceeds
+// MaxTxLabelLength. Callers can match this error with errors.Is.
+var ErrLabelTooLong = errors.New("transaction label exceeds limit")
+
 // TxWriter provides an interface for updating wallet txns.
 type TxWriter interface {
 	// LabelTx adds a label to a tx. If a label already exists, it will be
-	// overwritten.
+	// overwritten. Labels longer than MaxTxLabelLength bytes are rejected
+	// with ErrLabelTooLong.
 	LabelTx(ctx context.Context, hash chainhash.Hash, label string) error
 }
 
@@ -24,13 +39,24 @@ type TxWriter interface {
 var _ TxWriter = (*Wallet)(nil)
 
 // LabelTx adds a label to a tx. If a label already exists, it will be
-// overwritten.
+// overwritten. Labels longer than MaxTxLabelLength bytes are rejected with
+// ErrLabelTooLong.
+//
+// NOTE: This method is part of the TxWriter interface.
 func (w *Wallet) LabelTx(ctx context.Context,
 	hash chainhash.Hash, label string) error {
 
 	err := w.state.validateStarted()
 	if err != nil {
 		return err
+	}
+
+	// Reject an oversized label here rather than letting each store report
+	// its own constraint violation, which is how the same rejection reached
+	// callers as three unrelated errors.
+	if len(label) > MaxTxLabelLength {
+		return fmt.Errorf("%w: %d bytes, limit is %d", ErrLabelTooLong,
+			len(label), MaxTxLabelLength)
 	}
 
 	err = w.store.UpdateTx(ctx, db.UpdateTxParams{

--- a/wallet/tx_writer_test.go
+++ b/wallet/tx_writer_test.go
@@ -5,6 +5,7 @@
 package wallet
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
@@ -52,6 +53,65 @@ func TestLabelTxEmptyLabel(t *testing.T) {
 	err := w.LabelTx(t.Context(), *TstTxHash, empty)
 
 	require.ErrorIs(t, err, wtxmgr.ErrEmptyLabel)
+	mocks.store.AssertExpectations(t)
+}
+
+// TestLabelTxAtLimit tests that a label of exactly the maximum length reaches
+// the store, so the limit rejects only what lies past it.
+func TestLabelTxAtLimit(t *testing.T) {
+	t.Parallel()
+
+	w, mocks := createStartedWalletWithMocks(t)
+
+	longest := strings.Repeat("x", MaxTxLabelLength)
+	mocks.store.On("UpdateTx", mock.Anything, db.UpdateTxParams{
+		WalletID: w.id,
+		Txid:     *TstTxHash,
+		Label:    &longest,
+	}).Return(nil).Once()
+
+	err := w.LabelTx(t.Context(), *TstTxHash, longest)
+
+	require.NoError(t, err)
+	mocks.store.AssertExpectations(t)
+}
+
+// TestLabelTxTooLong tests that a label past the maximum length is rejected
+// with the wallet's own error before any store sees it. The store is left
+// without expectations on purpose: reaching it at all is the failure.
+func TestLabelTxTooLong(t *testing.T) {
+	t.Parallel()
+
+	w, mocks := createStartedWalletWithMocks(t)
+
+	err := w.LabelTx(
+		t.Context(), *TstTxHash, strings.Repeat("x", MaxTxLabelLength+1),
+	)
+
+	require.ErrorIs(t, err, ErrLabelTooLong)
+	mocks.store.AssertExpectations(t)
+}
+
+// TestLabelTxMultiByteTooLong tests that the limit counts bytes rather than
+// characters. A label of three-byte runes can sit well inside a character
+// limit and past a byte limit at once, which is the case where the stores
+// disagree: the SQL schemas would keep it and the legacy kvdb store would
+// refuse it, so the wallet settles which one it is.
+func TestLabelTxMultiByteTooLong(t *testing.T) {
+	t.Parallel()
+
+	w, mocks := createStartedWalletWithMocks(t)
+
+	// Three bytes per rune, so one rune more than a third of the limit is
+	// the shortest label that is inside it in characters and past it in
+	// bytes.
+	label := strings.Repeat("€", MaxTxLabelLength/3+1)
+	require.Greater(t, len(label), MaxTxLabelLength)
+	require.Less(t, len([]rune(label)), MaxTxLabelLength)
+
+	err := w.LabelTx(t.Context(), *TstTxHash, label)
+
+	require.ErrorIs(t, err, ErrLabelTooLong)
 	mocks.store.AssertExpectations(t)
 }
 


### PR DESCRIPTION
Follow-up to #1347, which covered `LabelTx` with integration tests and found
that the API has no limit of its own.

Every store refuses a label past 500 and each refuses it differently, so a
caller wanting to handle the case had to match a database driver's error:

| backend | error at 501 bytes |
|---|---|
| kvdb | `wtxmgr.ErrLabelTooLong` |
| SQLite | `*sqlite.Error: CHECK constraint failed: length(tx_label) <= 500 (275)` |
| PostgreSQL | `*pgconn.PgError: value too long for type character varying(500) (SQLSTATE 22001)` |

The stores also disagree on what they count. `wtxmgr` limits bytes while both
SQL schemas limit characters, so a 200-character label of three-byte runes was
refused by kvdb and stored as 600 bytes by the other two. There was no single
limit to publish.

This adds `wallet.MaxTxLabelLength` and `wallet.ErrLabelTooLong`, checked in
`LabelTx` above the stores. The `txwriter reject oversize label` integration
case becomes an `ErrorIs` like every other rejection in that suite, and the
boundary case takes the limit from the wallet, which retires the `itest`
package's last use of `wtxmgr`.

## The limit counts bytes

A byte budget of 500 is the stricter of the two readings: any label within it is
also within a 500-character limit, so no store constraint can fire for a label
the wallet already accepted. Checking characters instead would let the wallet
accept labels kvdb then refuses, which is the problem being fixed. Those store
constraints stay where they are, now as defence in depth rather than as the
contract.

**This tightens the SQL backends.** A label over 500 bytes but under 500
characters is accepted today and will be refused. Nothing in the codebase writes
labels that large, and the deprecated `LabelTransaction` has always documented
that the call fails when the label is too long.

## Testing

- `go test ./wallet/ -run TestLabelTx` — added cases at the limit, one byte past
  it, and a multi-byte label a character limit would have let through.
- `make itest icase='txwriter'` on `db=sqlite`, `db=kvdb` and `db=postgres`, and
  on `chain=bitcoind`.
- Full itest suite shuffled on sqlite (`-shuffleseed=42`) and kvdb
  (`-shuffleseed=7`), no failures or skips.
- `golangci-lint` clean on `wallet` and `itest`.
