### PR TITLE
bwtest: stop neutrino before closing database

### DIFF
--- a/bwtest/neutrino.go
+++ b/bwtest/neutrino.go
@@ -112,6 +112,11 @@ func (n *NeutrinoBackend) NewChainClient(ctx context.Context) (chain.Interface,
 		client.Stop()
 		client.WaitForShutdown()
 
+		// NeutrinoClient.Stop only shuts down the wallet-facing client.
+		// Stop the owned chain service and its goroutines before closing
+		// the filter store they access.
+		_ = chainService.Stop()
+
 		_ = spvdb.Close()
 		_ = os.RemoveAll(dataDir)
 	}


### PR DESCRIPTION
## Summary

Stop the per-subtest neutrino chain service before closing its filter database.

## Change Description

The [failed neutrino/kvdb CI job](https://github.com/btcsuite/btcwallet/actions/runs/34541363702/job/103084512879) panicked in getCheckpointedCFHeaders because NeutrinoClient.Stop only stops the btcwallet wrapper. The owned ChainService block-manager goroutine was still running when cleanup closed spvdb.

Cleanup now calls ChainService.Stop, which waits for service goroutines, before closing and removing the database. The manager-focused and full neutrino/kvdb integration matrices pass locally.