### PR TITLE
wallet: exclude key-only recovery accounts

### DIFF
--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -653,6 +653,11 @@ type ListAccountsQuery struct {
 	// name.
 	Name *string
 
+	// ChainSyncOnly excludes accounts with disabled chain synchronization
+	// before returning scan inputs. The default keeps ordinary listings
+	// inclusive, including accounts used only for key derivation.
+	ChainSyncOnly bool
+
 	// SkipBalance, when true, skips the dedicated AccountBalances query
 	// that the adapter normally runs alongside the list fetch. Each
 	// returned AccountInfo reports ConfirmedBalance and

--- a/wallet/internal/db/itest/accountstore_listaccounts_test.go
+++ b/wallet/internal/db/itest/accountstore_listaccounts_test.go
@@ -14,6 +14,100 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestListAccountsChainSyncOnly verifies the opt-in SQL filter excludes
+// NoChainSync accounts for each selector while default listing stays inclusive.
+func TestListAccountsChainSyncOnly(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: exercise each existing SQL selector with the same persisted
+	// policy pair so filtering cannot accidentally apply to only one query.
+	scope := db.KeyScopeBIP0084
+	ordinaryName, excludedName := "ordinary", "key-only"
+	tests := []struct {
+		name         string
+		query        db.ListAccountsQuery
+		wantDefault  []string
+		wantFiltered []string
+	}{
+		{
+			name:         "all accounts",
+			wantDefault:  []string{ordinaryName, excludedName},
+			wantFiltered: []string{ordinaryName},
+		},
+		{
+			name: "scope accounts",
+			query: db.ListAccountsQuery{
+				Scope: &scope,
+			},
+			wantDefault:  []string{ordinaryName, excludedName},
+			wantFiltered: []string{ordinaryName},
+		},
+		{
+			name: "ordinary name",
+			query: db.ListAccountsQuery{
+				Name: &ordinaryName,
+			},
+			wantDefault:  []string{ordinaryName},
+			wantFiltered: []string{ordinaryName},
+		},
+		{
+			name: "excluded name",
+			query: db.ListAccountsQuery{
+				Name: &excludedName,
+			},
+			wantDefault: []string{excludedName},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: each subtest owns its database lifecycle and creates
+			// an ordinary account plus one used only for key derivation.
+			store := NewTestStore(t)
+			walletID := newWallet(t, store, "chain-sync-list")
+
+			for _, name := range []string{ordinaryName, excludedName} {
+				_, err := store.CreateDerivedAccount(
+					t.Context(), db.CreateDerivedAccountParams{
+						WalletID:    walletID,
+						Scope:       scope,
+						Name:        name,
+						NoChainSync: name == excludedName,
+					}, SpendableDeriveFn(),
+				)
+				require.NoError(t, err)
+			}
+
+			// Act: run the same public selector with its inclusive default,
+			// then opt into scan-account filtering without changing identity.
+			query := test.query
+			query.WalletID = walletID
+			inclusive, inclusiveErr := store.ListAccounts(t.Context(), query)
+			query.ChainSyncOnly = true
+			filtered, filteredErr := store.ListAccounts(t.Context(), query)
+
+			// Assert: compare account membership, including the empty named
+			// result, to prove ordinary reads retain the excluded account.
+			require.NoError(t, inclusiveErr)
+			require.NoError(t, filteredErr)
+
+			var defaultNames, filteredNames []string
+			for _, account := range inclusive {
+				defaultNames = append(defaultNames, account.AccountName)
+			}
+
+			for _, account := range filtered {
+				filteredNames = append(filteredNames, account.AccountName)
+			}
+
+			require.ElementsMatch(t, test.wantDefault, defaultNames)
+			require.ElementsMatch(t, test.wantFiltered, filteredNames)
+		})
+	}
+}
+
 // TestListAccountsReturnsPublicKey verifies that the bulk read path
 // also surfaces the persisted PublicKey on every returned account.
 func TestListAccountsReturnsPublicKey(t *testing.T) {

--- a/wallet/internal/db/pg/accountstore_listaccounts.go
+++ b/wallet/internal/db/pg/accountstore_listaccounts.go
@@ -45,9 +45,10 @@ func (p accountListQueries) ListByScope(ctx context.Context,
 
 	rows, err := p.q.ListAccountsByWalletScope(
 		ctx, sqlc.ListAccountsByWalletScopeParams{
-			WalletID: int64(query.WalletID),
-			Purpose:  int64(query.Scope.Purpose),
-			CoinType: int64(query.Scope.Coin),
+			ChainSyncOnly: query.ChainSyncOnly,
+			WalletID:      int64(query.WalletID),
+			Purpose:       int64(query.Scope.Purpose),
+			CoinType:      int64(query.Scope.Coin),
 		},
 	)
 	if err != nil {
@@ -71,8 +72,9 @@ func (p accountListQueries) ListByName(ctx context.Context,
 
 	rows, err := p.q.ListAccountsByWalletAndName(
 		ctx, sqlc.ListAccountsByWalletAndNameParams{
-			WalletID:    int64(query.WalletID),
-			AccountName: *query.Name,
+			ChainSyncOnly: query.ChainSyncOnly,
+			WalletID:      int64(query.WalletID),
+			AccountName:   *query.Name,
 		},
 	)
 	if err != nil {
@@ -94,7 +96,14 @@ func (p accountListQueries) ListByName(ctx context.Context,
 func (p accountListQueries) ListAll(ctx context.Context,
 	query db.ListAccountsQuery) ([]db.AccountInfo, error) {
 
-	rows, err := p.q.ListAccountsByWallet(ctx, int64(query.WalletID))
+	// Forward the opt-in predicate to SQL so excluded scan accounts never
+	// reach row conversion, while ordinary account listing stays inclusive.
+	rows, err := p.q.ListAccountsByWallet(
+		ctx, sqlc.ListAccountsByWalletParams{
+			WalletID:      int64(query.WalletID),
+			ChainSyncOnly: query.ChainSyncOnly,
+		},
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/wallet/internal/db/sqlite/accountstore_listaccounts.go
+++ b/wallet/internal/db/sqlite/accountstore_listaccounts.go
@@ -45,9 +45,10 @@ func (s accountListQueries) ListByScope(ctx context.Context,
 
 	rows, err := s.q.ListAccountsByWalletScope(
 		ctx, sqlc.ListAccountsByWalletScopeParams{
-			WalletID: int64(query.WalletID),
-			Purpose:  int64(query.Scope.Purpose),
-			CoinType: int64(query.Scope.Coin),
+			ChainSyncOnly: query.ChainSyncOnly,
+			WalletID:      int64(query.WalletID),
+			Purpose:       int64(query.Scope.Purpose),
+			CoinType:      int64(query.Scope.Coin),
 		},
 	)
 	if err != nil {
@@ -71,8 +72,9 @@ func (s accountListQueries) ListByName(ctx context.Context,
 
 	rows, err := s.q.ListAccountsByWalletAndName(
 		ctx, sqlc.ListAccountsByWalletAndNameParams{
-			WalletID:    int64(query.WalletID),
-			AccountName: *query.Name,
+			ChainSyncOnly: query.ChainSyncOnly,
+			WalletID:      int64(query.WalletID),
+			AccountName:   *query.Name,
 		},
 	)
 	if err != nil {
@@ -94,7 +96,14 @@ func (s accountListQueries) ListByName(ctx context.Context,
 func (s accountListQueries) ListAll(ctx context.Context,
 	query db.ListAccountsQuery) ([]db.AccountInfo, error) {
 
-	rows, err := s.q.ListAccountsByWallet(ctx, int64(query.WalletID))
+	// Forward the opt-in predicate to SQL so excluded scan accounts never
+	// reach row conversion, while ordinary account listing stays inclusive.
+	rows, err := s.q.ListAccountsByWallet(
+		ctx, sqlc.ListAccountsByWalletParams{
+			WalletID:      int64(query.WalletID),
+			ChainSyncOnly: query.ChainSyncOnly,
+		},
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/wallet/internal/sql/pg/queries/accounts.sql
+++ b/wallet/internal/sql/pg/queries/accounts.sql
@@ -247,6 +247,7 @@ ORDER BY a.account_number NULLS LAST, a.account_name;
 
 -- name: ListAccountsByWalletScope :many
 -- Lists all accounts for a wallet and scope tuple.
+-- Scan callers opt in so ordinary account listing keeps key-only accounts.
 SELECT
     a.id,
     a.account_number,
@@ -267,13 +268,18 @@ FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
 INNER JOIN wallets AS w ON a.wallet_id = w.id
 WHERE
-    ks.wallet_id = $1
-    AND ks.purpose = $2
-    AND ks.coin_type = $3
+    ks.wallet_id = sqlc.arg('wallet_id')
+    AND ks.purpose = sqlc.arg('purpose')
+    AND ks.coin_type = sqlc.arg('coin_type')
+    AND (
+        sqlc.arg('chain_sync_only')::BOOLEAN = FALSE
+        OR a.no_chain_sync = FALSE
+    )
 ORDER BY a.account_number NULLS LAST, a.account_name;
 
 -- name: ListAccountsByWalletAndName :many
 -- Lists all accounts for a wallet filtered by account name.
+-- Scan callers opt in so ordinary account listing keeps key-only accounts.
 SELECT
     a.id,
     a.account_number,
@@ -293,11 +299,18 @@ SELECT
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
 INNER JOIN wallets AS w ON a.wallet_id = w.id
-WHERE ks.wallet_id = $1 AND a.account_name = $2
+WHERE
+    ks.wallet_id = sqlc.arg('wallet_id')
+    AND a.account_name = sqlc.arg('account_name')
+    AND (
+        sqlc.arg('chain_sync_only')::BOOLEAN = FALSE
+        OR a.no_chain_sync = FALSE
+    )
 ORDER BY a.account_number NULLS LAST, a.account_name;
 
 -- name: ListAccountsByWallet :many
 -- Lists all accounts for a wallet.
+-- Scan callers opt in so ordinary account listing keeps key-only accounts.
 SELECT
     a.id,
     a.account_number,
@@ -317,7 +330,12 @@ SELECT
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
 INNER JOIN wallets AS w ON a.wallet_id = w.id
-WHERE ks.wallet_id = $1
+WHERE
+    ks.wallet_id = sqlc.arg('wallet_id')
+    AND (
+        sqlc.arg('chain_sync_only')::BOOLEAN = FALSE
+        OR a.no_chain_sync = FALSE
+    )
 ORDER BY a.account_number NULLS LAST, a.account_name;
 
 -- name: UpdateAccountNameByWalletScopeAndNumber :execrows

--- a/wallet/internal/sql/pg/sqlc/accounts.sql.go
+++ b/wallet/internal/sql/pg/sqlc/accounts.sql.go
@@ -939,9 +939,19 @@ SELECT
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
 INNER JOIN wallets AS w ON a.wallet_id = w.id
-WHERE ks.wallet_id = $1
+WHERE
+    ks.wallet_id = $1
+    AND (
+        $2::BOOLEAN = FALSE
+        OR a.no_chain_sync = FALSE
+    )
 ORDER BY a.account_number NULLS LAST, a.account_name
 `
+
+type ListAccountsByWalletParams struct {
+	WalletID      int64
+	ChainSyncOnly bool
+}
 
 type ListAccountsByWalletRow struct {
 	ID                int64
@@ -962,8 +972,9 @@ type ListAccountsByWalletRow struct {
 }
 
 // Lists all accounts for a wallet.
-func (q *Queries) ListAccountsByWallet(ctx context.Context, walletID int64) ([]ListAccountsByWalletRow, error) {
-	rows, err := q.query(ctx, q.listAccountsByWalletStmt, ListAccountsByWallet, walletID)
+// Scan callers opt in so ordinary account listing keeps key-only accounts.
+func (q *Queries) ListAccountsByWallet(ctx context.Context, arg ListAccountsByWalletParams) ([]ListAccountsByWalletRow, error) {
+	rows, err := q.query(ctx, q.listAccountsByWalletStmt, ListAccountsByWallet, arg.WalletID, arg.ChainSyncOnly)
 	if err != nil {
 		return nil, err
 	}
@@ -1021,13 +1032,20 @@ SELECT
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
 INNER JOIN wallets AS w ON a.wallet_id = w.id
-WHERE ks.wallet_id = $1 AND a.account_name = $2
+WHERE
+    ks.wallet_id = $1
+    AND a.account_name = $2
+    AND (
+        $3::BOOLEAN = FALSE
+        OR a.no_chain_sync = FALSE
+    )
 ORDER BY a.account_number NULLS LAST, a.account_name
 `
 
 type ListAccountsByWalletAndNameParams struct {
-	WalletID    int64
-	AccountName string
+	WalletID      int64
+	AccountName   string
+	ChainSyncOnly bool
 }
 
 type ListAccountsByWalletAndNameRow struct {
@@ -1049,8 +1067,9 @@ type ListAccountsByWalletAndNameRow struct {
 }
 
 // Lists all accounts for a wallet filtered by account name.
+// Scan callers opt in so ordinary account listing keeps key-only accounts.
 func (q *Queries) ListAccountsByWalletAndName(ctx context.Context, arg ListAccountsByWalletAndNameParams) ([]ListAccountsByWalletAndNameRow, error) {
-	rows, err := q.query(ctx, q.listAccountsByWalletAndNameStmt, ListAccountsByWalletAndName, arg.WalletID, arg.AccountName)
+	rows, err := q.query(ctx, q.listAccountsByWalletAndNameStmt, ListAccountsByWalletAndName, arg.WalletID, arg.AccountName, arg.ChainSyncOnly)
 	if err != nil {
 		return nil, err
 	}
@@ -1112,13 +1131,18 @@ WHERE
     ks.wallet_id = $1
     AND ks.purpose = $2
     AND ks.coin_type = $3
+    AND (
+        $4::BOOLEAN = FALSE
+        OR a.no_chain_sync = FALSE
+    )
 ORDER BY a.account_number NULLS LAST, a.account_name
 `
 
 type ListAccountsByWalletScopeParams struct {
-	WalletID int64
-	Purpose  int64
-	CoinType int64
+	WalletID      int64
+	Purpose       int64
+	CoinType      int64
+	ChainSyncOnly bool
 }
 
 type ListAccountsByWalletScopeRow struct {
@@ -1140,8 +1164,14 @@ type ListAccountsByWalletScopeRow struct {
 }
 
 // Lists all accounts for a wallet and scope tuple.
+// Scan callers opt in so ordinary account listing keeps key-only accounts.
 func (q *Queries) ListAccountsByWalletScope(ctx context.Context, arg ListAccountsByWalletScopeParams) ([]ListAccountsByWalletScopeRow, error) {
-	rows, err := q.query(ctx, q.listAccountsByWalletScopeStmt, ListAccountsByWalletScope, arg.WalletID, arg.Purpose, arg.CoinType)
+	rows, err := q.query(ctx, q.listAccountsByWalletScopeStmt, ListAccountsByWalletScope,
+		arg.WalletID,
+		arg.Purpose,
+		arg.CoinType,
+		arg.ChainSyncOnly,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/wallet/internal/sql/pg/sqlc/querier.go
+++ b/wallet/internal/sql/pg/sqlc/querier.go
@@ -349,10 +349,13 @@ type Querier interface {
 	// Lists all accounts in a scope. Accounts without BIP44 numbers appear last.
 	ListAccountsByScope(ctx context.Context, scopeID int64) ([]ListAccountsByScopeRow, error)
 	// Lists all accounts for a wallet.
-	ListAccountsByWallet(ctx context.Context, walletID int64) ([]ListAccountsByWalletRow, error)
+	// Scan callers opt in so ordinary account listing keeps key-only accounts.
+	ListAccountsByWallet(ctx context.Context, arg ListAccountsByWalletParams) ([]ListAccountsByWalletRow, error)
 	// Lists all accounts for a wallet filtered by account name.
+	// Scan callers opt in so ordinary account listing keeps key-only accounts.
 	ListAccountsByWalletAndName(ctx context.Context, arg ListAccountsByWalletAndNameParams) ([]ListAccountsByWalletAndNameRow, error)
 	// Lists all accounts for a wallet and scope tuple.
+	// Scan callers opt in so ordinary account listing keeps key-only accounts.
 	ListAccountsByWalletScope(ctx context.Context, arg ListAccountsByWalletScopeParams) ([]ListAccountsByWalletScopeRow, error)
 	// Lists active wallet transaction rows and their raw transaction bytes.
 	//

--- a/wallet/internal/sql/sqlite/queries/accounts.sql
+++ b/wallet/internal/sql/sqlite/queries/accounts.sql
@@ -245,6 +245,7 @@ ORDER BY a.account_number IS NULL, a.account_number, a.account_name;
 
 -- name: ListAccountsByWalletScope :many
 -- Lists all accounts for a wallet and scope tuple.
+-- Scan callers opt in so ordinary account listing keeps key-only accounts.
 SELECT
     a.id,
     a.account_number,
@@ -265,13 +266,18 @@ FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
 INNER JOIN wallets AS w ON a.wallet_id = w.id
 WHERE
-    ks.wallet_id = ?
-    AND ks.purpose = ?
-    AND ks.coin_type = ?
+    ks.wallet_id = sqlc.arg('wallet_id')
+    AND ks.purpose = sqlc.arg('purpose')
+    AND ks.coin_type = sqlc.arg('coin_type')
+    AND (
+        cast(sqlc.arg('chain_sync_only') AS BOOLEAN) = FALSE
+        OR a.no_chain_sync = FALSE
+    )
 ORDER BY a.account_number IS NULL, a.account_number, a.account_name;
 
 -- name: ListAccountsByWalletAndName :many
 -- Lists all accounts for a wallet filtered by account name.
+-- Scan callers opt in so ordinary account listing keeps key-only accounts.
 SELECT
     a.id,
     a.account_number,
@@ -291,11 +297,17 @@ SELECT
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
 INNER JOIN wallets AS w ON a.wallet_id = w.id
-WHERE ks.wallet_id = ? AND a.account_name = ?
+WHERE
+    ks.wallet_id = sqlc.arg('wallet_id') AND a.account_name = sqlc.arg('account_name')
+    AND (
+        cast(sqlc.arg('chain_sync_only') AS BOOLEAN) = FALSE
+        OR a.no_chain_sync = FALSE
+    )
 ORDER BY a.account_number IS NULL, a.account_number, a.account_name;
 
 -- name: ListAccountsByWallet :many
 -- Lists all accounts for a wallet.
+-- Scan callers opt in so ordinary account listing keeps key-only accounts.
 SELECT
     a.id,
     a.account_number,
@@ -315,7 +327,12 @@ SELECT
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
 INNER JOIN wallets AS w ON a.wallet_id = w.id
-WHERE ks.wallet_id = ?
+WHERE
+    ks.wallet_id = sqlc.arg('wallet_id')
+    AND (
+        cast(sqlc.arg('chain_sync_only') AS BOOLEAN) = FALSE
+        OR a.no_chain_sync = FALSE
+    )
 ORDER BY a.account_number IS NULL, a.account_number, a.account_name;
 
 -- name: UpdateAccountNameByWalletScopeAndNumber :execrows

--- a/wallet/internal/sql/sqlite/sqlc/accounts.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/accounts.sql.go
@@ -946,9 +946,19 @@ SELECT
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
 INNER JOIN wallets AS w ON a.wallet_id = w.id
-WHERE ks.wallet_id = ?
+WHERE
+    ks.wallet_id = ?1
+    AND (
+        cast(?2 AS BOOLEAN) = FALSE
+        OR a.no_chain_sync = FALSE
+    )
 ORDER BY a.account_number IS NULL, a.account_number, a.account_name
 `
+
+type ListAccountsByWalletParams struct {
+	WalletID      int64
+	ChainSyncOnly bool
+}
 
 type ListAccountsByWalletRow struct {
 	ID                int64
@@ -969,8 +979,9 @@ type ListAccountsByWalletRow struct {
 }
 
 // Lists all accounts for a wallet.
-func (q *Queries) ListAccountsByWallet(ctx context.Context, walletID int64) ([]ListAccountsByWalletRow, error) {
-	rows, err := q.query(ctx, q.listAccountsByWalletStmt, ListAccountsByWallet, walletID)
+// Scan callers opt in so ordinary account listing keeps key-only accounts.
+func (q *Queries) ListAccountsByWallet(ctx context.Context, arg ListAccountsByWalletParams) ([]ListAccountsByWalletRow, error) {
+	rows, err := q.query(ctx, q.listAccountsByWalletStmt, ListAccountsByWallet, arg.WalletID, arg.ChainSyncOnly)
 	if err != nil {
 		return nil, err
 	}
@@ -1028,13 +1039,19 @@ SELECT
 FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
 INNER JOIN wallets AS w ON a.wallet_id = w.id
-WHERE ks.wallet_id = ? AND a.account_name = ?
+WHERE
+    ks.wallet_id = ?1 AND a.account_name = ?2
+    AND (
+        cast(?3 AS BOOLEAN) = FALSE
+        OR a.no_chain_sync = FALSE
+    )
 ORDER BY a.account_number IS NULL, a.account_number, a.account_name
 `
 
 type ListAccountsByWalletAndNameParams struct {
-	WalletID    int64
-	AccountName string
+	WalletID      int64
+	AccountName   string
+	ChainSyncOnly bool
 }
 
 type ListAccountsByWalletAndNameRow struct {
@@ -1056,8 +1073,9 @@ type ListAccountsByWalletAndNameRow struct {
 }
 
 // Lists all accounts for a wallet filtered by account name.
+// Scan callers opt in so ordinary account listing keeps key-only accounts.
 func (q *Queries) ListAccountsByWalletAndName(ctx context.Context, arg ListAccountsByWalletAndNameParams) ([]ListAccountsByWalletAndNameRow, error) {
-	rows, err := q.query(ctx, q.listAccountsByWalletAndNameStmt, ListAccountsByWalletAndName, arg.WalletID, arg.AccountName)
+	rows, err := q.query(ctx, q.listAccountsByWalletAndNameStmt, ListAccountsByWalletAndName, arg.WalletID, arg.AccountName, arg.ChainSyncOnly)
 	if err != nil {
 		return nil, err
 	}
@@ -1116,16 +1134,21 @@ FROM accounts AS a
 INNER JOIN key_scopes AS ks ON a.scope_id = ks.id
 INNER JOIN wallets AS w ON a.wallet_id = w.id
 WHERE
-    ks.wallet_id = ?
-    AND ks.purpose = ?
-    AND ks.coin_type = ?
+    ks.wallet_id = ?1
+    AND ks.purpose = ?2
+    AND ks.coin_type = ?3
+    AND (
+        cast(?4 AS BOOLEAN) = FALSE
+        OR a.no_chain_sync = FALSE
+    )
 ORDER BY a.account_number IS NULL, a.account_number, a.account_name
 `
 
 type ListAccountsByWalletScopeParams struct {
-	WalletID int64
-	Purpose  int64
-	CoinType int64
+	WalletID      int64
+	Purpose       int64
+	CoinType      int64
+	ChainSyncOnly bool
 }
 
 type ListAccountsByWalletScopeRow struct {
@@ -1147,8 +1170,14 @@ type ListAccountsByWalletScopeRow struct {
 }
 
 // Lists all accounts for a wallet and scope tuple.
+// Scan callers opt in so ordinary account listing keeps key-only accounts.
 func (q *Queries) ListAccountsByWalletScope(ctx context.Context, arg ListAccountsByWalletScopeParams) ([]ListAccountsByWalletScopeRow, error) {
-	rows, err := q.query(ctx, q.listAccountsByWalletScopeStmt, ListAccountsByWalletScope, arg.WalletID, arg.Purpose, arg.CoinType)
+	rows, err := q.query(ctx, q.listAccountsByWalletScopeStmt, ListAccountsByWalletScope,
+		arg.WalletID,
+		arg.Purpose,
+		arg.CoinType,
+		arg.ChainSyncOnly,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/wallet/internal/sql/sqlite/sqlc/querier.go
+++ b/wallet/internal/sql/sqlite/sqlc/querier.go
@@ -342,10 +342,13 @@ type Querier interface {
 	// Lists all accounts in a scope. Accounts without BIP44 numbers appear last.
 	ListAccountsByScope(ctx context.Context, scopeID int64) ([]ListAccountsByScopeRow, error)
 	// Lists all accounts for a wallet.
-	ListAccountsByWallet(ctx context.Context, walletID int64) ([]ListAccountsByWalletRow, error)
+	// Scan callers opt in so ordinary account listing keeps key-only accounts.
+	ListAccountsByWallet(ctx context.Context, arg ListAccountsByWalletParams) ([]ListAccountsByWalletRow, error)
 	// Lists all accounts for a wallet filtered by account name.
+	// Scan callers opt in so ordinary account listing keeps key-only accounts.
 	ListAccountsByWalletAndName(ctx context.Context, arg ListAccountsByWalletAndNameParams) ([]ListAccountsByWalletAndNameRow, error)
 	// Lists all accounts for a wallet and scope tuple.
+	// Scan callers opt in so ordinary account listing keeps key-only accounts.
 	ListAccountsByWalletScope(ctx context.Context, arg ListAccountsByWalletScopeParams) ([]ListAccountsByWalletScopeRow, error)
 	// Lists active wallet transaction rows and their raw transaction bytes.
 	//

--- a/wallet/syncer.go
+++ b/wallet/syncer.go
@@ -1974,17 +1974,20 @@ func (s *syncer) storeScanHorizons(ctx context.Context,
 	return s.storeTargetedScanHorizons(ctx, targets)
 }
 
-// storeFullScanHorizons loads full recovery horizon accounts from the Store,
-// skipping only the keyless raw-import bucket. The scan selects no account by
+// storeFullScanHorizons loads eligible recovery accounts from the Store,
+// skipping the keyless raw-import bucket. The scan selects no account by
 // number here, so each one is keyed on its durable store row ID and an imported
 // account cannot overwrite a derived account owning the same BIP44 number in
 // the same scope.
 func (s *syncer) storeFullScanHorizons(
 	ctx context.Context) ([]storeScanAccount, error) {
 
+	// Select eligible accounts in SQL before building recovery horizons;
+	// key-only accounts must never seed lookahead derivation.
 	accounts, err := s.store.ListAccounts(ctx, db.ListAccountsQuery{
-		WalletID:    s.walletID,
-		SkipBalance: true,
+		WalletID:      s.walletID,
+		SkipBalance:   true,
+		ChainSyncOnly: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list scan accounts: %w", err)
@@ -2190,9 +2193,12 @@ func keylessImportedAccount(info db.AccountInfo) bool {
 func (s *syncer) storeScanAddresses(
 	ctx context.Context) ([]address.Address, error) {
 
+	// Apply the account policy before paging addresses so key-only scripts
+	// never become scan watches, even when the recovery window is zero.
 	accounts, err := s.store.ListAccounts(ctx, db.ListAccountsQuery{
-		WalletID:    s.walletID,
-		SkipBalance: true,
+		WalletID:      s.walletID,
+		SkipBalance:   true,
+		ChainSyncOnly: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list scan accounts: %w", err)
@@ -2494,9 +2500,12 @@ func (s *syncer) resolveScanTargets(ctx context.Context,
 func (s *syncer) scanTargetNames(
 	ctx context.Context) (map[waddrmgr.AccountScope]string, error) {
 
+	// Resolve targets only from eligible SQL rows. An excluded explicit
+	// target then follows the existing missing-account error path.
 	accounts, err := s.store.ListAccounts(ctx, db.ListAccountsQuery{
-		WalletID:    s.walletID,
-		SkipBalance: true,
+		WalletID:      s.walletID,
+		SkipBalance:   true,
+		ChainSyncOnly: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list scan accounts: %w", err)

--- a/wallet/syncer_test.go
+++ b/wallet/syncer_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -473,9 +474,11 @@ func TestSyncerLoadScanState(t *testing.T) {
 	// The store returns one derived BIP0084 account, used for both the
 	// horizon and address loads.
 	accountNumber0 := uint32(0)
+	// Require scan-only selection at the Store boundary before loading rows.
 	store.On("ListAccounts", mock.Anything, mock.MatchedBy(
 		func(query db.ListAccountsQuery) bool {
-			return query.WalletID == walletID && query.SkipBalance
+			return query.WalletID == walletID && query.SkipBalance &&
+				query.ChainSyncOnly
 		},
 	)).Return([]db.AccountInfo{{
 		AccountID:     &accountNumber0,
@@ -2096,9 +2099,11 @@ func TestFullScanRecoverySeparatesStoreIDAndAccountNumber(t *testing.T) {
 		},
 	}
 
+	// Require scan-only selection at the Store boundary before loading rows.
 	store.On("ListAccounts", mock.Anything, mock.MatchedBy(
 		func(query db.ListAccountsQuery) bool {
-			return query.WalletID == walletID && query.SkipBalance
+			return query.WalletID == walletID && query.SkipBalance &&
+				query.ChainSyncOnly
 		},
 	)).Return(accounts, nil).Once()
 
@@ -2182,9 +2187,11 @@ func TestStoreScanHorizonsListAccounts(t *testing.T) {
 		IsWatchOnly:          true,
 	}}
 
+	// Require scan-only selection at the Store boundary before loading rows.
 	store.On("ListAccounts", mock.Anything, mock.MatchedBy(
 		func(query db.ListAccountsQuery) bool {
-			return query.WalletID == walletID && query.SkipBalance
+			return query.WalletID == walletID && query.SkipBalance &&
+				query.ChainSyncOnly
 		},
 	)).Return(accounts, nil).Once()
 
@@ -2203,6 +2210,194 @@ func TestStoreScanHorizonsListAccounts(t *testing.T) {
 	require.Equal(t, waddrmgr.KeyScopeBIP0084, props[0].KeyScope)
 	require.True(t, props[0].IsWatchOnly)
 	store.AssertExpectations(t)
+}
+
+// newSQLRecoverySyncer creates ordinary and NoChainSync accounts with one
+// persisted address each. Accounts and scripts are returned in that order so
+// tests can observe recovery policy without background synchronization.
+func newSQLRecoverySyncer(t *testing.T) (*syncer, []db.AccountInfo, [][]byte) {
+	t.Helper()
+
+	// Reuse the SQL Manager's real vault and derivation callbacks so the
+	// persisted account keys and scripts exercise the normal recovery path.
+	m := testSQLiteManager(t)
+	params := sqliteCreateParams(t)
+	params.Name = t.Name()
+	w, err := m.Create(params)
+	require.NoError(t, err)
+	require.NoError(t, w.keyVault.Unlock(t.Context(), params.PrivatePassphrase))
+	derive, err := w.buildAccountDeriveFn(t.Context())
+	require.NoError(t, err)
+
+	// Both accounts have identical setup except for the persisted policy;
+	// materializing an address also tests the non-lookahead watch source.
+	configs := []struct {
+		name        string
+		noChainSync bool
+	}{
+		{
+			name:        "ordinary",
+			noChainSync: false,
+		},
+		{
+			name:        "recovery-key-only",
+			noChainSync: true,
+		},
+	}
+
+	accounts := make([]db.AccountInfo, 0, len(configs))
+	scripts := make([][]byte, 0, len(configs))
+
+	for _, config := range configs {
+		_, err := w.store.CreateDerivedAccount(
+			t.Context(), db.CreateDerivedAccountParams{
+				WalletID:    w.id,
+				Scope:       db.KeyScopeBIP0084,
+				Name:        config.name,
+				NoChainSync: config.noChainSync,
+			}, derive,
+		)
+		require.NoError(t, err)
+		addr, err := w.store.NewDerivedAddress(
+			t.Context(), db.NewDerivedAddressParams{
+				WalletID:    w.id,
+				Scope:       db.KeyScopeBIP0084,
+				AccountName: config.name,
+			},
+		)
+		require.NoError(t, err)
+
+		// Snapshot the post-derivation counts for the rejection test's
+		// before/after comparison through the same Store read boundary.
+		account, err := w.store.GetAccount(t.Context(), db.GetAccountQuery{
+			WalletID:    w.id,
+			Scope:       db.KeyScopeBIP0084,
+			Name:        &config.name,
+			SkipBalance: true,
+		})
+		require.NoError(t, err)
+
+		accounts = append(accounts, *account)
+		scripts = append(scripts, addr.ScriptPubKey)
+	}
+
+	// A positive window forces recovery to derive beyond stored addresses;
+	// nil legacy stores select the existing SQL recovery derivation path.
+	s := newSyncer(Config{
+		RecoveryWindow: testScanRecoveryWindow,
+		ChainParams:    &chainParams,
+	}, nil, nil, &mockTxPublisher{}, w.store, w.id)
+
+	return s, accounts, scripts
+}
+
+// TestSyncerRecoveryExcludesNoChainSyncAccounts verifies that full SQL recovery
+// watches only the ordinary account, with the same count as ordinary targeting.
+func TestSyncerRecoveryExcludesNoChainSyncAccounts(t *testing.T) {
+	t.Parallel()
+
+	// Check the same admission policy at both lookahead depths, using a
+	// separate fixture so each subtest starts from independent account
+	// data.
+	for _, window := range []uint32{0, testScanRecoveryWindow} {
+		t.Run(fmt.Sprintf("window %d", window), func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: Persist both policies and their addresses so
+			// full recovery must filter horizon admission as well
+			// as already-materialized watches.
+			s, accounts, scripts := newSQLRecoverySyncer(t)
+			s.cfg.RecoveryWindow = window
+			targets := []waddrmgr.AccountScope{
+				{
+					Scope:   waddrmgr.KeyScopeBIP0084,
+					Account: *accounts[0].AccountNumber,
+				},
+			}
+
+			// Act: Initialize full recovery and the ordinary target
+			// separately from the same persisted snapshot, then
+			// obtain their observable filter scripts.
+			full, err := s.loadFullScanState(t.Context())
+			require.NoError(t, err)
+			targeted, err := s.loadTargetedScanState(
+				t.Context(), targets,
+			)
+			require.NoError(t, err)
+			fullScripts, err := full.BuildCFilterData()
+			require.NoError(t, err)
+			targetedScripts, err := targeted.BuildCFilterData()
+			require.NoError(t, err)
+
+			// Assert: Each ordinary branch retains its complete
+			// lookahead beyond its stored count, while the
+			// forbidden account contributes no watched script.
+			wantCount := int(
+				2*window + accounts[0].ExternalKeyCount +
+					accounts[0].InternalKeyCount,
+			)
+			require.Equal(t, wantCount, full.WatchListSize())
+			require.Equal(t, wantCount, targeted.WatchListSize())
+			require.Contains(t, fullScripts, scripts[0])
+			require.NotContains(t, fullScripts, scripts[1])
+			require.ElementsMatch(t, fullScripts, targetedScripts)
+		})
+	}
+}
+
+// TestSyncerRecoveryRejectsPersistedNoChainSync verifies SQL exclusion uses
+// normal target resolution without changing persisted recovery horizons.
+func TestSyncerRecoveryRejectsPersistedNoChainSync(t *testing.T) {
+	t.Parallel()
+
+	// Check the same admission policy at both lookahead depths, using a
+	// separate fixture so each subtest starts from independent account
+	// data.
+	for _, window := range []uint32{0, testScanRecoveryWindow} {
+		t.Run(fmt.Sprintf("window %d", window), func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: Use the real stored policy and retain the
+			// key counts after fixture derivation, so a partial
+			// recovery mutation remains observable.
+			s, accounts, _ := newSQLRecoverySyncer(t)
+			s.cfg.RecoveryWindow = window
+			before := accounts[1]
+			targets := []waddrmgr.AccountScope{
+				{
+					Scope:   waddrmgr.KeyScopeBIP0084,
+					Account: *before.AccountNumber,
+				},
+			}
+
+			// Act: Request recovery for the excluded account at
+			// this window size.
+			state, err := s.loadTargetedScanState(
+				t.Context(), targets,
+			)
+
+			// Assert: SQL excludes the account from target resolution,
+			// which returns the normal missing-account error without
+			// exposing state or advancing either stored branch count.
+			require.ErrorIs(t, err, db.ErrAccountNotFound)
+			require.Nil(t, state)
+			after, err := s.store.GetAccount(
+				t.Context(), db.GetAccountQuery{
+					WalletID:    s.walletID,
+					Scope:       before.KeyScope,
+					Name:        &before.AccountName,
+					SkipBalance: true,
+				},
+			)
+			require.NoError(t, err)
+			require.Equal(
+				t, before.ExternalKeyCount, after.ExternalKeyCount,
+			)
+			require.Equal(
+				t, before.InternalKeyCount, after.InternalKeyCount,
+			)
+		})
+	}
 }
 
 // TestStoreScanHorizonsGetAccount verifies targeted scan horizon reads resolve
@@ -2711,9 +2906,11 @@ func TestResolveScanTargetsDoesNotUseSQLAccountID(t *testing.T) {
 
 	id := importedID
 	number := otherNum
+	// Require scan-only selection at the Store boundary before loading rows.
 	store.On("ListAccounts", mock.Anything, mock.MatchedBy(
 		func(query db.ListAccountsQuery) bool {
-			return query.WalletID == walletID && query.SkipBalance
+			return query.WalletID == walletID && query.SkipBalance &&
+				query.ChainSyncOnly
 		},
 	)).Return([]db.AccountInfo{{
 		AccountID:     &id,
@@ -2810,9 +3007,11 @@ func TestStoreScanAddresses(t *testing.T) {
 		AccountName: waddrmgr.DefaultAccountName,
 		KeyScope:    db.KeyScopeBIP0084,
 	}}
+	// Require scan-only selection at the Store boundary before loading rows.
 	store.On("ListAccounts", mock.Anything, mock.MatchedBy(
 		func(query db.ListAccountsQuery) bool {
-			return query.WalletID == walletID && query.SkipBalance
+			return query.WalletID == walletID && query.SkipBalance &&
+				query.ChainSyncOnly
 		},
 	)).Return(accounts, nil).Once()
 
@@ -2870,9 +3069,11 @@ func TestStoreScanAddressesIncludesImportedAlias(t *testing.T) {
 		AccountName: waddrmgr.DefaultAccountName,
 		KeyScope:    db.KeyScopeBIP0084,
 	}}
+	// Require scan-only selection at the Store boundary before loading rows.
 	store.On("ListAccounts", mock.Anything, mock.MatchedBy(
 		func(query db.ListAccountsQuery) bool {
-			return query.WalletID == walletID && query.SkipBalance
+			return query.WalletID == walletID && query.SkipBalance &&
+				query.ChainSyncOnly
 		},
 	)).Return(accounts, nil).Once()
 
@@ -2924,9 +3125,11 @@ func TestStoreScanAddressesIncludesRawImportOnlyScope(t *testing.T) {
 	pkScript, err := txscript.PayToAddrScript(addr)
 	require.NoError(t, err)
 
+	// Require scan-only selection at the Store boundary before loading rows.
 	store.On("ListAccounts", mock.Anything, mock.MatchedBy(
 		func(query db.ListAccountsQuery) bool {
-			return query.WalletID == walletID && query.SkipBalance
+			return query.WalletID == walletID && query.SkipBalance &&
+				query.ChainSyncOnly
 		},
 	)).Return([]db.AccountInfo(nil), nil).Once()
 
@@ -2983,9 +3186,11 @@ func TestStoreScanAddressesNonDefaultScope(t *testing.T) {
 		AccountName: "custom",
 		KeyScope:    nonDefault,
 	}}
+	// Require scan-only selection at the Store boundary before loading rows.
 	store.On("ListAccounts", mock.Anything, mock.MatchedBy(
 		func(query db.ListAccountsQuery) bool {
-			return query.WalletID == walletID && query.SkipBalance
+			return query.WalletID == walletID && query.SkipBalance &&
+				query.ChainSyncOnly
 		},
 	)).Return(accounts, nil).Once()
 
@@ -3099,9 +3304,11 @@ func TestLoadWalletScanDataStore(t *testing.T) {
 		InternalKeyCount: 5,
 		KeyScope:         db.KeyScopeBIP0084,
 	}}
+	// Require scan-only selection at the Store boundary before loading rows.
 	store.On("ListAccounts", mock.Anything, mock.MatchedBy(
 		func(query db.ListAccountsQuery) bool {
-			return query.WalletID == walletID && query.SkipBalance
+			return query.WalletID == walletID && query.SkipBalance &&
+				query.ChainSyncOnly
 		},
 	)).Return(accounts, nil).Twice()
 


### PR DESCRIPTION
## Summary

Exclude NoChainSync accounts from recovery scan inputs.

## Change Description

Select eligible accounts in the existing SQL account-list queries before target resolution, horizon loading, and address loading. Keep ordinary account listing inclusive and use the existing missing-account error for excluded explicit targets. Cover persisted SQL policy at zero and positive recovery windows.

## Notes

Depends on #1367; review scope starts after that PR.
