### PR TITLE
wallet: route component requests through admission

### DIFF
--- a/wallet/address_manager.go
+++ b/wallet/address_manager.go
@@ -469,6 +469,106 @@ func (w *Wallet) addrBalances(ctx context.Context) (map[string]btcutil.Amount,
 	return balances, nil
 }
 
+// newAddressReq retains value parameters until derivation and notification end.
+type newAddressReq struct {
+	reqCtx
+
+	accountName string
+	addrType    waddrmgr.AddressType
+	change      bool
+	respChan    chan addressResp
+}
+
+// getUnusedAddressReq keeps lookup and fallback derivation in one admission.
+type getUnusedAddressReq struct {
+	reqCtx
+
+	accountName string
+	addrType    waddrmgr.AddressType
+	change      bool
+	respChan    chan addressResp
+}
+
+// addressResp carries either address acquisition result to a buffered receiver.
+type addressResp struct {
+	addr address.Address
+	err  error
+}
+
+// getAddressInfoReq borrows the destination until the accepted lookup ends.
+type getAddressInfoReq struct {
+	reqCtx
+
+	addr     address.Address
+	respChan chan addressInfoResp
+}
+
+// addressInfoResp returns metadata once the accepted lookup completes.
+type addressInfoResp struct {
+	info AddressInfo
+	err  error
+}
+
+// listAddressesReq keeps balance and address iteration under one admission.
+type listAddressesReq struct {
+	reqCtx
+
+	accountName string
+	addrType    waddrmgr.AddressType
+	respChan    chan listAddressesResp
+}
+
+// listAddressesResp returns the list after balance and address iteration end.
+type listAddressesResp struct {
+	addresses []AddressProperty
+	err       error
+}
+
+// importPublicKeyReq borrows the key through persistence and registration.
+type importPublicKeyReq struct {
+	reqCtx
+
+	pubKey      *btcec.PublicKey
+	addrType    waddrmgr.AddressType
+	respErrChan chan error
+}
+
+// importTaprootScriptReq retains the supplied script through vault encryption.
+type importTaprootScriptReq struct {
+	reqCtx
+
+	tapscript waddrmgr.Tapscript
+	respChan  chan addressInfoResp
+}
+
+// scriptForOutputReq borrows script bytes until spending lookups complete.
+type scriptForOutputReq struct {
+	reqCtx
+
+	output   wire.TxOut
+	respChan chan outputScriptResp
+}
+
+// outputScriptResp returns spending metadata after dependency access ends.
+type outputScriptResp struct {
+	info OutputScriptInfo
+	err  error
+}
+
+// getDerivationInfoReq borrows its destination until path lookup completes.
+type getDerivationInfoReq struct {
+	reqCtx
+
+	addr     address.Address
+	respChan chan derivationInfoResp
+}
+
+// derivationInfoResp preserves a path result across cancellation and shutdown.
+type derivationInfoResp struct {
+	info *psbt.Bip32Derivation
+	err  error
+}
+
 // NewAddress returns a new address for the given account and address type.
 // This method is a low-level primitive that will always derive a new, unused
 // address from the end of the address chain.
