### PR TITLE
wallet: reject nil Signer arguments before admission

### DIFF
--- a/wallet/signer.go
+++ b/wallet/signer.go
@@ -72,7 +72,8 @@ type Signer interface {
 	// will be the raw 32-byte shared secret (the X-coordinate of the
 	// result point).
 	//
-	// A nil remote key returns ErrNilArguments without deriving a wallet key.
+	// A nil remote key returns ErrNilArguments, and one that is not a curve
+	// point returns ErrInvalidSignParam; neither derives a wallet key.
 	ECDH(ctx context.Context, path BIP32Path, pub *btcec.PublicKey) (
 		[32]byte, error)
 
@@ -668,6 +669,17 @@ func (w *Wallet) ECDH(ctx context.Context, path BIP32Path,
 	if pub == nil {
 		return [32]byte{}, fmt.Errorf(
 			"%w: remote public key is nil", ErrNilArguments,
+		)
+	}
+
+	// A key that is not a curve point multiplies to the point at infinity,
+	// whose X coordinate is zero. That is a valid-looking 32-byte secret both
+	// sides could agree on without either holding a private key, so it has to
+	// be an error rather than a result.
+	if !pub.IsOnCurve() {
+		return [32]byte{}, fmt.Errorf(
+			"%w: remote public key is not a curve point",
+			ErrInvalidSignParam,
 		)
 	}
 

--- a/wallet/signer.go
+++ b/wallet/signer.go
@@ -98,7 +98,7 @@ type Signer interface {
 	// signature, which can then be manually assembled into the final
 	// witness.
 	//
-	// Nil params return ErrNilArguments.
+	// Nil params, or params with no Output, return ErrNilArguments.
 	ComputeUnlockingScript(ctx context.Context,
 		params *UnlockingScriptParams) (*UnlockingScript, error)
 
@@ -113,7 +113,7 @@ type Signer interface {
 	// final witness is created. For most common, single-signature spends,
 	// ComputeUnlockingScript should be used instead.
 	//
-	// Nil params return ErrNilArguments.
+	// Nil params, or params with no Details, return ErrNilArguments.
 	ComputeRawSig(ctx context.Context, params *RawSigParams) (
 		RawSignature, error)
 }
@@ -882,6 +882,14 @@ func (w *Wallet) ComputeUnlockingScript(ctx context.Context,
 		)
 	}
 
+	// Output is dereferenced unconditionally by the handler and is documented
+	// as required, so its absence is the same fault as a nil params.
+	if params.Output == nil {
+		return nil, fmt.Errorf(
+			"%w: unlocking script output is nil", ErrNilArguments,
+		)
+	}
+
 	// Admission keeps dependency access joined through concurrent Stop.
 	r := unlockingScriptReq{
 		reqCtx:   reqCtx{ctx: ctx},
@@ -1432,6 +1440,15 @@ func (w *Wallet) ComputeRawSig(ctx context.Context, params *RawSigParams) (
 	if params == nil {
 		return nil, fmt.Errorf(
 			"%w: raw signature params are nil", ErrNilArguments,
+		)
+	}
+
+	// Details carries the version-specific signing behavior and its own
+	// documentation requires it to be set. The handler calls through it
+	// unconditionally, so an unset interface faults there.
+	if params.Details == nil {
+		return nil, fmt.Errorf(
+			"%w: raw signature details are nil", ErrNilArguments,
 		)
 	}
 

--- a/wallet/signer.go
+++ b/wallet/signer.go
@@ -79,6 +79,8 @@ type Signer interface {
 	// SignDigest signs a message digest based on the provided intent. The
 	// returned Signature is a marker interface that can be asserted to the
 	// concrete signature types, ECDSASignature or SchnorrSignature.
+	//
+	// A nil intent returns ErrNilArguments.
 	SignDigest(ctx context.Context, path BIP32Path,
 		intent *SignDigestIntent) (Signature, error)
 
@@ -94,6 +96,8 @@ type Signer interface {
 	// multisig, the ComputeRawSig method should be used to generate the raw
 	// signature, which can then be manually assembled into the final
 	// witness.
+	//
+	// Nil params return ErrNilArguments.
 	ComputeUnlockingScript(ctx context.Context,
 		params *UnlockingScriptParams) (*UnlockingScript, error)
 
@@ -107,6 +111,8 @@ type Signer interface {
 	// where signatures may need to be exchanged and combined before the
 	// final witness is created. For most common, single-signature spends,
 	// ComputeUnlockingScript should be used instead.
+	//
+	// Nil params return ErrNilArguments.
 	ComputeRawSig(ctx context.Context, params *RawSigParams) (
 		RawSignature, error)
 }
@@ -712,6 +718,12 @@ func (w *Wallet) ecdh(ctx context.Context, path BIP32Path,
 
 // validateSignDigestIntent validates the parameters of a SignDigestIntent.
 func validateSignDigestIntent(intent *SignDigestIntent) error {
+	// Every field below is read through the intent, so its absence has to be
+	// answered before any of them are.
+	if intent == nil {
+		return fmt.Errorf("%w: intent is nil", ErrNilArguments)
+	}
+
 	// The digest must be exactly 32 bytes.
 	if len(intent.Digest) != chainhash.HashSize {
 		return ErrInvalidDigestSize
@@ -848,6 +860,14 @@ func (w *Wallet) ComputeUnlockingScript(ctx context.Context,
 	err := w.state.canSign()
 	if err != nil {
 		return nil, err
+	}
+
+	// The handler dereferences these params on its own goroutine, where a nil
+	// would fault with no caller to recover it.
+	if params == nil {
+		return nil, fmt.Errorf(
+			"%w: unlocking script params are nil", ErrNilArguments,
+		)
 	}
 
 	// Admission keeps dependency access joined through concurrent Stop.
@@ -1393,6 +1413,14 @@ func (w *Wallet) ComputeRawSig(ctx context.Context, params *RawSigParams) (
 	err := w.state.canSign()
 	if err != nil {
 		return nil, err
+	}
+
+	// The handler dereferences these params on its own goroutine, where a nil
+	// would fault with no caller to recover it.
+	if params == nil {
+		return nil, fmt.Errorf(
+			"%w: raw signature params are nil", ErrNilArguments,
+		)
 	}
 
 	// Admission keeps dependency access joined through concurrent Stop.

--- a/wallet/signer.go
+++ b/wallet/signer.go
@@ -71,6 +71,8 @@ type Signer interface {
 	// a key from the wallet and a remote public key. The output returned
 	// will be the raw 32-byte shared secret (the X-coordinate of the
 	// result point).
+	//
+	// A nil remote key returns ErrNilArguments without deriving a wallet key.
 	ECDH(ctx context.Context, path BIP32Path, pub *btcec.PublicKey) (
 		[32]byte, error)
 
@@ -652,6 +654,15 @@ func (w *Wallet) ECDH(ctx context.Context, path BIP32Path,
 	err := w.state.canSign()
 	if err != nil {
 		return [32]byte{}, err
+	}
+
+	// Reject the remote key before admission. The computation runs on its own
+	// goroutine, where a nil key would fault with no caller to recover it, and
+	// it would do so only after the leaf private key had been derived.
+	if pub == nil {
+		return [32]byte{}, fmt.Errorf(
+			"%w: remote public key is nil", ErrNilArguments,
+		)
 	}
 
 	// Admission keeps dependency access joined through concurrent Stop.

--- a/wallet/signer_test.go
+++ b/wallet/signer_test.go
@@ -3267,3 +3267,25 @@ func TestSignDigestLocked(t *testing.T) {
 	// Assert: Check for forbidden/locked error.
 	require.ErrorIs(t, err, ErrStateForbidden)
 }
+
+// TestECDHRejectsNilRemoteKey verifies that a nil remote public key is refused
+// before the operation is admitted, so no leaf private key is derived for a
+// request that cannot succeed.
+func TestECDHRejectsNilRemoteKey(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: An unlocked wallet whose store would serve the account secret
+	// if the request reached it. No expectation is registered for that read,
+	// so the mock fails the test if the derivation is attempted.
+	w, _ := createUnlockedWalletWithMocks(t)
+	path := BIP32Path{KeyScope: waddrmgr.KeyScopeBIP0084}
+
+	// Act: Ask for a shared secret with no counterparty key.
+	secret, err := w.ECDH(t.Context(), path, nil)
+
+	// Assert: The request is refused with the package's nil-argument identity,
+	// and returns the zero secret rather than faulting on the handler
+	// goroutine.
+	require.ErrorIs(t, err, ErrNilArguments)
+	require.Equal(t, [32]byte{}, secret)
+}

--- a/wallet/signer_test.go
+++ b/wallet/signer_test.go
@@ -3348,3 +3348,30 @@ func TestSignerRejectsNilArguments(t *testing.T) {
 	require.ErrorIs(t, err, ErrNilArguments)
 	require.Nil(t, rawSig)
 }
+
+// TestSignerRejectsUnsetRequiredParams verifies that a params struct missing a
+// field the handler dereferences unconditionally is refused at the boundary,
+// which is the likelier caller mistake than passing no params at all.
+func TestSignerRejectsUnsetRequiredParams(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: An unlocked wallet, so each call reaches the field check.
+	w, _ := createUnlockedWalletWithMocks(t)
+
+	// Act: Assemble an unlocking script for no output.
+	script, err := w.ComputeUnlockingScript(
+		t.Context(), &UnlockingScriptParams{},
+	)
+
+	// Assert: The absent output is reported rather than dereferenced on the
+	// handler goroutine.
+	require.ErrorIs(t, err, ErrNilArguments)
+	require.Nil(t, script)
+
+	// Act: Produce a raw signature with no version-specific details.
+	rawSig, err := w.ComputeRawSig(t.Context(), &RawSigParams{})
+
+	// Assert: The unset interface is reported before any key is derived.
+	require.ErrorIs(t, err, ErrNilArguments)
+	require.Nil(t, rawSig)
+}

--- a/wallet/signer_test.go
+++ b/wallet/signer_test.go
@@ -3289,3 +3289,35 @@ func TestECDHRejectsNilRemoteKey(t *testing.T) {
 	require.ErrorIs(t, err, ErrNilArguments)
 	require.Equal(t, [32]byte{}, secret)
 }
+
+// TestSignerRejectsNilArguments verifies that every Signer method taking a
+// pointer argument refuses a nil one before the request is admitted, rather
+// than faulting inside the handler goroutine that serves it.
+func TestSignerRejectsNilArguments(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: An unlocked wallet, so each call clears the signing-state gate
+	// and reaches the argument check under test.
+	w, _ := createUnlockedWalletWithMocks(t)
+	path := BIP32Path{KeyScope: waddrmgr.KeyScopeBIP0084}
+
+	// Act: Sign a digest with no intent.
+	_, err := w.SignDigest(t.Context(), path, nil)
+
+	// Assert: The absent intent is reported, not dereferenced.
+	require.ErrorIs(t, err, ErrNilArguments)
+
+	// Act: Assemble an unlocking script with no params.
+	script, err := w.ComputeUnlockingScript(t.Context(), nil)
+
+	// Assert: The absent params are reported before admission.
+	require.ErrorIs(t, err, ErrNilArguments)
+	require.Nil(t, script)
+
+	// Act: Produce a raw signature with no params.
+	rawSig, err := w.ComputeRawSig(t.Context(), nil)
+
+	// Assert: The same contract holds for the low-level signing entry point.
+	require.ErrorIs(t, err, ErrNilArguments)
+	require.Nil(t, rawSig)
+}

--- a/wallet/signer_test.go
+++ b/wallet/signer_test.go
@@ -3290,6 +3290,33 @@ func TestECDHRejectsNilRemoteKey(t *testing.T) {
 	require.Equal(t, [32]byte{}, secret)
 }
 
+// TestECDHRejectsOffCurveRemoteKey verifies that a remote key which is not a
+// curve point is refused rather than multiplied to the point at infinity,
+// whose X coordinate would be returned as an all-zero shared secret.
+func TestECDHRejectsOffCurveRemoteKey(t *testing.T) {
+	t.Parallel()
+
+	// Arrange: An unlocked wallet and a structurally valid but degenerate
+	// public key, the shape a caller gets by forgetting to parse one. No
+	// store expectation is registered, so a derivation attempt fails the test.
+	w, _ := createUnlockedWalletWithMocks(t)
+	path := BIP32Path{KeyScope: waddrmgr.KeyScopeBIP0084}
+	offCurve := &btcec.PublicKey{}
+
+	require.False(t, offCurve.IsOnCurve(), "probe key is a curve point")
+
+	// Act: Ask for a shared secret with the degenerate key.
+	secret, err := w.ECDH(t.Context(), path, offCurve)
+
+	// Assert: The key is refused before the account secret is read, which the
+	// strict mock enforces by failing on an unexpected call. Reaching the
+	// multiplication instead yields a nil error and 32 zero bytes: the X
+	// coordinate of the point at infinity, which both sides could agree on
+	// while holding no key at all.
+	require.ErrorIs(t, err, ErrInvalidSignParam)
+	require.Equal(t, [32]byte{}, secret)
+}
+
 // TestSignerRejectsNilArguments verifies that every Signer method taking a
 // pointer argument refuses a nil one before the request is admitted, rather
 // than faulting inside the handler goroutine that serves it.


### PR DESCRIPTION
Four `Signer` entry points dereference an argument without checking it, and
`ECDH` additionally returns an all-zero "shared secret" for a key that is not a
curve point. Three of the four fault on the goroutine `handleReq` spawns, where
nothing in the package recovers, so a caller mistake takes the process down
rather than returning an error.

Found while writing the Task 441 `DerivePubKey`/`ECDH` integration tests, which
could not assert the "reject invalid input without exposing secret material"
contract, because the invalid input was not rejected.

### ECDH, nil key

```
panic: runtime error: invalid memory address or nil pointer dereference
  secp256k1.(*PublicKey).AsJacobian(...)   pubkey.go:227
  secp256k1.GenerateSharedSecret(...)      ecdh.go:16
  wallet.(*Wallet).ecdh(...)               signer.go:694
  wallet.(*Wallet).handleECDH(...)         signer.go:679
  wallet.(*Wallet).handleReq(...)          controller.go:841
created by wallet.(*Wallet).mainLoop in goroutine 36
```

The fault happens **after** `derivePathPrivKey` produced the leaf private key,
and `defer privKey.Zero()` never runs because the goroutine dies.

### ECDH, off-curve key — the quieter one

A non-nil key that is not a curve point multiplies to the point at infinity,
whose X coordinate is zero:

```
err=<nil>  secret=0000000000000000000000000000000000000000000000000000000000000000
```

A caller who forgot to parse a peer key gets a deterministic, publicly
predictable 32 bytes and no error. Both sides can agree on it while holding no
key at all. That is worse than the nil case, because a fault is loud and this
is not.

### The other three, and their fields

| Method | Argument | Faults on |
| --- | --- | --- |
| `SignDigest` | `intent` | caller's goroutine, first field read |
| `ComputeUnlockingScript` | `params`, `params.Output` | handler goroutine |
| `ComputeRawSig` | `params`, `params.Details` | handler goroutine |

`Output` and `Details` are dereferenced unconditionally and documented as
required, so guarding them needs no judgement. `Tx` and `SigHashes` are left
alone, because deciding whether they are optional is a real design question.

### Identity

Every nil argument returns `ErrNilArguments`, which `SignPsbt` already returns
for structurally identical code (`wallet/psbt_manager.go:997`). The off-curve
key returns `ErrInvalidSignParam`, since it is invalid rather than absent. No
new exported identity. The `Signer` interface docs now state both contracts.

### Verification

- Every guard was removed again afterwards to confirm its test fails, and fails
  with the fault rather than a plain assertion error.
- The ECDH tests register no store expectation, so the strict mock fails the
  test if a key is derived at all — they prove "no derivation", not just "an
  error came back".
- `go test ./wallet/` passes; all four commits build and pass on their own.

Every guard fires in the exported method, before `sendReq` and before any Store
call, so none of them can behave differently per database backend. That is why
the regression lives in `wallet` unit tests rather than in `itest`: an
integration case would repeat one backend-independent assertion three times,
and would assert less than these do, since registering no store expectation
lets the strict mock prove no key was derived at all.

