### PR TITLE
wallet: carry account chain-sync policy

### DIFF
--- a/bwtest/harness_wallet.go
+++ b/bwtest/harness_wallet.go
@@ -543,7 +543,10 @@ func (h *HarnessTest) ensureAccount(w *wallet.Wallet,
 		}()
 	}
 
-	_, err = w.NewAccount(h.Context(), scope, name)
+	_, err = w.NewAccount(h.Context(), wallet.NewAccountParams{
+		Scope: scope,
+		Name:  name,
+	})
 	require.NoError(h, err, "failed to create account %q", name)
 }
 

--- a/itest/account_manager_test.go
+++ b/itest/account_manager_test.go
@@ -238,14 +238,16 @@ func testAccountManagerCreateAccountSequence(h *bwtest.HarnessTest) {
 	)
 }
 
-// testAccountManagerRejectAccountCreation verifies rejected names cannot alter
-// an existing account or its scope's account count.
+// testAccountManagerRejectAccountCreation verifies invalid, occupied, and
+// unsupported requests preserve public error identities and account state.
 func testAccountManagerRejectAccountCreation(h *bwtest.HarnessTest) {
 	const (
 		sourceName         = "account manager rejection source"
 		afterRejectionName = "account manager after rejection"
 	)
 
+	// Arrange: snapshot one existing account and its scope count so a
+	// rejected request cannot silently alter either observable value.
 	scope := waddrmgr.KeyScopeBIP0084
 	ctx := h.Context()
 	w, _ := h.NewWallet(bwtest.WalletFixture{Unlocked: true})
@@ -266,29 +268,44 @@ func testAccountManagerRejectAccountCreation(h *bwtest.HarnessTest) {
 
 	wantCount := len(accounts)
 
-	// These rejections have no stable public error identity yet, so the
-	// rows assert rejection and unchanged state only.
+	// Each request has one refusal reason; the backend must preserve its
+	// public identity without changing account state.
 	testCases := []struct {
 		name        string
 		accountName string
+		noChainSync bool
+		wantErr     error
 	}{
 		{
 			name:        "duplicate source name",
 			accountName: sourceName,
+			wantErr:     wallet.ErrAccountAlreadyExists,
 		},
 		{
 			name:        "empty name",
 			accountName: "",
+			wantErr:     wallet.ErrInvalidParam,
+		},
+		{
+			name:        "unsupported chain-sync exclusion",
+			accountName: "excluded account",
+			noChainSync: true,
+			wantErr:     wallet.ErrAccountOperationUnsupported,
 		},
 	}
 
 	for _, tc := range testCases {
+		// Act: submit the rejected request through the same public
+		// Wallet method for every maintained backend.
 		_, err := w.NewAccount(ctx, wallet.NewAccountParams{
-			Scope: scope,
-			Name:  tc.accountName,
+			Scope:       scope,
+			Name:        tc.accountName,
+			NoChainSync: tc.noChainSync,
 		})
 
-		require.Error(h, err, "%s was accepted", tc.name)
+		// Assert: check the public refusal and compare the pre-existing
+		// account and count to their pre-call snapshots.
+		require.ErrorIs(h, err, tc.wantErr, tc.name)
 
 		current, err := w.GetAccount(ctx, scope, sourceName)
 		require.NoError(

--- a/itest/account_manager_test.go
+++ b/itest/account_manager_test.go
@@ -110,7 +110,10 @@ func testAccountManagerCreateAccount(h *bwtest.HarnessTest) {
 	ctx := h.Context()
 	w, _ := h.NewWallet(bwtest.WalletFixture{Unlocked: true})
 
-	created, err := w.NewAccount(ctx, scope, accountName)
+	created, err := w.NewAccount(ctx, wallet.NewAccountParams{
+		Scope: scope,
+		Name:  accountName,
+	})
 
 	require.NoError(h, err, "failed to create derived account")
 	require.Equal(h, accountName, created.AccountName)
@@ -185,7 +188,10 @@ func testAccountManagerCreateAccountSequence(h *bwtest.HarnessTest) {
 
 	numbers := make([]wallet.AccountNumber, 0, len(names))
 	for _, name := range names {
-		created, err := w.NewAccount(ctx, scope, name)
+		created, err := w.NewAccount(ctx, wallet.NewAccountParams{
+			Scope: scope,
+			Name:  name,
+		})
 		require.NoError(h, err, "failed to create %q", name)
 		require.NotNil(h, created.AccountNumber, "%q has no number", name)
 
@@ -201,7 +207,10 @@ func testAccountManagerCreateAccountSequence(h *bwtest.HarnessTest) {
 
 	// A second scope allocates from its own counter, so its first
 	// user-created account repeats the first scope's starting number.
-	other, err := w.NewAccount(ctx, waddrmgr.KeyScopeBIP0044, otherScopeName)
+	other, err := w.NewAccount(ctx, wallet.NewAccountParams{
+		Scope: waddrmgr.KeyScopeBIP0044,
+		Name:  otherScopeName,
+	})
 	require.NoError(h, err, "failed to create other scope account")
 	require.NotNil(h, other.AccountNumber, "other scope has no number")
 
@@ -215,7 +224,10 @@ func testAccountManagerCreateAccountSequence(h *bwtest.HarnessTest) {
 	w = h.ReloadWallet(w)
 	h.UnlockWallet(w)
 
-	resumed, err := w.NewAccount(ctx, scope, resumedName)
+	resumed, err := w.NewAccount(ctx, wallet.NewAccountParams{
+		Scope: scope,
+		Name:  resumedName,
+	})
 	require.NoError(h, err, "failed to create account after reload")
 	require.NotNil(
 		h, resumed.AccountNumber, "resumed account has no number",
@@ -238,7 +250,10 @@ func testAccountManagerRejectAccountCreation(h *bwtest.HarnessTest) {
 	ctx := h.Context()
 	w, _ := h.NewWallet(bwtest.WalletFixture{Unlocked: true})
 
-	_, err := w.NewAccount(ctx, scope, sourceName)
+	_, err := w.NewAccount(ctx, wallet.NewAccountParams{
+		Scope: scope,
+		Name:  sourceName,
+	})
 	require.NoError(h, err, "failed to create rejection source")
 
 	existing, err := w.GetAccount(ctx, scope, sourceName)
@@ -268,7 +283,10 @@ func testAccountManagerRejectAccountCreation(h *bwtest.HarnessTest) {
 	}
 
 	for _, tc := range testCases {
-		_, err := w.NewAccount(ctx, scope, tc.accountName)
+		_, err := w.NewAccount(ctx, wallet.NewAccountParams{
+			Scope: scope,
+			Name:  tc.accountName,
+		})
 
 		require.Error(h, err, "%s was accepted", tc.name)
 
@@ -294,7 +312,10 @@ func testAccountManagerRejectAccountCreation(h *bwtest.HarnessTest) {
 
 	// The account number is allocated before the insert, so only the
 	// rolled-back transaction keeps a rejected call from consuming one.
-	next, err := w.NewAccount(ctx, scope, afterRejectionName)
+	next, err := w.NewAccount(ctx, wallet.NewAccountParams{
+		Scope: scope,
+		Name:  afterRejectionName,
+	})
 	require.NoError(h, err, "failed to create account after rejections")
 	require.NotNil(
 		h, next.AccountNumber, "account after rejections has no number",
@@ -324,12 +345,18 @@ func testAccountManagerEnforceAccountCreationLifecycle(h *bwtest.HarnessTest) {
 
 	require.NoError(h, w.Lock(ctx), "failed to lock wallet")
 
-	_, err = w.NewAccount(ctx, scope, lockedName)
+	_, err = w.NewAccount(ctx, wallet.NewAccountParams{
+		Scope: scope,
+		Name:  lockedName,
+	})
 
 	require.Error(h, err, "locked wallet created an account")
 	require.NoError(h, w.Stop(ctx), "failed to stop wallet")
 
-	_, err = w.NewAccount(ctx, scope, stoppedName)
+	_, err = w.NewAccount(ctx, wallet.NewAccountParams{
+		Scope: scope,
+		Name:  stoppedName,
+	})
 
 	require.ErrorIs(h, err, wallet.ErrWalletStopped)
 
@@ -356,7 +383,10 @@ func testAccountManagerRejectWatchOnlyAccountCreation(h *bwtest.HarnessTest) {
 	w, _ := h.NewWallet(bwtest.WalletFixture{WatchOnly: true})
 	require.True(h, w.IsWatchOnly(), "watch-only fixture is not watch-only")
 
-	_, err := w.NewAccount(ctx, waddrmgr.KeyScopeBIP0084, accountName)
+	_, err := w.NewAccount(ctx, wallet.NewAccountParams{
+		Scope: waddrmgr.KeyScopeBIP0084,
+		Name:  accountName,
+	})
 
 	require.Error(h, err, "watch-only wallet created an account")
 	_, err = w.GetAccount(ctx, waddrmgr.KeyScopeBIP0084, accountName)
@@ -374,7 +404,10 @@ func testAccountManagerRenameDerivedAccount(h *bwtest.HarnessTest) {
 	scope := waddrmgr.KeyScopeBIP0084
 	ctx := h.Context()
 	w, _ := h.NewWallet(bwtest.WalletFixture{Unlocked: true})
-	_, err := w.NewAccount(ctx, scope, sourceName)
+	_, err := w.NewAccount(ctx, wallet.NewAccountParams{
+		Scope: scope,
+		Name:  sourceName,
+	})
 	require.NoError(h, err, "failed to create derived rename source")
 
 	source, err := w.GetAccount(ctx, scope, sourceName)
@@ -535,9 +568,15 @@ func testAccountManagerRejectAccountRename(h *bwtest.HarnessTest) {
 	ctx := h.Context()
 	w, _ := h.NewWallet(bwtest.WalletFixture{Unlocked: true})
 
-	_, err := w.NewAccount(ctx, scope, sourceName)
+	_, err := w.NewAccount(ctx, wallet.NewAccountParams{
+		Scope: scope,
+		Name:  sourceName,
+	})
 	require.NoError(h, err, "failed to create rename source")
-	_, err = w.NewAccount(ctx, scope, duplicateTarget)
+	_, err = w.NewAccount(ctx, wallet.NewAccountParams{
+		Scope: scope,
+		Name:  duplicateTarget,
+	})
 	require.NoError(h, err, "failed to create duplicate rename target")
 
 	wantAccounts, err := w.ListAccounts(ctx)
@@ -604,7 +643,10 @@ func testAccountManagerEnforceAccountRenameLifecycle(h *bwtest.HarnessTest) {
 	scope := waddrmgr.KeyScopeBIP0084
 	ctx := h.Context()
 	w, _ := h.NewWallet(bwtest.WalletFixture{Unlocked: true})
-	_, err := w.NewAccount(ctx, scope, sourceName)
+	_, err := w.NewAccount(ctx, wallet.NewAccountParams{
+		Scope: scope,
+		Name:  sourceName,
+	})
 	require.NoError(h, err, "failed to create lifecycle source")
 
 	// Reload to reach the started but locked state this rename must be

--- a/wallet/account_info.go
+++ b/wallet/account_info.go
@@ -50,6 +50,10 @@ type AccountInfo struct {
 	// the account snapshot.
 	IsWatchOnly bool
 
+	// NoChainSync is the stored, immutable policy excluding the account from
+	// automatic chain synchronization; it does not change signing custody.
+	NoChainSync bool
+
 	// CreatedAt is the time the account was created. A zero time means the
 	// backing Store does not know the creation time.
 	CreatedAt time.Time

--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -176,6 +176,15 @@ func (w *Wallet) buildAccountDeriveFn(
 	return newAccountDeriveFn(masterKey, w.keyVault, fingerprint), nil
 }
 
+// NewAccountParams selects the next sequential account to create.
+type NewAccountParams struct {
+	// Scope identifies the purpose and coin type used for derivation.
+	Scope waddrmgr.KeyScope
+
+	// Name must be valid and unique within Scope.
+	Name string
+}
+
 // AccountManager provides a high-level interface for managing wallet
 // accounts.
 //
@@ -214,8 +223,8 @@ func (w *Wallet) buildAccountDeriveFn(
 type AccountManager interface {
 	// NewAccount creates a new account for a given key scope and name. The
 	// provided name must be unique within that key scope.
-	NewAccount(ctx context.Context, scope waddrmgr.KeyScope, name string) (
-		*AccountInfo, error)
+	NewAccount(ctx context.Context, params NewAccountParams) (*AccountInfo,
+		error)
 
 	// ListAccounts returns a list of all accounts managed by the wallet.
 	ListAccounts(ctx context.Context) ([]AccountInfo, error)
@@ -347,9 +356,9 @@ func (w *Wallet) accountInfoFromStore(
 type newAccountReq struct {
 	reqCtx
 
-	scope waddrmgr.KeyScope
-	name  string
-	resp  chan accountResp
+	// params carries the caller inputs through the existing admission path.
+	params NewAccountParams
+	resp   chan accountResp
 }
 
 // requireAccountNameAvailable reports a name already taken within scope as
@@ -384,8 +393,8 @@ func (w *Wallet) requireAccountNameAvailable(ctx context.Context,
 // restoring, new accounts may not be created when all of the previous 100
 // accounts have no transaction history (this is a deviation from the BIP0044
 // spec, which allows no unused account gaps).
-func (w *Wallet) NewAccount(ctx context.Context, scope waddrmgr.KeyScope,
-	name string) (*AccountInfo, error) {
+func (w *Wallet) NewAccount(ctx context.Context,
+	params NewAccountParams) (*AccountInfo, error) {
 
 	err := w.state.validateStarted()
 	if err != nil {
@@ -397,7 +406,7 @@ func (w *Wallet) NewAccount(ctx context.Context, scope waddrmgr.KeyScope,
 		return nil, err
 	}
 
-	err = waddrmgr.ValidateAccountName(name)
+	err = waddrmgr.ValidateAccountName(params.Name)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", ErrInvalidParam, err.Error())
 	}
@@ -415,8 +424,7 @@ func (w *Wallet) NewAccount(ctx context.Context, scope waddrmgr.KeyScope,
 
 	req := newAccountReq{
 		reqCtx: reqCtx{ctx: ctx},
-		scope:  scope,
-		name:   name,
+		params: params,
 		resp:   make(chan accountResp, 1),
 	}
 
@@ -439,7 +447,9 @@ func (w *Wallet) handleNewAccount(req newAccountReq) {
 	// An occupied name is reported ahead of the watch-only refusal and ahead
 	// of an exhausted derivation range, so the caller hears about the part of
 	// the request it can restate.
-	err := w.requireAccountNameAvailable(req.ctx, req.scope, req.name)
+	err := w.requireAccountNameAvailable(
+		req.ctx, req.params.Scope, req.params.Name,
+	)
 	if err != nil {
 		req.resp <- accountResp{err: err}
 		return
@@ -467,8 +477,8 @@ func (w *Wallet) handleNewAccount(req newAccountReq) {
 	info, err := w.store.CreateDerivedAccount(req.ctx,
 		db.CreateDerivedAccountParams{
 			WalletID: w.id,
-			Scope:    db.KeyScope(req.scope),
-			Name:     req.name,
+			Scope:    db.KeyScope(req.params.Scope),
+			Name:     req.params.Name,
 		}, deriveFn,
 	)
 	if err != nil {

--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -176,13 +176,18 @@ func (w *Wallet) buildAccountDeriveFn(
 	return newAccountDeriveFn(masterKey, w.keyVault, fingerprint), nil
 }
 
-// NewAccountParams selects the next sequential account to create.
+// NewAccountParams selects the next sequential account to create. The zero
+// NoChainSync value preserves automatic chain synchronization.
 type NewAccountParams struct {
 	// Scope identifies the purpose and coin type used for derivation.
 	Scope waddrmgr.KeyScope
 
 	// Name must be valid and unique within Scope.
 	Name string
+
+	// NoChainSync requests exclusion from automatic chain synchronization.
+	// True is currently rejected with ErrAccountOperationUnsupported.
+	NoChainSync bool
 }
 
 // AccountManager provides a high-level interface for managing wallet
@@ -222,7 +227,8 @@ type NewAccountParams struct {
 // Context cancellation and deadlines are preserved.
 type AccountManager interface {
 	// NewAccount creates a new account for a given key scope and name. The
-	// provided name must be unique within that key scope.
+	// provided name must be unique within that key scope. NoChainSync=true
+	// is currently rejected with ErrAccountOperationUnsupported.
 	NewAccount(ctx context.Context, params NewAccountParams) (*AccountInfo,
 		error)
 
@@ -330,6 +336,7 @@ func (w *Wallet) accountInfoFromStore(
 		masterFingerprint = &fingerprint
 	}
 
+	// Report the stored sync policy independently of signing custody.
 	return &AccountInfo{
 		AccountNumber:      accountNumber,
 		AccountName:        storeInfo.AccountName,
@@ -340,6 +347,7 @@ func (w *Wallet) accountInfoFromStore(
 		ConfirmedBalance:   storeInfo.ConfirmedBalance,
 		UnconfirmedBalance: storeInfo.UnconfirmedBalance,
 		IsWatchOnly:        storeInfo.IsWatchOnly,
+		NoChainSync:        storeInfo.NoChainSync,
 		CreatedAt:          storeInfo.CreatedAt,
 		KeyScope:           waddrmgr.KeyScope(storeInfo.KeyScope),
 		AddrSchema: waddrmgr.ScopeAddrSchema{
@@ -393,6 +401,8 @@ func (w *Wallet) requireAccountNameAvailable(ctx context.Context,
 // restoring, new accounts may not be created when all of the previous 100
 // accounts have no transaction history (this is a deviation from the BIP0044
 // spec, which allows no unused account gaps).
+// NoChainSync=true is currently rejected with ErrAccountOperationUnsupported
+// after the existing admission checks and before secret preparation.
 func (w *Wallet) NewAccount(ctx context.Context,
 	params NewAccountParams) (*AccountInfo, error) {
 
@@ -468,6 +478,17 @@ func (w *Wallet) handleNewAccount(req newAccountReq) {
 		return
 	}
 
+	// Keep exclusion unavailable until receiving and recovery honor it.
+	// Refuse after admission so no backend prepares secrets or mutates state.
+	if req.params.NoChainSync {
+		req.resp <- accountResp{
+			err: fmt.Errorf("no-chain-sync account creation: %w",
+				ErrAccountOperationUnsupported),
+		}
+
+		return
+	}
+
 	deriveFn, err := w.buildAccountDeriveFn(req.ctx)
 	if err != nil {
 		req.resp <- accountResp{err: accountManagerErr(err)}
@@ -476,9 +497,10 @@ func (w *Wallet) handleNewAccount(req newAccountReq) {
 
 	info, err := w.store.CreateDerivedAccount(req.ctx,
 		db.CreateDerivedAccountParams{
-			WalletID: w.id,
-			Scope:    db.KeyScope(req.params.Scope),
-			Name:     req.params.Name,
+			WalletID:    w.id,
+			Scope:       db.KeyScope(req.params.Scope),
+			Name:        req.params.Name,
+			NoChainSync: req.params.NoChainSync,
 		}, deriveFn,
 	)
 	if err != nil {

--- a/wallet/account_manager_benchmark_test.go
+++ b/wallet/account_manager_benchmark_test.go
@@ -370,9 +370,10 @@ func BenchmarkNewAccountAPI(b *testing.B) {
 				accountName := fmt.Sprintf("new-account-%d",
 					count)
 
-				_, err := w.NewAccount(
-					b.Context(), scopes[0], accountName,
-				)
+				_, err := w.NewAccount(b.Context(), NewAccountParams{
+					Scope: scopes[0],
+					Name:  accountName,
+				})
 				require.NoError(b, err)
 
 				count++

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -617,6 +617,8 @@ func TestListAccountsByNameNoMatch(t *testing.T) {
 func TestGetAccount(t *testing.T) {
 	t.Parallel()
 
+	// Arrange: return a stored exclusion policy on a spendable account so
+	// the public snapshot must use persisted data, not custody or a default.
 	w, deps := createStartedWalletWithMocks(t)
 
 	// Seed a non-zero cached master fingerprint so the
@@ -646,10 +648,16 @@ func TestGetAccount(t *testing.T) {
 		KeyScope:           dbScope,
 		ConfirmedBalance:   100,
 		UnconfirmedBalance: 23,
+		NoChainSync:        true,
 	}, nil).Once()
 
+	// Act: read the account through the public API and its Store snapshot.
 	info, err := w.GetAccount(t.Context(), scope, name)
+
+	// Assert: policy, identity, and balances survive the Wallet conversion,
+	// and the single expected Store read supplies the complete result.
 	require.NoError(t, err)
+	require.True(t, info.NoChainSync)
 	require.NotNil(t, info.AccountNumber)
 	require.Equal(t, AccountNumber(1), *info.AccountNumber)
 	require.Equal(t, name, info.AccountName)
@@ -658,6 +666,7 @@ func TestGetAccount(t *testing.T) {
 	require.NotNil(t, info.MasterKeyFingerprint)
 	require.Equal(t, MasterFingerprint(masterFP),
 		*info.MasterKeyFingerprint)
+	deps.store.AssertExpectations(t)
 }
 
 // TestGetAccountIncludesImportedPseudoAccount verifies that the AccountInfo
@@ -1083,9 +1092,10 @@ func TestNewAccount(t *testing.T) {
 	expectAccountDeriveSetup(t, deps, stub)
 	deps.store.On("CreateDerivedAccount", mock.Anything,
 		db.CreateDerivedAccountParams{
-			WalletID: 0,
-			Scope:    dbScope,
-			Name:     testAccountName,
+			WalletID:    0,
+			Scope:       dbScope,
+			Name:        testAccountName,
+			NoChainSync: false,
 		}, mock.Anything).Return(
 		&db.AccountInfo{
 			AccountNumber: &accountNumber,
@@ -1094,20 +1104,50 @@ func TestNewAccount(t *testing.T) {
 		}, nil,
 	).Once()
 
-	// Act: create the next account in the scope.
+	// Act: create the next account with the default synchronization policy.
 	account, err := w.NewAccount(t.Context(), NewAccountParams{
 		Scope: scope,
 		Name:  testAccountName,
 	})
 
 	// Assert: the account result contains the allocated number and canonical
-	// master fingerprint, and every required dependency call occurred.
+	// master fingerprint, retains chain sync, and fulfills the required calls.
 	require.NoError(t, err)
+	require.False(t, account.NoChainSync)
 	require.NotNil(t, account.AccountNumber)
 	require.Equal(t, AccountNumber(1), *account.AccountNumber)
 	require.NotNil(t, account.MasterKeyFingerprint)
 	require.Equal(t, MasterFingerprint(stub.masterKeyFingerprint),
 		*account.MasterKeyFingerprint)
+}
+
+// TestNewAccountNoChainSyncUnsupported verifies the common Wallet boundary
+// refuses exclusion before any backend can prepare secrets or mutate accounts.
+func TestNewAccountNoChainSyncUnsupported(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: allow the existing admission checks on an unlocked wallet
+	// with an available name. Strict mocks have no secret or write
+	// expectations, so crossing into creation would fail this test.
+	w, deps := createUnlockedWalletWithMocks(t)
+	scope := waddrmgr.KeyScopeBIP0084
+
+	expectAccountNameFree(t, deps, scope, testAccountName)
+
+	// Act: request exclusion through the public API while its receiving and
+	// recovery support is unavailable.
+	account, err := w.NewAccount(t.Context(), NewAccountParams{
+		Scope:       scope,
+		Name:        testAccountName,
+		NoChainSync: true,
+	})
+
+	// Assert: the stable unsupported error returns no account, and only the
+	// required read-only admission calls reach the Store and Vault.
+	require.ErrorIs(t, err, ErrAccountOperationUnsupported)
+	require.Nil(t, account)
+	deps.store.AssertExpectations(t)
+	deps.vault.AssertExpectations(t)
 }
 
 // TestNewAccountMissingHDSeedDefersToStore verifies that neutered-root kvdb
@@ -2534,8 +2574,10 @@ func TestImportAccount(t *testing.T) {
 		masterFP, addrType, false,
 	)
 
-	// Assert: the imported account is returned and all Store calls occurred.
+	// Assert: the unchanged import request retains chain sync, returns the
+	// imported account, and fulfills all required Store calls.
 	require.NoError(t, err)
+	require.False(t, props.NoChainSync)
 	require.Equal(t, testAccountName, props.AccountName)
 }
 

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -1095,7 +1095,10 @@ func TestNewAccount(t *testing.T) {
 	).Once()
 
 	// Act: create the next account in the scope.
-	account, err := w.NewAccount(t.Context(), scope, testAccountName)
+	account, err := w.NewAccount(t.Context(), NewAccountParams{
+		Scope: scope,
+		Name:  testAccountName,
+	})
 
 	// Assert: the account result contains the allocated number and canonical
 	// master fingerprint, and every required dependency call occurred.
@@ -1146,7 +1149,10 @@ func TestNewAccountMissingHDSeedDefersToStore(t *testing.T) {
 	}, nil).Once()
 
 	// Act: create an account through the deferred derivation path.
-	account, err := w.NewAccount(t.Context(), scope, testAccountName)
+	account, err := w.NewAccount(t.Context(), NewAccountParams{
+		Scope: scope,
+		Name:  testAccountName,
+	})
 
 	// Assert: the Store-provided result is returned and all expected admission
 	// and derivation calls occurred.
@@ -1257,15 +1263,18 @@ func TestNewAccountAdmission(t *testing.T) {
 	t.Run("not started", func(t *testing.T) {
 		t.Parallel()
 
-		// Arrange.
+		// Arrange: leave the wallet unstarted so lifecycle rejection
+		// must happen before account lookup or creation.
 		w, deps := createTestWalletWithMocks(t)
 
-		// Act.
-		account, err := w.NewAccount(
-			t.Context(), waddrmgr.KeyScopeBIP0084, testAccountName,
-		)
+		// Act: submit a valid account request before wallet startup.
+		account, err := w.NewAccount(t.Context(), NewAccountParams{
+			Scope: waddrmgr.KeyScopeBIP0084,
+			Name:  testAccountName,
+		})
 
-		// Assert.
+		// Assert: lifecycle refusal returns no account or backend identity
+		// and never reaches the account lookup.
 		require.Nil(t, account)
 		require.ErrorIs(t, err, ErrStateForbidden)
 		requireNoInternalIdentity(t, err)
@@ -1283,12 +1292,14 @@ func TestNewAccountAdmission(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		cancel()
 
-		// Act.
-		account, err := w.NewAccount(
-			ctx, waddrmgr.KeyScopeBIP0084, testAccountName,
-		)
+		// Act: submit a valid request after its caller has cancelled.
+		account, err := w.NewAccount(ctx, NewAccountParams{
+			Scope: waddrmgr.KeyScopeBIP0084,
+			Name:  testAccountName,
+		})
 
-		// Assert.
+		// Assert: cancellation wins over watch-only admission and no
+		// account lookup runs for the cancelled request.
 		require.Nil(t, account)
 		require.Equal(t, context.Canceled, err)
 		require.Empty(t, reportedIdentities(err))
@@ -1309,12 +1320,14 @@ func TestNewAccountAdmission(t *testing.T) {
 		)
 		t.Cleanup(cancel)
 
-		// Act.
-		account, err := w.NewAccount(
-			ctx, waddrmgr.KeyScopeBIP0084, testAccountName,
-		)
+		// Act: submit a valid request after its caller deadline expired.
+		account, err := w.NewAccount(ctx, NewAccountParams{
+			Scope: waddrmgr.KeyScopeBIP0084,
+			Name:  testAccountName,
+		})
 
-		// Assert.
+		// Assert: the deadline wins over watch-only admission and no
+		// account lookup runs for the expired request.
 		require.Nil(t, account)
 		require.Equal(t, context.DeadlineExceeded, err)
 		require.Empty(t, reportedIdentities(err))
@@ -2112,7 +2125,10 @@ func TestNewAccountVaultLockedForbidden(t *testing.T) {
 		Return([]byte(nil), keyvault.ErrVaultLocked).Once()
 
 	// Act: create an account while the vault is locked.
-	account, err := w.NewAccount(t.Context(), scope, testAccountName)
+	account, err := w.NewAccount(t.Context(), NewAccountParams{
+		Scope: scope,
+		Name:  testAccountName,
+	})
 
 	// Assert: the lock is reported as a forbidden state, the vault
 	// identity does not escape, and no account row was attempted.
@@ -2139,7 +2155,10 @@ func TestNewAccountWatchOnlyUnsupported(t *testing.T) {
 	expectAccountNameFree(t, deps, scope, testAccountName)
 
 	// Act: create a derived account on the watch-only wallet.
-	account, err := w.NewAccount(t.Context(), scope, testAccountName)
+	account, err := w.NewAccount(t.Context(), NewAccountParams{
+		Scope: scope,
+		Name:  testAccountName,
+	})
 
 	// Assert: the refusal is reported as unsupported, the internal
 	// derivation sentinel does not escape, and the only Store call was the
@@ -2162,9 +2181,10 @@ func TestNewAccountLocked(t *testing.T) {
 	w, deps := createStartedWalletWithMocks(t)
 
 	// Act: create an account while the wallet is locked.
-	account, err := w.NewAccount(
-		t.Context(), waddrmgr.KeyScopeBIP0084, testAccountName,
-	)
+	account, err := w.NewAccount(t.Context(), NewAccountParams{
+		Scope: waddrmgr.KeyScopeBIP0084,
+		Name:  testAccountName,
+	})
 
 	// Assert: the wallet reports its own forbidden state and performs
 	// neither the name lookup nor the account write.
@@ -2211,9 +2231,10 @@ func TestNewAccountOccupiedName(t *testing.T) {
 			expectAccountNameTaken(t, deps, scope, testAccountName)
 
 			// Act: create an account under the occupied name.
-			account, err := w.NewAccount(
-				t.Context(), scope, testAccountName,
-			)
+			account, err := w.NewAccount(t.Context(), NewAccountParams{
+				Scope: scope,
+				Name:  testAccountName,
+			})
 
 			// Assert: the conflict is the only outcome reported, and
 			// nothing was derived or written.
@@ -2292,9 +2313,10 @@ func TestNewAccountTranslatesStoreError(t *testing.T) {
 				Return((*db.AccountInfo)(nil), tc.inject).Once()
 
 			// Act: create the next account in the scope.
-			account, err := w.NewAccount(
-				t.Context(), tc.scope, testAccountName,
-			)
+			account, err := w.NewAccount(t.Context(), NewAccountParams{
+				Scope: tc.scope,
+				Name:  testAccountName,
+			})
 
 			// Assert: only the expected error identity is reported.
 			require.Nil(t, account)
@@ -2321,14 +2343,16 @@ func TestNewAccountInvalidName(t *testing.T) {
 		t.Run("invalid name "+name, func(t *testing.T) {
 			t.Parallel()
 
-			// Arrange.
+			// Arrange: use a watch-only wallet to prove invalid names
+			// are rejected before the custody restriction.
 			w, _ := createStartedWalletWithMocks(t)
 			w.isWatchOnly = true
 
-			// Act.
-			account, err := w.NewAccount(
-				t.Context(), waddrmgr.KeyScopeBIP0084, name,
-			)
+			// Act: request creation with an empty or reserved name.
+			account, err := w.NewAccount(t.Context(), NewAccountParams{
+				Scope: waddrmgr.KeyScopeBIP0084,
+				Name:  name,
+			})
 
 			// Assert: validation outranks the watch-only refusal.
 			require.Nil(t, account)
@@ -2722,9 +2746,10 @@ func TestNewAccountRejectsStopped(t *testing.T) {
 	require.NoError(t, w.Stop(t.Context()))
 
 	// Act: Attempt to create an account through the terminal Wallet.
-	_, err := w.NewAccount(
-		t.Context(), waddrmgr.KeyScopeBIP0084, testAccountName,
-	)
+	_, err := w.NewAccount(t.Context(), NewAccountParams{
+		Scope: waddrmgr.KeyScopeBIP0084,
+		Name:  testAccountName,
+	})
 
 	// Assert: The terminal sentinel proves the request was rejected before
 	// account derivation or Store access began.

--- a/wallet/manager_sqlite_test.go
+++ b/wallet/manager_sqlite_test.go
@@ -321,10 +321,10 @@ func TestManagerSQLiteReopenDerivesAddress(t *testing.T) {
 	require.NoError(t, w.keyVault.Unlock(t.Context(), privPass))
 	w.state.toUnlocked()
 
-	_, err = w.NewAccount(
-		t.Context(), waddrmgr.KeyScopeBIP0084,
-		waddrmgr.DefaultAccountName,
-	)
+	_, err = w.NewAccount(t.Context(), NewAccountParams{
+		Scope: waddrmgr.KeyScopeBIP0084,
+		Name:  waddrmgr.DefaultAccountName,
+	})
 	require.NoError(t, err)
 
 	addr, err := w.NewAddress(


### PR DESCRIPTION
## Summary

Implements roadmap Task 392.

## Change Description

Carry account sync policy through NewAccountParams and AccountInfo. Preserve
ordinary creation and reject NoChainSync=true after admission, before secret
preparation or storage mutation, until activation is enabled.

## Notes

Depends on #1365. The base branch task-account-creation-base mirrors its head
f7e1dc1e05f8fd74c66c65af81c5527efb4e7e05; review scope starts after #1365.
The account error boundary from #1358 is now merged into sql-wallet and
included in this base. Receiving remains outside this PR.