@@ -532,6 +632,39 @@ func (w *Wallet) NewAddress(ctx context.Context, accountName string,
 	if err != nil {
 		return nil, err
 	}
+
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := newAddressReq{
+		reqCtx:      reqCtx{ctx: ctx},
+		accountName: accountName,
+		addrType:    addrType,
+		change:      change,
+		respChan:    make(chan addressResp, 1),
+	}
+
+	err = w.sendReq(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	result := <-r.respChan
+
+	return result.addr, result.err
+}
+
+// handleNewAddress delivers the result of an accepted component request.
+func (w *Wallet) handleNewAddress(r newAddressReq) {
+	// Reuse address derivation shared with the unused-address fallback.
+	addr, err := w.newAddress(
+		r.ctx, r.accountName, r.addrType, r.change,
+	)
+	r.respChan <- addressResp{addr: addr, err: err}
+}
+
+// newAddress derives and registers an address inside its accepted request.
+func (w *Wallet) newAddress(ctx context.Context, accountName string,
+	addrType waddrmgr.AddressType, change bool) (address.Address, error) {
 
 	// Addresses cannot be derived from the catch-all imported accounts.
 	if accountName == waddrmgr.ImportedAddrAccountName {
@@ -613,49 +746,90 @@ func (w *Wallet) GetUnusedAddress(ctx context.Context, accountName string,
 		return nil, err
 	}
 
-	if accountName == waddrmgr.ImportedAddrAccountName {
-		return nil, ErrImportedAccountNoAddrGen
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := getUnusedAddressReq{
+		reqCtx:      reqCtx{ctx: ctx},
+		accountName: accountName,
+		addrType:    addrType,
+		change:      change,
+		respChan:    make(chan addressResp, 1),
 	}
 
-	keyScope, err := addrType.KeyScope()
-	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrUnknownAddrType, addrType)
-	}
-
-	req, err := addressPageRequest()
+	err = w.sendReq(ctx, r)
 	if err != nil {
 		return nil, err
 	}
 
+	// Once admitted, wait for the result even if cancellation arrives.
+	result := <-r.respChan
+
+	return result.addr, result.err
+}
+
+// handleGetUnusedAddress reuses or derives an address without a second
+// admission.
+// The admitted caller waits for this result before reusing its inputs.
+func (w *Wallet) handleGetUnusedAddress(r getUnusedAddressReq) {
+	if r.accountName == waddrmgr.ImportedAddrAccountName {
+		r.respChan <- addressResp{err: ErrImportedAccountNoAddrGen}
+
+		return
+	}
+
+	keyScope, err := r.addrType.KeyScope()
+	if err != nil {
+		r.respChan <- addressResp{
+			err: fmt.Errorf("%w: %v", ErrUnknownAddrType, r.addrType),
+		}
+
+		return
+	}
+
+	req, err := addressPageRequest()
+	if err != nil {
+		r.respChan <- addressResp{err: err}
+
+		return
+	}
+
 	addresses := w.store.IterAddresses(
-		ctx, db.ListAddressesQuery{
+		r.ctx, db.ListAddressesQuery{
 			WalletID:    w.id,
-			AccountName: &accountName,
+			AccountName: &r.accountName,
 			Scope:       (*db.KeyScope)(&keyScope),
 			Page:        req,
 		},
 	)
 	for storeAddr, err := range addresses {
 		if err != nil {
-			return nil, err
+			r.respChan <- addressResp{err: err}
+
+			return
 		}
 
 		unusedAddr, ok, err := nextUnusedStoreAddress(
-			storeAddr, change, w.cfg.ChainParams,
+			storeAddr, r.change, w.cfg.ChainParams,
 		)
 		if err != nil {
-			return nil, err
+			r.respChan <- addressResp{err: err}
+
+			return
 		}
 
 		if !ok {
 			continue
 		}
 
-		return unusedAddr, nil
+		r.respChan <- addressResp{addr: unusedAddr}
+
+		return
 	}
 
 	// Otherwise, we'll generate a new one.
-	return w.NewAddress(ctx, accountName, addrType, change)
+	responseAddr, responseErr := w.newAddress(
+		r.ctx, r.accountName, r.addrType, r.change,
+	)
+	r.respChan <- addressResp{addr: responseAddr, err: responseErr}
 }
 
 // nextUnusedStoreAddress returns the unused address candidate represented by a
@@ -696,6 +870,35 @@ func (w *Wallet) GetAddressInfo(ctx context.Context, a address.Address) (
 		return AddressInfo{}, err
 	}
 
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := getAddressInfoReq{
+		reqCtx:   reqCtx{ctx: ctx},
+		addr:     a,
+		respChan: make(chan addressInfoResp, 1),
+	}
+
+	err = w.sendReq(ctx, r)
+	if err != nil {
+		return AddressInfo{}, err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	result := <-r.respChan
+
+	return result.info, result.err
+}
+
+// handleGetAddressInfo delivers the result of an accepted component request.
+func (w *Wallet) handleGetAddressInfo(r getAddressInfoReq) {
+	// Reuse metadata lookup shared with nested signing and script queries.
+	info, err := w.getAddressInfo(r.ctx, r.addr)
+	r.respChan <- addressInfoResp{info: info, err: err}
+}
+
+// getAddressInfo resolves metadata while its outer request owns Store access.
+func (w *Wallet) getAddressInfo(ctx context.Context, a address.Address) (
+	AddressInfo, error) {
+
 	scriptPubKey, err := txscript.PayToAddrScript(a)
 	if err != nil {
 		return AddressInfo{}, fmt.Errorf("pay to addr script: %w", err)
@@ -732,32 +935,62 @@ func (w *Wallet) ListAddresses(ctx context.Context, accountName string,
 		return nil, err
 	}
 
-	req, err := addressPageRequest()
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := listAddressesReq{
+		reqCtx:      reqCtx{ctx: ctx},
+		accountName: accountName,
+		addrType:    addrType,
+		respChan:    make(chan listAddressesResp, 1),
+	}
+
+	err = w.sendReq(ctx, r)
 	if err != nil {
 		return nil, err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	result := <-r.respChan
+
+	return result.addresses, result.err
+}
+
+// handleListAddresses reads addresses and balances within one accepted request.
+// The admitted caller waits for this result before reusing its inputs.
+func (w *Wallet) handleListAddresses(r listAddressesReq) {
+	req, err := addressPageRequest()
+	if err != nil {
+		r.respChan <- listAddressesResp{err: err}
+
+		return
 	}
 
 	query, storeAddrType, err := listAddressesQuery(
-		w.id, req, accountName, addrType,
+		w.id, req, r.accountName, r.addrType,
 	)
 	if err != nil {
-		return nil, err
+		r.respChan <- listAddressesResp{err: err}
+
+		return
 	}
 
-	balances, err := w.addrBalances(ctx)
+	balances, err := w.addrBalances(r.ctx)
 	if err != nil {
-		return nil, err
+		r.respChan <- listAddressesResp{err: err}
+
+		return
 	}
 
 	properties := make([]AddressProperty, 0)
 
-	addresses := w.store.IterAddresses(ctx, query)
+	addresses := w.store.IterAddresses(r.ctx, query)
 	for storeAddr, err := range addresses {
 		if err != nil {
-			return nil, err
+			r.respChan <- listAddressesResp{err: err}
+
+			return
 		}
 
-		if accountName == db.DefaultImportedAccountName &&
+		if r.accountName == db.DefaultImportedAccountName &&
 			!walletAddressTypeMatches(storeAddr, storeAddrType) {
 
 			continue
@@ -776,7 +1009,7 @@ func (w *Wallet) ListAddresses(ctx context.Context, accountName string,
 		})
 	}
 
-	return properties, nil
+	r.respChan <- listAddressesResp{addresses: properties}
 }
 
 // walletAddressTypeMatches reports whether a store address row matches a
@@ -837,27 +1070,53 @@ func (w *Wallet) ImportPublicKey(ctx context.Context, pubKey *btcec.PublicKey,
 		return err
 	}
 
-	storeAddrType, err := addresstype.FromWallet(addrType)
-	if err != nil {
-		return fmt.Errorf("%w: %v", ErrUnknownAddrType, addrType)
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := importPublicKeyReq{
+		reqCtx:      reqCtx{ctx: ctx},
+		pubKey:      pubKey,
+		addrType:    addrType,
+		respErrChan: make(chan error, 1),
 	}
 
-	serializedPubKey := pubKey.SerializeCompressed()
+	err = w.sendReq(ctx, r)
+	if err != nil {
+		return err
+	}
 
-	addr, err := addrType.AddrFromPubKeyBytes(
+	// Once admitted, wait for the result even if cancellation arrives.
+	return <-r.respErrChan
+}
+
+// handleImportPublicKey persists and registers an accepted public-key import.
+// The admitted caller waits for this result before reusing its inputs.
+func (w *Wallet) handleImportPublicKey(r importPublicKeyReq) {
+	storeAddrType, err := addresstype.FromWallet(r.addrType)
+	if err != nil {
+		r.respErrChan <- fmt.Errorf("%w: %v", ErrUnknownAddrType, r.addrType)
+
+		return
+	}
+
+	serializedPubKey := r.pubKey.SerializeCompressed()
+
+	addr, err := r.addrType.AddrFromPubKeyBytes(
 		serializedPubKey, w.cfg.ChainParams,
 	)
 	if err != nil {
-		return fmt.Errorf("derive imported address: %w", err)
+		r.respErrChan <- fmt.Errorf("derive imported address: %w", err)
+
+		return
 	}
 
 	scriptPubKey, err := txscript.PayToAddrScript(addr)
 	if err != nil {
-		return fmt.Errorf("pay to addr script: %w", err)
+		r.respErrChan <- fmt.Errorf("pay to addr script: %w", err)
+
+		return
 	}
 
 	_, err = w.store.NewImportedAddress(
-		ctx, db.NewImportedAddressParams{
+		r.ctx, db.NewImportedAddressParams{
 			WalletID:     w.id,
 			AddressType:  storeAddrType.Type,
 			ScriptPubKey: scriptPubKey,
@@ -865,10 +1124,12 @@ func (w *Wallet) ImportPublicKey(ctx context.Context, pubKey *btcec.PublicKey,
 		},
 	)
 	if err != nil {
-		return err
+		r.respErrChan <- err
+
+		return
 	}
 
-	return w.cfg.Chain.NotifyReceived([]address.Address{addr})
+	r.respErrChan <- w.cfg.Chain.NotifyReceived([]address.Address{addr})
 }
 
 // ImportTaprootScript imports a taproot script for tracking. Script presence
@@ -884,30 +1145,64 @@ func (w *Wallet) ImportTaprootScript(ctx context.Context,
 		return AddressInfo{}, err
 	}
 
-	taprootKey, err := tapscript.TaprootKey()
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := importTaprootScriptReq{
+		reqCtx:    reqCtx{ctx: ctx},
+		tapscript: tapscript,
+		respChan:  make(chan addressInfoResp, 1),
+	}
+
+	err = w.sendReq(ctx, r)
 	if err != nil {
 		return AddressInfo{}, err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	result := <-r.respChan
+
+	return result.info, result.err
+}
+
+// handleImportTaprootScript encrypts and registers the accepted script
+// import.
+// The admitted caller waits for this result before reusing its inputs.
+func (w *Wallet) handleImportTaprootScript(r importTaprootScriptReq) {
+	taprootKey, err := r.tapscript.TaprootKey()
+	if err != nil {
+		r.respChan <- addressInfoResp{err: err}
+
+		return
 	}
 
 	addr, err := address.NewAddressTaproot(
 		schnorr.SerializePubKey(taprootKey), w.cfg.ChainParams,
 	)
 	if err != nil {
-		return AddressInfo{}, fmt.Errorf("taproot address: %w", err)
+		r.respChan <- addressInfoResp{
+			err: fmt.Errorf("taproot address: %w", err),
+		}
+
+		return
 	}
 
 	scriptPubKey, err := txscript.PayToAddrScript(addr)
 	if err != nil {
-		return AddressInfo{}, fmt.Errorf("pay to addr script: %w", err)
+		r.respChan <- addressInfoResp{
+			err: fmt.Errorf("pay to addr script: %w", err),
+		}
+
+		return
 	}
 
-	encryptedScript, err := encryptTaprootScript(w.keyVault, &tapscript)
+	encryptedScript, err := encryptTaprootScript(w.keyVault, &r.tapscript)
 	if err != nil {
-		return AddressInfo{}, err
+		r.respChan <- addressInfoResp{err: err}
+
+		return
 	}
 
 	storeInfo, err := w.store.NewImportedAddress(
-		ctx, db.NewImportedAddressParams{
+		r.ctx, db.NewImportedAddressParams{
 			WalletID:        w.id,
 			AddressType:     db.TaprootPubKey,
 			ScriptPubKey:    scriptPubKey,
@@ -915,22 +1210,28 @@ func (w *Wallet) ImportTaprootScript(ctx context.Context,
 		},
 	)
 	if err != nil {
-		return AddressInfo{}, err
+		r.respChan <- addressInfoResp{err: err}
+
+		return
 	}
 
 	storeInfo.HasScript = true
 
 	info, err := addressInfoFromStoreAddress(storeInfo, w.cfg.ChainParams)
 	if err != nil {
-		return AddressInfo{}, err
+		r.respChan <- addressInfoResp{err: err}
+
+		return
 	}
 
 	err = w.cfg.Chain.NotifyReceived([]address.Address{addr})
 	if err != nil {
-		return AddressInfo{}, err
+		r.respChan <- addressInfoResp{err: err}
+
+		return
 	}
 
-	return info, nil
+	r.respChan <- addressInfoResp{info: info}
 }
 
 // encryptTaprootScript encodes and encrypts taproot script data before the
@@ -995,6 +1296,35 @@ func (w *Wallet) ScriptForOutput(ctx context.Context, output wire.TxOut) (
 		return OutputScriptInfo{}, err
 	}
 
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := scriptForOutputReq{
+		reqCtx:   reqCtx{ctx: ctx},
+		output:   output,
+		respChan: make(chan outputScriptResp, 1),
+	}
+
+	err = w.sendReq(ctx, r)
+	if err != nil {
+		return OutputScriptInfo{}, err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	result := <-r.respChan
+
+	return result.info, result.err
+}
+
+// handleScriptForOutput delivers the result of an accepted component request.
+func (w *Wallet) handleScriptForOutput(r scriptForOutputReq) {
+	// Reuse script lookup without re-entering admission from signing or PSBTs.
+	info, err := w.scriptForOutput(r.ctx, r.output)
+	r.respChan <- outputScriptResp{info: info, err: err}
+}
+
+// scriptForOutput resolves spending data without re-entering admission.
+func (w *Wallet) scriptForOutput(ctx context.Context, output wire.TxOut) (
+	OutputScriptInfo, error) {
+
 	// First, we'll extract the address from the output's pkScript.
 	addr := extractAddrFromPKScript(output.PkScript, w.cfg.ChainParams)
 	if addr == nil {
@@ -1002,7 +1332,7 @@ func (w *Wallet) ScriptForOutput(ctx context.Context, output wire.TxOut) (
 			ErrUnableToExtractAddress, output.PkScript)
 	}
 
-	addressInfo, err := w.GetAddressInfo(ctx, addr)
+	addressInfo, err := w.getAddressInfo(ctx, addr)
 	if err != nil {
 		return OutputScriptInfo{}, fmt.Errorf("unable to get address info "+
 			"for %s: %w", addr.String(), err)
@@ -1102,13 +1432,37 @@ func (w *Wallet) GetDerivationInfo(ctx context.Context,
 		return nil, err
 	}
 
-	// We'll use the address to look up the derivation path.
-	addressInfo, err := w.GetAddressInfo(ctx, addr)
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := getDerivationInfoReq{
+		reqCtx:   reqCtx{ctx: ctx},
+		addr:     addr,
+		respChan: make(chan derivationInfoResp, 1),
+	}
+
+	err = w.sendReq(ctx, r)
 	if err != nil {
 		return nil, err
 	}
 
-	return derivationForAddressInfo(addressInfo)
+	// Once admitted, wait for the result even if cancellation arrives.
+	result := <-r.respChan
+
+	return result.info, result.err
+}
+
+// handleGetDerivationInfo resolves the path under its accepted outer request.
+// The admitted caller waits for this result before reusing its inputs.
+func (w *Wallet) handleGetDerivationInfo(r getDerivationInfoReq) {
+	// We'll use the address to look up the derivation path.
+	addressInfo, err := w.getAddressInfo(r.ctx, r.addr)
+	if err != nil {
+		r.respChan <- derivationInfoResp{err: err}
+
+		return
+	}
+
+	responseInfo, responseErr := derivationForAddressInfo(addressInfo)
+	r.respChan <- derivationInfoResp{info: responseInfo, err: responseErr}
 }
 
 // derivationForAddressInfo constructs a PSBT Bip32Derivation struct from a

--- a/wallet/address_manager_test.go
+++ b/wallet/address_manager_test.go
@@ -7,6 +7,7 @@ package wallet
 import (
 	"bytes"
 	"iter"
+	"sync"
 	"testing"
 
 	"github.com/btcsuite/btcd/address/v2"
@@ -22,6 +23,78 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+// TestAddressManagerFallbackDuringStop keeps nested address derivation and
+// notification inside the accepted unused-address request during shutdown.
+func TestAddressManagerFallbackDuringStop(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Pause an unused-address scan until shutdown closes admission.
+	// An empty result then forces derivation through the accepted request.
+	w, deps := createTestWalletWithMocks(t)
+	startLoadedWalletForTest(t, w)
+
+	enteredChan := make(chan struct{})
+	releaseChan := make(chan struct{})
+	unblock := sync.OnceFunc(func() { close(releaseChan) })
+	t.Cleanup(unblock)
+
+	scope := db.KeyScope(waddrmgr.KeyScopeBIP0084)
+	name := "fallback"
+	page, err := addressPageRequest()
+	require.NoError(t, err)
+	deps.store.On("IterAddresses", mock.Anything, db.ListAddressesQuery{
+		WalletID:    w.id,
+		AccountName: &name,
+		Scope:       &scope,
+		Page:        page,
+	}).Run(func(mock.Arguments) {
+		close(enteredChan)
+
+		<-releaseChan
+	}).Return(addressIter()).Once()
+
+	addr, err := address.NewAddressWitnessPubKeyHash(
+		make([]byte, 20), w.cfg.ChainParams,
+	)
+	require.NoError(t, err)
+	expectStoreNewAddress(
+		t, w, deps, name, waddrmgr.KeyScopeBIP0084, false, addr,
+	)
+	deps.vault.On("Lock").Return().Once()
+
+	resultChan := make(chan addressResp, 1)
+	go func() {
+		addr, err := w.GetUnusedAddress(
+			t.Context(), name, waddrmgr.WitnessPubKey, false,
+		)
+		resultChan <- addressResp{addr: addr, err: err}
+	}()
+
+	<-enteredChan
+
+	// Act: Begin shutdown while the accepted scan is paused. Its fallback
+	// must still derive and register an address without another admission.
+	stoppedChan := make(chan error, 1)
+	go func() { stoppedChan <- w.Stop(t.Context()) }()
+
+	<-w.lifetimeCtx.Done()
+
+	// Assert: Stop waits for accepted work, and release permits the fallback
+	// to return its address. Fixture cleanup verifies chain registration.
+	select {
+	case err := <-stoppedChan:
+		t.Fatalf("Stop returned before address work: %v", err)
+	default:
+	}
+
+	unblock()
+
+	result := <-resultChan
+	require.NoError(t, result.err)
+	require.Equal(t, addr, result.addr)
+	require.NoError(t, <-stoppedChan)
+}
 
 // storeDerivationAccountPubKey returns a deterministic account-level public key
 // for store-native address derivation tests.

--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -855,6 +855,18 @@ func (w *Wallet) handleReq(req any) {
 	case privKeyForAddressReq:
 		w.handleGetPrivKeyForAddress(r)
 
+	case decorateInputsReq:
+		w.handleDecorateInputs(r)
+
+	case fundPsbtReq:
+		w.handleFundPsbt(r)
+
+	case signPsbtReq:
+		w.handleSignPsbt(r)
+
+	case finalizePsbtReq:
+		w.handleFinalizePsbt(r)
+
 	case newAccountReq:
 		w.handleNewAccount(r)
 	case renameAccountReq:

--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -822,6 +822,9 @@ func (w *Wallet) handleReq(req any) {
 	case listTxnsReq:
 		w.handleListTxns(r)
 
+	case labelTxReq:
+		w.handleLabelTx(r)
+
 	case newAccountReq:
 		w.handleNewAccount(r)
 	case renameAccountReq:

--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -766,7 +766,7 @@ type reqCtx struct {
 // Component responses have capacity one and each handler sends exactly once,
 // so delivery cannot block even before the admitted caller receives its result.
 //
-//nolint:cyclop,funlen // Enumerate all request routes in one table.
+//nolint:cyclop,gocyclo,funlen // Enumerate all request routes in one table.
 func (w *Wallet) handleReq(req any) {
 	defer w.wg.Done()
 
@@ -833,6 +833,27 @@ func (w *Wallet) handleReq(req any) {
 
 	case broadcastReq:
 		w.handleBroadcast(r)
+
+	case derivePubKeyReq:
+		w.handleDerivePubKey(r)
+
+	case ecdhReq:
+		w.handleECDH(r)
+
+	case signDigestReq:
+		w.handleSignDigest(r)
+
+	case unlockingScriptReq:
+		w.handleComputeUnlockingScript(r)
+
+	case rawSigReq:
+		w.handleComputeRawSig(r)
+
+	case derivePrivKeyReq:
+		w.handleDerivePrivKey(r)
+
+	case privKeyForAddressReq:
+		w.handleGetPrivKeyForAddress(r)
 
 	case newAccountReq:
 		w.handleNewAccount(r)

--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -762,6 +762,8 @@ type reqCtx struct {
 // type switch is the single routing table for concurrent public method work.
 // Component responses have capacity one and each handler sends exactly once,
 // so delivery cannot block even before the admitted caller receives its result.
+//
+//nolint:cyclop // Enumerate all request routes in one table.
 func (w *Wallet) handleReq(req any) {
 	defer w.wg.Done()
 
@@ -771,6 +773,30 @@ func (w *Wallet) handleReq(req any) {
 
 	case rescanReq:
 		w.handleRescanReq(r)
+
+	case newAddressReq:
+		w.handleNewAddress(r)
+
+	case getUnusedAddressReq:
+		w.handleGetUnusedAddress(r)
+
+	case getAddressInfoReq:
+		w.handleGetAddressInfo(r)
+
+	case listAddressesReq:
+		w.handleListAddresses(r)
+
+	case importPublicKeyReq:
+		w.handleImportPublicKey(r)
+
+	case importTaprootScriptReq:
+		w.handleImportTaprootScript(r)
+
+	case scriptForOutputReq:
+		w.handleScriptForOutput(r)
+
+	case getDerivationInfoReq:
+		w.handleGetDerivationInfo(r)
 
 	case newAccountReq:
 		w.handleNewAccount(r)

--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -219,6 +219,9 @@ func (w *Wallet) Start(startCtx context.Context) error {
 	// 4. Start background goroutines.
 	w.wg.Add(1)
 
+	// Requests retain their own contexts; the routed legacy tip accessor still
+	// has no context parameter. Its existing exemption follows the call path.
+	//nolint:contextcheck // SyncedTo takes no context.
 	go w.mainLoop()
 
 	w.wg.Add(1)
@@ -797,6 +800,21 @@ func (w *Wallet) handleReq(req any) {
 
 	case getDerivationInfoReq:
 		w.handleGetDerivationInfo(r)
+
+	case listUnspentReq:
+		w.handleListUnspent(r)
+
+	case getUtxoReq:
+		w.handleGetUtxo(r)
+
+	case leaseOutputReq:
+		w.handleLeaseOutput(r)
+
+	case releaseOutputReq:
+		w.handleReleaseOutput(r)
+
+	case listLeasedOutputsReq:
+		w.handleListLeasedOutputs(r)
 
 	case newAccountReq:
 		w.handleNewAccount(r)

--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -766,7 +766,7 @@ type reqCtx struct {
 // Component responses have capacity one and each handler sends exactly once,
 // so delivery cannot block even before the admitted caller receives its result.
 //
-//nolint:cyclop // Enumerate all request routes in one table.
+//nolint:cyclop,funlen // Enumerate all request routes in one table.
 func (w *Wallet) handleReq(req any) {
 	defer w.wg.Done()
 
@@ -824,6 +824,9 @@ func (w *Wallet) handleReq(req any) {
 
 	case labelTxReq:
 		w.handleLabelTx(r)
+
+	case createTransactionReq:
+		w.handleCreateTransaction(r)
 
 	case newAccountReq:
 		w.handleNewAccount(r)

--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -510,6 +510,27 @@ func (w *Wallet) ChangePassphrase(ctx context.Context,
 	return reqErr
 }
 
+// infoReq keeps metadata work inside the accepted handler's Wallet lifetime.
+type infoReq struct {
+	reqCtx
+
+	respChan chan infoResp
+}
+
+// infoResp lets an accepted metadata read finish after its caller cancels.
+type infoResp struct {
+	info *Info
+	err  error
+}
+
+// rescanReq transfers the target list to the existing joined syncer.
+type rescanReq struct {
+	typ         scanType
+	startHeight uint32
+	targets     []waddrmgr.AccountScope
+	respErrChan chan error
+}
+
 // Info returns a comprehensive snapshot of the wallet's static configuration
 // and dynamic synchronization state.
 //
@@ -520,21 +541,52 @@ func (w *Wallet) Info(ctx context.Context) (*Info, error) {
 		return nil, err
 	}
 
-	walletInfo, err := w.store.GetWallet(ctx, w.cfg.Name)
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := infoReq{
+		reqCtx:   reqCtx{ctx: ctx},
+		respChan: make(chan infoResp, 1),
+	}
+
+	err = w.sendReq(ctx, r)
 	if err != nil {
-		return nil, fmt.Errorf("get wallet info: %w", err)
+		return nil, err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	result := <-r.respChan
+
+	return result.info, result.err
+}
+
+// handleInfo assembles an accepted snapshot without checking admission again.
+// The admitted caller waits for this result before reusing its inputs.
+func (w *Wallet) handleInfo(r infoReq) {
+	// The outer request owns dependency access until this snapshot completes.
+	walletInfo, err := w.store.GetWallet(r.ctx, w.cfg.Name)
+	if err != nil {
+		r.respChan <- infoResp{err: fmt.Errorf("get wallet info: %w", err)}
+
+		return
 	}
 
 	syncedTo, err := db.OptionalBlockStampFromBlock(walletInfo.SyncedTo)
 	if err != nil {
-		return nil, fmt.Errorf("decode wallet sync tip: %w", err)
+		r.respChan <- infoResp{
+			err: fmt.Errorf("decode wallet sync tip: %w", err),
+		}
+
+		return
 	}
 
 	// Info is an ownership boundary, so return a fresh network snapshot
 	// instead of exposing the Wallet's retained mutable configuration.
 	chainParams, err := cloneChainParams(*w.cfg.ChainParams)
 	if err != nil {
-		return nil, fmt.Errorf("copy chain parameters: %w", err)
+		r.respChan <- infoResp{
+			err: fmt.Errorf("copy chain parameters: %w", err),
+		}
+
+		return
 	}
 
 	info := &Info{
@@ -548,7 +600,7 @@ func (w *Wallet) Info(ctx context.Context) (*Info, error) {
 		RecoveryProgress: 0,
 	}
 
-	return info, nil
+	r.respChan <- infoResp{info: info}
 }
 
 // Resync rewinds the wallet's synchronization state to a specific block
@@ -577,8 +629,7 @@ func (w *Wallet) Rescan(ctx context.Context, startHeight uint32,
 	)
 }
 
-// submitRescanRequest validates the rescan request and submits it to the
-// syncer.
+// submitRescanRequest admits a scan description before chain access.
 func (w *Wallet) submitRescanRequest(ctx context.Context, typ scanType,
 	startHeight uint32, targets []waddrmgr.AccountScope) error {
 
@@ -588,10 +639,36 @@ func (w *Wallet) submitRescanRequest(ctx context.Context, typ scanType,
 		return err
 	}
 
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := rescanReq{
+		typ:         typ,
+		startHeight: startHeight,
+		targets:     targets,
+		respErrChan: make(chan error, 1),
+	}
+
+	err = w.sendReq(ctx, r)
+	if err != nil {
+		return err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	return <-r.respErrChan
+}
+
+// handleRescanReq validates an accepted scan and transfers it to the syncer.
+// The response acknowledges transfer, preserving asynchronous scan semantics.
+func (w *Wallet) handleRescanReq(r rescanReq) {
+	startHeight := r.startHeight
+
 	// BlockStamp.Height is int32, so we need to ensure the requested
 	// startHeight does not exceed math.MaxInt32.
 	if startHeight > math.MaxInt32 {
-		return fmt.Errorf("%w: %d", ErrStartHeightTooLarge, startHeight)
+		r.respErrChan <- fmt.Errorf(
+			"%w: %d", ErrStartHeightTooLarge, startHeight,
+		)
+
+		return
 	}
 
 	startHeightInt32 := int32(startHeight)
@@ -599,25 +676,31 @@ func (w *Wallet) submitRescanRequest(ctx context.Context, typ scanType,
 	// Fetch the current best block to ensure we don't resync past the tip.
 	_, bestHeightInt32, err := w.cfg.Chain.GetBestBlock()
 	if err != nil {
-		return fmt.Errorf("unable to get chain tip: %w", err)
+		r.respErrChan <- fmt.Errorf("unable to get chain tip: %w", err)
+
+		return
 	}
 
 	if startHeightInt32 > bestHeightInt32 {
-		return fmt.Errorf("%w: start height %d is greater than "+
+		r.respErrChan <- fmt.Errorf("%w: start height %d is greater than "+
 			"current chain tip %d", ErrStartHeightTooHigh,
 			startHeight, bestHeightInt32)
+
+		return
 	}
 
 	// Submit the rescan request to the syncer.
 	req := &scanReq{
-		typ: typ,
+		typ: r.typ,
 		startBlock: waddrmgr.BlockStamp{
 			Height: startHeightInt32,
 		},
-		targets: targets,
+		targets: r.targets,
 	}
 
-	return w.sync.requestScan(ctx, req)
+	// The existing joined worker owns scans after transfer. Its lifetime must
+	// also cancel a full mailbox send when shutdown stops consuming scans.
+	r.respErrChan <- w.sync.requestScan(w.lifetimeCtx, req)
 }
 
 // mainLoop is the central event loop for the wallet, responsible for
@@ -677,10 +760,18 @@ type reqCtx struct {
 
 // handleReq owns completion bookkeeping for requests accepted by mainLoop. Its
 // type switch is the single routing table for concurrent public method work.
+// Component responses have capacity one and each handler sends exactly once,
+// so delivery cannot block even before the admitted caller receives its result.
 func (w *Wallet) handleReq(req any) {
 	defer w.wg.Done()
 
 	switch r := req.(type) {
+	case infoReq:
+		w.handleInfo(r)
+
+	case rescanReq:
+		w.handleRescanReq(r)
+
 	case newAccountReq:
 		w.handleNewAccount(r)
 	case renameAccountReq:

--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -816,6 +816,12 @@ func (w *Wallet) handleReq(req any) {
 	case listLeasedOutputsReq:
 		w.handleListLeasedOutputs(r)
 
+	case getTxReq:
+		w.handleGetTx(r)
+
+	case listTxnsReq:
+		w.handleListTxns(r)
+
 	case newAccountReq:
 		w.handleNewAccount(r)
 	case renameAccountReq:

--- a/wallet/controller.go
+++ b/wallet/controller.go
@@ -828,6 +828,12 @@ func (w *Wallet) handleReq(req any) {
 	case createTransactionReq:
 		w.handleCreateTransaction(r)
 
+	case checkMempoolAcceptanceReq:
+		w.handleCheckMempoolAcceptance(r)
+
+	case broadcastReq:
+		w.handleBroadcast(r)
+
 	case newAccountReq:
 		w.handleNewAccount(r)
 	case renameAccountReq:

--- a/wallet/controller_test.go
+++ b/wallet/controller_test.go
@@ -651,8 +651,7 @@ func TestSubmitRescanRequest_Errors(t *testing.T) {
 
 		// Arrange: Setup a started wallet where best block lookup fails.
 		w, deps := createTestWalletWithMocks(t)
-		require.NoError(t, w.state.toStarting())
-		require.NoError(t, w.state.toStarted())
+		startLoadedWalletForTest(t, w)
 
 		deps.syncer.On("syncState").Return(syncStateSynced)
 		deps.chain.On("GetBestBlock").Return(
@@ -1289,6 +1288,142 @@ func TestHandleChangePassphraseReq_Errors(t *testing.T) {
 	require.ErrorIs(t, err, ErrStateForbidden)
 }
 
+// TestControllerInfoWaitsForAcceptedResult verifies that caller cancellation
+// cannot discard an accepted result or let Stop pass unfinished Store work.
+func TestControllerInfoWaitsForAcceptedResult(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "Success",
+		},
+		{
+			name: "Dependency error",
+			err:  errDBMock,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange: Hold an accepted Store read that ignores cancellation.
+			// Its release determines when both Info and shutdown can finish.
+			w, deps := createTestWalletWithMocks(t)
+			startLoadedWalletForTest(t, w)
+
+			enteredChan := make(chan struct{})
+			releaseChan := make(chan struct{})
+			unblock := sync.OnceFunc(func() { close(releaseChan) })
+			t.Cleanup(unblock)
+
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+
+			deps.store.On("GetWallet", ctx, "").Run(
+				func(mock.Arguments) {
+					close(enteredChan)
+					<-releaseChan
+				},
+			).Return(&db.WalletInfo{}, tc.err).Once()
+			deps.vault.On("Lock").Return().Once()
+
+			if tc.err == nil {
+				deps.chain.On("BackEnd").Return("mock").Once()
+				deps.syncer.On("syncState").Return(syncStateSynced).Twice()
+			}
+
+			resultChan := make(chan infoResp, 1)
+			go func() {
+				info, err := w.Info(ctx)
+				resultChan <- infoResp{info: info, err: err}
+			}()
+
+			<-enteredChan
+
+			// Act: Cancel after admission and begin shutdown while Store is
+			// held. Neither path may abandon the accepted operation.
+			cancel()
+
+			stoppedChan := make(chan error, 1)
+			go func() { stoppedChan <- w.Stop(t.Context()) }()
+
+			<-w.lifetimeCtx.Done()
+
+			// Assert: Both calls stay joined until release, then Info returns
+			// the ordinary result and Stop completes its vault teardown.
+			select {
+			case result := <-resultChan:
+				t.Fatalf("Info returned before Store completion: %v",
+					result.err)
+			case err := <-stoppedChan:
+				t.Fatalf("Stop returned before Store completion: %v", err)
+			case <-time.After(20 * time.Millisecond):
+			}
+
+			unblock()
+
+			result := <-resultChan
+			require.ErrorIs(t, result.err, tc.err)
+
+			if tc.err == nil {
+				require.Equal(t, "mock", result.info.Backend)
+			} else {
+				require.Nil(t, result.info)
+			}
+
+			require.NoError(t, <-stoppedChan)
+		})
+	}
+}
+
+// TestControllerRescanFullMailboxStops prevents an accepted scan from
+// stranding Stop when the syncer stops consuming its already-full mailbox.
+func TestControllerRescanFullMailboxStops(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Use the real mailboxChan transfer with a queued scan and no
+	// consumer, matching the syncer's shutdown state. Chain entry proves the
+	// new request is accepted before shutdown begins.
+	w, deps := createTestWalletWithMocks(t)
+
+	mailboxChan := make(chan *scanReq, 1)
+	mailboxChan <- &scanReq{}
+
+	w.sync = &syncer{scanReqChan: mailboxChan}
+	startLoadedWalletForTest(t, w)
+	deps.syncer.On("syncState").Return(syncStateSynced).Once()
+	deps.vault.On("Lock").Return().Once()
+
+	enteredChan := make(chan struct{})
+	deps.chain.On("GetBestBlock").Run(func(mock.Arguments) {
+		close(enteredChan)
+	}).Return(&chainhash.Hash{}, int32(100), nil).Once()
+
+	resultChan := make(chan error, 1)
+	go func() { resultChan <- w.Resync(t.Context(), 10) }()
+
+	<-enteredChan
+
+	// Act: Stop while the accepted transfer cannot enqueue another scan.
+	stoppedChan := make(chan error, 1)
+	go func() { stoppedChan <- w.Stop(t.Context()) }()
+
+	// Assert: Wallet cancellation releases the mailbox send and its handler;
+	// the original queued scan stays intact and the new caller gets the
+	// transfer's cancellation error rather than a substituted shutdown error.
+	select {
+	case err := <-stoppedChan:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("full scan mailboxChan stranded Stop")
+	}
+
+	require.ErrorIs(t, <-resultChan, context.Canceled)
+	require.Len(t, mailboxChan, 1)
+}
+
 // TestControllerInfo verifies the Info method. It checks that the wallet
 // correctly aggregates information from its subsystems (chain backend,
 // address manager, and syncer).
@@ -1366,8 +1501,16 @@ func TestControllerInfoCopiesChainParams(t *testing.T) {
 	chain.On("BackEnd").Return("mock").Twice()
 
 	params := chaincfg.MainNetParams
+	// This fixture assembles its own runtime; the shared start helper
+	// only starts the request loop and joins it before storage cleanup.
+	ctx, cancel := context.WithCancel(t.Context())
+
 	w := &Wallet{
-		store: store,
+		lifetimeCtx: ctx,
+		cancel:      cancel,
+		requestChan: make(chan any),
+		lockTimer:   time.NewTimer(time.Hour),
+		store:       store,
 		cfg: Config{
 			Name:        "isolated",
 			Chain:       chain,
@@ -1375,8 +1518,9 @@ func TestControllerInfoCopiesChainParams(t *testing.T) {
 		},
 		state: newWalletState(nil),
 	}
-	require.NoError(t, w.state.toStarting())
-	require.NoError(t, w.state.toStarted())
+	// Disable auto-lock timing so this fixture exercises only its API call.
+	w.lockTimer.Stop()
+	startLoadedWalletForTest(t, w)
 
 	// Act: Mutate nested values in the first Info result, then request a new
 	// snapshot from the same retained Wallet configuration.
@@ -1443,8 +1587,7 @@ func TestControllerResync(t *testing.T) {
 		t.Parallel()
 
 		w, deps := createTestWalletWithMocks(t)
-		require.NoError(t, w.state.toStarting())
-		require.NoError(t, w.state.toStarted())
+		startLoadedWalletForTest(t, w)
 
 		deps.syncer.On("syncState").Return(syncStateSynced)
 		deps.chain.On("GetBestBlock").Return(
@@ -1459,8 +1602,7 @@ func TestControllerResync(t *testing.T) {
 		t.Parallel()
 
 		w, deps := createTestWalletWithMocks(t)
-		require.NoError(t, w.state.toStarting())
-		require.NoError(t, w.state.toStarted())
+		startLoadedWalletForTest(t, w)
 
 		deps.syncer.On("syncState").Return(syncStateSynced)
 		deps.chain.On("GetBestBlock").Return(
@@ -1486,8 +1628,7 @@ func TestControllerRescan(t *testing.T) {
 		t.Parallel()
 
 		w, _ := createTestWalletWithMocks(t)
-		require.NoError(t, w.state.toStarting())
-		require.NoError(t, w.state.toStarted())
+		startLoadedWalletForTest(t, w)
 
 		err := w.Rescan(t.Context(), 50, nil)
 		require.ErrorIs(t, err, ErrNoScanTargets)
@@ -1497,8 +1638,7 @@ func TestControllerRescan(t *testing.T) {
 		t.Parallel()
 
 		w, deps := createTestWalletWithMocks(t)
-		require.NoError(t, w.state.toStarting())
-		require.NoError(t, w.state.toStarted())
+		startLoadedWalletForTest(t, w)
 
 		deps.syncer.On("syncState").Return(syncStateSynced)
 
@@ -1775,8 +1915,7 @@ func TestSubmitRescanRequest_HeightOverflow(t *testing.T) {
 	// Arrange: Setup a wallet and attempt a rescan with an invalid height.
 	w, deps := createTestWalletWithMocks(t)
 
-	require.NoError(t, w.state.toStarting())
-	require.NoError(t, w.state.toStarted())
+	startLoadedWalletForTest(t, w)
 
 	deps.syncer.On("syncState").Return(syncStateSynced).Maybe()
 

--- a/wallet/deprecated_test.go
+++ b/wallet/deprecated_test.go
@@ -6,6 +6,7 @@ package wallet
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"fmt"
 	"math"
@@ -2397,6 +2398,9 @@ func runTestCase(t *testing.T, w *Wallet, scope waddrmgr.KeyScope,
 func TestOpenWithRetryRoutedSigning(t *testing.T) {
 	t.Parallel()
 
+	// Arrange: Create a spendable legacy database with its own passphrases
+	// and key material so reopening must recover the real signing state.
+
 	var (
 		pubPass  = []byte("public")
 		privPass = []byte("private")
@@ -2420,7 +2424,8 @@ func TestOpenWithRetryRoutedSigning(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// Act: reopen through the deprecated constructor.
+	// Act: Reopen through the retained constructor, initialize its request
+	// runtime, and use the recovered vault for the routed signing calls.
 	w, err := OpenWithRetry(
 		dbConn, pubPass, nil, &chainParams, 0,
 		defaultSyncRetryInterval,
@@ -2434,11 +2439,13 @@ func TestOpenWithRetryRoutedSigning(t *testing.T) {
 	require.NoError(t, w.keyVault.Unlock(t.Context(), privPass))
 	require.False(t, w.keyVault.IsLocked())
 
-	// This constructor cannot Start: it has no chain to verify a birthday
-	// against. Claim the signing-capable state directly so the routed public
-	// call below is reachable.
-	require.NoError(t, w.state.toStarting())
-	require.NoError(t, w.state.toStarted())
+	// The legacy constructor does not assemble a request runtime. This
+	// fixture supplies it so signing is admitted without starting chain sync.
+	w.lifetimeCtx, w.cancel = context.WithCancel(t.Context())
+	w.requestChan = make(chan any)
+	w.lockTimer = time.NewTimer(time.Hour)
+	w.lockTimer.Stop()
+	startLoadedWalletForTest(t, w)
 	w.state.toUnlocked()
 
 	// A wallet that has synced has a birthday block; CreateDeprecated leaves

--- a/wallet/psbt_manager.go
+++ b/wallet/psbt_manager.go
@@ -367,6 +367,58 @@ type PsbtManager interface {
 		*psbt.Packet, error)
 }
 
+// decorateInputsReq borrows the packet until accepted enrichment completes.
+type decorateInputsReq struct {
+	reqCtx
+
+	packet      *psbt.Packet
+	skipUnknown bool
+	respChan    chan psbtPacketResp
+}
+
+// psbtPacketResp returns the operation result after in-place input updates.
+type psbtPacketResp struct {
+	packet *psbt.Packet
+	err    error
+}
+
+// fundPsbtReq borrows funding data through authoring and packet population.
+type fundPsbtReq struct {
+	reqCtx
+
+	intent   *FundIntent
+	respChan chan fundPsbtResp
+}
+
+// fundPsbtResp delivers funding results only after packet mutation ends.
+type fundPsbtResp struct {
+	packet      *psbt.Packet
+	changeIndex int32
+	err         error
+}
+
+// signPsbtReq borrows signing metadata until signing and callbacks complete.
+type signPsbtReq struct {
+	reqCtx
+
+	params   *SignPsbtParams
+	respChan chan signPsbtResp
+}
+
+// signPsbtResp returns signed indices with the original packet.
+type signPsbtResp struct {
+	result *SignPsbtResult
+	err    error
+}
+
+// finalizePsbtReq keeps final witness assembly joined through completion.
+type finalizePsbtReq struct {
+	reqCtx
+
+	packet      *psbt.Packet
+	respErrChan chan error
+}
+
 // DecorateInputs enriches a PSBT's inputs with UTXO and derivation information.
 //
 // It iterates through all inputs in the PSBT and:
@@ -383,6 +435,36 @@ func (w *Wallet) DecorateInputs(ctx context.Context, packet *psbt.Packet,
 	if err != nil {
 		return nil, err
 	}
+
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := decorateInputsReq{
+		reqCtx:      reqCtx{ctx: ctx},
+		packet:      packet,
+		skipUnknown: skipUnknown,
+		respChan:    make(chan psbtPacketResp, 1),
+	}
+
+	err = w.sendReq(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	result := <-r.respChan
+
+	return result.packet, result.err
+}
+
+// handleDecorateInputs delivers the result of an accepted component request.
+func (w *Wallet) handleDecorateInputs(r decorateInputsReq) {
+	// Reuse decoration shared with funding without a second admission.
+	packet, err := w.decorateInputs(r.ctx, r.packet, r.skipUnknown)
+	r.respChan <- psbtPacketResp{packet: packet, err: err}
+}
+
+// decorateInputs completes its accepted operation with the caller's packet.
+func (w *Wallet) decorateInputs(ctx context.Context, packet *psbt.Packet,
+	skipUnknown bool) (*psbt.Packet, error) {
 
 	// We'll iterate through all the inputs of the PSBT and decorate them
 	// if they are owned by the wallet. The `skipUnknown` parameter
@@ -589,6 +671,8 @@ func validatePsbtParentOutput(outPoint wire.OutPoint,
 // public CreateTransaction wrapper. Their construction flow is identical
 // today, but keeping the wrappers independent prevents direct-transaction watch
 // delivery from leaking into PSBT-specific lease, cleanup, and publication.
+// Accepted funding finishes before return, including packet updates and any
+// supplied coin selector, even if the caller cancels after admission.
 func (w *Wallet) FundPsbt(ctx context.Context, intent *FundIntent) (
 	*psbt.Packet, int32, error) {
 
@@ -597,23 +681,48 @@ func (w *Wallet) FundPsbt(ctx context.Context, intent *FundIntent) (
 		return nil, 0, err
 	}
 
-	// Validate the funding intent before proceeding.
+	// Validate the packet shape before admitting funding work.
 	err = w.validateFundIntent(intent)
 	if err != nil {
 		return nil, 0, err
 	}
 
-	// Create a TxIntent from the FundIntent.
-	txIntent := w.createTxIntent(intent)
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := fundPsbtReq{
+		reqCtx:   reqCtx{ctx: ctx},
+		intent:   intent,
+		respChan: make(chan fundPsbtResp, 1),
+	}
 
-	err = normalizeAndValidateTxIntent(txIntent)
+	err = w.sendReq(ctx, r)
 	if err != nil {
 		return nil, 0, err
 	}
 
-	inputSource, changeSource, err := w.prepareTxAuthSources(ctx, txIntent)
+	// Once admitted, wait for the result even if cancellation arrives.
+	result := <-r.respChan
+
+	return result.packet, result.changeIndex, result.err
+}
+
+// handleFundPsbt completes its accepted operation with the caller's packet.
+// The admitted caller waits for this result before reusing its inputs.
+func (w *Wallet) handleFundPsbt(r fundPsbtReq) {
+	// Create a TxIntent from the FundIntent.
+	txIntent := w.createTxIntent(r.intent)
+
+	err := normalizeAndValidateTxIntent(txIntent)
 	if err != nil {
-		return nil, 0, err
+		r.respChan <- fundPsbtResp{err: err}
+
+		return
+	}
+
+	inputSource, changeSource, err := w.prepareTxAuthSources(r.ctx, txIntent)
+	if err != nil {
+		r.respChan <- fundPsbtResp{err: err}
+
+		return
 	}
 
 	// Create the transaction through the shared authoring boundary.
@@ -621,18 +730,22 @@ func (w *Wallet) FundPsbt(ctx context.Context, intent *FundIntent) (
 		txIntent.Outputs, txIntent.FeeRate, inputSource, changeSource,
 	)
 	if err != nil {
-		return nil, 0, err
+		r.respChan <- fundPsbtResp{err: err}
+
+		return
 	}
 
 	// Populate the PSBT packet with the new transaction details.
 	packet, changeIndex, err := w.populatePsbtPacket(
-		ctx, intent.Packet, authoredTx,
+		r.ctx, r.intent.Packet, authoredTx,
 	)
 	if err != nil {
-		return nil, 0, err
+		r.respChan <- fundPsbtResp{err: err}
+
+		return
 	}
 
-	return packet, changeIndex, nil
+	r.respChan <- fundPsbtResp{packet: packet, changeIndex: changeIndex}
 }
 
 // populatePsbtPacket updates the PSBT packet with the new transaction details,
@@ -660,7 +773,7 @@ func (w *Wallet) populatePsbtPacket(ctx context.Context, packet *psbt.Packet,
 	// derivation information from the wallet. We set `skipUnknown` to
 	// false because all inputs in the `authoredTx` must be known to the
 	// wallet.
-	_, err := w.DecorateInputs(ctx, packet, false)
+	_, err := w.decorateInputs(ctx, packet, false)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -872,6 +985,9 @@ func (w *Wallet) createTxIntent(intent *FundIntent) *TxIntent {
 //  4. Signing: dispatching to `signTaprootPsbtInput` or `signBip32PsbtInput` to
 //     generate the raw ECDSA or Schnorr signature using the underlying
 //     `Signer`.
+//
+// Accepted signing finishes before return, including partial signatures and
+// supplied input tweakers, even if the caller cancels after admission.
 func (w *Wallet) SignPsbt(ctx context.Context, params *SignPsbtParams) (
 	*SignPsbtResult, error) {
 
@@ -884,7 +1000,28 @@ func (w *Wallet) SignPsbt(ctx context.Context, params *SignPsbtParams) (
 		return nil, ErrNilArguments
 	}
 
-	packet := params.Packet
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := signPsbtReq{
+		reqCtx:   reqCtx{ctx: ctx},
+		params:   params,
+		respChan: make(chan signPsbtResp, 1),
+	}
+
+	err = w.sendReq(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	result := <-r.respChan
+
+	return result.result, result.err
+}
+
+// handleSignPsbt completes its accepted operation with the caller's packet.
+// The admitted caller waits for this result before reusing its inputs.
+func (w *Wallet) handleSignPsbt(r signPsbtReq) {
+	packet := r.params.Packet
 
 	// signedInputs will track the indices of all inputs that we
 	// successfully sign during this operation. This is useful for callers
@@ -897,9 +1034,13 @@ func (w *Wallet) SignPsbt(ctx context.Context, params *SignPsbtParams) (
 	// has at least a WitnessUtxo or NonWitnessUtxo, which is crucial for
 	// signature generation. If this check fails, it indicates a malformed
 	// or incomplete PSBT that cannot be signed.
-	err = psbt.InputsReadyToSign(packet)
+	err := psbt.InputsReadyToSign(packet)
 	if err != nil {
-		return nil, fmt.Errorf("psbt inputs not ready: %w", err)
+		r.respChan <- signPsbtResp{
+			err: fmt.Errorf("psbt inputs not ready: %w", err),
+		}
+
+		return
 	}
 
 	// We create a `PrevOutputFetcher` to allow `txscript` to retrieve the
@@ -910,7 +1051,11 @@ func (w *Wallet) SignPsbt(ctx context.Context, params *SignPsbtParams) (
 	// signatures for each input.
 	prevOutFetcher, err := PsbtPrevOutputFetcher(packet)
 	if err != nil {
-		return nil, fmt.Errorf("error creating prevOutFetcher: %w", err)
+		r.respChan <- signPsbtResp{
+			err: fmt.Errorf("error creating prevOutFetcher: %w", err),
+		}
+
+		return
 	}
 
 	sigHashes := txscript.NewTxSigHashes(
@@ -924,10 +1069,12 @@ func (w *Wallet) SignPsbt(ctx context.Context, params *SignPsbtParams) (
 	// signing process accordingly.
 	for i := range packet.Inputs {
 		signed, err := w.signPsbtInput(
-			ctx, packet, i, sigHashes, params.InputTweakers,
+			r.ctx, packet, i, sigHashes, r.params.InputTweakers,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("input %d: %w", i, err)
+			r.respChan <- signPsbtResp{err: fmt.Errorf("input %d: %w", i, err)}
+
+			return
 		}
 
 		if signed {
@@ -946,10 +1093,12 @@ func (w *Wallet) SignPsbt(ctx context.Context, params *SignPsbtParams) (
 	// Finally, return the result, which includes the list of inputs that
 	// were successfully signed and the modified (partially) signed PSBT
 	// packet.
-	return &SignPsbtResult{
-		SignedInputs: signedInputs,
-		Packet:       packet,
-	}, nil
+	r.respChan <- signPsbtResp{
+		result: &SignPsbtResult{
+			SignedInputs: signedInputs,
+			Packet:       packet,
+		},
+	}
 }
 
 // signPsbtInput attempts to sign a single input of the PSBT. It returns true
@@ -1623,21 +1772,44 @@ func (w *Wallet) FinalizePsbt(ctx context.Context, packet *psbt.Packet) error {
 		return err
 	}
 
-	// Check that the PSBT is structurally ready to be signed/finalized.
-	err = psbt.InputsReadyToSign(packet)
-	if err != nil {
-		return fmt.Errorf("psbt inputs not ready: %w", err)
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := finalizePsbtReq{
+		reqCtx:      reqCtx{ctx: ctx},
+		packet:      packet,
+		respErrChan: make(chan error, 1),
 	}
 
-	tx := packet.UnsignedTx
+	err = w.sendReq(ctx, r)
+	if err != nil {
+		return err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	return <-r.respErrChan
+}
+
+// handleFinalizePsbt completes its accepted operation with the caller's packet.
+// The admitted caller waits for this result before reusing its inputs.
+func (w *Wallet) handleFinalizePsbt(r finalizePsbtReq) {
+	// Check that the PSBT is structurally ready to be signed/finalized.
+	err := psbt.InputsReadyToSign(r.packet)
+	if err != nil {
+		r.respErrChan <- fmt.Errorf("psbt inputs not ready: %w", err)
+
+		return
+	}
+
+	tx := r.packet.UnsignedTx
 
 	// We create a `PrevOutputFetcher` to allow `txscript` to retrieve the
 	// previous transaction outputs needed for sighash generation. This is
 	// required for generating valid signatures, as the value and script of
 	// the UTXO being spent are part of the signed digest.
-	prevOutFetcher, err := PsbtPrevOutputFetcher(packet)
+	prevOutFetcher, err := PsbtPrevOutputFetcher(r.packet)
 	if err != nil {
-		return fmt.Errorf("error creating prevOutFetcher: %w", err)
+		r.respErrChan <- fmt.Errorf("error creating prevOutFetcher: %w", err)
+
+		return
 	}
 
 	// Compute the transaction's sighashes. This is an optimization to
@@ -1649,22 +1821,26 @@ func (w *Wallet) FinalizePsbt(ctx context.Context, packet *psbt.Packet) error {
 	// Iterate through each input in the PSBT. For each input, we will
 	// check if we can sign and finalize it (i.e., if we own the UTXO and
 	// have the private key).
-	for i := range packet.Inputs {
-		err := w.finalizeInput(ctx, packet, i, sigHashes)
+	for i := range r.packet.Inputs {
+		err := w.finalizeInput(r.ctx, r.packet, i, sigHashes)
 		if err != nil {
-			return err
+			r.respErrChan <- err
+
+			return
 		}
 	}
 
 	// Finally, attempt to finalize the entire PSBT. This will check if all
 	// inputs have final scripts (either added by us above or constructed
 	// from PartialSigs by the psbt library) and strip the partial data.
-	err = psbt.MaybeFinalizeAll(packet)
+	err = psbt.MaybeFinalizeAll(r.packet)
 	if err != nil {
-		return fmt.Errorf("error finalizing PSBT: %w", err)
+		r.respErrChan <- fmt.Errorf("error finalizing PSBT: %w", err)
+
+		return
 	}
 
-	return nil
+	r.respErrChan <- nil
 }
 
 // finalizeInput attempts to finalize a single input of the PSBT.

--- a/wallet/psbt_manager.go
+++ b/wallet/psbt_manager.go
@@ -1523,7 +1523,7 @@ func (w *Wallet) signTaprootPsbtInput(ctx context.Context, packet *psbt.Packet,
 	}
 
 	// Compute the raw signature.
-	sig, err := w.ComputeRawSig(ctx, params)
+	sig, err := w.computeRawSig(ctx, params)
 	if err != nil {
 		return fmt.Errorf("%w: %w", errComputeRawSig, err)
 	}
@@ -1596,7 +1596,7 @@ func (w *Wallet) signBip32PsbtInput(ctx context.Context, packet *psbt.Packet,
 	}
 
 	// Compute the raw signature.
-	sig, err := w.ComputeRawSig(ctx, params)
+	sig, err := w.computeRawSig(ctx, params)
 	if err != nil {
 		return fmt.Errorf("%w: %w", errComputeRawSig, err)
 	}
@@ -1704,7 +1704,7 @@ func (w *Wallet) finalizeInput(ctx context.Context, packet *psbt.Packet,
 		HashType:   pInput.SighashType,
 	}
 
-	unlockingScript, err := w.ComputeUnlockingScript(ctx, params)
+	unlockingScript, err := w.computeUnlockingScript(ctx, params)
 	if err != nil {
 		// If we can't generate the script (e.g. we don't own the key,
 		// or it's a type we don't support yet, or the account is

--- a/wallet/psbt_manager.go
+++ b/wallet/psbt_manager.go
@@ -430,7 +430,7 @@ func (w *Wallet) decorateInput(ctx context.Context, pInput *psbt.PInput,
 
 	// Reuse the same wallet lookup and script-construction path as the signer,
 	// so PSBT decoration and spending metadata stay in sync.
-	scriptInfo, err := w.ScriptForOutput(ctx, *utxo)
+	scriptInfo, err := w.scriptForOutput(ctx, *utxo)
 	if err != nil {
 		return err
 	}
@@ -701,7 +701,7 @@ func (w *Wallet) populatePsbtPacket(ctx context.Context, packet *psbt.Packet,
 func (w *Wallet) addChangeOutputInfo(ctx context.Context, packet *psbt.Packet,
 	authoredTx *txauthor.AuthoredTx) error {
 	// First, we'll get the script information for the change output.
-	changeScriptInfo, err := w.ScriptForOutput(
+	changeScriptInfo, err := w.scriptForOutput(
 		ctx, *authoredTx.Tx.TxOut[authoredTx.ChangeIndex],
 	)
 	if err != nil {

--- a/wallet/psbt_manager_test.go
+++ b/wallet/psbt_manager_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"sync"
 	"testing"
 
 	"github.com/btcsuite/btcd/address/v2"
@@ -34,6 +35,154 @@ var (
 	errDb           = errors.New("db error")
 	errAddrNotFound = errors.New("addr not found")
 )
+
+// TestDecorateInputsPartialError preserves the first input's enrichment when
+// a later input fails, including nested lookups during graceful shutdown.
+func TestDecorateInputsPartialError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: The first input belongs to the wallet and the second
+	// fails lookup. Pause the first lookup so its nested address
+	// resolution and partial enrichment both happen after Stop begins.
+	w, deps := createTestWalletWithMocks(t)
+	startLoadedWalletForTest(t, w)
+	deps.vault.On("Lock").Return().Once()
+
+	key, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	t.Cleanup(key.Zero)
+	addr, err := address.NewAddressWitnessPubKeyHash(
+		address.Hash160(key.PubKey().SerializeCompressed()),
+		&chainParams,
+	)
+	require.NoError(t, err)
+	script, err := txscript.PayToAddrScript(addr)
+	require.NoError(t, err)
+
+	outpoint := wire.OutPoint{Hash: chainhash.Hash{1}}
+	other := wire.OutPoint{Hash: chainhash.Hash{2}}
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(&wire.TxIn{PreviousOutPoint: outpoint})
+	tx.AddTxIn(&wire.TxIn{PreviousOutPoint: other})
+	packet, err := psbt.NewFromUnsignedTx(tx)
+	require.NoError(t, err)
+
+	output := wire.NewTxOut(1000, script)
+	enteredChan := make(chan struct{})
+	releaseChan := make(chan struct{})
+	unblock := sync.OnceFunc(func() { close(releaseChan) })
+	t.Cleanup(unblock)
+	deps.store.On("GetUtxo", mock.Anything, db.GetUtxoQuery{
+		WalletID: w.id,
+		OutPoint: outpoint,
+	}).Run(func(mock.Arguments) {
+		close(enteredChan)
+		<-releaseChan
+	}).Return(testStoreUtxoInfo(outpoint, output), nil).Once()
+	deps.store.On("GetTxDetail", mock.Anything, db.GetTxDetailQuery{
+		WalletID: w.id,
+		Txid:     outpoint.Hash,
+	}).Return(testStoreTxDetail(outpoint.Hash, output), nil).Once()
+	deps.store.On("GetUtxo", mock.Anything, db.GetUtxoQuery{
+		WalletID: w.id,
+		OutPoint: other,
+	}).Return((*db.UtxoInfo)(nil), errDb).Once()
+	expectSignerDerivedAddressInfo(
+		t, w, deps, addr, db.WitnessPubKey, key.PubKey(),
+	)
+	deps.store.ExpectedCalls[len(deps.store.ExpectedCalls)-1].Once()
+
+	resultChan := make(chan error, 1)
+	go func() {
+		_, err := w.DecorateInputs(t.Context(), packet, false)
+		resultChan <- err
+	}()
+
+	<-enteredChan
+
+	// Act: Begin Stop before releasing the first dependency. The nested
+	// address lookup must finish inside the already admitted operation.
+	stoppedChan := make(chan error, 1)
+	go func() { stoppedChan <- w.Stop(t.Context()) }()
+
+	<-w.lifetimeCtx.Done()
+	unblock()
+
+	// Assert: After completion and joined shutdown, the first input retains
+	// its enrichment and the second reports the original lookup failure.
+	require.ErrorIs(t, <-resultChan, errDb)
+
+	require.NoError(t, <-stoppedChan)
+	require.Same(t, tx, packet.UnsignedTx)
+
+	require.Equal(t, output, packet.Inputs[0].WitnessUtxo)
+	require.Len(t, packet.Inputs[0].Bip32Derivation, 1)
+	require.Nil(t, packet.Inputs[1].WitnessUtxo)
+}
+
+// TestFundPsbtPopulationError verifies that completed funding errors retain
+// partial population in the original packet after the operation completes.
+func TestFundPsbtPopulationError(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Reuse the existing authoring fixture, then stop funding
+	// in its first decoration lookup, after it replaces the supplied
+	// transaction and input/output metadata. Return a real Store error.
+	w, deps := createTestWalletWithMocks(t)
+	startLoadedWalletForTest(t, w)
+	deps.syncer.On("syncState").Return(syncStateSynced).Once()
+	deps.vault.On("Lock").Return().Once()
+	fixture := expectDefaultAuthoringSources(t, w, deps)
+	tx := wire.NewMsgTx(2)
+	tx.AddTxOut(&fixture.payment)
+	packet, err := psbt.NewFromUnsignedTx(tx)
+	require.NoError(t, err)
+
+	packet.Outputs[0].RedeemScript = []byte{7}
+	enteredChan := make(chan struct{})
+	releaseChan := make(chan struct{})
+	unblock := sync.OnceFunc(func() { close(releaseChan) })
+	t.Cleanup(unblock)
+	deps.store.On("GetUtxo", mock.Anything, db.GetUtxoQuery{
+		WalletID: w.id,
+		OutPoint: fixture.utxo.OutPoint,
+	}).Run(func(mock.Arguments) {
+		close(enteredChan)
+		<-releaseChan
+	}).Return((*db.UtxoInfo)(nil), errDb).Once()
+
+	resultChan := make(chan error, 1)
+	go func() {
+		_, _, err := w.FundPsbt(t.Context(), &FundIntent{
+			Packet:  packet,
+			Policy:  &InputsPolicy{},
+			FeeRate: defaultFeeRate,
+		})
+		resultChan <- err
+	}()
+
+	<-enteredChan
+
+	// Act: Start shutdown while funding is paused, then let the Store
+	// report its error so accepted work can complete before vault teardown.
+	stoppedChan := make(chan error, 1)
+	go func() { stoppedChan <- w.Stop(t.Context()) }()
+
+	<-w.lifetimeCtx.Done()
+	unblock()
+
+	// Assert: Once funding and Stop complete, the failed packet retains
+	// its populated transaction and reset metadata for caller inspection.
+	require.ErrorIs(t, <-resultChan, errDb)
+
+	require.NoError(t, <-stoppedChan)
+
+	require.NotSame(t, tx, packet.UnsignedTx)
+	require.Len(t, packet.Inputs, 1)
+	require.Equal(t, fixture.utxo.OutPoint,
+		packet.UnsignedTx.TxIn[0].PreviousOutPoint)
+	require.Empty(t, packet.Outputs[0].RedeemScript)
+}
 
 // testStoreTxDetail builds a store transaction detail for a parent tx.
 func testStoreTxDetail(txHash chainhash.Hash,
@@ -3029,6 +3178,7 @@ func TestSignPsbt(t *testing.T) {
 			// Assert: the input is reported signed and the packet
 			// carries the generated signature.
 			require.NoError(t, err)
+			require.Same(t, packet, result.Packet)
 			require.Len(t, result.SignedInputs, 1)
 			require.Equal(t, uint32(0), result.SignedInputs[0])
 			require.Len(t, packet.Inputs[0].PartialSigs, 1)
@@ -3099,7 +3249,6 @@ func TestSignPsbtClassifiesSignError(t *testing.T) {
 		name      string
 		storeErr  error
 		wantError error
-		cancel    bool
 	}{
 		{
 			name:     "missing account skips input",
@@ -3109,7 +3258,6 @@ func TestSignPsbtClassifiesSignError(t *testing.T) {
 			name:      "canceled context returns error",
 			storeErr:  context.Canceled,
 			wantError: context.Canceled,
-			cancel:    true,
 		},
 		{
 			name:      "store failure returns error",
@@ -3167,17 +3315,10 @@ func TestSignPsbtClassifiesSignError(t *testing.T) {
 				(*db.AccountSecret)(nil), tc.storeErr,
 			).Once()
 
-			ctx := t.Context()
-			if tc.cancel {
-				var cancel context.CancelFunc
-
-				ctx, cancel = context.WithCancel(ctx)
-				cancel()
-			}
-
-			// Act.
+			// Act: Deliver the Store's error through an admitted public call.
+			// A pre-canceled context could reject before reaching the Store.
 			result, err := w.SignPsbt(
-				ctx, &SignPsbtParams{Packet: packet},
+				t.Context(), &SignPsbtParams{Packet: packet},
 			)
 
 			// Assert: Only explicit ownership failures are skipped.

--- a/wallet/signer.go
+++ b/wallet/signer.go
@@ -481,6 +481,100 @@ var _ SpendDetails = (*LegacySpendDetails)(nil)
 var _ SpendDetails = (*SegwitV0SpendDetails)(nil)
 var _ SpendDetails = (*TaprootSpendDetails)(nil)
 
+// derivePubKeyReq retains account selection until accepted derivation ends.
+type derivePubKeyReq struct {
+	reqCtx
+
+	params   DerivePubKeyParams
+	respChan chan pubKeyResp
+}
+
+// pubKeyResp returns the derived public key after the accepted lookup ends.
+type pubKeyResp struct {
+	key *btcec.PublicKey
+	err error
+}
+
+// ecdhReq borrows the remote key until accepted secret computation ends.
+type ecdhReq struct {
+	reqCtx
+
+	path     BIP32Path
+	pub      *btcec.PublicKey
+	respChan chan ecdhResp
+}
+
+// ecdhResp returns the shared secret after temporary key cleanup.
+type ecdhResp struct {
+	secret [32]byte
+	err    error
+}
+
+// signDigestReq borrows digest and tweak bytes through vault-backed signing.
+type signDigestReq struct {
+	reqCtx
+
+	path     BIP32Path
+	intent   *SignDigestIntent
+	respChan chan signatureResp
+}
+
+// signatureResp delivers the completed signature without retaining its key.
+type signatureResp struct {
+	signature Signature
+	err       error
+}
+
+// unlockingScriptReq borrows transaction data until assembly completes.
+type unlockingScriptReq struct {
+	reqCtx
+
+	params   *UnlockingScriptParams
+	respChan chan unlockingScriptResp
+}
+
+// unlockingScriptResp retains completed unlocking data for its caller.
+type unlockingScriptResp struct {
+	script *UnlockingScript
+	err    error
+}
+
+// rawSigReq borrows signing inputs until its accepted vault operation ends.
+type rawSigReq struct {
+	reqCtx
+
+	params   *RawSigParams
+	respChan chan rawSigResp
+}
+
+// rawSigResp returns the signature after signing and key cleanup complete.
+type rawSigResp struct {
+	signature RawSignature
+	err       error
+}
+
+// derivePrivKeyReq keeps an exported key joined until it can be delivered.
+type derivePrivKeyReq struct {
+	reqCtx
+
+	path     BIP32Path
+	respChan chan privKeyResp
+}
+
+// privKeyForAddressReq borrows the destination through exported-key lookup.
+type privKeyForAddressReq struct {
+	reqCtx
+
+	addr     address.Address
+	respChan chan privKeyResp
+}
+
+// privKeyResp delivers exported key ownership to its noncanceling waiter.
+type privKeyResp struct {
+	key *btcec.PrivateKey
+	err error
+}
+
 // DerivePubKey derives a public child key from a semantically selected
 // account. The account XPub is read from the durable store, then the branch and
 // child index are derived in memory. Public derivation requires a started
@@ -499,7 +593,29 @@ func (w *Wallet) DerivePubKey(ctx context.Context,
 		return nil, err
 	}
 
-	return w.resolveDerivedPubKeyFromStore(ctx, params)
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := derivePubKeyReq{
+		reqCtx:   reqCtx{ctx: ctx},
+		params:   params,
+		respChan: make(chan pubKeyResp, 1),
+	}
+
+	err = w.sendReq(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	result := <-r.respChan
+
+	return result.key, result.err
+}
+
+// handleDerivePrivKey delivers the result of an accepted component request.
+func (w *Wallet) handleDerivePrivKey(r derivePrivKeyReq) {
+	// Transfer the exported key to its waiting caller, which owns zeroing it.
+	key, err := w.derivePathPrivKey(r.ctx, r.path)
+	r.respChan <- privKeyResp{key: key, err: err}
 }
 
 // derivePathPrivKey resolves the signing private key for a full BIP-32 path.
@@ -537,6 +653,36 @@ func (w *Wallet) ECDH(ctx context.Context, path BIP32Path,
 	if err != nil {
 		return [32]byte{}, err
 	}
+
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := ecdhReq{
+		reqCtx:   reqCtx{ctx: ctx},
+		path:     path,
+		pub:      pub,
+		respChan: make(chan ecdhResp, 1),
+	}
+
+	err = w.sendReq(ctx, r)
+	if err != nil {
+		return [32]byte{}, err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	result := <-r.respChan
+
+	return result.secret, result.err
+}
+
+// handleECDH delivers the result of an accepted component request.
+func (w *Wallet) handleECDH(r ecdhReq) {
+	// The operation zeroes its derived private key before delivery.
+	secret, err := w.ecdh(r.ctx, r.path, r.pub)
+	r.respChan <- ecdhResp{secret: secret, err: err}
+}
+
+// ecdh computes the shared secret within an accepted vault operation.
+func (w *Wallet) ecdh(ctx context.Context, path BIP32Path,
+	pub *btcec.PublicKey) ([32]byte, error) {
 
 	privKey, err := w.derivePathPrivKey(ctx, path)
 	if err != nil {
@@ -591,6 +737,36 @@ func (w *Wallet) SignDigest(ctx context.Context, path BIP32Path,
 	if err != nil {
 		return nil, err
 	}
+
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := signDigestReq{
+		reqCtx:   reqCtx{ctx: ctx},
+		path:     path,
+		intent:   intent,
+		respChan: make(chan signatureResp, 1),
+	}
+
+	err = w.sendReq(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	result := <-r.respChan
+
+	return result.signature, result.err
+}
+
+// handleSignDigest delivers the result of an accepted component request.
+func (w *Wallet) handleSignDigest(r signDigestReq) {
+	// The operation zeroes its derived private key before delivery.
+	signature, err := w.signDigest(r.ctx, r.path, r.intent)
+	r.respChan <- signatureResp{signature: signature, err: err}
+}
+
+// signDigest signs the requested digest and zeroes its key before completion.
+func (w *Wallet) signDigest(ctx context.Context, path BIP32Path,
+	intent *SignDigestIntent) (Signature, error) {
 
 	privKey, err := w.derivePathPrivKey(ctx, path)
 	if err != nil {
@@ -653,7 +829,8 @@ func signDigestECDSA(privKey *btcec.PrivateKey,
 }
 
 // ComputeUnlockingScript generates the full sigScript and witness required to
-// spend a UTXO.
+// spend a UTXO. A supplied tweaker finishes before return even if the caller
+// cancels after admission.
 func (w *Wallet) ComputeUnlockingScript(ctx context.Context,
 	params *UnlockingScriptParams) (*UnlockingScript, error) {
 
@@ -661,6 +838,36 @@ func (w *Wallet) ComputeUnlockingScript(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := unlockingScriptReq{
+		reqCtx:   reqCtx{ctx: ctx},
+		params:   params,
+		respChan: make(chan unlockingScriptResp, 1),
+	}
+
+	err = w.sendReq(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	result := <-r.respChan
+
+	return result.script, result.err
+}
+
+// handleComputeUnlockingScript delivers the result of an accepted component
+// request.
+func (w *Wallet) handleComputeUnlockingScript(r unlockingScriptReq) {
+	// Reuse the signing operation also called from admitted PSBT finalization.
+	script, err := w.computeUnlockingScript(r.ctx, r.params)
+	r.respChan <- unlockingScriptResp{script: script, err: err}
+}
+
+// computeUnlockingScript assembles spending data inside its accepted request.
+func (w *Wallet) computeUnlockingScript(ctx context.Context,
+	params *UnlockingScriptParams) (*UnlockingScript, error) {
 
 	// First, we'll fetch the managed address that corresponds to the
 	// output being spent. This will be used to look up the private key
@@ -999,6 +1206,13 @@ func deriveStoredAccountChildKey(vault keyvault.Vault,
 	return privKey, nil
 }
 
+// handleDerivePubKey delivers the result of an accepted component request.
+func (w *Wallet) handleDerivePubKey(r derivePubKeyReq) {
+	// Keep the existing Store-backed key resolver inside accepted work.
+	key, err := w.resolveDerivedPubKeyFromStore(r.ctx, r.params)
+	r.respChan <- pubKeyResp{key: key, err: err}
+}
+
 // resolveDerivedPubKeyFromStore resolves one derived public key from the
 // account-level extended public key stored behind the wallet store. It is the
 // public-key counterpart of resolveDerivedPrivKeyFromStore and, since the
@@ -1160,7 +1374,8 @@ func redeemSigScript(redeemScript []byte) ([]byte, error) {
 }
 
 // ComputeRawSig generates a raw signature for a single transaction input. The
-// caller is responsible for assembling the final witness.
+// caller is responsible for assembling the final witness. A supplied tweaker
+// finishes before return even if the caller cancels after admission.
 func (w *Wallet) ComputeRawSig(ctx context.Context, params *RawSigParams) (
 	RawSignature, error) {
 
@@ -1168,6 +1383,36 @@ func (w *Wallet) ComputeRawSig(ctx context.Context, params *RawSigParams) (
 	if err != nil {
 		return nil, err
 	}
+
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := rawSigReq{
+		reqCtx:   reqCtx{ctx: ctx},
+		params:   params,
+		respChan: make(chan rawSigResp, 1),
+	}
+
+	err = w.sendReq(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	result := <-r.respChan
+
+	return result.signature, result.err
+}
+
+// handleComputeRawSig delivers the result of an accepted component request.
+func (w *Wallet) handleComputeRawSig(r rawSigReq) {
+	// Reuse raw signing shared with PSBTs and finish key cleanup before
+	// delivery.
+	signature, err := w.computeRawSig(r.ctx, r.params)
+	r.respChan <- rawSigResp{signature: signature, err: err}
+}
+
+// computeRawSig signs and zeroes its key inside the accepted request.
+func (w *Wallet) computeRawSig(ctx context.Context, params *RawSigParams) (
+	RawSignature, error) {
 
 	privKey, err := w.derivePathPrivKey(ctx, params.Path)
 	if err != nil {
@@ -1197,7 +1442,8 @@ func (w *Wallet) ComputeRawSig(ctx context.Context, params *RawSigParams) (
 // DerivePrivKey derives a private key from a full BIP-32 derivation
 // path.
 //
-// DANGER: This method exports sensitive key material.
+// DANGER: This method exports sensitive key material. Once admitted, the call
+// waits for key delivery despite cancellation. The caller must zero the key.
 func (w *Wallet) DerivePrivKey(ctx context.Context, path BIP32Path) (
 	*btcec.PrivateKey, error) {
 
@@ -1206,12 +1452,28 @@ func (w *Wallet) DerivePrivKey(ctx context.Context, path BIP32Path) (
 		return nil, err
 	}
 
-	return w.derivePathPrivKey(ctx, path)
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := derivePrivKeyReq{
+		reqCtx:   reqCtx{ctx: ctx},
+		path:     path,
+		respChan: make(chan privKeyResp, 1),
+	}
+
+	err = w.sendReq(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	result := <-r.respChan
+
+	return result.key, result.err
 }
 
 // GetPrivKeyForAddress returns the private key for a given address.
 //
-// DANGER: This method exports sensitive key material.
+// DANGER: This method exports sensitive key material. Once admitted, the call
+// waits for key delivery despite cancellation. The caller must zero the key.
 func (w *Wallet) GetPrivKeyForAddress(ctx context.Context, a address.Address) (
 	*btcec.PrivateKey, error) {
 
@@ -1220,7 +1482,22 @@ func (w *Wallet) GetPrivKeyForAddress(ctx context.Context, a address.Address) (
 		return nil, err
 	}
 
-	return w.privKeyForAddress(ctx, a)
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := privKeyForAddressReq{
+		reqCtx:   reqCtx{ctx: ctx},
+		addr:     a,
+		respChan: make(chan privKeyResp, 1),
+	}
+
+	err = w.sendReq(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	result := <-r.respChan
+
+	return result.key, result.err
 }
 
 // PrivKeyForAddress looks up the associated private key for a wallet address.
@@ -1240,6 +1517,14 @@ func (w *Wallet) PrivKeyForAddress(a address.Address) (
 	}
 
 	return w.privKeyForAddress(context.Background(), a)
+}
+
+// handleGetPrivKeyForAddress delivers the result of an accepted component
+// request.
+func (w *Wallet) handleGetPrivKeyForAddress(r privKeyForAddressReq) {
+	// Reuse address-key lookup and transfer the exported key to its caller.
+	key, err := w.privKeyForAddress(r.ctx, r.addr)
+	r.respChan <- privKeyResp{key: key, err: err}
 }
 
 // privKeyForAddress resolves the private key for a wallet address through the

--- a/wallet/signer.go
+++ b/wallet/signer.go
@@ -665,7 +665,7 @@ func (w *Wallet) ComputeUnlockingScript(ctx context.Context,
 	// First, we'll fetch the managed address that corresponds to the
 	// output being spent. This will be used to look up the private key
 	// required for signing.
-	scriptInfo, err := w.ScriptForOutput(ctx, *params.Output)
+	scriptInfo, err := w.scriptForOutput(ctx, *params.Output)
 	if err != nil {
 		return nil, err
 	}
@@ -1250,7 +1250,7 @@ func (w *Wallet) PrivKeyForAddress(a address.Address) (
 func (w *Wallet) privKeyForAddress(ctx context.Context,
 	a address.Address) (*btcec.PrivateKey, error) {
 
-	info, err := w.GetAddressInfo(ctx, a)
+	info, err := w.getAddressInfo(ctx, a)
 	switch {
 	case err == nil && canUseAddressInfoDerivation(info):
 		return w.privKeyForAddressInfo(ctx, info)

--- a/wallet/signer_test.go
+++ b/wallet/signer_test.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -80,6 +81,151 @@ func expectStorePubKey(t *testing.T, mocks *mockWalletDeps,
 	_, pubKey := deriveLeafKeys(t, acct, path.Branch, path.Index)
 
 	return pubKey
+}
+
+// TestSignerKeepsTweakerLifetime verifies that cancellation cannot return a
+// callback-backed signing call while the callback still uses its private key.
+func TestSignerKeepsTweakerLifetime(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Resolve a real fixture key, then pause the caller's tweaker.
+	// Returning its error later avoids unrelated signature-assembly setup.
+	w, deps := createTestWalletWithMocks(t)
+	startLoadedWalletForTest(t, w)
+	w.state.toUnlocked()
+
+	path := BIP32Path{KeyScope: waddrmgr.KeyScopeBIP0084}
+	key, _ := expectStoreSignerPrivKey(
+		t, deps, w.id, path.KeyScope, path.DerivationPath,
+	)
+	t.Cleanup(key.Zero)
+	deps.vault.On("Lock").Return().Once()
+
+	enteredChan := make(chan *btcec.PrivateKey, 1)
+	releaseChan := make(chan struct{})
+	unblock := sync.OnceFunc(func() { close(releaseChan) })
+	t.Cleanup(unblock)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	resultChan := make(chan error, 1)
+	go func() {
+		_, err := w.ComputeRawSig(ctx, &RawSigParams{
+			Path:    path,
+			Details: LegacySpendDetails{},
+			Tweaker: func(key *btcec.PrivateKey) (*btcec.PrivateKey, error) {
+				enteredChan <- key
+
+				<-releaseChan
+
+				return nil, errTweakMock
+			},
+		})
+		resultChan <- err
+	}()
+
+	resolvedKey := <-enteredChan
+
+	// Act: Cancel the caller and initiate shutdown while its own callback is
+	// active; both waits must retain the callback's synchronous lifetime.
+	cancel()
+
+	stoppedChan := make(chan error, 1)
+	go func() { stoppedChan <- w.Stop(t.Context()) }()
+
+	<-w.lifetimeCtx.Done()
+
+	// Assert: Neither waiter returns early. Once released, the callback error
+	// reaches the caller and its temporary key is zeroed before Stop ends.
+	select {
+	case err := <-resultChan:
+		t.Fatalf("signer returned during its tweaker: %v", err)
+	case err := <-stoppedChan:
+		t.Fatalf("Stop returned during a tweaker: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	unblock()
+	require.ErrorIs(t, <-resultChan, errTweakMock)
+	require.NoError(t, <-stoppedChan)
+	require.True(t, resolvedKey.Key.IsZero())
+}
+
+// TestUnsafeSignerDeliversCanceledKey verifies that accepted key derivation
+// delivers its result to the caller responsible for zeroing it.
+func TestUnsafeSignerDeliversCanceledKey(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: Hold the existing deterministic key resolver inside the vault
+	// so cancellation and Stop happen before the accepted key can be returned.
+	w, deps := createTestWalletWithMocks(t)
+	startLoadedWalletForTest(t, w)
+	w.state.toUnlocked()
+
+	path := BIP32Path{KeyScope: waddrmgr.KeyScopeBIP0084}
+	key, _ := expectStoreSignerPrivKey(
+		t, deps, w.id, path.KeyScope, path.DerivationPath,
+	)
+	t.Cleanup(key.Zero)
+
+	enteredChan := make(chan struct{})
+	releaseChan := make(chan struct{})
+	unblock := sync.OnceFunc(func() { close(releaseChan) })
+	t.Cleanup(unblock)
+
+	for _, call := range deps.vault.ExpectedCalls {
+		call.Run(func(mock.Arguments) {
+			close(enteredChan)
+
+			<-releaseChan
+		})
+	}
+
+	deps.vault.On("Lock").Return().Once()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	resultChan := make(chan privKeyResp, 1)
+	go func() {
+		key, err := w.DerivePrivKey(ctx, path)
+		resultChan <- privKeyResp{key: key, err: err}
+	}()
+
+	<-enteredChan
+
+	// Act: Cancel the caller and begin Stop before resolving the key. The
+	// accepted export must retain its receiver until key delivery completes.
+	cancel()
+
+	stoppedChan := make(chan error, 1)
+	go func() { stoppedChan <- w.Stop(t.Context()) }()
+
+	<-w.lifetimeCtx.Done()
+
+	// Assert: Both calls wait for resolution. After release, the caller
+	// receives the expected key and zeros it; Stop joins the accepted work.
+	select {
+	case response := <-resultChan:
+		t.Fatalf("key export returned early: %v", response.err)
+	case err := <-stoppedChan:
+		t.Fatalf("Stop returned before key resolution: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	unblock()
+
+	response := <-resultChan
+	require.NoError(t, response.err)
+
+	require.NotNil(t, response.key)
+	defer response.key.Zero()
+
+	require.Equal(t, key.Serialize(), response.key.Serialize())
+	response.key.Zero()
+	require.True(t, response.key.Key.IsZero())
+	require.NoError(t, <-stoppedChan)
 }
 
 // TestDerivePubKeySuccess tests the successful derivation of a public key

--- a/wallet/signer_test.go
+++ b/wallet/signer_test.go
@@ -1693,7 +1693,15 @@ func TestScriptForOutputWatchOnlyTaprootSQL(t *testing.T) {
 	t.Cleanup(vault.Lock)
 
 	chain := &bwmock.Chain{}
+	// This fixture assembles its own runtime; the shared start helper
+	// only starts the request loop and joins it before storage cleanup.
+	ctx, cancel := context.WithCancel(t.Context())
+
 	w := &Wallet{
+		lifetimeCtx: ctx,
+		cancel:      cancel,
+		requestChan: make(chan any),
+		lockTimer:   time.NewTimer(time.Hour),
 		store:       store,
 		keyVault:    vault,
 		cache:       newStoreRuntimeCache(store),
@@ -1705,8 +1713,9 @@ func TestScriptForOutputWatchOnlyTaprootSQL(t *testing.T) {
 		},
 		id: walletInfo.ID,
 	}
-	require.NoError(t, w.state.toStarting())
-	require.NoError(t, w.state.toStarted())
+	// Disable auto-lock timing so this fixture exercises only its API call.
+	w.lockTimer.Stop()
+	startLoadedWalletForTest(t, w)
 
 	tapscript := newTestTapscript(t)
 	leafScript := tapscript.Leaves[0].Script
@@ -2033,12 +2042,20 @@ func newSQLAddressSigningWallet(t *testing.T) (*Wallet, *bwmock.Chain,
 		identityDecrypt, nil,
 	).Maybe()
 
+	// This fixture assembles its own runtime; the shared start helper
+	// only starts the request loop and joins it before storage cleanup.
+	ctx, cancel := context.WithCancel(t.Context())
+
 	w = &Wallet{
-		addrStore: addrStore,
-		store:     store,
-		keyVault:  vault,
-		cache:     newStoreRuntimeCache(store),
-		state:     newWalletState(nil),
+		lifetimeCtx: ctx,
+		cancel:      cancel,
+		requestChan: make(chan any),
+		lockTimer:   time.NewTimer(time.Hour),
+		addrStore:   addrStore,
+		store:       store,
+		keyVault:    vault,
+		cache:       newStoreRuntimeCache(store),
+		state:       newWalletState(nil),
 		cfg: Config{
 			DB:          legacyDB,
 			Chain:       chain,
@@ -2047,8 +2064,9 @@ func newSQLAddressSigningWallet(t *testing.T) (*Wallet, *bwmock.Chain,
 		id: walletInfo.ID,
 	}
 
-	require.NoError(t, w.state.toStarting())
-	require.NoError(t, w.state.toStarted())
+	// Disable auto-lock timing so this fixture exercises only its API call.
+	w.lockTimer.Stop()
+	startLoadedWalletForTest(t, w)
 	w.state.toUnlocked()
 
 	t.Cleanup(func() {

--- a/wallet/tx_creator.go
+++ b/wallet/tx_creator.go
@@ -640,12 +640,28 @@ func normalizeAndValidateTxIntent(intent *TxIntent) error {
 	return validateTxIntent(intent)
 }
 
+// createTransactionReq borrows the intent until authoring and source use end.
+type createTransactionReq struct {
+	reqCtx
+
+	intent   *TxIntent
+	respChan chan authoredTxResp
+}
+
+// authoredTxResp returns the transaction after accepted authoring completes.
+type authoredTxResp struct {
+	tx  *txauthor.AuthoredTx
+	err error
+}
+
 // CreateTransaction creates a new unsigned transaction spending unspent outputs
 // to the given outputs. It is the direct-transaction wrapper around the neutral
 // authoring boundary and the main implementation of the TxCreator interface.
 // Direct-transaction watch delivery belongs to this wrapper; PSBT funding calls
 // the neutral boundary independently so its lease, cleanup, and publication
 // obligations remain in FundPsbt.
+// Accepted authoring and any supplied coin selector finish before return,
+// even if the caller cancels after admission.
 func (w *Wallet) CreateTransaction(ctx context.Context, intent *TxIntent) (
 	*txauthor.AuthoredTx, error) {
 
@@ -654,19 +670,46 @@ func (w *Wallet) CreateTransaction(ctx context.Context, intent *TxIntent) (
 		return nil, err
 	}
 
-	err = normalizeAndValidateTxIntent(intent)
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := createTransactionReq{
+		reqCtx:   reqCtx{ctx: ctx},
+		intent:   intent,
+		respChan: make(chan authoredTxResp, 1),
+	}
+
+	err = w.sendReq(ctx, r)
 	if err != nil {
 		return nil, err
 	}
 
-	inputSource, changeSource, err := w.prepareTxAuthSources(ctx, intent)
+	// Once admitted, wait for the result even if cancellation arrives.
+	result := <-r.respChan
+
+	return result.tx, result.err
+}
+
+// handleCreateTransaction keeps source setup and authoring within one
+// admission.
+// The admitted caller waits for this result before reusing its inputs.
+func (w *Wallet) handleCreateTransaction(r createTransactionReq) {
+	err := normalizeAndValidateTxIntent(r.intent)
 	if err != nil {
-		return nil, err
+		r.respChan <- authoredTxResp{err: err}
+
+		return
 	}
 
-	return w.authorTransaction(
-		intent.Outputs, intent.FeeRate, inputSource, changeSource,
+	inputSource, changeSource, err := w.prepareTxAuthSources(r.ctx, r.intent)
+	if err != nil {
+		r.respChan <- authoredTxResp{err: err}
+
+		return
+	}
+
+	responseTx, responseErr := w.authorTransaction(
+		r.intent.Outputs, r.intent.FeeRate, inputSource, changeSource,
 	)
+	r.respChan <- authoredTxResp{tx: responseTx, err: responseErr}
 }
 
 // authorTransaction creates an unsigned transaction from the outputs, fee rate,

--- a/wallet/tx_creator_test.go
+++ b/wallet/tx_creator_test.go
@@ -950,12 +950,14 @@ func TestCreateTransactionDefaultPolicy(t *testing.T) {
 	w, mocks := createStartedWalletWithMocks(t)
 	mocks.syncer.On("syncState").Return(syncStateSynced).Once()
 	fixture := expectDefaultAuthoringSources(t, w, mocks)
+	intent := &TxIntent{
+		Outputs: []wire.TxOut{fixture.payment},
+		FeeRate: defaultFeeRate,
+	}
 
 	// Act: Omit Inputs so CreateTransaction must install the default
 	// automatic-selection policy before preparing its sources.
-	authored, err := w.CreateTransaction(t.Context(), &TxIntent{
-		Outputs: []wire.TxOut{fixture.payment}, FeeRate: defaultFeeRate,
-	})
+	authored, err := w.CreateTransaction(t.Context(), intent)
 
 	// Assert: The wrapper must select the fixture's sole UTXO, publish the
 	// exact 99,700-sat payment, and report -1 because no change survived.
@@ -966,6 +968,9 @@ func TestCreateTransactionDefaultPolicy(t *testing.T) {
 		authored.Tx.TxIn[0].PreviousOutPoint)
 	require.Len(t, authored.Tx.TxOut, 1)
 	require.Equal(t, fixture.payment, *authored.Tx.TxOut[0])
+
+	// Default normalization remains visible on the supplied intent.
+	require.IsType(t, &InputsPolicy{}, intent.Inputs)
 }
 
 // TestCreateTransactionInvalidIntent tests that an error is returned when an

--- a/wallet/tx_publisher.go
+++ b/wallet/tx_publisher.go
@@ -57,6 +57,23 @@ type TxPublisher interface {
 // A compile time check to ensure that Wallet implements the interface.
 var _ TxPublisher = (*Wallet)(nil)
 
+// checkMempoolAcceptanceReq borrows the transaction until the chain check ends.
+type checkMempoolAcceptanceReq struct {
+	reqCtx
+
+	tx          *wire.MsgTx
+	respErrChan chan error
+}
+
+// broadcastReq keeps recording, registration and publication in one admission.
+type broadcastReq struct {
+	reqCtx
+
+	tx          *wire.MsgTx
+	label       string
+	respErrChan chan error
+}
+
 // CheckMempoolAcceptance checks if a transaction would be accepted by the
 // mempool without broadcasting.
 //
@@ -66,7 +83,7 @@ var _ TxPublisher = (*Wallet)(nil)
 // rejected.
 //
 // NOTE: This is part of the TxPublisher interface.
-func (w *Wallet) CheckMempoolAcceptance(_ context.Context,
+func (w *Wallet) CheckMempoolAcceptance(ctx context.Context,
 	tx *wire.MsgTx) error {
 
 	err := w.state.validateStarted()
@@ -77,6 +94,34 @@ func (w *Wallet) CheckMempoolAcceptance(_ context.Context,
 	if tx == nil {
 		return ErrTxCannotBeNil
 	}
+
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := checkMempoolAcceptanceReq{
+		reqCtx: reqCtx{ctx: ctx},
+		tx:     tx,
+
+		respErrChan: make(chan error, 1),
+	}
+
+	err = w.sendReq(ctx, r)
+	if err != nil {
+		return err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	return <-r.respErrChan
+}
+
+// handleCheckMempoolAcceptance delivers the result of an accepted component
+// request.
+func (w *Wallet) handleCheckMempoolAcceptance(r checkMempoolAcceptanceReq) {
+	// Reuse acceptance checks also performed inside an admitted broadcast.
+	r.respErrChan <- w.checkMempoolAcceptance(r.ctx, r.tx)
+}
+
+// checkMempoolAcceptance queries the chain inside its accepted request.
+func (w *Wallet) checkMempoolAcceptance(_ context.Context,
+	tx *wire.MsgTx) error {
 
 	// TODO(yy): thread context through.
 	// The TestMempoolAccept rpc expects a slice of transactions.
@@ -131,14 +176,38 @@ func (w *Wallet) Broadcast(ctx context.Context, tx *wire.MsgTx,
 		return ErrTxCannotBeNil
 	}
 
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := broadcastReq{
+		reqCtx:      reqCtx{ctx: ctx},
+		tx:          tx,
+		label:       label,
+		respErrChan: make(chan error, 1),
+	}
+
+	err = w.sendReq(ctx, r)
+	if err != nil {
+		return err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	return <-r.respErrChan
+}
+
+// handleBroadcast records and publishes within the accepted outer request.
+// The admitted caller waits for this result before reusing its inputs.
+func (w *Wallet) handleBroadcast(r broadcastReq) {
 	// We'll start by checking if the tx is acceptable to the mempool.
-	err = w.checkMempool(ctx, tx)
+	err := w.checkMempool(r.ctx, r.tx)
 	if errors.Is(err, errAlreadyBroadcasted) {
-		return nil
+		r.respErrChan <- nil
+
+		return
 	}
 
 	if err != nil {
-		return err
+		r.respErrChan <- err
+
+		return
 	}
 
 	// First, we'll attempt to add the tx to our wallet's DB. This will
@@ -149,43 +218,51 @@ func (w *Wallet) Broadcast(ctx context.Context, tx *wire.MsgTx,
 	// recorded reports whether a tx row was actually written; it gates the
 	// invalidation below so a wallet-unrelated tx (never recorded) is not
 	// invalidated, which would clobber the publish error with ErrTxNotFound.
-	ourAddrs, recorded, err := w.addTxToWallet(ctx, tx, label)
+	ourAddrs, recorded, err := w.addTxToWallet(r.ctx, r.tx, r.label)
 	if err != nil {
-		return err
+		r.respErrChan <- err
+
+		return
 	}
 
 	// Now, we'll attempt to publish the tx. On successful attempt, we
 	// return immediately. On any failures, we invalidate it in the tx store
 	// to prevent subsequent attempts with stale transaction data.
-	err = w.publishTx(tx, ourAddrs)
+	err = w.publishTx(r.tx, ourAddrs)
 	if err == nil {
-		return nil
+		r.respErrChan <- nil
+
+		return
 	}
 
-	txid := tx.TxHash()
+	txid := r.tx.TxHash()
 	log.Errorf("%v: broadcast failed: %v", txid, err)
 
 	// If we never recorded this tx (it is wallet-unrelated), there is
 	// nothing to invalidate, so we return the original publish error as-is
 	// rather than overwriting it with cleanup context.
 	if !recorded {
-		return err
+		r.respErrChan <- err
+
+		return
 	}
 
 	// If the tx was rejected for any other reason, then we'll invalidate it
 	// from the tx store, as otherwise, we'll attempt to continually
 	// re-broadcast it, and the UTXO state of the wallet won't be accurate.
-	removeErr := w.invalidateUnminedTx(ctx, tx)
+	removeErr := w.invalidateUnminedTx(r.ctx, r.tx)
 	if removeErr != nil {
 		log.Warnf("Unable to invalidate tx %v after broadcast failed: %v",
 			txid, removeErr)
 
 		// Return a wrapped error to give the caller full context.
-		return fmt.Errorf("broadcast failed: %w; and failed to "+
+		r.respErrChan <- fmt.Errorf("broadcast failed: %w; and failed to "+
 			"invalidate in wallet: %v", err, removeErr)
+
+		return
 	}
 
-	return err
+	r.respErrChan <- err
 }
 
 var (
@@ -211,7 +288,7 @@ func (w *Wallet) checkMempool(ctx context.Context,
 	tx *wire.MsgTx) error {
 
 	// We'll start by checking if the tx is acceptable to the mempool.
-	err := w.CheckMempoolAcceptance(ctx, tx)
+	err := w.checkMempoolAcceptance(ctx, tx)
 
 	switch {
 	// If the tx is already in the mempool or confirmed, we can return

--- a/wallet/tx_reader.go
+++ b/wallet/tx_reader.go
@@ -215,6 +215,35 @@ type TxDetail struct {
 	Label string
 }
 
+// getTxReq owns the value hash until the accepted detail lookup finishes.
+type getTxReq struct {
+	reqCtx
+
+	txHash   chainhash.Hash
+	respChan chan txDetailResp
+}
+
+// txDetailResp retains a completed detail independently of its waiting caller.
+type txDetailResp struct {
+	detail *TxDetail
+	err    error
+}
+
+// listTxnsReq keeps range and tip reads within the same accepted request.
+type listTxnsReq struct {
+	reqCtx
+
+	startHeight int32
+	endHeight   int32
+	respChan    chan txDetailsResp
+}
+
+// txDetailsResp delivers a complete history result after cancellation or Stop.
+type txDetailsResp struct {
+	details []*TxDetail
+	err     error
+}
+
 // GetTx returns a detailed description of a tx given its tx hash.
 //
 // NOTE: This method is part of the TxReader interface.
@@ -226,10 +255,22 @@ func (w *Wallet) GetTx(ctx context.Context, txHash chainhash.Hash) (
 		return nil, err
 	}
 
-	//nolint:contextcheck // SyncedTo takes no context.
-	currentHeight := w.SyncedTo().Height
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := getTxReq{
+		reqCtx:   reqCtx{ctx: ctx},
+		txHash:   txHash,
+		respChan: make(chan txDetailResp, 1),
+	}
 
-	return w.getTxDetail(ctx, txHash, currentHeight)
+	err = w.sendReq(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	result := <-r.respChan
+
+	return result.detail, result.err
 }
 
 // ListTxns returns detailed transaction views over a block range.
@@ -243,10 +284,33 @@ func (w *Wallet) ListTxns(ctx context.Context, startHeight, endHeight int32) (
 		return nil, err
 	}
 
-	//nolint:contextcheck // SyncedTo takes no context.
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := listTxnsReq{
+		reqCtx:      reqCtx{ctx: ctx},
+		startHeight: startHeight,
+		endHeight:   endHeight,
+		respChan:    make(chan txDetailsResp, 1),
+	}
+
+	err = w.sendReq(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	result := <-r.respChan
+
+	return result.details, result.err
+}
+
+// handleGetTx delivers the result of an accepted component request.
+func (w *Wallet) handleGetTx(r getTxReq) {
+	// Keep the accepted tip read with the existing transaction-detail mapper.
+	// The legacy tip accessor is joined by this accepted outer read.
 	currentHeight := w.SyncedTo().Height
 
-	return w.listTxDetails(ctx, startHeight, endHeight, currentHeight)
+	detail, err := w.getTxDetail(r.ctx, r.txHash, currentHeight)
+	r.respChan <- txDetailResp{detail: detail, err: err}
 }
 
 // getTxDetail loads one transaction through the detailed store path and builds
@@ -267,6 +331,18 @@ func (w *Wallet) getTxDetail(ctx context.Context, txHash chainhash.Hash,
 	}
 
 	return w.buildTxDetailFromStore(txDetails, currentHeight)
+}
+
+// handleListTxns delivers the result of an accepted component request.
+func (w *Wallet) handleListTxns(r listTxnsReq) {
+	// Keep the accepted tip read with the existing transaction-list mapper.
+	// Reuse the existing detailed mapper with the accepted tip snapshot.
+	currentHeight := w.SyncedTo().Height
+
+	details, err := w.listTxDetails(
+		r.ctx, r.startHeight, r.endHeight, currentHeight,
+	)
+	r.respChan <- txDetailsResp{details: details, err: err}
 }
 
 // listTxDetails loads detailed transactions over the requested wallet range and

--- a/wallet/tx_writer.go
+++ b/wallet/tx_writer.go
@@ -38,6 +38,15 @@ type TxWriter interface {
 // A compile time check to ensure that Wallet implements the interface.
 var _ TxWriter = (*Wallet)(nil)
 
+// labelTxReq keeps the value label and hash joined through Store completion.
+type labelTxReq struct {
+	reqCtx
+
+	hash        chainhash.Hash
+	label       string
+	respErrChan chan error
+}
+
 // LabelTx adds a label to a tx. If a label already exists, it will be
 // overwritten. Labels longer than MaxTxLabelLength bytes are rejected with
 // ErrLabelTooLong.
@@ -59,18 +68,43 @@ func (w *Wallet) LabelTx(ctx context.Context,
 			len(label), MaxTxLabelLength)
 	}
 
-	err = w.store.UpdateTx(ctx, db.UpdateTxParams{
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := labelTxReq{
+		reqCtx:      reqCtx{ctx: ctx},
+		hash:        hash,
+		label:       label,
+		respErrChan: make(chan error, 1),
+	}
+
+	err = w.sendReq(ctx, r)
+	if err != nil {
+		return err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	return <-r.respErrChan
+}
+
+// handleLabelTx updates the label under an already accepted request's
+// ownership.
+// The admitted caller waits for this result before reusing its inputs.
+func (w *Wallet) handleLabelTx(r labelTxReq) {
+	err := w.store.UpdateTx(r.ctx, db.UpdateTxParams{
 		WalletID: w.id,
-		Txid:     hash,
-		Label:    &label,
+		Txid:     r.hash,
+		Label:    &r.label,
 	})
 	if err != nil {
 		if errors.Is(err, db.ErrTxNotFound) {
-			return fmt.Errorf("update tx label: %w", ErrTxNotFound)
+			r.respErrChan <- fmt.Errorf("update tx label: %w", ErrTxNotFound)
+
+			return
 		}
 
-		return fmt.Errorf("update tx label: %w", err)
+		r.respErrChan <- fmt.Errorf("update tx label: %w", err)
+
+		return
 	}
 
-	return nil
+	r.respErrChan <- nil
 }

--- a/wallet/utxo_manager.go
+++ b/wallet/utxo_manager.go
@@ -135,6 +135,72 @@ type UtxoManager interface {
 	ListLeasedOutputs(ctx context.Context) ([]*LeasedOutput, error)
 }
 
+// listUnspentReq keeps query and tip reads inside one accepted operation.
+type listUnspentReq struct {
+	reqCtx
+
+	query    UtxoQuery
+	respChan chan utxosResp
+}
+
+// utxosResp returns the selected outputs after accepted Store access ends.
+type utxosResp struct {
+	utxos []*Utxo
+	err   error
+}
+
+// getUtxoReq carries a value outpoint without retaining caller-owned data.
+type getUtxoReq struct {
+	reqCtx
+
+	prevOut  wire.OutPoint
+	respChan chan utxoResp
+}
+
+// utxoResp preserves the accepted lookup result across shutdown.
+type utxoResp struct {
+	utxo *Utxo
+	err  error
+}
+
+// leaseOutputReq owns the value parameters until Store records the lease.
+type leaseOutputReq struct {
+	reqCtx
+
+	id       wtxmgr.LockID
+	op       wire.OutPoint
+	duration time.Duration
+	respChan chan leaseOutputResp
+}
+
+// leaseOutputResp returns the expiration after Store records the lease.
+type leaseOutputResp struct {
+	expiration time.Time
+	err        error
+}
+
+// releaseOutputReq keeps the Store mutation joined until it completes.
+type releaseOutputReq struct {
+	reqCtx
+
+	id          wtxmgr.LockID
+	op          wire.OutPoint
+	respErrChan chan error
+}
+
+// listLeasedOutputsReq keeps lease iteration within Wallet admission.
+type listLeasedOutputsReq struct {
+	reqCtx
+
+	respChan chan leasedOutputsResp
+}
+
+// leasedOutputsResp returns the list after accepted lease iteration ends.
+type leasedOutputsResp struct {
+	outputs []*LeasedOutput
+	err     error
+}
+
 // ListUnspent returns the wallet-owned UTXOs that match the provided query.
 //
 // NOTE: This is part of the UtxoManager interface implementation.
@@ -146,22 +212,44 @@ func (w *Wallet) ListUnspent(ctx context.Context,
 		return nil, err
 	}
 
-	log.Debugf("ListUnspent using query: %v", query)
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := listUnspentReq{
+		reqCtx:   reqCtx{ctx: ctx},
+		query:    query,
+		respChan: make(chan utxosResp, 1),
+	}
 
-	//nolint:contextcheck // SyncedTo takes no context.
+	err = w.sendReq(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	result := <-r.respChan
+
+	return result.utxos, result.err
+}
+
+// handleListUnspent reads and maps UTXOs under its accepted request.
+// The admitted caller waits for this result before reusing its inputs.
+func (w *Wallet) handleListUnspent(r listUnspentReq) {
+	log.Debugf("ListUnspent using query: %v", r.query)
+
 	currentHeight := w.SyncedTo().Height
-	minConfs := query.MinConfs
-	maxConfs := query.MaxConfs
+	minConfs := r.query.MinConfs
+	maxConfs := r.query.MaxConfs
 
 	infos, err := w.store.ListUTXOs(
-		ctx, db.ListUtxosQuery{
+		r.ctx, db.ListUtxosQuery{
 			WalletID: w.id,
 			MinConfs: &minConfs,
 			MaxConfs: &maxConfs,
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("list utxos: %w", err)
+		r.respChan <- utxosResp{err: fmt.Errorf("list utxos: %w", err)}
+
+		return
 	}
 
 	utxos := make([]*Utxo, 0, len(infos))
@@ -171,7 +259,7 @@ func (w *Wallet) ListUnspent(ctx context.Context,
 		// The store has no scope to disambiguate a bare account name,
 		// so the wallet applies the account-name filter here rather
 		// than in the ListUTXOs query.
-		if query.Account != "" && accountName != query.Account {
+		if r.query.Account != "" && accountName != r.query.Account {
 			continue
 		}
 
@@ -179,7 +267,9 @@ func (w *Wallet) ListUnspent(ctx context.Context,
 			&infos[i], accountName, currentHeight,
 		)
 		if err != nil {
-			return nil, err
+			r.respChan <- utxosResp{err: err}
+
+			return
 		}
 
 		utxos = append(utxos, utxo)
@@ -192,7 +282,7 @@ func (w *Wallet) ListUnspent(ctx context.Context,
 		return utxos[i].Amount < utxos[j].Amount
 	})
 
-	return utxos, nil
+	r.respChan <- utxosResp{utxos: utxos}
 }
 
 // walletUtxoAccountName returns the wallet-facing account name for a store UTXO
@@ -294,32 +384,58 @@ func (w *Wallet) GetUtxo(ctx context.Context,
 		return nil, err
 	}
 
-	//nolint:contextcheck // SyncedTo takes no context.
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := getUtxoReq{
+		reqCtx:   reqCtx{ctx: ctx},
+		prevOut:  prevOut,
+		respChan: make(chan utxoResp, 1),
+	}
+
+	err = w.sendReq(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	result := <-r.respChan
+
+	return result.utxo, result.err
+}
+
+// handleGetUtxo resolves the output and tip within its accepted request.
+// The admitted caller waits for this result before reusing its inputs.
+func (w *Wallet) handleGetUtxo(r getUtxoReq) {
 	currentHeight := w.SyncedTo().Height
 
-	info, err := w.store.GetUtxo(ctx, db.GetUtxoQuery{
+	info, err := w.store.GetUtxo(r.ctx, db.GetUtxoQuery{
 		WalletID: w.id,
-		OutPoint: prevOut,
+		OutPoint: r.prevOut,
 	})
 	if err != nil {
 		// Translate the internal store sentinel into the public,
 		// wallet-owned error so callers do not couple to the internal
 		// db package.
 		if errors.Is(err, db.ErrUtxoNotFound) {
-			return nil, ErrUnknownOutput
+			r.respChan <- utxoResp{err: ErrUnknownOutput}
+
+			return
 		}
 
-		return nil, fmt.Errorf("get utxo: %w", err)
+		r.respChan <- utxoResp{err: fmt.Errorf("get utxo: %w", err)}
+
+		return
 	}
 
 	utxo, err := w.buildWalletUtxoFromStore(
 		info, walletUtxoAccountName(info), currentHeight,
 	)
 	if err != nil {
-		return nil, err
+		r.respChan <- utxoResp{err: err}
+
+		return
 	}
 
-	return utxo, nil
+	r.respChan <- utxoResp{utxo: utxo}
 }
 
 // LeaseOutput locks an output for a given duration, reserving it so that it is
@@ -341,12 +457,35 @@ func (w *Wallet) LeaseOutput(ctx context.Context, id wtxmgr.LockID,
 		return time.Time{}, err
 	}
 
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := leaseOutputReq{
+		reqCtx:   reqCtx{ctx: ctx},
+		id:       id,
+		op:       op,
+		duration: duration,
+		respChan: make(chan leaseOutputResp, 1),
+	}
+
+	err = w.sendReq(ctx, r)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	result := <-r.respChan
+
+	return result.expiration, result.err
+}
+
+// handleLeaseOutput records the lease while Wallet owns the Store call.
+// The admitted caller waits for this result before reusing its inputs.
+func (w *Wallet) handleLeaseOutput(r leaseOutputReq) {
 	lease, err := w.store.LeaseOutput(
-		ctx, db.LeaseOutputParams{
+		r.ctx, db.LeaseOutputParams{
 			WalletID: w.id,
-			ID:       db.LockID(id),
-			OutPoint: op,
-			Duration: duration,
+			ID:       db.LockID(r.id),
+			OutPoint: r.op,
+			Duration: r.duration,
 		},
 	)
 	if err != nil {
@@ -355,16 +494,28 @@ func (w *Wallet) LeaseOutput(ctx context.Context, id wtxmgr.LockID,
 		// db package.
 		switch {
 		case errors.Is(err, db.ErrUtxoNotFound):
-			return time.Time{}, ErrUnknownOutput
+			r.respChan <- leaseOutputResp{err: ErrUnknownOutput}
+
+			return
 
 		case errors.Is(err, db.ErrOutputAlreadyLeased):
-			return time.Time{}, ErrOutputAlreadyLocked
+			r.respChan <- leaseOutputResp{
+				expiration: time.Time{},
+				err:        ErrOutputAlreadyLocked,
+			}
+
+			return
 		}
 
-		return time.Time{}, fmt.Errorf("lease output: %w", err)
+		r.respChan <- leaseOutputResp{
+			expiration: time.Time{},
+			err:        fmt.Errorf("lease output: %w", err),
+		}
+
+		return
 	}
 
-	return lease.Expiration, nil
+	r.respChan <- leaseOutputResp{expiration: lease.Expiration}
 }
 
 // ReleaseOutput unlocks a previously leased output, making it available for
@@ -381,29 +532,55 @@ func (w *Wallet) ReleaseOutput(ctx context.Context, id wtxmgr.LockID,
 		return err
 	}
 
-	params := db.ReleaseOutputParams{
-		WalletID: w.id,
-		ID:       [32]byte(id),
-		OutPoint: op,
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := releaseOutputReq{
+		reqCtx:      reqCtx{ctx: ctx},
+		id:          id,
+		op:          op,
+		respErrChan: make(chan error, 1),
 	}
 
-	err = w.store.ReleaseOutput(ctx, params)
+	err = w.sendReq(ctx, r)
+	if err != nil {
+		return err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	return <-r.respErrChan
+}
+
+// handleReleaseOutput releases the lease while Wallet owns the Store call.
+// The admitted caller waits for this result before reusing its inputs.
+func (w *Wallet) handleReleaseOutput(r releaseOutputReq) {
+	params := db.ReleaseOutputParams{
+		WalletID: w.id,
+		ID:       [32]byte(r.id),
+		OutPoint: r.op,
+	}
+
+	err := w.store.ReleaseOutput(r.ctx, params)
 	if err != nil {
 		// Translate the internal store sentinels into the public,
 		// wallet-owned errors so callers do not couple to the internal
 		// db package.
 		switch {
 		case errors.Is(err, db.ErrUtxoNotFound):
-			return ErrUnknownOutput
+			r.respErrChan <- ErrUnknownOutput
+
+			return
 
 		case errors.Is(err, db.ErrOutputUnlockNotAllowed):
-			return ErrOutputUnlockNotAllowed
+			r.respErrChan <- ErrOutputUnlockNotAllowed
+
+			return
 		}
 
-		return fmt.Errorf("release output: %w", err)
+		r.respErrChan <- fmt.Errorf("release output: %w", err)
+
+		return
 	}
 
-	return nil
+	r.respErrChan <- nil
 }
 
 // ListLeasedOutputs returns the wallet-owned outputs that currently have active
@@ -418,9 +595,34 @@ func (w *Wallet) ListLeasedOutputs(
 		return nil, err
 	}
 
-	leases, err := w.store.ListLeasedOutputs(ctx, w.id)
+	// Admission keeps dependency access joined through concurrent Stop.
+	r := listLeasedOutputsReq{
+		reqCtx: reqCtx{ctx: ctx},
+
+		respChan: make(chan leasedOutputsResp, 1),
+	}
+
+	err = w.sendReq(ctx, r)
 	if err != nil {
-		return nil, fmt.Errorf("list leased outputs: %w", err)
+		return nil, err
+	}
+
+	// Once admitted, wait for the result even if cancellation arrives.
+	result := <-r.respChan
+
+	return result.outputs, result.err
+}
+
+// handleListLeasedOutputs maps leases within its accepted request.
+// The admitted caller waits for this result before reusing its inputs.
+func (w *Wallet) handleListLeasedOutputs(r listLeasedOutputsReq) {
+	leases, err := w.store.ListLeasedOutputs(r.ctx, w.id)
+	if err != nil {
+		r.respChan <- leasedOutputsResp{
+			err: fmt.Errorf("list leased outputs: %w", err),
+		}
+
+		return
 	}
 
 	outputs := make([]*LeasedOutput, len(leases))
@@ -432,5 +634,5 @@ func (w *Wallet) ListLeasedOutputs(
 		}
 	}
 
-	return outputs, nil
+	r.respChan <- leasedOutputsResp{outputs: outputs}
 }


### PR DESCRIPTION
## Summary

Route maintained wallet component operations through the existing request admission and shutdown drain.

## Change Description

Keep handlers in their owning components and wait synchronously for every accepted operation, including through caller cancellation and shutdown. Reuse existing operations with their original inputs and keep nested work inside the accepted handler. Cover the shared completion contract and distinct mailbox, callback, key-delivery and partial-PSBT regressions, with repeated per-method lifecycle tests removed. Commits are grouped by complete component.
