### PR TITLE
wallet: activate exact no-chain-sync accounts

### DIFF
--- a/itest/account_manager_test.go
+++ b/itest/account_manager_test.go
@@ -167,6 +167,89 @@ func testAccountManagerCreateAccount(h *bwtest.HarnessTest) {
 	require.Equal(h, want, durableInfo)
 }
 
+// testAccountManagerActivateNoChainSyncAccount verifies exact SQL activation
+// persists across reload without enabling receiving, while kvdb fails closed.
+func testAccountManagerActivateNoChainSyncAccount(h *bwtest.HarnessTest) {
+	// Arrange: use the harness-owned lifecycle and a sparse exact number in
+	// an existing supported scope. Snapshot accounts for the kvdb refusal.
+	const accountName = "excluded account"
+
+	ctx := h.Context()
+	scope := waddrmgr.KeyScopeBIP0084
+	number := wallet.AccountNumber(7)
+	w, _ := h.NewWallet(bwtest.WalletFixture{Unlocked: true})
+	before, err := w.ListAccountsByScope(ctx, scope)
+	require.NoError(h, err)
+
+	// Act: request exclusion through the same public account operation for
+	// each database; only the documented SQL exact subset admits this value.
+	created, err := w.NewAccount(ctx, wallet.NewAccountParams{
+		Scope:         scope,
+		Name:          accountName,
+		AccountNumber: &number,
+		NoChainSync:   true,
+	})
+
+	// Assert: the configured database determines the expected contract, not
+	// the operation result. A kvdb refusal must leave the account set intact.
+	if *dbBackend == "kvdb" {
+		require.ErrorIs(h, err, wallet.ErrAccountOperationUnsupported)
+		require.Nil(h, created)
+
+		after, err := w.ListAccountsByScope(ctx, scope)
+		require.NoError(h, err)
+		require.Equal(h, before, after)
+
+		return
+	}
+
+	// SQL returns the exact identity and policy without allocating any child
+	// address. An immediate read must agree with the atomic creation result.
+	require.NoError(h, err)
+	require.Equal(h, number, *created.AccountNumber)
+	require.True(h, created.NoChainSync)
+	require.Zero(h, created.ExternalKeyCount)
+	require.Zero(h, created.InternalKeyCount)
+
+	addresses, err := w.ListAddresses(ctx, accountName, waddrmgr.WitnessPubKey)
+	require.NoError(h, err)
+	require.Empty(h, addresses)
+
+	got, err := w.GetAccount(ctx, scope, accountName)
+	require.NoError(h, err)
+	require.Equal(h, created, got)
+
+	// Receiving remains forbidden even for a newly admitted account. These
+	// narrow postconditions ensure activation did not bypass either guard.
+	addr, err := w.NewAddress(
+		ctx, accountName, waddrmgr.WitnessPubKey, false,
+	)
+	require.ErrorIs(h, err, wallet.ErrAccountOperationUnsupported)
+	require.Nil(h, addr)
+	addr, err = w.GetUnusedAddress(
+		ctx, accountName, waddrmgr.WitnessPubKey, false,
+	)
+	require.ErrorIs(h, err, wallet.ErrAccountOperationUnsupported)
+	require.Nil(h, addr)
+
+	after, err := w.GetAccount(ctx, scope, accountName)
+	require.NoError(h, err)
+	require.Equal(h, created, after)
+
+	addresses, err = w.ListAddresses(
+		ctx, accountName, waddrmgr.WitnessPubKey,
+	)
+	require.NoError(h, err)
+	require.Empty(h, addresses)
+
+	// A fresh Manager reads the policy from durable storage; comparing the
+	// complete account also detects any receiving counter mutation on reload.
+	w = h.ReloadWallet(w)
+	durable, err := w.GetAccount(ctx, scope, accountName)
+	require.NoError(h, err)
+	require.Equal(h, created, durable)
+}
+
 // testAccountManagerCreateAccountSequence verifies that derived account numbers
 // are allocated contiguously within a key scope, that each scope allocates from
 // its own counter, and that the counter survives a wallet reload.

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -44,6 +44,10 @@ var allTestCases = []*testCase{
 		TestFunc: testAccountManagerCreateAccount,
 	},
 	{
+		Name:     "account manager activate no chain sync account",
+		TestFunc: testAccountManagerActivateNoChainSyncAccount,
+	},
+	{
 		Name:     "account manager create account sequence",
 		TestFunc: testAccountManagerCreateAccountSequence,
 	},

--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -243,7 +243,8 @@ type NewAccountParams struct {
 	AccountNumber *AccountNumber
 
 	// NoChainSync requests exclusion from automatic chain synchronization.
-	// True is currently rejected with ErrAccountOperationUnsupported.
+	// True requires exact SQL selection; other requests return
+	// ErrAccountOperationUnsupported.
 	NoChainSync bool
 }
 
