### PR TITLE
wallet+kvdb: clear a transaction label with an empty one

### DIFF
--- a/bwtest/mock/tx_store.go
+++ b/bwtest/mock/tx_store.go
@@ -122,6 +122,14 @@ func (m *TxStore) PutTxLabel(ns walletdb.ReadWriteBucket,
 	return args.Error(0)
 }
 
+// DeleteTxLabel implements the wtxmgr.TxStore interface.
+func (m *TxStore) DeleteTxLabel(ns walletdb.ReadWriteBucket,
+	txid chainhash.Hash) error {
+
+	args := m.Called(ns, txid)
+	return args.Error(0)
+}
+
 // RangeTransactions implements the wtxmgr.TxStore interface.
 func (m *TxStore) RangeTransactions(ns walletdb.ReadBucket, begin,
 	end int32, f func([]wtxmgr.TxDetails) (bool, error)) error {

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -290,6 +290,10 @@ var allTestCases = []*testCase{
 		TestFunc: testLabelTxReplace,
 	},
 	{
+		Name:     "txwriter clear label",
+		TestFunc: testLabelTxClear,
+	},
+	{
 		Name:     "txwriter label boundaries",
 		TestFunc: testLabelTxBoundaries,
 	},

--- a/itest/tx_writer_test.go
+++ b/itest/tx_writer_test.go
@@ -93,6 +93,61 @@ func testLabelTxReplace(h *bwtest.HarnessTest) {
 	)
 }
 
+// testLabelTxClear verifies that an empty label removes the label a
+// transaction already had, that removing a label a transaction never had is
+// not an error, and that a cleared label stays cleared across a reload.
+//
+// The empty label is the only way to remove one through this API, so a wallet
+// that refused it would leave a caller no way to undo a label at all.
+func testLabelTxClear(h *bwtest.HarnessTest) {
+	const label = "rent for march"
+
+	w, funding := h.NewWallet(bwtest.WalletFixture{
+		AddrType: txWriterFundingType,
+		Amounts:  []btcutil.Amount{oneBTC},
+	})
+
+	txHash := funding.WalletOutpoints[0].Hash
+
+	err := w.LabelTx(h.Context(), txHash, label)
+	require.NoError(h, err, "failed to label transaction")
+
+	err = w.LabelTx(h.Context(), txHash, "")
+
+	require.NoError(h, err, "clearing a label was refused")
+
+	detail, err := w.GetTx(h.Context(), txHash)
+	require.NoError(h, err, "failed to read the cleared transaction")
+	require.Empty(h, detail.Label, "point read still reports a label")
+
+	details, err := w.ListTxns(h.Context(), unminedHeight, 0)
+	require.NoError(h, err, "failed to list transactions")
+
+	listed := make(map[chainhash.Hash]string, len(details))
+	for _, detail := range details {
+		listed[detail.Hash] = detail.Label
+	}
+
+	// Assert the transaction is listed before reading its label, so an
+	// absent entry fails here rather than reading as an empty label.
+	require.Contains(h, listed, txHash, "list read lost the transaction")
+	require.Empty(h, listed[txHash], "list read still reports a label")
+
+	// A transaction with no label is what the caller asked for and already
+	// has, so asking again is not an error.
+	err = w.LabelTx(h.Context(), txHash, "")
+	require.NoError(h, err, "clearing an absent label was refused")
+
+	// The removal is durable rather than a property of the running wallet.
+	reloaded := h.ReloadWallet(w)
+
+	detail, err = reloaded.GetTx(h.Context(), txHash)
+	require.NoError(h, err, "reloaded wallet lost the transaction")
+	require.Empty(
+		h, detail.Label, "reloaded wallet restored the cleared label",
+	)
+}
+
 // testLabelTxBoundaries verifies the ends of the label length range the wallet
 // accepts: one byte, and a label of exactly wallet.MaxTxLabelLength bytes.
 //
