### PR TITLE
wallet: create accounts in custom scopes

### DIFF
--- a/itest/account_manager_test.go
+++ b/itest/account_manager_test.go
@@ -3,6 +3,8 @@
 package itest
 
 import (
+	"testing"
+
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
 	"github.com/btcsuite/btcwallet/bwtest"
@@ -298,6 +300,93 @@ func testAccountManagerAdvanceAccountCursor(h *bwtest.HarnessTest) {
 	// Assert: the cursor advanced past seven and did not retreat for two.
 	require.NoError(h, err)
 	require.Equal(h, wallet.AccountNumber(8), *next.AccountNumber)
+}
+
+// testAccountManagerCreateCustomScopeAccount verifies that exact root-derived
+// creation persists a new scope and either sync policy across wallet reload.
+func testAccountManagerCreateCustomScopeAccount(h *bwtest.HarnessTest) {
+	// Harness subtests own distinct wallet names and databases, so each policy
+	// must establish its scope without reusing the other policy's metadata.
+	tests := []struct {
+		name        string
+		noChainSync bool
+	}{
+		{
+			name:        "chain sync enabled",
+			noChainSync: false,
+		},
+		{
+			name:        "chain sync excluded",
+			noChainSync: true,
+		},
+	}
+
+	for _, tc := range tests {
+		h.Run(tc.name, func(t *testing.T) {
+			h := h.Subtest(t)
+
+			// Arrange: use a fresh unlocked wallet so each policy must
+			// establish the custom scope without previously stored metadata.
+			// Snapshot accounts to detect mutation on kvdb's refusal path.
+			const accountName = "custom scope account"
+
+			ctx := h.Context()
+			scope := waddrmgr.KeyScope{
+				Purpose: 1017,
+				Coin:    h.NetParams().HDCoinType,
+			}
+			schema := waddrmgr.ScopeAddrSchema{
+				ExternalAddrType: waddrmgr.WitnessPubKey,
+				InternalAddrType: waddrmgr.WitnessPubKey,
+			}
+			number := wallet.AccountNumber(7)
+			w, _ := h.NewWallet(bwtest.WalletFixture{Unlocked: true})
+			before, err := w.ListAccounts(ctx)
+			require.NoError(h, err)
+
+			// Act: supply both required new-scope inputs through the public
+			// creation operation, varying only the requested sync policy.
+			created, err := w.NewAccount(ctx, wallet.NewAccountParams{
+				Scope:         scope,
+				Name:          accountName,
+				AddrSchema:    &schema,
+				AccountNumber: &number,
+				NoChainSync:   tc.noChainSync,
+			})
+
+			// Assert: backend configuration selects kvdb's documented
+			// refusal; SQL below must persist the custom scope and policy.
+			if *dbBackend != string(wallet.DBBackendSQLite) &&
+				*dbBackend != string(wallet.DBBackendPostgres) {
+
+				require.ErrorIs(h, err, wallet.ErrAccountOperationUnsupported)
+				require.Nil(h, created)
+
+				after, err := w.ListAccounts(ctx)
+				require.NoError(h, err)
+				// Scope traversal order does not change the account set.
+				require.ElementsMatch(h, before, after)
+
+				return
+			}
+
+			// Check the requested custom-scope identity and policy before
+			// comparing the full snapshot across the persistence boundary.
+			require.NoError(h, err)
+			require.Equal(h, number, *created.AccountNumber)
+			require.Equal(h, scope, created.KeyScope)
+			require.Equal(h, schema, created.AddrSchema)
+			require.Equal(h, tc.noChainSync, created.NoChainSync)
+			require.False(h, created.IsImported)
+
+			// Reopen through the harness to expose lost scope or account
+			// metadata rather than repeating an immediate account read.
+			w = h.ReloadWallet(w)
+			durable, err := w.GetAccount(ctx, scope, accountName)
+			require.NoError(h, err)
+			require.Equal(h, created, durable)
+		})
+	}
 }
 
 // testAccountManagerCreateAccountSequence verifies that derived account numbers

--- a/itest/list_on_test.go
+++ b/itest/list_on_test.go
@@ -43,6 +43,11 @@ var allTestCases = []*testCase{
 		Name:     "account manager create account",
 		TestFunc: testAccountManagerCreateAccount,
 	},
+	// Custom scopes must persist their schema together with the account.
+	{
+		Name:     "account manager create custom scope account",
+		TestFunc: testAccountManagerCreateCustomScopeAccount,
+	},
 	{
 		Name:     "account manager create exact account",
 		TestFunc: testAccountManagerCreateExactAccount,

--- a/wallet/account_derive.go
+++ b/wallet/account_derive.go
@@ -31,10 +31,9 @@ var errWatchOnlyAccountDerivation = errors.New(
 // encrypts the resulting private key via vault, and returns the
 // DerivedAccountData that the backend persists alongside the row.
 //
-// masterPrivKey must be the wallet's decrypted master HD private key,
-// loaded by Wallet.NewAccount before opening the store transaction. The
+// masterPrivKey must be the wallet's decrypted master HD private key. The
 // closure does not access w.store or open any database transaction, so it
-// is safe for the backend to invoke from inside its write tx.
+// is safe to construct and invoke after the store's transactional checks.
 //
 // The fingerprint argument is the BIP32 master-key fingerprint corresponding
 // to masterPrivKey (computed once by Wallet.NewAccount via

--- a/wallet/account_manager.go
+++ b/wallet/account_manager.go
@@ -137,7 +137,9 @@ func newAccountErr(err error) error {
 		isAddrMgrErr(err, waddrmgr.ErrLocked):
 		publicErr = ErrStateForbidden
 
-	case errors.Is(err, db.ErrUnknownKeyScope):
+	// A transactional scope-schema conflict is also invalid creation input.
+	case errors.Is(err, db.ErrUnknownKeyScope),
+		errors.Is(err, db.ErrInvalidParam):
 		publicErr = ErrInvalidParam
 
 	case isAccountMissing(err):
@@ -193,11 +195,10 @@ func validateAccountName(name string) error {
 	return publicAccountErr(waddrmgr.ValidateAccountName(name), ErrInvalidParam)
 }
 
-// buildAccountDeriveFn returns an AccountDerivationFunc closure. Spendable
-// wallets normally preload the master HD private key before the store opens
-// its write transaction. Neutered-root kvdb wallets are the exception: they
-// need to defer a missing-root-key error to the store callback so kvdb can
-// derive from the scoped coin-type key inside its walletdb transaction.
+// buildAccountDeriveFn preloads encrypted root bytes without reentering the
+// Store's write transaction. Its callback decrypts only after transactional
+// scope checks pass. A missing root stays deferred so neutered-root kvdb
+// wallets can derive from their scoped coin-type key inside walletdb.
 func (w *Wallet) buildAccountDeriveFn(
 	ctx context.Context) (db.AccountDerivationFunc, error) {
 
@@ -225,24 +226,32 @@ func (w *Wallet) buildAccountDeriveFn(
 		return nil, fmt.Errorf("load encrypted master HD priv: %w", err)
 	}
 
-	plaintext, err := w.keyVault.Decrypt(waddrmgr.CKTPrivate, encrypted)
-	if err != nil {
-		return nil, fmt.Errorf("decrypt master HD priv: %w", err)
-	}
+	// Capture ciphertext only: a scope established by another writer can
+	// conflict after admission, and its transaction must refuse before crypto.
+	return func(ctx context.Context, scope db.KeyScope, accountNumber uint32,
+		walletIsWatchOnly bool) (*db.DerivedAccountData, error) {
 
-	masterKey, err := hdkeychain.NewKeyFromString(string(plaintext))
-	zero.Bytes(plaintext)
+		plaintext, err := w.keyVault.Decrypt(waddrmgr.CKTPrivate, encrypted)
+		if err != nil {
+			return nil, fmt.Errorf("decrypt master HD priv: %w", err)
+		}
 
-	if err != nil {
-		return nil, fmt.Errorf("parse master HD priv: %w", err)
-	}
+		masterKey, err := hdkeychain.NewKeyFromString(string(plaintext))
+		zero.Bytes(plaintext)
 
-	fingerprint, err := masterKeyFingerprint(masterKey)
-	if err != nil {
-		return nil, fmt.Errorf("master key fingerprint: %w", err)
-	}
+		if err != nil {
+			return nil, fmt.Errorf("parse master HD priv: %w", err)
+		}
 
-	return newAccountDeriveFn(masterKey, w.keyVault, fingerprint), nil
+		fingerprint, err := masterKeyFingerprint(masterKey)
+		if err != nil {
+			return nil, fmt.Errorf("master key fingerprint: %w", err)
+		}
+
+		return newAccountDeriveFn(masterKey, w.keyVault, fingerprint)(
+			ctx, scope, accountNumber, walletIsWatchOnly,
+		)
+	}, nil
 }
 
 // NewAccountParams selects the next or an exact account to create. The zero
@@ -251,11 +260,18 @@ type NewAccountParams struct {
 	// Scope identifies the purpose and coin type used for derivation.
 	Scope waddrmgr.KeyScope
 
+	// AddrSchema specifies both account-key branch types. A new custom scope
+	// requires it and AccountNumber; an existing scope requires a match.
+	// Nil reuses persisted schema or a canonical scope's default. Invalid or
+	// conflicting schemas return ErrInvalidParam before secret preparation.
+	AddrSchema *waddrmgr.ScopeAddrSchema
+
 	// Name must be valid and unique within Scope.
 	Name string
 
-	// AccountNumber requests this exact root-derived account in a canonical
-	// SQL scope, leaving lower holes available. Nil selects the next account.
+	// AccountNumber requests this exact root-derived SQL account, leaving
+	// lower holes available. Nil selects the next account in an existing or
+	// canonical scope.
 	// Modern kvdb rejects exact selection with ErrAccountOperationUnsupported.
 	AccountNumber *AccountNumber
 
@@ -302,7 +318,8 @@ type NewAccountParams struct {
 // and internal failures retained only as diagnostic text.
 type AccountManager interface {
 	// NewAccount creates the next or requested exact root-derived account. The
-	// provided name must be unique within that key scope. NoChainSync=true
+	// provided name must be unique within that key scope. A new custom scope
+	// requires AddrSchema and AccountNumber. NoChainSync=true
 	// is supported only for exact SQL selection; other requests return
 	// ErrAccountOperationUnsupported.
 	// ErrIndeterminateCommit means persistence may have succeeded; callers
@@ -470,7 +487,8 @@ func (w *Wallet) requireAccountNameAvailable(ctx context.Context,
 
 // NewAccount creates the next or requested exact root-derived account and
 // returns its persisted info. The name and number must be unused in the scope.
-// Exact selection supports canonical SQL scopes and leaves lower holes free.
+// A new custom SQL scope requires AddrSchema and an exact AccountNumber.
+// Exact selection leaves lower holes free; existing schemas must match.
 // NoChainSync=true excludes automatic synchronization and recovery only with
 // exact SQL selection. Sequential exclusion and exact kvdb requests return
 // ErrAccountOperationUnsupported before preparing secrets.
@@ -513,9 +531,9 @@ func (w *Wallet) NewAccount(ctx context.Context,
 		NoChainSync:   params.NoChainSync,
 	}
 
-	err = dbParams.Validate()
+	err = validateNewAccountSchema(&dbParams, params.AddrSchema)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", ErrInvalidParam, err.Error())
+		return nil, err
 	}
 
 	// Spendable derivation requires an unlocked wallet; watch-only wallets
@@ -548,8 +566,17 @@ func (w *Wallet) NewAccount(ctx context.Context,
 // handleNewAccount performs derivation and persistence only after mainLoop
 // admits the request; handleReq owns its shutdown completion.
 func (w *Wallet) handleNewAccount(req newAccountReq) {
+	// Admission makes Stop drain the persisted-scope read together with the
+	// write. Reject scope conflicts before preparing secrets or mutating Store.
+	err := w.validateNewAccountScope(req.ctx, &req.params)
+	if err != nil {
+		req.resp <- accountResp{err: err}
+
+		return
+	}
+
 	// An occupied name takes precedence over mode or derivation refusals.
-	err := w.requireAccountNameAvailable(
+	err = w.requireAccountNameAvailable(
 		req.ctx, waddrmgr.KeyScope(req.params.Scope), req.params.Name,
 	)
 	if err != nil {
@@ -607,6 +634,76 @@ func (w *Wallet) handleNewAccount(req newAccountReq) {
 		info: account,
 		err:  err,
 	}
+}
+
+// validateNewAccountSchema checks branch types and the complete path without
+// Store access, so NewAccount can reject malformed input before admission.
+func validateNewAccountSchema(params *db.CreateDerivedAccountParams,
+	schema *waddrmgr.ScopeAddrSchema) error {
+
+	// The legacy conversion folds script-path taproot into its key-path
+	// counterpart. Reject it before that information is lost; Store validation
+	// rejects the remaining non-account branch types after conversion.
+	if schema != nil && (schema.ExternalAddrType == waddrmgr.TaprootScript ||
+		schema.InternalAddrType == waddrmgr.TaprootScript) {
+
+		return fmt.Errorf("script-path account schema: %w", ErrInvalidParam)
+	}
+
+	converted, err := dbScopeAddrSchema(schema)
+	if err != nil {
+		return fmt.Errorf("%w: %s", ErrInvalidParam, err.Error())
+	}
+
+	params.AddrSchema = converted
+
+	// Reject the complete hardened path before any secret preparation; reuse
+	// Store validation so the public and persistence boundaries agree.
+	err = params.Validate()
+	if err != nil {
+		return fmt.Errorf("%w: %s", ErrInvalidParam, err.Error())
+	}
+
+	return nil
+}
+
+// validateNewAccountScope checks persisted scope metadata rather than account
+// overrides and requires enough information to establish a new custom scope.
+func (w *Wallet) validateNewAccountScope(ctx context.Context,
+	params *db.CreateDerivedAccountParams) error {
+
+	// Omission preserves lazy canonical creation without an extra read.
+	defaultSchema, canonical := db.ScopeAddrMap[params.Scope]
+	if canonical && params.AddrSchema == nil {
+		return nil
+	}
+
+	schema, err := w.store.GetKeyScopeSchema(ctx, w.id, params.Scope)
+	switch {
+	case errors.Is(err, db.ErrKeyScopeNotFound):
+		if !canonical {
+			if params.AddrSchema == nil || params.AccountNumber == nil {
+				return fmt.Errorf("new scope needs schema and number: %w",
+					db.ErrInvalidParam)
+			}
+
+			return nil
+		}
+
+		// Receiving APIs map address types to canonical scopes. A newly
+		// created scope must retain that mapping; an existing scope below
+		// remains governed by its persisted schema, including overrides.
+		schema = defaultSchema
+
+	case err != nil:
+		return err
+	}
+
+	if params.AddrSchema != nil && *params.AddrSchema != schema {
+		return fmt.Errorf("conflicting scope schema: %w", db.ErrInvalidParam)
+	}
+
+	return nil
 }
 
 // propertiesToAccountInfo wraps a waddrmgr.AccountProperties + total balance

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -2065,6 +2065,10 @@ func TestNewAccountInvalidPath(t *testing.T) {
 		Scope:         waddrmgr.KeyScopeBIP0084,
 		Name:          testAccountName,
 		AccountNumber: &number,
+		AddrSchema: &waddrmgr.ScopeAddrSchema{
+			ExternalAddrType: waddrmgr.WitnessPubKey,
+			InternalAddrType: waddrmgr.WitnessPubKey,
+		},
 	})
 
 	// Assert: validation exposes only the public identity and no account,
@@ -2098,7 +2102,18 @@ func TestNewAccountExactUnsupported(t *testing.T) {
 			t.Parallel()
 
 			w, deps := createUnlockedWalletWithMocks(t)
-			scope := waddrmgr.KeyScopeBIP0084
+			scope := waddrmgr.KeyScope{
+				Purpose: 1017,
+			}
+			schema := waddrmgr.ScopeAddrSchema{
+				ExternalAddrType: waddrmgr.WitnessPubKey,
+				InternalAddrType: waddrmgr.WitnessPubKey,
+			}
+			deps.store.On("GetKeyScopeSchema", mock.Anything, w.id,
+				db.KeyScope(scope)).Return(
+				db.ScopeAddrSchema{}, db.ErrKeyScopeNotFound,
+			).Once()
+
 			number := AccountNumber(7)
 
 			expectAccountNameAvailable(deps, scope, testAccountName)
@@ -2108,6 +2123,7 @@ func TestNewAccountExactUnsupported(t *testing.T) {
 				Scope:         scope,
 				Name:          testAccountName,
 				AccountNumber: &number,
+				AddrSchema:    &schema,
 				NoChainSync:   test.noChainSync,
 			})
 
@@ -2297,6 +2313,233 @@ func TestNewAccountCustomScopeMissingFields(t *testing.T) {
 			// neither a partial result nor any secret or write call occurs.
 			require.ErrorIs(t, err, ErrInvalidParam)
 			require.Nil(t, info)
+		})
+	}
+}
+
+// TestNewAccountInvalidSchema verifies non-account branch types are rejected
+// before any scope read, secret preparation, or account mutation.
+func TestNewAccountInvalidSchema(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: zero branch values are valid P2PKH, so each row changes only
+	// the invalid branch. Cover lossy taproot conversion on both branches.
+	tests := []struct {
+		name     string
+		external waddrmgr.AddressType
+		internal waddrmgr.AddressType
+	}{
+		{
+			name:     "raw key",
+			external: waddrmgr.RawPubKey,
+		},
+		{
+			name:     "script hash",
+			external: waddrmgr.Script,
+		},
+		{
+			name:     "witness script",
+			external: waddrmgr.WitnessScript,
+		},
+		{
+			name:     "external taproot script",
+			external: waddrmgr.TaprootScript,
+		},
+		{
+			name:     "internal taproot script",
+			internal: waddrmgr.TaprootScript,
+		},
+		{
+			name:     "unknown external type",
+			external: waddrmgr.AddressType(255),
+		},
+		{
+			name:     "unknown internal type",
+			internal: waddrmgr.AddressType(255),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			w, _ := createUnlockedWalletWithMocks(t)
+			w.addrStore = nil
+			number := AccountNumber(7)
+
+			// Act: submit the malformed schema through the public request.
+			info, err := w.NewAccount(t.Context(), NewAccountParams{
+				Scope: waddrmgr.KeyScope{
+					Purpose: 1017,
+				},
+				Name:          testAccountName,
+				AccountNumber: &number,
+				AddrSchema: &waddrmgr.ScopeAddrSchema{
+					ExternalAddrType: test.external,
+					InternalAddrType: test.internal,
+				},
+			})
+
+			// Assert: no backend identity or partial account escapes, and
+			// the strict mocks allow no secret, read, or mutation calls.
+			require.ErrorIs(t, err, ErrInvalidParam)
+			require.NotErrorIs(t, err, db.ErrInvalidParam)
+			require.Nil(t, info)
+		})
+	}
+}
+
+// TestNewAccountScopeSchemaConflict verifies scope assertions fail before
+// secrets, including a new canonical scope that would change receiving types.
+func TestNewAccountScopeSchemaConflict(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: each scope read yields a witness schema or reports an absent
+	// BIP84 scope. The supplied P2PKH branch conflicts with either authority.
+	tests := []struct {
+		name     string
+		purpose  uint32
+		external waddrmgr.AddressType
+		internal waddrmgr.AddressType
+		readErr  error
+	}{
+		{
+			name:     "external mismatch",
+			purpose:  1017,
+			external: waddrmgr.PubKeyHash,
+			internal: waddrmgr.WitnessPubKey,
+		},
+		{
+			name:     "internal mismatch",
+			purpose:  1017,
+			external: waddrmgr.WitnessPubKey,
+			internal: waddrmgr.PubKeyHash,
+		},
+		{
+			name:     "absent canonical mismatch",
+			purpose:  84,
+			external: waddrmgr.PubKeyHash,
+			internal: waddrmgr.PubKeyHash,
+			readErr:  db.ErrKeyScopeNotFound,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			w, deps := createUnlockedWalletWithMocks(t)
+			w.addrStore = nil
+			scope := waddrmgr.KeyScope{
+				Purpose: test.purpose,
+			}
+			number := AccountNumber(7)
+
+			deps.store.On("GetKeyScopeSchema", mock.Anything, w.id,
+				db.KeyScope(scope)).Return(
+				db.ScopeAddrMap[db.KeyScopeBIP0084], test.readErr,
+			).Once()
+
+			// Act: try to create an account with an incompatible schema.
+			info, err := w.NewAccount(t.Context(), NewAccountParams{
+				Scope:         scope,
+				Name:          testAccountName,
+				AccountNumber: &number,
+				AddrSchema: &waddrmgr.ScopeAddrSchema{
+					ExternalAddrType: test.external,
+					InternalAddrType: test.internal,
+				},
+			})
+
+			// Assert: only the scope read occurs; no root preparation or
+			// mutation can establish the incompatible account.
+			require.ErrorIs(t, err, ErrInvalidParam)
+			require.Nil(t, info)
+		})
+	}
+}
+
+// TestNewAccountExistingScopeSchema verifies omission and equality reuse the
+// persisted schema, even when a canonical scope differs from its default map.
+func TestNewAccountExistingScopeSchema(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: use all four supported key-derived branch forms across two
+	// persisted schemas. Every row has the same read, derivation, and write.
+	legacy := waddrmgr.ScopeAddrSchema{
+		ExternalAddrType: waddrmgr.PubKeyHash,
+		InternalAddrType: waddrmgr.NestedWitnessPubKey,
+	}
+	witness := waddrmgr.ScopeAddrSchema{
+		ExternalAddrType: waddrmgr.WitnessPubKey,
+		InternalAddrType: waddrmgr.TaprootPubKey,
+	}
+
+	tests := []struct {
+		name      string
+		purpose   uint32
+		supplied  *waddrmgr.ScopeAddrSchema
+		persisted waddrmgr.ScopeAddrSchema
+	}{
+		{
+			name:      "custom matching schema",
+			purpose:   1017,
+			supplied:  &witness,
+			persisted: witness,
+		},
+		{
+			name:      "custom omitted schema",
+			purpose:   1017,
+			persisted: witness,
+		},
+		{
+			name:      "canonical persisted override",
+			purpose:   84,
+			supplied:  &legacy,
+			persisted: legacy,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			w, deps := createUnlockedWalletWithMocks(t)
+			w.addrStore = nil
+			scope := waddrmgr.KeyScope{
+				Purpose: test.purpose,
+			}
+			number := AccountNumber(7)
+			supplied, err := dbScopeAddrSchema(test.supplied)
+			require.NoError(t, err)
+			persisted, err := dbScopeAddrSchema(&test.persisted)
+			require.NoError(t, err)
+			deps.store.On("GetKeyScopeSchema", mock.Anything, w.id,
+				db.KeyScope(scope)).Return(*persisted, nil).Once()
+			expectAccountNameAvailable(deps, scope, testAccountName)
+			expectAccountDeriveSetup(t, deps, newStubAccountDeriveFn(t))
+			deps.store.On("CreateDerivedAccount", mock.Anything,
+				db.CreateDerivedAccountParams{
+					WalletID:      w.id,
+					Scope:         db.KeyScope(scope),
+					Name:          testAccountName,
+					AccountNumber: (*uint32)(&number),
+					AddrSchema:    supplied,
+				}, mock.Anything).Return(&db.AccountInfo{
+				AccountNumber: (*uint32)(&number),
+				AddrSchema:    *persisted,
+			}, nil).Once()
+
+			// Act: create through the same public operation regardless of
+			// whether the request supplies or omits the persisted schema.
+			info, err := w.NewAccount(t.Context(), NewAccountParams{
+				Scope:         scope,
+				Name:          testAccountName,
+				AccountNumber: &number,
+				AddrSchema:    test.supplied,
+			})
+
+			// Assert: the result reports persisted branch types, with one
+			// creation and no additional source of scope metadata.
+			require.NoError(t, err)
+			require.Equal(t, test.persisted, info.AddrSchema)
 		})
 	}
 }

--- a/wallet/account_manager_test.go
+++ b/wallet/account_manager_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -250,10 +251,8 @@ func newStubAccountDeriveFn(t *testing.T) stubAccountDeriveFn {
 	}
 }
 
-// expectAccountDeriveSetup wires the mock expectations the new wallet
-// NewAccount path performs before invoking w.store.CreateDerivedAccount.
-// Decrypt returns a fresh copy so the wallet's post-parse zero.Bytes call
-// does not corrupt the shared stub across multiple invocations.
+// expectAccountDeriveSetup supplies the encrypted bytes required before the
+// Store transaction, without expecting key decryption.
 func expectAccountDeriveSetup(t *testing.T, deps *mockWalletDeps,
 	stub stubAccountDeriveFn) {
 
@@ -261,10 +260,6 @@ func expectAccountDeriveSetup(t *testing.T, deps *mockWalletDeps,
 
 	deps.store.On("GetEncryptedHDSeed", mock.Anything, uint32(0)).
 		Return(append([]byte(nil), stub.encryptedSeed...), nil).Once()
-	deps.vault.On("Decrypt", waddrmgr.CKTPrivate,
-		mock.Anything).Return(
-		append([]byte(nil), stub.plaintextMasterKey...), nil,
-	).Once()
 }
 
 // hardenedKey converts a plain BIP32 child index to its hardened
@@ -952,6 +947,15 @@ func TestNewAccount(t *testing.T) {
 
 	expectAccountNameAvailable(deps, scope, testAccountName)
 	expectAccountDeriveSetup(t, deps, stub)
+	// The Store callback owns decryption. Return a fresh plaintext copy so
+	// its post-parse zeroing cannot alter the shared derivation fixture.
+	deps.vault.On("Decrypt", waddrmgr.CKTPrivate, stub.encryptedSeed).
+		Return(append([]byte(nil), stub.plaintextMasterKey...), nil).Once()
+	deps.vault.On("Encrypt", waddrmgr.CKTPrivate, mock.Anything).
+		Return([]byte("encrypted account"), nil).Once()
+	// NewAccount waits for the handler result before these values are asserted.
+	var deriveErr error
+
 	deps.store.On("CreateDerivedAccount", mock.Anything,
 		db.CreateDerivedAccountParams{
 			WalletID:    0,
@@ -964,7 +968,15 @@ func TestNewAccount(t *testing.T) {
 			AccountName:   testAccountName,
 			KeyScope:      dbScope,
 		}, nil,
-	).Once()
+	).Once().Run(func(args mock.Arguments) {
+		// Model the Store invoking derivation only after admission succeeds.
+		deriveFn, ok := args.Get(2).(db.AccountDerivationFunc)
+		if ok {
+			_, deriveErr = deriveFn(
+				t.Context(), dbScope, accountNumber, false,
+			)
+		}
+	})
 
 	// Act: Create the account through the public request path.
 	account, err := w.NewAccount(t.Context(), NewAccountParams{
@@ -974,6 +986,7 @@ func TestNewAccount(t *testing.T) {
 
 	// Assert: The public result reports the number and default sync policy.
 	require.NoError(t, err)
+	require.NoError(t, deriveErr)
 	require.False(t, account.NoChainSync)
 	require.Equal(t, AccountNumber(1), *account.AccountNumber)
 
@@ -1143,6 +1156,22 @@ func TestNewAccountLocked(t *testing.T) {
 	deps.vault.On("Decrypt", waddrmgr.CKTPrivate, mock.Anything).
 		Return(nil, keyvault.ErrVaultLocked).Once()
 
+	// The Store invokes derivation after its scope check. Record the callback
+	// error for assertions after the admitted handler returns.
+	var deriveErr error
+
+	deps.store.On("CreateDerivedAccount", mock.Anything, mock.Anything,
+		mock.Anything).Return(nil, keyvault.ErrVaultLocked).Once().Run(
+		func(args mock.Arguments) {
+			deriveFn, ok := args.Get(2).(db.AccountDerivationFunc)
+			if ok {
+				_, deriveErr = deriveFn(
+					t.Context(), db.KeyScope(scope), 1, false,
+				)
+			}
+		},
+	)
+
 	// Act: Reach the Vault through account creation after admission.
 	_, err := w.NewAccount(t.Context(), NewAccountParams{
 		Scope: scope,
@@ -1150,6 +1179,7 @@ func TestNewAccountLocked(t *testing.T) {
 	})
 
 	// Assert: A later Vault failure has the same wallet-owned state identity.
+	require.ErrorIs(t, deriveErr, keyvault.ErrVaultLocked)
 	require.ErrorIs(t, err, ErrStateForbidden)
 	require.NotErrorIs(t, err, keyvault.ErrVaultLocked)
 }
@@ -2154,4 +2184,119 @@ func TestNewAccountCancellationPreservesCommitError(t *testing.T) {
 	require.NotErrorIs(t, err, context.Canceled)
 	require.NotErrorIs(t, err, dbruntime.ErrAmbiguousTxCommit)
 	require.Nil(t, <-infos)
+}
+
+// TestNewAccountScopeReadDrains verifies shutdown waits for persisted scope
+// validation before releasing the Wallet's Store and key material.
+func TestNewAccountScopeReadDrains(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: pause the scope read before it reports a missing custom scope.
+	// Strict mocks forbid secrets or mutation; fixture cleanup checks calls.
+	w, deps := createTestWalletWithMocks(t)
+	startLoadedWalletForTest(t, w)
+	w.state.toUnlocked()
+
+	scope := waddrmgr.KeyScope{
+		Purpose: 1017,
+	}
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	resume := sync.OnceFunc(func() { close(release) })
+	t.Cleanup(resume)
+	deps.store.On("GetKeyScopeSchema", mock.Anything, w.id,
+		db.KeyScope(scope)).Run(func(mock.Arguments) {
+		close(entered)
+		<-release
+	}).Return(db.ScopeAddrSchema{}, db.ErrKeyScopeNotFound).Once()
+	deps.vault.On("Lock").Return().Once()
+
+	result := make(chan accountResp, 1)
+	go func() {
+		info, err := w.NewAccount(t.Context(), NewAccountParams{
+			Scope: scope,
+			Name:  testAccountName,
+		})
+		result <- accountResp{info: info, err: err}
+	}()
+
+	<-entered
+
+	// Act: close admission while the scope read remains blocked. Stop must
+	// retain this request even though it has not prepared secrets or written.
+	stopped := make(chan error, 1)
+	go func() { stopped <- w.Stop(t.Context()) }()
+
+	<-w.lifetimeCtx.Done()
+
+	// Assert: observe that Stop cannot finish before the read returns, then
+	// release it and check the admitted request's ordinary missing-input error.
+	select {
+	case err := <-stopped:
+		t.Fatalf("Stop returned before scope validation: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	resume()
+
+	response := <-result
+	require.ErrorIs(t, response.err, ErrInvalidParam)
+	require.Nil(t, response.info)
+	require.NoError(t, <-stopped)
+}
+
+// TestNewAccountCustomScopeMissingFields verifies an unknown scope cannot be
+// established without both its branch schema and exact account selection.
+func TestNewAccountCustomScopeMissingFields(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: vary only the missing input; scope lookup is the sole expected
+	// dependency call, so any secret preparation or mutation fails the mocks.
+	number := AccountNumber(7)
+
+	tests := []struct {
+		name   string
+		number *AccountNumber
+		schema *waddrmgr.ScopeAddrSchema
+	}{
+		{
+			name:   "missing schema",
+			number: &number,
+		},
+		{
+			name: "missing number",
+			schema: &waddrmgr.ScopeAddrSchema{
+				ExternalAddrType: waddrmgr.WitnessPubKey,
+				InternalAddrType: waddrmgr.WitnessPubKey,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			w, deps := createUnlockedWalletWithMocks(t)
+			w.addrStore = nil
+			scope := waddrmgr.KeyScope{
+				Purpose: 1017,
+			}
+			deps.store.On("GetKeyScopeSchema", mock.Anything, w.id,
+				db.KeyScope(scope)).Return(
+				db.ScopeAddrSchema{}, db.ErrKeyScopeNotFound,
+			).Once()
+
+			// Act: request an account in a scope with no persisted schema.
+			info, err := w.NewAccount(t.Context(), NewAccountParams{
+				Scope:         scope,
+				Name:          testAccountName,
+				AccountNumber: test.number,
+				AddrSchema:    test.schema,
+			})
+
+			// Assert: the missing input is a public request error, and
+			// neither a partial result nor any secret or write call occurs.
+			require.ErrorIs(t, err, ErrInvalidParam)
+			require.Nil(t, info)
+		})
+	}
 }

--- a/wallet/internal/bwtest/mock/store.go
+++ b/wallet/internal/bwtest/mock/store.go
@@ -531,3 +531,13 @@ func (m *Store) RollbackToBlock(ctx context.Context, height uint32) error {
 
 	return args.Error(0)
 }
+
+// GetKeyScopeSchema records the admission read so tests can forbid secret
+// preparation and mutation when a scope assertion fails.
+func (m *Store) GetKeyScopeSchema(ctx context.Context, walletID uint32,
+	scope db.KeyScope) (db.ScopeAddrSchema, error) {
+
+	args := m.Called(ctx, walletID, scope)
+
+	return args.Get(0).(db.ScopeAddrSchema), args.Error(1)
+}

--- a/wallet/internal/db/accountstore_createderived.go
+++ b/wallet/internal/db/accountstore_createderived.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil/v2/hdkeychain"
@@ -61,15 +62,28 @@ func (params *CreateDerivedAccountParams) Validate() error {
 		return fmt.Errorf("hardened scope component: %w", ErrInvalidParam)
 	}
 
-	// Exact selection is restricted to canonical scopes and excludes the
-	// imported-account sentinel; nil retains the existing sequential subset.
+	// Exact selection excludes the imported-account sentinel; nil retains
+	// the existing sequential subset.
 	if params.AccountNumber != nil {
 		if *params.AccountNumber > MaxAccountNumber {
 			return fmt.Errorf("exact account number: %w", ErrInvalidParam)
 		}
+	}
 
-		if _, ok := ScopeAddrMap[params.Scope]; !ok {
-			return fmt.Errorf("exact account scope: %w", ErrInvalidParam)
+	// Account branches must be derivable from one key; script-bearing and
+	// raw-key forms cannot serve as account address schemas.
+	if params.AddrSchema != nil {
+		allowed := []AddressType{
+			PubKeyHash, NestedWitnessPubKey, WitnessPubKey, TaprootPubKey,
+		}
+		for _, addrType := range []AddressType{
+			params.AddrSchema.ExternalAddrType,
+			params.AddrSchema.InternalAddrType,
+		} {
+			if !slices.Contains(allowed, addrType) {
+				return fmt.Errorf("account branch schema: %w",
+					ErrInvalidParam)
+			}
 		}
 	}
 
@@ -110,9 +124,11 @@ type CreateDerivedAccountOps interface {
 	// scope. The persisted schema may differ from ScopeAddrMap when the
 	// scope was originally created with a non-default override (e.g. an
 	// imported account that overrode the BIP44 / BIP49 / BIP84 / BIP86
-	// defaults).
+	// defaults). schema supplies creation metadata for an absent scope;
+	// existing scopes return their persisted schema for comparison.
 	EnsureScope(ctx context.Context, walletID uint32,
-		scope KeyScope) (int64, ScopeAddrSchema, error)
+		scope KeyScope, schema *ScopeAddrSchema) (int64, ScopeAddrSchema,
+		error)
 
 	// AllocateAccountNumber reserves the next or requested account number
 	// and advances the scope cursor without consuming lower holes. A nil
@@ -251,11 +267,9 @@ func CreateDerivedAccountWithOps(ctx context.Context,
 		return nil, fmt.Errorf("wallet watch only: %w", err)
 	}
 
-	scopeID, addrSchema, err := ops.EnsureScope(
-		ctx, params.WalletID, params.Scope,
-	)
+	scopeID, addrSchema, err := ensureDerivedAccountScope(ctx, params, ops)
 	if err != nil {
-		return nil, fmt.Errorf("ensure scope: %w", err)
+		return nil, err
 	}
 
 	allocated, accNumPreview, err := allocateAndPreviewAccountNumber(
@@ -298,4 +312,27 @@ func CreateDerivedAccountWithOps(ctx context.Context,
 		derived.PublicKey, &masterFingerprint,
 		0, 0,
 	), nil
+}
+
+// ensureDerivedAccountScope checks the persisted schema in the creation
+// transaction before allocation, since another creator may have established
+// the scope after public admission.
+func ensureDerivedAccountScope(ctx context.Context,
+	params CreateDerivedAccountParams,
+	ops CreateDerivedAccountOps) (int64, ScopeAddrSchema, error) {
+
+	scopeID, schema, err := ops.EnsureScope(
+		ctx, params.WalletID, params.Scope, params.AddrSchema,
+	)
+	if err != nil {
+		return 0, ScopeAddrSchema{}, fmt.Errorf("ensure scope: %w", err)
+	}
+
+	if params.AddrSchema != nil && *params.AddrSchema != schema {
+		return 0, ScopeAddrSchema{}, fmt.Errorf(
+			"conflicting scope schema: %w", ErrInvalidParam,
+		)
+	}
+
+	return scopeID, schema, nil
 }

--- a/wallet/internal/db/accountstore_createderived_test.go
+++ b/wallet/internal/db/accountstore_createderived_test.go
@@ -36,7 +36,7 @@ func TestCreateDerivedAccountParamsValidate(t *testing.T) {
 }
 
 // TestCreateDerivedAccountRejectsInvalidPath verifies malformed derivation
-// components and unsupported exact scopes fail before backend operations.
+// components fail before backend operations.
 func TestCreateDerivedAccountRejectsInvalidPath(t *testing.T) {
 	t.Parallel()
 
@@ -59,10 +59,6 @@ func TestCreateDerivedAccountRejectsInvalidPath(t *testing.T) {
 			name:   "reserved number",
 			scope:  KeyScopeBIP0084,
 			number: MaxAccountNumber + 1,
-		},
-		{
-			name:  "custom scope",
-			scope: KeyScope{Purpose: 1017},
 		},
 	}
 	for _, test := range tests {
@@ -122,6 +118,7 @@ func TestCreateDerivedAccountWithOps(t *testing.T) {
 	).Once()
 	ensureScopeCall := ops.On(
 		"EnsureScope", mock.Anything, uint32(7), params.Scope,
+		params.AddrSchema,
 	).Return(int64(11), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
 	allocateCall := ops.On(
 		"AllocateAccountNumber", mock.Anything, int64(11),
@@ -199,6 +196,7 @@ func TestCreateDerivedAccountWithOpsNilAccountNumber(t *testing.T) {
 			Purpose: 49,
 			Coin:    0,
 		},
+		(*ScopeAddrSchema)(nil),
 	).Return(int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
 	ops.On(
 		"AllocateAccountNumber", mock.Anything, int64(8),
@@ -242,6 +240,7 @@ func TestCreateDerivedAccountWithOpsMaxAccountNumber(t *testing.T) {
 			Purpose: 49,
 			Coin:    0,
 		},
+		(*ScopeAddrSchema)(nil),
 	).Return(int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
 	ops.On(
 		"AllocateAccountNumber", mock.Anything, int64(8),
@@ -297,6 +296,7 @@ func TestCreateDerivedAccountWithOpsWrapsStageErrors(t *testing.T) {
 						Purpose: 49,
 						Coin:    0,
 					},
+					(*ScopeAddrSchema)(nil),
 				).Return(int64(0), ScopeAddrSchema{}, errTestScope).Once()
 
 				return ops
@@ -315,6 +315,7 @@ func TestCreateDerivedAccountWithOpsWrapsStageErrors(t *testing.T) {
 						Purpose: 49,
 						Coin:    0,
 					},
+					(*ScopeAddrSchema)(nil),
 				).Return(
 					int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil,
 				).Once()
@@ -340,7 +341,9 @@ func TestCreateDerivedAccountWithOpsWrapsStageErrors(t *testing.T) {
 				ops.On("EnsureScope", mock.Anything, uint32(7), KeyScope{
 					Purpose: 49,
 					Coin:    0,
-				}).Return(
+				},
+					(*ScopeAddrSchema)(nil),
+				).Return(
 					int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil,
 				).Once()
 				ops.On(
@@ -410,6 +413,7 @@ func TestCreateDerivedAccountWithOpsDeriveFnInvokedOnce(t *testing.T) {
 			Purpose: 49,
 			Coin:    0,
 		},
+		(*ScopeAddrSchema)(nil),
 	).Return(int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
 	ops.On(
 		"AllocateAccountNumber", mock.Anything, int64(8),
@@ -460,6 +464,7 @@ func TestCreateDerivedAccountWithOpsRollsBackOnDeriveFnError(t *testing.T) {
 			Purpose: 49,
 			Coin:    0,
 		},
+		(*ScopeAddrSchema)(nil),
 	).Return(int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
 	ops.On(
 		"AllocateAccountNumber", mock.Anything, int64(8),
@@ -521,6 +526,7 @@ func TestCreateDerivedAccountWithOpsRejectsInvalidDerivedDataNil(t *testing.T) {
 			Purpose: 49,
 			Coin:    0,
 		},
+		(*ScopeAddrSchema)(nil),
 	).Return(int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
 	ops.On(
 		"AllocateAccountNumber", mock.Anything, int64(8),
@@ -563,6 +569,7 @@ func TestCreateDerivedAccountWithOpsRejectsInvalidDerivedDataMissingPublicKey(
 			Purpose: 49,
 			Coin:    0,
 		},
+		(*ScopeAddrSchema)(nil),
 	).Return(int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
 	ops.On(
 		"AllocateAccountNumber", mock.Anything, int64(8),
@@ -605,6 +612,7 @@ func TestCreateDerivedAccountWithOpsRejectsInvalidDerivedDataMissingPrivateKey(
 			Purpose: 49,
 			Coin:    0,
 		},
+		(*ScopeAddrSchema)(nil),
 	).Return(int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
 	ops.On(
 		"AllocateAccountNumber", mock.Anything, int64(8),
@@ -647,6 +655,7 @@ func TestCreateDerivedAccountWithOpsRejectsInvalidDerivedDataWatchOnlyHasPriv(
 			Purpose: 49,
 			Coin:    0,
 		},
+		(*ScopeAddrSchema)(nil),
 	).Return(int64(8), ScopeAddrMap[KeyScopeBIP0049Plus], nil).Once()
 	ops.On(
 		"AllocateAccountNumber", mock.Anything, int64(8),
@@ -702,9 +711,10 @@ func (m *mockCreateDerivedAccountOps) WalletWatchOnly(ctx context.Context,
 // EnsureScope implements CreateDerivedAccountOps.
 func (m *mockCreateDerivedAccountOps) EnsureScope(ctx context.Context,
 	walletID uint32,
-	scope KeyScope) (int64, ScopeAddrSchema, error) {
+	scope KeyScope, addrSchema *ScopeAddrSchema) (int64, ScopeAddrSchema,
+	error) {
 
-	args := m.Called(ctx, walletID, scope)
+	args := m.Called(ctx, walletID, scope, addrSchema)
 
 	scopeID, ok := args.Get(0).(int64)
 	if !ok {
@@ -821,4 +831,43 @@ func testValidWatchOnlyDeriveFn() AccountDerivationFunc {
 	return (&deriveFnRecorder{
 		returnData: newWatchOnlyDerivedAccountData(),
 	}).fn()
+}
+
+// TestCreateDerivedAccountRejectsScopeConflict verifies that a scope created
+// with a different schema after admission cannot allocate or derive an account.
+func TestCreateDerivedAccountRejectsScopeConflict(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: the transaction sees a scope whose persisted branch differs
+	// from the caller's assertion. No allocation or insert is expected.
+	params := testCreateDerivedAccountParams()
+	params.AddrSchema = &ScopeAddrSchema{
+		ExternalAddrType: PubKeyHash,
+		InternalAddrType: PubKeyHash,
+	}
+	ops := &mockCreateDerivedAccountOps{}
+	ops.On("WalletWatchOnly", mock.Anything, params.WalletID).
+		Return(false, nil).Once()
+	ops.On("EnsureScope", mock.Anything, params.WalletID, params.Scope,
+		params.AddrSchema).Return(
+		int64(1), ScopeAddrMap[KeyScopeBIP0084], nil,
+	).Once()
+
+	// Retain the callback recorder so an early derivation cannot be hidden
+	// by the later schema error returned from the transaction.
+	derive := &deriveFnRecorder{
+		returnData: newSpendableDerivedAccountData(),
+	}
+
+	// Act: attempt creation using the same transaction workflow as SQL.
+	info, err := CreateDerivedAccountWithOps(
+		t.Context(), params, ops, derive.fn(),
+	)
+
+	// Assert: the conflicting request exposes no account and stops before
+	// allocation, key derivation, or insertion can modify account state.
+	require.ErrorIs(t, err, ErrInvalidParam)
+	require.Nil(t, info)
+	require.Empty(t, derive.calls)
+	ops.AssertExpectations(t)
 }

--- a/wallet/internal/db/data_types.go
+++ b/wallet/internal/db/data_types.go
@@ -534,10 +534,14 @@ type CreateDerivedAccountParams struct {
 	// Scope is the key scope for the new account.
 	Scope KeyScope
 
+	// AddrSchema selects a new scope's schema or asserts equality with an
+	// existing scope. Nil reuses persisted metadata or the canonical default.
+	AddrSchema *ScopeAddrSchema
+
 	// Name is the name of the new account.
 	Name string
 
-	// AccountNumber selects an exact canonical-scope account on SQL stores.
+	// AccountNumber selects an exact account on SQL stores.
 	// Nil allocates the next account; exact creation leaves lower holes free.
 	// The legacy kvdb store does not support exact selection.
 	AccountNumber *uint32

--- a/wallet/internal/db/interface.go
+++ b/wallet/internal/db/interface.go
@@ -244,6 +244,11 @@ type WalletStore interface {
 
 // AccountStore defines the database actions for managing accounts.
 type AccountStore interface {
+	// GetKeyScopeSchema reads the persisted scope schema, independently of
+	// account overrides, or returns ErrKeyScopeNotFound when absent.
+	GetKeyScopeSchema(ctx context.Context, walletID uint32,
+		scope KeyScope) (ScopeAddrSchema, error)
+
 	// CreateDerivedAccount creates a new derived account with the given
 	// name and scope. SQL stores honor an optional exact AccountNumber and
 	// advance the cursor without consuming lower holes; kvdb rejects exact
@@ -252,7 +257,7 @@ type AccountStore interface {
 	// and persists it with the row.
 	//
 	// If the key scope does not exist, it will be automatically created
-	// using the address schema from ScopeAddrMap with no coin public/private
+	// using AddrSchema or the ScopeAddrMap default with no coin public/private
 	// key material. Spendable scopes may later gain a key_scope_secrets row;
 	// watch-only scopes remain absent from that table.
 	CreateDerivedAccount(ctx context.Context,

--- a/wallet/internal/db/kvdb/accountstore_createderived.go
+++ b/wallet/internal/db/kvdb/accountstore_createderived.go
@@ -84,10 +84,13 @@ func (o *createDerivedAccountOps) WalletWatchOnly(
 	return o.mgr.WatchOnly(), nil
 }
 
-// EnsureScope implements db.CreateDerivedAccountOps. waddrmgr scopes are
+// EnsureScope implements db.CreateDerivedAccountOps. The schema input is
+// unused because kvdb only loads existing scopes; the shared workflow checks
+// their persisted schema against the caller's assertion. waddrmgr scopes are
 // pre-registered; the call only fetches and caches the scoped manager.
 func (o *createDerivedAccountOps) EnsureScope(_ context.Context, _ uint32,
-	scope db.KeyScope) (int64, db.ScopeAddrSchema, error) {
+	scope db.KeyScope, _ *db.ScopeAddrSchema) (int64, db.ScopeAddrSchema,
+	error) {
 
 	waddrScope := waddrmgr.KeyScope{
 		Purpose: scope.Purpose,

--- a/wallet/internal/db/kvdb/accountstore_getaccount.go
+++ b/wallet/internal/db/kvdb/accountstore_getaccount.go
@@ -337,3 +337,23 @@ func translateAccountErr(err error, notFound error) error {
 
 	return fmt.Errorf("waddrmgr: %w", err)
 }
+
+// GetKeyScopeSchema reads the legacy scoped manager's authoritative schema;
+// the single-wallet adapter does not use the SQL wallet identifier.
+func (s *Store) GetKeyScopeSchema(ctx context.Context, _ uint32,
+	scope db.KeyScope) (db.ScopeAddrSchema, error) {
+
+	err := ctx.Err()
+	if err != nil {
+		return db.ScopeAddrSchema{}, err
+	}
+
+	mgr, err := s.addrStore.FetchScopedKeyManager(waddrmgr.KeyScope(scope))
+	if err != nil {
+		return db.ScopeAddrSchema{}, translateAccountErr(
+			err, db.ErrKeyScopeNotFound,
+		)
+	}
+
+	return db.ScopeAddrSchemaFromWaddrmgr(mgr.AddrSchema())
+}

--- a/wallet/internal/db/pg/accountstore_createderived.go
+++ b/wallet/internal/db/pg/accountstore_createderived.go
@@ -53,10 +53,10 @@ func (o createDerivedAccountOps) WalletWatchOnly(ctx context.Context,
 
 // EnsureScope implements db.CreateDerivedAccountOps.
 func (o createDerivedAccountOps) EnsureScope(ctx context.Context,
-	walletID uint32,
-	scope db.KeyScope) (int64, db.ScopeAddrSchema, error) {
+	walletID uint32, scope db.KeyScope,
+	schema *db.ScopeAddrSchema) (int64, db.ScopeAddrSchema, error) {
 
-	return ensureKeyScope(ctx, o.q, walletID, scope, nil)
+	return ensureKeyScope(ctx, o.q, walletID, scope, schema)
 }
 
 // AllocateAccountNumber implements db.CreateDerivedAccountOps.

--- a/wallet/internal/db/pg/keyscopestore_ensurekeyscope.go
+++ b/wallet/internal/db/pg/keyscopestore_ensurekeyscope.go
@@ -2,6 +2,9 @@ package pg
 
 import (
 	"context"
+	"database/sql"
+	"errors"
+	"fmt"
 
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wallet/internal/sql/pg/sqlc"
@@ -97,4 +100,29 @@ func (o pgEnsureKeyScopeOps) CreateKeyScope(ctx context.Context,
 			),
 		},
 	)
+}
+
+// GetKeyScopeSchema reads scope metadata before account secret preparation,
+// without inferring it from an account's possibly overridden schema.
+func (s *Store) GetKeyScopeSchema(ctx context.Context, walletID uint32,
+	scope db.KeyScope) (db.ScopeAddrSchema, error) {
+
+	var schema db.ScopeAddrSchema
+
+	err := s.execRead(ctx, func(q *sqlc.Queries) error {
+		var err error
+
+		schema, err = getPersistedKeyScopeSchema(ctx, q, walletID, scope)
+
+		return err
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return db.ScopeAddrSchema{}, db.ErrKeyScopeNotFound
+	}
+
+	if err != nil {
+		return db.ScopeAddrSchema{}, fmt.Errorf("get scope schema: %w", err)
+	}
+
+	return schema, nil
 }

--- a/wallet/internal/db/sqlite/accountstore_createderived.go
+++ b/wallet/internal/db/sqlite/accountstore_createderived.go
@@ -53,10 +53,10 @@ func (o createDerivedAccountOps) WalletWatchOnly(ctx context.Context,
 
 // EnsureScope implements db.CreateDerivedAccountOps.
 func (o createDerivedAccountOps) EnsureScope(ctx context.Context,
-	walletID uint32,
-	scope db.KeyScope) (int64, db.ScopeAddrSchema, error) {
+	walletID uint32, scope db.KeyScope,
+	schema *db.ScopeAddrSchema) (int64, db.ScopeAddrSchema, error) {
 
-	return ensureKeyScope(ctx, o.q, walletID, scope, nil)
+	return ensureKeyScope(ctx, o.q, walletID, scope, schema)
 }
 
 // AllocateAccountNumber implements db.CreateDerivedAccountOps.

--- a/wallet/internal/db/sqlite/keyscopestore_ensurekeyscope.go
+++ b/wallet/internal/db/sqlite/keyscopestore_ensurekeyscope.go
@@ -2,6 +2,9 @@ package sqlite
 
 import (
 	"context"
+	"database/sql"
+	"errors"
+	"fmt"
 
 	"github.com/btcsuite/btcwallet/wallet/internal/db"
 	"github.com/btcsuite/btcwallet/wallet/internal/sql/sqlite/sqlc"
@@ -97,4 +100,29 @@ func (o sqliteEnsureKeyScopeOps) CreateKeyScope(ctx context.Context,
 			),
 		},
 	)
+}
+
+// GetKeyScopeSchema reads scope metadata before account secret preparation,
+// without inferring it from an account's possibly overridden schema.
+func (s *Store) GetKeyScopeSchema(ctx context.Context, walletID uint32,
+	scope db.KeyScope) (db.ScopeAddrSchema, error) {
+
+	var schema db.ScopeAddrSchema
+
+	err := s.execRead(ctx, func(q *sqlc.Queries) error {
+		var err error
+
+		schema, err = getPersistedKeyScopeSchema(ctx, q, walletID, scope)
+
+		return err
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return db.ScopeAddrSchema{}, db.ErrKeyScopeNotFound
+	}
+
+	if err != nil {
+		return db.ScopeAddrSchema{}, fmt.Errorf("get scope schema: %w", err)
+	}
+
+	return schema, nil
 }


### PR DESCRIPTION
## Summary

Implements roadmap Task 390: create exact root-derived accounts in custom SQL scopes.

## Change Description

Add an optional address schema to account creation, validate it before secret preparation, and reuse existing scope metadata and atomic creation. Preserve kvdb rejection and ambiguous-commit behavior.

Verified unit and race tests, SQLite/PostgreSQL database tests, all nine chain/database integration combinations, and lint.

## Notes

Depends on #1369, which consolidates exact-account creation and no-chain-sync activation. Targets `task-exact-account`; review scope begins after that dependency and includes only the four custom-scope commits.
