### PR TITLE
wallet: reject NoChainSync receiving requests

### DIFF
--- a/wallet/address_manager.go
+++ b/wallet/address_manager.go
@@ -168,7 +168,8 @@ type OutputScriptInfo struct {
 // addresses and scripts.
 type AddressManager interface {
 	// NewAddress returns a new address for the given account and address
-	// type.
+	// type. NoChainSync accounts return ErrAccountOperationUnsupported
+	// because receiving requires automatic chain tracking.
 	//
 	// NOTE: This method should be used with caution. Unlike
 	// GetUnusedAddress, it does not scan for previously derived but unused
@@ -180,11 +181,10 @@ type AddressManager interface {
 		addrType waddrmgr.AddressType,
 		change bool) (address.Address, error)
 
-	// GetUnusedAddress returns the first, oldest, unused address by
-	// scanning forward from the start of the derivation path. This method
-	// is the recommended default for obtaining a new receiving address, as
-	// it prevents address reuse and avoids creating gaps in the address
-	// chain that could impact wallet recovery.
+	// GetUnusedAddress returns the oldest address not recorded as used by
+	// the wallet, or allocates one if none remains. NoChainSync accounts
+	// return ErrAccountOperationUnsupported because their address use is not
+	// tracked automatically.
 	GetUnusedAddress(ctx context.Context, accountName string,
 		addrType waddrmgr.AddressType, change bool) (
 		address.Address, error)
@@ -572,6 +572,8 @@ type derivationInfoResp struct {
 // NewAddress returns a new address for the given account and address type.
 // This method is a low-level primitive that will always derive a new, unused
 // address from the end of the address chain.
+// NoChainSync accounts return ErrAccountOperationUnsupported before allocation
+// because receiving requires automatic chain tracking.
 //
 // It returns the next external or internal address for the wallet dictated by
 // the value of the `change` parameter. If change is true, then an internal
@@ -676,15 +678,26 @@ func (w *Wallet) newAddress(ctx context.Context, accountName string,
 		return nil, fmt.Errorf("%w: %v", ErrUnknownAddrType, addrType)
 	}
 
+	// Require receiving admission during the allocation's existing account
+	// read, so excluded accounts consume no child and need no extra lookup.
 	addrInfo, err := w.store.NewDerivedAddress(
 		ctx, db.NewDerivedAddressParams{
-			WalletID:    w.id,
-			AccountName: accountName,
-			Scope:       db.KeyScope(keyScope),
-			Change:      change,
+			WalletID:         w.id,
+			AccountName:      accountName,
+			Scope:            db.KeyScope(keyScope),
+			Change:           change,
+			RequireChainSync: true,
 		},
 	)
 	if err != nil {
+		// Keep the Store identity internal while exposing the established
+		// public unsupported-operation error with the refusal diagnostic.
+		if errors.Is(err, db.ErrAccountOperationUnsupported) {
+			return nil, fmt.Errorf(
+				"%w: %s", ErrAccountOperationUnsupported, err.Error(),
+			)
+		}
+
 		return nil, err
 	}
 
@@ -705,13 +718,15 @@ func (w *Wallet) newAddress(ctx context.Context, accountName string,
 
 // GetUnusedAddress returns the first, oldest, unused address by scanning
 // forward from the start of the derivation path. The address is considered
-// "unused" if it has never appeared in a transaction. This method is the
-// recommended default for obtaining a new receiving address. It prevents
-// address reuse and avoids creating gaps in the address chain, which is
-// critical for reliable wallet recovery under standards like BIP44 that
-// enforce a gap limit of 20 unused addresses. If all previously derived
-// addresses have been used, this method will delegate to NewAddress to
-// generate a new one.
+// "unused" if the wallet has not recorded it as used. For accounts that track
+// address use, this is the recommended default for obtaining a receiving
+// address: it avoids reuse and gaps in the address chain, supporting recovery
+// under standards like BIP44 that enforce a gap limit of 20 unused addresses.
+// If all previously derived addresses have been used, this method delegates
+// to NewAddress to generate a new one.
+// NoChainSync accounts return ErrAccountOperationUnsupported because their
+// address use is not tracked automatically. Rejection does not allocate a child
+// or register a chain watch.
 //
 // TODO(yy): The current implementation of GetUnusedAddress is inefficient for
 // wallets with a large number of used addresses. It iterates from the first
@@ -803,6 +818,18 @@ func (w *Wallet) handleGetUnusedAddress(r getUnusedAddressReq) {
 	for storeAddr, err := range addresses {
 		if err != nil {
 			r.respChan <- addressResp{err: err}
+
+			return
+		}
+
+		// Read the policy from the existing account join before treating a
+		// locally unused child as a receiving address.
+		if storeAddr.NoChainSync {
+			r.respChan <- addressResp{
+				err: fmt.Errorf("%w: account %q has chain "+
+					"synchronization disabled",
+					ErrAccountOperationUnsupported, r.accountName),
+			}
 
 			return
 		}

--- a/wallet/address_manager_test.go
+++ b/wallet/address_manager_test.go
@@ -6,6 +6,7 @@ package wallet
 
 import (
 	"bytes"
+	"fmt"
 	"iter"
 	"sync"
 	"testing"
@@ -353,13 +354,16 @@ func expectStoreNewAddress(t *testing.T, w *Wallet, deps *mockWalletDeps,
 
 	t.Helper()
 
+	// Public receiving requires the Store to reject excluded accounts before
+	// allocation and forward the caller context; success requires watching.
 	deps.store.On(
-		"NewDerivedAddress", mock.Anything,
+		"NewDerivedAddress", t.Context(),
 		db.NewDerivedAddressParams{
-			WalletID:    w.id,
-			AccountName: accountName,
-			Scope:       db.KeyScope(scope),
-			Change:      change,
+			WalletID:         w.id,
+			AccountName:      accountName,
+			Scope:            db.KeyScope(scope),
+			Change:           change,
+			RequireChainSync: true,
 		},
 	).Return(addressInfoFromAddr(t, addr), nil).Once()
 	deps.chain.On("NotifyReceived", []address.Address{addr}).Return(nil).Once()
@@ -541,13 +545,20 @@ func TestNewAddress(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
+			// Arrange: strict Store and chain mocks allow only the receiving
+			// operation appropriate to this selector and account policy.
 			w, deps := createStartedWalletWithMocks(t)
 
 			if tc.expectErr {
+				// Act: submit an invalid receiving selector before any
+				// account lookup or allocation expectations are declared.
 				_, err := w.NewAddress(
 					t.Context(), tc.accountName,
 					tc.addrType, tc.change,
 				)
+
+				// Assert: validation returns an error while strict Store
+				// mocks forbid policy reads or address allocation.
 				require.Error(t, err)
 
 				return
@@ -586,6 +597,7 @@ func TestNewAddress(t *testing.T) {
 			expectStoreNewAddress(
 				t, w, deps, tc.accountName, scope, tc.change, addr,
 			)
+
 			expectStoreAddressInfo(t, w, deps, addr,
 				derivedAddressInfoFromAddr(
 					t, addr, storeAddrType.Type, tc.accountName, scope,
@@ -593,10 +605,15 @@ func TestNewAddress(t *testing.T) {
 				),
 			)
 
+			// Act: allocate through the public API, which requires receiving
+			// admission before allocation and watches the successful result.
 			addr, err = w.NewAddress(
 				t.Context(), tc.accountName,
 				tc.addrType, tc.change,
 			)
+
+			// Assert: preserve the requested address type and branch while
+			// satisfying exactly the permitted allocation and watch calls.
 			require.NoError(t, err)
 			require.NotNil(t, addr)
 
@@ -605,8 +622,49 @@ func TestNewAddress(t *testing.T) {
 			addrInfo, err := w.GetAddressInfo(t.Context(), addr)
 			require.NoError(t, err)
 			require.Equal(t, tc.change, addrInfo.Internal)
+			deps.store.AssertExpectations(t)
+			deps.chain.AssertExpectations(t)
+			deps.vault.AssertExpectations(t)
 		})
 	}
+}
+
+// TestNewAddressNoChainSync verifies that a Store admission refusal becomes
+// the public receiving error without returning an address or registering it.
+func TestNewAddressNoChainSync(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: reject in the allocation's existing account read;
+	// strict mocks permit no extra lookup or notification.
+	accountName := "key-only"
+	w, deps := createStartedWalletWithMocks(t)
+	deps.store.On("NewDerivedAddress", t.Context(),
+		db.NewDerivedAddressParams{
+			WalletID:         w.id,
+			AccountName:      accountName,
+			Scope:            db.KeyScopeBIP0084,
+			RequireChainSync: true,
+		},
+	).Return((*db.AddressInfo)(nil), fmt.Errorf(
+		"%w: account %q has chain synchronization disabled",
+		db.ErrAccountOperationUnsupported, accountName,
+	)).Once()
+
+	// Act: request public receiving on the excluded account to
+	// exercise the wallet's translation of the Store refusal.
+	addr, err := w.NewAddress(
+		t.Context(), accountName, waddrmgr.WitnessPubKey, false,
+	)
+
+	// Assert: expose only the wallet error and no address; every
+	// permitted Store call occurs and the chain is never notified.
+	require.ErrorIs(t, err, ErrAccountOperationUnsupported)
+	require.NotErrorIs(t, err, db.ErrAccountOperationUnsupported)
+	require.ErrorContains(t, err, accountName)
+	require.ErrorContains(t, err, "chain synchronization disabled")
+	require.Nil(t, addr)
+	deps.store.AssertExpectations(t)
+	deps.chain.AssertExpectations(t)
 }
 
 // TestGetUnusedAddress tests the GetUnusedAddress method to ensure it
@@ -616,6 +674,9 @@ func TestGetUnusedAddress(t *testing.T) {
 
 	const importedXpubName = "imported-xpub"
 
+	// Arrange: supply stored derivation records so selection can use their
+	// branch and local use metadata directly. Strict mocks permit no account
+	// lookup or watch registration when an existing address is returned.
 	w, deps := createStartedWalletWithMocks(t)
 
 	firstAddr, _ := address.NewAddressWitnessPubKeyHash(
@@ -640,12 +701,17 @@ func TestGetUnusedAddress(t *testing.T) {
 		nil,
 	))).Once()
 
+	// Act: select the oldest external address not locally recorded as used.
 	unusedAddr, err := w.GetUnusedAddress(
 		t.Context(), defaultName, waddrmgr.WitnessPubKey, false,
 	)
+
+	// Assert: receiving keeps the first unused address instead of allocating.
 	require.NoError(t, err)
 	require.Equal(t, firstAddr.String(), unusedAddr.String())
 
+	// Arrange: an imported xpub child has a derivation path, so its local
+	// use metadata supports the same stored-address selection.
 	importedXpubAddr, _ := address.NewAddressWitnessPubKeyHash(
 		[]byte{
 			31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
@@ -669,44 +735,49 @@ func TestGetUnusedAddress(t *testing.T) {
 			Page:        req,
 		},
 	).Return(addressIter(*importedXpubInfo)).Once()
+
+	// Act: select a receiving address from the imported xpub account.
 	unusedImportedAddr, err := w.GetUnusedAddress(
 		t.Context(), importedXpubName, waddrmgr.WitnessPubKey, false,
 	)
+
+	// Assert: the existing unused xpub child remains usable without allocation.
 	require.NoError(t, err)
 	require.Equal(t, importedXpubAddr.String(), unusedImportedAddr.String())
 
+	// Arrange: make the stored child used so ordinary receiving must allocate
+	// its next child. Strict mocks permit only the scan, allocation, and watch.
 	usedFirstAddr := derivedAddressInfoFromAddr(
-		t, firstAddr, db.WitnessPubKey, defaultName, scope, false,
-		0, 0, nil,
+		t, firstAddr, db.WitnessPubKey, defaultName, scope, false, 0, 0, nil,
 	)
 	usedFirstAddr.IsUsed = true
+	deps.store.On("IterAddresses", t.Context(), db.ListAddressesQuery{
+		WalletID:    w.id,
+		AccountName: &defaultName,
+		Scope:       &dbScope,
+		Page:        req,
+	}).Return(addressIter(*usedFirstAddr)).Once()
 
-	deps.store.On(
-		"IterAddresses", mock.Anything,
-		db.ListAddressesQuery{
-			WalletID:    w.id,
-			AccountName: &defaultName,
-			Scope:       &dbScope,
-			Page:        req,
-		},
-	).Return(addressIter(*usedFirstAddr)).Once()
-
-	nextAddrVal, _ := address.NewAddressWitnessPubKeyHash(
+	nextAddrVal, err := address.NewAddressWitnessPubKeyHash(
 		[]byte{
 			1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
 			11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
 		}, w.cfg.ChainParams,
 	)
+	require.NoError(t, err)
 	expectStoreNewAddress(t, w, deps, defaultName, scope, false, nextAddrVal)
 
+	// Act: exhaust the used-address scan and enter the existing NewAddress
+	// fallback, which must make a receiving allocation request.
 	nextAddr, err := w.GetUnusedAddress(
 		t.Context(), defaultName, waddrmgr.WitnessPubKey, false,
 	)
+
+	// Assert: ordinary fallback still returns the new address and registers it.
 	require.NoError(t, err)
+	require.Equal(t, nextAddrVal, nextAddr)
 
-	// The next unused address should not be the same as the first one.
-	require.NotEqual(t, firstAddr.String(), nextAddr.String())
-
+	// Arrange: provide an unused internal child to preserve change selection.
 	changeAddrVal, _ := address.NewAddressWitnessPubKeyHash(
 		[]byte{
 			21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
@@ -727,11 +798,126 @@ func TestGetUnusedAddress(t *testing.T) {
 		0, nil,
 	))).Once()
 
+	// Act: request the unused child on the change branch of the same account.
 	unusedChangeAddr, err := w.GetUnusedAddress(
 		t.Context(), defaultName, waddrmgr.WitnessPubKey, true,
 	)
+
+	// Assert: selection returns the requested internal child, and every
+	// expected scan, fallback allocation, and notification occurred.
 	require.NoError(t, err)
 	require.Equal(t, changeAddrVal.String(), unusedChangeAddr.String())
+	deps.store.AssertExpectations(t)
+	deps.chain.AssertExpectations(t)
+}
+
+// TestGetUnusedAddressNoChainSync verifies receiving rejection both when a
+// stored child exposes account policy and when an empty account needs
+// allocation.
+func TestGetUnusedAddressNoChainSync(t *testing.T) {
+	t.Parallel()
+
+	accountName := "key-only"
+	scope := waddrmgr.KeyScopeBIP0084
+	dbScope := db.KeyScope(scope)
+	req, err := addressPageRequest()
+	require.NoError(t, err)
+
+	// Both receiving branches obey the same policy; each lookup path below
+	// has independent mocks so its permitted operations remain explicit.
+	testCases := []struct {
+		name   string
+		change bool
+	}{
+		{
+			name:   "external",
+			change: false,
+		},
+		{
+			name:   "internal",
+			change: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name+" stored child", func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: return an unused child on the requested branch
+			// that would be selected without the stored policy guard.
+			w, deps := createStartedWalletWithMocks(t)
+			child, err := address.NewAddressWitnessPubKeyHash(
+				make([]byte, 20), w.cfg.ChainParams,
+			)
+			require.NoError(t, err)
+			info := derivedAddressInfoFromAddr(
+				t, child, db.WitnessPubKey, accountName, scope,
+				tc.change, 0, 0, nil,
+			)
+			info.NoChainSync = true
+			deps.store.On("IterAddresses", t.Context(), db.ListAddressesQuery{
+				WalletID:    w.id,
+				AccountName: &accountName,
+				Scope:       &dbScope,
+				Page:        req,
+			}).Return(addressIter(*info)).Once()
+
+			// Act: request receiving reuse from the excluded account.
+			addr, err := w.GetUnusedAddress(
+				t.Context(), accountName, waddrmgr.WitnessPubKey, tc.change,
+			)
+
+			// Assert: reject with the public diagnostic and no address;
+			// strict mocks forbid allocation, account reads and watching.
+			require.ErrorIs(t, err, ErrAccountOperationUnsupported)
+			require.NotErrorIs(t, err, db.ErrAccountOperationUnsupported)
+			require.ErrorContains(t, err, accountName)
+			require.ErrorContains(t, err, "chain synchronization disabled")
+			require.Nil(t, addr)
+			deps.store.AssertExpectations(t)
+			deps.chain.AssertExpectations(t)
+		})
+
+		t.Run(tc.name+" empty account", func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: an empty scan reaches NewAddress, whose existing
+			// allocation call refuses before consuming a child index.
+			w, deps := createStartedWalletWithMocks(t)
+			deps.store.On("IterAddresses", t.Context(), db.ListAddressesQuery{
+				WalletID:    w.id,
+				AccountName: &accountName,
+				Scope:       &dbScope,
+				Page:        req,
+			}).Return(addressIter()).Once()
+			deps.store.On("NewDerivedAddress", t.Context(),
+				db.NewDerivedAddressParams{
+					WalletID:         w.id,
+					AccountName:      accountName,
+					Scope:            dbScope,
+					Change:           tc.change,
+					RequireChainSync: true,
+				},
+			).Return((*db.AddressInfo)(nil), fmt.Errorf(
+				"%w: account %q has chain synchronization disabled",
+				db.ErrAccountOperationUnsupported, accountName,
+			)).Once()
+
+			// Act: exhaust the scan and request a fresh receiving child.
+			addr, err := w.GetUnusedAddress(
+				t.Context(), accountName, waddrmgr.WitnessPubKey, tc.change,
+			)
+
+			// Assert: translate the Store refusal to the public error;
+			// strict mocks forbid extra account reads or notification.
+			require.ErrorIs(t, err, ErrAccountOperationUnsupported)
+			require.NotErrorIs(t, err, db.ErrAccountOperationUnsupported)
+			require.ErrorContains(t, err, accountName)
+			require.ErrorContains(t, err, "chain synchronization disabled")
+			require.Nil(t, addr)
+			deps.store.AssertExpectations(t)
+			deps.chain.AssertExpectations(t)
+		})
+	}
 }
 
 // TestGetAddressInfo tests the GetAddressInfo method to ensure it returns

--- a/wallet/internal/db/addressstore_newderived.go
+++ b/wallet/internal/db/addressstore_newderived.go
@@ -26,6 +26,10 @@ var (
 // and maps it onto this struct, so the workflow stays free of backend row
 // types and generics.
 type DerivedAddressAccount struct {
+	// NoChainSync lets receiving admission use the account already loaded
+	// for allocation, before consuming a child or invoking derivation.
+	NoChainSync bool
+
 	// AccountID is the backend account row ID.
 	AccountID int64
 
@@ -139,6 +143,13 @@ func NewDerivedAddressWithOps(ctx context.Context,
 		}
 
 		return nil, fmt.Errorf("get account: %w", err)
+	}
+
+	// A receiving request needs chain tracking. Enforce it using the account
+	// already loaded, while leaving internal allocation free of this promise.
+	if params.RequireChainSync && account.NoChainSync {
+		return nil, fmt.Errorf("%w: account %q has chain synchronization "+
+			"disabled", ErrAccountOperationUnsupported, key.AccountName)
 	}
 
 	// Non-derived accounts have a NULL account_number; their derivation uses

--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -700,6 +700,11 @@ type RenameAccountParams struct {
 // AddressInfo represents a wallet-managed address, including its properties and
 // derivation information.
 type AddressInfo struct {
+	// NoChainSync carries the owning account's stored policy in account
+	// address listings, allowing receiving admission without another lookup.
+	// Other address results do not populate this field.
+	NoChainSync bool
+
 	// ID is the database unique identifier for the address.
 	//
 	// NOTE: uint32 is used to ensure compatibility with standard SQL
@@ -837,6 +842,11 @@ type NewDerivedAddressParams struct {
 	// Change indicates whether to create a change address (true) or an
 	// external address (false).
 	Change bool
+
+	// RequireChainSync rejects NoChainSync accounts before allocating a
+	// receiving address. The false default preserves internal key and change
+	// allocation; this requirement never changes the stored account policy.
+	RequireChainSync bool
 }
 
 // NewImportedAddressParams defines the input required to import a single

--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -53,6 +53,10 @@ var (
 	// database.
 	ErrAccountNotFound = errors.New("account not found")
 
+	// ErrAccountOperationUnsupported reports that the stored account policy
+	// cannot satisfy an operation's requirements, before any mutation.
+	ErrAccountOperationUnsupported = errors.New("account operation unsupported")
+
 	// ErrAddressNotFound is returned when an address is not found in the
 	// database.
 	ErrAddressNotFound = errors.New("address not found")
@@ -325,6 +329,8 @@ type AddressStore interface {
 	// account and key scope. The concrete backend owns address derivation:
 	// SQL backends use their configured AddressDerivationFunc, while kvdb
 	// preserves legacy waddrmgr derivation semantics.
+	// RequireChainSync rejects an excluded account before counter allocation
+	// or derivation, using the account read already required by the operation.
 	NewDerivedAddress(ctx context.Context,
 		params NewDerivedAddressParams) (*AddressInfo, error)
 

--- a/wallet/internal/db/itest/addressstore_test.go
+++ b/wallet/internal/db/itest/addressstore_test.go
@@ -1931,20 +1931,12 @@ func TestListAddressesWatchOnlyWallet(t *testing.T) {
 }
 
 // TestNewDerivedAddress verifies that NewDerivedAddress correctly creates
-// derived addresses with proper AddressInfo fields for both external and
-// change addresses.
+// derived receiving addresses with proper AddressInfo fields on both branches.
 func TestNewDerivedAddress(t *testing.T) {
 	t.Parallel()
 
 	store := NewTestStore(t)
 	walletID := newWallet(t, store, "wallet-derived")
-
-	// Create account in BIP44 scope.
-	accountName := "derived-test"
-	createDerivedAccount(t, store, walletID, db.KeyScopeBIP0044, accountName)
-	account := getAccountByName(
-		t, store, walletID, db.KeyScopeBIP0044, accountName,
-	)
 
 	testCases := []struct {
 		name           string
@@ -1965,11 +1957,38 @@ func TestNewDerivedAddress(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			info := newDerivedAddress(
-				t, store, walletID, db.KeyScopeBIP0044, accountName, tc.change,
+			// Arrange: create a separate ordinary account so each branch
+			// starts at index zero and supplies its own expected identity.
+			accountName := tc.name
+			account, err := store.CreateDerivedAccount(
+				t.Context(), db.CreateDerivedAccountParams{
+					WalletID: walletID,
+					Scope:    db.KeyScopeBIP0044,
+					Name:     accountName,
+				}, SpendableDeriveFn(),
+			)
+			require.NoError(t, err)
+
+			query := listAccountAddressesQuery(
+				t, walletID, db.KeyScopeBIP0044, accountName, 10,
 			)
 
-			// Verify AddressInfo fields.
+			// Act: require a receiving address on the selected branch so the
+			// Store must enforce the policy loaded with its owning account.
+			info, err := store.NewDerivedAddress(
+				t.Context(), db.NewDerivedAddressParams{
+					WalletID:         walletID,
+					Scope:            db.KeyScopeBIP0044,
+					AccountName:      accountName,
+					Change:           tc.change,
+					RequireChainSync: true,
+				},
+			)
+
+			// Assert: successful receiving allocation produces the first child
+			// with the identity and derivation metadata of its owning account.
+			require.NoError(t, err)
+			require.Zero(t, info.Index)
 			require.NotZero(t, info.ID)
 			require.NotZero(t, info.AccountID)
 			require.False(t, info.IsImported)
@@ -1985,6 +2004,107 @@ func TestNewDerivedAddress(t *testing.T) {
 				t, *account.MasterKeyFingerprint,
 				info.MasterKeyFingerprint,
 			)
+
+			// Act: use ordinary account listing to read the persisted child.
+			listed, err := store.ListAddresses(t.Context(), query)
+
+			// Assert: the existing join supplies the policy needed for
+			// receiving rejection while retaining ordinary lookup visibility.
+			require.NoError(t, err)
+			require.Len(t, listed.Items, 1)
+			require.Equal(t, info.ID, listed.Items[0].ID)
+			require.False(t, listed.Items[0].NoChainSync)
+		})
+	}
+}
+
+// TestNewDerivedAddressNoChainSync verifies that receiving rejection performs
+// no derivation, persists no child, and leaves the branch index intact.
+func TestNewDerivedAddressNoChainSync(t *testing.T) {
+	t.Parallel()
+
+	// The same refusal contract applies to each independently allocated branch.
+	testCases := []struct {
+		name   string
+		change bool
+	}{
+		{
+			name:   "external",
+			change: false,
+		},
+		{
+			name:   "internal",
+			change: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: use a real Store with an observed derivation callback
+			// so a rollback cannot hide derivation performed before refusal.
+			deriveCalls := 0
+			derive := mockDeriveFunc()
+			store := NewTestStoreWithDerive(t, func(ctx context.Context,
+				params db.AddressDerivationParams) (*db.DerivedAddressData,
+				error) {
+
+				deriveCalls++
+
+				return derive(ctx, params)
+			})
+			walletID := newWallet(t, store, "wallet-untracked-receiving")
+			accountName := "key-only"
+			_, err := store.CreateDerivedAccount(
+				t.Context(), db.CreateDerivedAccountParams{
+					WalletID:    walletID,
+					Scope:       db.KeyScopeBIP0044,
+					Name:        accountName,
+					NoChainSync: true,
+				}, SpendableDeriveFn(),
+			)
+			require.NoError(t, err)
+
+			callsBefore := deriveCalls
+			query := listAccountAddressesQuery(
+				t, walletID, db.KeyScopeBIP0044, accountName, 10,
+			)
+
+			// Act: request receiving allocation on the excluded account;
+			// stored policy must reject before deriving or consuming a child.
+			info, err := store.NewDerivedAddress(
+				t.Context(), db.NewDerivedAddressParams{
+					WalletID:         walletID,
+					Scope:            db.KeyScopeBIP0044,
+					AccountName:      accountName,
+					Change:           tc.change,
+					RequireChainSync: true,
+				},
+			)
+
+			// Assert: refusal never invokes derivation or persists a child.
+			require.ErrorIs(t, err, db.ErrAccountOperationUnsupported)
+			require.Nil(t, info)
+			require.Equal(t, callsBefore, deriveCalls)
+			listed, err := store.ListAddresses(t.Context(), query)
+			require.NoError(t, err)
+			require.Empty(t, listed.Items)
+
+			// Probe the next raw allocation to prove refusal left this branch
+			// at index zero; raw allocation has no receiving requirement.
+			next := newDerivedAddress(
+				t, store, walletID, db.KeyScopeBIP0044,
+				accountName, tc.change,
+			)
+			require.Zero(t, next.Index)
+
+			// The existing account join must still expose the excluded policy
+			// on that child, allowing receiving reuse to reject it as well.
+			listed, err = store.ListAddresses(t.Context(), query)
+			require.NoError(t, err)
+			require.Len(t, listed.Items, 1)
+			require.Equal(t, next.ID, listed.Items[0].ID)
+			require.True(t, listed.Items[0].NoChainSync)
 		})
 	}
 }

--- a/wallet/internal/db/pg/addressstore_common.go
+++ b/wallet/internal/db/pg/addressstore_common.go
@@ -93,7 +93,7 @@ func addressRowToInfo[T addressInfoRow](row T) (*db.AddressInfo, error) {
 		)
 
 	case sqlc.ListAddressesByAccountRow:
-		return addressFieldsToInfo(
+		info, err := addressFieldsToInfo(
 			base.ID,
 			sql.NullInt64{Int64: base.DerivedAddressID, Valid: true},
 			sql.NullInt64{Int64: base.AccountID, Valid: true},
@@ -110,6 +110,15 @@ func addressRowToInfo[T addressInfoRow](row T) (*db.AddressInfo, error) {
 			base.ScriptPubKey, base.PubKey, base.CreatedAt,
 			base.WalletIsWatchOnly, base.HasScript, base.IsUsed,
 		)
+		if err != nil {
+			return nil, err
+		}
+
+		// The existing account join supplies receiving policy without a
+		// separate lookup or hiding this child from ordinary address lists.
+		info.NoChainSync = base.NoChainSync
+
+		return info, nil
 
 	default:
 		return nil, fmt.Errorf("%w: %T", errUnknownAddressRowType, row)

--- a/wallet/internal/db/pg/addressstore_newderived.go
+++ b/wallet/internal/db/pg/addressstore_newderived.go
@@ -68,7 +68,10 @@ func (o newDerivedAddressOps) GetAccount(ctx context.Context,
 		return db.DerivedAddressAccount{}, err
 	}
 
+	// Receiving admission uses this same account read before allocating,
+	// avoiding a separate policy lookup in the public API.
 	return db.DerivedAddressAccount{
+		NoChainSync:       row.NoChainSync,
 		AccountID:         row.ID,
 		AccountNumber:     row.AccountNumber,
 		AccountName:       row.AccountName,

--- a/wallet/internal/db/sqlite/addressstore_common.go
+++ b/wallet/internal/db/sqlite/addressstore_common.go
@@ -93,7 +93,7 @@ func addressRowToInfo[T addressInfoRow](row T) (*db.AddressInfo, error) {
 		)
 
 	case sqlc.ListAddressesByAccountRow:
-		return addressFieldsToInfo(
+		info, err := addressFieldsToInfo(
 			base.ID,
 			sql.NullInt64{Int64: base.DerivedAddressID, Valid: true},
 			sql.NullInt64{Int64: base.AccountID, Valid: true},
@@ -110,6 +110,15 @@ func addressRowToInfo[T addressInfoRow](row T) (*db.AddressInfo, error) {
 			base.ScriptPubKey, base.PubKey, base.CreatedAt,
 			base.WalletIsWatchOnly, base.HasScript, base.IsUsed,
 		)
+		if err != nil {
+			return nil, err
+		}
+
+		// The existing account join supplies receiving policy without a
+		// separate lookup or hiding this child from ordinary address lists.
+		info.NoChainSync = base.NoChainSync
+
+		return info, nil
 
 	default:
 		return nil, fmt.Errorf("%w: %T", errUnknownAddressRowType, row)

--- a/wallet/internal/db/sqlite/addressstore_newderived.go
+++ b/wallet/internal/db/sqlite/addressstore_newderived.go
@@ -68,7 +68,10 @@ func (o newDerivedAddressOps) GetAccount(ctx context.Context,
 		return db.DerivedAddressAccount{}, err
 	}
 
+	// Receiving admission uses this same account read before allocating,
+	// avoiding a separate policy lookup in the public API.
 	return db.DerivedAddressAccount{
+		NoChainSync:       row.NoChainSync,
 		AccountID:         row.ID,
 		AccountNumber:     row.AccountNumber,
 		AccountName:       row.AccountName,

--- a/wallet/internal/sql/pg/queries/addresses.sql
+++ b/wallet/internal/sql/pg/queries/addresses.sql
@@ -172,6 +172,8 @@ SELECT
     da.account_id,
     acc.account_number,
     acc.account_name,
+    -- Receiving admission uses the account already joined by this query.
+    acc.no_chain_sync,
     ks.purpose,
     ks.coin_type,
     a.script_type_id,

--- a/wallet/internal/sql/pg/sqlc/addresses.sql.go
+++ b/wallet/internal/sql/pg/sqlc/addresses.sql.go
@@ -322,6 +322,8 @@ SELECT
     da.account_id,
     acc.account_number,
     acc.account_name,
+    -- Receiving admission uses the account already joined by this query.
+    acc.no_chain_sync,
     ks.purpose,
     ks.coin_type,
     a.script_type_id,
@@ -378,6 +380,7 @@ type ListAddressesByAccountRow struct {
 	AccountID         int64
 	AccountNumber     sql.NullInt64
 	AccountName       string
+	NoChainSync       bool
 	Purpose           int64
 	CoinType          int64
 	ScriptTypeID      int16
@@ -418,6 +421,7 @@ func (q *Queries) ListAddressesByAccount(ctx context.Context, arg ListAddressesB
 			&i.AccountID,
 			&i.AccountNumber,
 			&i.AccountName,
+			&i.NoChainSync,
 			&i.Purpose,
 			&i.CoinType,
 			&i.ScriptTypeID,

--- a/wallet/internal/sql/sqlite/queries/addresses.sql
+++ b/wallet/internal/sql/sqlite/queries/addresses.sql
@@ -176,6 +176,8 @@ SELECT
     da.account_id,
     acc.account_number,
     acc.account_name,
+    -- Receiving admission uses the account already joined by this query.
+    acc.no_chain_sync,
     ks.purpose,
     ks.coin_type,
     a.script_type_id,

--- a/wallet/internal/sql/sqlite/sqlc/addresses.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/addresses.sql.go
@@ -323,6 +323,8 @@ SELECT
     da.account_id,
     acc.account_number,
     acc.account_name,
+    -- Receiving admission uses the account already joined by this query.
+    acc.no_chain_sync,
     ks.purpose,
     ks.coin_type,
     a.script_type_id,
@@ -381,6 +383,7 @@ type ListAddressesByAccountRow struct {
 	AccountID         int64
 	AccountNumber     sql.NullInt64
 	AccountName       string
+	NoChainSync       bool
 	Purpose           int64
 	CoinType          int64
 	ScriptTypeID      int64
@@ -421,6 +424,7 @@ func (q *Queries) ListAddressesByAccount(ctx context.Context, arg ListAddressesB
 			&i.AccountID,
 			&i.AccountNumber,
 			&i.AccountName,
+			&i.NoChainSync,
 			&i.Purpose,
 			&i.CoinType,
 			&i.ScriptTypeID,


### PR DESCRIPTION
## Summary

Implements roadmap Task 393: reject receiving requests for NoChainSync accounts.

## Change Description

Guard NewAddress before allocation using its existing account read. Guard GetUnusedAddress using policy from its existing address query, with the guarded allocation fallback for an empty result. Reuse the public unsupported-operation error and preserve internal change allocation without adding database queries.

Update both API docs and existing wallet/SQL tests. Unit, SQLite/PostgreSQL integration, ordinary receiving checks across all three backends, lint, and generation checks pass.

## Notes

Depends on #1366; review scope starts after it. Automatic scan exclusions remain in #1368. Separate key allocation belongs to Task 395, as described in [roadmap PR #34](https://github.com/yyforyongyu/btcwallet-sql-roadmap/pull/34).
