### PR TITLE
wallet: reject empty passphrases for SQL watch-only wallets

### DIFF
--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -53,8 +53,8 @@ var (
 	// match the one guarding the wallet.
 	ErrInvalidPassphrase = keyvault.ErrInvalidPassphrase
 
-	// ErrEmptyPassphrase is returned when a passphrase change selects no
-	// passphrase or omits a required private passphrase.
+	// ErrEmptyPassphrase is returned when wallet creation or a passphrase
+	// change omits a required passphrase.
 	ErrEmptyPassphrase = keyvault.ErrEmptyPassphrase
 )
 

--- a/wallet/internal/keyvault/keyvault.go
+++ b/wallet/internal/keyvault/keyvault.go
@@ -12,8 +12,8 @@ import (
 // ErrInvalidPassphrase reports that the provided vault passphrase is wrong.
 var ErrInvalidPassphrase = errors.New("invalid vault passphrase")
 
-// ErrEmptyPassphrase reports that a passphrase rotation request selected no
-// passphrase or omitted a required private passphrase.
+// ErrEmptyPassphrase reports that wallet creation or passphrase rotation
+// omitted a required passphrase.
 var ErrEmptyPassphrase = errors.New("empty vault passphrase")
 
 // ErrVaultLocked reports that an operation requiring unlocked runtime state

--- a/wallet/internal/keyvault/vault.go
+++ b/wallet/internal/keyvault/vault.go
@@ -21,13 +21,6 @@ var (
 	errRootKeyNotPrivate = errors.New(
 		"spendable wallet requires a private root key",
 	)
-
-	// errEmptyPassphrase reports that an empty private passphrase was
-	// supplied for a spendable wallet, mirroring
-	// waddrmgr.ErrEmptyPassphrase.
-	errEmptyPassphrase = errors.New(
-		"spendable wallet requires a non-empty private passphrase",
-	)
 )
 
 // WalletVault adapts db.Store wallet secret storage to the wallet key-vault

--- a/wallet/internal/keyvault/vault_genesis.go
+++ b/wallet/internal/keyvault/vault_genesis.go
@@ -19,10 +19,10 @@ import (
 // decryptWalletSecrets.
 //
 // A watch-only wallet holds no signing material, so only the script crypto key
-// is produced and hdRootKey is ignored (it may be nil or neutered) and the
-// passphrase may be empty. A spendable wallet requires a non-nil, private
-// hdRootKey and a non-empty privatePassphrase; violations are rejected before
-// any secret material is derived.
+// is produced and hdRootKey is ignored (it may be nil or neutered). Every
+// wallet requires a non-empty privatePassphrase because it protects the script
+// crypto key. A spendable wallet additionally requires a non-nil, private
+// hdRootKey. Violations are rejected before any secret material is derived.
 //
 // The returned secrets contain only ciphertext. Every plaintext buffer this
 // function controls is zeroed before returning; the one copy it cannot wipe is
@@ -47,9 +47,9 @@ func createWalletSecretsWithScrypt(privatePassphrase []byte,
 	hdRootKey *hdkeychain.ExtendedKey, watchOnly bool,
 	scrypt *waddrmgr.ScryptOptions) (*db.WalletSecrets, error) {
 
-	// Validate the spendable inputs up front, before any secret material is
-	// derived or persisted. Watch-only wallets hold no signing material, so
-	// they accept a nil (or neutered) root key and an empty passphrase.
+	// Validate the genesis inputs up front, before any secret material is
+	// derived or persisted. Watch-only wallets accept a nil (or neutered)
+	// root key but still require a passphrase for their script key.
 	err := validateGenesisInputs(privatePassphrase, hdRootKey, watchOnly)
 	if err != nil {
 		return nil, err
@@ -123,12 +123,15 @@ func createWalletSecretsWithScrypt(privatePassphrase []byte,
 	return secrets, nil
 }
 
-// validateGenesisInputs rejects invalid spendable-wallet genesis inputs before
-// any secret material is derived or persisted. Watch-only wallets hold no
-// signing material, so they accept a nil (or neutered) root key and an empty
-// passphrase and always pass.
+// validateGenesisInputs rejects invalid genesis inputs before any secret
+// material is derived or persisted. Watch-only wallets accept a nil or
+// neutered root key, but every wallet requires a non-empty private passphrase.
 func validateGenesisInputs(privatePassphrase []byte,
 	hdRootKey *hdkeychain.ExtendedKey, watchOnly bool) error {
+
+	if len(privatePassphrase) == 0 {
+		return fmt.Errorf("private passphrase: %w", ErrEmptyPassphrase)
+	}
 
 	if watchOnly {
 		return nil
@@ -144,12 +147,6 @@ func validateGenesisInputs(privatePassphrase []byte,
 	// spendable wallet's master private key.
 	if !hdRootKey.IsPrivate() {
 		return errRootKeyNotPrivate
-	}
-
-	// The private passphrase protects the master key, so it may not be
-	// empty. This mirrors waddrmgr.Create's rejection.
-	if len(privatePassphrase) == 0 {
-		return errEmptyPassphrase
 	}
 
 	return nil

--- a/wallet/internal/keyvault/vault_genesis_test.go
+++ b/wallet/internal/keyvault/vault_genesis_test.go
@@ -131,8 +131,7 @@ func TestCreateWalletSecretsRoundtrip(t *testing.T) {
 }
 
 // TestCreateWalletSecretsInputGuards verifies that CreateWalletSecrets rejects
-// invalid spendable inputs before deriving secret material, while watch-only
-// wallets keep accepting a neutered xpub and an empty passphrase.
+// invalid genesis inputs before deriving secret material.
 func TestCreateWalletSecretsInputGuards(t *testing.T) {
 	t.Parallel()
 
@@ -180,7 +179,21 @@ func TestCreateWalletSecretsInputGuards(t *testing.T) {
 			passphrase: nil,
 			rootKey:    testGenesisRootKey,
 			watchOnly:  false,
-			wantErr:    errEmptyPassphrase,
+			wantErr:    ErrEmptyPassphrase,
+		},
+		{
+			name:       "watch-only neutered key",
+			passphrase: passphrase,
+			rootKey: func(t *testing.T) *hdkeychain.ExtendedKey {
+				t.Helper()
+
+				neutered, err := testGenesisRootKey(t).Neuter()
+				require.NoError(t, err)
+
+				return neutered
+			},
+			watchOnly: true,
+			wantErr:   nil,
 		},
 		{
 			name:       "watch-only neutered key empty passphrase",
@@ -194,7 +207,7 @@ func TestCreateWalletSecretsInputGuards(t *testing.T) {
 				return neutered
 			},
 			watchOnly: true,
-			wantErr:   nil,
+			wantErr:   ErrEmptyPassphrase,
 		},
 	}
 

--- a/wallet/manager.go
+++ b/wallet/manager.go
@@ -105,7 +105,9 @@ type CreateWalletParams struct {
 	// Remove this field with kvdb support.
 	PubPassphrase []byte
 
-	// PrivatePassphrase is the private passphrase for the wallet.
+	// PrivatePassphrase protects the wallet's secret material. SQL backends
+	// require it for every wallet; legacy kvdb permits it to be empty when
+	// creating a watch-only wallet.
 	PrivatePassphrase []byte
 }
 

--- a/wallet/manager_sqlite_test.go
+++ b/wallet/manager_sqlite_test.go
@@ -170,6 +170,24 @@ func TestNewManagerClassifiesDatabaseIdentityMismatch(t *testing.T) {
 	require.Nil(t, rejected)
 }
 
+// TestManagerSQLiteCreateWatchOnlyRejectsEmptyPrivatePassphrase verifies the
+// SQL Manager surfaces the public empty-passphrase sentinel and no Wallet when
+// watch-only creation omits the passphrase protecting its script key.
+func TestManagerSQLiteCreateWatchOnlyRejectsEmptyPrivatePassphrase(
+	t *testing.T) {
+
+	t.Parallel()
+
+	m := testSQLiteManager(t)
+	w, err := m.Create(CreateWalletParams{
+		Name:      testWalletName,
+		Mode:      ModeShell,
+		WatchOnly: true,
+	})
+	require.ErrorIs(t, err, ErrEmptyPassphrase)
+	require.Nil(t, w)
+}
+
 // TestSQLiteCreateWalletParamsBirthdayVerbatim verifies that the SQLite
 // create params persist the birthday they are handed verbatim. The caller owns
 // the margin decision — Create applies waddrmgr's safety margin — so this
@@ -210,10 +228,9 @@ func TestSQLiteCreateWalletParamsBirthdayVerbatim(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Arrange: a spendable seed-import create. A
-			// non-empty private passphrase is required because
-			// the store-backed key vault rejects an empty
-			// passphrase for a spendable wallet.
+			// Arrange: a spendable seed-import create. The
+			// store-backed key vault requires a non-empty private
+			// passphrase for every wallet.
 			params := CreateWalletParams{
 				Name:              testWalletName,
 				Mode:              ModeImportSeed,

--- a/wallet/manager_test.go
+++ b/wallet/manager_test.go
@@ -744,18 +744,17 @@ func TestManagerDeriveRootKey(t *testing.T) {
 }
 
 // TestManagerKVDBCreateWatchOnlyShell verifies that the legacy kvdb backend
-// creates a rootless watch-only wallet, which is the one watch-only shape its
-// format can represent and what the legacy watch-only constructor built.
+// creates a rootless watch-only wallet with an empty private passphrase,
+// preserving the behavior of the legacy watch-only constructor.
 func TestManagerKVDBCreateWatchOnlyShell(t *testing.T) {
 	t.Parallel()
 
 	params := CreateWalletParams{
-		Name:              testWalletName,
-		Mode:              ModeShell,
-		WatchOnly:         true,
-		PubPassphrase:     []byte("public"),
-		PrivatePassphrase: []byte("private"),
-		Birthday:          time.Now(),
+		Name:          testWalletName,
+		Mode:          ModeShell,
+		WatchOnly:     true,
+		PubPassphrase: []byte("public"),
+		Birthday:      time.Now(),
 	}
 
 	w, err := testKVDBManager(t).Create(params)


### PR DESCRIPTION
## Change Description

SQL watch-only wallet creation accepts an empty private passphrase, but the
resulting wallet cannot rotate that credential. Every SQL wallet has a script
crypto key protected by the private passphrase, including watch-only wallets.

Require a non-empty private passphrase before the SQL watch-only shortcut and
return `wallet.ErrEmptyPassphrase` with `private passphrase` context. Watch-only
wallets still accept nil or neutered root keys. Legacy kvdb continues to permit
an empty private passphrase when creating a watch-only wallet.

Regression coverage checks SQL rejection, acceptance of a neutered root key
with a non-empty passphrase, the public Manager error identity, and kvdb
compatibility.

This follows up on #1349 and its
[Task 427](https://github.com/yyforyongyu/btcwallet-sql-roadmap/blob/main/tasks/427-controller-lifecycle-credential-itests.md)
credential coverage. That PR has merged; this PR now targets `sql-wallet`
directly and reuses its `ErrEmptyPassphrase` sentinel.

## Steps to Test

```bash
make itest db=kvdb icase='manager create watchonly'
make itest db=sqlite icase='manager create watchonly'
make itest db=postgres icase='manager create watchonly'
```

## Pull Request Checklist

### Testing

- [ ] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation

- [x] The change is not insubstantial.
- [x] The change follows the code documentation and line-length guidelines.
- [x] The commit follows the repository's ideal commit structure.
- [x] No new logging statements are introduced.
