### PR TITLE
wallet: create exact accounts with sync policy

### DIFF
--- a/itest/account_manager_test.go
+++ b/itest/account_manager_test.go
@@ -104,17 +104,22 @@ func deterministicImportedAccountKeys(
 // testAccountManagerCreateAccount verifies that a new derived account's
 // returned view matches an immediate read and survives a wallet reload.
 func testAccountManagerCreateAccount(h *bwtest.HarnessTest) {
+	// Arrange: create an unlocked wallet with the harness so this ordinary
+	// sequential request exercises the same contract on every backend.
 	const accountName = "account manager created"
 
 	scope := waddrmgr.KeyScopeBIP0084
 	ctx := h.Context()
 	w, _ := h.NewWallet(bwtest.WalletFixture{Unlocked: true})
 
+	// Act: create one root-derived account through the public operation.
 	created, err := w.NewAccount(ctx, wallet.NewAccountParams{
 		Scope: scope,
 		Name:  accountName,
 	})
 
+	// Assert: compare returned key facts and the complete account view with
+	// immediate and reopened reads to prove durable sequential creation.
 	require.NoError(h, err, "failed to create derived account")
 	require.Equal(h, accountName, created.AccountName)
 	require.NotNil(
@@ -167,6 +172,56 @@ func testAccountManagerCreateAccount(h *bwtest.HarnessTest) {
 	require.Equal(h, want, durableInfo)
 }
 
+// testAccountManagerCreateExactAccount verifies an exact account's disabled
+// chain synchronization and complete account facts survive reopening.
+func testAccountManagerCreateExactAccount(h *bwtest.HarnessTest) {
+	// Exact selection is SQL-only; the sequential case covers kvdb.
+	if *dbBackend != string(wallet.DBBackendSQLite) &&
+		*dbBackend != string(wallet.DBBackendPostgres) {
+
+		h.Skip("exact account creation requires SQL")
+	}
+
+	// Arrange: a sparse, excluded account exercises exact activation; the
+	// harness owns the unlocked wallet and its cleanup.
+	w, _ := h.NewWallet(bwtest.WalletFixture{Unlocked: true})
+	number := wallet.AccountNumber(7)
+	params := wallet.NewAccountParams{
+		Scope:         waddrmgr.KeyScopeBIP0084,
+		Name:          "sparse exact",
+		AccountNumber: &number,
+		NoChainSync:   true,
+	}
+
+	// Act: create publicly through both derivation and storage.
+	created, err := w.NewAccount(h.Context(), params)
+
+	// Assert: compare exact identity and full facts after reopen,
+	// normalizing key prefixes with the existing comparison helper.
+	require.NoError(h, err)
+	require.Equal(h, number, *created.AccountNumber)
+	require.True(h, created.NoChainSync)
+	require.Zero(h, created.ExternalKeyCount)
+	require.Zero(h, created.InternalKeyCount)
+
+	// Account creation alone must leave child addresses unallocated.
+	addresses, err := w.ListAddresses(
+		h.Context(), params.Name, waddrmgr.WitnessPubKey,
+	)
+	require.NoError(h, err)
+	require.Empty(h, addresses)
+
+	want := *created
+	want.PublicKey = canonicalAccountKey(h, want.PublicKey)
+	w = h.ReloadWallet(w)
+	durable, err := w.GetAccount(
+		h.Context(), params.Scope, params.Name,
+	)
+	require.NoError(h, err)
+	durable.PublicKey = canonicalAccountKey(h, durable.PublicKey)
+	require.Equal(h, want, *durable)
+}
+
 // testAccountManagerFillAccountHole verifies that reopening after sparse
 // allocation leaves lower exact account numbers available.
 func testAccountManagerFillAccountHole(h *bwtest.HarnessTest) {
@@ -201,6 +256,48 @@ func testAccountManagerFillAccountHole(h *bwtest.HarnessTest) {
 	// Assert: earlier sparse creation did not consume the requested hole.
 	require.NoError(h, err)
 	require.Equal(h, hole, *filled.AccountNumber)
+}
+
+// testAccountManagerAdvanceAccountCursor checks durable sparse allocation.
+func testAccountManagerAdvanceAccountCursor(h *bwtest.HarnessTest) {
+	// kvdb rejects exact requests, so this SQL cursor contract is inapplicable.
+	if *dbBackend != string(wallet.DBBackendSQLite) &&
+		*dbBackend != string(wallet.DBBackendPostgres) {
+
+		h.Skip("exact account creation requires SQL")
+	}
+
+	// Arrange: persist excluded seven and ordinary two, then reopen so the
+	// next request observes only the durable cursor left by both writes.
+	w, _ := h.NewWallet(bwtest.WalletFixture{Unlocked: true})
+	number := wallet.AccountNumber(7)
+	params := wallet.NewAccountParams{
+		Scope:         waddrmgr.KeyScopeBIP0084,
+		Name:          "excluded sparse",
+		AccountNumber: &number,
+		NoChainSync:   true,
+	}
+	_, err := w.NewAccount(h.Context(), params)
+	require.NoError(h, err)
+
+	hole := wallet.AccountNumber(2)
+	params.Name = "lower hole"
+	params.AccountNumber = &hole
+	params.NoChainSync = false
+	_, err = w.NewAccount(h.Context(), params)
+	require.NoError(h, err)
+	w = h.ReloadWallet(w)
+	h.UnlockWallet(w)
+
+	params.Name = "next sequential"
+	params.AccountNumber = nil
+
+	// Act: allocate the next account without an exact selector.
+	next, err := w.NewAccount(h.Context(), params)
+
+	// Assert: the cursor advanced past seven and did not retreat for two.
+	require.NoError(h, err)
+	require.Equal(h, wallet.AccountNumber(8), *next.AccountNumber)
 }
 
 // testAccountManagerCreateAccountSequence verifies that derived account numbers

--- a/itest/account_manager_test.go
+++ b/itest/account_manager_test.go
@@ -167,6 +167,42 @@ func testAccountManagerCreateAccount(h *bwtest.HarnessTest) {
 	require.Equal(h, want, durableInfo)
 }
 
+// testAccountManagerFillAccountHole verifies that reopening after sparse
+// allocation leaves lower exact account numbers available.
+func testAccountManagerFillAccountHole(h *bwtest.HarnessTest) {
+	// Exact lower-hole creation is unavailable on kvdb.
+	if *dbBackend != string(wallet.DBBackendSQLite) &&
+		*dbBackend != string(wallet.DBBackendPostgres) {
+
+		h.Skip("exact account creation requires SQL")
+	}
+
+	// Arrange: persist sparse seven and reopen before requesting lower two,
+	// so the hole must remain available in durable allocation state.
+	w, _ := h.NewWallet(bwtest.WalletFixture{Unlocked: true})
+	number := wallet.AccountNumber(7)
+	params := wallet.NewAccountParams{
+		Scope:         waddrmgr.KeyScopeBIP0084,
+		Name:          "sparse before hole",
+		AccountNumber: &number,
+	}
+	_, err := w.NewAccount(h.Context(), params)
+	require.NoError(h, err)
+	w = h.ReloadWallet(w)
+	h.UnlockWallet(w)
+
+	hole := wallet.AccountNumber(2)
+	params.Name = "lower hole"
+	params.AccountNumber = &hole
+
+	// Act: fill the lower hole through public creation after reopening.
+	filled, err := w.NewAccount(h.Context(), params)
+
+	// Assert: earlier sparse creation did not consume the requested hole.
+	require.NoError(h, err)
+	require.Equal(h, hole, *filled.AccountNumber)
+}
+
 // testAccountManagerCreateAccountSequence verifies that derived account numbers
 // are allocated contiguously within a key scope, that each scope allocates from
 // its own counter, and that the counter survives a wallet reload.

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -44,8 +44,16 @@ var allTestCases = []*testCase{
 		TestFunc: testAccountManagerCreateAccount,
 	},
 	{
+		Name:     "account manager create exact account",
+		TestFunc: testAccountManagerCreateExactAccount,
+	},
+	{
 		Name:     "account manager fill account hole",
 		TestFunc: testAccountManagerFillAccountHole,
+	},
+	{
+		Name:     "account manager advance account cursor",
+		TestFunc: testAccountManagerAdvanceAccountCursor,
 	},
 	{
 		Name:     "account manager create account sequence",

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -44,6 +44,10 @@ var allTestCases = []*testCase{
 		TestFunc: testAccountManagerCreateAccount,
 	},
 	{
+		Name:     "account manager fill account hole",
+		TestFunc: testAccountManagerFillAccountHole,
+	},
+	{
 		Name:     "account manager create account sequence",
 		TestFunc: testAccountManagerCreateAccountSequence,
 	},

--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -260,7 +260,8 @@ type NewAccountParams struct {
 	AccountNumber *AccountNumber
 
 	// NoChainSync requests exclusion from automatic chain synchronization.
-	// True is currently rejected with ErrAccountOperationUnsupported.
+	// True requires exact SQL selection; other requests return
+	// ErrAccountOperationUnsupported.
 	NoChainSync bool
 }
 
@@ -302,7 +303,8 @@ type NewAccountParams struct {
 type AccountManager interface {
 	// NewAccount creates the next or requested exact root-derived account. The
 	// provided name must be unique within that key scope. NoChainSync=true
-	// is currently rejected with ErrAccountOperationUnsupported.
+	// is supported only for exact SQL selection; other requests return
+	// ErrAccountOperationUnsupported.
 	// ErrIndeterminateCommit means persistence may have succeeded; callers
 	// must inspect stored state before retrying, never blindly repeat it.
 	NewAccount(ctx context.Context, params NewAccountParams) (*AccountInfo,
@@ -469,8 +471,9 @@ func (w *Wallet) requireAccountNameAvailable(ctx context.Context,
 // NewAccount creates the next or requested exact root-derived account and
 // returns its persisted info. The name and number must be unused in the scope.
 // Exact selection supports canonical SQL scopes and leaves lower holes free.
-// Exact kvdb requests and NoChainSync=true return
-// ErrAccountOperationUnsupported after admission and before secret preparation.
+// NoChainSync=true excludes automatic synchronization and recovery only with
+// exact SQL selection. Sequential exclusion and exact kvdb requests return
+// ErrAccountOperationUnsupported before preparing secrets.
 // Failures return no account; ErrIndeterminateCommit means persistence may
 // have succeeded. Once admitted, the call waits for the Store outcome even
 // after cancellation; the Store still receives the caller context.
@@ -561,20 +564,22 @@ func (w *Wallet) handleNewAccount(req newAccountReq) {
 		return
 	}
 
-	// Keep exclusion unavailable until receiving and recovery honor it.
-	// Refuse after admission so no backend prepares secrets or mutates state.
-	if req.params.NoChainSync {
-		req.resp <- accountResp{
-			err: fmt.Errorf("no-chain-sync account creation: %w",
-				ErrAccountOperationUnsupported),
-		}
+	// When an account does not watch for on-chain synchronization, its
+	// account number must be specified; sequential allocation is unsupported.
+	switch {
+	case req.params.AccountNumber == nil:
+		if req.params.NoChainSync {
+			req.resp <- accountResp{
+				err: fmt.Errorf("no-chain-sync account creation: %w",
+					ErrAccountOperationUnsupported),
+			}
 
-		return
-	}
+			return
+		}
 
 	// Wallet assembly supplies addrStore only for the sequential kvdb subset.
 	// Reject exact selection after admission but before root preparation.
-	if req.params.AccountNumber != nil && w.addrStore != nil {
+	case w.addrStore != nil:
 		req.resp <- accountResp{
 			err: fmt.Errorf("kvdb exact account creation: %w",
 				ErrAccountOperationUnsupported),

--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -27,6 +27,7 @@ import (
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/addresstype"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	dbruntime "github.com/btcsuite/btcwallet/wallet/internal/db/runtime"
 	"github.com/btcsuite/btcwallet/wallet/internal/keyvault"
 )
 
@@ -114,7 +115,13 @@ func newAccountErr(err error) error {
 	var publicErr error
 
 	switch {
-	case isAccountNameConflict(err):
+	// A failed commit may wrap cancellation after persistence; report
+	// uncertainty before the ordinary caller-error boundary can mask it.
+	case errors.Is(err, dbruntime.ErrAmbiguousTxCommit):
+		return fmt.Errorf("%w: %s", ErrIndeterminateCommit, err.Error())
+
+	case isAccountNameConflict(err),
+		errors.Is(err, db.ErrAccountNumberConflict):
 		publicErr = ErrAccountAlreadyExists
 
 	case errors.Is(err, errWatchOnlyAccountDerivation),
@@ -291,6 +298,8 @@ type AccountManager interface {
 	// NewAccount creates a new account for a given key scope and name. The
 	// provided name must be unique within that key scope. NoChainSync=true
 	// is currently rejected with ErrAccountOperationUnsupported.
+	// ErrIndeterminateCommit means persistence may have succeeded; callers
+	// must inspect stored state before retrying, never blindly repeat it.
 	NewAccount(ctx context.Context, params NewAccountParams) (*AccountInfo,
 		error)
 

--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -245,7 +245,7 @@ func (w *Wallet) buildAccountDeriveFn(
 	return newAccountDeriveFn(masterKey, w.keyVault, fingerprint), nil
 }
 
-// NewAccountParams selects the next sequential account to create. The zero
+// NewAccountParams selects the next or an exact account to create. The zero
 // NoChainSync value preserves automatic chain synchronization.
 type NewAccountParams struct {
 	// Scope identifies the purpose and coin type used for derivation.
@@ -253,6 +253,11 @@ type NewAccountParams struct {
 
 	// Name must be valid and unique within Scope.
 	Name string
+
+	// AccountNumber requests this exact root-derived account in a canonical
+	// SQL scope, leaving lower holes available. Nil selects the next account.
+	// Modern kvdb rejects exact selection with ErrAccountOperationUnsupported.
+	AccountNumber *AccountNumber
 
 	// NoChainSync requests exclusion from automatic chain synchronization.
 	// True is currently rejected with ErrAccountOperationUnsupported.
@@ -295,7 +300,7 @@ type NewAccountParams struct {
 // Errors expose wallet-owned identities, with caller cancellation preserved
 // and internal failures retained only as diagnostic text.
 type AccountManager interface {
-	// NewAccount creates a new account for a given key scope and name. The
+	// NewAccount creates the next or requested exact root-derived account. The
 	// provided name must be unique within that key scope. NoChainSync=true
 	// is currently rejected with ErrAccountOperationUnsupported.
 	// ErrIndeterminateCommit means persistence may have succeeded; callers
@@ -433,7 +438,7 @@ type newAccountReq struct {
 	reqCtx
 
 	// params carries the caller inputs through the existing admission path.
-	params NewAccountParams
+	params db.CreateDerivedAccountParams
 	resp   chan accountResp
 }
 
@@ -461,13 +466,14 @@ func (w *Wallet) requireAccountNameAvailable(ctx context.Context,
 	return err
 }
 
-// NewAccount creates the next account and returns its account info. The name
-// must be unique under the key scope. In order to support automatic seed
-// restoring, new accounts may not be created when all of the previous 100
-// accounts have no transaction history (this is a deviation from the BIP0044
-// spec, which allows no unused account gaps).
-// NoChainSync=true is currently rejected with ErrAccountOperationUnsupported
-// after the existing admission checks and before secret preparation.
+// NewAccount creates the next or requested exact root-derived account and
+// returns its persisted info. The name and number must be unused in the scope.
+// Exact selection supports canonical SQL scopes and leaves lower holes free.
+// Exact kvdb requests and NoChainSync=true return
+// ErrAccountOperationUnsupported after admission and before secret preparation.
+// Failures return no account; ErrIndeterminateCommit means persistence may
+// have succeeded. Once admitted, the call waits for the Store outcome even
+// after cancellation; the Store still receives the caller context.
 func (w *Wallet) NewAccount(ctx context.Context,
 	params NewAccountParams) (*AccountInfo, error) {
 
@@ -487,6 +493,28 @@ func (w *Wallet) NewAccount(ctx context.Context,
 		return nil, err
 	}
 
+	// Snapshot selection before validation so admission carries the same
+	// account number through derivation and persistence.
+	if params.AccountNumber != nil {
+		number := *params.AccountNumber
+		params.AccountNumber = &number
+	}
+
+	// Validate the same complete path that the admitted Store write consumes,
+	// before checking signing readiness or loading any root material.
+	dbParams := db.CreateDerivedAccountParams{
+		WalletID:      w.id,
+		Scope:         db.KeyScope(params.Scope),
+		Name:          params.Name,
+		AccountNumber: (*uint32)(params.AccountNumber),
+		NoChainSync:   params.NoChainSync,
+	}
+
+	err = dbParams.Validate()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidParam, err.Error())
+	}
+
 	// Spendable derivation requires an unlocked wallet; watch-only wallets
 	// instead report their mode refusal after checking name availability.
 	if !w.IsWatchOnly() {
@@ -498,7 +526,7 @@ func (w *Wallet) NewAccount(ctx context.Context,
 
 	req := newAccountReq{
 		reqCtx: reqCtx{ctx: ctx},
-		params: params,
+		params: dbParams,
 		resp:   make(chan accountResp, 1),
 	}
 
@@ -507,10 +535,9 @@ func (w *Wallet) NewAccount(ctx context.Context,
 		return nil, err
 	}
 
-	resp, err := waitForReq(ctx, req.resp)
-	if err != nil {
-		return nil, err
-	}
+	// An admitted write may commit despite cancellation. Await its outcome
+	// so cancellation cannot hide the Store's indeterminate-commit identity.
+	resp := <-req.resp
 
 	return resp.info, newAccountErr(resp.err)
 }
@@ -520,7 +547,7 @@ func (w *Wallet) NewAccount(ctx context.Context,
 func (w *Wallet) handleNewAccount(req newAccountReq) {
 	// An occupied name takes precedence over mode or derivation refusals.
 	err := w.requireAccountNameAvailable(
-		req.ctx, req.params.Scope, req.params.Name,
+		req.ctx, waddrmgr.KeyScope(req.params.Scope), req.params.Name,
 	)
 	if err != nil {
 		req.resp <- accountResp{err: err}
@@ -545,6 +572,17 @@ func (w *Wallet) handleNewAccount(req newAccountReq) {
 		return
 	}
 
+	// Wallet assembly supplies addrStore only for the sequential kvdb subset.
+	// Reject exact selection after admission but before root preparation.
+	if req.params.AccountNumber != nil && w.addrStore != nil {
+		req.resp <- accountResp{
+			err: fmt.Errorf("kvdb exact account creation: %w",
+				ErrAccountOperationUnsupported),
+		}
+
+		return
+	}
+
 	deriveFn, err := w.buildAccountDeriveFn(req.ctx)
 	if err != nil {
 		req.resp <- accountResp{err: err}
@@ -552,14 +590,7 @@ func (w *Wallet) handleNewAccount(req newAccountReq) {
 		return
 	}
 
-	info, err := w.store.CreateDerivedAccount(req.ctx,
-		db.CreateDerivedAccountParams{
-			WalletID:    w.id,
-			Scope:       db.KeyScope(req.params.Scope),
-			Name:        req.params.Name,
-			NoChainSync: req.params.NoChainSync,
-		}, deriveFn,
-	)
+	info, err := w.store.CreateDerivedAccount(req.ctx, req.params, deriveFn)
 	if err != nil {
 		req.resp <- accountResp{err: err}
 

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/wallet/internal/addresstype"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
+	dbruntime "github.com/btcsuite/btcwallet/wallet/internal/db/runtime"
 	"github.com/btcsuite/btcwallet/wallet/internal/keyvault"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -1007,6 +1008,18 @@ func TestNewAccountStoreErrors(t *testing.T) {
 			want:     ErrAccountAlreadyExists,
 		},
 		{
+			name:     "occupied number",
+			storeErr: db.ErrAccountNumberConflict,
+			want:     ErrAccountAlreadyExists,
+		},
+		{
+			name: "indeterminate cancellation",
+			storeErr: &dbruntime.AmbiguousTxCommitError{
+				Err: context.Canceled,
+			},
+			want: ErrIndeterminateCommit,
+		},
+		{
 			name:     "sql exhaustion",
 			storeErr: db.ErrMaxAccountNumberReached,
 			want:     ErrAccountDerivationExhausted,
@@ -1034,7 +1047,8 @@ func TestNewAccountStoreErrors(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Arrange: Let derivation reach the Store outcome under test.
+			// Arrange: A failed Store write also supplies a candidate account;
+			// the public boundary must discard it when exposing the failure.
 			w, deps := createUnlockedWalletWithMocks(t)
 			stub := newStubAccountDeriveFn(t)
 			scope := waddrmgr.KeyScopeBIP0084
@@ -1044,15 +1058,16 @@ func TestNewAccountStoreErrors(t *testing.T) {
 			deps.store.On(
 				"CreateDerivedAccount", mock.Anything, mock.Anything,
 				mock.Anything,
-			).Return((*db.AccountInfo)(nil), test.storeErr).Once()
+			).Return(&db.AccountInfo{}, test.storeErr).Once()
 
 			// Act: Create through the public boundary, not the mapper.
-			_, err := w.NewAccount(t.Context(), NewAccountParams{
+			info, err := w.NewAccount(t.Context(), NewAccountParams{
 				Scope: scope,
 				Name:  testAccountName,
 			})
 
 			// Assert: Expose the public outcome and strip the Store cause.
+			require.Nil(t, info)
 			require.ErrorIs(t, err, test.want)
 			require.NotErrorIs(t, err, test.storeErr)
 		})

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -2017,3 +2017,140 @@ func TestExtractAddrFromPKScript(t *testing.T) {
 		})
 	}
 }
+
+// TestNewAccountInvalidPath verifies Wallet runs shared path validation before
+// loading secrets or invoking Store operations.
+func TestNewAccountInvalidPath(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: use an invalid exact number and strict mocks with no expected
+	// calls. The shared validator's tests own the complete path-input matrix.
+	w, _ := createStartedWalletWithMocks(t)
+	w.addrStore = nil
+	number := AccountNumber(db.MaxAccountNumber + 1)
+
+	// Act: enter creation through the public boundary with a malformed path.
+	info, err := w.NewAccount(t.Context(), NewAccountParams{
+		Scope:         waddrmgr.KeyScopeBIP0084,
+		Name:          testAccountName,
+		AccountNumber: &number,
+	})
+
+	// Assert: validation exposes only the public identity and no account,
+	// without making a secret or Store call before refusing the request.
+	require.ErrorIs(t, err, ErrInvalidParam)
+	require.NotErrorIs(t, err, db.ErrInvalidParam)
+	require.Nil(t, info)
+}
+
+// TestNewAccountExactUnsupported verifies kvdb rejects exact creation with
+// either policy after admission and before root preparation or Store mutation.
+func TestNewAccountExactUnsupported(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: vary the unsupported mode with identical read-only admission
+	// expectations. Any secret or creation call would fail the strict mocks.
+	tests := []struct {
+		name        string
+		noChainSync bool
+	}{
+		{
+			name: "kvdb exact",
+		},
+		{
+			name:        "kvdb no chain sync",
+			noChainSync: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			w, deps := createUnlockedWalletWithMocks(t)
+			scope := waddrmgr.KeyScopeBIP0084
+			number := AccountNumber(7)
+
+			expectAccountNameAvailable(deps, scope, testAccountName)
+
+			// Act: submit a valid path with the unsupported backend/policy.
+			info, err := w.NewAccount(t.Context(), NewAccountParams{
+				Scope:         scope,
+				Name:          testAccountName,
+				AccountNumber: &number,
+				NoChainSync:   test.noChainSync,
+			})
+
+			// Assert: both forms preserve the public unsupported outcome
+			// and stop after the required admission reads.
+			require.ErrorIs(t, err, ErrAccountOperationUnsupported)
+			require.Nil(t, info)
+		})
+	}
+}
+
+// TestNewAccountCancellationPreservesCommitError verifies cancellation cannot
+// hide an uncertain commit after the exact-account request has been admitted.
+func TestNewAccountCancellationPreservesCommitError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: hold an admitted Store write until explicitly released with
+	// an ambiguous result. Cleanup releases it before the fixture drains Stop.
+	w, deps := createUnlockedWalletWithMocks(t)
+	w.addrStore = nil
+	scope := waddrmgr.KeyScopeBIP0084
+	number := AccountNumber(7)
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	resumeCtx, resume := context.WithCancel(t.Context())
+	t.Cleanup(resume)
+
+	entered := make(chan struct{})
+	infos := make(chan *AccountInfo, 1)
+	result := make(chan error, 1)
+
+	expectAccountNameAvailable(deps, scope, testAccountName)
+	expectAccountDeriveSetup(t, deps, newStubAccountDeriveFn(t))
+	deps.store.On("CreateDerivedAccount", ctx,
+		db.CreateDerivedAccountParams{
+			WalletID:      w.id,
+			Scope:         db.KeyScope(scope),
+			Name:          testAccountName,
+			AccountNumber: (*uint32)(&number),
+		}, mock.Anything).Run(func(mock.Arguments) {
+		close(entered)
+		<-resumeCtx.Done()
+	}).Return(&db.AccountInfo{}, &dbruntime.AmbiguousTxCommitError{
+		Err: context.Canceled,
+	}).Once()
+
+	// Act: cancel after admission, while the write's outcome is still held.
+	go func() {
+		info, err := w.NewAccount(ctx, NewAccountParams{
+			Scope:         scope,
+			Name:          testAccountName,
+			AccountNumber: &number,
+		})
+		infos <- info
+
+		result <- err
+	}()
+
+	<-entered
+	cancel()
+
+	// Assert: the bounded observation window detects premature cancellation;
+	// only explicit Store release may supply the authoritative public result.
+	select {
+	case err := <-result:
+		t.Fatalf("NewAccount returned before the Store outcome: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	resume()
+
+	err := <-result
+	require.ErrorIs(t, err, ErrIndeterminateCommit)
+	require.NotErrorIs(t, err, context.Canceled)
+	require.NotErrorIs(t, err, dbruntime.ErrAmbiguousTxCommit)
+	require.Nil(t, <-infos)
+}

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -1154,8 +1154,8 @@ func TestNewAccountLocked(t *testing.T) {
 	require.NotErrorIs(t, err, keyvault.ErrVaultLocked)
 }
 
-// TestNewAccountNoChainSyncUnsupported verifies the common Wallet boundary
-// refuses exclusion before any backend can prepare secrets or mutate accounts.
+// TestNewAccountNoChainSyncUnsupported verifies sequential creation refuses
+// exclusion before preparing secrets or mutating accounts.
 func TestNewAccountNoChainSyncUnsupported(t *testing.T) {
 	t.Parallel()
 
@@ -1163,12 +1163,13 @@ func TestNewAccountNoChainSyncUnsupported(t *testing.T) {
 	// with an available name. Strict mocks have no secret or write
 	// expectations, so crossing into creation would fail this test.
 	w, deps := createUnlockedWalletWithMocks(t)
+	w.addrStore = nil
 	scope := waddrmgr.KeyScopeBIP0084
 
 	expectAccountNameAvailable(deps, scope, testAccountName)
 
-	// Act: request exclusion through the public API while its receiving and
-	// recovery support is unavailable.
+	// Act: request exclusion without an exact account number through the
+	// admitted public API, which otherwise selects sequential allocation.
 	account, err := w.NewAccount(t.Context(), NewAccountParams{
 		Scope:       scope,
 		Name:        testAccountName,

--- a/wallet/internal/db/accountstore_createderived.go
+++ b/wallet/internal/db/accountstore_createderived.go
@@ -115,8 +115,10 @@ type CreateDerivedAccountOps interface {
 		scope KeyScope) (int64, ScopeAddrSchema, error)
 
 	// AllocateAccountNumber reserves the next or requested account number
-	// and advances the scope cursor without consuming lower holes.
-	AllocateAccountNumber(ctx context.Context, scopeID int64) (int64, error)
+	// and advances the scope cursor without consuming lower holes. A nil
+	// selector requests the next account; a value requests that exact number.
+	AllocateAccountNumber(ctx context.Context, scopeID int64,
+		accountNumber *uint32) (int64, error)
 
 	// CreateDerivedAccount inserts the derived account row using the provided
 	// scope ID, allocated account number, public account name, requested
@@ -186,9 +188,10 @@ func deriveAndValidate(ctx context.Context, scope KeyScope, accNum uint32,
 // the cyclop budget and the "allocate then preview" pair is described
 // in one place.
 func allocateAndPreviewAccountNumber(ctx context.Context,
-	ops CreateDerivedAccountOps, scopeID int64) (int64, uint32, error) {
+	ops CreateDerivedAccountOps, scopeID int64,
+	accountNumber *uint32) (int64, uint32, error) {
 
-	allocated, err := ops.AllocateAccountNumber(ctx, scopeID)
+	allocated, err := ops.AllocateAccountNumber(ctx, scopeID, accountNumber)
 	if err != nil {
 		return 0, 0, fmt.Errorf("allocate account number: %w", err)
 	}
@@ -256,7 +259,7 @@ func CreateDerivedAccountWithOps(ctx context.Context,
 	}
 
 	allocated, accNumPreview, err := allocateAndPreviewAccountNumber(
-		ctx, ops, scopeID,
+		ctx, ops, scopeID, params.AccountNumber,
 	)
 	if err != nil {
 		return nil, err

--- a/wallet/internal/db/accountstore_createderived.go
+++ b/wallet/internal/db/accountstore_createderived.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"time"
+
+	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
 )
 
 var (
@@ -46,7 +48,32 @@ func (params *CreateDerivedAccountParams) Validate() error {
 		return ErrMissingAccountName
 	}
 
-	return requireUnreservedAccountName(params.Name)
+	err := requireUnreservedAccountName(params.Name)
+	if err != nil {
+		return err
+	}
+
+	// Validate before adding hardened offsets so malformed path components
+	// cannot wrap into a different derivation path or consume a scope cursor.
+	if params.Scope.Purpose >= hdkeychain.HardenedKeyStart ||
+		params.Scope.Coin >= hdkeychain.HardenedKeyStart {
+
+		return fmt.Errorf("hardened scope component: %w", ErrInvalidParam)
+	}
+
+	// Exact selection is restricted to canonical scopes and excludes the
+	// imported-account sentinel; nil retains the existing sequential subset.
+	if params.AccountNumber != nil {
+		if *params.AccountNumber > MaxAccountNumber {
+			return fmt.Errorf("exact account number: %w", ErrInvalidParam)
+		}
+
+		if _, ok := ScopeAddrMap[params.Scope]; !ok {
+			return fmt.Errorf("exact account scope: %w", ErrInvalidParam)
+		}
+	}
+
+	return nil
 }
 
 // CreateDerivedAccountRow contains the backend-independent fields the shared
@@ -65,7 +92,7 @@ type CreateDerivedAccountRow struct {
 //   - load the wallet watch-only mode so the returned AccountInfo matches the
 //     stored wallet state
 //   - ensure the requested key scope exists before allocating from its counter
-//   - allocate the next derived account number for that scope
+//   - reserve the next or requested derived account number for that scope
 //   - insert the derived account row with the allocated number and requested
 //     synchronization policy
 //   - normalize the inserted row into the public AccountInfo result
@@ -87,8 +114,8 @@ type CreateDerivedAccountOps interface {
 	EnsureScope(ctx context.Context, walletID uint32,
 		scope KeyScope) (int64, ScopeAddrSchema, error)
 
-	// AllocateAccountNumber advances and returns the next derived account
-	// number for the provided scope row.
+	// AllocateAccountNumber reserves the next or requested account number
+	// and advances the scope cursor without consuming lower holes.
 	AllocateAccountNumber(ctx context.Context, scopeID int64) (int64, error)
 
 	// CreateDerivedAccount inserts the derived account row using the provided

--- a/wallet/internal/db/accountstore_createderived_test.go
+++ b/wallet/internal/db/accountstore_createderived_test.go
@@ -94,22 +94,26 @@ func TestCreateDerivedAccountRejectsInvalidPath(t *testing.T) {
 func TestCreateDerivedAccountWithOps(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: configure every backend stage for one successful derived account
-	// with the non-default synchronization policy. The exact insert expectation
-	// proves the shared workflow forwards the policy once and in order.
+	// Arrange: request a sparse exact number and bind that same selector to
+	// the allocator expectation, so shared orchestration cannot drop it.
+	number := uint32(12)
 	params := CreateDerivedAccountParams{
 		WalletID: 7,
 		Scope: KeyScope{
 			Purpose: 49,
 			Coin:    0,
 		},
-		Name:        "savings",
-		NoChainSync: true,
+		Name:          "savings",
+		AccountNumber: &number,
+		NoChainSync:   true,
 	}
 	createdAt := time.Unix(123, 0)
 	expectedRow := CreateDerivedAccountRow{
-		AccountNumber: sql.NullInt64{Int64: 12, Valid: true},
-		CreatedAt:     createdAt,
+		AccountNumber: sql.NullInt64{
+			Int64: 12,
+			Valid: true,
+		},
+		CreatedAt: createdAt,
 	}
 
 	ops := &mockCreateDerivedAccountOps{}
@@ -121,6 +125,7 @@ func TestCreateDerivedAccountWithOps(t *testing.T) {
 	).Return(int64(11), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
 	allocateCall := ops.On(
 		"AllocateAccountNumber", mock.Anything, int64(11),
+		params.AccountNumber,
 	).Return(int64(12), nil).Once()
 	createCall := ops.On(
 		"CreateDerivedAccount", mock.Anything, int64(11), int64(12),
@@ -129,16 +134,15 @@ func TestCreateDerivedAccountWithOps(t *testing.T) {
 
 	mock.InOrder(walletCall, ensureScopeCall, allocateCall, createCall)
 
-	// Act: run the backend-independent workflow with the configured operations
-	// and valid watch-only derivation result.
+	// Act: use the shared workflow with valid derived material so the
+	// allocator result reaches the persisted account and returned view.
 	ctx := t.Context()
 	info, err := CreateDerivedAccountWithOps(
 		ctx, params, ops, testValidWatchOnlyDeriveFn(),
 	)
 
-	// Assert: the normalized result retains all existing account properties and
-	// the requested policy, while every expected backend stage runs exactly
-	// once.
+	// Assert: the exact identity and normalized account facts survive the
+	// complete workflow; expectations verify each required adapter call once.
 	require.NoError(t, err)
 	require.NotNil(t, info.AccountNumber)
 	require.Equal(t, uint32(12), *info.AccountNumber)
@@ -196,7 +200,10 @@ func TestCreateDerivedAccountWithOpsNilAccountNumber(t *testing.T) {
 			Coin:    0,
 		},
 	).Return(int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
-	ops.On("AllocateAccountNumber", mock.Anything, int64(8)).Return(
+	ops.On(
+		"AllocateAccountNumber", mock.Anything, int64(8),
+		(*uint32)(nil),
+	).Return(
 		int64(9), nil,
 	).Once()
 	ops.On(
@@ -236,7 +243,10 @@ func TestCreateDerivedAccountWithOpsMaxAccountNumber(t *testing.T) {
 			Coin:    0,
 		},
 	).Return(int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
-	ops.On("AllocateAccountNumber", mock.Anything, int64(8)).Return(
+	ops.On(
+		"AllocateAccountNumber", mock.Anything, int64(8),
+		(*uint32)(nil),
+	).Return(
 		int64(^uint32(0))+1, nil,
 	).Once()
 
@@ -308,7 +318,10 @@ func TestCreateDerivedAccountWithOpsWrapsStageErrors(t *testing.T) {
 				).Return(
 					int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil,
 				).Once()
-				ops.On("AllocateAccountNumber", mock.Anything, int64(8)).Return(
+				ops.On(
+					"AllocateAccountNumber", mock.Anything, int64(8),
+					(*uint32)(nil),
+				).Return(
 					int64(0), errTestBoom,
 				).Once()
 
@@ -330,7 +343,10 @@ func TestCreateDerivedAccountWithOpsWrapsStageErrors(t *testing.T) {
 				}).Return(
 					int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil,
 				).Once()
-				ops.On("AllocateAccountNumber", mock.Anything, int64(8)).Return(
+				ops.On(
+					"AllocateAccountNumber", mock.Anything, int64(8),
+					(*uint32)(nil),
+				).Return(
 					int64(9), nil,
 				).Once()
 				ops.On("CreateDerivedAccount", mock.Anything, int64(8),
@@ -395,7 +411,10 @@ func TestCreateDerivedAccountWithOpsDeriveFnInvokedOnce(t *testing.T) {
 			Coin:    0,
 		},
 	).Return(int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
-	ops.On("AllocateAccountNumber", mock.Anything, int64(8)).Return(
+	ops.On(
+		"AllocateAccountNumber", mock.Anything, int64(8),
+		(*uint32)(nil),
+	).Return(
 		int64(9), nil,
 	).Once()
 	ops.On(
@@ -442,7 +461,10 @@ func TestCreateDerivedAccountWithOpsRollsBackOnDeriveFnError(t *testing.T) {
 			Coin:    0,
 		},
 	).Return(int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
-	ops.On("AllocateAccountNumber", mock.Anything, int64(8)).Return(
+	ops.On(
+		"AllocateAccountNumber", mock.Anything, int64(8),
+		(*uint32)(nil),
+	).Return(
 		int64(9), nil,
 	).Once()
 
@@ -500,7 +522,10 @@ func TestCreateDerivedAccountWithOpsRejectsInvalidDerivedDataNil(t *testing.T) {
 			Coin:    0,
 		},
 	).Return(int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
-	ops.On("AllocateAccountNumber", mock.Anything, int64(8)).Return(
+	ops.On(
+		"AllocateAccountNumber", mock.Anything, int64(8),
+		(*uint32)(nil),
+	).Return(
 		int64(9), nil,
 	).Once()
 
@@ -539,7 +564,10 @@ func TestCreateDerivedAccountWithOpsRejectsInvalidDerivedDataMissingPublicKey(
 			Coin:    0,
 		},
 	).Return(int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
-	ops.On("AllocateAccountNumber", mock.Anything, int64(8)).Return(
+	ops.On(
+		"AllocateAccountNumber", mock.Anything, int64(8),
+		(*uint32)(nil),
+	).Return(
 		int64(9), nil,
 	).Once()
 
@@ -578,7 +606,10 @@ func TestCreateDerivedAccountWithOpsRejectsInvalidDerivedDataMissingPrivateKey(
 			Coin:    0,
 		},
 	).Return(int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
-	ops.On("AllocateAccountNumber", mock.Anything, int64(8)).Return(
+	ops.On(
+		"AllocateAccountNumber", mock.Anything, int64(8),
+		(*uint32)(nil),
+	).Return(
 		int64(9), nil,
 	).Once()
 
@@ -617,7 +648,10 @@ func TestCreateDerivedAccountWithOpsRejectsInvalidDerivedDataWatchOnlyHasPriv(
 			Coin:    0,
 		},
 	).Return(int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
-	ops.On("AllocateAccountNumber", mock.Anything, int64(8)).Return(
+	ops.On(
+		"AllocateAccountNumber", mock.Anything, int64(8),
+		(*uint32)(nil),
+	).Return(
 		int64(9), nil,
 	).Once()
 
@@ -689,9 +723,9 @@ func (m *mockCreateDerivedAccountOps) EnsureScope(ctx context.Context,
 
 // AllocateAccountNumber implements CreateDerivedAccountOps.
 func (m *mockCreateDerivedAccountOps) AllocateAccountNumber(ctx context.Context,
-	scopeID int64) (int64, error) {
+	scopeID int64, accountNumber *uint32) (int64, error) {
 
-	args := m.Called(ctx, scopeID)
+	args := m.Called(ctx, scopeID, accountNumber)
 
 	accountNum, ok := args.Get(0).(int64)
 	if !ok {

--- a/wallet/internal/db/accountstore_createderived_test.go
+++ b/wallet/internal/db/accountstore_createderived_test.go
@@ -35,6 +35,60 @@ func TestCreateDerivedAccountParamsValidate(t *testing.T) {
 	require.ErrorIs(t, err, ErrReservedAccountName)
 }
 
+// TestCreateDerivedAccountRejectsInvalidPath verifies malformed derivation
+// components and unsupported exact scopes fail before backend operations.
+func TestCreateDerivedAccountRejectsInvalidPath(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: isolate each invalid path component with no expected backend
+	// calls, so entering the allocation stages fails the test.
+	tests := []struct {
+		name   string
+		scope  KeyScope
+		number uint32
+	}{
+		{
+			name:  "hardened purpose",
+			scope: KeyScope{Purpose: 1 << 31},
+		},
+		{
+			name:  "hardened coin",
+			scope: KeyScope{Purpose: 84, Coin: 1 << 31},
+		},
+		{
+			name:   "reserved number",
+			scope:  KeyScopeBIP0084,
+			number: MaxAccountNumber + 1,
+		},
+		{
+			name:  "custom scope",
+			scope: KeyScope{Purpose: 1017},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ops := &mockCreateDerivedAccountOps{}
+			params := CreateDerivedAccountParams{
+				Scope:         test.scope,
+				Name:          "invalid-path",
+				AccountNumber: &test.number,
+			}
+
+			// Act: enter the same validation path SQL transactions use.
+			info, err := CreateDerivedAccountWithOps(
+				t.Context(), params, ops, testValidDeriveFn(),
+			)
+
+			// Assert: no backend stage ran and no partial result escaped.
+			require.ErrorIs(t, err, ErrInvalidParam)
+			require.Nil(t, info)
+			ops.AssertExpectations(t)
+		})
+	}
+}
+
 // TestCreateDerivedAccountWithOps verifies that the shared helper owns the
 // common derived-account workflow and returns the normalized AccountInfo.
 func TestCreateDerivedAccountWithOps(t *testing.T) {

--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -537,6 +537,11 @@ type CreateDerivedAccountParams struct {
 	// Name is the name of the new account.
 	Name string
 
+	// AccountNumber selects an exact canonical-scope account on SQL stores.
+	// Nil allocates the next account; exact creation leaves lower holes free.
+	// The legacy kvdb store does not support exact selection.
+	AccountNumber *uint32
+
 	// NoChainSync requests that automatic chain synchronization skip this
 	// account. The legacy kvdb backend ignores this field.
 	NoChainSync bool

--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -61,6 +61,10 @@ var (
 	// within a wallet and key scope.
 	ErrAccountNameConflict = errors.New("account name conflict")
 
+	// ErrAccountNumberConflict reports an occupied derived account number
+	// within a key scope, distinct from an occupied name.
+	ErrAccountNumberConflict = errors.New("account number conflict")
+
 	// ErrAddressNotFound is returned when an address is not found in the
 	// database.
 	ErrAddressNotFound = errors.New("address not found")

--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -241,7 +241,9 @@ type WalletStore interface {
 // AccountStore defines the database actions for managing accounts.
 type AccountStore interface {
 	// CreateDerivedAccount creates a new derived account with the given
-	// name and scope. After allocating the account number, the store
+	// name and scope. SQL stores honor an optional exact AccountNumber and
+	// advance the cursor without consuming lower holes; kvdb rejects exact
+	// selection. After allocating the account number, the store
 	// invokes deriveFn to obtain the wallet-derived account material
 	// and persists it with the row.
 	//

--- a/wallet/internal/db/itest/accountstore_createderived_test.go
+++ b/wallet/internal/db/itest/accountstore_createderived_test.go
@@ -573,3 +573,73 @@ func TestCreateDerivedAccountExactConcurrent(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, largest+1, *next.AccountNumber)
 }
+
+// TestCreateDerivedAccountExactRollback verifies that either uniqueness
+// constraint rolls back the complete account write and its cursor update.
+func TestCreateDerivedAccountExactRollback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		number uint32
+		want   error
+	}{
+		{
+			name:   "taken",
+			number: 7,
+			want:   db.ErrAccountNameConflict,
+		},
+		{
+			name:   "occupied number",
+			number: 0,
+			want:   db.ErrAccountNumberConflict,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: each constraint gets an independent account zero;
+			// exact seven collides by name, while zero collides by number.
+			store := NewTestStore(t)
+			params := db.CreateDerivedAccountParams{
+				WalletID: newWallet(t, store, "exact-rollback"),
+				Scope:    db.KeyScopeBIP0084,
+				Name:     "taken",
+			}
+			_, err := store.CreateDerivedAccount(
+				t.Context(), params, SpendableDeriveFn(),
+			)
+			require.NoError(t, err)
+
+			params.Name = test.name
+			params.AccountNumber = &test.number
+
+			// Act: attempt the conflicting exact creation in a real write
+			// transaction, including derivation and secret persistence.
+			info, err := store.CreateDerivedAccount(
+				t.Context(), params, SpendableDeriveFn(),
+			)
+
+			// Assert: the conflict returns no account and leaves the one
+			// original account, secret and scope cursor unchanged.
+			requireConstraintSQLError(t, err)
+			require.ErrorIs(t, err, test.want)
+			require.Nil(t, info)
+
+			// Raw counts expose orphan secrets and the allocation cursor,
+			// which normal account reads cannot observe independently.
+			var accounts, secrets, next int
+
+			err = store.DB().QueryRowContext(t.Context(), `
+				SELECT (SELECT count(*) FROM accounts),
+				       (SELECT count(*) FROM account_secrets),
+				       (SELECT next_account_number FROM key_scopes)
+			`).Scan(&accounts, &secrets, &next)
+			require.NoError(t, err)
+			require.Equal(t, 1, accounts)
+			require.Equal(t, 1, secrets)
+			require.Equal(t, 1, next)
+		})
+	}
+}

--- a/wallet/internal/db/itest/accountstore_createderived_test.go
+++ b/wallet/internal/db/itest/accountstore_createderived_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/stretchr/testify/require"
 )
@@ -642,4 +643,82 @@ func TestCreateDerivedAccountExactRollback(t *testing.T) {
 			require.Equal(t, 1, next)
 		})
 	}
+}
+
+// TestCreateDerivedAccountExactInvalidChildRollback verifies that derivation
+// failure preserves both stored key material and the pre-request cursor.
+func TestCreateDerivedAccountExactInvalidChildRollback(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: account zero fixes the durable cursor at one before an exact
+	// request would speculatively advance it beyond a failed child at seven.
+	store := NewTestStore(t)
+	params := db.CreateDerivedAccountParams{
+		WalletID: newWallet(t, store, "invalid-child"),
+		Scope:    db.KeyScopeBIP0084,
+		Name:     "existing",
+	}
+	_, err := store.CreateDerivedAccount(
+		t.Context(), params, SpendableDeriveFn(),
+	)
+	require.NoError(t, err)
+
+	number := uint32(7)
+	params.Name = "invalid child"
+	params.AccountNumber = &number
+
+	// Act: fail derivation after allocation so rollback must undo the cursor
+	// update as well as avoid persisting a partial derived account.
+	info, err := store.CreateDerivedAccount(
+		t.Context(), params,
+		func(context.Context, db.KeyScope, uint32,
+			bool) (*db.DerivedAccountData, error) {
+
+			return nil, hdkeychain.ErrInvalidChild
+		},
+	)
+
+	// Assert: preserve the callback error and return no account. Physical
+	// counts and cursor reads expose partial writes hidden by account reads.
+	require.ErrorIs(t, err, hdkeychain.ErrInvalidChild)
+	require.Nil(t, info)
+
+	var accounts, secrets, next int
+
+	err = store.DB().QueryRowContext(t.Context(), `
+		SELECT (SELECT count(*) FROM accounts),
+		       (SELECT count(*) FROM account_secrets),
+		       (SELECT next_account_number FROM key_scopes)
+	`).Scan(&accounts, &secrets, &next)
+	require.NoError(t, err)
+	require.Equal(t, 1, accounts)
+	require.Equal(t, 1, secrets)
+	require.Equal(t, 1, next)
+}
+
+// TestCreateDerivedAccountExactMaxNumber checks the last accepted account.
+func TestCreateDerivedAccountExactMaxNumber(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: request the accepted maximum in an unused scope so no existing
+	// identity or allocation can hide an off-by-one admission failure.
+	store := NewTestStore(t)
+	number := db.MaxAccountNumber
+	params := db.CreateDerivedAccountParams{
+		WalletID:      newWallet(t, store, "max-account"),
+		Scope:         db.KeyScopeBIP0084,
+		Name:          "last",
+		AccountNumber: &number,
+	}
+
+	// Act: create the boundary account through the same transactional Store
+	// path as other exact requests, with valid spendable material.
+	info, err := store.CreateDerivedAccount(
+		t.Context(), params, SpendableDeriveFn(),
+	)
+
+	// Assert: the accepted maximum is returned without truncation or a
+	// sequential fallback; path-validation tests cover the first rejection.
+	require.NoError(t, err)
+	require.Equal(t, number, *info.AccountNumber)
 }

--- a/wallet/internal/db/itest/accountstore_createderived_test.go
+++ b/wallet/internal/db/itest/accountstore_createderived_test.go
@@ -478,3 +478,98 @@ func TestCreateDerivedAccountConcurrent(t *testing.T) {
 		require.Equal(t, uint32(i), results[i])
 	}
 }
+
+// TestCreateDerivedAccountExactConcurrent verifies a sparse first account and
+// competing exact/sequential requests share one monotonic allocation cursor.
+func TestCreateDerivedAccountExactConcurrent(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: use a new scope to prove sparse creation needs no fillers.
+	store := NewTestStore(t)
+	number := uint32(7)
+	params := db.CreateDerivedAccountParams{
+		WalletID:      newWallet(t, store, "exact-race"),
+		Scope:         db.KeyScopeBIP0084,
+		Name:          "sparse",
+		AccountNumber: &number,
+	}
+	first, err := store.CreateDerivedAccount(
+		t.Context(), params, SpendableDeriveFn(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, number, *first.AccountNumber)
+
+	var count int
+
+	err = store.DB().QueryRowContext(
+		t.Context(), "SELECT count(*) FROM accounts",
+	).Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	type result struct {
+		info  *db.AccountInfo
+		err   error
+		exact bool
+	}
+
+	results := make(chan result, 2)
+	start := make(chan struct{})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	// Act: release both bounded requests together. Buffered results let both
+	// workers exit before the owner asserts outcomes; no worker calls FailNow.
+	number++
+
+	for i := range 2 {
+		request := params
+
+		request.Name = "racer-" + strconv.Itoa(i)
+		if i == 1 {
+			request.AccountNumber = nil
+		}
+
+		go func() {
+			<-start
+
+			info, err := store.CreateDerivedAccount(
+				ctx, request, SpendableDeriveFn(),
+			)
+			results <- result{info, err, request.AccountNumber != nil}
+		}()
+	}
+
+	close(start)
+
+	outcomes := []result{<-results, <-results}
+
+	// Assert: only exact allocation may lose to a number conflict. Every
+	// success is unique and the next sequential allocation follows their max.
+	seen := map[uint32]bool{7: true}
+
+	largest := uint32(7)
+	for _, outcome := range outcomes {
+		if outcome.err != nil {
+			require.True(t, outcome.exact)
+			require.ErrorIs(t, outcome.err, db.ErrAccountNumberConflict)
+			require.Nil(t, outcome.info)
+
+			continue
+		}
+
+		n := *outcome.info.AccountNumber
+		require.False(t, seen[n])
+		seen[n] = true
+		largest = max(largest, n)
+	}
+
+	params.AccountNumber = nil
+	params.Name = "next"
+	next, err := store.CreateDerivedAccount(
+		t.Context(), params, SpendableDeriveFn(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, largest+1, *next.AccountNumber)
+}

--- a/wallet/internal/db/kvdb/accountstore_createderived.go
+++ b/wallet/internal/db/kvdb/accountstore_createderived.go
@@ -20,6 +20,12 @@ func (s *Store) CreateDerivedAccount(ctx context.Context,
 	params db.CreateDerivedAccountParams,
 	deriveFn db.AccountDerivationFunc) (*db.AccountInfo, error) {
 
+	// waddrmgr owns sequential allocation in the legacy store. Refuse exact
+	// selection before a transaction can allocate or derive any account.
+	if params.AccountNumber != nil {
+		return nil, fmt.Errorf("kvdb exact account: %w", db.ErrInvalidParam)
+	}
+
 	// The legacy format has no per-account synchronization policy. Normalize
 	// the by-value request so the shared workflow also returns the stored false
 	// value while kvdb silently retains its historical behavior.

--- a/wallet/internal/db/kvdb/accountstore_createderived.go
+++ b/wallet/internal/db/kvdb/accountstore_createderived.go
@@ -120,9 +120,11 @@ func (o *createDerivedAccountOps) EnsureScope(_ context.Context, _ uint32,
 	return 0, addrSchema, nil
 }
 
-// AllocateAccountNumber implements db.CreateDerivedAccountOps.
+// AllocateAccountNumber implements db.CreateDerivedAccountOps. The selector
+// is unused because CreateDerivedAccount rejects exact requests before opening
+// the transaction; this adapter retains sequential allocation.
 func (o *createDerivedAccountOps) AllocateAccountNumber(_ context.Context,
-	_ int64) (int64, error) {
+	_ int64, _ *uint32) (int64, error) {
 
 	if o.scopedMgr == nil {
 		return 0, errScopedMgrUninitialized

--- a/wallet/internal/db/kvdb/accountstore_test.go
+++ b/wallet/internal/db/kvdb/accountstore_test.go
@@ -501,6 +501,48 @@ func TestCreateDerivedAccount(t *testing.T) {
 	require.Equal(t, savingsAccountName, read.AccountName)
 }
 
+// TestCreateDerivedAccountRejectsExact verifies an unsupported exact request
+// neither derives material nor consumes the next legacy account number.
+func TestCreateDerivedAccountRejectsExact(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: use a real legacy store and a callback that records invocation
+	// to prove rejection precedes key preparation as well as persistence.
+	store, mgr, cleanup := newAccountStoreFixture(t)
+	t.Cleanup(cleanup)
+
+	number := uint32(7)
+	params := db.CreateDerivedAccountParams{
+		Scope:         db.KeyScopeBIP0084,
+		Name:          savingsAccountName,
+		AccountNumber: &number,
+	}
+	called := false
+	deriveFn := func(context.Context, db.KeyScope, uint32,
+		bool) (*db.DerivedAccountData, error) {
+
+		called = true
+
+		return &db.DerivedAccountData{}, nil
+	}
+
+	// Act: reject exact creation, then retry the same name sequentially to
+	// expose either an accidentally persisted account or an advanced cursor.
+	info, err := store.CreateDerivedAccount(t.Context(), params, deriveFn)
+	params.AccountNumber = nil
+	next, nextErr := store.CreateDerivedAccount(
+		t.Context(), params, kvdbDeriveFnFixture(t, mgr),
+	)
+
+	// Assert: no exact result or derivation occurred, and the first available
+	// legacy number remains one because the default account already exists.
+	require.ErrorIs(t, err, db.ErrInvalidParam)
+	require.Nil(t, info)
+	require.False(t, called)
+	require.NoError(t, nextErr)
+	require.Equal(t, uint32(1), *next.AccountNumber)
+}
+
 // TestCreateDerivedAccountRollsBackOnDeriveError verifies that when the
 // derivation callback fails after the account number has been allocated,
 // the underlying walletdb transaction rolls back so the lastAccount counter

--- a/wallet/internal/db/pg/accountstore_createderived.go
+++ b/wallet/internal/db/pg/accountstore_createderived.go
@@ -63,6 +63,20 @@ func (o createDerivedAccountOps) EnsureScope(ctx context.Context,
 func (o createDerivedAccountOps) AllocateAccountNumber(ctx context.Context,
 	scopeID int64, accountNumber *uint32) (int64, error) {
 
+	// Both request forms update the same scope row in the account write
+	// transaction, serializing allocation and rolling it back on failure.
+	if accountNumber != nil {
+		number := int64(*accountNumber)
+		err := o.q.AdvanceNextAccountNumber(
+			ctx, sqlc.AdvanceNextAccountNumberParams{
+				MinimumNextAccount: number + 1,
+				ScopeID:            scopeID,
+			},
+		)
+
+		return number, err
+	}
+
 	return o.q.GetAndIncrementNextAccountNumber(ctx, scopeID)
 }
 

--- a/wallet/internal/db/pg/accountstore_createderived.go
+++ b/wallet/internal/db/pg/accountstore_createderived.go
@@ -61,7 +61,7 @@ func (o createDerivedAccountOps) EnsureScope(ctx context.Context,
 
 // AllocateAccountNumber implements db.CreateDerivedAccountOps.
 func (o createDerivedAccountOps) AllocateAccountNumber(ctx context.Context,
-	scopeID int64) (int64, error) {
+	scopeID int64, accountNumber *uint32) (int64, error) {
 
 	return o.q.GetAndIncrementNextAccountNumber(ctx, scopeID)
 }

--- a/wallet/internal/db/pg/errors.go
+++ b/wallet/internal/db/pg/errors.go
@@ -14,6 +14,9 @@ import (
 // key scope.
 const accountNameConstraint = "uidx_accounts_wallet_scope_account_name"
 
+// accountNumberConstraint identifies the derived-number index within a scope.
+const accountNumberConstraint = "uidx_accounts_scope_account_number"
+
 // SQLSTATE helper constants support PostgreSQL error classification.
 const (
 	// connectionExceptionClass identifies PostgreSQL SQLSTATE class 08,
@@ -95,6 +98,14 @@ func mapErr(err error) *dberr.SQLError {
 			pgErr.ConstraintName == accountNameConstraint {
 
 			err = fmt.Errorf("%w: %w", db.ErrAccountNameConflict, err)
+		}
+
+		// Exact allocation needs the occupied-number identity while the
+		// original driver cause retains normal SQL classification.
+		if pgErr.Code == codeUniqueViolation &&
+			pgErr.ConstraintName == accountNumberConstraint {
+
+			err = fmt.Errorf("%w: %w", db.ErrAccountNumberConflict, err)
 		}
 
 		return mapCode(pgErr.Code, err)

--- a/wallet/internal/db/pg/errors_test.go
+++ b/wallet/internal/db/pg/errors_test.go
@@ -120,8 +120,8 @@ func TestMapErr(t *testing.T) {
 	require.Equal(t, dberr.ClassFatal, err.Class())
 }
 
-// TestMapErrAccountNameConflict verifies only the account-name unique index is
-// marked as an account conflict.
+// TestMapErrAccountNameConflict keeps name and number collision identities
+// distinct without classifying unrelated unique failures.
 func TestMapErrAccountNameConflict(t *testing.T) {
 	t.Parallel()
 
@@ -129,11 +129,17 @@ func TestMapErrAccountNameConflict(t *testing.T) {
 		name       string
 		constraint string
 		want       bool
+		wantNumber bool
 	}{
 		{
 			name:       "account name",
 			constraint: accountNameConstraint,
 			want:       true,
+		},
+		{
+			name:       "account number",
+			constraint: accountNumberConstraint,
+			wantNumber: true,
 		},
 		{
 			name:       "other unique index",
@@ -154,10 +160,13 @@ func TestMapErrAccountNameConflict(t *testing.T) {
 			// Act: Classify the driver failure through the backend mapper.
 			err := mapErr(cause)
 
-			// Assert: Only the name index gains the Store conflict identity.
+			// Assert: Each known index gains only its matching Store identity.
 			require.ErrorIs(t, err, cause)
 			require.Equal(t, test.want, errors.Is(
 				err, db.ErrAccountNameConflict,
+			))
+			require.Equal(t, test.wantNumber, errors.Is(
+				err, db.ErrAccountNumberConflict,
 			))
 		})
 	}

--- a/wallet/internal/db/sqlite/accountstore_createderived.go
+++ b/wallet/internal/db/sqlite/accountstore_createderived.go
@@ -63,6 +63,20 @@ func (o createDerivedAccountOps) EnsureScope(ctx context.Context,
 func (o createDerivedAccountOps) AllocateAccountNumber(ctx context.Context,
 	scopeID int64, accountNumber *uint32) (int64, error) {
 
+	// Both request forms update the same scope row in the account write
+	// transaction, serializing allocation and rolling it back on failure.
+	if accountNumber != nil {
+		number := int64(*accountNumber)
+		err := o.q.AdvanceNextAccountNumber(
+			ctx, sqlc.AdvanceNextAccountNumberParams{
+				MinimumNextAccount: number + 1,
+				ScopeID:            scopeID,
+			},
+		)
+
+		return number, err
+	}
+
 	return o.q.GetAndIncrementNextAccountNumber(ctx, scopeID)
 }
 

--- a/wallet/internal/db/sqlite/accountstore_createderived.go
+++ b/wallet/internal/db/sqlite/accountstore_createderived.go
@@ -61,7 +61,7 @@ func (o createDerivedAccountOps) EnsureScope(ctx context.Context,
 
 // AllocateAccountNumber implements db.CreateDerivedAccountOps.
 func (o createDerivedAccountOps) AllocateAccountNumber(ctx context.Context,
-	scopeID int64) (int64, error) {
+	scopeID int64, accountNumber *uint32) (int64, error) {
 
 	return o.q.GetAndIncrementNextAccountNumber(ctx, scopeID)
 }

--- a/wallet/internal/db/sqlite/errors.go
+++ b/wallet/internal/db/sqlite/errors.go
@@ -70,6 +70,16 @@ func mapErr(err error) *dberr.SQLError {
 		err = fmt.Errorf("%w: %w", db.ErrAccountNameConflict, err)
 	}
 
+	// Number collisions use the migrated column tuple; other unique
+	// violations must not masquerade as an occupied exact account.
+	if code == sqlite3.SQLITE_CONSTRAINT_UNIQUE && strings.Contains(
+		sqliteErr.Error(), "UNIQUE constraint failed: accounts.scope_id, "+
+			"accounts.account_number",
+	) {
+
+		err = fmt.Errorf("%w: %w", db.ErrAccountNumberConflict, err)
+	}
+
 	return dberr.NewSQLError(dberr.BackendSQLite, reason, codeString, err)
 }
 

--- a/wallet/internal/db/sqlite/errors_test.go
+++ b/wallet/internal/db/sqlite/errors_test.go
@@ -35,7 +35,7 @@ func TestMapErrConstraint(t *testing.T) {
 	)`)
 	require.NoError(t, err)
 
-	// Match the migrated partial index so the negative control produces the
+	// Match the migrated partial index so the number collision produces the
 	// same account-number diagnostic as a persisted derived account.
 	_, err = dbConn.ExecContext(ctx, `CREATE UNIQUE INDEX
 		uidx_accounts_scope_account_number
@@ -60,6 +60,7 @@ func TestMapErrConstraint(t *testing.T) {
 	require.Equal(t, dberr.ReasonConstraint, sqlErr.Reason)
 	require.Equal(t, dberr.ClassPermanent, sqlErr.Class())
 	require.ErrorIs(t, sqlErr, db.ErrAccountNameConflict)
+	require.NotErrorIs(t, sqlErr, db.ErrAccountNumberConflict)
 
 	// Act: Violate the other unique key with a different account name.
 	_, err = dbConn.ExecContext(
@@ -67,8 +68,11 @@ func TestMapErrConstraint(t *testing.T) {
 	)
 	require.Error(t, err)
 
-	// Assert: A number collision must not claim the name is occupied.
-	require.NotErrorIs(t, mapErr(err), db.ErrAccountNameConflict)
+	sqlErr = mapErr(err)
+
+	// Assert: The number collision preserves its distinct Store identity.
+	require.NotErrorIs(t, sqlErr, db.ErrAccountNameConflict)
+	require.ErrorIs(t, sqlErr, db.ErrAccountNumberConflict)
 }
 
 // TestMapErrReadOnly verifies that SQLite query-only failures are mapped to

--- a/wallet/internal/sql/pg/queries/key_scopes.sql
+++ b/wallet/internal/sql/pg/queries/key_scopes.sql
@@ -58,6 +58,17 @@ SET next_account_number = next_account_number + 1
 WHERE id = $1
 RETURNING (next_account_number - 1)::BIGINT AS account_number;
 
+-- name: AdvanceNextAccountNumber :exec
+-- Reserves the cursor past an exact account without consuming lower holes.
+-- Updating this row serializes exact and sequential allocation in the caller's
+-- account transaction, including when the cursor already exceeds the minimum.
+UPDATE key_scopes
+SET
+    next_account_number = greatest(
+        next_account_number, sqlc.arg(minimum_next_account)::BIGINT
+    )
+WHERE id = sqlc.arg(scope_id);
+
 -- name: ListKeyScopesByWallet :many
 -- Lists all key scopes for a wallet, ordered by ID.
 SELECT

--- a/wallet/internal/sql/pg/sqlc/db.go
+++ b/wallet/internal/sql/pg/sqlc/db.go
@@ -33,6 +33,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.acquireUtxoLeaseStmt, err = db.PrepareContext(ctx, AcquireUtxoLease); err != nil {
 		return nil, fmt.Errorf("error preparing query AcquireUtxoLease: %w", err)
 	}
+	if q.advanceNextAccountNumberStmt, err = db.PrepareContext(ctx, AdvanceNextAccountNumber); err != nil {
+		return nil, fmt.Errorf("error preparing query AdvanceNextAccountNumber: %w", err)
+	}
 	if q.advanceNextExternalIndexStmt, err = db.PrepareContext(ctx, AdvanceNextExternalIndex); err != nil {
 		return nil, fmt.Errorf("error preparing query AdvanceNextExternalIndex: %w", err)
 	}
@@ -339,6 +342,11 @@ func (q *Queries) Close() error {
 	if q.acquireUtxoLeaseStmt != nil {
 		if cerr := q.acquireUtxoLeaseStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing acquireUtxoLeaseStmt: %w", cerr)
+		}
+	}
+	if q.advanceNextAccountNumberStmt != nil {
+		if cerr := q.advanceNextAccountNumberStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing advanceNextAccountNumberStmt: %w", cerr)
 		}
 	}
 	if q.advanceNextExternalIndexStmt != nil {
@@ -863,6 +871,7 @@ type Queries struct {
 	accountBalanceStmt                          *sql.Stmt
 	accountBalancesByIDsStmt                    *sql.Stmt
 	acquireUtxoLeaseStmt                        *sql.Stmt
+	advanceNextAccountNumberStmt                *sql.Stmt
 	advanceNextExternalIndexStmt                *sql.Stmt
 	advanceNextInternalIndexStmt                *sql.Stmt
 	balanceStmt                                 *sql.Stmt
@@ -968,6 +977,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		accountBalanceStmt:                          q.accountBalanceStmt,
 		accountBalancesByIDsStmt:                    q.accountBalancesByIDsStmt,
 		acquireUtxoLeaseStmt:                        q.acquireUtxoLeaseStmt,
+		advanceNextAccountNumberStmt:                q.advanceNextAccountNumberStmt,
 		advanceNextExternalIndexStmt:                q.advanceNextExternalIndexStmt,
 		advanceNextInternalIndexStmt:                q.advanceNextInternalIndexStmt,
 		balanceStmt:                                 q.balanceStmt,

--- a/wallet/internal/sql/pg/sqlc/key_scopes.sql.go
+++ b/wallet/internal/sql/pg/sqlc/key_scopes.sql.go
@@ -9,6 +9,28 @@ import (
 	"context"
 )
 
+const AdvanceNextAccountNumber = `-- name: AdvanceNextAccountNumber :exec
+UPDATE key_scopes
+SET
+    next_account_number = greatest(
+        next_account_number, $1::BIGINT
+    )
+WHERE id = $2
+`
+
+type AdvanceNextAccountNumberParams struct {
+	MinimumNextAccount int64
+	ScopeID            int64
+}
+
+// Reserves the cursor past an exact account without consuming lower holes.
+// Updating this row serializes exact and sequential allocation in the caller's
+// account transaction, including when the cursor already exceeds the minimum.
+func (q *Queries) AdvanceNextAccountNumber(ctx context.Context, arg AdvanceNextAccountNumberParams) error {
+	_, err := q.exec(ctx, q.advanceNextAccountNumberStmt, AdvanceNextAccountNumber, arg.MinimumNextAccount, arg.ScopeID)
+	return err
+}
+
 const CreateKeyScope = `-- name: CreateKeyScope :one
 INSERT INTO key_scopes (
     wallet_id,

--- a/wallet/internal/sql/pg/sqlc/querier.go
+++ b/wallet/internal/sql/pg/sqlc/querier.go
@@ -41,6 +41,10 @@ type Querier interface {
 	// - Locks the target utxo row during resolution so concurrent spend updates on
 	//   that row serialize with lease acquisition.
 	AcquireUtxoLease(ctx context.Context, arg AcquireUtxoLeaseParams) (time.Time, error)
+	// Reserves the cursor past an exact account without consuming lower holes.
+	// Updating this row serializes exact and sequential allocation in the caller's
+	// account transaction, including when the cursor already exceeds the minimum.
+	AdvanceNextAccountNumber(ctx context.Context, arg AdvanceNextAccountNumberParams) error
 	// Advances the external branch's next index to the supplied value during
 	// recovery horizon extension. The GREATEST guard keeps the counter monotonic
 	// so a slower concurrent writer cannot regress it below an already-recorded

--- a/wallet/internal/sql/sqlite/queries/key_scopes.sql
+++ b/wallet/internal/sql/sqlite/queries/key_scopes.sql
@@ -58,6 +58,17 @@ SET next_account_number = next_account_number + 1
 WHERE id = ?
 RETURNING next_account_number - 1 AS account_number;
 
+-- name: AdvanceNextAccountNumber :exec
+-- Reserves the cursor past an exact account without consuming lower holes.
+-- The existing immediate transaction keeps this update and the account/key
+-- inserts atomic, including when the cursor already exceeds the minimum.
+UPDATE key_scopes
+SET
+    next_account_number = max(
+        next_account_number, cast(sqlc.arg(minimum_next_account) AS INTEGER)
+    )
+WHERE id = sqlc.arg(scope_id);
+
 -- name: ListKeyScopesByWallet :many
 -- Lists all key scopes for a wallet, ordered by ID.
 SELECT

--- a/wallet/internal/sql/sqlite/sqlc/db.go
+++ b/wallet/internal/sql/sqlite/sqlc/db.go
@@ -33,6 +33,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.acquireUtxoLeaseStmt, err = db.PrepareContext(ctx, AcquireUtxoLease); err != nil {
 		return nil, fmt.Errorf("error preparing query AcquireUtxoLease: %w", err)
 	}
+	if q.advanceNextAccountNumberStmt, err = db.PrepareContext(ctx, AdvanceNextAccountNumber); err != nil {
+		return nil, fmt.Errorf("error preparing query AdvanceNextAccountNumber: %w", err)
+	}
 	if q.advanceNextExternalIndexStmt, err = db.PrepareContext(ctx, AdvanceNextExternalIndex); err != nil {
 		return nil, fmt.Errorf("error preparing query AdvanceNextExternalIndex: %w", err)
 	}
@@ -336,6 +339,11 @@ func (q *Queries) Close() error {
 	if q.acquireUtxoLeaseStmt != nil {
 		if cerr := q.acquireUtxoLeaseStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing acquireUtxoLeaseStmt: %w", cerr)
+		}
+	}
+	if q.advanceNextAccountNumberStmt != nil {
+		if cerr := q.advanceNextAccountNumberStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing advanceNextAccountNumberStmt: %w", cerr)
 		}
 	}
 	if q.advanceNextExternalIndexStmt != nil {
@@ -855,6 +863,7 @@ type Queries struct {
 	accountBalanceStmt                          *sql.Stmt
 	accountBalancesByIDsStmt                    *sql.Stmt
 	acquireUtxoLeaseStmt                        *sql.Stmt
+	advanceNextAccountNumberStmt                *sql.Stmt
 	advanceNextExternalIndexStmt                *sql.Stmt
 	advanceNextInternalIndexStmt                *sql.Stmt
 	balanceStmt                                 *sql.Stmt
@@ -959,6 +968,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		accountBalanceStmt:                          q.accountBalanceStmt,
 		accountBalancesByIDsStmt:                    q.accountBalancesByIDsStmt,
 		acquireUtxoLeaseStmt:                        q.acquireUtxoLeaseStmt,
+		advanceNextAccountNumberStmt:                q.advanceNextAccountNumberStmt,
 		advanceNextExternalIndexStmt:                q.advanceNextExternalIndexStmt,
 		advanceNextInternalIndexStmt:                q.advanceNextInternalIndexStmt,
 		balanceStmt:                                 q.balanceStmt,

--- a/wallet/internal/sql/sqlite/sqlc/key_scopes.sql.go
+++ b/wallet/internal/sql/sqlite/sqlc/key_scopes.sql.go
@@ -9,6 +9,28 @@ import (
 	"context"
 )
 
+const AdvanceNextAccountNumber = `-- name: AdvanceNextAccountNumber :exec
+UPDATE key_scopes
+SET
+    next_account_number = max(
+        next_account_number, cast(?1 AS INTEGER)
+    )
+WHERE id = ?2
+`
+
+type AdvanceNextAccountNumberParams struct {
+	MinimumNextAccount int64
+	ScopeID            int64
+}
+
+// Reserves the cursor past an exact account without consuming lower holes.
+// The existing immediate transaction keeps this update and the account/key
+// inserts atomic, including when the cursor already exceeds the minimum.
+func (q *Queries) AdvanceNextAccountNumber(ctx context.Context, arg AdvanceNextAccountNumberParams) error {
+	_, err := q.exec(ctx, q.advanceNextAccountNumberStmt, AdvanceNextAccountNumber, arg.MinimumNextAccount, arg.ScopeID)
+	return err
+}
+
 const CreateKeyScope = `-- name: CreateKeyScope :one
 INSERT INTO key_scopes (
     wallet_id,

--- a/wallet/internal/sql/sqlite/sqlc/querier.go
+++ b/wallet/internal/sql/sqlite/sqlc/querier.go
@@ -41,6 +41,10 @@ type Querier interface {
 	// - SQLite executes the resolution and lease write atomically inside one
 	//   statement, which avoids stale-ID races between separate helper calls.
 	AcquireUtxoLease(ctx context.Context, arg AcquireUtxoLeaseParams) (time.Time, error)
+	// Reserves the cursor past an exact account without consuming lower holes.
+	// The existing immediate transaction keeps this update and the account/key
+	// inserts atomic, including when the cursor already exceeds the minimum.
+	AdvanceNextAccountNumber(ctx context.Context, arg AdvanceNextAccountNumberParams) error
 	// Advances the external branch's next index to the supplied value during
 	// recovery horizon extension. The MAX guard keeps the counter monotonic so a
 	// slower concurrent writer cannot regress it below an already-recorded index.

--- a/wallet/syncer_test.go
+++ b/wallet/syncer_test.go
@@ -2217,16 +2217,17 @@ func TestStoreScanHorizonsListAccounts(t *testing.T) {
 func newSQLRecoverySyncer(t *testing.T) (*syncer, []db.AccountInfo, [][]byte) {
 	t.Helper()
 
-	// Reuse the SQL Manager's real vault and derivation callbacks so the
-	// persisted account keys and scripts exercise the normal recovery path.
+	// Use public account creation with the real SQL vault, admitting the
+	// Wallet without background synchronization so recovery remains observable.
 	m := testSQLiteManager(t)
 	params := sqliteCreateParams(t)
 	params.Name = t.Name()
 	w, err := m.Create(params)
 	require.NoError(t, err)
+	startLoadedWalletForTest(t, w)
 	require.NoError(t, w.keyVault.Unlock(t.Context(), params.PrivatePassphrase))
-	derive, err := w.buildAccountDeriveFn(t.Context())
-	require.NoError(t, err)
+	// Admit signing requests while background synchronization stays disabled.
+	w.state.toUnlocked()
 
 	// Both accounts have identical setup except for the persisted policy;
 	// materializing an address also tests the non-lookahead watch source.
@@ -2247,15 +2248,16 @@ func newSQLRecoverySyncer(t *testing.T) (*syncer, []db.AccountInfo, [][]byte) {
 	accounts := make([]db.AccountInfo, 0, len(configs))
 	scripts := make([][]byte, 0, len(configs))
 
-	for _, config := range configs {
-		_, err := w.store.CreateDerivedAccount(
-			t.Context(), db.CreateDerivedAccountParams{
-				WalletID:    w.id,
-				Scope:       db.KeyScopeBIP0084,
-				Name:        config.name,
-				NoChainSync: config.noChainSync,
-			}, derive,
-		)
+	for i, config := range configs {
+		// Exact creation carries the policy without deriving child addresses;
+		// the existing address fixture below is a separate deliberate write.
+		number := AccountNumber(i)
+		_, err := w.NewAccount(t.Context(), NewAccountParams{
+			Scope:         waddrmgr.KeyScopeBIP0084,
+			Name:          config.name,
+			AccountNumber: &number,
+			NoChainSync:   config.noChainSync,
+		})
 		require.NoError(t, err)
 		addr, err := w.store.NewDerivedAddress(
 			t.Context(), db.NewDerivedAddressParams{


### PR DESCRIPTION
## Summary

Create next-or-exact root-derived SQL accounts, including exact accounts with automatic chain synchronization disabled. Implements roadmap Task 343 and Task 468.

## Change Description

Reuse atomic account creation and the scope cursor for sparse numbers and lower holes. Preserve public conflict and indeterminate-commit errors, sequential behavior, and unsupported kvdb exact selection. An admitted creation waits for its Store outcome so cancellation cannot hide an uncertain commit.

## Notes

Prerequisites #1366, #1367, and #1368 are merged into sql-wallet. This PR contains only the eight exact-account and activation commits, including the work formerly in #1370.
