### PR TITLE
wallet: report exact synchronization status

### DIFF
--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -597,7 +597,7 @@ func (w *Wallet) handleInfo(r infoReq) {
 	}
 
 	state := w.sync.syncState()
-	liveReady := state == syncStateSynced
+	liveReady := state == syncStateSynced || state == syncStateRescanning
 
 	synced := liveReady &&
 		syncedTo.Height == bestHeight && syncedTo.Hash.IsEqual(bestHash)

--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -71,7 +71,8 @@ type UnlockRequest struct {
 }
 
 // Info provides a comprehensive snapshot of the wallet's static configuration
-// and dynamic synchronization state.
+// and dynamic synchronization state. Producing the snapshot reads the observed
+// tip from the chain source and fails if that tip is unavailable.
 type Info struct {
 	// BirthdayBlock is the block from which the wallet started scanning.
 	BirthdayBlock waddrmgr.BlockStamp
@@ -87,7 +88,8 @@ type Info struct {
 	// Locked indicates if the wallet is currently locked.
 	Locked bool
 
-	// Synced indicates if the wallet is synced to the chain tip.
+	// Synced is true only when live delivery is ready and SyncedTo exactly
+	// matches the observed chain tip by height and hash.
 	Synced bool
 
 	// SyncedTo is the block to which the wallet is currently synced.
@@ -147,7 +149,8 @@ type Controller interface {
 	ChangePassphrase(ctx context.Context, req ChangePassphraseRequest) error
 
 	// Info returns a comprehensive snapshot of the wallet's static
-	// configuration and dynamic synchronization state.
+	// configuration and dynamic synchronization state. It returns an error
+	// if the chain source's observed tip cannot be read.
 	Info(ctx context.Context) (*Info, error)
 
 	// Start starts the background processes necessary to manage the wallet.
@@ -528,7 +531,8 @@ type rescanReq struct {
 }
 
 // Info returns a comprehensive snapshot of the wallet's static configuration
-// and dynamic synchronization state.
+// and dynamic synchronization state. It returns an error if the chain source's
+// observed tip cannot be read.
 //
 // This is part of the Controller interface.
 func (w *Wallet) Info(ctx context.Context) (*Info, error) {
@@ -585,12 +589,25 @@ func (w *Wallet) handleInfo(r infoReq) {
 		return
 	}
 
+	bestHash, bestHeight, err := w.cfg.Chain.GetBestBlock()
+	if err != nil {
+		r.respChan <- infoResp{err: fmt.Errorf("get chain tip: %w", err)}
+
+		return
+	}
+
+	state := w.sync.syncState()
+	liveReady := state == syncStateSynced
+
+	synced := liveReady &&
+		syncedTo.Height == bestHeight && syncedTo.Hash.IsEqual(bestHash)
+
 	info := &Info{
 		BirthdayBlock: w.birthdayBlock,
 		Backend:       w.cfg.Chain.BackEnd(),
 		ChainParams:   &chainParams,
 		Locked:        !w.state.isUnlocked(),
-		Synced:        w.state.isSynced(),
+		Synced:        synced,
 		SyncedTo:      syncedTo,
 	}
 

--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -92,13 +92,6 @@ type Info struct {
 
 	// SyncedTo is the block to which the wallet is currently synced.
 	SyncedTo waddrmgr.BlockStamp
-
-	// IsRecoveryMode indicates if the wallet is currently in recovery
-	// mode.
-	IsRecoveryMode bool
-
-	// RecoveryProgress is the progress of the recovery (0.0 - 1.0).
-	RecoveryProgress float64
 }
 
 // ChangePassphraseRequest contains the parameters for changing wallet
@@ -593,14 +586,12 @@ func (w *Wallet) handleInfo(r infoReq) {
 	}
 
 	info := &Info{
-		BirthdayBlock:    w.birthdayBlock,
-		Backend:          w.cfg.Chain.BackEnd(),
-		ChainParams:      &chainParams,
-		Locked:           !w.state.isUnlocked(),
-		Synced:           w.state.isSynced(),
-		SyncedTo:         syncedTo,
-		IsRecoveryMode:   w.state.isRecoveryMode(),
-		RecoveryProgress: 0,
+		BirthdayBlock: w.birthdayBlock,
+		Backend:       w.cfg.Chain.BackEnd(),
+		ChainParams:   &chainParams,
+		Locked:        !w.state.isUnlocked(),
+		Synced:        w.state.isSynced(),
+		SyncedTo:      syncedTo,
 	}
 
 	r.respChan <- infoResp{info: info}

--- a/wallet/controller_test.go
+++ b/wallet/controller_test.go
@@ -1630,6 +1630,28 @@ func TestControllerInfoExactSyncStatus(t *testing.T) {
 			expectSync:  false,
 		},
 		{
+			name:        "targeted rescan at exact live tip",
+			syncState:   syncStateRescanning,
+			walletTip:   &db.Block{Hash: syncedHash, Height: 100},
+			chainHash:   syncedHash,
+			chainHeight: 100,
+			expectSync:  true,
+		},
+		{
+			name:        "targeted rescan with height mismatch",
+			syncState:   syncStateRescanning,
+			walletTip:   &db.Block{Hash: syncedHash, Height: 99},
+			chainHash:   syncedHash,
+			chainHeight: 100,
+		},
+		{
+			name:        "targeted rescan with hash mismatch",
+			syncState:   syncStateRescanning,
+			walletTip:   &db.Block{Hash: syncedHash, Height: 100},
+			chainHash:   otherHash,
+			chainHeight: 100,
+		},
+		{
 			name:        "live delivery not ready",
 			syncState:   syncStateSyncing,
 			walletTip:   &db.Block{Hash: syncedHash, Height: 100},

--- a/wallet/controller_test.go
+++ b/wallet/controller_test.go
@@ -1331,7 +1331,7 @@ func TestControllerInfoWaitsForAcceptedResult(t *testing.T) {
 
 			if tc.err == nil {
 				deps.chain.On("BackEnd").Return("mock").Once()
-				deps.syncer.On("syncState").Return(syncStateSynced).Twice()
+				deps.syncer.On("syncState").Return(syncStateSynced).Once()
 			}
 
 			resultChan := make(chan infoResp, 1)

--- a/wallet/controller_test.go
+++ b/wallet/controller_test.go
@@ -1332,6 +1332,9 @@ func TestControllerInfoWaitsForAcceptedResult(t *testing.T) {
 			if tc.err == nil {
 				deps.chain.On("BackEnd").Return("mock").Once()
 				deps.syncer.On("syncState").Return(syncStateSynced).Once()
+				deps.chain.On("GetBestBlock").Return(
+					&chainhash.Hash{}, int32(0), nil,
+				).Once()
 			}
 
 			resultChan := make(chan infoResp, 1)
@@ -1451,8 +1454,10 @@ func TestControllerInfo(t *testing.T) {
 	// Mock the chain backend to return a specific name.
 	deps.chain.On("BackEnd").Return("mock")
 
-	// Mock syncState to indicate the wallet is fully synced.
-	deps.syncer.On("syncState").Return(syncStateSynced)
+	deps.syncer.On("syncState").Return(syncStateSynced).Once()
+	deps.chain.On("GetBestBlock").Return(
+		&syncedTo.Hash, int32(syncedTo.Height), nil,
+	).Once()
 
 	// Allow Stop to clear secret material.
 	expectStopTeardown(deps)
@@ -1489,16 +1494,22 @@ func TestControllerInfoCopiesChainParams(t *testing.T) {
 
 	const mutatedName = "mutated"
 
-	// Arrange: Build a started Wallet around strict Store and Chain mocks.
+	// Arrange: Build a started Wallet around strict Store, Chain, and Syncer
+	// mocks.
 	// Two calls are expected so a mutation of the first result can be checked
 	// against a separately produced second snapshot.
 	store := &walletmock.Store{}
 	chain := &bwmock.Chain{}
+	syncer := &mockChainSyncer{}
 
 	store.On("GetWallet", mock.Anything, "isolated").Return(
 		&db.WalletInfo{}, nil,
 	).Twice()
 	chain.On("BackEnd").Return("mock").Twice()
+	syncer.On("syncState").Return(syncStateBackendSyncing).Twice()
+	chain.On("GetBestBlock").Return(
+		&chainhash.Hash{}, int32(0), nil,
+	).Twice()
 
 	params := chaincfg.MainNetParams
 	// This fixture assembles its own runtime; the shared start helper
@@ -1516,6 +1527,7 @@ func TestControllerInfoCopiesChainParams(t *testing.T) {
 			Chain:       chain,
 			ChainParams: &params,
 		},
+		sync:  syncer,
 		state: newWalletState(nil),
 	}
 	// Disable auto-lock timing so this fixture exercises only its API call.
@@ -1539,6 +1551,7 @@ func TestControllerInfoCopiesChainParams(t *testing.T) {
 	require.Equal(t, params.PowLimit, second.ChainParams.PowLimit)
 	store.AssertExpectations(t)
 	chain.AssertExpectations(t)
+	syncer.AssertExpectations(t)
 }
 
 // TestControllerInfoSyncTipErrors verifies Info preserves Store errors and
@@ -1570,13 +1583,164 @@ func TestControllerInfoSyncTipErrors(t *testing.T) {
 		deps.store.On("GetWallet", mock.Anything, "").Return(
 			&db.WalletInfo{}, nil,
 		).Once()
-		deps.syncer.On("syncState").Return(syncStateSynced)
+		deps.syncer.On("syncState").Return(syncStateSynced).Once()
+		deps.chain.On("GetBestBlock").Return(
+			&chainhash.Hash{}, int32(0), nil,
+		).Once()
 		deps.chain.On("BackEnd").Return("mock")
 
 		info, err := w.Info(t.Context())
 		require.NoError(t, err)
 		require.Equal(t, int32(-1), info.SyncedTo.Height)
+		require.False(t, info.Synced)
 	})
+}
+
+// TestControllerInfoExactSyncStatus verifies that Info reports synchronized
+// only when live delivery is ready and the committed Wallet tip exactly matches
+// the observed chain tip.
+func TestControllerInfoExactSyncStatus(t *testing.T) {
+	t.Parallel()
+
+	syncedHash := chainhash.Hash{100}
+	otherHash := chainhash.Hash{101}
+
+	testCases := []struct {
+		name        string
+		syncState   syncState
+		walletTip   *db.Block
+		chainHash   chainhash.Hash
+		chainHeight int32
+		expectSync  bool
+	}{
+		{
+			name:        "exact ready tip",
+			syncState:   syncStateSynced,
+			walletTip:   &db.Block{Hash: syncedHash, Height: 100},
+			chainHash:   syncedHash,
+			chainHeight: 100,
+			expectSync:  true,
+		},
+		{
+			name:        "backend not ready",
+			syncState:   syncStateBackendSyncing,
+			walletTip:   &db.Block{Hash: syncedHash, Height: 100},
+			chainHash:   syncedHash,
+			chainHeight: 100,
+			expectSync:  false,
+		},
+		{
+			name:        "live delivery not ready",
+			syncState:   syncStateSyncing,
+			walletTip:   &db.Block{Hash: syncedHash, Height: 100},
+			chainHash:   syncedHash,
+			chainHeight: 100,
+			expectSync:  false,
+		},
+		{
+			name:        "height mismatch",
+			syncState:   syncStateSynced,
+			walletTip:   &db.Block{Hash: syncedHash, Height: 99},
+			chainHash:   syncedHash,
+			chainHeight: 100,
+			expectSync:  false,
+		},
+		{
+			name:        "same height hash mismatch",
+			syncState:   syncStateSynced,
+			walletTip:   &db.Block{Hash: syncedHash, Height: 100},
+			chainHash:   otherHash,
+			chainHeight: 100,
+			expectSync:  false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: Start a Wallet with independently controlled
+			// committed, observed, and live-delivery state.
+			w, deps := createTestWalletWithMocks(t)
+			startLoadedWalletForTest(t, w)
+
+			deps.store.On("GetWallet", mock.Anything, "").Return(
+				&db.WalletInfo{SyncedTo: testCase.walletTip}, nil,
+			).Once()
+			deps.syncer.On("syncState").Return(
+				testCase.syncState,
+			).Once()
+			deps.chain.On("GetBestBlock").Return(
+				&testCase.chainHash, testCase.chainHeight, nil,
+			).Once()
+			deps.chain.On("BackEnd").Return("mock")
+
+			// Act: Read the public Wallet snapshot.
+			info, err := w.Info(t.Context())
+
+			// Assert: Readiness alone is insufficient; both tip fields
+			// must identify the same block.
+			require.NoError(t, err)
+			require.Equal(t, testCase.expectSync, info.Synced)
+		})
+	}
+}
+
+// TestControllerInfoChainTipError verifies that Info cannot report a
+// successful snapshot when the observed chain tip is unavailable.
+func TestControllerInfoChainTipError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Start a Wallet with a committed tip while the chain source
+	// fails to provide its observed tip.
+	w, deps := createTestWalletWithMocks(t)
+	startLoadedWalletForTest(t, w)
+
+	deps.store.On("GetWallet", mock.Anything, "").Return(
+		&db.WalletInfo{SyncedTo: &db.Block{
+			Hash: chainhash.Hash{100}, Height: 100,
+		}}, nil,
+	).Once()
+	deps.chain.On("GetBestBlock").Return(
+		(*chainhash.Hash)(nil), int32(0), errBestBlock,
+	).Once()
+
+	// Act: Read the public Wallet snapshot.
+	_, err := w.Info(t.Context())
+
+	// Assert: The source error remains identifiable through the public call.
+	require.ErrorIs(t, err, errBestBlock)
+}
+
+// TestControllerInfoSmallGapReportsUnsynced verifies that Info remains exact
+// while the wallet's committed tip trails the observed tip by one block.
+func TestControllerInfoSmallGapReportsUnsynced(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Keep the live delivery state ready while the persisted Wallet
+	// tip trails the observed source by one block.
+	w, deps := createTestWalletWithMocks(t)
+	startLoadedWalletForTest(t, w)
+
+	walletHash := chainhash.Hash{99}
+	bestHash := chainhash.Hash{100}
+	deps.store.On("GetWallet", mock.Anything, "").Return(
+		&db.WalletInfo{SyncedTo: &db.Block{
+			Hash: walletHash, Height: 99,
+		}}, nil,
+	).Once()
+	deps.syncer.On("syncState").Return(syncStateSynced).Once()
+	deps.chain.On("GetBestBlock").Return(
+		&bestHash, int32(100), nil,
+	).Once()
+	deps.chain.On("BackEnd").Return("mock")
+
+	// Act: Read the public snapshot without changing admission state.
+	info, err := w.Info(t.Context())
+
+	// Assert: Info does not conflate admission readiness with exact sync.
+	require.NoError(t, err)
+	require.False(t, info.Synced)
 }
 
 // TestControllerResync verifies the Resync method.

--- a/wallet/state.go
+++ b/wallet/state.go
@@ -333,9 +333,3 @@ func (s *walletState) canLock() error {
 func (s *walletState) canChangePassphrase() error {
 	return s.validateStarted()
 }
-
-// isRecoveryMode returns true if the wallet is currently syncing or rescanning.
-func (s *walletState) isRecoveryMode() bool {
-	sync := s.syncState()
-	return sync == syncStateSyncing || sync == syncStateRescanning
-}

--- a/wallet/state_test.go
+++ b/wallet/state_test.go
@@ -162,7 +162,6 @@ func TestStateSynchronization(t *testing.T) {
 	// Act & Assert.
 	require.Equal(t, syncStateSynced, s.syncState())
 	require.True(t, s.isSynced())
-	require.False(t, s.isRecoveryMode())
 
 	// Arrange: Mock syncer to return Syncing.
 	// Note: We need to reset expectations or use a new mock/state if rigid.
@@ -173,7 +172,6 @@ func TestStateSynchronization(t *testing.T) {
 	// Act & Assert.
 	require.Equal(t, syncStateSyncing, s.syncState())
 	require.False(t, s.isSynced())
-	require.True(t, s.isRecoveryMode())
 }
 
 // TestStateNilSyncer verifies behavior when syncer is nil (defensive check).
@@ -556,34 +554,6 @@ func TestStateAuthChecks(t *testing.T) {
 		require.ErrorIs(t, changeErr, ErrWalletStopped)
 		require.NotErrorIs(t, changeErr, ErrStateForbidden)
 	})
-}
-
-// TestStateIsRecoveryMode verifies the recovery mode check.
-func TestStateIsRecoveryMode(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name       string
-		sync       syncState
-		isRecovery bool
-	}{
-		{"backend syncing", syncStateBackendSyncing, false},
-		{"syncing", syncStateSyncing, true},
-		{"synced", syncStateSynced, false},
-		{"rescanning", syncStateRescanning, true},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			ms := &mockChainSyncer{}
-			ms.On("syncState").Return(tc.sync)
-
-			state := newWalletState(ms)
-			require.Equal(t, tc.isRecovery, state.isRecoveryMode())
-		})
-	}
 }
 
 // TestStateAuxiliaryMethods verifies helper methods like canUnlock, canLock,

--- a/wallet/syncer.go
+++ b/wallet/syncer.go
@@ -108,9 +108,8 @@ const (
 	// chain tip.
 	syncStateSynced
 
-	// syncStateRescanning indicates the wallet is running a historical
-	// scan for specific user-provided targets, such as accounts or
-	// addresses, without rewinding the global synchronization state.
+	// syncStateRescanning indicates a historical scan of user-provided
+	// targets without rewinding the Wallet's live synchronization tip.
 	syncStateRescanning
 )
 

--- a/wallet/syncer.go
+++ b/wallet/syncer.go
@@ -290,13 +290,6 @@ func (s *syncer) syncState() syncState {
 	return syncState(s.state.Load())
 }
 
-// isRecoveryMode returns true if the wallet is currently syncing or
-// rescanning.
-func (s *syncer) isRecoveryMode() bool {
-	status := s.syncState()
-	return status == syncStateSyncing || status == syncStateRescanning
-}
-
 // initChainSync performs the initial setup for the chain synchronization loop.
 // This includes waiting for the backend to sync, checking for rollbacks, and
 // enabling block notifications. It returns an error if any of these setup
@@ -1827,11 +1820,11 @@ func (s *syncer) extractAddrEntries(txOuts []*wire.TxOut) []AddrEntry {
 func (s *syncer) handleScanReq(ctx context.Context,
 	req *scanReq) error {
 
-	// If the wallet is already syncing or rescanning, we can't accept a
-	// full resync request. This prevents conflicting rescan operations.
-	if s.isRecoveryMode() {
+	// Existing sync or scan work must finish before another scan can run.
+	state := s.syncState()
+	if state == syncStateSyncing || state == syncStateRescanning {
 		return fmt.Errorf("%w: wallet is currently %s",
-			ErrStateForbidden, s.syncState())
+			ErrStateForbidden, state)
 	}
 
 	if req.typ == scanTypeTargeted {

--- a/wallet/syncer_test.go
+++ b/wallet/syncer_test.go
@@ -53,10 +53,9 @@ func TestSyncerInitialization(t *testing.T) {
 	)
 
 	// Assert: Verify that the syncer is correctly initialized in the
-	// backend syncing state and is not in recovery mode.
+	// backend syncing state.
 	require.NotNil(t, s)
 	require.Equal(t, syncStateBackendSyncing, s.syncState())
-	require.False(t, s.isRecoveryMode())
 }
 
 // TestSyncerRequestScan verifies that scan requests are correctly accepted

--- a/wallet/syncer_test.go
+++ b/wallet/syncer_test.go
@@ -5808,9 +5808,9 @@ func TestDispatchScanStrategy_AutoError(t *testing.T) {
 func TestAdvanceChainSync_SmallGap(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: Setup a store-backed syncer for a small gap where silent
-	// sync is preferred. The wallet has no accounts to scan, so the scan
-	// batch only advances the synced tip.
+	// Arrange: Setup a store-backed syncer that is currently ready and one
+	// block behind. The wallet has no accounts to scan, so the scan batch
+	// only advances the synced tip.
 	mockChain := &bwmock.Chain{}
 	store := &walletmock.Store{}
 
@@ -5818,8 +5818,9 @@ func TestAdvanceChainSync_SmallGap(t *testing.T) {
 		Config{Chain: mockChain}, nil, nil, nil,
 		store, uint32(0),
 	)
+	s.state.Store(uint32(syncStateSynced))
 
-	mockChain.On("GetBestBlock").Return(&chainhash.Hash{}, int32(105),
+	mockChain.On("GetBestBlock").Return(&chainhash.Hash{}, int32(101),
 		nil).Once()
 	expectSyncedTip(store, waddrmgr.BlockStamp{Height: 100})
 	store.On("ListAccounts", mock.Anything, mock.Anything).Return(
@@ -5828,7 +5829,7 @@ func TestAdvanceChainSync_SmallGap(t *testing.T) {
 		page.Result[db.AddressInfo, uint32]{}, nil).Maybe()
 	store.On("ListOutputsToWatch", mock.Anything, mock.Anything).Return(
 		([]db.UtxoInfo)(nil), nil).Once()
-	mockChain.On("GetBlockHashes", int64(101), int64(105)).Return(
+	mockChain.On("GetBlockHashes", int64(101), int64(101)).Return(
 		[]chainhash.Hash{{0x01}}, nil).Once()
 	mockChain.On("GetBlockHeaders", mock.Anything).Return(
 		[]*wire.BlockHeader{{}}, nil).Once()
@@ -5838,10 +5839,10 @@ func TestAdvanceChainSync_SmallGap(t *testing.T) {
 	// Act: Advance chain sync.
 	finished, err := s.advanceChainSync(t.Context())
 
-	// Assert: Verify state transition to backend-syncing.
+	// Assert: A one-block gap does not revoke operation admission.
 	require.NoError(t, err)
 	require.False(t, finished)
-	require.Equal(t, uint32(syncStateBackendSyncing), s.state.Load())
+	require.Equal(t, syncStateSynced, s.syncState())
 	store.AssertExpectations(t)
 }
 

--- a/wallet/syncer_test.go
+++ b/wallet/syncer_test.go
@@ -4485,6 +4485,141 @@ func TestFilterBatch_Match(t *testing.T) {
 	require.Equal(t, hash, matched[0])
 }
 
+// TestScanWithTargetsPreservesLiveSyncState verifies that targeted scans leave
+// committed tips unchanged while Info observes any source advancement.
+func TestScanWithTargetsPreservesLiveSyncState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		advanceTip bool
+	}{
+		{name: "unchanged tip"},
+		{name: "source advances during rescan", advanceTip: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: Start two independent Wallets at the same live
+			// tip.
+			s, _, _ := newStoreScanSyncer(t)
+			other, _, _ := newStoreScanSyncer(t)
+
+			mockChain := &bwmock.Chain{}
+			defer mockChain.AssertExpectations(t)
+
+			s.cfg.Chain = mockChain
+			s.cfg.SyncMethod = SyncMethodAuto
+			s.cfg.MaxCFilterItems = 100
+			s.cfg.RecoveryWindow = testScanRecoveryWindow
+			other.cfg.Chain = mockChain
+
+			syncedToBefore, err := s.syncedTo(t.Context())
+			require.NoError(t, err)
+
+			bestBlock := mockChain.On("GetBestBlock").Return(
+				&syncedToBefore.Hash, syncedToBefore.Height, nil,
+			)
+			mockChain.On("BackEnd").Return("mock")
+
+			wallets := make([]*Wallet, 0, 2)
+			for _, syncer := range []*syncer{s, other} {
+				finished, err := syncer.advanceChainSync(
+					t.Context(),
+				)
+				require.NoError(t, err)
+				require.True(t, finished)
+
+				w, _ := createTestWalletWithMocks(t)
+				w.cfg = syncer.cfg
+				w.store = syncer.store
+				w.sync = syncer
+				w.state = newWalletState(syncer)
+				startLoadedWalletForTest(t, w)
+				wallets = append(wallets, w)
+			}
+
+			assertLiveStatus := func(synced bool) {
+				t.Helper()
+
+				for _, w := range wallets {
+					info, err := w.Info(t.Context())
+					require.NoError(t, err)
+					require.Equal(t, synced, info.Synced)
+					require.Equal(
+						t, syncedToBefore, info.SyncedTo,
+					)
+				}
+			}
+			assertLiveStatus(true)
+
+			req := &scanReq{
+				startBlock: syncedToBefore,
+				targets: []waddrmgr.AccountScope{{
+					Scope:   waddrmgr.KeyScopeBIP0084,
+					Account: waddrmgr.DefaultAccountNum,
+				}},
+			}
+
+			blockHashes := []chainhash.Hash{syncedToBefore.Hash}
+			filter, err := gcs.BuildGCSFilter(
+				builder.DefaultP, builder.DefaultM,
+				[16]byte{}, nil,
+			)
+			require.NoError(t, err)
+
+			height := int64(syncedToBefore.Height)
+			mockChain.On("GetBlockHashes", height, height).Return(
+				blockHashes, nil,
+			).Once()
+			mockChain.On(
+				"GetCFilters", blockHashes, wire.GCSFilterRegular,
+			).Return([]*gcs.Filter{filter}, nil).Run(
+				func(_ mock.Arguments) {
+					require.Equal(t, uint32(syncStateRescanning),
+						s.state.Load())
+					require.Equal(t, uint32(syncStateSynced),
+						other.state.Load())
+
+					if tc.advanceTip {
+						bestBlock.Return(
+							&chainhash.Hash{1},
+							syncedToBefore.Height+1, nil,
+						)
+					}
+
+					assertLiveStatus(!tc.advanceTip)
+				},
+			).Once()
+			mockChain.On("GetBlockHeaders", blockHashes).Return(
+				[]*wire.BlockHeader{
+					&chaincfg.SimNetParams.GenesisBlock.Header,
+				}, nil,
+			).Once()
+			mockChain.On("GetBlocks", blockHashes).Return(
+				[]*wire.MsgBlock{chaincfg.SimNetParams.GenesisBlock},
+				nil,
+			).Once()
+
+			// Act: Complete a targeted scan while the source may
+			// advance independently of either Wallet.
+			err = s.scanWithTargets(t.Context(), req)
+
+			// Assert: Only source advancement changes Info.Synced.
+			require.NoError(t, err)
+
+			syncedToAfter, err := s.syncedTo(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, syncedToBefore, syncedToAfter)
+			require.Equal(t, uint32(syncStateSynced), s.state.Load())
+			require.Equal(t, uint32(syncStateSynced), other.state.Load())
+			assertLiveStatus(!tc.advanceTip)
+		})
+	}
+}
+
 // TestScanWithTargets_Empty verifies handling of empty batch results.
 func TestScanWithTargets_Empty(t *testing.T) {
 	t.Parallel()
@@ -4764,6 +4899,7 @@ func TestScanWithTargets_Errors(t *testing.T) {
 		// Arrange: a real-backend syncer where GetBestBlock fails after
 		// the targeted scan state has loaded through the Store.
 		s, _, _ := newStoreScanSyncer(t)
+		s.state.Store(uint32(syncStateSynced))
 
 		mockChain := &bwmock.Chain{}
 		s.cfg.Chain = mockChain
@@ -4778,13 +4914,16 @@ func TestScanWithTargets_Errors(t *testing.T) {
 		}
 
 		mockChain.On("GetBestBlock").Return(nil, int32(0),
-			errBestBlock).Once()
+			errBestBlock).Run(func(_ mock.Arguments) {
+			require.Equal(t, syncStateRescanning, s.syncState())
+		}).Once()
 
 		// Act: Attempt targeted scan.
 		err := s.scanWithTargets(t.Context(), req)
 
 		// Assert: Verify failure.
 		require.ErrorContains(t, err, "best block fail")
+		require.Equal(t, syncStateSynced, s.syncState())
 	})
 
 	t.Run("GetBlockHashes_Failure", func(t *testing.T) {


### PR DESCRIPTION
## Change Description

Implements [Task 455](https://github.com/yyforyongyu/btcwallet-sql-roadmap/blob/main/tasks/455-exact-wallet-sync-status.md).

`Wallet.Info().Synced` is true only when live processing is ready and the
committed wallet tip exactly matches the observed chain tip by height and
hash. A wallet one block behind reports `Synced=false` without changing the
existing small-gap operation policy.

- Keep `Info.SyncedTo` equal to the committed wallet tip.
- Remove unsupported `Info.IsRecoveryMode` and `Info.RecoveryProgress`,
  together with their unused helpers.
- Retain private `syncStateRescanning` and existing scan/spend admission.
  Targeted rescans alone do not make public `Info.Synced` false, advance
  `SyncedTo`, or change another wallet's readiness.
- Read `GetBestBlock` inside the admitted `Info` handler and preserve source
  errors. Keep the existing `chainSyncer` interface unchanged, with no
  duplicate scan-admission flag or status wrapper.
- Reuse existing controller/syncer test files and fixtures, including the
  real-store two-wallet regression and existing mock-backed batch checks.

### Why keep the direct tip read?

Targeted rescans currently occupy the same sync loop that processes live
notifications. A loop-owned tip cache can therefore remain equal to
`SyncedTo` after the source has advanced, incorrectly reporting synchronized.

The direct query costs one source read per `Info` call and makes source
availability part of that call's result. When the source advances during a
rescan, `Info` reports unsynced while `SyncedTo` stays at the committed tip.
Independent tip observation or parallel live processing needs separate work
before introducing a cache.

The three commits separate recovery-field removal, exact-tip reporting, and
targeted-rescan status, with each change's related tests alongside it.

## Steps to Test

Run the wallet tests with race detection and shuffled order:

```bash
go test -race -shuffle=on -count=1 ./wallet/...
make fmt
make lint-check
```

Run Task 433's existing controller-info scenario unchanged on all three
database backends:

```bash
make itest chain=btcd db=kvdb icase="controller info"
make itest chain=btcd db=sqlite icase="controller info"
make itest chain=btcd db=postgres icase="controller info"
```

## Pull Request Checklist

### Testing

- [ ] The PR passes all CI checks.
- [x] Tests cover exact match, height/hash mismatch, source failure, and
  delivery-not-ready cases.
- [x] Tests distinguish small-gap operation admission from exact public status.
- [x] Targeted-scan tests cover unchanged/advancing source tips, two-wallet
  independence, committed-tip preservation, and state restoration on failure.
- [x] The unchanged controller-info scenario passes locally on kvdb, SQLite,
  and PostgreSQL.

### Code Style and Documentation

- [x] The change is scoped to one roadmap task.
- [x] Public synchronization behavior and the source-read failure are documented.
- [x] No new logging statements are introduced.