@@ -103,8 +158,8 @@ func testLabelTxReplace(h *bwtest.HarnessTest) {
 //
 // The first value past the limit is refused rather than accepted, so it is
 // asserted separately in testLabelTxRejectOversize. The empty label below this
-// range still has no single behavior to assert: the SQL backends accept it and
-// clear the label, while kvdb refuses it.
+// range is not a boundary of it at all: it removes a label rather than setting
+// a short one, and testLabelTxClear covers it.
 func testLabelTxBoundaries(h *bwtest.HarnessTest) {
 	w, funding := h.NewWallet(bwtest.WalletFixture{
 		AddrType: txWriterFundingType,

--- a/wallet/internal/db/kvdb/txstore.go
+++ b/wallet/internal/db/kvdb/txstore.go
@@ -292,6 +292,20 @@ func (s *Store) UpdateTx(_ context.Context, params db.UpdateTxParams) error {
 			return db.ErrTxNotFound
 		}
 
+		// The empty label is how a caller removes one, and this store
+		// records the absence of a label as a missing entry rather than
+		// as a stored empty value, so clearing is a delete.
+		if len(*label) == 0 {
+			err = s.txStore.DeleteTxLabel(ns, params.Txid)
+			if err != nil {
+				return fmt.Errorf(
+					"delete transaction label: %w", err,
+				)
+			}
+
+			return nil
+		}
+
 		err = s.txStore.PutTxLabel(ns, params.Txid, *label)
 		if err != nil {
 			return fmt.Errorf("put transaction label: %w", err)

--- a/wallet/internal/db/kvdb/txstore_test.go
+++ b/wallet/internal/db/kvdb/txstore_test.go
@@ -1123,9 +1123,10 @@ func TestUpdateTxRejectsUnsupportedPatches(t *testing.T) {
 	require.ErrorIs(t, err, errNotImplemented)
 }
 
-// TestUpdateTxEmptyLabelPreservesLegacyError verifies that kvdb keeps the
-// legacy empty-label rejection instead of reaching into private buckets.
-func TestUpdateTxEmptyLabelPreservesLegacyError(t *testing.T) {
+// TestUpdateTxEmptyLabelClears verifies that an empty label removes the label
+// a transaction already had, which is what the Store contract means by an
+// empty label and what the SQL backends do with one.
+func TestUpdateTxEmptyLabelClears(t *testing.T) {
 	t.Parallel()
 
 	dbConn, cleanup := newTestDB(t)
@@ -1162,7 +1163,60 @@ func TestUpdateTxEmptyLabelPreservesLegacyError(t *testing.T) {
 		Txid:     rec.Hash,
 		Label:    &empty,
 	})
-	require.ErrorContains(t, err, "empty transaction label not allowed")
+	require.NoError(t, err)
+
+	err = walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(wtxmgrNamespaceKey)
+		require.NotNil(t, ns)
+
+		// The label reads back as absent rather than as a stored empty
+		// value, which is the only form this store can report without
+		// erroring.
+		details, err := txStore.TxDetails(ns, &rec.Hash)
+		require.NoError(t, err)
+		require.NotNil(t, details)
+		require.Empty(t, details.Label)
+
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// TestUpdateTxEmptyLabelWithoutLabel verifies that clearing a label a
+// transaction never had succeeds. The caller asked for a transaction with no
+// label and already has one, so there is nothing to refuse.
+func TestUpdateTxEmptyLabelWithoutLabel(t *testing.T) {
+	t.Parallel()
+
+	dbConn, cleanup := newTestDB(t)
+	t.Cleanup(cleanup)
+
+	txStore := newTxStore(t, dbConn)
+	store := NewStore(dbConn, txStore, nil)
+
+	txMsg := &wire.MsgTx{Version: 1}
+	txMsg.AddTxIn(&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+		Hash: chainhash.Hash{13},
+	}})
+	txMsg.AddTxOut(&wire.TxOut{Value: 1000, PkScript: []byte{0x51}})
+	rec, err := wtxmgr.NewTxRecordFromMsgTx(txMsg, time.Now())
+	require.NoError(t, err)
+
+	err = walletdb.Update(dbConn, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+		require.NotNil(t, ns)
+
+		return txStore.InsertTx(ns, rec, nil)
+	})
+	require.NoError(t, err)
+
+	empty := ""
+	err = store.UpdateTx(t.Context(), db.UpdateTxParams{
+		WalletID: 0,
+		Txid:     rec.Hash,
+		Label:    &empty,
+	})
+	require.NoError(t, err)
 
 	err = walletdb.View(dbConn, func(tx walletdb.ReadTx) error {
 		ns := tx.ReadBucket(wtxmgrNamespaceKey)
@@ -1171,7 +1225,7 @@ func TestUpdateTxEmptyLabelPreservesLegacyError(t *testing.T) {
 		details, err := txStore.TxDetails(ns, &rec.Hash)
 		require.NoError(t, err)
 		require.NotNil(t, details)
-		require.Equal(t, label, details.Label)
+		require.Empty(t, details.Label)
 
 		return nil
 	})

--- a/wallet/tx_writer.go
+++ b/wallet/tx_writer.go
@@ -30,8 +30,9 @@ var ErrLabelTooLong = errors.New("transaction label exceeds limit")
 // TxWriter provides an interface for updating wallet txns.
 type TxWriter interface {
 	// LabelTx adds a label to a tx. If a label already exists, it will be
-	// overwritten. Labels longer than MaxTxLabelLength bytes are rejected
-	// with ErrLabelTooLong.
+	// overwritten, and an empty label clears any existing one. Labels
+	// longer than MaxTxLabelLength bytes are rejected with
+	// ErrLabelTooLong.
 	LabelTx(ctx context.Context, hash chainhash.Hash, label string) error
 }
 
@@ -39,8 +40,8 @@ type TxWriter interface {
 var _ TxWriter = (*Wallet)(nil)
 
 // LabelTx adds a label to a tx. If a label already exists, it will be
-// overwritten. Labels longer than MaxTxLabelLength bytes are rejected with
-// ErrLabelTooLong.
+// overwritten, and an empty label clears any existing one. Labels longer than
+// MaxTxLabelLength bytes are rejected with ErrLabelTooLong.
 //
 // NOTE: This method is part of the TxWriter interface.
 func (w *Wallet) LabelTx(ctx context.Context,

--- a/wallet/tx_writer_test.go
+++ b/wallet/tx_writer_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
-	"github.com/btcsuite/btcwallet/wtxmgr"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -36,8 +35,9 @@ func TestLabelTxSuccess(t *testing.T) {
 	mocks.store.AssertExpectations(t)
 }
 
-// TestLabelTxEmptyLabel tests that an empty label is forwarded to the store and
-// preserves the legacy label error.
+// TestLabelTxEmptyLabel tests that an empty label reaches the store, which is
+// how a caller clears a label. The wallet neither refuses it nor turns it into
+// something else on the way.
 func TestLabelTxEmptyLabel(t *testing.T) {
 	t.Parallel()
 
@@ -48,11 +48,11 @@ func TestLabelTxEmptyLabel(t *testing.T) {
 		WalletID: w.id,
 		Txid:     *TstTxHash,
 		Label:    &empty,
-	}).Return(wtxmgr.ErrEmptyLabel).Once()
+	}).Return(nil).Once()
 
 	err := w.LabelTx(t.Context(), *TstTxHash, empty)
 
-	require.ErrorIs(t, err, wtxmgr.ErrEmptyLabel)
+	require.NoError(t, err)
 	mocks.store.AssertExpectations(t)
 }
 

--- a/wtxmgr/deprecated.go
+++ b/wtxmgr/deprecated.go
@@ -32,6 +32,25 @@ func (s *Store) PutTxLabel(ns walletdb.ReadWriteBucket, txid chainhash.Hash,
 	return PutTxLabel(labelBucket, txid, label)
 }
 
+// DeleteTxLabel removes any label recorded for the transaction. A transaction
+// with no label is not an error: the result of this call is that the
+// transaction has none either way.
+//
+// Removing the entry is what "no label" looks like in this store. A zero-length
+// label cannot be written in its place, because FetchTxLabel reports a stored
+// label of zero length as ErrEmptyLabel rather than as the absence of one.
+func (s *Store) DeleteTxLabel(ns walletdb.ReadWriteBucket,
+	txid chainhash.Hash) error {
+
+	labelBucket := ns.NestedReadWriteBucket(bucketTxLabels)
+	if labelBucket == nil {
+		// No label has ever been written, so there is none to remove.
+		return nil
+	}
+
+	return labelBucket.Delete(txid[:])
+}
+
 // TxDetails looks up all recorded details regarding a transaction with some
 // hash.  In case of a hash collision, the most recent transaction with a
 // matching hash is returned.

--- a/wtxmgr/interface.go
+++ b/wtxmgr/interface.go
@@ -117,6 +117,11 @@ type TxStore interface {
 	PutTxLabel(ns walletdb.ReadWriteBucket, txid chainhash.Hash,
 		label string) error
 
+	// DeleteTxLabel removes any label recorded for the transaction, which
+	// is how this store records a transaction that has none. A transaction
+	// that already has no label is not an error.
+	DeleteTxLabel(ns walletdb.ReadWriteBucket, txid chainhash.Hash) error
+
 	// RangeTransactions runs the function f on all transaction details
 	// between blocks on the best chain over the height range [begin,end].
 	// The special height -1 may be used to also include unmined

--- a/wtxmgr/tx_test.go
+++ b/wtxmgr/tx_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/btcsuite/btcwallet/walletdb"
 	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
 	"github.com/lightningnetwork/lnd/clock"
+	"github.com/stretchr/testify/require"
 )
 
 // Received transaction output for mainnet outpoint
@@ -2431,6 +2432,65 @@ func TestTxLabel(t *testing.T) {
 	if err != ErrTxLabelNotFound {
 		t.Fatalf("expected: %v, got: %v", ErrTxLabelNotFound, err)
 	}
+}
+
+// TestDeleteTxLabel tests removing a transaction's label, which is how a
+// transaction with no label is recorded: the entry is absent rather than
+// present and empty, because a stored zero-length label reads back as an
+// error.
+func TestDeleteTxLabel(t *testing.T) {
+	t.Parallel()
+
+	store, db, err := testStore(t)
+	require.NoError(t, err)
+	defer db.Close()
+
+	txid := &chainhash.Hash{3}
+
+	getBucket := func(tx walletdb.ReadWriteTx) walletdb.ReadWriteBucket {
+		testBucket := tx.ReadWriteBucket(namespaceKey)
+		require.NotNil(t, testBucket)
+
+		return testBucket
+	}
+
+	tryDeleteLabel := func() error {
+		return walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+			return store.DeleteTxLabel(getBucket(tx), *txid)
+		})
+	}
+
+	// Deleting before any label has been written must succeed: the caller
+	// asked for a transaction with no label and already has one.
+	err = tryDeleteLabel()
+	require.NoError(t, err)
+
+	// Write a label, then remove it.
+	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		return store.PutTxLabel(getBucket(tx), *txid, "test label")
+	})
+	require.NoError(t, err)
+
+	err = tryDeleteLabel()
+	require.NoError(t, err)
+
+	// The label is gone rather than empty, so the lookup that reports a
+	// missing label is what answers now.
+	err = walletdb.View(db, func(tx walletdb.ReadTx) error {
+		testBucket := tx.ReadBucket(namespaceKey)
+		require.NotNil(t, testBucket)
+
+		_, err := store.FetchTxLabel(testBucket, *txid)
+		require.ErrorIs(t, err, ErrTxLabelNotFound)
+
+		// The wallet-facing read reports it as no label at all.
+		label, err := store.TxLabel(testBucket, *txid)
+		require.NoError(t, err)
+		require.Empty(t, label)
+
+		return nil
+	})
+	require.NoError(t, err)
 }
 
 func assertBalance(t *testing.T, s *Store, ns walletdb.ReadWriteBucket,


### PR DESCRIPTION
Follow-up to #1347, which covered `LabelTx` with integration tests and found
that an empty label means two different things depending on the backend.

**Stacked on #1361.** Its two commits are included here until it merges; the
three commits from `wtxmgr: delete a transaction label` onwards are this PR's.

## The gap

`db.UpdateTxParams.Label` documents the empty string as valid and as clearing
any prior label, and both SQL schemas default `tx_label` to `''`. SQLite and
PostgreSQL implement exactly that. The legacy kvdb store refused the same call
with `wtxmgr.ErrEmptyLabel`, because it forwarded every label to `PutTxLabel`,
which rejects an empty one — even when the transaction had no label to clear.

Measured on all three backends before the change:

| probe | sqlite / postgres | kvdb |
|---|---|---|
| `""` over an existing label | cleared | `ErrEmptyLabel`, label kept |
| `""` on an unlabeled transaction | no-op | `ErrEmptyLabel` |
| after a reload | still cleared | original label still there |

So clearing a label succeeded or failed depending on which database the wallet
was opened with, and no caller could clear one portably at all. `LabelTx` is the
only public way to remove a label, so on kvdb there was none.

## The change

kvdb routes an empty label to a new `wtxmgr.DeleteTxLabel` instead of
`PutTxLabel`. That store records a transaction with no label as a missing entry
rather than a stored empty value — `FetchTxLabel` reports a zero-length stored
label as `ErrEmptyLabel` — so clearing has to be a delete, and the labels bucket
is private to `wtxmgr`, which is why the method belongs there. `PutTxLabel` is
untouched, so the deprecated `LabelTransaction` keeps refusing an empty label
exactly as before.

`wallet/tx_writer_test.go`'s `TestLabelTxEmptyLabel` asserted the kvdb refusal as
though it were the wallet's contract, by mocking the store into returning it. It
now asserts what the API promises.

## Testing

- `go test ./wtxmgr/... -run TxLabel` — added `TestDeleteTxLabel`, covering a
  delete before any label exists, after one is written, and the read-back that
  reports no label rather than an error.
- `go test ./wallet/internal/db/kvdb/ -run TestUpdateTx` — clearing an existing
  label and clearing when there is none.
- New integration case `txwriter clear label`: clears a label, clears again when
  there is none, and proves the removal survives a reload. It runs unchanged on
  kvdb, SQLite and PostgreSQL — it could not be written before this change.
- Full itest suite shuffled on sqlite (`-shuffleseed=42`) and kvdb
  (`-shuffleseed=7`), no failures or skips; `golangci-lint` clean on `wallet`,
  `bwtest` and `itest`.