@@ -294,7 +295,8 @@ type NewAccountParams struct {
 type AccountManager interface {
 	// NewAccount creates the next or requested exact root-derived account. The
 	// provided name must be unique within that key scope. NoChainSync=true
-	// is currently rejected with ErrAccountOperationUnsupported.
+	// is supported only for exact SQL selection; other requests return
+	// ErrAccountOperationUnsupported.
 	NewAccount(ctx context.Context, params NewAccountParams) (*AccountInfo,
 		error)
 
@@ -428,8 +430,9 @@ func (w *Wallet) accountInfoFromStore(
 // NewAccount creates the next or requested exact root-derived account and
 // returns its persisted info. The name and number must be unused in the scope.
 // Exact selection supports canonical SQL scopes and leaves lower holes free.
-// Exact kvdb requests and NoChainSync=true return
-// ErrAccountOperationUnsupported after admission and before secret preparation.
+// NoChainSync=true persists exclusion from receiving and positive-lookahead
+// recovery only with exact SQL selection. Sequential exclusion and exact kvdb
+// requests return ErrAccountOperationUnsupported before secret preparation.
 // Failures return no account; ErrIndeterminateCommit means persistence may
 // have succeeded.
 func (w *Wallet) NewAccount(ctx context.Context,
@@ -448,13 +451,6 @@ func (w *Wallet) NewAccount(ctx context.Context,
 	err := w.validateNewAccountRequest(ctx, storeParams)
 	if err != nil {
 		return nil, err
-	}
-
-	// Keep exclusion unavailable until receiving and recovery honor it.
-	// Refuse here so no backend prepares secrets or mutates account state.
-	if params.NoChainSync {
-		return nil, fmt.Errorf("no-chain-sync account creation: %w",
-			ErrAccountOperationUnsupported)
 	}
 
 	// Wallet assembly supplies addrStore only for kvdb, whose allocator is
@@ -484,7 +480,7 @@ func (w *Wallet) NewAccount(ctx context.Context,
 
 // validateNewAccountRequest fixes admission precedence before derivation or
 // mutation: caller and request errors win first, followed by lock state, name
-// collisions, and finally the watch-only restriction.
+// collisions, the watch-only restriction, and the chain-sync policy.
 func (w *Wallet) validateNewAccountRequest(ctx context.Context,
 	params db.CreateDerivedAccountParams) error {
 
@@ -539,7 +535,15 @@ func (w *Wallet) validateNewAccountRequest(ctx context.Context,
 		return accountManagerErr(errWatchOnlyAccountDerivation)
 	}
 
-	return nil
+	// When an account does not watch for on-chain synchronization, its
+	// account number must be specified; sequential allocation is unsupported.
+	switch {
+	case !params.NoChainSync, params.AccountNumber != nil:
+		return nil
+	}
+
+	return fmt.Errorf("no-chain-sync account creation: %w",
+		ErrAccountOperationUnsupported)
 }
 
 // propertiesToAccountInfo wraps a waddrmgr.AccountProperties + total balance

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -734,30 +734,31 @@ func TestNewAccount(t *testing.T) {
 	deps.vault.AssertExpectations(t)
 }
 
-// TestNewAccountNoChainSyncUnsupported verifies the common Wallet boundary
-// refuses exclusion before any backend can prepare secrets or mutate accounts.
+// TestNewAccountNoChainSyncUnsupported verifies sequential creation refuses
+// exclusion before preparing secrets or mutating accounts.
 func TestNewAccountNoChainSyncUnsupported(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: allow the existing admission checks on an unlocked wallet
-	// with an available name. Strict mocks have no secret or write
-	// expectations, so crossing into creation would fail this test.
+	// Arrange: use the SQL backend marker and allow only admission reads.
+	// Strict mocks reject secret preparation or account mutation so a missing
+	// policy check cannot silently admit sequential creation.
 	w, deps := createStartedWalletWithMocks(t)
+	w.addrStore = nil
 	scope := waddrmgr.KeyScopeBIP0084
 
 	deps.vault.On("IsLocked").Return(false).Once()
 	expectAccountNameAvailable(deps, scope, testAccountName)
 
-	// Act: request exclusion through the public API while its receiving and
-	// recovery support is unavailable.
+	// Act: request no chain synchronization without specifying an account
+	// number, which would otherwise select sequential allocation.
 	account, err := w.NewAccount(t.Context(), NewAccountParams{
 		Scope:       scope,
 		Name:        testAccountName,
 		NoChainSync: true,
 	})
 
-	// Assert: the stable unsupported error returns no account, and only the
-	// required read-only admission calls reach the Store and Vault.
+	// Assert: the public unsupported error returns no account, and only
+	// admission reads occurred before the sequential request was refused.
 	require.ErrorIs(t, err, ErrAccountOperationUnsupported)
 	require.Nil(t, account)
 	deps.store.AssertExpectations(t)
@@ -2211,47 +2212,71 @@ func TestNewAccountSQLFailureIdentity(t *testing.T) {
 	}
 }
 
-// TestNewAccountExact forwards an explicit account number through the existing
-// public operation and returns the exact identity with chain sync enabled.
+// TestNewAccountExact verifies exact SQL creation carries either sync policy
+// through the atomic Store request and public result without chain work.
 func TestNewAccountExact(t *testing.T) {
 	t.Parallel()
 
-	// Arrange: model SQL assembly and expect the exact request after normal
-	// name admission and root preparation, using the existing Store interface.
-	w, deps := createStartedWalletWithMocks(t)
-	w.addrStore = nil
-	scope := waddrmgr.KeyScopeBIP0084
-	number := AccountNumber(7)
-	storeNumber := uint32(number)
+	tests := []struct {
+		name        string
+		noChainSync bool
+	}{
+		{
+			name: "ordinary account",
+		},
+		{
+			name:        "excluded account",
+			noChainSync: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 
-	expectAccountNameAvailable(deps, scope, testAccountName)
-	expectAccountDeriveSetup(t, deps, newStubAccountDeriveFn(t))
-	deps.store.On("CreateDerivedAccount", mock.Anything,
-		db.CreateDerivedAccountParams{
-			WalletID:      w.id,
-			Scope:         db.KeyScope(scope),
-			Name:          testAccountName,
-			AccountNumber: &storeNumber,
-		}, mock.Anything).Return(&db.AccountInfo{
-		AccountNumber: &storeNumber,
-		AccountName:   testAccountName,
-		KeyScope:      db.KeyScope(scope),
-	}, nil).Once()
+			// Arrange: model SQL assembly and expect only admission,
+			// root preparation, and one atomic account creation. Any
+			// address or chain operation fails the strict mocks.
+			w, deps := createStartedWalletWithMocks(t)
+			w.addrStore = nil
+			scope := waddrmgr.KeyScopeBIP0084
+			number := AccountNumber(7)
+			storeNumber := uint32(number)
 
-	// Act: request a sparse exact account through NewAccountParams.
-	info, err := w.NewAccount(t.Context(), NewAccountParams{
-		Scope:         scope,
-		Name:          testAccountName,
-		AccountNumber: &number,
-	})
+			expectAccountNameAvailable(deps, scope, testAccountName)
+			expectAccountDeriveSetup(t, deps, newStubAccountDeriveFn(t))
+			deps.store.On("CreateDerivedAccount", mock.Anything,
+				db.CreateDerivedAccountParams{
+					WalletID:      w.id,
+					Scope:         db.KeyScope(scope),
+					Name:          testAccountName,
+					AccountNumber: &storeNumber,
+					NoChainSync:   test.noChainSync,
+				}, mock.Anything).Return(&db.AccountInfo{
+				AccountNumber: &storeNumber,
+				AccountName:   testAccountName,
+				KeyScope:      db.KeyScope(scope),
+				NoChainSync:   test.noChainSync,
+			}, nil).Once()
 
-	// Assert: the requested number survives public conversion, chain sync
-	// remains enabled, and all required preparation/store calls occurred.
-	require.NoError(t, err)
-	require.Equal(t, number, *info.AccountNumber)
-	require.False(t, info.NoChainSync)
-	deps.store.AssertExpectations(t)
-	deps.vault.AssertExpectations(t)
+			// Act: request a sparse exact account with the selected
+			// policy through the maintained public operation.
+			info, err := w.NewAccount(t.Context(), NewAccountParams{
+				Scope:         scope,
+				Name:          testAccountName,
+				AccountNumber: &number,
+				NoChainSync:   test.noChainSync,
+			})
+
+			// Assert: both the exact number and persisted policy survive
+			// conversion, with all required calls and no chain work.
+			require.NoError(t, err)
+			require.Equal(t, number, *info.AccountNumber)
+			require.Equal(t, test.noChainSync, info.NoChainSync)
+			deps.store.AssertExpectations(t)
+			deps.vault.AssertExpectations(t)
+			deps.chain.AssertExpectations(t)
+		})
+	}
 }
 
 // TestNewAccountInvalidPath verifies the public boundary refuses malformed
@@ -2305,8 +2330,8 @@ func TestNewAccountInvalidPath(t *testing.T) {
 	}
 }
 
-// TestNewAccountExactUnsupported verifies both kvdb and disabled chain sync
-// reject exact creation after admission and before root or Store mutation.
+// TestNewAccountExactUnsupported verifies kvdb rejects exact creation with
+// either policy after admission and before root preparation or Store mutation.
 func TestNewAccountExactUnsupported(t *testing.T) {
 	t.Parallel()
 
@@ -2320,7 +2345,7 @@ func TestNewAccountExactUnsupported(t *testing.T) {
 			name: "kvdb exact",
 		},
 		{
-			name:        "sql no chain sync",
+			name:        "kvdb no chain sync",
 			noChainSync: true,
 		},
 	}
@@ -2329,10 +2354,6 @@ func TestNewAccountExactUnsupported(t *testing.T) {
 			t.Parallel()
 
 			w, deps := createStartedWalletWithMocks(t)
-			if test.noChainSync {
-				w.addrStore = nil
-			}
-
 			scope := waddrmgr.KeyScopeBIP0084
 			number := AccountNumber(7)
 

--- a/wallet/syncer_test.go
+++ b/wallet/syncer_test.go
@@ -2258,16 +2258,15 @@ func TestSyncerRecoveryRejectsNoChainSyncTarget(t *testing.T) {
 func newSQLRecoverySyncer(t *testing.T) (*syncer, []db.AccountInfo, [][]byte) {
 	t.Helper()
 
-	// Reuse the SQL Manager's real vault and derivation callbacks so the
-	// persisted account keys and scripts exercise the normal recovery path.
+	// Use public account creation with the real SQL vault, admitting the
+	// Wallet without background synchronization so recovery remains observable.
 	m := testSQLiteManager(t)
 	params := sqliteCreateParams(t)
 	params.Name = t.Name()
 	w, err := m.Create(params)
 	require.NoError(t, err)
+	startLoadedWalletForTest(t, w)
 	require.NoError(t, w.keyVault.Unlock(t.Context(), params.PrivatePassphrase))
-	derive, err := w.buildAccountDeriveFn(t.Context())
-	require.NoError(t, err)
 
 	// Both accounts have identical setup except for the persisted policy;
 	// materializing an address also tests the non-lookahead watch source.
@@ -2288,16 +2287,20 @@ func newSQLRecoverySyncer(t *testing.T) (*syncer, []db.AccountInfo, [][]byte) {
 	accounts := make([]db.AccountInfo, 0, len(configs))
 	scripts := make([][]byte, 0, len(configs))
 
-	for _, config := range configs {
-		_, err := w.store.CreateDerivedAccount(
-			t.Context(), db.CreateDerivedAccountParams{
-				WalletID:    w.id,
-				Scope:       db.KeyScopeBIP0084,
-				Name:        config.name,
-				NoChainSync: config.noChainSync,
-			}, derive,
-		)
+	for i, config := range configs {
+		// Exact creation carries the policy without deriving child addresses;
+		// the existing address fixture below is a separate deliberate write.
+		number := AccountNumber(i)
+		created, err := w.NewAccount(t.Context(), NewAccountParams{
+			Scope:         waddrmgr.KeyScopeBIP0084,
+			Name:          config.name,
+			AccountNumber: &number,
+			NoChainSync:   config.noChainSync,
+		})
 		require.NoError(t, err)
+		require.Equal(t, config.noChainSync, created.NoChainSync)
+		require.Zero(t, created.ExternalKeyCount)
+		require.Zero(t, created.InternalKeyCount)
 		addr, err := w.store.NewDerivedAddress(
 			t.Context(), db.NewDerivedAddressParams{
 				WalletID:    w.id,


### PR DESCRIPTION
## Summary

Implements roadmap Task 468.

## Change Description

Allow NoChainSync=true for exact root-derived SQL accounts through NewAccountParams. Reuse atomic account creation to persist and return the policy without deriving receiving addresses or admitting positive-lookahead recovery. Preserve sequential and modern kvdb refusal.

Wallet tests, the nine chain/database activation combinations, existing creation/refusal cases, lint, and commit hygiene pass.

## Notes

Complete dependency stack:

- #1365 (Task 345, persisted account policy) and #1358 (Task 378, account errors) feed #1366 (Task 392, creation request).
- #1366 feeds #1369 (Task 343, exact allocation) and #1367 (Task 393, receiving rejection).
- #1365 also feeds #1368 (Task 452, recovery exclusion).
- This PR depends on #1369, #1367, and #1368.

The base branch combines those three reviewed prerequisite heads. Review scope starts after all dependencies and contains only this PR's two activation/test commits. Keep this PR draft until its prerequisite stack is ready; rebase the task-only commits as the dependencies land.
